### PR TITLE
ref: Simulate half of await with macro

### DIFF
--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -62,18 +62,25 @@ macro_rules! tryf {
 /// Allows the user to use a very simple version of `await` for chaining futures.
 #[macro_export]
 macro_rules! and_then {
-    ({ $($chunks:tt)* }) => {{and_then_impl!($($chunks)*)}};
-}
-
-#[macro_export]
-macro_rules! and_then_impl {
-    ($expr:expr) => ($expr);
     () => ();
 
-    (let $target:pat = await [ $expr:expr ]; $($rest:tt)*) => {
-        ((|| $expr)().into_future().and_then(move |$target| { and_then_impl!($($rest)*) }))
+    ({ await!($expr:expr); $($rest:tt)* }) => {
+        and_then!({ let _ = await!($expr); $($rest)* })
     };
 
-    ($stuff:expr; $($rest:tt)*) => { {$stuff; and_then_impl!($($rest)*)} };
-    ($stuff:stmt; $($rest:tt)*) => { {$stuff; and_then_impl!($($rest)*)} };
+    ({ let $target:pat = await!($expr:expr); $($rest:tt)* }) => {
+        (|| $expr)()
+            .into_future()
+            .map_err(::std::convert::From::from)
+            .and_then(move |$target| and_then!({$($rest)*}))
+    };
+
+    ({ $stuff:expr; $($rest:tt)* }) => {
+        {$stuff; and_then!({$($rest)*})}
+    };
+    ({ $stuff:stmt; $($rest:tt)* }) => {
+        {$stuff; and_then!({$($rest)*})}
+    };
+
+    ($expr:expr) => ($expr);
 }

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -62,13 +62,18 @@ macro_rules! tryf {
 /// Allows the user to use a very simple version of `await` for chaining futures.
 #[macro_export]
 macro_rules! and_then {
-    (let $target:pat = await $expr:expr; $($rest:tt)*) => {
-        (|| $expr)().into_future().and_then(move |$target| { and_then!($($rest)*) })
+    ({ $($chunks:tt)* }) => {{and_then_impl!($($chunks)*)}};
+}
+
+#[macro_export]
+macro_rules! and_then_impl {
+    ($expr:expr) => ($expr);
+    () => ();
+
+    (let $target:pat = await [ $expr:expr ]; $($rest:tt)*) => {
+        ((|| $expr)().into_future().and_then(move |$target| { and_then_impl!($($rest)*) }))
     };
 
-    ($stuff:expr; $($rest:tt)*) => { {$stuff; and_then!($($rest)*)} };
-    ($stuff:stmt; $($rest:tt)*) => { {$stuff; and_then!($($rest)*)} };
-
-    ($expr:expr) => ($expr);
-    () => ()
+    ($stuff:expr; $($rest:tt)*) => { {$stuff; and_then_impl!($($rest)*)} };
+    ($stuff:stmt; $($rest:tt)*) => { {$stuff; and_then_impl!($($rest)*)} };
 }

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -58,3 +58,17 @@ macro_rules! tryf {
         }
     };
 }
+
+/// Allows the user to use a very simple version of `await` for chaining futures.
+#[macro_export]
+macro_rules! and_then {
+    (let $target:pat = await $expr:expr; $($rest:tt)*) => {
+        (|| $expr)().into_future().and_then(move |$target| { and_then!($($rest)*) })
+    };
+
+    ($stuff:expr; $($rest:tt)*) => { {$stuff; and_then!($($rest)*)} };
+    ($stuff:stmt; $($rest:tt)*) => { {$stuff; and_then!($($rest)*)} };
+
+    ($expr:expr) => ($expr);
+    () => ()
+}

--- a/server/src/endpoints/forward.rs
+++ b/server/src/endpoints/forward.rs
@@ -41,65 +41,68 @@ fn get_forwarded_for<S>(request: &HttpRequest<S>) -> String {
 }
 
 fn forward_upstream(request: &HttpRequest<ServiceState>) -> ResponseFuture<HttpResponse, Error> {
-    let config = request.state().config();
-    let upstream = config.upstream_descriptor();
+    {and_then! {
+        let config = request.state().config();
+        let upstream = config.upstream_descriptor();
 
-    let path_and_query = request
-        .uri()
-        .path_and_query()
-        .map(|pq| pq.as_str())
-        .unwrap_or("");
+        let path_and_query = request
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("");
 
-    let mut forwarded_request_builder = ClientRequest::build();
-    for (key, value) in request.headers() {
-        // Since there is no API in actix-web to access the raw, not-yet-decompressed stream, we
-        // must not forward the content-encoding header, as the actix http client will do its own
-        // content encoding. Also remove content-length because it's likely wrong.
-        if HOP_BY_HOP_HEADERS.contains(key) || IGNORED_REQUEST_HEADERS.contains(key) {
-            continue;
-        }
-        forwarded_request_builder.header(key.clone(), value.clone());
-    }
-    forwarded_request_builder
-        .no_default_headers()
-        .disable_decompress()
-        .method(request.method().clone())
-        .uri(upstream.get_url(path_and_query))
-        .set_header("Host", upstream.host())
-        .set_header("X-Forwarded-For", get_forwarded_for(request))
-        .set_header("Connection", "close");
-
-    ForwardBody::new(request)
-        .limit(config.max_api_payload_size())
-        .map_err(Error::from)
-        .and_then(move |data| forwarded_request_builder.body(data).map_err(Error::from))
-        .and_then(move |request| request.send().map_err(Error::from))
-        .and_then(move |response| {
-            let mut forwarded_response = HttpResponse::build(response.status());
-            // For the response body we're able to disable all automatic decompression and
-            // compression done by actix-web or actix' http client.
-            //
-            // 0. use ClientRequestBuilder::disable_decompress() (see above)
-            //
-            // 1. Set content-encoding to identity such that actix-web will not attempt to compress
-            //    again
-            forwarded_response.content_encoding(ContentEncoding::Identity);
-
-            for (key, value) in response.headers() {
-                // 2. Just pass content-length, content-encoding etc through
-                if HOP_BY_HOP_HEADERS.contains(key) {
-                    continue;
-                }
-                forwarded_response.header(key.clone(), value.clone());
+        let mut forwarded_request_builder = ClientRequest::build();
+        for (key, value) in request.headers() {
+            // Since there is no API in actix-web to access the raw, not-yet-decompressed stream, we
+            // must not forward the content-encoding header, as the actix http client will do its own
+            // content encoding. Also remove content-length because it's likely wrong.
+            if HOP_BY_HOP_HEADERS.contains(key) || IGNORED_REQUEST_HEADERS.contains(key) {
+                continue;
             }
+            forwarded_request_builder.header(key.clone(), value.clone());
+        };
 
-            Ok(if response.headers().get(header::CONTENT_TYPE).is_some() {
-                forwarded_response.streaming(response.payload())
-            } else {
-                forwarded_response.finish()
-            })
+        forwarded_request_builder
+            .no_default_headers()
+            .disable_decompress()
+            .method(request.method().clone())
+            .uri(upstream.get_url(path_and_query))
+            .set_header("Host", upstream.host())
+            .set_header("X-Forwarded-For", get_forwarded_for(request))
+            .set_header("Connection", "close");
+
+        let data = await ForwardBody::new(request)
+            .limit(config.max_api_payload_size())
+            .map_err(Error::from);
+
+        let request = await forwarded_request_builder.body(data).map_err(Error::from);
+
+        let response = await request.send().map_err(Error::from);
+
+        let mut forwarded_response = HttpResponse::build(response.status());
+        // For the response body we're able to disable all automatic decompression and
+        // compression done by actix-web or actix' http client.
+        //
+        // 0. use ClientRequestBuilder::disable_decompress() (see above)
+        //
+        // 1. Set content-encoding to identity such that actix-web will not attempt to compress
+        //    again
+        forwarded_response.content_encoding(ContentEncoding::Identity);
+
+        for (key, value) in response.headers() {
+            // 2. Just pass content-length, content-encoding etc through
+            if HOP_BY_HOP_HEADERS.contains(key) {
+                continue;
+            }
+            forwarded_response.header(key.clone(), value.clone());
+        };
+
+        Ok(if response.headers().get(header::CONTENT_TYPE).is_some() {
+            forwarded_response.streaming(response.payload())
+        } else {
+            forwarded_response.finish()
         })
-        .responder()
+    }}.responder()
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {

--- a/server/src/endpoints/forward.rs
+++ b/server/src/endpoints/forward.rs
@@ -71,13 +71,11 @@ fn forward_upstream(request: &HttpRequest<ServiceState>) -> ResponseFuture<HttpR
             .set_header("X-Forwarded-For", get_forwarded_for(request))
             .set_header("Connection", "close");
 
-        let data = await[ForwardBody::new(request)
-                             .limit(config.max_api_payload_size())
-                             .map_err(Error::from)];
+        let data = await!(ForwardBody::new(request).limit(config.max_api_payload_size()));
 
-        let request = await[forwarded_request_builder.body(data).map_err(Error::from)];
+        let request = await!(forwarded_request_builder.body(data));
 
-        let response = await[request.send().map_err(Error::from)];
+        let response = await!(request.send());
 
         let mut forwarded_response = HttpResponse::build(response.status());
         // For the response body we're able to disable all automatic decompression and

--- a/server/src/endpoints/public_keys.rs
+++ b/server/src/endpoints/public_keys.rs
@@ -10,12 +10,10 @@ fn get_public_keys(
     state: CurrentServiceState,
     body: SignedJson<GetPublicKeys>,
 ) -> Box<Future<Item = Json<GetPublicKeysResult>, Error = Error>> {
-    let res = state.key_cache().send(body.inner);
-
-    Box::new(
-        res.map_err(Error::from)
-            .and_then(|x| x.map_err(Error::from).map(Json)),
-    )
+    Box::new(and_then! {
+        let res = await state.key_cache().send(body.inner).map_err(Error::from);
+        res.map_err(Error::from).map(Json)
+    })
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {

--- a/server/src/endpoints/public_keys.rs
+++ b/server/src/endpoints/public_keys.rs
@@ -11,8 +11,9 @@ fn get_public_keys(
     body: SignedJson<GetPublicKeys>,
 ) -> Box<Future<Item = Json<GetPublicKeysResult>, Error = Error>> {
     Box::new(and_then!({
-        let res = await[state.key_cache().send(body.inner).map_err(Error::from)];
-        res.map_err(Error::from).map(Json)
+        let result = await!(state.key_cache().send(body.inner));
+        let body = await!(result);
+        Ok(Json(body))
     }))
 }
 

--- a/server/src/endpoints/public_keys.rs
+++ b/server/src/endpoints/public_keys.rs
@@ -10,10 +10,10 @@ fn get_public_keys(
     state: CurrentServiceState,
     body: SignedJson<GetPublicKeys>,
 ) -> Box<Future<Item = Json<GetPublicKeysResult>, Error = Error>> {
-    Box::new(and_then! {
-        let res = await state.key_cache().send(body.inner).map_err(Error::from);
+    Box::new(and_then!({
+        let res = await[state.key_cache().send(body.inner).map_err(Error::from)];
         res.map_err(Error::from).map(Json)
-    })
+    }))
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -130,36 +130,38 @@ fn store_event(
     let event_manager = request.state().event_manager();
     let project_manager = request.state().project_cache();
 
-    let future = project_manager
-        .send(GetProject { id: project_id })
-        .map_err(BadStoreRequest::ScheduleFailed)
-        .and_then(move |project| {
-            project
-                .send(GetEventAction::cached(meta.clone()))
-                .map_err(BadStoreRequest::ScheduleFailed)
-                .and_then(
-                    |action| match action.map_err(|_| BadStoreRequest::ProjectFailed)? {
-                        EventAction::Accept => Ok(()),
-                        EventAction::Discard => Err(BadStoreRequest::EventRejected),
-                    },
-                )
-                .and_then(move |_| {
-                    StoreBody::new(&request)
-                        .limit(config.max_event_payload_size())
-                        .map_err(BadStoreRequest::PayloadError)
-                })
-                .and_then(move |data| {
-                    event_manager
-                        .send(QueueEvent {
-                            data,
-                            meta,
-                            project,
-                        })
-                        .map_err(BadStoreRequest::ScheduleFailed)
-                        .and_then(|result| result.map_err(BadStoreRequest::ProcessingFailed))
-                        .map(|id| StoreResponse { id })
-                })
-        })
+    let future = {and_then! {
+        let project = await project_manager
+            .send(GetProject { id: project_id })
+            .map_err(BadStoreRequest::ScheduleFailed);
+
+        let action = await project
+            .send(GetEventAction::cached(meta.clone()))
+            .map_err(BadStoreRequest::ScheduleFailed);
+
+        let _ = await (match action.map_err(|_| BadStoreRequest::ProjectFailed)? {
+            EventAction::Accept => Ok(()),
+            EventAction::Discard => Err(BadStoreRequest::EventRejected),
+        });
+
+        let data = await StoreBody::new(&request)
+            .limit(config.max_event_payload_size())
+            .map_err(BadStoreRequest::PayloadError);
+
+        let result = await event_manager
+            .send(QueueEvent {
+                data,
+                meta,
+                project,
+            })
+            .map_err(BadStoreRequest::ScheduleFailed);
+
+        result
+            .map_err(BadStoreRequest::ProcessingFailed)
+            .map(|id| StoreResponse { id })
+    }};
+
+    Box::new(future
         .map(|response| {
             metric!(counter("event.accepted") += 1);
             Json(response)
@@ -167,9 +169,7 @@ fn store_event(
         .map_err(|error| {
             metric!(counter("event.rejected") += 1);
             error
-        });
-
-    Box::new(future)
+        }))
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {


### PR DESCRIPTION
This adds a macro that lets you write this:

    and_then! {
        let foo = await bar;
        Ok(foo * 42)
    }

Instead of this:

    bar.and_then(|foo| Ok(foo * 42))

await currently only works in variable declarations, nowhere else.