### PR TITLE
fix: Correctly log event metrics

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -295,6 +295,7 @@ impl Handler<HandleEvent> for EventManager {
             })
             .into_actor(self)
             .timeout(self.config.event_buffer_expiry(), ProcessingError::Timeout)
+            .map(|_, _, _| metric!(counter("event.accepted") += 1))
             .map_err(move |error, _, _| {
                 error!("error processing event {}: {}", event_id, error);
                 metric!(counter("event.rejected") += 1);

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -174,12 +174,8 @@ fn store_event(
                         })
                         .map_err(BadStoreRequest::ScheduleFailed)
                         .and_then(|result| result.map_err(BadStoreRequest::ProcessingFailed))
-                        .map(|id| StoreResponse { id })
+                        .map(|id| Json(StoreResponse { id }))
                 })
-        })
-        .map(|response| {
-            metric!(counter("event.accepted") += 1);
-            Json(response)
         })
         .map_err(move |error| {
             if log_failed_payloads {


### PR DESCRIPTION
This only logs `event.accepted` if actual processing has completed and the
event has been sent to upstream completely. Otherwise, always `event.rejected`
is logged:

 * The event is rejected synchronously due to cached project configs, body
   overflows, or JSON parsing errors

 * The event is rejected asynchronously, after fetching the project config,
   due to processing errors, or after timing out.