### PR TITLE
fix: Don't timeout when query is being slow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ pytest:
 tests/venv/bin/python: Makefile
 	rm -rf tests/venv
 	virtualenv -ppython3 tests/venv
-	tests/venv/bin/pip install -U pytest pytest-localserver hypothesis requests flask sentry-sdk
+	tests/venv/bin/pip install -U pytest pytest-localserver requests flask sentry-sdk
 
 integration-test: tests/venv/bin/python
 	cargo build

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -197,7 +197,7 @@ struct Cache {
     relay_expiry: u32,
     /// The cache timeout for non-existing entries.
     miss_expiry: u32,
-    /// The number of seconds to buffer batched queries before sending them upstream.
+    /// The buffer timeout for batched queries before sending them upstream in ms.
     batch_interval: u32,
 }
 
@@ -270,7 +270,7 @@ impl Default for Cache {
             project_expiry: 300,
             relay_expiry: 3600,
             miss_expiry: 60,
-            batch_interval: 5,
+            batch_interval: 100,
         }
     }
 }
@@ -625,7 +625,7 @@ impl Config {
     /// Returns the number of seconds during which batchable queries are collected before sending
     /// them in a single request.
     pub fn query_batch_interval(&self) -> Duration {
-        Duration::from_secs(self.values.cache.batch_interval.into())
+        Duration::from_millis(self.values.cache.batch_interval.into())
     }
 
     /// Returns the maximum size of an event payload in bytes.

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -180,10 +180,12 @@ struct Limits {
 /// Controls authentication with upstream.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
-struct Auth {
-    /// The number of seconds between auth attempts.
+struct Http {
+    /// Timeout for upstream requests in seconds.
+    timeout: u32,
+    /// Interval between failed request retries in seconds.
     retry_interval: u32,
-    /// The maximum number of retries before shutting down.
+    /// The maximum number of retries for failed upstream requests.
     max_retries: u32,
 }
 
@@ -255,9 +257,10 @@ impl Default for Limits {
     }
 }
 
-impl Default for Auth {
+impl Default for Http {
     fn default() -> Self {
-        Auth {
+        Http {
+            timeout: 5,
             retry_interval: 15,
             max_retries: 3,
         }
@@ -291,7 +294,7 @@ struct ConfigValues {
     #[serde(default)]
     relay: Relay,
     #[serde(default)]
-    auth: Auth,
+    http: Http,
     #[serde(default)]
     cache: Cache,
     #[serde(default)]
@@ -597,14 +600,19 @@ impl Config {
         &self.values.metrics.prefix
     }
 
-    /// Returns the upstream authentication retry interval.
-    pub fn auth_retry_interval(&self) -> Duration {
-        Duration::from_secs(self.values.auth.retry_interval.into())
+    /// Returns the default timeout for all upstream HTTP requests.
+    pub fn http_timeout(&self) -> Duration {
+        Duration::from_secs(self.values.http.timeout.into())
     }
 
-    /// Returns the maximum number of auth retries.
+    /// Returns the failed upstream request retry interval.
+    pub fn http_retry_interval(&self) -> Duration {
+        Duration::from_secs(self.values.http.retry_interval.into())
+    }
+
+    /// Returns the maximum number of request retries.
     pub fn auth_max_retries(&self) -> u32 {
-        self.values.auth.max_retries
+        self.values.http.max_retries
     }
 
     /// Returns the expiry timeout for cached projects.

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -611,7 +611,7 @@ impl Config {
     }
 
     /// Returns the maximum number of request retries.
-    pub fn auth_max_retries(&self) -> u32 {
+    pub fn http_max_retries(&self) -> u32 {
         self.values.http.max_retries
     }
 

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -2,6 +2,7 @@
 use std::borrow::Cow;
 use std::str;
 use std::sync::Arc;
+use std::time::Duration;
 
 use actix::prelude::*;
 use actix_web::client::{ClientRequest, ClientRequestBuilder, ClientResponse, SendRequestError};
@@ -183,6 +184,8 @@ impl UpstreamRelay {
         let future =
             self.send_request(method, path, |builder| {
                 builder
+                    // Set to really large value because batching adds up to large response times
+                    .timeout(self.config.query_batch_interval() * 5)
                     .header("X-Sentry-Relay-Signature", signature)
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(json)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -144,6 +144,19 @@ class SentryLike(object):
             *self.server_address
         )
 
+    def iter_public_keys(self):
+        try:
+            yield self.public_key
+        except AttributeError:
+            pass
+
+        if self.upstream is not None:
+            if isinstance(self.upstream, tuple):
+                for upstream in self.upstream:
+                    yield from upstream.iter_public_keys()
+            else:
+                yield from self.upstream.iter_public_keys()
+
 
 class Sentry(SentryLike):
     def __init__(self, server_address, app):
@@ -296,4 +309,4 @@ def gobetween(background_process, random_port, config_dir):
     ]
 )
 def relay_chain(request, mini_sentry, relay, gobetween):
-    return request.param(mini_sentry, relay, gobetween)
+    return lambda: request.param(mini_sentry, relay, gobetween)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,10 +45,6 @@ def mini_sentry(request):
     test_failures = []
     authenticated_relays = {}
 
-    @app.route("/api/0/projects/<org>/<project>/releases/<release>/files/", methods=["POST"])
-    def dummy_upload(**opts):
-        return Response(flask_request.data, content_type='application/octet-stream')
-
     @app.route("/api/0/relays/register/challenge/", methods=["POST"])
     def get_challenge():
         relay_id = flask_request.json["relay_id"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -203,7 +203,7 @@ def relay(tmpdir, mini_sentry, request, random_port, background_process, config_
                         "tls_private_key": None,
                         "tls_cert": None,
                     },
-                    "sentry": {"dsn": mini_sentry.dsn},
+                    "sentry": {"enabled": False},
                     "limits": {"max_api_file_upload_size": "1MiB"},
                     "cache": {"batch_interval": 0},
                 }

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -120,6 +120,10 @@ def test_store(mini_sentry, relay, gobetween):
 
 
 def test_limits(mini_sentry, relay):
+    @mini_sentry.app.route("/api/0/projects/<org>/<project>/releases/<release>/files/", methods=["POST"])
+    def dummy_upload(**opts):
+        return Response(request.data, content_type='application/octet-stream')
+
     relay = relay(mini_sentry)
     relay.wait_relay_healthcheck()
 


### PR DESCRIPTION
Actix' default timeout is one second, but that does not really help if
we, by default, wait 5 seconds for batching. Adjust timeout of SendQuery
to be a multiple of the batch_timeout.