### PR TITLE
fix: Make exception values larger

### DIFF
--- a/general/src/protocol/exception.rs
+++ b/general/src/protocol/exception.rs
@@ -10,7 +10,7 @@ pub struct Exception {
     pub ty: Annotated<String>,
 
     /// Human readable display value.
-    #[metastructure(max_chars = "summary")]
+    #[metastructure(max_chars = "message")]
     pub value: Annotated<JsonLenientString>,
 
     /// Module name of this exception.


### PR DESCRIPTION
This goes from 1000 chars to 8000. Python limit was 4000.

In Python sometimes you end up with a formatted stacktrace in exception msg and you don't care enough to fix it. Another case is having stacktraces from other languages embedded there. In both cases the out-of-the-box behavior should be "slightly useful, but kinda shitty" instead of "useless".