### PR TITLE
feat: Log internal errors with causes

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -18,7 +18,7 @@ use actors::project::{
 };
 use actors::upstream::{SendRequest, UpstreamRelay, UpstreamRequestError};
 use extractors::EventMeta;
-use utils::{SyncActorFuture, SyncHandle};
+use utils::{LogError, SyncActorFuture, SyncHandle};
 
 macro_rules! clone {
     (@param _) => ( _ );
@@ -351,7 +351,7 @@ impl Handler<HandleEvent> for EventManager {
             .sync(&self.shutdown, ProcessingError::Shutdown)
             .map(|_, _, _| metric!(counter("event.accepted") += 1))
             .map_err(move |error, _, _| {
-                warn!("error processing event {}: {}", event_id, error);
+                warn!("error processing event {}: {}", event_id, LogError(&error));
                 metric!(counter("event.rejected") += 1);
             });
 

--- a/server/src/actors/keys.rs
+++ b/server/src/actors/keys.rs
@@ -14,7 +14,7 @@ use semaphore_common::{Config, PublicKey, RelayId, RetryBackoff};
 
 use actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
 use actors::upstream::{SendQuery, UpstreamQuery, UpstreamRelay};
-use utils::{self, ApiErrorResponse, Response, SyncActorFuture, SyncHandle};
+use utils::{self, ApiErrorResponse, LogError, Response, SyncActorFuture, SyncHandle};
 
 #[derive(Fail, Debug)]
 #[fail(display = "failed to fetch keys")]
@@ -162,7 +162,7 @@ impl KeyCache {
                         }
                     }
                     Err(error) => {
-                        error!("error fetching public keys: {}", error);
+                        error!("error fetching public keys: {}", LogError(&error));
 
                         if !slf.shutdown.requested() {
                             // Put the channels back into the queue, in addition to channels that have

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -17,7 +17,7 @@ use semaphore_common::{processor::PiiConfig, Config, ProjectId, PublicKey, Retry
 use actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
 use actors::upstream::{SendQuery, UpstreamQuery, UpstreamRelay};
 use extractors::EventMeta;
-use utils::{self, One, Response, SyncActorFuture, SyncHandle};
+use utils::{self, LogError, One, Response, SyncActorFuture, SyncHandle};
 
 #[derive(Fail, Debug)]
 pub enum ProjectError {
@@ -449,7 +449,7 @@ impl ProjectCache {
                         }
                     }
                     Err(error) => {
-                        error!("error fetching project states: {}", error);
+                        error!("error fetching project states: {}", LogError(&error));
 
                         if !slf.shutdown.requested() {
                             // Put the channels back into the queue, in addition to channels that have

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -26,10 +26,10 @@ pub enum UpstreamRequestError {
     #[fail(display = "attempted to send upstream request without credentials configured")]
     NoCredentials,
 
-    #[fail(display = "could not parse json payload returned by upstream: {}", _0)]
+    #[fail(display = "could not parse json payload returned by upstream")]
     InvalidJson(#[cause] JsonPayloadError),
 
-    #[fail(display = "could not send request to upstream: {}", _0)]
+    #[fail(display = "could not send request to upstream")]
     SendFailed(#[cause] SendRequestError),
 
     #[fail(display = "failed to create upstream request: {}", _0)]
@@ -169,7 +169,7 @@ impl Handler<Authenticate> for UpstreamRelay {
         let credentials = match self.config.credentials() {
             Some(x) => x,
             None => {
-                warn!("no credentials configured, not authenticating.");
+                warn!("no credentials configured, not authenticating");
                 return Box::new(fut::err(()));
             }
         };

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -16,6 +16,8 @@ use semaphore_common::{
     Config, RegisterChallenge, RegisterRequest, RegisterResponse, Registration, RetryBackoff,
 };
 
+use utils::LogError;
+
 #[derive(Fail, Debug)]
 pub enum UpstreamRequestError {
     #[fail(display = "attempted to send request while not yet authenticated")]
@@ -196,7 +198,7 @@ impl Handler<Authenticate> for UpstreamRelay {
                 slf.auth_state = AuthState::Registered;
             })
             .map_err(|err, slf, ctx| {
-                error!("authentication encountered error: {}", err);
+                error!("authentication encountered error: {}", LogError(&err));
 
                 let interval = slf.backoff.next_backoff();
                 debug!(

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -40,7 +40,7 @@ pub enum ServerErrorKind {
     TlsInitFailed,
 
     /// TLS support was not compiled in
-    #[fail(display = "compile with the `with_ssl` feature to enable SSL support.")]
+    #[fail(display = "compile with the `with_ssl` feature to enable SSL support")]
     TlsNotSupported,
 }
 

--- a/server/src/utils/log.rs
+++ b/server/src/utils/log.rs
@@ -1,0 +1,23 @@
+use std::fmt;
+
+use failure::Fail;
+use log;
+
+pub struct LogError<'a, E: Fail>(pub &'a E);
+
+impl<'a, E: Fail> fmt::Display for LogError<'a, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)?;
+        for cause in (self.0 as &Fail).iter_causes() {
+            write!(f, "\n  caused by: {}", cause)?;
+        }
+
+        if log_enabled!(log::Level::Debug) {
+            if let Some(backtrace) = self.0.backtrace() {
+                write!(f, "\n\n{:?}", backtrace)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -1,9 +1,11 @@
 mod actix;
 mod api;
+mod log;
 mod sync;
 mod timer;
 
 pub use self::actix::*;
 pub use self::api::*;
+pub use self::log::*;
 pub use self::sync::*;
 pub use self::timer::*;

--- a/server/src/utils/sync.rs
+++ b/server/src/utils/sync.rs
@@ -130,7 +130,10 @@ impl<F, E> SyncedFuture<F, E> {
             Err(e) => Err(e),
             Ok(Async::Ready(v)) => Ok(Async::Ready(v)),
             Ok(Async::NotReady) => match timeout.poll() {
-                Err(_) => Err(self.error.take().unwrap()),
+                Err(_) => {
+                    error!("synced future spawned after timeout expired");
+                    Err(self.error.take().unwrap())
+                }
                 Ok(Async::Ready(_)) => Err(self.error.take().unwrap()),
                 Ok(Async::NotReady) => {
                     self.inner = Some((future, timeout));


### PR DESCRIPTION
Adds a wrapper that logs failures with their full chain:

```
 DEBUG semaphore_server::actors::upstream   > scheduling authentication retry in 0 seconds
 INFO  semaphore_server::actors::upstream   > registering with upstream (http://localhost:8000/)
 ERROR semaphore_server::actors::upstream   > authentication encountered error: could not send request to upstream
  caused by: Failed to connect to host: Connection refused (os error 61)
  caused by: Connection refused (os error 61)
  caused by: Connection refused (os error 61)
```