### PR TITLE
feat: Add scripts and configs for release management

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+store: zeus
+targets:
+  - github
+  - pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,9 @@ matrix:
         - BUILD_ARCH=x86_64
       after_success:
         - npm install -g @zeus-ci/cli
-        - zeus upload -t "application/octet-stream" target/x86_64-unknown-linux-gnu/release/semaphore
+        - zeus upload -t "application/octet-stream"
+                      -n semaphore-Linux-x86_64
+                      target/x86_64-unknown-linux-gnu/release/semaphore
     - os: linux
       language: generic
       env:
@@ -53,13 +55,17 @@ matrix:
         - BUILD_ARCH=i686
       after_success:
         - npm install -g @zeus-ci/cli
-        - zeus upload -t "application/octet-stream" target/i686-unknown-linux-gnu/release/semaphore
+        - zeus upload -t "application/octet-stream"
+                      -n semaphore-Linux-i686
+                      target/i686-unknown-linux-gnu/release/semaphore
     - os: osx
       osx_image: xcode7.3
       env: SUITE=releasebuild
       after_success:
         - npm install -g @zeus-ci/cli
-        - zeus upload -t "application/octet-stream" target/release/semaphore
+        - zeus upload -t "application/octet-stream"
+                      -n semaphore-Darwin-x86_64
+                      target/release/semaphore
 
     # Python builds
     - os: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+## 0.1.0
+
+An initial release of the tool.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "semaphore"
 readme = "README.md"
 version = "0.1.0"
 build = "build.rs"
+publish = false
 
 [features]
 default = []
@@ -30,23 +31,18 @@ uuid = "0.6.3"
 
 [dependencies.semaphore-aorta]
 path = "aorta"
-version = "0.1.0"
 
 [dependencies.semaphore-common]
 path = "common"
-version = "0.1.0"
 
 [dependencies.semaphore-config]
 path = "config"
-version = "0.1.0"
 
 [dependencies.semaphore-server]
 path = "server"
-version = "0.1.0"
 
 [dependencies.semaphore-trove]
 path = "trove"
-version = "0.1.0"
 
 [target."cfg(not(windows))".dependencies]
 openssl-probe = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ functionality from the Sentry SDKs as well as the Sentry server into a proxy pro
 
 ## Quickstart
 
-Semaphore needs a relay ready sentry installation to connect to.  It stores all
+Semaphore needs a relay ready sentry installation to connect to. It stores all
 of its settings in a `.semaphore` folder in the current working directory by
-default.  The initial config can be created through a wizard:
+default. The initial config can be created through a wizard:
 
     semaphore config init
 
@@ -48,25 +48,25 @@ to the `semaphore` command with the path to an alternative location.
 ## Upstream Registration
 
 When the semaphore runs it registers itself with the upstream configured sentry
-instance as a relay.  Right now relays can only directly connect to Sentry as
-they do not yet proxy through non store requests.  Each relay is identified by
-the `(relay_id, public_key)` tuple upstream.  Multiple relays can share the same
+instance as a relay. Right now relays can only directly connect to Sentry as
+they do not yet proxy through non store requests. Each relay is identified by
+the `(relay_id, public_key)` tuple upstream. Multiple relays can share the same
 public key if they run with different relay IDs.
 
 At present Sentry requires the relays to be explicitly whitelisted by their public
-key.  This is done through the ``SENTRY_RELAY_WHITELIST_PK`` config key which is
+key. This is done through the `SENTRY_RELAY_WHITELIST_PK` config key which is
 a list of permitted public keys.
 
 ## Metrics and Crash Reporting
 
-By default the relay currently reports directly to sentry.io.  This can be disabled
-by setting the `sentry.enabled` key to `false`.  Additionally a different DSN can
-be supplied with `sentry.dsn`.  Crash reporting will become opt-in before the initial
+By default the relay currently reports directly to sentry.io. This can be disabled
+by setting the `sentry.enabled` key to `false`. Additionally a different DSN can
+be supplied with `sentry.dsn`. Crash reporting will become opt-in before the initial
 public release.
 
