### PR TITLE
feat: Refactor skip_serialization attribute

### DIFF
--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -9,6 +9,8 @@ extern crate synstructure;
 extern crate quote;
 extern crate proc_macro2;
 
+use std::str::FromStr;
+
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{Data, Ident, Lit, LitBool, LitStr, Meta, MetaNameValue, NestedMeta};
@@ -61,18 +63,13 @@ fn process_wrapper_struct_derive(
         return Err(s);
     }
 
-    let mut skip_serialization_body = TokenStream::new();
-
     let type_attrs = parse_type_attributes(&s.ast().attrs);
     if type_attrs.tag_key.is_some() {
         panic!("tag_key not supported on structs");
     }
 
-    if type_attrs.never_skip_serialization {
-        quote!(false)
-    } else {
-        quote!(crate::types::ToValue::skip_serialization(&self.0))
-    }.to_tokens(&mut skip_serialization_body);
+    let field_attrs = parse_field_attributes(&s.variants()[0].bindings()[0].ast().attrs);
+    let skip_serialization_attr = field_attrs.skip_serialization.as_tokens();
 
     let name = &s.ast().ident;
 
@@ -99,12 +96,12 @@ fn process_wrapper_struct_derive(
                     crate::types::ToValue::to_value(self.0)
                 }
 
-                fn serialize_payload<S>(&self, __serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize_payload<S>(&self, __serializer: S, __behavior: crate::types::SkipSerialization) -> Result<S::Ok, S::Error>
                 where
                     Self: Sized,
                     S: __serde::ser::Serializer
                 {
-                    crate::types::ToValue::serialize_payload(&self.0, __serializer)
+                    crate::types::ToValue::serialize_payload(&self.0, __serializer, #skip_serialization_attr)
                 }
 
                 fn extract_child_meta(&self) -> crate::types::MetaMap
@@ -114,11 +111,11 @@ fn process_wrapper_struct_derive(
                     crate::types::ToValue::extract_child_meta(&self.0)
                 }
 
-                fn skip_serialization(&self) -> bool
+                fn skip_serialization(&self, __behavior: crate::types::SkipSerialization) -> bool
                 where
                     Self: Sized,
                 {
-                    #skip_serialization_body
+                    crate::types::ToValue::skip_serialization(&self.0, #skip_serialization_attr)
                 }
             }
         }),
@@ -213,7 +210,7 @@ fn process_enum_struct_derive(
             (quote! {
                 #type_name::#variant_name(ref __value) => {
                     let mut __map_ser = __serde::Serializer::serialize_map(__serializer, None)?;
-                    crate::types::ToValue::serialize_payload(__value, __serde::private::ser::FlatMapSerializer(&mut __map_ser))?;
+                    crate::types::ToValue::serialize_payload(__value, __serde::private::ser::FlatMapSerializer(&mut __map_ser), __behavior)?;
                     __serde::ser::SerializeMap::serialize_key(&mut __map_ser, #tag_key_str)?;
                     __serde::ser::SerializeMap::serialize_value(&mut __map_ser, #tag)?;
                     __serde::ser::SerializeMap::end(__map_ser)
@@ -235,7 +232,7 @@ fn process_enum_struct_derive(
             }).to_tokens(&mut to_value_body);
             (quote! {
                 #type_name::#variant_name(ref __value) => {
-                    crate::types::ToValue::serialize_payload(__value, __serializer)
+                    crate::types::ToValue::serialize_payload(__value, __serializer, __behavior)
                 }
             }).to_tokens(&mut serialize_body);
         }
@@ -301,7 +298,7 @@ fn process_enum_struct_derive(
                         }
                     }
 
-                    fn serialize_payload<S>(&self, __serializer: S) -> Result<S::Ok, S::Error>
+                    fn serialize_payload<S>(&self, __serializer: S, __behavior: crate::types::SkipSerialization) -> Result<S::Ok, S::Error>
                     where
                         S: __serde::ser::Serializer
                     {
@@ -420,11 +417,6 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
     if type_attrs.tag_key.is_some() {
         panic!("tag_key not supported on structs");
     }
-    if type_attrs.never_skip_serialization {
-        (quote! {
-            return false;
-        }).to_tokens(&mut skip_serialization_body);
-    }
 
     let mut is_tuple_struct = false;
     for (index, bi) in variant.bindings().iter().enumerate() {
@@ -443,6 +435,8 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                 .unwrap_or_else(|| index.to_string())
         });
         let field_name = LitStr::new(&field_name, Span::call_site());
+
+        let skip_serialization_attr = field_attrs.skip_serialization.as_tokens();
 
         if field_attrs.additional_properties {
             if is_tuple_struct {
@@ -469,9 +463,9 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
             }).to_tokens(&mut process_child_values_body);
             (quote! {
                 for (__key, __value) in #bi.iter() {
-                    if !__value.skip_serialization() {
+                    if !__value.skip_serialization(#skip_serialization_attr) {
                         __serde::ser::SerializeMap::serialize_key(&mut __map_serializer, __key)?;
-                        __serde::ser::SerializeMap::serialize_value(&mut __map_serializer, &crate::types::SerializePayload(__value))?;
+                        __serde::ser::SerializeMap::serialize_value(&mut __map_serializer, &crate::types::SerializePayload(__value, __behavior))?;
                     }
                 }
             }).to_tokens(&mut serialize_body);
@@ -483,6 +477,13 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                     }
                 }
             }).to_tokens(&mut extract_child_meta_body);
