### PR TITLE
fix: Do not skip null values in pairlists

### DIFF
--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -626,10 +626,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
     }
 
     let ast = s.ast();
-    let expectation = LitStr::new(
-        &ast.ident.to_string().to_lowercase(),
-        Span::call_site(),
-    );
+    let expectation = LitStr::new(&ast.ident.to_string().to_lowercase(), Span::call_site());
     let mut variant = variant.clone();
     for binding in variant.bindings_mut() {
         binding.style = synstructure::BindStyle::Move;

--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -1018,7 +1018,7 @@ impl SkipSerialization {
 
 impl Default for SkipSerialization {
     fn default() -> SkipSerialization {
-        SkipSerialization::Null(true)
+        SkipSerialization::Never
     }
 }
 
@@ -1049,6 +1049,9 @@ fn parse_field_attributes(
     }
 
     let mut rv = FieldAttrs::default();
+    if !*is_tuple_struct {
+        rv.skip_serialization = SkipSerialization::Null(false);
+    }
     rv.field_name = bi_ast
         .ident
         .as_ref()

--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -667,7 +667,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
                 quote! {
                     crate::types::Annotated(Some(crate::types::Value::Array(mut __arr)), mut __meta) => {
                         if __arr.len() != #bindings_count {
-                            __meta.add_error(Error::expected(&format!("a {}-tuple", #bindings_count)));
+                            __meta.add_error(Error::expected(concat!("a ", stringify!(#bindings_count), "-tuple")));
                             __meta.set_original_value(Some(__arr));
                             Annotated(None, __meta)
                         } else {

--- a/general/src/protocol/tags.rs
+++ b/general/src/protocol/tags.rs
@@ -6,17 +6,11 @@ pub struct TagEntry(
     #[metastructure(
         pii = "true",
         max_chars = "tag_key",
-        match_regex = r"^[a-zA-Z0-9_\.:-]+\z",
-        skip_serialization = "never"
+        match_regex = r"^[a-zA-Z0-9_\.:-]+\z"
     )]
     pub Annotated<String>,
-    #[metastructure(
-        pii = "true",
-        max_chars = "tag_value",
-        match_regex = r"^[^\n]+\z",
-        skip_serialization = "never"
-    )]
-    pub Annotated<String>,
+    #[metastructure(pii = "true", max_chars = "tag_value", match_regex = r"^[^\n]+\z")]
+    pub  Annotated<String>,
 );
 
 impl AsPair for TagEntry {


### PR DESCRIPTION
Tuples and tuple structs are a kind of array, but we never excluded them from the "structs always default to skip_serialization=null" rule we established in our custom derive.