### PR TITLE
fix(general): Include original_value in Meta::eq

### DIFF
--- a/general/src/protocol/logentry.rs
+++ b/general/src/protocol/logentry.rs
@@ -169,7 +169,7 @@ fn test_logentry_invalid_params() {
 
     let entry = Annotated::new(LogEntry {
         message: Annotated::new("Hello, %s!".to_string()),
-        params: Annotated::from_error(Error::expected("message parameters"), Some(Value::U64(42))),
+        params: Annotated::from_error(Error::expected("message parameters"), Some(Value::I64(42))),
         ..LogEntry::default()
     });
 

--- a/general/src/protocol/request.rs
+++ b/general/src/protocol/request.rs
@@ -610,7 +610,7 @@ fn test_query_string_legacy_nested() {
 fn test_query_invalid() {
     let query = Annotated::<Query>::from_error(
         Error::expected("query-string or map"),
-        Some(Value::U64(64)),
+        Some(Value::I64(42)),
     );
     assert_eq_dbg!(query, Annotated::from_json("42").unwrap());
 }
@@ -648,7 +648,7 @@ fn test_cookies_array() {
     )));
     map.push(Annotated::new((
         Annotated::new("invalid".to_string()),
-        Annotated::from_error(Error::expected("a string"), Some(Value::U64(42))),
+        Annotated::from_error(Error::expected("a string"), Some(Value::I64(42))),
     )));
 
     let cookies = Annotated::new(Cookies(PairList(map)));
@@ -666,7 +666,7 @@ fn test_cookies_object() {
     )));
     map.push(Annotated::new((
         Annotated::new("invalid".to_string()),
-        Annotated::from_error(Error::expected("a string"), Some(Value::U64(42))),
+        Annotated::from_error(Error::expected("a string"), Some(Value::I64(42))),
     )));
 
     let cookies = Annotated::new(Cookies(PairList(map)));

--- a/general/src/types/meta.rs
+++ b/general/src/types/meta.rs
@@ -426,7 +426,10 @@ pub struct MetaInner {
 
 impl MetaInner {
     pub fn is_empty(&self) -> bool {
-        self.original_length.is_none() && self.remarks.is_empty() && self.errors.is_empty()
+        self.original_length.is_none()
+            && self.remarks.is_empty()
+            && self.errors.is_empty()
+            && self.original_value.is_none()
     }
 }
 
@@ -599,6 +602,7 @@ impl PartialEq for MetaInner {
         self.remarks == other.remarks
             && self.errors == other.errors
             && self.original_length == other.original_length
+            && self.original_value == other.original_value
     }
 }
 

--- a/general/tests/snapshots/test_fixtures__cocoa_normalized.snap
+++ b/general/tests/snapshots/test_fixtures__cocoa_normalized.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-01-22T13:21:53.613414+00:00"
+created: "2019-01-22T17:08:57.342718+00:00"
 creator: insta@0.4.1
 expression: SerializableAnnotated(&event)
 source: general/tests/test_fixtures.rs
@@ -9,7 +9,7 @@ level: fatal
 type: error
 transaction: sentry_ios_cocoapods.ViewController
 logger: ""
-platform: other
+platform: cocoa
 timestamp: "[timestamp]"
 received: "[received]"
 release: io.sentry.sentry-ios-cocoapods-1.0

--- a/general/tests/snapshots/test_fixtures__dotnet_normalized.snap
+++ b/general/tests/snapshots/test_fixtures__dotnet_normalized.snap
@@ -1,7 +1,7 @@
 ---
-created: "2019-01-21T22:41:01.926577+00:00"
-creator: insta@0.4.0
-expression: event
+created: "2019-01-22T17:08:57.295360+00:00"
+creator: insta@0.4.1
+expression: SerializableAnnotated(&event)
 source: general/tests/test_fixtures.rs
 ---
 event_id: 04e03764d7024caab8736daeefbb9bee
@@ -174,7 +174,7 @@ modules:
   fwwefxr0.3z0: 0.0.0.0
   nbxk3h5b.orp: 0.0.0.0
   netstandard: 2.0.0.0
