### PR TITLE
fix(general): Match user agent normalization in Sentry

### DIFF
--- a/general/src/filter/browser_extensions.rs
+++ b/general/src/filter/browser_extensions.rs
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_when_disabled() {
+    fn test_dont_filter_when_disabled() {
         let events = [
             get_event_with_exception_source("https://fscr.kaspersky-labs.com/B-9B72-7B7/main.js"),
             get_event_with_exception_value("fb_xd_fragment"),
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_events_with_known_browser_extension_source() {
+    fn test_filter_known_browser_extension_source() {
         let sources = [
             "https://graph.facebook.com/",
             "https://connect.facebook.net/en_US/sdk.js",
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_events_with_known_browser_extension_values() {
+    fn test_filter_known_browser_extension_values() {
         let exceptions = [
             "what does conduitPage even do",
             "null is not an object (evaluating 'elt.parentNode')",
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_with_unkown_browser_extenstion_source_or_value() {
+    fn test_dont_filter_unkown_browser_extension() {
         let events = [
             get_event_with_exception_source("https://some/resonable/source.js"),
             get_event_with_exception_value("some perfectly reasonable value"),

--- a/general/src/filter/legacy_browsers.rs
+++ b/general/src/filter/legacy_browsers.rs
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_if_filter_is_disabled() {
+    fn test_dont_filter_when_disabled() {
         let evt = testutils::get_event_with_user_agent(IE8_UA);
         let filter_result = should_filter(
             &evt,
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_default_browsers_when_default_option_is_specified() {
+    fn test_filter_default_browsers() {
         for old_user_agent in &[
             IE9_UA,
             IE_MOBILE9_UA,
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn default_filter_should_not_filter_browsers_above_the_minimum_required_versions() {
+    fn test_dont_filter_default_above_minimum_versions() {
         for old_user_agent in &[
             IE10_UA,
             SAFARI_6_UA,
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_the_events_from_browsers_that_are_configured() {
+    fn test_filter_configured_browsers() {
         let test_configs = [
             (
                 IE10_UA,
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_the_events_from_browsers_that_are_not_configured() {
+    fn test_dont_filter_unconfigured_browsers() {
         let test_configs = [
             (IE11_UA, LegacyBrowser::Ie10),
             (IE10_UA, LegacyBrowser::Ie9),
@@ -355,7 +355,7 @@ mod tests {
             "Opera/9.80 (J2ME/MIDP; Opera Mini/7.0.32796/59.323; U; fr) Presto/2.12.423 Version/12.16";
 
         #[test]
-        fn it_should_filter_user_agents_in_the_same_way_as_sentry() {
+        fn test_filter_sentry_user_agents() {
             let test_configs = [
                 (ANDROID2_S_UA, LegacyBrowser::Default),
                 (IE9_S_UA, LegacyBrowser::Default),
@@ -396,7 +396,7 @@ mod tests {
         }
 
         #[test]
-        fn it_should_not_filter_user_agents_in_the_same_way_as_sentry() {
+        fn test_dont_filter_sentry_allowed_user_agents() {
             let test_configs = [
                 (ANDROID4_S_UA, LegacyBrowser::Default),
                 (IE10_S_UA, LegacyBrowser::Default),

--- a/general/src/filter/localhost.rs
+++ b/general/src/filter/localhost.rs
@@ -70,7 +70,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_if_filter_is_disabled() {
+    fn test_dont_filter_when_disabled() {
         for event in &[
             get_event_with_ip_addr("127.0.0.1"),
             get_event_with_domain("localhost"),
@@ -85,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_events_with_local_ip() {
+    fn test_filter_local_ip() {
         for ip_addr in &["127.0.0.1", "::1"] {
             let event = get_event_with_ip_addr(ip_addr);
             let filter_result = should_filter(&event, &test_utils::get_f_config(true));
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_with_non_local_ip() {
+    fn test_dont_filter_non_local_ip() {
         for ip_addr in &["133.12.12.1", "2001:db8:0:0:0:ff00:42:8329"] {
             let event = get_event_with_ip_addr(ip_addr);
             let filter_result = should_filter(&event, &test_utils::get_f_config(true));
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_with_missing_ip_or_domains() {
+    fn test_dont_filter_missing_ip_or_domains() {
         let event = Event::default();
         let filter_result = should_filter(&event, &test_utils::get_f_config(true));
         assert_eq!(
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_events_with_local_domains() {
+    fn test_filter_local_domains() {
         for domain in &["127.0.0.1", "localhost"] {
             let event = get_event_with_domain(domain);
             let filter_result = should_filter(&event, &test_utils::get_f_config(true));
@@ -138,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_with_non_local_domains() {
+    fn test_dont_filter_non_local_domains() {
         for domain in &["my.dom.com", "123.123.123.44"] {
             let event = get_event_with_domain(domain);
             let filter_result = should_filter(&event, &test_utils::get_f_config(true));

--- a/general/src/filter/web_crawlers.rs
+++ b/general/src/filter/web_crawlers.rs
@@ -55,7 +55,7 @@ mod tests {
     use crate::testutils;
 
     #[test]
-    fn it_should_not_filter_events_when_disabled() {
+    fn test_filter_when_disabled() {
         let evt = testutils::get_event_with_user_agent("Googlebot");
         let filter_result = should_filter(&evt, &test_utils::get_f_config(false));
         assert_eq!(
@@ -66,7 +66,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_filter_events_from_banned_user_agents() {
+    fn test_filter_banned_user_agents() {
         let user_agents = [
             "Mediapartners-Google",
             "AdsBot-Google",
@@ -104,7 +104,7 @@ mod tests {
     }
 
     #[test]
-    fn it_should_not_filter_events_from_normal_user_agents() {
+    fn test_dont_filter_normal_user_agents() {
         for user_agent in &["some user agent", "IE", "ie", "opera", "safari"] {
             let event = testutils::get_event_with_user_agent(user_agent);
             let filter_result = should_filter(&event, &test_utils::get_f_config(true));

--- a/general/src/store/normalize/user_agent.rs
+++ b/general/src/store/normalize/user_agent.rs
@@ -124,21 +124,21 @@ mod tests {
     }
 
     #[test]
-    fn test_events_without_user_agents_should_not_add_contexts() {
+    fn test_skip_no_user_agent() {
         let mut event = Event::default();
         normalize_user_agent(&mut event);
         assert_eq!(event.contexts.value(), None);
     }
 
     #[test]
-    fn test_events_with_unrecognizable_user_agents_should_not_add_contexts() {
+    fn test_skip_unrecognizable_user_agent() {
         let mut event = testutils::get_event_with_user_agent("a dont no");
         normalize_user_agent(&mut event);
         assert_eq!(event.contexts.value(), None);
     }
 
     #[test]
-    fn test_a_user_agent_with_browser_information_fills_the_browser_context_in() {
+    fn test_browser_context() {
         let ua = "Mozilla/5.0 (-; -; -) - Chrome/18.0.1025.133 Mobile Safari/535.19";
 
         let mut event = testutils::get_event_with_user_agent(ua);
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn test_a_user_agent_with_os_information_fills_the_os_context_in() {
+    fn test_os_context() {
         let ua = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) - -";
 
         let mut event = testutils::get_event_with_user_agent(ua);
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_a_user_agent_with_short_os_version() {
+    fn test_os_context_short_version() {
         let ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) - (-)";
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_a_user_agent_with_full_os_version() {
+    fn test_os_context_full_version() {
         let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) - (-)";
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
@@ -213,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    fn test_a_user_agent_with_device_information_fills_the_device_context_in() {
+    fn test_device_context() {
         let ua = "- (-; -; Galaxy Nexus Build/IMM76B) - (-) ";
 
         let mut event = testutils::get_event_with_user_agent(ua);
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn test_a_user_agent_with_all_info_fills_everything_in() {
+    fn test_all_contexts() {
         let mut event = testutils::get_event_with_user_agent(GOOD_UA);
         normalize_user_agent(&mut event);
         assert_annotated_matches!(event.contexts, @r###"
@@ -257,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_agent_does_not_override_already_pre_filled_event_info() {
+    fn test_user_agent_does_not_override_prefilled() {
         let mut event = testutils::get_event_with_user_agent(GOOD_UA);
         let mut contexts = Contexts::new();
         contexts.add(Context::Browser(Box::new(BrowserContext {

--- a/general/src/testutils.rs
+++ b/general/src/testutils.rs
@@ -35,6 +35,44 @@ macro_rules! assert_eq_dbg {
     };
 }
 
+macro_rules! assert_annotated_matches {
+    ($value:expr, @$snapshot:literal) => {
+        ::insta::assert_snapshot_matches!(
+            $value.to_json_pretty().unwrap(),
+            stringify!($value),
+            @$snapshot
+        )
+    };
+    ($value:expr, $debug_expr:expr, @$snapshot:literal) => {
+        ::insta::assert_snapshot_matches!(
+            $value.to_json_pretty().unwrap(),
+            $debug_expr,
+            @$snapshot
+        )
+    };
+    ($name:expr, $value:expr) => {
+        ::insta::assert_snapshot_matches!(
+            $name,
+            $value.to_json_pretty().unwrap(),
+            stringify!($value)
+        )
+    };
+    ($name:expr, $value:expr, $debug_expr:expr) => {
+        ::insta::assert_snapshot_matches!(
+            $name,
+            $value.to_json_pretty().unwrap(),
+            $debug_expr
+        )
+    };
+    ($value:expr) => {
+        ::insta::assert_snapshot_matches!(
+            None::<String>,
+            $value.to_json_pretty().unwrap(),
+            stringify!($value)
+        )
+    };
+}
+
 /// Creates an Event with the specified user agent.
 pub(super) fn get_event_with_user_agent(user_agent: &str) -> Event {
     let mut headers = Vec::new();


### PR DESCRIPTION
This fixes a bug when parsing version strings from user agents. Sentry skips empty version components (e.g. a missing patch), whereas we output dots.

Note that Sentry had potentially invalid behavior. A version `1..2` would be formatted as `"1.2"`, whereas we now output just `"1"`, as it is more correct.