### PR TITLE
feat: Add more metrics and logging for event processing

### DIFF
--- a/server/src/actors/keys.rs
+++ b/server/src/actors/keys.rs
@@ -201,11 +201,11 @@ impl Actor for KeyCache {
     type Context = Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        info!("key manager started");
+        info!("key cache started");
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        info!("key manager stopped");
+        info!("key cache stopped");
     }
 }
 

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -460,11 +460,11 @@ impl Actor for ProjectCache {
     type Context = Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        info!("project manager started");
+        info!("project cache started");
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        info!("project manager stopped");
+        info!("project cache stopped");
     }
 }
 


### PR DESCRIPTION
We measure three timers while handling events, once they have been initially accepted:
1. `event.wait_time`: The time we take to get all dependencies for events before
   they actually start processing. This includes scheduling overheads, project config
   fetching, batched requests and congestions in the sync processor arbiter. This does
   not include delays in the incoming request (body upload) and skips all events that are
   fast-rejected.
2. `event.processing_time`: The time the sync processor takes to parse the event payload,
   apply normalizations, strip PII and finally re-serialize it into a byte stream. This
   is recorded directly in the EventProcessor.
3. `event.total_time`: The full time an event takes from being initially accepted up to
   being sent to the upstream (including delays in the upstream). This can be regarded
   the total time an event spent in this relay, corrected by incoming network delays.

In addition to this, we log `TRACE` messages with event IDs for:
1. Event being queued: Event was accepted synchronously and passed to the event manager, but might be rejected later due to a fetched project config.
2. Event started processing: `SyncArbiter` has scheduled a task for this specific event
3. Event will be uploaded Sentry

**Change:** Processing errors are now logged with `WARN` level, since this we expect a lot of events to drop out. 