-Stats can be submitted to a statsd server by configuring `metrics.statsd` key.  It
-can be put to a `ip:port` tuple.  Additionally `metrics.prefix` can be configured
-to have a different prefix (the default is `sentry.relay`).  This prefix is added
+Stats can be submitted to a statsd server by configuring `metrics.statsd` key. It
+can be put to a `ip:port` tuple. Additionally `metrics.prefix` can be configured
+to have a different prefix (the default is `sentry.relay`). This prefix is added
 in front of all metrics.
 
 ## License
@@ -83,3 +83,14 @@ relay:
 
     $ cargo install systemfd cargo-watch
     $ make devserver
+
+### Release management
+
+Use the `./scripts/bump-version.sh` script to bump versions:
+
+    # Check that there is a changelog entry, update configuration files, commit and tag the changes
+    $ bash ./scripts/bump-version.sh patch
+    # Check that everything looks good, then push the new release
+    $ git push origin master NEW_VERSION
+
+Do not forget to update `CHANGELOG.md`, the versioning script will remind you to do it.

--- a/aorta/Cargo.toml
+++ b/aorta/Cargo.toml
@@ -34,7 +34,6 @@ version = "0.4.2"
 
 [dependencies.semaphore-common]
 path = "../common"
-version = "0.1.0"
 
 [dependencies.uuid]
 features = ["v4", "serde"]