-platform: other
+platform: csharp
 timestamp: "[timestamp]"
 received: "[received]"
 release: e386dfd

--- a/general/tests/snapshots/test_fixtures__legacy_node_exception_normalized.snap
+++ b/general/tests/snapshots/test_fixtures__legacy_node_exception_normalized.snap
@@ -1,7 +1,7 @@
 ---
-created: "2019-01-21T22:41:01.909103+00:00"
-creator: insta@0.4.0
-expression: event
+created: "2019-01-22T17:08:57.279123+00:00"
+creator: insta@0.4.1
+expression: SerializableAnnotated(&event)
 source: general/tests/test_fixtures.rs
 ---
 event_id: c99bf5ef2eb447d59183ced79601b547
@@ -67,7 +67,7 @@ modules:
   utils-merge: 1.0.1
   uuid: 3.0.0
   vary: 1.1.2
-platform: other
+platform: node
 timestamp: "[timestamp]"
 received: "[received]"
 release: randomRelease

--- a/general/tests/snapshots/test_fixtures__legacy_python_normalized.snap
+++ b/general/tests/snapshots/test_fixtures__legacy_python_normalized.snap
@@ -1,7 +1,7 @@
 ---
-created: "2019-01-21T22:41:01.905145+00:00"
-creator: insta@0.4.0
-expression: event
+created: "2019-01-22T17:08:57.275762+00:00"
+creator: insta@0.4.1
+expression: SerializableAnnotated(&event)
 source: general/tests/test_fixtures.rs
 ---
 event_id: b308014887f5418c8f797159bfb6fc42
@@ -12,7 +12,7 @@ logentry:
 logger: ""
 modules:
   python: 3.7.0
-platform: other
+platform: python
 timestamp: "[timestamp]"
 received: "[received]"
 exception:

--- a/general/tests/test_fixtures.rs
+++ b/general/tests/test_fixtures.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 
 use insta::assert_serialized_snapshot_matches;
@@ -6,13 +7,41 @@ use semaphore_general::protocol::Event;
 use semaphore_general::store::{StoreConfig, StoreProcessor};
 use semaphore_general::types::{Annotated, SerializableAnnotated};
 
+lazy_static::lazy_static! {
+    static ref VALID_PLATOFORMS: BTreeSet<String> = {
+        let mut platforms = BTreeSet::new();
+        platforms.insert("as3".to_string());
+        platforms.insert("c".to_string());
+        platforms.insert("cfml".to_string());
+        platforms.insert("cocoa".to_string());
+        platforms.insert("csharp".to_string());
+        platforms.insert("go".to_string());
+        platforms.insert("java".to_string());
+        platforms.insert("javascript".to_string());
+        platforms.insert("node".to_string());
+        platforms.insert("objc".to_string());
+        platforms.insert("other".to_string());
+        platforms.insert("perl".to_string());
+        platforms.insert("php".to_string());
+        platforms.insert("python".to_string());
+        platforms.insert("ruby".to_string());
+        platforms.insert("elixir".to_string());
+        platforms.insert("haskell".to_string());
+        platforms.insert("groovy".to_string());
+        platforms.insert("native".to_string());
+        platforms
+    };
+}
+
 macro_rules! event_snapshot {
     ($id:expr) => {
         let id: &str = &$id;
         let data = fs::read_to_string(format!("tests/fixtures/payloads/{}.json", id)).unwrap();
         let mut event = Annotated::<Event>::from_json(&data).unwrap();
         assert_serialized_snapshot_matches!($id, SerializableAnnotated(&event));
-        let mut processor = StoreProcessor::new(StoreConfig::default(), None);
+        let mut config = StoreConfig::default();
+        config.valid_platforms = VALID_PLATOFORMS.clone();
+        let mut processor = StoreProcessor::new(config, None);
         process_value(&mut event, &mut processor, ProcessingState::root());
         assert_serialized_snapshot_matches!(format!("{}_normalized", $id), SerializableAnnotated(&event), {
             ".received" => "[received]",


### PR DESCRIPTION
This was previously completely left out, and some tests actually made wrong assertions.