### PR TITLE
test(integration): Disable Sentry in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -202,7 +202,7 @@ def relay(tmpdir, mini_sentry, request, random_port, background_process, config_
                         "tls_private_key": None,
                         "tls_cert": None,
                     },
-                    "sentry": {"dsn": mini_sentry.dsn},
+                    "sentry": {"enabled": False},
                 }
             )
         )


### PR DESCRIPTION
We should not send events that occur during testing to the mini_sentry. If we want to properly fix this, we should create a separate instance that accepts internal error events.