### PR TITLE
fix: Still write user-agent when os-context conflicts

### DIFF
--- a/general/src/protocol/contexts.rs
+++ b/general/src/protocol/contexts.rs
@@ -420,6 +420,12 @@ impl std::ops::DerefMut for ContextInner {
     }
 }
 
+impl From<Context> for ContextInner {
+    fn from(c: Context) -> ContextInner {
+        ContextInner(c)
+    }
+}
+
 /// An object holding multiple contexts.
 #[derive(Clone, Debug, PartialEq, Empty, ToValue, ProcessValue, Default)]
 pub struct Contexts(pub Object<ContextInner>);

--- a/general/src/store/normalize/user_agent.rs
+++ b/general/src/store/normalize/user_agent.rs
@@ -53,7 +53,7 @@ pub fn normalize_user_agent(event: &mut Event) {
     //
     // Why not move the existing `contexts.os` into a different key on conflicts? Because we still
     // want to index (derive tags from) the SDK-sent context.
-    let os_context_key = match event.platform.value().map(|x| x.as_str()) {
+    let os_context_key = match event.platform.as_str() {
         Some("javascript") => OsContext::default_key(),
         _ => "client_os",
     };


### PR DESCRIPTION
## Problem

The `os` context is defined as "the OS of the device that sent the event" in the docs. Previously the server backfilled the `os` context based on the User-Agent *only* for JS events.

We recently changed this ([https://github.com/getsentry/sentry/pull/10679](https://github.com/getsentry/sentry/pull/10679)) to do this for all events from all platforms. Therefore we can no longer have certainty which device the OS context is referring to: For SDKs that send OS contexts, it likely refers to the device where the event originated, as the docs define. For SDKs that do not send OS contexts, it can be whatever is in the user-agent.

As a concrete example:

- PHP sends an OS context. Therefore the OS context refers to the server's OS.
- Python does not send an OS context. Therefore the OS context refers to the HTTP client's OS.

*However*, the way the UI displays things makes it confusing. There, the browser context and OS context are pulled together and shown in one line:

![context](https://user-images.githubusercontent.com/837573/63757381-3dee2400-c8ba-11e9-8650-8d0e7abf2c73.png)


This makes users expect something that is the opposite of what the interface docs suggest: The OS context (the one stored in the `os` key) is expected to refer to the client device.

## Solution

* Write user-agent derived OS context into a different key for anything but JS.
* Prefer `client_os` over `os` for this bar (keep fallback to `os` for JS).

This needs to be deployed **AFTER** the UI knows to prefer `client_os` over `os` for this bar.