### PR TITLE
test: Decrease timeouts and do not assert empty queues

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -287,6 +287,7 @@ def relay(tmpdir, mini_sentry, request, random_port, background_process, config_
             "limits": {"max_api_file_upload_size": "1MiB"},
             "cache": {"batch_interval": 0},
             "logging": {"level": "debug"},
+            "http": {"timeout": 2},
         }
 
         if options is not None:

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -156,7 +156,7 @@ def test_event_timeout(mini_sentry, relay):
 
     @mini_sentry.app.endpoint("get_project_config")
     def get_project_config():
-        sleep(1.5)
+        sleep(1.5) # Causes the first event to drop, but not the second one
         return get_project_config_original()
 
     relay = relay(mini_sentry, {'cache': {'event_expiry': 1}})
@@ -165,7 +165,7 @@ def test_event_timeout(mini_sentry, relay):
     mini_sentry.project_configs[42] = relay.basic_project_config()
 
     relay.send_event(42, {"message": "invalid"}).raise_for_status()
-    sleep(1)
+    sleep(1) # Sleep so that the second event also has to wait but succeeds
     relay.send_event(42, {"message": "correct"}).raise_for_status()
 
     assert mini_sentry.captured_events.get(timeout=1)["message"] == "correct"
@@ -202,7 +202,8 @@ def test_query_retry(failure_type, mini_sentry, relay):
     hub.capture_message("hü")
     client.drain_events()
 
-    event = mini_sentry.captured_events.get(timeout=5)
+    # relay's http timeout is 2 seconds, and retry interval 1s * 1.5^n
+    event = mini_sentry.captured_events.get(timeout=4)
     assert event["message"] == "hü"
     assert retry_count == 2
 


### PR DESCRIPTION
I would expect that an event should only take a few milliseconds (tops!) to get
processed by semaphore and sent to the upstream. That is, without batch query
delays. Consequently, we can lower test timeouts to get faster failures.

Also, this PR removes invalid assertions to `captured_events.empty()`, as
described here: https://github.com/getsentry/semaphore/pull/63#issuecomment-417044547.