### PR TITLE
fix: Actually restore datascrubbing defaults

### DIFF
--- a/general/src/datascrubbing/config.rs
+++ b/general/src/datascrubbing/config.rs
@@ -61,10 +61,10 @@ impl Default for DataScrubbingConfig {
     fn default() -> DataScrubbingConfig {
         DataScrubbingConfig {
             exclude_fields: Default::default(),
-            scrub_data: true,
-            scrub_ip_addresses: true,
+            scrub_data: false,
+            scrub_ip_addresses: false,
             sensitive_fields: Default::default(),
-            scrub_defaults: true,
+            scrub_defaults: false,
             pii_config: AtomicLazyCell::new(),
         }
     }

--- a/general/src/datascrubbing/convert.rs
+++ b/general/src/datascrubbing/convert.rs
@@ -166,6 +166,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     }
 
     #[test]
+    fn test_datascrubbing_default() {
+        insta::assert_json_snapshot!(to_pii_config(&Default::default()), @"null");
+    }
+
+    #[test]
     fn test_convert_default_pii_config() {
         insta::assert_json_snapshot!(simple_enabled_pii_config(), @r###"
         {


### PR DESCRIPTION
https://github.com/getsentry/semaphore/pull/227/commits/71531c006841d8218c6fda406cfddd66c8aa9263 was incorrectly committed -- it intended to disable PII stripping by default, but actually didn't.