--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -895,7 +895,7 @@ dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semaphore-common 0.1.0",
- "sentry-types 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -929,7 +929,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sentry-types 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -938,11 +938,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.3.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "debugid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1442,11 +1442,6 @@ dependencies = [
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
-[[patch.unused]]
-name = "sentry-types"
-version = "0.3.3"
-source = "git+https://github.com/getsentry/rust-sentry-types?rev=2a4807c83cf561e42b59202ad6cc56d88d34a5ec#2a4807c83cf561e42b59202ad6cc56d88d34a5ec"
-
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
@@ -1473,7 +1468,7 @@ source = "git+https://github.com/getsentry/rust-sentry-types?rev=2a4807c83cf561e
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
 "checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
-"checksum debugid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "308e6fc5d8be4107b5cf09c6eff8da84d5b4d2dafe1109916fc71e2cafe67611"
+"checksum debugid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57c49686e3eebf4e7cf157f690fca61284e864fb5ce717634af4528f171048e0"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0f24d1fb71a4a6b9330c8ca04cbd4e7cc5d846b54ca74ff376bc7c9f798d"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
@@ -1552,7 +1547,7 @@ source = "git+https://github.com/getsentry/rust-sentry-types?rev=2a4807c83cf561e
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
-"checksum sentry-types 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "68da67b29fca49c30fc806e96dde37b32283274080c3525ee0612fc987331a53"
+"checksum sentry-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f87fd1dafe3f33330a399abe6458b30de0d53501b2a282adda1a6b94cf07a9"
 "checksum serde 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "21924cc18e5281f232a17c040355fac97732b42cf019c24996a1642bcb169cdb"
 "checksum serde_derive 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "9c624a90bec6fe9bc60d275d7af71c72c26b24cd6c6776d8e344dc4044caa3e2"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"

--- a/cabi/Cargo.toml
+++ b/cabi/Cargo.toml
@@ -18,10 +18,12 @@ debug = true
 lto = true
 
 [dependencies]
-semaphore-aorta = { version = "0.1.0", path = "../aorta" }
 failure = "0.1.1"
 uuid = "0.6.3"
 serde_json = "1.0.17"
 chrono = "0.4.2"
 serde_derive = "1.0.45"
 serde = "1.0.45"
+
+[dependencies.semaphore-aorta]
+path = "../aorta"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -26,8 +26,6 @@ version = "0.4.1"
 
 [dependencies.semaphore-aorta]
 path = "../aorta"
-version = "0.1.0"
 
 [dependencies.semaphore-common]
 path = "../common"
-version = "0.1.0"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+if [ -z "${1:-}" ]; then
+    set -- "patch"
+fi
+
+if [ "$(git diff --stat 2> /dev/null | grep -v CHANGELOG.md |  sed '$d')" != "" ]; then
+    echo "ERROR: There are uncommitted changes in this repository!"
+    echo "Please commit all changes before tagging a new version."
+    exit 1
+fi
+
+VERSION=$(grep '^version' Cargo.toml | cut -d\" -f2 | head -1)
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+case $1 in
+major)
+    TARGET="$(($MAJOR + 1)).0.0"
+    ;;
+minor)
+    TARGET="$MAJOR.$(($MINOR + 1)).0"
+    ;;
+patch)
+    TARGET="$MAJOR.$MINOR.$(($PATCH + 1))"
+    ;;
+*)
+    if ! echo "$1" | grep -Eq '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'; then
+        echo "Usage: $0 <version | major | minor | patch>"
+        echo "ERROR: Version must be a valid semver in format 'x.y.z'"
+        exit 1
+    fi
+
+    TARGET="$1"
+    ;;
+esac
+
+echo "Current version: $VERSION"
+echo "Bumping version: $TARGET"
+
+# Check that there's a valid CHANGELOG entry for the new version
+UNRELEASED_MARKER="[Unreleased]"
+echo "Checking changelog entry..."
+CHANGELOG_NEW=$(cat CHANGELOG.md \
+                | sed -E -e "1,/^## +(\\$UNRELEASED_MARKER|$TARGET)/ d"  \
+                | sed -E -e "/^## /,$ d"                                 \
+                | sed -E -e "/^ *$/ d")
+
+if [ -z "${CHANGELOG_NEW}" ]; then
+    echo "ERROR: Invalid or empty CHANGELOG entry for version ${TARGET}!"
+    echo "ERROR: Put your changes after the unreleased placeholder (${UNRELEASED_MARKER})."
+    exit 1
+fi
+echo "Changelog entry found."
+# Replace version in CHANGELOG
+sed -i '' -e "s/\\${UNRELEASED_MARKER}/${TARGET}/" CHANGELOG.md
+
+VERSION_RE=${VERSION//\./\\.}
+find . -name Cargo.toml -type f -exec sed -i '' -e "1,/^version/ s/^version.*/version = \"$TARGET\"/" {} \;
+cargo update -p semaphore
+
+git commit -a -m "release: $TARGET" > /dev/null
+git tag "$TARGET"
+
+echo
+echo "Updated version and tagged release $TARGET, please run:"
+echo " git push origin master $TARGET"

--- a/scripts/docker-build-linux.sh
+++ b/scripts/docker-build-linux.sh
@@ -23,7 +23,7 @@ docker run \
         -v `pwd`:/work \
         -v $HOME/.cargo/registry:/usr/local/cargo/registry \
         -it $DOCKER_ARCH/rust:jessie \
-        bash -c "./scripts/prepare-build.sh && cargo build --release --locked --target=${TARGET}"
+        bash -c "./scripts/prepare-build.sh >/dev/null && cargo build --release --locked --target=${TARGET}"
 
 # Fix permissions for shared directories
 USER_ID=$(id -u)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,16 +46,12 @@ libc = "0.2.40"
 
 [dependencies.semaphore-aorta]
 path = "../aorta"
-version = "0.1.0"
 
 [dependencies.semaphore-config]
 path = "../config"
-version = "0.1.0"
 
 [dependencies.semaphore-common]
 path = "../common"
-version = "0.1.0"
 
 [dependencies.semaphore-trove]
 path = "../trove"
-version = "0.1.0"

--- a/trove/Cargo.toml
+++ b/trove/Cargo.toml
@@ -24,8 +24,6 @@ serde_derive = "1.0.45"
 
 [dependencies.semaphore-aorta]
 path = "../aorta"
-version = "0.1.0"
 
 [dependencies.semaphore-common]
 path = "../common"
-version = "0.1.0"


### PR DESCRIPTION
We tried to add support for `cargo release` (https://github.com/sunng87/cargo-release) workflow, but unfortunately it lacks certain functionality to handle version bumping for subprojects (aorta, trove, etc.)
Therefore: a single bump-version script for now.