### PR TITLE
fix: Move stacktrace trimming to trimmingprocessor

### DIFF
--- a/general/src/store/mod.rs
+++ b/general/src/store/mod.rs
@@ -30,14 +30,6 @@ pub struct StoreConfig {
     pub protocol_version: Option<String>,
     pub grouping_config: Option<Value>,
 
-    /// Hard limit for stacktrace frames
-    /// Corresponds to SENTRY_STACKTRACE_FRAMES_HARD_LIMIT
-    pub stacktrace_frames_hard_limit: Option<usize>,
-
-    /// Soft limit for stacktrace frames
-    /// Corresponds to SENTRY_MAX_STACKTRACE_FRAMES
-    pub max_stacktrace_frames: Option<usize>,
-
     pub valid_platforms: BTreeSet<String>,
     pub max_secs_in_future: Option<i64>,
     pub max_secs_in_past: Option<i64>,

--- a/general/src/store/normalize/stacktrace.rs
+++ b/general/src/store/normalize/stacktrace.rs
@@ -3,7 +3,7 @@ use std::mem;
 use url::Url;
 
 use crate::protocol::{Frame, RawStacktrace};
-use crate::types::{Annotated, Array, Empty, Meta};
+use crate::types::{Annotated, Empty, Meta};
 
 fn is_url(filename: &str) -> bool {
     filename.starts_with("file:")
@@ -38,69 +38,6 @@ pub fn process_non_raw_frame(frame: &mut Frame, _meta: &mut Meta) {
                         frame.filename = Annotated::new(path.to_string());
                     }
                 }
-            }
-        }
-    }
-}
-
-pub fn enforce_frame_hard_limit(frames: &mut Array<Frame>, meta: &mut Meta, limit: usize) {
-    // Trim down the frame list to a hard limit. Leave the last frame in place in case
-    // it's useful for debugging.
-    let original_length = frames.len();
-    if original_length >= limit {
-        meta.set_original_length(Some(original_length));
-
-        let last_frame = frames.pop();
-        frames.truncate(limit - 1);
-        if let Some(last_frame) = last_frame {
-            frames.push(last_frame);
-        }
-    }
-}
-
-/// Remove excess metadata for middle frames which go beyond `frame_allowance`.
-///
-/// This is supposed to be equivalent to `slim_frame_data` in Sentry.
-pub fn slim_frame_data(frames: &mut Array<Frame>, frame_allowance: usize) {
-    let frames_len = frames.len();
-
-    if frames_len <= frame_allowance {
-        return;
-    }
-
-    // Avoid ownership issues by only storing indices
-    let mut app_frame_indices = Vec::with_capacity(frames_len);
-    let mut system_frame_indices = Vec::with_capacity(frames_len);
-
-    for (i, frame) in frames.iter().enumerate() {
-        if let Some(frame) = frame.value() {
-            match frame.in_app.value() {
-                Some(true) => app_frame_indices.push(i),
-                _ => system_frame_indices.push(i),
-            }
-        }
-    }
-
-    let app_count = app_frame_indices.len();
-    let system_allowance_half = frame_allowance.saturating_sub(app_count) / 2;
-    let system_frames_to_remove = &system_frame_indices
-        [system_allowance_half..system_frame_indices.len() - system_allowance_half];
-
-    let remaining = frames_len
-        .saturating_sub(frame_allowance)
-        .saturating_sub(system_frames_to_remove.len());
-    let app_allowance_half = app_count.saturating_sub(remaining) / 2;
-    let app_frames_to_remove =
-        &app_frame_indices[app_allowance_half..app_frame_indices.len() - app_allowance_half];
-
-    // TODO: Which annotation to set?
-
-    for i in system_frames_to_remove.iter().chain(app_frames_to_remove) {
-        if let Some(frame) = frames.get_mut(*i) {
-            if let Some(ref mut frame) = frame.value_mut().as_mut() {
-                frame.vars = Annotated::empty();
-                frame.pre_context = Annotated::empty();
-                frame.post_context = Annotated::empty();
             }
         }
     }
@@ -184,41 +121,6 @@ fn test_coerce_empty_filename() {
 }
 
 #[test]
-fn test_frame_hard_limit() {
-    fn create_frame(filename: &str) -> Annotated<Frame> {
-        Annotated::new(Frame {
-            filename: Annotated::new(filename.to_string()),
-            ..Default::default()
-        })
-    }
-
-    let mut frames = Annotated::new(vec![
-        create_frame("foo1.py"),
-        create_frame("foo2.py"),
-        create_frame("foo3.py"),
-        create_frame("foo4.py"),
-        create_frame("foo5.py"),
-    ]);
-
-    frames.apply(|f, m| enforce_frame_hard_limit(f, m, 3));
-
-    let mut expected_meta = Meta::default();
-    expected_meta.set_original_length(Some(5));
-
-    assert_eq_dbg!(
-        frames,
-        Annotated(
-            Some(vec![
-                create_frame("foo1.py"),
-                create_frame("foo2.py"),
-                create_frame("foo5.py"),
-            ]),
-            expected_meta
-        )
-    );
-}
-
-#[test]
 fn test_is_url() {
     assert!(is_url("http://example.org/"));
     assert!(is_url("https://example.org/"));
@@ -230,75 +132,4 @@ fn test_is_url() {
     assert!(!is_url("webpack:///./app/index.jsx")); // webpack bundle
     assert!(!is_url("data:,"));
     assert!(!is_url("blob:\x00"));
-}
-
-#[test]
-fn test_slim_frame_data_under_max() {
-    let mut frames = vec![Annotated::new(Frame {
-        filename: Annotated::new("foo".to_string()),
-        pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
-        context_line: Annotated::new("b".to_string()),
-        post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
-        ..Default::default()
-    })];
-
-    let old_frames = frames.clone();
-    slim_frame_data(&mut frames, 4);
-
-    assert_eq_dbg!(frames, old_frames);
-}
-
-#[test]
-fn test_slim_frame_data_over_max() {
-    let mut frames = vec![];
-
-    for n in 0..5 {
-        frames.push(Annotated::new(Frame {
-            filename: Annotated::new(format!("foo {}", n)),
-            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
-            context_line: Annotated::new("b".to_string()),
-            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
-            ..Default::default()
-        }));
-    }
-
-    slim_frame_data(&mut frames, 4);
-
-    let expected = vec![
-        Annotated::new(Frame {
-            filename: Annotated::new("foo 0".to_string()),
-            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
-            context_line: Annotated::new("b".to_string()),
-            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
-            ..Default::default()
-        }),
-        Annotated::new(Frame {
-            filename: Annotated::new("foo 1".to_string()),
-            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
-            context_line: Annotated::new("b".to_string()),
-            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
-            ..Default::default()
-        }),
-        Annotated::new(Frame {
-            filename: Annotated::new("foo 2".to_string()),
-            context_line: Annotated::new("b".to_string()),
-            ..Default::default()
-        }),
-        Annotated::new(Frame {
-            filename: Annotated::new("foo 3".to_string()),
-            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
-            context_line: Annotated::new("b".to_string()),
-            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
-            ..Default::default()
-        }),
-        Annotated::new(Frame {
-            filename: Annotated::new("foo 4".to_string()),
-            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
-            context_line: Annotated::new("b".to_string()),
-            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
-            ..Default::default()
-        }),
-    ];
-
-    assert_eq_dbg!(frames, expected);
 }

--- a/general/src/store/trimming.rs
+++ b/general/src/store/trimming.rs
@@ -4,7 +4,8 @@ use serde_json;
 
 use crate::processor::{estimate_size_flat, process_chunked_value, BagSize, Chunk, MaxChars};
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
-use crate::types::{Array, Empty, Meta, Object, RemarkType, Value, ValueAction};
+use crate::protocol::{Frame, RawStacktrace};
+use crate::types::{Annotated, Array, Empty, Meta, Object, RemarkType, Value, ValueAction};
 
 #[derive(Clone, Debug)]
 struct BagSizeState {
@@ -235,6 +236,25 @@ impl Processor for TrimmingProcessor {
         value.process_child_values(self, state);
         ValueAction::Keep
     }
+
+    fn process_raw_stacktrace(
+        &mut self,
+        stacktrace: &mut RawStacktrace,
+        _meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ValueAction {
+        stacktrace
+            .frames
+            .apply(|frames, meta| enforce_frame_hard_limit(frames, meta, 250));
+
+        stacktrace.process_child_values(self, state);
+
+        stacktrace
+            .frames
+            .apply(|frames, _meta| slim_frame_data(frames, 50));
+
+        ValueAction::Keep
+    }
 }
 
 /// Trims the string to the given maximum length and updates meta data.
@@ -299,8 +319,68 @@ fn trim_string(value: &mut String, meta: &mut Meta, max_chars: MaxChars) {
     });
 }
 
-#[cfg(test)]
-use crate::types::Annotated;
+fn enforce_frame_hard_limit(frames: &mut Array<Frame>, meta: &mut Meta, limit: usize) {
+    // Trim down the frame list to a hard limit. Leave the last frame in place in case
+    // it's useful for debugging.
+    let original_length = frames.len();
+    if original_length >= limit {
+        meta.set_original_length(Some(original_length));
+
+        let last_frame = frames.pop();
+        frames.truncate(limit - 1);
+        if let Some(last_frame) = last_frame {
+            frames.push(last_frame);
+        }
+    }
+}
+
+/// Remove excess metadata for middle frames which go beyond `frame_allowance`.
+///
+/// This is supposed to be equivalent to `slim_frame_data` in Sentry.
+fn slim_frame_data(frames: &mut Array<Frame>, frame_allowance: usize) {
+    let frames_len = frames.len();
+
+    if frames_len <= frame_allowance {
+        return;
+    }
+
+    // Avoid ownership issues by only storing indices
+    let mut app_frame_indices = Vec::with_capacity(frames_len);
+    let mut system_frame_indices = Vec::with_capacity(frames_len);
+
+    for (i, frame) in frames.iter().enumerate() {
+        if let Some(frame) = frame.value() {
+            match frame.in_app.value() {
+                Some(true) => app_frame_indices.push(i),
+                _ => system_frame_indices.push(i),
+            }
+        }
+    }
+
+    let app_count = app_frame_indices.len();
+    let system_allowance_half = frame_allowance.saturating_sub(app_count) / 2;
+    let system_frames_to_remove = &system_frame_indices
+        [system_allowance_half..system_frame_indices.len() - system_allowance_half];
+
+    let remaining = frames_len
+        .saturating_sub(frame_allowance)
+        .saturating_sub(system_frames_to_remove.len());
+    let app_allowance_half = app_count.saturating_sub(remaining) / 2;
+    let app_frames_to_remove =
+        &app_frame_indices[app_allowance_half..app_frame_indices.len() - app_allowance_half];
+
+    // TODO: Which annotation to set?
+
+    for i in system_frames_to_remove.iter().chain(app_frames_to_remove) {
+        if let Some(frame) = frames.get_mut(*i) {
+            if let Some(ref mut frame) = frame.value_mut().as_mut() {
+                frame.vars = Annotated::empty();
+                frame.pre_context = Annotated::empty();
+                frame.post_context = Annotated::empty();
+            }
+        }
+    }
+}
 
 #[test]
 fn test_string_trimming() {
@@ -690,4 +770,110 @@ fn test_newtypes_do_not_add_to_depth() {
         value.to_json().unwrap(),
         r#"{"inner":{"inner":{"inner":"hi"}}}"#
     );
+}
+
+#[test]
+fn test_frame_hard_limit() {
+    fn create_frame(filename: &str) -> Annotated<Frame> {
+        Annotated::new(Frame {
+            filename: Annotated::new(filename.to_string()),
+            ..Default::default()
+        })
+    }
+
+    let mut frames = Annotated::new(vec![
+        create_frame("foo1.py"),
+        create_frame("foo2.py"),
+        create_frame("foo3.py"),
+        create_frame("foo4.py"),
+        create_frame("foo5.py"),
+    ]);
+
+    frames.apply(|f, m| enforce_frame_hard_limit(f, m, 3));
+
+    let mut expected_meta = Meta::default();
+    expected_meta.set_original_length(Some(5));
+
+    assert_eq_dbg!(
+        frames,
+        Annotated(
+            Some(vec![
+                create_frame("foo1.py"),
+                create_frame("foo2.py"),
+                create_frame("foo5.py"),
+            ]),
+            expected_meta
+        )
+    );
+}
+
+#[test]
+fn test_slim_frame_data_under_max() {
+    let mut frames = vec![Annotated::new(Frame {
+        filename: Annotated::new("foo".to_string()),
+        pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
+        context_line: Annotated::new("b".to_string()),
+        post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
+        ..Default::default()
+    })];
+
+    let old_frames = frames.clone();
+    slim_frame_data(&mut frames, 4);
+
+    assert_eq_dbg!(frames, old_frames);
+}
+
+#[test]
+fn test_slim_frame_data_over_max() {
+    let mut frames = vec![];
+
+    for n in 0..5 {
+        frames.push(Annotated::new(Frame {
+            filename: Annotated::new(format!("foo {}", n)),
+            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
+            context_line: Annotated::new("b".to_string()),
+            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
+            ..Default::default()
+        }));
+    }
+
+    slim_frame_data(&mut frames, 4);
+
+    let expected = vec![
+        Annotated::new(Frame {
+            filename: Annotated::new("foo 0".to_string()),
+            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
+            context_line: Annotated::new("b".to_string()),
+            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
+            ..Default::default()
+        }),
+        Annotated::new(Frame {
+            filename: Annotated::new("foo 1".to_string()),
+            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
+            context_line: Annotated::new("b".to_string()),
+            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
+            ..Default::default()
+        }),
+        Annotated::new(Frame {
+            filename: Annotated::new("foo 2".to_string()),
+            context_line: Annotated::new("b".to_string()),
+            ..Default::default()
+        }),
+        Annotated::new(Frame {
+            filename: Annotated::new("foo 3".to_string()),
+            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
+            context_line: Annotated::new("b".to_string()),
+            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
+            ..Default::default()
+        }),
+        Annotated::new(Frame {
+            filename: Annotated::new("foo 4".to_string()),
+            pre_context: Annotated::new(vec![Annotated::new("a".to_string())]),
+            context_line: Annotated::new("b".to_string()),
+            post_context: Annotated::new(vec![Annotated::new("c".to_string())]),
+            ..Default::default()
+        }),
+    ];
+
+    assert_eq_dbg!(frames, expected);
 }


### PR DESCRIPTION
This is done such that stacktraces are trimmed after processing (most
importantly minidump processing)

https://github.com/getsentry/symbolicator/pull/95 is related