### PR TITLE
fix: Log failed payloads of annotated parsing

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -4,11 +4,12 @@ use actix::prelude::*;
 use bytes::Bytes;
 use futures::prelude::*;
 use num_cpus;
+use sentry::{self, integrations::failure::event_from_fail};
 use serde_json;
 use uuid::Uuid;
 
 use semaphore_common::v8::{self, Annotated, Event};
-use semaphore_common::Config;
+use semaphore_common::{Config, ProjectId};
 
 use actors::project::{
     EventAction, GetEventAction, GetProjectId, GetProjectState, Project, ProjectError, ProjectState,
@@ -73,10 +74,12 @@ impl Actor for EventProcessor {
 }
 
 struct ProcessEvent {
-    pub data: Arc<Bytes>,
+    pub data: Bytes,
     pub meta: Arc<EventMeta>,
     pub event_id: Uuid,
+    pub project_id: ProjectId,
     pub project_state: Arc<ProjectState>,
+    pub log_failed_payloads: bool,
 }
 
 struct ProcessEventResponse {
@@ -91,8 +94,25 @@ impl Handler<ProcessEvent> for EventProcessor {
     type Result = Result<ProcessEventResponse, ProcessingError>;
 
     fn handle(&mut self, message: ProcessEvent, _context: &mut Self::Context) -> Self::Result {
-        let mut event = Annotated::<Event>::from_json_bytes(&message.data)
-            .map_err(ProcessingError::InvalidJson)?;
+        let mut event = Annotated::<Event>::from_json_bytes(&message.data).map_err(|error| {
+            if message.log_failed_payloads {
+                let mut event = event_from_fail(&error);
+
+                event.message = Some(format!("body: {}", String::from_utf8_lossy(&message.data)));
+                if let Some(exception) = event.exceptions.last_mut() {
+                    exception.ty = "BadEventPayload".into();
+                }
+
+                event.user = Some(sentry::User {
+                    id: Some(message.project_id.to_string()),
+                    ..Default::default()
+                });
+
+                sentry::capture_event(event);
+            }
+
+            ProcessingError::InvalidJson(error)
+        })?;
 
         if let Some(event) = event.value_mut() {
             event.id.set_value(Some(Some(message.event_id)))
@@ -153,7 +173,7 @@ struct EventIdHelper {
 }
 
 pub struct QueueEvent {
-    pub data: Arc<Bytes>,
+    pub data: Bytes,
     pub meta: Arc<EventMeta>,
     pub project: Addr<Project>,
 }
@@ -190,7 +210,7 @@ impl Handler<QueueEvent> for EventManager {
 }
 
 struct HandleEvent {
-    pub data: Arc<Bytes>,
+    pub data: Bytes,
     pub meta: Arc<EventMeta>,
     pub project: Addr<Project>,
     pub event_id: Uuid,
@@ -206,6 +226,7 @@ impl Handler<HandleEvent> for EventManager {
     fn handle(&mut self, message: HandleEvent, _context: &mut Self::Context) -> Self::Result {
         let upstream = self.upstream.clone();
         let processor = self.processor.clone();
+        let log_failed_payloads = self.config.log_failed_payloads();
 
         let HandleEvent {
             data,
@@ -215,49 +236,50 @@ impl Handler<HandleEvent> for EventManager {
         } = message;
 
         let future = project
-            .send(GetEventAction::fetched(meta.clone()))
+            .send(GetProjectId)
             .map_err(ProcessingError::ScheduleFailed)
-            .and_then(|action| match action.map_err(ProcessingError::PiiFailed)? {
-                EventAction::Accept => Ok(()),
-                EventAction::Discard => Err(ProcessingError::EventRejected),
-            })
-            .and_then(clone!(project, |_| project
-                .send(GetProjectState)
-                .map_err(ProcessingError::ScheduleFailed)
-                .and_then(|result| result.map_err(ProcessingError::PiiFailed))))
-            .and_then(clone!(meta, event_id, |project_state| processor
-                .send(ProcessEvent {
-                    data,
-                    meta,
-                    event_id,
-                    project_state,
-                })
-                .map_err(ProcessingError::ScheduleFailed)
-                .flatten()))
-            .join(
+            .and_then(|option| option.ok_or(ProcessingError::ProjectFailed))
+            .and_then(move |project_id| {
                 project
-                    .send(GetProjectId)
+                    .send(GetEventAction::fetched(meta.clone()))
                     .map_err(ProcessingError::ScheduleFailed)
-                    .and_then(|option| option.ok_or(ProcessingError::ProjectFailed)),
-            )
-            .and_then(move |(processed, project_id)| {
-                let request = SendRequest::post(format!("/api/{}/store/", project_id)).build(
-                    move |builder| {
-                        if let Some(origin) = meta.origin() {
-                            builder.header("Origin", origin.to_string());
-                        }
+                    .and_then(|action| match action.map_err(ProcessingError::PiiFailed)? {
+                        EventAction::Accept => Ok(()),
+                        EventAction::Discard => Err(ProcessingError::EventRejected),
+                    })
+                    .and_then(clone!(project, |_| project
+                        .send(GetProjectState)
+                        .map_err(ProcessingError::ScheduleFailed)
+                        .and_then(|result| result.map_err(ProcessingError::PiiFailed))))
+                    .and_then(clone!(meta, event_id, data, |project_state| processor
+                        .send(ProcessEvent {
+                            data,
+                            meta,
+                            event_id,
+                            project_id,
+                            project_state,
+                            log_failed_payloads,
+                        })
+                        .map_err(ProcessingError::ScheduleFailed)
+                        .flatten()))
+                    .and_then(move |processed| {
+                        let request = SendRequest::post(format!("/api/{}/store/", project_id))
+                            .build(move |builder| {
+                                if let Some(origin) = meta.origin() {
+                                    builder.header("Origin", origin.to_string());
+                                }
 
-                        builder
-                            .header("X-Sentry-Auth", meta.auth().to_string())
-                            .header("X-Forwarded-For", meta.forwarded_for())
-                            .body(processed.data)
-                    },
-                );
+                                builder
+                                    .header("X-Sentry-Auth", meta.auth().to_string())
+                                    .header("X-Forwarded-For", meta.forwarded_for())
+                                    .body(processed.data)
+                            });
 
-                upstream
-                    .send(request)
-                    .map_err(ProcessingError::ScheduleFailed)
-                    .and_then(|result| result.map_err(ProcessingError::SendFailed))
+                        upstream
+                            .send(request)
+                            .map_err(ProcessingError::ScheduleFailed)
+                            .and_then(|result| result.map_err(ProcessingError::SendFailed))
+                    })
             })
             .into_actor(self)
             .timeout(self.config.event_buffer_expiry(), ProcessingError::Timeout)

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -237,8 +237,8 @@ impl Handler<HandleEvent> for EventManager {
 
         let future = project
             .send(GetProjectId)
+            .map(|one| one.into_inner())
             .map_err(ProcessingError::ScheduleFailed)
-            .and_then(|option| option.ok_or(ProcessingError::ProjectFailed))
             .and_then(move |project_id| {
                 project
                     .send(GetEventAction::fetched(meta.clone()))

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -15,7 +15,7 @@ use semaphore_common::{processor::PiiConfig, Config, ProjectId, PublicKey, Retry
 
 use actors::upstream::{SendQuery, UpstreamQuery, UpstreamRelay, UpstreamRequestError};
 use extractors::EventMeta;
-use utils::Response;
+use utils::{One, Response};
 
 #[derive(Fail, Debug)]
 pub enum ProjectError {
@@ -122,14 +122,14 @@ impl Actor for Project {
 pub struct GetProjectId;
 
 impl Message for GetProjectId {
-    type Result = Option<ProjectId>;
+    type Result = One<ProjectId>;
 }
 
 impl Handler<GetProjectId> for Project {
-    type Result = Option<ProjectId>;
+    type Result = One<ProjectId>;
 
     fn handle(&mut self, _message: GetProjectId, _context: &mut Context<Self>) -> Self::Result {
-        Some(self.id)
+        One(self.id)
     }
 }
 

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -5,6 +5,33 @@ use actix::prelude::*;
 use failure::Fail;
 use futures::prelude::*;
 
+#[derive(Debug, Default)]
+pub struct One<T>(pub T);
+
+impl<T> One<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for One<T> {
+    fn from(value: T) -> Self {
+        One(value)
+    }
+}
+
+impl<A, M, T: 'static> MessageResponse<A, M> for One<T>
+where
+    A: Actor,
+    M: Message<Result = One<T>>,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self);
+        }
+    }
+}
+
 pub enum Response<T, E> {
     Reply(Result<T, E>),
     Async(ResponseFuture<T, E>),


### PR DESCRIPTION
This logs errors with event payloads to sentry that occur during parsing of the
`Annotated<Event>`, which may include validation errors or bugs in meta data
parsing. Previously, the code only logged raw JSON parse errors, which are less 
useful to us.

**Details:** Actual event processing (parsing, normalization, PII stripping and
re-serialization) happens in asynchronous processors spawned in a `SyncArbiter`.
The incoming store request does not wait for its result, so neither does its future
(see the `QueueEvent` message for details). Thus, payload errors need to be 
logged in the `EventManager` or `EventProcessor`, and not the store endpoint.

I've chosen to move the logging code to `EventProcessor`, since this sustains
the highest coupling between the error source and logging code.