### PR TITLE
ref(general): Use an enum of defined errors

### DIFF
--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -660,7 +660,8 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                             #valid_match_arm
                             crate::types::Annotated(None, __meta) => crate::types::Annotated(None, __meta),
                             crate::types::Annotated(Some(__value), mut __meta) => {
-                                __meta.add_unexpected_value_error(#expectation, __value);
+                                __meta.add_error(crate::types::Error::expected(#expectation));
+                                __meta.set_original_value(Some(__value));
                                 crate::types::Annotated(None, __meta)
                             }
                         }

--- a/general/src/macros.rs
+++ b/general/src/macros.rs
@@ -32,7 +32,8 @@ macro_rules! numeric_meta_structure {
                         Some(x) => Annotated::new(x),
                         None => {
                             let mut meta = crate::types::Meta::default();
-                            meta.add_unexpected_value_error($expectation, value);
+                            meta.add_error(crate::types::Error::expected($expectation));
+                            meta.set_original_value(Some(value));
                             Annotated(None, meta)
                         }
                     }
@@ -52,7 +53,7 @@ macro_rules! primitive_meta_structure_through_string {
                     Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                         Ok(value) => Annotated(Some(value), meta),
                         Err(err) => {
-                            meta.add_error(err.to_string());
+                            meta.add_error(crate::types::Error::invalid(err));
                             meta.set_original_value(Some(value));
                             Annotated(None, meta)
                         }
@@ -60,7 +61,8 @@ macro_rules! primitive_meta_structure_through_string {
                     Annotated(Some(Value::Null), meta) => Annotated(None, meta),
                     Annotated(None, meta) => Annotated(None, meta),
                     Annotated(Some(value), mut meta) => {
-                        meta.add_unexpected_value_error($expectation, value);
+                        meta.add_error(crate::types::Error::expected($expectation));
+                        meta.set_original_value(Some(value));
                         Annotated(None, meta)
                     }
                 }
@@ -91,7 +93,8 @@ macro_rules! primitive_meta_structure {
                     Annotated(Some(Value::Null), meta) => Annotated(None, meta),
                     Annotated(None, meta) => Annotated(None, meta),
                     Annotated(Some(value), mut meta) => {
-                        meta.add_unexpected_value_error($expectation, value);
+                        meta.add_error(crate::types::Error::expected($expectation));
+                        meta.set_original_value(Some(value));
                         Annotated(None, meta)
                     }
                 }

--- a/general/src/processor/funcs.rs
+++ b/general/src/processor/funcs.rs
@@ -1,5 +1,5 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::types::Annotated;
+use crate::types::{Annotated, ErrorKind};
 
 /// Processes the value using the given processor.
 #[inline]
@@ -14,6 +14,6 @@ where
 /// Attaches a value required error if the value is missing.
 pub fn require_value<T>(annotated: &mut Annotated<T>) {
     if annotated.value().is_none() && !annotated.meta().has_errors() {
-        annotated.meta_mut().add_error("value required");
+        annotated.meta_mut().add_error(ErrorKind::MissingAttribute);
     }
 }

--- a/general/src/protocol/breadcrumb.rs
+++ b/general/src/protocol/breadcrumb.rs
@@ -115,9 +115,12 @@ fn test_breadcrumb_default_values() {
 
 #[test]
 fn test_breadcrumb_invalid() {
+    use crate::types::ErrorKind;
+
     let breadcrumb = Annotated::new(Breadcrumb {
-        timestamp: Annotated::from_error("value required", None),
+        timestamp: Annotated::from_error(ErrorKind::MissingAttribute, None),
         ..Default::default()
     });
+
     assert_eq_dbg!(breadcrumb, Annotated::from_json("{}").unwrap());
 }

--- a/general/src/protocol/clientsdk.rs
+++ b/general/src/protocol/clientsdk.rs
@@ -102,13 +102,16 @@ fn test_client_sdk_default_values() {
 
 #[test]
 fn test_client_sdk_invalid() {
+    use crate::types::ErrorKind;
+
     let json = r#"{"name":"sentry.rust"}"#;
     let entry = Annotated::new(ClientSdkInfo {
         name: Annotated::new("sentry.rust".to_string()),
-        version: Annotated::from_error("value required", None),
+        version: Annotated::from_error(ErrorKind::MissingAttribute, None),
         integrations: Annotated::empty(),
         packages: Annotated::empty(),
         other: Default::default(),
     });
+
     assert_eq_dbg!(entry, Annotated::from_json(json).unwrap());
 }

--- a/general/src/protocol/debugmeta.rs
+++ b/general/src/protocol/debugmeta.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::processor::ProcessValue;
 use crate::protocol::Addr;
-use crate::types::{Annotated, Array, FromValue, Object, ToValue, Value};
+use crate::types::{Annotated, Array, Error, FromValue, Object, ToValue, Value};
 
 /// Holds information about the system SDK.
 ///
@@ -70,14 +70,15 @@ impl FromValue for DebugId {
             Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                 Ok(value) => Annotated(Some(value), meta),
                 Err(err) => {
-                    meta.add_error(err.to_string());
+                    meta.add_error(Error::invalid(err));
                     meta.set_original_value(Some(value));
                     Annotated(None, meta)
                 }
             },
             Annotated(Some(Value::Null), meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_unexpected_value_error("debug id", value);
+                meta.add_error(Error::expected("debug id"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
             Annotated(None, meta) => Annotated(None, meta),

--- a/general/src/protocol/stacktrace.rs
+++ b/general/src/protocol/stacktrace.rs
@@ -224,6 +224,8 @@ fn test_stacktrace_roundtrip() {
 
 #[test]
 fn test_stacktrace_default_values() {
+    use crate::types::ErrorKind;
+
     let json = "{}";
     let input = Annotated::new(Stacktrace {
         frames: Annotated::new(vec![Annotated::new(Default::default())]),
@@ -231,7 +233,7 @@ fn test_stacktrace_default_values() {
     });
 
     let output = Annotated::new(Stacktrace {
-        frames: Annotated::from_error("value required", None),
+        frames: Annotated::from_error(ErrorKind::MissingAttribute, None),
         ..Default::default()
     });
 
@@ -241,8 +243,10 @@ fn test_stacktrace_default_values() {
 
 #[test]
 fn test_stacktrace_invalid() {
+    use crate::types::ErrorKind;
+
     let stack = Annotated::new(Stacktrace {
-        frames: Annotated::from_error("value required", None),
+        frames: Annotated::from_error(ErrorKind::MissingAttribute, None),
         registers: Annotated::empty(),
         other: Default::default(),
     });

--- a/general/src/protocol/types.rs
+++ b/general/src/protocol/types.rs
@@ -8,7 +8,7 @@ use serde::ser::{Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::processor::ProcessValue;
-use crate::types::{Annotated, Array, FromValue, Meta, Object, ToValue, Value};
+use crate::types::{Annotated, Array, Error, ErrorKind, FromValue, Meta, Object, ToValue, Value};
 
 /// A array like wrapper used in various places.
 #[derive(Clone, Debug, PartialEq, ToValue, ProcessValue)]
@@ -81,7 +81,8 @@ impl<T: FromValue> FromValue for Values<T> {
             }
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_unexpected_value_error("array or values", value);
+                meta.add_error(Error::expected("array or values"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
         }
@@ -114,7 +115,7 @@ macro_rules! hex_metrastructure {
                     Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                         Ok(value) => Annotated(Some(value), meta),
                         Err(err) => {
-                            meta.add_error(err.to_string());
+                            meta.add_error(Error::invalid(err));
                             meta.set_original_value(Some(value));
                             Annotated(None, meta)
                         }
@@ -126,7 +127,8 @@ macro_rules! hex_metrastructure {
                     }
                     Annotated(None, meta) => Annotated(None, meta),
                     Annotated(Some(value), mut meta) => {
-                        meta.add_unexpected_value_error($expectation, value);
+                        meta.add_error(Error::expected($expectation));
+                        meta.set_original_value(Some(value));
                         Annotated(None, meta)
                     }
                 }
@@ -201,13 +203,15 @@ impl FromValue for IpAddr {
                 if value == "{{auto}}" || net::IpAddr::from_str(&value).is_ok() {
                     return Annotated(Some(IpAddr(value)), meta);
                 }
-                meta.add_unexpected_value_error("an ip address", Value::String(value));
+                meta.add_error(Error::expected("an ip address"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
             Annotated(Some(Value::Null), meta) => Annotated(None, meta),
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_unexpected_value_error("an ip address", value);
+                meta.add_error(Error::expected("an ip address"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
         }
@@ -286,7 +290,7 @@ impl FromValue for Level {
             Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                 Ok(value) => Annotated(Some(value), meta),
                 Err(err) => {
-                    meta.add_error(err.to_string());
+                    meta.add_error(Error::invalid(err));
                     meta.set_original_value(Some(value));
                     Annotated(None, meta)
                 }
@@ -294,7 +298,7 @@ impl FromValue for Level {
             Annotated(Some(Value::U64(val)), mut meta) => match Level::from_python_level(val) {
                 Some(value) => Annotated(Some(value), meta),
                 None => {
-                    meta.add_error("unknown numeric level");
+                    meta.add_error(ErrorKind::InvalidData);
                     meta.set_original_value(Some(val));
                     Annotated(None, meta)
                 }
@@ -303,7 +307,7 @@ impl FromValue for Level {
                 match Level::from_python_level(val as u64) {
                     Some(value) => Annotated(Some(value), meta),
                     None => {
-                        meta.add_error("unknown numeric level");
+                        meta.add_error(ErrorKind::InvalidData);
                         meta.set_original_value(Some(val));
                         Annotated(None, meta)
                     }
@@ -312,7 +316,8 @@ impl FromValue for Level {
             Annotated(Some(Value::Null), meta) => Annotated(None, meta),
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_unexpected_value_error("level", value);
+                meta.add_error(Error::expected("level"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
         }
@@ -390,14 +395,15 @@ impl FromValue for LenientString {
                 if num.abs() < (1i64 << 53) as f64 {
                     Annotated(Some(num.trunc().to_string()), meta)
                 } else {
-                    meta.add_error("non integer value");
+                    meta.add_error(Error::expected("number with JSON precision"));
                     meta.set_original_value(Some(num));
                     Annotated(None, meta)
                 }
             }
             Annotated(None, meta) | Annotated(Some(Value::Null), meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_unexpected_value_error("primitive", value);
+                meta.add_error(Error::expected("primitive value"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
         }.map_value(LenientString)
@@ -479,7 +485,8 @@ impl FromValue for ThreadId {
             Annotated(Some(Value::Null), meta) => Annotated(None, meta),
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_unexpected_value_error("thread id", value);
+                meta.add_error(Error::expected("thread id"));
+                meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }
         }
@@ -652,7 +659,7 @@ fn test_ip_addr() {
     );
     assert_eq_dbg!(
         Annotated::from_error(
-            "expected an ip address",
+            Error::expected("an ip address"),
             Some(Value::String("clearly invalid value".into()))
         ),
         Annotated::<IpAddr>::from_json("\"clearly invalid value\"").unwrap()

--- a/general/src/store/remove_other.rs
+++ b/general/src/store/remove_other.rs
@@ -1,6 +1,6 @@
 use crate::processor::{ProcessingState, Processor};
 use crate::protocol::Event;
-use crate::types::{Meta, ValueAction};
+use crate::types::{ErrorKind, Meta, ValueAction};
 
 pub struct RemoveOtherProcessor;
 
@@ -8,14 +8,14 @@ impl Processor for RemoveOtherProcessor {
     fn process_event(
         &mut self,
         event: &mut Event,
-        meta: &mut Meta,
+        _meta: &mut Meta,
         _state: ProcessingState,
     ) -> ValueAction {
-        for key in event.other.keys() {
-            meta.add_error(format!("Unknown key: {}", key));
+        for value in event.other.values_mut() {
+            value.set_value(None);
+            value.meta_mut().add_error(ErrorKind::InvalidAttribute);
         }
 
-        event.other.clear();
         ValueAction::Keep
     }
 }

--- a/general/src/store/request.rs
+++ b/general/src/store/request.rs
@@ -4,7 +4,7 @@ use serde::de::IgnoredAny;
 use url::Url;
 
 use crate::protocol::{Query, Request};
-use crate::types::{Annotated, Meta, Object, Value, ValueAction};
+use crate::types::{Annotated, ErrorKind, Meta, Object, Value, ValueAction};
 
 lazy_static! {
     static ref METHOD_RE: Regex = Regex::new(r"^[A-Z\-_]{3,32}$").unwrap();
@@ -30,9 +30,9 @@ fn normalize_url(request: &mut Request) {
 
     let mut url = match url_result {
         Ok(url) => url,
-        Err(err) => {
+        Err(_) => {
             // TODO: Remove value here or not?
-            request.url.meta_mut().add_error(err.to_string());
+            request.url.meta_mut().add_error(ErrorKind::InvalidData);
             return;
         }
     };
@@ -67,7 +67,7 @@ fn normalize_method(method: &mut String, meta: &mut Meta) -> ValueAction {
     method.make_ascii_uppercase();
 
     if !meta.has_errors() && METHOD_RE.is_match(&method) {
-        meta.add_error("invalid http method");
+        meta.add_error(ErrorKind::InvalidData);
         return ValueAction::DeleteSoft;
     }
 

--- a/general/src/testutils.rs
+++ b/general/src/testutils.rs
@@ -11,6 +11,9 @@ macro_rules! assert_eq_str {
             difference::Changeset::new(&left, &right, "\n")
         )
     }};
+    ($left:expr, $right:expr) => {
+        assert_eq_str($left, $right)
+    };
 }
 
 macro_rules! assert_eq_dbg {
@@ -26,4 +29,7 @@ macro_rules! assert_eq_dbg {
             difference::Changeset::new(&format!("{:#?}", left), &format!("{:#?}", right), "\n")
         )
     }};
+    ($left:expr, $right:expr) => {
+        assert_eq_dbg($left, $right)
+    };
 }

--- a/general/src/types/meta.rs
+++ b/general/src/types/meta.rs
@@ -311,7 +311,10 @@ impl Error {
 
     /// Creates an error that describes an invalid value.
     pub fn expected(expectation: &str) -> Self {
-        Error::invalid(format!("expected {}", expectation))
+        // Does not use `Error::invalid` to avoid the string copy.
+        Error::with(ErrorKind::InvalidData, |error| {
+            error.insert("reason", format!("expected {}", expectation));
+        })
     }
 
     /// Returns the kind of this error.

--- a/general/src/types/mod.rs
+++ b/general/src/types/mod.rs
@@ -12,6 +12,6 @@ mod value;
 
 pub use self::annotated::{Annotated, MetaMap, MetaTree, ValueAction};
 pub use self::impls::SerializePayload;
-pub use self::meta::{Meta, Range, Remark, RemarkType};
+pub use self::meta::{Error, ErrorKind, Meta, Range, Remark, RemarkType};
 pub use self::traits::{FromValue, ToValue};
 pub use self::value::{Array, Map, Object, Value, ValueDescription};

--- a/general/src/types/value.rs
+++ b/general/src/types/value.rs
@@ -12,10 +12,10 @@ use crate::types::{Annotated, Meta};
 pub type Array<T> = Vec<Annotated<T>>;
 
 /// Alias for maps.
-pub type Map<K, T> = BTreeMap<K, Annotated<T>>;
+pub type Map<K, T> = BTreeMap<K, T>;
 
 /// Alias for typed objects.
-pub type Object<T> = Map<String, T>;
+pub type Object<T> = Map<String, Annotated<T>>;
 
 /// Represents a boxed value.
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
This PR prepares meta errors for the use in Sentry. There are two fundamental changes:

 - There is an enum white list for errors and their string representations (corresponding to Sentry's `EventError`). In the JSON payloads, errors are always rendered as the string. Relay will only ever generate errors from this enum. For compatibility reasons, there's an `Unknown(String)` fallback variant. 
 - Errors can carry an optional data bag (`Map<String, Value>`, not annotated). In this case they are serialized as tuple: `["error_kind", {"some": "data"}]`.

The entire code has been updated to only emit the new error kinds. There are two helpers which are used by most of the code:

 - `Error::invalid(reason)`: Creates an "invalid data" error with a reason string in is data bag. Used for parsing and most of validation.
 - `Error::expected(what)`: Creates an "invalid data" error with "expected what" as reason. Used for type mismatches in `ToValue`.

Note that this implementation now generates heaps of small data bags for the most common errors.

See https://github.com/getsentry/sentry/pull/10823