### PR TITLE
feat(general): Reject non http/https in help_link

### DIFF
--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -269,10 +269,12 @@ impl<'a> NormalizeProcessor<'a> {
                 // the operating system version the event was generated on. Some
                 // normalization still works without sdk_info, such as mach_exception
                 // names (they can only occur on macOS).
+                //
+                // We also want to validate some other aspects of it.
                 for exception in exceptions {
                     if let Some(exception) = exception.value_mut() {
                         if let Some(mechanism) = exception.mechanism.value_mut() {
-                            mechanism::normalize_mechanism_meta(mechanism, os_hint);
+                            mechanism::normalize_mechanism(mechanism, os_hint);
                         }
                     }
                 }

--- a/general/src/store/normalize/mechanism.rs
+++ b/general/src/store/normalize/mechanism.rs
@@ -1,5 +1,5 @@
 use crate::protocol::{Context, ContextInner, Event, Mechanism};
-use crate::types::{Annotated, ValueAction, Error};
+use crate::types::{Annotated, Error, ValueAction};
 
 #[cfg(test)]
 use crate::protocol::{CError, MachException, MechanismMeta, PosixSignal};


### PR DESCRIPTION
This rejects non http/https links in the system for help_link. Refs https://github.com/getsentry/sentry/pull/12659