### PR TITLE
ref: Consolidate some actor related logging messages

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -95,14 +95,6 @@ impl EventProcessor {
 
 impl Actor for EventProcessor {
     type Context = SyncContext<Self>;
-
-    fn started(&mut self, _ctx: &mut Self::Context) {
-        info!("event processing worker started");
-    }
-
-    fn stopped(&mut self, _ctx: &mut Self::Context) {
-        info!("event processing worker stopped");
-    }
 }
 
 struct ProcessEvent {
@@ -155,9 +147,12 @@ impl EventManager {
         // TODO: Make the number configurable via config file
         let thread_count = num_cpus::get();
 
+        info!("starting {} event processing workers", thread_count);
+        let processor = SyncArbiter::start(thread_count, EventProcessor::new);
+
         EventManager {
             upstream,
-            processor: SyncArbiter::start(thread_count, EventProcessor::new),
+            processor,
         }
     }
 }

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -186,15 +186,15 @@ impl Handler<Authenticate> for UpstreamRelay {
             .send_query(request)
             .into_actor(self)
             .and_then(|challenge, actor, _context| {
-                info!("got register challenge (token = {})", challenge.token());
+                debug!("got register challenge (token = {})", challenge.token());
                 actor.auth_state = AuthState::RegisterChallengeResponse;
                 let challenge_response = challenge.create_response();
 
-                info!("sending register challenge response");
+                debug!("sending register challenge response");
                 actor.send_query(challenge_response).into_actor(actor)
             })
             .map(|_, actor, _context| {
-                info!("relay successfully registered with upstream");
+                debug!("relay successfully registered with upstream");
                 actor.auth_state = AuthState::Registered;
                 ()
             })
@@ -202,7 +202,7 @@ impl Handler<Authenticate> for UpstreamRelay {
                 error!("authentication encountered error: {}", err);
 
                 let interval = actor.backoff.next_backoff();
-                info!(
+                debug!(
                     "scheduling authentication retry in {} seconds",
                     interval.as_secs()
                 );


### PR DESCRIPTION
Startup logging was slighly too verbose in INFO level, especially
authentication. This PR changes all those messages to `debug!()`.

Also, event processing workers used to individually report startup on the INFO
channel. Now, only the `EventManager` logs how many woker threads are being
spawned.