### PR TITLE
feat: Cancel event processing after a configured timeout

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -290,7 +290,6 @@ impl Handler<HandleEvent> for EventManager {
             .map_err(move |error, _, _| {
                 error!("error processing event {}: {}", event_id, error);
                 metric!(counter("event.rejected") += 1);
-                ()
             });
 
         Box::new(future)

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -10,7 +10,7 @@ use url::Url;
 use uuid::Uuid;
 
 use semaphore_common::v8::{self, Annotated, Event};
-use semaphore_common::Auth;
+use semaphore_common::{Auth, Config};
 
 use actors::project::{
     EventAction, GetEventAction, GetProjectId, GetProjectState, Project, ProjectError, ProjectState,
@@ -56,6 +56,9 @@ pub enum ProcessingError {
 
     #[fail(display = "could not send event to upstream")]
     SendFailed(#[cause] UpstreamRequestError),
+
+    #[fail(display = "event exceeded its configured lifetime")]
+    Timeout,
 }
 
 #[derive(Debug, Clone)]
@@ -137,12 +140,13 @@ impl Handler<ProcessEvent> for EventProcessor {
 }
 
 pub struct EventManager {
+    config: Arc<Config>,
     upstream: Addr<UpstreamRelay>,
     processor: Addr<EventProcessor>,
 }
 
 impl EventManager {
-    pub fn new(upstream: Addr<UpstreamRelay>) -> Self {
+    pub fn new(config: Arc<Config>, upstream: Addr<UpstreamRelay>) -> Self {
         // TODO: Make the number configurable via config file
         let thread_count = num_cpus::get();
 
@@ -150,6 +154,7 @@ impl EventManager {
         let processor = SyncArbiter::start(thread_count, EventProcessor::new);
 
         EventManager {
+            config,
             upstream,
             processor,
         }
@@ -223,7 +228,7 @@ impl Message for HandleEvent {
 }
 
 impl Handler<HandleEvent> for EventManager {
-    type Result = ResponseFuture<(), ()>;
+    type Result = ResponseActFuture<Self, (), ()>;
 
     fn handle(&mut self, message: HandleEvent, _context: &mut Self::Context) -> Self::Result {
         let upstream = self.upstream.clone();
@@ -280,7 +285,9 @@ impl Handler<HandleEvent> for EventManager {
                     .map_err(ProcessingError::ScheduleFailed)
                     .and_then(|result| result.map_err(ProcessingError::SendFailed))
             })
-            .map_err(move |error| {
+            .into_actor(self)
+            .timeout(self.config.event_buffer_expiry(), ProcessingError::Timeout)
+            .map_err(move |error, _, _| {
                 error!("error processing event {}: {}", event_id, error);
                 metric!(counter("event.rejected") += 1);
                 ()

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -260,7 +260,6 @@ impl ProjectState {
             return EventAction::Discard;
         }
 
-        // TODO: Use real config here.
         if self.outdated(config) {
             // if the state is out of date, we proceed as if it was still up to date. The
             // upstream relay (or sentry) will still filter events.

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -196,7 +196,6 @@ impl Handler<Authenticate> for UpstreamRelay {
             .map(|_, actor, _context| {
                 debug!("relay successfully registered with upstream");
                 actor.auth_state = AuthState::Registered;
-                ()
             })
             .map_err(|err, actor, context| {
                 error!("authentication encountered error: {}", err);
@@ -209,8 +208,6 @@ impl Handler<Authenticate> for UpstreamRelay {
 
                 actor.auth_state = AuthState::Error;
                 context.notify_later(Authenticate, interval);
-
-                ()
             });
 
         Box::new(future)

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -93,7 +93,7 @@ pub fn run(config: Config) -> Result<(), ServerError> {
         upstream_relay: upstream_relay.clone(),
         key_cache: KeyCache::new(config.clone(), upstream_relay.clone()).start(),
         project_cache: ProjectCache::new(config.clone(), upstream_relay.clone()).start(),
-        event_manager: EventManager::new(upstream_relay.clone()).start(),
+        event_manager: EventManager::new(config.clone(), upstream_relay.clone()).start(),
     };
 
     let mut server = server::new(move || make_app(service_state.clone()));

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -2,6 +2,7 @@ import errno
 import gzip
 import socket
 import time
+import queue
 
 from datetime import datetime
 
@@ -171,7 +172,7 @@ def test_event_timeout(mini_sentry, relay):
     relay.send_event(42, {"message": "correct"}).raise_for_status()
 
     assert mini_sentry.captured_events.get(timeout=1)["message"] == "correct"
-    assert mini_sentry.captured_events.get(timeout=1) is None
+    pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=2))
 
 
 @pytest.mark.parametrize("failure_type", ["timeout", "socketerror"])

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -127,21 +127,8 @@ def test_store_node_base64(mini_sentry, relay_chain):
     relay.wait_relay_healthcheck()
 
     mini_sentry.project_configs[42] = relay.basic_project_config()
-
     payload = b"eJytVctu2zAQ/BWDFzuAJYt6WVIfaAsE6KFBi6K3IjAoiXIYSyRLUm7cwP/eJaXEcZr0Bd/E5e7OzJIc3aKOak3WFBXoXCmhislOTDqiNmiO6E1FpWGCo+LrLTI7eZ8Fm1vS9nZ9SNeGVBujSAXhW9QoAq1dZcNaymEF2aUQRkOOXHFRU/9aQ13LOOUCFSkO56gSrf2O5qjpeTWAI963rf+ScMF3nej1ayhifEWkREVDWk3nqBN13/4KgPbzv4bHOb6Hx+kRPihTppf/DTukPVKbRwe44AjuYkhXPb8gjP8Gdfz4C7Q4Xz4z2xFs1QpSnwQqCZKDsPAIy6jdAPfhZGDpASwKnxJ2Ml1p+qcDW9EbQ7mGmPaH2hOgJg8exdOolegkNPlnuIVUbEsMXZhOLuy19TRfMF7Tm0d3555AGB8R+Fhe08o88zCN6h9ScH1hWyoKhLmBUYE3gIuoyWeypXzyaqLot54pOpsqG5ievYB0t+dDQcPWs+mVMVIXi0WSZDQgASF108Q4xqSMaUmDKkuzrEzD5E29Vgx8jSpvWQZ5sizxMgqbKCMJDYPEp73P10psfCYWGE/PfMbhibftzGGiSyvYUVzZGQD7kQaRplf0/M4WZ5x+nzg/nE1HG5yeuRZSaPNA5uX+cr+HrmAQXJO78bmRTIiZPDnHHtiDj+6hiqz18AXdFLHm6kymQNvMx9iP4GBRqSipK9V3pc0d3Fk76Dmyg6XaDD2GE3FJbs7QJvRTaGJFiw2zfQM/8jEEDOto7YkeSlHsBy7mXN4bbR4yIRpYuj2rYR3B2i67OnGNQ1dTqZ00Y3Zo11dEUV49iDDtlX3TWMkI+9hPrSaYwJaq1Xhd35Mfb70LUr0Dlt4nJTycwOOuSGv/VCDErByDNE/iZZLXQY3zOAnDvElpjJcJTXCUZSEZZYGMTlqKAc68IPPC5RccwQUvgsDdUmGPxJKx/GVLTCNUZ39Fzt5/AgZYWKw="  # noqa
-
-    response = requests.post(
-        relay.url + "/api/42/store/",
-        data=payload,
-        headers={
-            "Content-Type": "application/octet-stream",
-            "X-Sentry-Auth": (
-                "Sentry sentry_version=5, sentry_timestamp=1535376240291, "
-                "sentry_client=raven-node/2.6.3, "
-                "sentry_key={}".format(relay.dsn_public_key)
-            ),
-        },
-    )
+    response = relay.send_event(42, payload)
     response.raise_for_status()
 
     event = mini_sentry.captured_events.get(timeout=10)
@@ -155,20 +142,7 @@ def test_store_pii_stripping(mini_sentry, relay):
     relay.wait_relay_healthcheck()
 
     mini_sentry.project_configs[42] = relay.basic_project_config()
-
-    response = requests.post(
-        relay.url + "/api/42/store/",
-        data='{"message":"test@mail.org"}',
-        headers={
-            "Content-Type": "application/octet-stream",
-            "X-Sentry-Auth": (
-                "Sentry sentry_version=5, sentry_timestamp=1535376240291, "
-                "sentry_client=raven-node/2.6.3, "
-                "sentry_key={}".format(relay.dsn_public_key)
-            ),
-        },
-    )
-    response.raise_for_status()
+    relay.send_event(42, {"message": "test@mail.org"}).raise_for_status()
 
     event = mini_sentry.captured_events.get(timeout=10)
     assert mini_sentry.captured_events.empty()

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -170,9 +170,8 @@ def test_event_timeout(mini_sentry, relay):
     sleep(1)
     relay.send_event(42, {"message": "correct"}).raise_for_status()
 
-    event = mini_sentry.captured_events.get(timeout=1)
-    assert event["message"] == "correct"
-    assert mini_sentry.captured_events.empty()
+    assert mini_sentry.captured_events.get(timeout=1)["message"] == "correct"
+    assert mini_sentry.captured_events.get(timeout=1) is None
 
 
 @pytest.mark.parametrize("failure_type", ["timeout", "socketerror"])


### PR DESCRIPTION
The purpose of this change is to introduce a general timeout configured via [`cache.event_expiry`](https://github.com/getsentry/semaphore/blob/03b678fcb19b14b549aa49d13c3bba0edd08de4d/common/src/config.rs#L576-L579) after which events are dropped. This should ensure that with very high backlogs, only latest events are being ingested into Sentry.

Valid reasons for processing taking that long are:

 - The upstream is currently down and cannot serve project configs or relay public keys
 - The upstream is temporarily congested and cannot accept events in the required speed
 - There is a huge amount of events coming in that is creating backpressure on the processing workers

### Tasks

- [x] Timeout processing futures based on configuration (@jan-auer)
- [x] Auto-cancel pending buffered queries (keys and projects, @jan-auer)
- [x] Add tests to ensure old events are being dropped (@untitaker)