+            (quote! {
+                for (__key, __value) in #bi.iter() {
+                    if !__value.skip_serialization(#skip_serialization_attr) {
+                        return false;
+                    }
+                }
+            }).to_tokens(&mut skip_serialization_body);
         } else {
             let field_attrs_name = Ident::new(
                 &format!("__field_attrs_{}", {
@@ -544,8 +545,8 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                     __arr.push(Annotated::map_value(#bi, crate::types::ToValue::to_value));
                 }).to_tokens(&mut to_value_body);
                 (quote! {
-                    if !#bi.skip_serialization() {
-                        __serde::ser::SerializeSeq::serialize_element(&mut __seq_serializer, &crate::types::SerializePayload(#bi))?;
+                    if !#bi.skip_serialization(#skip_serialization_attr) {
+                        __serde::ser::SerializeSeq::serialize_element(&mut __seq_serializer, &crate::types::SerializePayload(#bi, __behavior))?;
                     }
                 }).to_tokens(&mut serialize_body);
             } else {
@@ -553,9 +554,9 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                     __map.insert(#field_name.to_string(), Annotated::map_value(#bi, crate::types::ToValue::to_value));
                 }).to_tokens(&mut to_value_body);
                 (quote! {
-                    if !#bi.skip_serialization() {
+                    if !#bi.skip_serialization(#skip_serialization_attr) {
                         __serde::ser::SerializeMap::serialize_key(&mut __map_serializer, #field_name)?;
-                        __serde::ser::SerializeMap::serialize_value(&mut __map_serializer, &crate::types::SerializePayload(#bi))?;
+                        __serde::ser::SerializeMap::serialize_value(&mut __map_serializer, &crate::types::SerializePayload(#bi, __behavior))?;
                     }
                 }).to_tokens(&mut serialize_body);
             }
@@ -602,13 +603,13 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                     #enter_state,
                 );
             }).to_tokens(&mut process_child_values_body);
-        }
 
-        (quote! {
-            if !#bi.skip_serialization() {
-                return false;
-            }
-        }).to_tokens(&mut skip_serialization_body);
+            (quote! {
+                if !#bi.skip_serialization(#skip_serialization_attr) {
+                    return false;
+                }
+            }).to_tokens(&mut skip_serialization_body);
+        }
     }
 
     let ast = s.ast();
@@ -709,7 +710,7 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                         #to_value
                     }
 
-                    fn serialize_payload<S>(&self, __serializer: S) -> Result<S::Ok, S::Error>
+                    fn serialize_payload<S>(&self, __serializer: S, __behavior: crate::types::SkipSerialization) -> Result<S::Ok, S::Error>
                     where
                         Self: Sized,
                         S: __serde::ser::Serializer
@@ -729,7 +730,7 @@ fn process_metastructure_impl(s: synstructure::Structure, t: Trait) -> TokenStre
                     }
 
                     #[allow(unreachable_code)]
