### PR TITLE
ci: Do not wait for Docker Cloud while releasing

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,5 @@ store: zeus
 targets:
   - github
   - pypi
+ignoredChecks:
+  - ci/dockercloud


### PR DESCRIPTION
Although we now build Docker images on Travis, let's leave Docker Cloud running in the background to track its performance. 