### PR TITLE
fix: Do not always set user ip

### DIFF
--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -241,7 +241,7 @@ impl<'a> NormalizeProcessor<'a> {
             .and_then(|env| env.get("REMOTE_ADDR"))
             .and_then(Annotated::<Value>::as_str)
             .and_then(|ip| IpAddr::parse(ip).ok())
-            .or(self.config.client_ip.clone());
+            .or_else(|| self.config.client_ip.clone());
 
         if let Some(ip_address) = ip_address {
             let platform = event.platform.value().map(String::as_str);

--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -254,6 +254,7 @@ impl<'a> NormalizeProcessor<'a> {
                 .unwrap_or(false);
             let is_missing = user.ip_address.value().is_none();
 
+            // In an ideal world all SDKs would set {{auto}} explicitly.
             let set_if_missing = match platform {
                 Some("javascript") | Some("cocoa") | Some("objc") => true,
                 _ => false,

--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -666,13 +666,10 @@ fn test_user_ip_from_remote_addr() {
         ..Event::default()
     });
 
-    let mut processor = NormalizeProcessor::new(
-        Arc::new(StoreConfig {
-            valid_platforms: Some("javascript".to_owned()).into_iter().collect(),
-            ..Default::default()
-        }),
-        None,
-    );
+    let mut config = StoreConfig::default();
+    config.valid_platforms.insert("javascript".to_owned());
+
+    let mut processor = NormalizeProcessor::new(Arc::new(config), None);
     process_value(&mut event, &mut processor, ProcessingState::root());
 
     let user = event

--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -244,7 +244,7 @@ impl<'a> NormalizeProcessor<'a> {
             .or_else(|| self.config.client_ip.clone());
 
         if let Some(ip_address) = ip_address {
-            let platform = event.platform.value().map(String::as_str);
+            let platform = event.platform.as_str();
             let user = event.user.value_mut().get_or_insert_with(User::default);
 
             let is_auto = user

--- a/general/tests/snapshots/test_fixtures__dotnet-2.snap
+++ b/general/tests/snapshots/test_fixtures__dotnet-2.snap
@@ -177,8 +177,6 @@ timestamp: "[timestamp]"
 received: "[received]"
 release: e386dfd
 environment: Production
-user:
-  ip_address: "::1"
 request:
   url: /Home/PostIndex
   method: POST


### PR DESCRIPTION
This reverts a decision made in #171. Users started complaining about server IP addresses cluttering their sentry events.

The list of platforms is restored from the old Python code.