### PR TITLE
feat: The last release of .NET Framework

### DIFF
--- a/general/src/store/normalize/contexts.rs
+++ b/general/src/store/normalize/contexts.rs
@@ -54,6 +54,8 @@ fn normalize_runtime_context(runtime: &mut RuntimeContext) {
                     "461310" => Some("4.7.1".to_string()),
                     "461808" => Some("4.7.2".to_string()),
                     "461814" => Some("4.7.2".to_string()),
+                    "528040" => Some("4.8".to_string()),
+                    "528049" => Some("4.8".to_string()),
                     _ => None,
                 };
 


### PR DESCRIPTION
Earlier this(last?) month Microsoft shipped the last release of the .NET Framework.
Adding the mappings of release number to display the expected (display) version: **4.8**

```
.NET Framework 4.8
On Windows 10 May 2019 Update: 528040
On all others Windows operating systems (including other Windows 10 operating systems): 528049
```
