### PR TITLE
feat: Allow to specify custom HTTP Host header

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -127,38 +127,15 @@ pub struct Relay {
 
 impl Default for Relay {
     fn default() -> Self {
-        let minimal = MinimalRelay::default();
         Relay {
-            upstream: minimal.upstream,
-            host: minimal.host,
-            port: minimal.port,
-            tls_port: None,
-            tls_identity_path: None,
-            tls_identity_password: None,
-        }
-    }
-}
-
-/// Relay specific configuration values.
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(default)]
-pub struct MinimalRelay {
-    /// The upstream relay or sentry instance.
-    pub upstream: UpstreamDescriptor<'static>,
-    /// The host the relay should bind to (network interface)
-    pub host: IpAddr,
-    /// The port to bind for the unencrypted relay HTTP server.
-    pub port: u16,
-}
-
-impl Default for MinimalRelay {
-    fn default() -> Self {
-        MinimalRelay {
             upstream: "https://ingest.sentry.io/"
                 .parse::<UpstreamDescriptor>()
                 .unwrap(),
             host: "127.0.0.1".parse().unwrap(),
             port: 3000,
+            tls_port: None,
+            tls_identity_path: None,
+            tls_identity_password: None,
         }
     }
 }
@@ -331,7 +308,7 @@ pub struct MinimalSentry {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct MinimalConfig {
     /// The relay part of the config.
-    pub relay: MinimalRelay,
+    pub relay: Relay,
     /// Turn on crash reporting?
     pub sentry: MinimalSentry,
 }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -127,15 +127,38 @@ pub struct Relay {
 
 impl Default for Relay {
     fn default() -> Self {
+        let minimal = MinimalRelay::default();
         Relay {
+            upstream: minimal.upstream,
+            host: minimal.host,
+            port: minimal.port,
+            tls_port: None,
+            tls_identity_path: None,
+            tls_identity_password: None,
+        }
+    }
+}
+
+/// Relay specific configuration values.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(default)]
+pub struct MinimalRelay {
+    /// The upstream relay or sentry instance.
+    pub upstream: UpstreamDescriptor<'static>,
+    /// The host the relay should bind to (network interface)
+    pub host: IpAddr,
+    /// The port to bind for the unencrypted relay HTTP server.
+    pub port: u16,
+}
+
+impl Default for MinimalRelay {
+    fn default() -> Self {
+        MinimalRelay {
             upstream: "https://ingest.sentry.io/"
                 .parse::<UpstreamDescriptor>()
                 .unwrap(),
             host: "127.0.0.1".parse().unwrap(),
             port: 3000,
-            tls_port: None,
-            tls_identity_path: None,
-            tls_identity_password: None,
         }
     }
 }
@@ -305,7 +328,7 @@ pub struct MinimalSentry {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct MinimalConfig {
     /// The relay part of the config.
-    pub relay: Relay,
+    pub relay: MinimalRelay,
     /// Turn on crash reporting?
     pub sentry: MinimalSentry,
 }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -113,15 +113,15 @@ impl ConfigObject for Credentials {
 pub struct Relay {
     /// The upstream relay or sentry instance.
     pub upstream: UpstreamDescriptor<'static>,
-    /// The host the relay should bind to (network interface)
+    /// The host the relay should bind to (network interface).
     pub host: IpAddr,
     /// The port to bind for the unencrypted relay HTTP server.
     pub port: u16,
     /// Optional port to bind for the encrypted relay HTTPS server.
     pub tls_port: Option<u16>,
-    /// The path to the identity (DER-encoded PKCS12) to use for TLS
+    /// The path to the identity (DER-encoded PKCS12) to use for TLS.
     pub tls_identity_path: Option<PathBuf>,
-    /// Password for the PKCS12 archive
+    /// Password for the PKCS12 archive.
     pub tls_identity_password: Option<String>,
 }
 
@@ -255,6 +255,8 @@ struct Http {
     timeout: u32,
     /// Maximum interval between failed request retries in seconds.
     max_retry_interval: u32,
+    /// The custom HTTP Host header to send to the upstream.
+    host_header: Option<String>,
 }
 
 impl Default for Http {
@@ -262,6 +264,7 @@ impl Default for Http {
         Http {
             timeout: 5,
             max_retry_interval: 60,
+            host_header: None,
         }
     }
 }
@@ -509,6 +512,11 @@ impl Config {
         &self.values.relay.upstream
     }
 
+    /// Returns the custom HTTP "Host" header.
+    pub fn http_host_header(&self) -> Option<&str> {
+        self.values.http.host_header.as_ref().map(|x| x.as_str())
+    }
+
     /// Returns the listen address.
     pub fn listen_addr(&self) -> SocketAddr {
         (self.values.relay.host, self.values.relay.port).into()
@@ -539,7 +547,7 @@ impl Config {
             .relay
             .tls_identity_password
             .as_ref()
-            .map(|x| &**x)
+            .map(|x| x.as_str())
     }
 
     /// Returns the log level.

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -95,10 +95,16 @@ impl UpstreamRelay {
         F: FnOnce(&mut ClientRequestBuilder) -> Result<ClientRequest, ActixError>,
         P: AsRef<str>,
     {
+        let host_header = self
+            .config
+            .http_host_header()
+            .unwrap_or_else(|| self.config.upstream_descriptor().host());
+
         let mut builder = ClientRequest::build();
         builder
             .method(method)
-            .uri(self.config.upstream_descriptor().get_url(path.as_ref()));
+            .uri(self.config.upstream_descriptor().get_url(path.as_ref()))
+            .set_header("Host", host_header);
 
         if let Some(ref credentials) = self.config.credentials() {
             builder.header("X-Sentry-Relay-Id", credentials.id.to_string());

--- a/server/src/endpoints/forward.rs
+++ b/server/src/endpoints/forward.rs
@@ -69,12 +69,13 @@ fn forward_upstream(request: &HttpRequest<ServiceState>) -> ResponseFuture<HttpR
         forwarded_request_builder.header(key.clone(), value.clone());
     }
 
+    let host_header = config.http_host_header().unwrap_or_else(|| upstream.host());
     forwarded_request_builder
         .no_default_headers()
         .disable_decompress()
         .method(request.method().clone())
         .uri(upstream.get_url(path_and_query))
-        .set_header("Host", upstream.host())
+        .set_header("Host", host_header)
         .set_header("X-Forwarded-For", ForwardedFor::from(request))
         .set_header("Connection", "close")
         .timeout(config.http_timeout());


### PR DESCRIPTION
@jan-auer I reverted our `MinimalRelay` changes for now, because we actually prompt users for those TLS settings (when they want): https://github.com/getsentry/semaphore/blob/master/src/cli.rs#L194-L210
