### PR TITLE
fix: Dont move stacktrace before normalizing it

### DIFF
--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -248,6 +248,8 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ValueAction {
+        event.process_child_values(self, state);
+
         // Override internal attributes, even if they were set in the payload
         event.project = Annotated::from(self.config.project_id);
         event.key_id = Annotated::from(self.config.key_id.clone());
@@ -274,17 +276,16 @@ impl<'a> Processor for NormalizeProcessor<'a> {
             event.client_sdk.set_value(self.get_sdk_info());
         }
 
+        event
+            .stacktrace
+            .apply(stacktrace::process_non_raw_stacktrace);
+
         // Normalize connected attributes and interfaces
         self.normalize_release_dist(event);
         self.normalize_timestamps(event);
         self.normalize_event_tags(event);
         self.normalize_exceptions(event);
         self.normalize_user_ip(event);
-        event
-            .stacktrace
-            .apply(stacktrace::process_non_raw_stacktrace);
-
-        event.process_child_values(self, state);
 
         ValueAction::Keep
     }


### PR DESCRIPTION
What happens right now is:

1. `event.process_child_values()` recurses and processes an exception without stacktrace (therefore no abs_path normalized)
2. stacktrace is moved into exception, `event.stacktrace` is now empty
3. `event.stacktrace` is now normalized, but it's `null` so there's nothing to do

Reorder calls to:

1. `event.process_child_values()` recurses and processes an exception without stacktrace (therefore no abs_path normalized)
2. `event.stacktrace` is now normalized, not `null`
3. stacktrace is moved