### PR TITLE
ref(upstream): Experiment with the SendRequest message

### DIFF
--- a/server/src/actors/keys.rs
+++ b/server/src/actors/keys.rs
@@ -248,10 +248,14 @@ impl Message for GetPublicKeys {
 }
 
 impl UpstreamRequest for GetPublicKeys {
-    type Response = GetPublicKeysResult;
+    type Result = GetPublicKeysResult;
 
-    fn get_upstream_request_target(&self) -> (Method, Cow<str>) {
-        (Method::POST, Cow::Borrowed("/api/0/relays/publickeys/"))
+    fn method(&self) -> Method {
+        Method::POST
+    }
+
+    fn path(&self) -> Cow<str> {
+        Cow::Borrowed("/api/0/relays/publickeys/")
     }
 }
 

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -125,10 +125,14 @@ pub struct GetProjectStatesResponse {
 }
 
 impl UpstreamRequest for GetProjectStates {
-    type Response = GetProjectStatesResponse;
+    type Result = GetProjectStatesResponse;
 
-    fn get_upstream_request_target(&self) -> (Method, Cow<str>) {
-        (Method::POST, Cow::Borrowed("/api/0/relays/projectconfigs/"))
+    fn method(&self) -> Method {
+        Method::POST
+    }
+
+    fn path(&self) -> Cow<str> {
+        Cow::Borrowed("/api/0/relays/projectconfigs/")
     }
 }
 

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -11,8 +11,8 @@ use actix::ResponseFuture;
 
 use actix_web;
 use actix_web::client::ClientRequest;
+use actix_web::client::ClientResponse;
 use actix_web::http::Method;
-use actix_web::Binary;
 use actix_web::Body;
 use actix_web::HttpMessage;
 
@@ -21,7 +21,7 @@ use serde::ser::Serialize;
 
 use http::header;
 
-use futures::Future;
+use futures::{future, Future, IntoFuture};
 
 use semaphore_aorta::UpstreamDescriptor;
 use semaphore_config::Credentials;
@@ -79,6 +79,12 @@ pub enum SendRequestError {
     #[fail(display = "attempted to send upstream request without credentials configured")]
     NoCredentials,
 
+    #[fail(display = "could not sign request with streaming body")]
+    SignatureUnsupported,
+
+    #[fail(display = "could not read json response")]
+    InvalidJson(#[fail(cause)] actix_web::error::JsonPayloadError),
+
     #[fail(display = "failed to send request to upstream")]
     Other(actix_web::Error),
 }
@@ -89,48 +95,127 @@ impl From<actix_web::Error> for SendRequestError {
     }
 }
 
-pub trait UpstreamRequest: Serialize {
-    type Response: DeserializeOwned + 'static + Send;
-
-    fn get_upstream_request_target(&self) -> (Method, Cow<str>);
+impl From<actix_web::error::JsonPayloadError> for SendRequestError {
+    fn from(err: actix_web::error::JsonPayloadError) -> SendRequestError {
+        SendRequestError::InvalidJson(err)
+    }
 }
 
-pub struct SendRequest<T: UpstreamRequest>(pub T);
+pub trait IntoClientRequest {
+    type Result: FromClientResponse + 'static + Send;
 
-impl<T: UpstreamRequest> Message for SendRequest<T> {
-    type Result = Result<<T as UpstreamRequest>::Response, SendRequestError>;
+    fn sign(&self) -> bool;
+
+    fn into_client_request(
+        self,
+        upstream: &UpstreamDescriptor,
+    ) -> Result<ClientRequest, actix_web::Error>;
 }
 
-impl<T: UpstreamRequest> Handler<SendRequest<T>> for UpstreamRelay {
-    type Result = ResponseFuture<<T as UpstreamRequest>::Response, SendRequestError>;
-    fn handle(&mut self, msg: SendRequest<T>, _ctx: &mut Context<Self>) -> Self::Result {
+pub trait FromClientResponse {
+    type Item: Send;
+    type Error: Into<SendRequestError>;
+    type Future: IntoFuture<Item = Self::Item, Error = Self::Error>;
+
+    fn from_client_response(response: ClientResponse) -> Self::Future;
+}
+
+// impl FromClientResponse for ClientResponse {
+//     type Item = Self;
+//     type Error = SendRequestError;
+//     type Future = Result<ClientResponse, Self::Error>;
+
+//     fn from_client_response(response: ClientResponse) -> Self::Future {
+//         Ok(response)
+//     }
+// }
+
+pub struct SendRequest<T>(pub T);
+
+impl<T: IntoClientRequest> Message for SendRequest<T> {
+    type Result = Result<<T::Result as FromClientResponse>::Item, SendRequestError>;
+}
+
+impl<T: IntoClientRequest> Handler<SendRequest<T>> for UpstreamRelay {
+    type Result = ResponseFuture<<T::Result as FromClientResponse>::Item, SendRequestError>;
+
+    fn handle(&mut self, message: SendRequest<T>, _context: &mut Context<Self>) -> Self::Result {
+        let SendRequest(request) = message;
+        let should_sign = request.sign();
+        let mut client_request = tryf!(request.into_client_request(&self.upstream));
+
         let credentials = tryf!(self.assert_authenticated());
-        let (method, url) = {
-            let (method, path) = msg.0.get_upstream_request_target();
-            (method, self.upstream.get_url(&path))
-        };
-        let (json, signature) = credentials.secret_key.pack(msg.0);
-
-        let request = tryf!(
-            ClientRequest::build()
-                .method(method)
-                .uri(url)
-                .header("X-Sentry-Relay-Id", format!("{}", credentials.id.simple()))
-                .header("X-Sentry-Relay-Signature", signature)
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(header::CONTENT_LENGTH, format!("{}", json.len()))
-                .body(Body::Binary(Binary::Bytes(json.into())))
+        client_request.headers_mut().append(
+            "X-Sentry-Relay-Id",
+            header::HeaderValue::from_str(&credentials.id.simple().to_string()).unwrap(),
         );
 
-        Box::new(
-            request
-                .send()
-                .map_err(|e| actix_web::Error::from(e).into())
-                .and_then(|response| {
-                    response
-                        .json()
-                        .map_err(|e| actix_web::Error::from(e).into())
-                }),
-        )
+        if should_sign {
+            let signature = match client_request.body() {
+                Body::Binary(binary) => credentials.secret_key.sign(binary.as_ref()),
+                Body::Empty => credentials.secret_key.sign(&[]),
+                _ => return Box::new(future::err(SendRequestError::SignatureUnsupported)),
+            };
+
+            client_request.headers_mut().insert(
+                "X-Sentry-Relay-Signature",
+                header::HeaderValue::from_str(&signature).unwrap(),
+            );
+        }
+
+        let future = client_request
+            .send()
+            .map_err(|e| SendRequestError::Other(actix_web::Error::from(e)))
+            .and_then(|r| {
+                T::Result::from_client_response(r)
+                    .into_future()
+                    .map_err(Into::into)
+            });
+
+        Box::new(future)
+    }
+}
+
+pub trait UpstreamRequest: Serialize {
+    type Result: DeserializeOwned + 'static + Send;
+
+    fn path(&self) -> Cow<str>;
+
+    fn method(&self) -> Method;
+}
+
+pub struct UpstreamResponse<T>(::std::marker::PhantomData<T>);
+
+impl<T> FromClientResponse for UpstreamResponse<T>
+where
+    T: DeserializeOwned + 'static + Send,
+{
+    type Item = T;
+    type Error = actix_web::error::JsonPayloadError;
+    type Future = actix_web::dev::JsonBody<ClientResponse, T>;
+
+    fn from_client_response(response: ClientResponse) -> Self::Future {
+        response.json()
+    }
+}
+
+impl<T> IntoClientRequest for T
+where
+    T: UpstreamRequest,
+{
+    type Result = UpstreamResponse<<Self as UpstreamRequest>::Result>;
+
+    fn into_client_request(
+        self,
+        upstream: &UpstreamDescriptor,
+    ) -> Result<ClientRequest, actix_web::Error> {
+        ClientRequest::build()
+            .method(self.method())
+            .uri(upstream.get_url(self.path().as_ref()))
+            .json(self)
+    }
+
+    fn sign(&self) -> bool {
+        true
     }
 }


### PR DESCRIPTION
This is a refactor of the `SendRequest` message in the `UpstreamRelay` actor.

TBH, I don't like this approach at the moment. I'll try out a more copy-paste way to get the forward endpoint into the upstream relay actor.