### PR TITLE
feat: Handle rate limits and report them to clients

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -67,7 +67,7 @@ enum ProcessingError {
     #[fail(display = "could not send event to upstream")]
     SendFailed(#[cause] UpstreamRequestError),
 
-    #[fail(display = "sending failed due to rate limit for {}s", _0)]
+    #[fail(display = "sending failed due to rate limit ({}s)", _0)]
     RateLimited(u64),
 
     #[fail(display = "event exceeded its configured lifetime")]

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -306,6 +306,7 @@ impl Handler<HandleEvent> for EventManager {
                     .and_then(|action| match action.map_err(ProcessingError::NoAction)? {
                         EventAction::Accept => Ok(()),
                         EventAction::Discard => Err(ProcessingError::EventRejected),
+                        EventAction::RateLimit(_) => Err(ProcessingError::EventRejected),
                     })
                     .and_then(clone!(project, |_| project
                         .send(GetProjectState)

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -315,8 +315,8 @@ impl Handler<HandleEvent> for EventManager {
                     .map_err(ProcessingError::ScheduleFailed)
                     .and_then(|action| match action.map_err(ProcessingError::NoAction)? {
                         EventAction::Accept => Ok(()),
+                        EventAction::RetryAfter(s) => Err(ProcessingError::RateLimited(s)),
                         EventAction::Discard => Err(ProcessingError::EventRejected),
-                        EventAction::RateLimit(s) => Err(ProcessingError::RateLimited(s)),
                     })
                     .and_then(clone!(project, |_| project
                         .send(GetProjectState)

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::path::Path;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use actix::fut;
 use actix::prelude::*;
@@ -341,6 +341,8 @@ impl GetEventAction {
 pub enum EventAction {
     /// The event should be discarded.
     Discard,
+    /// The event should be discarded and the client should back off for some time.
+    RateLimit(u64),
     /// The event should be processed and sent to upstream.
     Accept,
 }

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -362,7 +362,9 @@ impl Handler<GetEventAction> for Project {
         // backoff duration must yield a positive number or it would otherwise panic.
         let now = Instant::now();
         if now < self.retry_after {
-            return Response::ok(EventAction::RetryAfter((now - self.retry_after).as_secs()));
+            // Compensate for the missing subsec part by adding 1s
+            let secs = (self.retry_after - now).as_secs() + 1;
+            return Response::ok(EventAction::RetryAfter(secs));
         }
 
         if message.fetch {

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -345,7 +345,7 @@ pub enum EventAction {
     /// The event should be discarded.
     Discard,
     /// The event should be discarded and the client should back off for some time.
-    RateLimit(u64),
+    RetryAfter(u64),
     /// The event should be processed and sent to upstream.
     Accept,
 }
@@ -362,7 +362,7 @@ impl Handler<GetEventAction> for Project {
         // backoff duration must yield a positive number or it would otherwise panic.
         let now = Instant::now();
         if now < self.retry_after {
-            return Response::ok(EventAction::RateLimit((now - self.retry_after).as_secs()));
+            return Response::ok(EventAction::RetryAfter((now - self.retry_after).as_secs()));
         }
 
         if message.fetch {

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -118,7 +118,8 @@ impl UpstreamRelay {
                         .unwrap_or(0f64)
                         .max(0f64);
 
-                    Err(UpstreamRequestError::RateLimited(retry_after as u64))
+                    // Compensate for the missing subsec part by adding 1s
+                    Err(UpstreamRequestError::RateLimited(retry_after as u64 + 1))
                 }
                 code if !code.is_success() => Err(UpstreamRequestError::ResponseError(code)),
                 _ => Ok(response),

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -116,10 +116,10 @@ impl UpstreamRelay {
                         .and_then(|v| v.to_str().ok())
                         .and_then(|s| s.parse::<f64>().ok())
                         .unwrap_or(0f64)
-                        .max(0f64);
+                        .max(0f64)
+                        .ceil();
 
-                    // Compensate for the missing subsec part by adding 1s
-                    Err(UpstreamRequestError::RateLimited(retry_after as u64 + 1))
+                    Err(UpstreamRequestError::RateLimited(retry_after as u64))
                 }
                 code if !code.is_success() => Err(UpstreamRequestError::ResponseError(code)),
                 _ => Ok(response),

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -127,7 +127,7 @@ fn store_event(
                 .and_then(
                     |action| match action.map_err(BadStoreRequest::ProjectFailed)? {
                         EventAction::Accept => Ok(()),
-                        EventAction::RateLimit(secs) => Err(BadStoreRequest::RateLimited(secs)),
+                        EventAction::RetryAfter(secs) => Err(BadStoreRequest::RateLimited(secs)),
                         EventAction::Discard => Err(BadStoreRequest::EventRejected),
                     },
                 ).and_then(move |_| {

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -40,7 +40,7 @@ enum BadStoreRequest {
     #[fail(display = "failed to read request body")]
     PayloadError(#[cause] StorePayloadError),
 
-    #[fail(display = "event rejected due to rate limiting")]
+    #[fail(display = "event rejected due to rate limit ({}s)", _0)]
     RateLimited(u64),
 
     #[fail(display = "event submission rejected")]


### PR DESCRIPTION
This PR adds a rate limiting function to the `Project` actors. Every time the server returns status code `429`, we bump an internal `retry_after` threshold. While that instant has not elapsed, we synchronously reject all events that are submitted to store. 

Relevant changes include:

 - If a client request returns status code `429`, we return `UpstreamRequestError::RateLimited(secs)`. In case the `Retry-After` header is missing, **we will not start to rate limit**.
 - After sending store events to upstream, we check for that error and tell the `ProjectActor` to rate limit.
 - `GetEventAction` now checks for the `retry_after` and optionally returns `EventAction::RetryAfter(secs)`.
 - The store endpoint now returns proper status codes for rate limiting and service inavailability.

**Known Issue**: If the `Project` actor's queue is currently full, the request for bumping retry_after will fail silently. I guess this is fine, since all messages answer almost instantly and we do not have such high concurrency on a single project.