### PR TITLE
feat: Ask customers on config init if they want to report to sentry

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -117,11 +117,21 @@ pub struct Relay {
     pub tls_cert: Option<PathBuf>,
 }
 
+/// Controls interal reporting to Sentry.
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(default)]
+pub struct MinimalSentry {
+    /// Set to true to enable sentry reporting to the default dsn.
+    pub enabled: bool,
+}
+
 /// Minimal version of a config for dumping out.
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct MinimalConfig {
     /// The relay part of the config.
     pub relay: Relay,
+    /// Turn on crash reporting?
+    pub sentry: MinimalSentry,
 }
 
 /// Controls the log format
@@ -281,7 +291,9 @@ impl Default for Cache {
 impl Default for Sentry {
     fn default() -> Self {
         Sentry {
-            dsn: None,
+            dsn: "https://0cc4a37e5aab4da58366266a87a95740@sentry.io/1269704"
+                .parse()
+                .ok(),
             enabled: false,
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,6 +211,13 @@ pub fn init_config<'a, P: AsRef<Path>>(
             }
         }
 
+        println!("Do you want to enable the internal crash reporting?");
+        mincfg.sentry.enabled = Select::new()
+            .default(0)
+            .item("yes, share relay internal crash reports with sentry.io")
+            .item("no, do not share crash reports")
+            .interact()? == 0;
+
         mincfg.save_in_folder(&config_path)?;
         done_something = true;
     }


### PR DESCRIPTION
This re-enables sentry reporting after prompting users for it.