### PR TITLE
ref: Make uaparser optional

### DIFF
--- a/general/Cargo.toml
+++ b/general/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.98", features = ["derive"] }
 serde_json = "1.0.40"
 serde_urlencoded = "0.5.5"
 smallvec = { version = "0.6.10", features = ["serde"] }
-uaparser = "0.3.1"
+uaparser = { version = "0.3.1", optional = true }
 url = "2.0.0"
 uuid = { version = "0.7.4", features = ["v4", "serde"] }
 
@@ -37,3 +37,4 @@ insta = "0.10.1"
 
 [features]
 bench = []
+default = ["uaparser"]

--- a/general/src/filter/mod.rs
+++ b/general/src/filter/mod.rs
@@ -18,10 +18,14 @@ mod common;
 mod config;
 mod csp;
 mod error_messages;
+
+#[cfg(feature = "uaparser")]
 mod legacy_browsers;
+#[cfg(feature = "uaparser")]
+mod web_crawlers;
+
 mod localhost;
 mod releases;
-mod web_crawlers;
 
 #[cfg(test)]
 mod test_utils;
@@ -47,8 +51,11 @@ pub fn should_filter(
     error_messages::should_filter(event, &config.error_messages)?;
     localhost::should_filter(event, &config.localhost)?;
     browser_extensions::should_filter(event, &config.browser_extensions)?;
-    legacy_browsers::should_filter(event, &config.legacy_browsers)?;
-    web_crawlers::should_filter(event, &config.web_crawlers)?;
+    #[cfg(feature = "uaparser")]
+    {
+        legacy_browsers::should_filter(event, &config.legacy_browsers)?;
+        web_crawlers::should_filter(event, &config.web_crawlers)?;
+    }
 
     Ok(())
 }

--- a/general/src/lib.rs
+++ b/general/src/lib.rs
@@ -21,4 +21,5 @@ pub mod protocol;
 pub mod store;
 pub mod types;
 
+#[cfg(feature = "uaparser")]
 mod user_agent;

--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -25,6 +25,8 @@ mod logentry;
 mod mechanism;
 mod request;
 mod stacktrace;
+
+#[cfg(feature = "uaparser")]
 mod user_agent;
 
 /// Validate fields that go into a `sentry.models.BoundedIntegerField`.
@@ -287,9 +289,13 @@ impl<'a> NormalizeProcessor<'a> {
         }
     }
 
-    fn normalize_user_agent(&self, event: &mut Event) {
+    fn normalize_user_agent(&self, _event: &mut Event) {
         if self.config.normalize_user_agent.unwrap_or(false) {
-            user_agent::normalize_user_agent(event);
+            #[cfg(feature = "uaparser")]
+            user_agent::normalize_user_agent(_event);
+
+            #[cfg(not(feature = "uaparser"))]
+            panic!("semaphore not built with uaparser feature");
         }
     }
 }

--- a/general/src/testutils.rs
+++ b/general/src/testutils.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "uaparser")]
 use crate::protocol::{Event, Headers, PairList, Request};
+#[cfg(feature = "uaparser")]
 use crate::types::Annotated;
 
 macro_rules! assert_eq_str {
@@ -35,6 +37,7 @@ macro_rules! assert_eq_dbg {
     };
 }
 
+#[cfg(feature = "uaparser")]
 macro_rules! assert_annotated_matches {
     ($value:expr, @$snapshot:literal) => {
         ::insta::assert_snapshot_matches!(
@@ -73,6 +76,7 @@ macro_rules! assert_annotated_matches {
     };
 }
 
+#[cfg(feature = "uaparser")]
 /// Creates an Event with the specified user agent.
 pub(super) fn get_event_with_user_agent(user_agent: &str) -> Event {
     let mut headers = Vec::new();


### PR DESCRIPTION
uaparser does not compile on wasm targets, and I want to get semaphore running in piinguin again