### PR TITLE
fix: Allow unknown contexts

### DIFF
--- a/general/src/protocol/contexts.rs
+++ b/general/src/protocol/contexts.rs
@@ -264,8 +264,6 @@ pub enum Context {
     Trace(Box<TraceContext>),
     /// Information related to Monitors feature.
     Monitor(Object<Value>),
-    /// Information related to sessionstack plugin.
-    Sessionstack(Object<Value>),
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(fallback_variant)]
     Other(Object<Value>),

--- a/general/src/store/normalize/contexts.rs
+++ b/general/src/store/normalize/contexts.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 
 use crate::protocol::{Context, OsContext, RuntimeContext};
-use crate::types::{Empty, Object, Value};
+use crate::types::Empty;
 
 lazy_static::lazy_static! {
     /// Environment.OSVersion (GetVersionEx) or RuntimeInformation.OSDescription on Windows
@@ -97,37 +97,16 @@ fn normalize_os_context(os: &mut OsContext) {
     }
 }
 
-fn normalize_other_context(other: &mut Object<Value>) {
-    if let Some(ty) = other.get_mut("type") {
-        if ty.as_str() != Some("default") {
-            ty.set_value(Some("default".to_string().into()));
-        }
-    }
-}
-
 pub fn normalize_context(context: &mut Context) {
     match context {
         Context::Runtime(runtime) => normalize_runtime_context(runtime),
         Context::Os(os) => normalize_os_context(os),
-        Context::Other(other) => normalize_other_context(other),
         _ => (),
     }
 }
 
 #[cfg(test)]
-use crate::{protocol::LenientString, types::Annotated};
-
-#[test]
-fn test_arbitrary_type() {
-    let mut other = Object::new();
-    other.insert(
-        "type".to_string(),
-        Annotated::from(Value::String("foo".to_string())),
-    );
-
-    normalize_other_context(&mut other);
-    assert_eq_dbg!(other.get("type").and_then(|a| a.as_str()), Some("default"));
-}
+use crate::protocol::LenientString;
 
 #[test]
 fn test_dotnet_framework_472() {


### PR DESCRIPTION
Other option considered: Pass a list of known context types from Sentry to Semaphore. This will not become possible when store normalization ever happens outside of sentry, so the idea has been dropped.