### PR TITLE
fix: Fix graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,13 +5,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.5"
+source = "git+https://github.com/actix/actix-web?rev=86fdbb47a59f7b963ed2d03720420d22a2732c50#86fdbb47a59f7b963ed2d03720420d22a2732c50"
 dependencies = [
  "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -50,7 +50,7 @@ dependencies = [
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -83,7 +83,7 @@ name = "actix_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -238,7 +238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -450,7 +450,7 @@ dependencies = [
  "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -615,7 +615,7 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -700,12 +700,12 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,7 +739,7 @@ name = "http"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -768,13 +768,13 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -981,7 +981,7 @@ name = "marshal_derive"
 version = "0.1.0"
 source = "git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab#692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1044,7 +1044,7 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1259,12 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,7 +1292,7 @@ name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1406,13 +1406,13 @@ name = "reqwest"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
@@ -1527,7 +1527,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "semaphore-common 0.1.3",
@@ -1552,7 +1552,7 @@ dependencies = [
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "marshal 0.1.0 (git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1561,7 +1561,7 @@ dependencies = [
  "serde 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
  "serde_derive 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1572,9 +1572,9 @@ name = "semaphore-server"
 version = "0.1.3"
 dependencies = [
  "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-web 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 0.7.5 (git+https://github.com/actix/actix-web?rev=86fdbb47a59f7b963ed2d03720420d22a2732c50)",
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,7 +1584,7 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1595,6 +1595,7 @@ dependencies = [
  "serde 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
  "serde_derive 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1624,7 +1625,7 @@ dependencies = [
  "im 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1640,7 +1641,7 @@ name = "sentry-actix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "actix-web 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 0.7.5 (git+https://github.com/actix/actix-web?rev=86fdbb47a59f7b963ed2d03720420d22a2732c50)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1693,7 +1694,7 @@ name = "serde_derive"
 version = "1.0.999"
 source = "git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d#880a8c0181ad7202950f24cc8f6872994913441d"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1730,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1812,7 +1813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1820,7 +1821,7 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1830,7 +1831,7 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1957,7 +1958,7 @@ name = "tokio-codec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1967,10 +1968,10 @@ name = "tokio-core"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2012,9 +2013,9 @@ name = "tokio-io"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2025,7 +2026,7 @@ dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2050,7 +2051,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2062,7 +2063,7 @@ name = "tokio-tcp"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2078,7 +2079,7 @@ dependencies = [
  "crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2121,9 +2122,9 @@ name = "tokio-udp"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2135,13 +2136,13 @@ name = "tokio-uds"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2156,7 +2157,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2179,7 +2180,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2318,7 +2319,7 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2408,7 +2409,7 @@ dependencies = [
 
 [metadata]
 "checksum actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "79ad2aaef6647ec755ad4e6581e578694fda752c021bde3e0dd7f1174e25e74a"
-"checksum actix-web 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d0eddc44f25a168d776edf60477bd3d46566f89286e66288da8e196072e5a870"
+"checksum actix-web 0.7.5 (git+https://github.com/actix/actix-web?rev=86fdbb47a59f7b963ed2d03720420d22a2732c50)" = "<none>"
 "checksum actix_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b9d1525ef45e5e021f0b93dace157dcab5d792acb4cc78f3213787d65e2bb92"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
@@ -2429,7 +2430,7 @@ dependencies = [
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e178b8e0e239e844b083d5a0d4a156b2654e67f9f80144d48398fcd736a24fb8"
+"checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
 "checksum cadence 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "532a688a320f1a7e3838b8175d26d009672ddedc7a043e5097ec422a153b87c2"
 "checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
@@ -2511,7 +2512,7 @@ dependencies = [
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "492158e732f2e2de81c592f0a2427e57e12cd3d59877378fe7af624b6bbe0ca1"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
-"checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum marshal 0.1.0 (git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab)" = "<none>"
 "checksum marshal_derive 0.1.0 (git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab)" = "<none>"
@@ -2522,7 +2523,7 @@ dependencies = [
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "4fcfcb32d63961fb6f367bfd5d21e4600b92cd310f71f9dca25acae196eb1560"
-"checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
+"checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum native-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8b0a7bd714e83db15676d31caf968ad7318e9cc35f93c85a90231c8f22867549"
@@ -2545,7 +2546,7 @@ dependencies = [
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ae1b463255bf6613ad435f8997cb57f5d045ef35eb255f5a3d6085be936bd79"
-"checksum proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "37460f858ac0db19bceb2585494de611c9d8618062e6da2994a211b600cc4fc9"
+"checksum proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee80fbbe0ae60bcad82d15bc59d5fe2aaebc1b83fbfb145abc8c74f8e769549"
 "checksum queryst 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb1789ca5bef81bf9fc02e4600e323c3ef5416dd958e4c9cc0d6ae25683d401"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
@@ -2585,7 +2586,7 @@ dependencies = [
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
 "checksum serde_test 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)" = "2b02cabcf876f98ad70cd9ba101883328e6a598ef254874614132fde8084aed7"
 "checksum serde_urlencoded 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aaed41d9fb1e2f587201b863356590c90c1157495d811430a0c0325fe8169650"
-"checksum serde_yaml 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef7eb021f0174685afeeb1ae5383565a9de958396c15c2ac258dd7df89971268"
+"checksum serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46f14cb1eaa4ee296e6d9e0cc8ea96f772369d7b40987253772efbe2a63fd984"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
@@ -2596,7 +2597,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum subtle 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8daf2e8fdde6bc5ae2d5f39716ec1f8b2c0435cda89211e3334071b5208e8515"
+"checksum subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5938f1b89f10d6356339f071eca74209deeae0b6891c2678d655feb78637e369"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "2.32.0", default-features = false, features = ["wrap_help"] 
 failure = "0.1.2"
 pretty_env_logger = "0.2.4"
 futures = "0.1.23"
-log = { version = "0.4.4", features = ["serde"] }
+log = { version = "0.4.5", features = ["serde"] }
 sentry = "0.9.0"
 dialoguer = "0.1.0"
 uuid = "0.6.5"
@@ -47,5 +47,6 @@ clap = { version = "2.32.0", default-features = false }
 [patch.crates-io]
 serde = { git = "https://github.com/mitsuhiko/serde", rev = "880a8c0181ad7202950f24cc8f6872994913441d" }
 serde_derive = { git = "https://github.com/mitsuhiko/serde", rev = "880a8c0181ad7202950f24cc8f6872994913441d" }
+actix-web = { git = "https://github.com/actix/actix-web", rev = "86fdbb47a59f7b963ed2d03720420d22a2732c50" }
 
 [workspace]

--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -345,7 +345,7 @@ name = "marshal_derive"
 version = "0.1.0"
 source = "git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab#692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,7 +412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +435,7 @@ name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ dependencies = [
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "marshal 0.1.0 (git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -575,7 +575,7 @@ dependencies = [
  "serde 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
  "serde_derive 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -609,7 +609,7 @@ name = "serde_derive"
 version = "1.0.999"
 source = "git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d#880a8c0181ad7202950f24cc8f6872994913441d"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -681,7 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -689,7 +689,7 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -699,7 +699,7 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -871,7 +871,7 @@ dependencies = [
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
-"checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum marshal 0.1.0 (git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab)" = "<none>"
 "checksum marshal_derive 0.1.0 (git+https://github.com/getsentry/marshal?rev=692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab)" = "<none>"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -882,7 +882,7 @@ dependencies = [
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06a2b6aae052309c2fd2161ef58f5067bc17bb758377a0de9d4b279d603fdd8a"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum proc-macro2 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "37460f858ac0db19bceb2585494de611c9d8618062e6da2994a211b600cc4fc9"
+"checksum proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee80fbbe0ae60bcad82d15bc59d5fe2aaebc1b83fbfb145abc8c74f8e769549"
 "checksum queryst 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb1789ca5bef81bf9fc02e4600e323c3ef5416dd958e4c9cc0d6ae25683d401"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
@@ -903,12 +903,12 @@ dependencies = [
 "checksum serde_derive 1.0.999 (git+https://github.com/mitsuhiko/serde?rev=880a8c0181ad7202950f24cc8f6872994913441d)" = "<none>"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
 "checksum serde_test 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)" = "2b02cabcf876f98ad70cd9ba101883328e6a598ef254874614132fde8084aed7"
-"checksum serde_yaml 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef7eb021f0174685afeeb1ae5383565a9de958396c15c2ac258dd7df89971268"
+"checksum serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46f14cb1eaa4ee296e6d9e0cc8ea96f772369d7b40987253772efbe2a63fd984"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum subtle 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8daf2e8fdde6bc5ae2d5f39716ec1f8b2c0435cda89211e3334071b5208e8515"
+"checksum subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5938f1b89f10d6356339f071eca74209deeae0b6891c2678d655feb78637e369"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4.6"
 failure = "0.1.2"
 failure_derive = "0.1.2"
 lazy_static = "1.1.0"
-log = { version = "0.4.4", features = ["serde"] }
+log = { version = "0.4.5", features = ["serde"] }
 human-size = "0.4.0"
 marshal = { git = "https://github.com/getsentry/marshal", rev = "692fa3b83ecee7d9ed3e2fbfe3ac8576cea0d5ab" }
 parking_lot = "0.6.4"
@@ -25,7 +25,7 @@ sentry-types = "0.6.2"
 serde = "1.0.76"
 serde_derive = "1.0.76"
 serde_json = "1.0.26"
-serde_yaml = "0.8.2"
+serde_yaml = "0.8.3"
 url = "1.7.1"
 uuid = { version = "0.6.5", features = ["v4", "serde"] }
 regex = "1.0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,9 +15,9 @@ with_ssl = ["native-tls", "actix-web/tls"]
 
 [dependencies]
 actix = "0.7.4"
-actix-web = { version = "0.7.4", default-features = false, features = ["brotli", "flate2-c"] }
+actix-web = { version = "0.7.5", default-features = false, features = ["brotli", "flate2-c"] }
 base64 = "0.9.2"
-bytes = "0.4.9"
+bytes = "0.4.10"
 chrono = { version = "0.4.6", features = ["serde"] }
 clap = "2.32.0"
 failure = "0.1.2"
@@ -26,18 +26,19 @@ flate2 = "1.0.2"
 futures = "0.1.23"
 lazy_static = "1.1.0"
 listenfd = "0.3.3"
-log = "0.4.4"
+log = "0.4.5"
+native-tls = { version = "0.2.1", optional = true }
 num_cpus = "1.8.0"
+parking_lot = "0.6.4"
 regex = "1.0.4"
 sentry = "0.9.0"
 sentry-actix = "0.4.0"
 serde = "1.0.76"
 serde_derive = "1.0.76"
 serde_json = "1.0.26"
+tokio-timer = "0.2.6"
 url = "1.7.1"
 uuid = { version = "0.6.5", features = ["v4"] }
-parking_lot = "0.6.3"
-native-tls = { version = "0.2.1", optional = true }
 
 [dependencies.semaphore-common]
 path = "../common"

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -361,10 +361,8 @@ impl Handler<Shutdown> for EventManager {
 
     fn handle(&mut self, message: Shutdown, _context: &mut Self::Context) -> Self::Result {
         match message.timeout {
-            Some(timeout) => self.shutdown.start(timeout),
+            Some(timeout) => self.shutdown.timeout(timeout),
             None => self.shutdown.now(),
         }
-
-        Box::new(self.shutdown.clone())
     }
 }

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -42,8 +42,11 @@ pub enum ProcessingError {
     #[fail(display = "invalid JSON data")]
     InvalidJson(#[cause] v8::Error),
 
-    #[fail(display = "could not schedule project fetching")]
+    #[fail(display = "could not schedule project fetch")]
     ScheduleFailed(#[cause] MailboxError),
+
+    #[fail(display = "failed to determine event action")]
+    NoAction(#[cause] ProjectError),
 
     #[fail(display = "failed to resolve PII config for project")]
     PiiFailed(#[cause] ProjectError),
@@ -300,7 +303,7 @@ impl Handler<HandleEvent> for EventManager {
                 project
                     .send(GetEventAction::fetched(meta.clone()))
                     .map_err(ProcessingError::ScheduleFailed)
-                    .and_then(|action| match action.map_err(ProcessingError::PiiFailed)? {
+                    .and_then(|action| match action.map_err(ProcessingError::NoAction)? {
                         EventAction::Accept => Ok(()),
                         EventAction::Discard => Err(ProcessingError::EventRejected),
                     })

--- a/server/src/actors/keys.rs
+++ b/server/src/actors/keys.rs
@@ -172,7 +172,7 @@ impl KeyCache {
                     }
                 }
 
-                if !slf.key_channels.is_empty() && !slf.shutdown.requested() {
+                if !slf.key_channels.is_empty() {
                     slf.schedule_fetch(ctx);
                 }
 

--- a/server/src/actors/keys.rs
+++ b/server/src/actors/keys.rs
@@ -157,7 +157,7 @@ impl KeyCache {
                     Err(error) => {
                         error!("error fetching public keys: {}", error);
 
-                        if !slf.shutdown.started() {
+                        if !slf.shutdown.requested() {
                             // Put the channels back into the queue, in addition to channels that have
                             // been pushed in the meanwhile. We will retry again shortly.
                             slf.key_channels.extend(channels);
@@ -165,7 +165,7 @@ impl KeyCache {
                     }
                 }
 
-                if !slf.key_channels.is_empty() && !slf.shutdown.started() {
+                if !slf.key_channels.is_empty() && !slf.shutdown.requested() {
                     ctx.run_later(slf.next_backoff(), Self::fetch_keys);
                 }
 
@@ -306,10 +306,8 @@ impl Handler<Shutdown> for KeyCache {
 
     fn handle(&mut self, message: Shutdown, _context: &mut Self::Context) -> Self::Result {
         match message.timeout {
-            Some(timeout) => self.shutdown.start(timeout),
+            Some(timeout) => self.shutdown.timeout(timeout),
             None => self.shutdown.now(),
         }
-
-        Box::new(self.shutdown.clone())
     }
 }

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -444,7 +444,7 @@ impl ProjectCache {
                     Err(error) => {
                         error!("error fetching project states: {}", error);
 
-                        if !slf.shutdown.started() {
+                        if !slf.shutdown.requested() {
                             // Put the channels back into the queue, in addition to channels that have
                             // been pushed in the meanwhile. We will retry again shortly.
                             slf.state_channels.extend(channels);
@@ -452,7 +452,7 @@ impl ProjectCache {
                     }
                 }
 
-                if !slf.state_channels.is_empty() && !slf.shutdown.started() {
+                if !slf.state_channels.is_empty() && !slf.shutdown.requested() {
                     ctx.run_later(slf.next_backoff(), Self::fetch_states);
                 }
 
@@ -529,10 +529,8 @@ impl Handler<Shutdown> for ProjectCache {
 
     fn handle(&mut self, message: Shutdown, _context: &mut Self::Context) -> Self::Result {
         match message.timeout {
-            Some(timeout) => self.shutdown.start(timeout),
+            Some(timeout) => self.shutdown.timeout(timeout),
             None => self.shutdown.now(),
         }
-
-        Box::new(self.shutdown.clone())
     }
 }

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -459,7 +459,7 @@ impl ProjectCache {
                     }
                 }
 
-                if !slf.state_channels.is_empty() && !slf.shutdown.requested() {
+                if !slf.state_channels.is_empty() {
                     slf.schedule_fetch(ctx);
                 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,6 +18,7 @@ extern crate sentry;
 extern crate sentry_actix;
 extern crate serde;
 extern crate serde_json;
+extern crate tokio_timer;
 extern crate url;
 extern crate uuid;
 

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -1,7 +1,9 @@
 mod actix;
 mod api;
 mod sync;
+mod timer;
 
 pub use self::actix::*;
 pub use self::api::*;
 pub use self::sync::*;
+pub use self::timer::*;

--- a/server/src/utils/sync.rs
+++ b/server/src/utils/sync.rs
@@ -130,7 +130,7 @@ impl<F, E> SyncedFuture<F, E> {
             Err(e) => Err(e),
             Ok(Async::Ready(v)) => Ok(Async::Ready(v)),
             Ok(Async::NotReady) => match timeout.poll() {
-                Err(_) => unreachable!(),
+                Err(_) => Err(self.error.take().unwrap()),
                 Ok(Async::Ready(_)) => Err(self.error.take().unwrap()),
                 Ok(Async::NotReady) => {
                     self.inner = Some((future, timeout));

--- a/server/src/utils/sync.rs
+++ b/server/src/utils/sync.rs
@@ -3,33 +3,28 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use actix::prelude::*;
+use futures::future::{Either, Shared};
 use futures::prelude::*;
+use futures::sync::oneshot;
 use parking_lot::RwLock;
+use tokio_timer::Delay;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Fail, Copy, Clone, Eq, PartialEq)]
 #[fail(display = "timed out")]
 pub struct TimeoutError;
 
 #[derive(Debug)]
 struct SyncHandleInner {
     count: AtomicUsize,
-    timeout: RwLock<Option<Instant>>,
+    sync_tx: RwLock<Option<oneshot::Sender<()>>>,
 }
 
 impl SyncHandleInner {
-    fn new() -> Self {
+    pub fn new() -> Self {
         SyncHandleInner {
             count: AtomicUsize::new(0),
-            timeout: RwLock::new(None),
+            sync_tx: RwLock::new(None),
         }
-    }
-
-    pub fn remaining(&self) -> usize {
-        self.count.load(Ordering::Relaxed)
-    }
-
-    pub fn timed_out(&self) -> bool {
-        self.timeout.read().map_or(false, |t| Instant::now() >= t)
     }
 
     pub fn acquire(&self) {
@@ -38,83 +33,125 @@ impl SyncHandleInner {
 
     pub fn release(&self) {
         self.count.fetch_sub(1, Ordering::Relaxed);
+        self.check();
+    }
+
+    fn check(&self) {
+        if self.count.load(Ordering::Acquire) == 0 {
+            if let Some(tx) = self.sync_tx.write().take() {
+                tx.send(()).ok();
+            }
+        }
     }
 }
 
-#[derive(Debug, Clone)]
 pub struct SyncHandle {
     inner: Arc<SyncHandleInner>,
+    timeout_tx: Option<oneshot::Sender<()>>,
+    timeout_rx: Shared<oneshot::Receiver<()>>,
+    future: Option<Shared<ResponseFuture<(), TimeoutError>>>,
 }
 
 impl SyncHandle {
     pub fn new() -> Self {
+        let (sender, receiver) = oneshot::channel();
+
         SyncHandle {
             inner: Arc::new(SyncHandleInner::new()),
+            timeout_tx: Some(sender),
+            timeout_rx: receiver.shared(),
+            future: None,
         }
     }
 
-    pub fn start(&self, timeout: Duration) {
-        self.inner
-            .timeout
-            .write()
-            .get_or_insert_with(|| Instant::now() + timeout);
+    pub fn now(&mut self) -> ResponseFuture<(), TimeoutError> {
+        self.timeout(Duration::new(0, 0))
     }
 
-    pub fn now(&self) {
-        *self.inner.timeout.write() = Some(Instant::now())
+    pub fn timeout(&mut self, timeout: Duration) -> ResponseFuture<(), TimeoutError> {
+        let future = match self.future {
+            Some(ref future) => future,
+            None => {
+                let timeout_tx = self
+                    .timeout_tx
+                    .take()
+                    .expect("SyncHandle future created twice");
+
+                let (sync_tx, sync_rx) = oneshot::channel();
+                *self.inner.sync_tx.write() = Some(sync_tx);
+                self.inner.check();
+
+                let future = sync_rx.select2(Delay::new(Instant::now() + timeout)).then(
+                    move |result| match result {
+                        Ok(Either::A(_)) => Ok(()),
+                        Ok(Either::B(_)) => {
+                            timeout_tx.send(()).ok();
+                            Err(TimeoutError)
+                        }
+                        Err(_) => unreachable!(),
+                    },
+                );
+
+                let shared = (Box::new(future) as ResponseFuture<_, _>).shared();
+                self.future.get_or_insert(shared)
+            }
+        };
+
+        Box::new(future.clone().then(|result| match result {
+            Ok(_) => Ok(()),
+            Err(_) => Err(TimeoutError),
+        }))
     }
 
-    pub fn started(&self) -> bool {
-        self.inner.timeout.read().is_some()
-    }
-
-    pub fn succeeded(&self) -> bool {
-        self.inner.remaining() == 0
-    }
-
-    pub fn timed_out(&self) -> bool {
-        self.inner.timed_out()
-    }
-}
-
-impl Default for SyncHandle {
-    fn default() -> Self {
-        SyncHandle::new()
-    }
-}
-
-impl Future for SyncHandle {
-    type Item = ();
-    type Error = TimeoutError;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        if self.succeeded() {
-            Ok(Async::Ready(()))
-        } else if self.timed_out() {
-            Err(TimeoutError)
-        } else {
-            Ok(Async::NotReady)
-        }
+    pub fn requested(&self) -> bool {
+        self.future.is_some()
     }
 }
 
 #[derive(Debug)]
 pub struct SyncedFuture<F, E> {
-    handle: Arc<SyncHandleInner>,
-    inner: F,
+    sync: Arc<SyncHandleInner>,
+    inner: Option<(F, Shared<oneshot::Receiver<()>>)>,
     error: Option<E>,
 }
 
 impl<F, E> SyncedFuture<F, E> {
     pub fn new(inner: F, handle: &SyncHandle, error: E) -> Self {
-        let handle = handle.inner.clone();
-        handle.acquire();
+        handle.inner.acquire();
 
         SyncedFuture {
-            handle,
-            inner,
+            sync: handle.inner.clone(),
+            inner: Some((inner, handle.timeout_rx.clone())),
             error: Some(error),
         }
+    }
+
+    fn poll<P, R>(&mut self, poll: P) -> Poll<R, E>
+    where
+        P: FnOnce(&mut F) -> Poll<R, E>,
+    {
+        // NOTE: This implementation is taken from `futures::future::Select2`. We cannot use that
+        // here directly since `ActorFuture` does not offer the same functionality.
+        let (mut future, mut timeout) = self.inner.take().expect("cannot poll SyncedFuture twice");
+
+        let result = match poll(&mut future) {
+            Err(e) => Err(e),
+            Ok(Async::Ready(v)) => Ok(Async::Ready(v)),
+            Ok(Async::NotReady) => match timeout.poll() {
+                Err(_) => unreachable!(),
+                Ok(Async::Ready(_)) => Err(self.error.take().unwrap()),
+                Ok(Async::NotReady) => {
+                    self.inner = Some((future, timeout));
+                    Ok(Async::NotReady)
+                }
+            },
+        };
+
+        if self.inner.is_none() {
+            self.sync.release();
+        }
+
+        result
     }
 }
 
@@ -126,15 +163,7 @@ where
     type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        if self.handle.timed_out() {
-            return Err(self.error.take().unwrap());
-        }
-
-        let poll = self.inner.poll();
-        if let Ok(Async::Ready(_)) = &poll {
-            self.handle.release();
-        }
-        poll
+        self.poll(F::poll)
     }
 }
 
@@ -151,15 +180,7 @@ where
         srv: &mut Self::Actor,
         ctx: &mut <Self::Actor as Actor>::Context,
     ) -> Poll<Self::Item, Self::Error> {
-        if self.handle.timed_out() {
-            return Err(self.error.take().unwrap());
-        }
-
-        let poll = self.inner.poll(srv, ctx);
-        if let Ok(Async::Ready(_)) = &poll {
-            self.handle.release();
-        }
-        poll
+        self.poll(|future| future.poll(srv, ctx))
     }
 }
 

--- a/server/src/utils/timer.rs
+++ b/server/src/utils/timer.rs
@@ -1,0 +1,17 @@
+use actix::{fut, prelude::*};
+use std::time::{Duration, Instant};
+use tokio_timer::Delay;
+
+pub fn run_later<A, F>(
+    timeout: Duration,
+    f: F,
+) -> impl ActorFuture<Item = (), Error = (), Actor = A>
+where
+    A: Actor,
+    F: FnOnce(&mut A, &mut A::Context) + 'static,
+{
+    fut::wrap_future(Delay::new(Instant::now() + timeout)).then(|_, actor, context| {
+        f(actor, context);
+        fut::ok(())
+    })
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -36,14 +36,7 @@ pub fn init_logging(config: &Config) {
         dsn: config
             .sentry_dsn()
             .map(|dsn| dsn.to_string().parse().unwrap()),
-        in_app_include: vec![
-            "semaphore_common::",
-            "semaphore_aorta::",
-            "semaphore_config::",
-            "semaphore_common::",
-            "semaphore_server::",
-            "sentry_relay::",
-        ],
+        in_app_include: vec!["semaphore_common::", "semaphore_server::", "semaphore::"],
         release: sentry_crate_release!(),
         ..Default::default()
     });
@@ -53,7 +46,7 @@ pub fn init_logging(config: &Config) {
     }
 
     if env::var("RUST_LOG").is_err() {
-        let mut log = match config.log_level_filter() {
+        let log = match config.log_level_filter() {
             LevelFilter::Off => "",
             LevelFilter::Error => "ERROR",
             LevelFilter::Warn => "WARN",
@@ -62,18 +55,17 @@ pub fn init_logging(config: &Config) {
                 "INFO,\
                  actix_web::pipeline=DEBUG,\
                  semaphore_common=DEBUG,\
-                 semaphore_aorta=DEBUG,\
-                 semaphore_config=DEBUG,\
-                 semaphore_common=DEBUG,\
                  semaphore_server=DEBUG,\
-                 sentry_relay=DEBUG"
+                 semaphore=DEBUG"
             }
-            LevelFilter::Trace => "TRACE",
+            LevelFilter::Trace => {
+                "INFO,\
+                 actix_web::pipeline=DEBUG,\
+                 semaphore_common=TRACE,\
+                 semaphore_server=TRACE,\
+                 semaphore=TRACE"
+            }
         }.to_string();
-
-        if config.log_failed_payloads() {
-            log.push_str(",semaphore_server::payloads::failed=DEBUG");
-        }
 
         env::set_var("RUST_LOG", log);
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import pytest
 import json
+import signal
 import socket
 import subprocess
 import time
@@ -245,6 +246,15 @@ class Relay(SentryLike):
         self.public_key = public_key
         self.relay_id = relay_id
 
+    def shutdown(self, graceful=True):
+        sig = signal.SIGTERM if graceful else signal.SIGINT
+        self.process.send_signal(sig)
+
+        try:
+            self.process.wait(12)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            raise
 
 @pytest.fixture
 def background_process(request):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -286,7 +286,7 @@ def relay(tmpdir, mini_sentry, request, random_port, background_process, config_
             "sentry": {"dsn": mini_sentry.internal_error_dsn},
             "limits": {"max_api_file_upload_size": "1MiB"},
             "cache": {"batch_interval": 0},
-            "logging": {"level": "debug"},
+            "logging": {"level": "trace"},
             "http": {"timeout": 2},
         }
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -153,7 +153,6 @@ def test_event_timeout(mini_sentry, relay):
     from time import sleep
 
     get_project_config_original = mini_sentry.app.view_functions["get_project_config"]
-
     @mini_sentry.app.endpoint("get_project_config")
     def get_project_config():
         sleep(1.5) # Causes the first event to drop, but not the second one
@@ -169,6 +168,44 @@ def test_event_timeout(mini_sentry, relay):
     relay.send_event(42, {"message": "correct"}).raise_for_status()
 
     assert mini_sentry.captured_events.get(timeout=1)["message"] == "correct"
+    pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+
+
+def test_graceful_shutdown(mini_sentry, relay):
+    from time import sleep
+
+    get_project_config_original = mini_sentry.app.view_functions["get_project_config"]
+    @mini_sentry.app.endpoint("get_project_config")
+    def get_project_config():
+        sleep(1) # Causes the process to wait for one second before shutting down
+        return get_project_config_original()
+
+    relay = relay(mini_sentry)
+    relay.wait_relay_healthcheck()
+
+    mini_sentry.project_configs[42] = relay.basic_project_config()
+    relay.send_event(42, {"message": "hello, world"}).raise_for_status()
+
+    relay.shutdown(graceful=True)
+    assert mini_sentry.captured_events.get(timeout=0)["message"] == "hello, world"
+
+
+def test_forced_shutdown(mini_sentry, relay):
+    from time import sleep
+
+    get_project_config_original = mini_sentry.app.view_functions["get_project_config"]
+    @mini_sentry.app.endpoint("get_project_config")
+    def get_project_config():
+        sleep(1) # Causes the process to wait for one second before shutting down
+        return get_project_config_original()
+
+    relay = relay(mini_sentry)
+    relay.wait_relay_healthcheck()
+
+    mini_sentry.project_configs[42] = relay.basic_project_config()
+    relay.send_event(42, {"message": "hello, world"}).raise_for_status()
+
+    relay.shutdown(graceful=False)
     pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
 
 


### PR DESCRIPTION
Please bear with me while this hopeless case of over-engineering comes to an end. **TL;DR:** Futures don't work as I thought when implementing the first version of `Future::sync(&SyncHandle, _)`.

### Actix

First off, there was a tiny bug in actix that would cause the system to shut down immediately. It's fixed now and we're waiting for an actix release.

### Synchronization

Next some terminology to explain the following:
- `SyncHandle`: A thing that knows whether the system is shutting down. It can be triggered with a timeout.
 - `SyncedFuture`: A future that blocks shutdown of the handle. It will be cancelled if it is still running after the timeout.
- _Handle future_: A future returned from `SyncHandle::timeout` or `SyncHandle::now` that will resolve when the above has finished (either due to timeout or because all synced futures have completed).

Next, the old implementation of `SyncHandle` / `SyncFuture` would never wake up suspended threads. It now uses bidirectional oneshot channels to do exactly that:

1. `timeout_tx` / `timeout_rx` signals all `SyncedFutures` that they should error now. The _rx_ is shared and can be cloned for every future. When a future completes, it drops its clone of the rx. 
2. `sync_tx` / `sync_rx` signals the handle future that it is done. 

**Note** that the entire handle future is shared and cloneable, so that if multiple signals are emitted they will all resolve to the same future. For "performance" reasons, the internal refcount is modified with `Order::Relaxed`, but read with `Order::Acquire` to make sure that all prior modifications can be read. 

### Caches

Finally, there was a bug in both caches: They did already sync upstream queries, but they did not sync the batch timeout. Consequently, the shutdown would finish **before** a batch query could even be sent. Now, we manually spawn a delayed future that can be synchronized. 

Ideally, we could use `actix::utils::TimerFunc` directly, which is used by `AsyncContext::run_later` internally. However, that type is private for now, so I've introduced a helper `utils::run_later` that accomplishes the same.