### PR TITLE
ref(general): Permit invalid emails in user interface

### DIFF
--- a/general/src/protocol/user.rs
+++ b/general/src/protocol/user.rs
@@ -31,12 +31,7 @@ pub struct User {
     pub id: Annotated<LenientString>,
 
     /// Email address of the user.
-    #[metastructure(
-        pii = "true",
-        max_chars = "email",
-        match_regex = r"@",
-        skip_serialization = "empty"
-    )]
+    #[metastructure(pii = "true", max_chars = "email", skip_serialization = "empty")]
     pub email: Annotated<String>,
 
     /// Remote IP address of the user. Defaults to "{{auto}}".

--- a/general/src/store/mod.rs
+++ b/general/src/store/mod.rs
@@ -87,27 +87,3 @@ impl<'a> Processor for StoreProcessor<'a> {
             })
     }
 }
-
-#[cfg(test)]
-use {crate::processor::process_value, crate::types::Annotated};
-
-#[test]
-fn test_schema_processor_invoked() {
-    use crate::protocol::User;
-
-    let mut event = Annotated::new(Event {
-        user: Annotated::new(User {
-            email: Annotated::new("bananabread".to_owned()),
-            ..Default::default()
-        }),
-        ..Default::default()
-    });
-
-    let mut processor = StoreProcessor::new(StoreConfig::default(), None);
-    process_value(&mut event, &mut processor, ProcessingState::root());
-
-    assert_eq_dbg!(
-        event.value().unwrap().user.value().unwrap().email.value(),
-        None
-    );
-}

--- a/general/src/store/schema.rs
+++ b/general/src/store/schema.rs
@@ -164,18 +164,10 @@ mod tests {
             ..Default::default()
         });
 
+        let expected = user.clone();
         process_value(&mut user, &mut SchemaProcessor, ProcessingState::root());
 
-        assert_eq_dbg!(
-            user,
-            Annotated::new(User {
-                email: Annotated::from_error(
-                    Error::invalid("invalid characters in string"),
-                    Some(Value::String("bananabread".to_string()))
-                ),
-                ..Default::default()
-            })
-        );
+        assert_eq_dbg!(user, expected);
     }
 
     #[test]


### PR DESCRIPTION
Permits any value as `user.email`, which is required for PII stripped events. This changes the behavior from current Python.