-                    fn skip_serialization(&self) -> bool {
+                    fn skip_serialization(&self, __behavior: crate::types::SkipSerialization) -> bool {
                         let #serialize_pat = self;
                         #skip_serialization_body;
                         true
@@ -823,7 +824,6 @@ fn parse_pii_kind(kind: &str) -> TokenStream {
 struct TypeAttrs {
     process_func: Option<String>,
     tag_key: Option<String>,
-    never_skip_serialization: bool,
 }
 
 fn parse_type_attributes(attrs: &[syn::Attribute]) -> TypeAttrs {
@@ -862,16 +862,6 @@ fn parse_type_attributes(attrs: &[syn::Attribute]) -> TypeAttrs {
                                         panic!("Got non string literal for tag_key");
                                     }
                                 }
-                            } else if ident == "skip_serialization" {
-                                match lit {
-                                    Lit::Str(litstr) => match litstr.value().as_ref() {
-                                        "never" => rv.never_skip_serialization = true,
-                                        _ => panic!("Unknown value for skip_serialization"),
-                                    },
-                                    _ => {
-                                        panic!("Got non string literal for skip_serialization");
-                                    }
-                                }
                             } else {
                                 panic!("Unknown attribute")
                             }
@@ -897,6 +887,46 @@ struct FieldAttrs {
     bag_size: TokenStream,
     pii_kind: TokenStream,
     legacy_aliases: Vec<String>,
+    skip_serialization: SkipSerialization,
+}
+
+#[derive(Copy, Clone)]
+enum SkipSerialization {
+    Null,
+    Empty,
+    Never,
+    Inherit,
+}
+
+impl SkipSerialization {
+    fn as_tokens(&self) -> TokenStream {
+        match *self {
+            SkipSerialization::Never => quote!(crate::types::SkipSerialization::Never),
+            SkipSerialization::Null => quote!(crate::types::SkipSerialization::Null),
+            SkipSerialization::Empty => quote!(crate::types::SkipSerialization::Empty),
+            SkipSerialization::Inherit => quote!(__behavior),
+        }
+    }
+}
+
+impl Default for SkipSerialization {
+    fn default() -> SkipSerialization {
+        SkipSerialization::Inherit
+    }
+}
+
+impl FromStr for SkipSerialization {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, ()> {
+        Ok(match s {
+            "null" => SkipSerialization::Null,
+            "empty" => SkipSerialization::Empty,
+            "never" => SkipSerialization::Never,
+            "inherit" => SkipSerialization::Inherit,
+            _ => Err(())?,
+        })
+    }
 }
 
 fn parse_field_attributes(attrs: &[syn::Attribute]) -> FieldAttrs {
@@ -1001,6 +1031,16 @@ fn parse_field_attributes(attrs: &[syn::Attribute]) -> FieldAttrs {
                                 match lit {
                                     Lit::Str(litstr) => {
                                         rv.legacy_aliases.push(litstr.value());
+                                    }
+                                    _ => {
+                                        panic!("Got non string literal for legacy_alias");
+                                    }
+                                }
+                            } else if ident == "skip_serialization" {
+                                match lit {
+                                    Lit::Str(litstr) => {
+                                        rv.skip_serialization = FromStr::from_str(&litstr.value())
+                                            .expect("Unknown value for skip_serialization");
                                     }
                                     _ => {
                                         panic!("Got non string literal for legacy_alias");

--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -911,7 +911,7 @@ impl SkipSerialization {
 
 impl Default for SkipSerialization {
     fn default() -> SkipSerialization {
-        SkipSerialization::Inherit
+        SkipSerialization::Null
     }
 }
 

--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -899,8 +899,8 @@ enum SkipSerialization {
 }
 
 impl SkipSerialization {
-    fn as_tokens(&self) -> TokenStream {
-        match *self {
+    fn as_tokens(self) -> TokenStream {
+        match self {
             SkipSerialization::Never => quote!(crate::types::SkipSerialization::Never),
             SkipSerialization::Null => quote!(crate::types::SkipSerialization::Null),
             SkipSerialization::Empty => quote!(crate::types::SkipSerialization::Empty),

--- a/general/src/macros.rs
+++ b/general/src/macros.rs
@@ -5,7 +5,11 @@ macro_rules! primitive_to_value {
                 Value::$meta_type(self)
             }
 
-            fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+            fn serialize_payload<S>(
+                &self,
+                s: S,
+                _behavior: crate::types::SkipSerialization,
+            ) -> Result<S::Ok, S::Error>
             where
                 Self: Sized,
                 S: serde::Serializer,
@@ -73,7 +77,11 @@ macro_rules! primitive_meta_structure_through_string {
             fn to_value(self) -> Value {
                 Value::String(self.to_string())
             }
-            fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+            fn serialize_payload<S>(
+                &self,
+                s: S,
+                _behavior: crate::types::SkipSerialization,
+            ) -> Result<S::Ok, S::Error>
             where
                 Self: Sized,
                 S: serde::ser::Serializer,

--- a/general/src/processor/size.rs
+++ b/general/src/processor/size.rs
@@ -2,13 +2,13 @@ use serde::de::value::Error;
 use serde::ser::{self, Serialize};
 use smallvec::SmallVec;
 
-use crate::types::{Annotated, ToValue};
+use crate::types::{Annotated, SkipSerialization, ToValue};
 
 /// Estimates the size in bytes this would be in JSON.
 pub fn estimate_size<T: ToValue>(value: &Annotated<T>) -> usize {
     let mut ser = SizeEstimatingSerializer::new();
     if let Some(ref value) = value.0 {
-        ToValue::serialize_payload(value, &mut ser).unwrap();
+        ToValue::serialize_payload(value, &mut ser, SkipSerialization::Null).unwrap();
     }
     ser.size()
 }

--- a/general/src/protocol/clientsdk.rs
+++ b/general/src/protocol/clientsdk.rs
@@ -22,9 +22,11 @@ pub struct ClientSdkInfo {
     pub version: Annotated<String>,
 
     /// List of integrations that are enabled in the SDK.
+    #[metastructure(skip_serialization = "empty")]
     pub integrations: Annotated<Array<String>>,
 
     /// List of installed and loaded SDK packages.
+    #[metastructure(skip_serialization = "empty")]
     pub packages: Annotated<Array<ClientSdkPackage>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/general/src/protocol/debugmeta.rs
+++ b/general/src/protocol/debugmeta.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::processor::ProcessValue;
 use crate::protocol::Addr;
-use crate::types::{Annotated, Array, Error, FromValue, Object, ToValue, Value};
+use crate::types::{Annotated, Array, Error, FromValue, Object, SkipSerialization, ToValue, Value};
 
 /// Holds information about the system SDK.
 ///
@@ -91,7 +91,7 @@ impl ToValue for DebugId {
         Value::String(self.to_string())
     }
 
-    fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {

--- a/general/src/protocol/debugmeta.rs
+++ b/general/src/protocol/debugmeta.rs
@@ -164,9 +164,11 @@ pub enum DebugImage {
 pub struct DebugMeta {
     /// Information about the system SDK (e.g. iOS SDK).
     #[metastructure(field = "sdk_info")]
+    #[metastructure(skip_serialization = "empty")]
     pub system_sdk: Annotated<SystemSdkInfo>,
 
     /// List of debug information files (debug images).
+    #[metastructure(skip_serialization = "empty")]
     pub images: Annotated<Array<DebugImage>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/general/src/protocol/event.rs
+++ b/general/src/protocol/event.rs
@@ -180,6 +180,7 @@ pub struct Event {
     pub logger: Annotated<String>,
 
     /// Name and versions of installed modules.
+    #[metastructure(skip_serialization = "empty")]
     pub modules: Annotated<Object<String>>,
 
     /// Platform identifier of this event (defaults to "other").
@@ -217,18 +218,22 @@ pub struct Event {
 
     /// Information about the user who triggered this event.
     #[metastructure(legacy_alias = "sentry.interfaces.User")]
+    #[metastructure(skip_serialization = "empty")]
     pub user: Annotated<User>,
 
     /// Information about a web request that occurred during the event.
     #[metastructure(legacy_alias = "sentry.interfaces.Http")]
+    #[metastructure(skip_serialization = "empty")]
     pub request: Annotated<Request>,
 
     /// Contexts describing the environment (e.g. device, os or browser).
     #[metastructure(legacy_alias = "sentry.interfaces.Contexts")]
+    #[metastructure(skip_serialization = "empty")]
     pub contexts: Annotated<Contexts>,
 
     /// List of breadcrumbs recorded before this event.
     #[metastructure(legacy_alias = "sentry.interfaces.Breadcrumbs")]
+    #[metastructure(skip_serialization = "empty")]
     pub breadcrumbs: Annotated<Values<Breadcrumb>>,
 
     /// One or multiple chained (nested) exceptions.
@@ -237,6 +242,7 @@ pub struct Event {
     pub exceptions: Annotated<Values<Exception>>,
 
     /// Deprecated event stacktrace.
+    #[metastructure(skip_serialization = "empty")]
     pub stacktrace: Annotated<Stacktrace>,
 
     /// Simplified template error location information.
@@ -244,24 +250,30 @@ pub struct Event {
     pub template_info: Annotated<TemplateInfo>,
 
     /// Threads that were active when the event occurred.
+    #[metastructure(skip_serialization = "empty")]
     pub threads: Annotated<Values<Thread>>,
 
     /// Custom tags for this event.
+    #[metastructure(skip_serialization = "empty")]
     pub tags: Annotated<Tags>,
 
     /// Arbitrary extra information set by the user.
     #[metastructure(bag_size = "large")]
+    #[metastructure(skip_serialization = "empty")]
     pub extra: Annotated<Object<Value>>,
 
     /// Meta data for event processing and debugging.
+    #[metastructure(skip_serialization = "empty")]
     pub debug_meta: Annotated<DebugMeta>,
 
     /// Information about the Sentry SDK that generated this event.
     #[metastructure(field = "sdk")]
+    #[metastructure(skip_serialization = "empty")]
     pub client_sdk: Annotated<ClientSdkInfo>,
 
     /// Errors encountered during processing. Intended to be phased out in favor of
     /// annotation/metadata system.
+    #[metastructure(skip_serialization = "empty")]
     pub errors: Annotated<Array<EventProcessingError>>,
 
     /// Project key which sent this event.

--- a/general/src/protocol/event.rs
+++ b/general/src/protocol/event.rs
@@ -13,7 +13,9 @@ use crate::protocol::{
     Breadcrumb, ClientSdkInfo, Contexts, DebugMeta, Exception, Fingerprint, Level, LogEntry,
     Request, Stacktrace, Tags, TemplateInfo, Thread, User, Values,
 };
-use crate::types::{Annotated, Array, ErrorKind, FromValue, Object, ToValue, Value};
+use crate::types::{
+    Annotated, Array, ErrorKind, FromValue, Object, SkipSerialization, ToValue, Value,
+};
 
 /// Wrapper around a UUID with slightly different formatting.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -111,7 +113,7 @@ impl ToValue for EventType {
         Value::String(format!("{}", self))
     }
 
-    fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
     where
         Self: Sized,
         S: Serializer,

--- a/general/src/protocol/fingerprint.rs
+++ b/general/src/protocol/fingerprint.rs
@@ -1,6 +1,6 @@
 use crate::processor::ProcessValue;
 use crate::protocol::LenientString;
-use crate::types::{Annotated, Error, ErrorKind, FromValue, ToValue, Value};
+use crate::types::{Annotated, Error, ErrorKind, FromValue, SkipSerialization, ToValue, Value};
 
 /// A fingerprint value.
 #[derive(Debug, Clone, PartialEq)]
@@ -89,7 +89,7 @@ impl ToValue for Fingerprint {
         )
     }
 
-    fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
     where
         Self: Sized,
         S: serde::Serializer,

--- a/general/src/protocol/logentry.rs
+++ b/general/src/protocol/logentry.rs
@@ -17,7 +17,7 @@ pub struct LogEntry {
     pub formatted: Annotated<String>,
 
     /// Positional parameters to be interpolated into the log message.
-    #[metastructure(pii_kind = "databag", skip_serialization = "null")]
+    #[metastructure(pii_kind = "databag")]
     pub params: Annotated<Array<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/general/src/protocol/logentry.rs
+++ b/general/src/protocol/logentry.rs
@@ -17,17 +17,13 @@ pub struct LogEntry {
     pub formatted: Annotated<String>,
 
     /// Positional parameters to be interpolated into the log message.
-    #[metastructure(pii_kind = "databag")]
-    pub params: Annotated<Params>,
+    #[metastructure(pii_kind = "databag", skip_serialization = "null")]
+    pub params: Annotated<Array<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, pii_kind = "databag")]
     pub other: Object<Value>,
 }
-
-#[derive(Debug, Clone, PartialEq, Default, FromValue, ToValue, ProcessValue)]
-#[metastructure(skip_serialization = "never")]
-pub struct Params(Array<Value>);
 
 impl FromValue for LogEntry {
     fn from_value(value: Annotated<Value>) -> Annotated<Self> {
@@ -43,7 +39,7 @@ impl FromValue for LogEntry {
                 struct Helper {
                     message: Annotated<String>,
                     formatted: Annotated<String>,
-                    params: Annotated<Params>,
+                    params: Annotated<Array<Value>>,
                     #[metastructure(additional_properties)]
                     other: Object<Value>,
                 }
@@ -84,10 +80,10 @@ fn test_logentry_roundtrip() {
     let entry = Annotated::new(LogEntry {
         message: Annotated::new("Hello, %s %s!".to_string()),
         formatted: Annotated::empty(),
-        params: Annotated::new(Params(vec![
+        params: Annotated::new(vec![
             Annotated::new(Value::String("World".to_string())),
             Annotated::new(Value::I64(1)),
-        ])),
+        ]),
         other: {
             let mut map = Object::new();
             map.insert(
@@ -122,7 +118,7 @@ fn test_logentry_from_message() {
 fn test_logenty_empty_params() {
     let input = r#"{"params":[]}"#;
     let entry = Annotated::new(LogEntry {
-        params: Annotated::new(Params(vec![])),
+        params: Annotated::new(vec![]),
         ..Default::default()
     });
 

--- a/general/src/protocol/mechanism.rs
+++ b/general/src/protocol/mechanism.rs
@@ -89,10 +89,12 @@ pub struct Mechanism {
 
     /// Additional attributes depending on the mechanism type.
     #[metastructure(pii_kind = "databag")]
+    #[metastructure(skip_serialization = "empty")]
     // TODO: Cap?
     pub data: Annotated<Object<Value>>,
 
     /// Operating system or runtime meta information.
+    #[metastructure(skip_serialization = "empty")]
     pub meta: Annotated<MechanismMeta>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/general/src/protocol/request.rs
+++ b/general/src/protocol/request.rs
@@ -234,23 +234,27 @@ pub struct Request {
 
     /// URL encoded HTTP query string.
     #[metastructure(pii_kind = "databag", bag_size = "small")]
+    #[metastructure(skip_serialization = "empty")]
     pub query_string: Annotated<Query>,
 
     /// The fragment of the request URL.
     #[metastructure(pii_kind = "freeform", max_chars = "summary")]
+    #[metastructure(skip_serialization = "empty")]
     pub fragment: Annotated<String>,
 
     /// URL encoded contents of the Cookie header.
     #[metastructure(pii_kind = "databag", bag_size = "medium")]
+    #[metastructure(skip_serialization = "empty")]
     pub cookies: Annotated<Cookies>,
 
     /// HTTP request headers.
-    #[metastructure(pii_kind = "databag")]
     #[metastructure(pii_kind = "databag", bag_size = "large")]
+    #[metastructure(skip_serialization = "empty")]
     pub headers: Annotated<Headers>,
 
     /// Server environment data, such as CGI/WSGI.
     #[metastructure(pii_kind = "databag", bag_size = "large")]
+    #[metastructure(skip_serialization = "empty")]
     pub env: Annotated<Object<Value>>,
 
     /// The inferred content type of the request payload.

--- a/general/src/protocol/stacktrace.rs
+++ b/general/src/protocol/stacktrace.rs
@@ -7,6 +7,7 @@ use crate::types::{Annotated, Array, Object, Value};
 pub struct Frame {
     /// Name of the frame's function. This might include the name of a class.
     #[metastructure(max_chars = "symbol")]
+    #[metastructure(skip_serialization = "empty")]
     pub function: Annotated<String>,
 
     /// Potentially mangled name of the symbol as it appears in an executable.
@@ -22,6 +23,7 @@ pub struct Frame {
     /// Note that this might also include a class name if that is something the
     /// language natively considers to be part of the stack (for instance in Java).
     #[metastructure(pii_kind = "freeform")]
+    #[metastructure(skip_serialization = "empty")]
     // TODO: Cap? This can be a FS path or a dotted path
     pub module: Annotated<String>,
 
@@ -30,15 +32,18 @@ pub struct Frame {
     /// For instance this can be a dylib for native languages, the name of the jar
     /// or .NET assembly.
     #[metastructure(pii_kind = "freeform")]
+    #[metastructure(skip_serialization = "empty")]
     // TODO: Cap? This can be a FS path or a dotted path
     pub package: Annotated<String>,
 
     /// The source file name (basename only).
     #[metastructure(pii_kind = "freeform", max_chars = "short_path")]
+    #[metastructure(skip_serialization = "empty")]
     pub filename: Annotated<String>,
 
     /// Absolute path to the source file.
     #[metastructure(pii_kind = "freeform", max_chars = "path")]
+    #[metastructure(skip_serialization = "empty")]
     pub abs_path: Annotated<String>,
 
     /// Line number within the source file.
@@ -51,14 +56,17 @@ pub struct Frame {
 
     /// Source code leading up to the current line.
     #[metastructure(field = "pre_context")]
+    #[metastructure(skip_serialization = "empty")]
     pub pre_lines: Annotated<Array<String>>,
 
     /// Source code of the current line.
     #[metastructure(field = "context_line")]
+    #[metastructure(skip_serialization = "empty")]
     pub current_line: Annotated<String>,
 
     /// Source code of the lines after the current line.
     #[metastructure(field = "post_context")]
+    #[metastructure(skip_serialization = "empty")]
     pub post_lines: Annotated<Array<String>>,
 
     /// Override whether this frame should be considered in-app.
@@ -66,6 +74,7 @@ pub struct Frame {
 
     /// Local variables in a convenient format.
     #[metastructure(pii_kind = "databag")]
+    #[metastructure(skip_serialization = "empty")]
     pub vars: Annotated<FrameVariables>,
 
     /// Start address of the containing code module (image).

--- a/general/src/protocol/types.rs
+++ b/general/src/protocol/types.rs
@@ -18,6 +18,7 @@ use crate::types::{
 pub struct Values<T> {
     /// The values of the collection.
     #[metastructure(required = "true")]
+    #[metastructure(skip_serialization = "empty")]
     pub values: Annotated<Array<T>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/general/src/protocol/types.rs
+++ b/general/src/protocol/types.rs
@@ -8,7 +8,9 @@ use serde::ser::{Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::processor::ProcessValue;
-use crate::types::{Annotated, Array, Error, ErrorKind, FromValue, Meta, Object, ToValue, Value};
+use crate::types::{
+    Annotated, Array, Error, ErrorKind, FromValue, Meta, Object, SkipSerialization, ToValue, Value,
+};
 
 /// A array like wrapper used in various places.
 #[derive(Clone, Debug, PartialEq, ToValue, ProcessValue)]
@@ -139,7 +141,11 @@ macro_rules! hex_metrastructure {
             fn to_value(self) -> Value {
                 Value::String(self.to_string())
             }
-            fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+            fn serialize_payload<S>(
+                &self,
+                s: S,
+                _behavior: crate::types::SkipSerialization,
+            ) -> Result<S::Ok, S::Error>
             where
                 Self: Sized,
                 S: Serializer,
@@ -329,7 +335,7 @@ impl ToValue for Level {
         Value::String(self.to_string())
     }
 
-    fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
     where
         Self: Sized,
         S: Serializer,
@@ -501,7 +507,7 @@ impl ToValue for ThreadId {
         }
     }
 
-    fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
     where
         Self: Sized,
         S: Serializer,

--- a/general/src/types/annotated.rs
+++ b/general/src/types/annotated.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_derive::Serialize;
 use serde_json;
 
-use crate::types::{Error, FromValue, Map, Meta, ToValue, Value};
+use crate::types::{Error, FromValue, Map, Meta, SkipSerialization, ToValue, Value};
 
 /// Represents a tree of meta objects.
 #[derive(Default, Debug, Serialize)]
@@ -262,7 +262,11 @@ impl<T: ToValue> Annotated<T> {
 
         if let Some(ref value) = self.0 {
             use serde::private::ser::FlatMapSerializer;
-            ToValue::serialize_payload(value, FlatMapSerializer(&mut map_ser))?;
+            ToValue::serialize_payload(
+                value,
+                FlatMapSerializer(&mut map_ser),
+                SkipSerialization::Null,
+            )?;
         }
 
         if !meta_tree.is_empty() {
@@ -292,7 +296,9 @@ impl<T: ToValue> Annotated<T> {
         let mut ser = serde_json::Serializer::new(Vec::with_capacity(128));
 
         match self.0 {
-            Some(ref value) => ToValue::serialize_payload(value, &mut ser)?,
+            Some(ref value) => {
+                ToValue::serialize_payload(value, &mut ser, SkipSerialization::Null)?
+            }
             None => ser.serialize_unit()?,
         }
 
@@ -304,7 +310,9 @@ impl<T: ToValue> Annotated<T> {
         let mut ser = serde_json::Serializer::pretty(Vec::with_capacity(128));
 
         match self.0 {
-            Some(ref value) => ToValue::serialize_payload(value, &mut ser)?,
+            Some(ref value) => {
+                ToValue::serialize_payload(value, &mut ser, SkipSerialization::Null)?
+            }
             None => ser.serialize_unit()?,
         }
 
@@ -312,13 +320,18 @@ impl<T: ToValue> Annotated<T> {
     }
 
     /// Checks if this value can be skipped upon serialization.
-    pub fn skip_serialization(&self) -> bool {
+    pub fn skip_serialization(&self, behavior: SkipSerialization) -> bool {
+        println!("behavior: {:?}", behavior);
+        if behavior == SkipSerialization::Never {
+            return false;
+        }
+
         if !self.1.is_empty() {
             return false;
         }
 
         if let Some(ref value) = self.0 {
-            value.skip_serialization()
+            behavior == SkipSerialization::Empty && value.skip_serialization(behavior)
         } else {
             true
         }

--- a/general/src/types/annotated.rs
+++ b/general/src/types/annotated.rs
@@ -321,7 +321,6 @@ impl<T: ToValue> Annotated<T> {
 
     /// Checks if this value can be skipped upon serialization.
     pub fn skip_serialization(&self, behavior: SkipSerialization) -> bool {
-        println!("behavior: {:?}", behavior);
         if behavior == SkipSerialization::Never {
             return false;
         }

--- a/general/src/types/mod.rs
+++ b/general/src/types/mod.rs
@@ -13,5 +13,5 @@ mod value;
 pub use self::annotated::{Annotated, MetaMap, MetaTree, ValueAction};
 pub use self::impls::SerializePayload;
 pub use self::meta::{Error, ErrorKind, Meta, Range, Remark, RemarkType};
-pub use self::traits::{FromValue, ToValue};
+pub use self::traits::{FromValue, SkipSerialization, ToValue};
 pub use self::value::{Array, Map, Object, Value, ValueDescription};

--- a/general/src/types/traits.rs
+++ b/general/src/types/traits.rs
@@ -2,6 +2,13 @@ use std::fmt::Debug;
 
 use crate::types::{Annotated, MetaMap, MetaTree, Value};
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum SkipSerialization {
+    Null,
+    Empty,
+    Never,
+}
+
 /// Implemented for all meta structures.
 pub trait FromValue: Debug {
     /// Creates a meta structure from an annotated boxed value.
@@ -26,7 +33,7 @@ pub trait ToValue: Debug {
     }
 
     /// Efficiently serializes the payload directly.
-    fn serialize_payload<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    fn serialize_payload<S>(&self, s: S, behavior: SkipSerialization) -> Result<S::Ok, S::Error>
     where
         Self: Sized,
         S: serde::Serializer;
@@ -50,7 +57,8 @@ pub trait ToValue: Debug {
 
     /// Whether the value should not be serialized. Should at least return true if the value would
     /// serialize to an empty array, empty object or null.
-    fn skip_serialization(&self) -> bool {
+    fn skip_serialization(&self, behavior: SkipSerialization) -> bool {
+        let _behavior = behavior;
         false
     }
 }


### PR DESCRIPTION
Fields now inherit `skip_serialization` to allow modifying the ToValue behavior of `Object` and `Array`.

In the following example, `null` values are serialized for every level within `frame.vars`:

```
struct Frame {
    #[metastructure(skip_serialization = "never")]
    vars: Annotated<Object<Value>>
}
```

in this example, an empty `bar.values` would not be serialized even though the inner `Bar` struct has no annotations. Likewise an empty `Bar` (having no value for `values`) will not be serialized.

```
struct Foo {
    #[metastructure(skip_serialization = "empty")]
    bar: Annotated<Bar>
}

struct Bar {
    values: Annotated<Array<String>>
}

// Input 1:
// {"bar": {"values": []}}
// Input 2:
// {"bar": {"values": null}}
// Input 3:
// {"bar": {}}
// After:
// {}

```

However, if I were to annotate `values` with `#[metastructure(skip_serialization = "never")]`, an empty array will always be serialized while a missing value for `values` will still result in `bar` not being serialized.

The kickoff for this PR was a bug where a stack frame with `"vars": {"foo": null}` would end up as a frame without any variables. While this PR is not really necessary to fix that bug, it still should make it easier to port interfaces and behavior from Python, as `skip_serialization` is a property of the attribute there and not of the type.
