### PR TITLE
ref(general): Do not require breadcrumb timestamps

### DIFF
--- a/general/src/protocol/breadcrumb.rs
+++ b/general/src/protocol/breadcrumb.rs
@@ -10,8 +10,7 @@ use crate::types::{Annotated, Object, Value};
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, ToValue, ProcessValue)]
 #[metastructure(process_func = "process_breadcrumb", value_type = "Breadcrumb")]
 pub struct Breadcrumb {
-    /// The timestamp of the breadcrumb (required).
-    #[metastructure(required = "true")]
+    /// The timestamp of the breadcrumb.
     pub timestamp: Annotated<DateTime<Utc>>,
 
     /// The type of the breadcrumb.
@@ -22,7 +21,7 @@ pub struct Breadcrumb {
     #[metastructure(max_chars = "enumlike")]
     pub category: Annotated<String>,
 
-    /// Severity level of the breadcrumb (required).
+    /// Severity level of the breadcrumb.
     pub level: Annotated<Level>,
 
     /// Human readable message for the breadcrumb.

--- a/general/src/protocol/logentry.rs
+++ b/general/src/protocol/logentry.rs
@@ -8,7 +8,7 @@ use crate::types::{Annotated, Array, FromValue, Object, Value};
 #[derive(Clone, Debug, Default, PartialEq, Empty, ToValue, ProcessValue)]
 #[metastructure(process_func = "process_logentry", value_type = "LogEntry")]
 pub struct LogEntry {
-    /// The log message with parameter placeholders (required).
+    /// The log message with parameter placeholders.
     #[metastructure(pii = "true", max_chars = "message")]
     pub message: Annotated<String>,
 

--- a/general/src/store/schema.rs
+++ b/general/src/store/schema.rs
@@ -172,23 +172,6 @@ mod tests {
     }
 
     #[test]
-    fn test_breadcrumb_missing_attribute() {
-        use crate::protocol::Breadcrumb;
-        use crate::types::ErrorKind;
-
-        let mut crumb = Annotated::new(Breadcrumb::default());
-
-        process_value(&mut crumb, &mut SchemaProcessor, ProcessingState::root());
-
-        let expected = Annotated::new(Breadcrumb {
-            timestamp: Annotated::from_error(ErrorKind::MissingAttribute, None),
-            ..Default::default()
-        });
-
-        assert_eq_dbg!(crumb, expected);
-    }
-
-    #[test]
     fn test_client_sdk_missing_attribute() {
         use crate::protocol::ClientSdkInfo;
         use crate::types::ErrorKind;


### PR DESCRIPTION
The UI will not break with this and render the current time instead. We should submit a patch that renders nothing instead.