### PR TITLE
fix: Use correct order in X-Forwarded-For headers

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -345,6 +345,7 @@ impl Handler<HandleEvent> for EventManager {
                                 builder
                                     .header("X-Sentry-Auth", meta.auth().to_string())
                                     .header("X-Forwarded-For", meta.forwarded_for())
+                                    .header("Content-Type", "application/json")
                                     .body(processed.data)
                             });
 

--- a/server/src/extractors/forwarded_for.rs
+++ b/server/src/extractors/forwarded_for.rs
@@ -39,7 +39,7 @@ impl<'a, S> From<&'a HttpRequest<S>> for ForwardedFor {
         } else if peer_addr.is_empty() {
             forwarded.to_string()
         } else {
-            format!("{}, {}", peer_addr, forwarded)
+            format!("{}, {}", forwarded, peer_addr)
         })
     }
 }


### PR DESCRIPTION
The peer's address needs to be appended to the end of an existing `X-Forwarded-For` header:

> If a request goes through multiple proxies, the IP addresses of each successive proxy is listed. This means, the right-most IP address is the IP address of the most recent proxy and the left-most IP address is the IP address of the originating client.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#Syntax