### PR TITLE
deploy: Upload source bundles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ ENV OPENSSL_STATIC=1
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-      curl build-essential git zip \
-      # For librdkafka
-      libclang-3.9-dev clang-3.9 \
+    curl build-essential git zip \
+    # For librdkafka
+    libclang-3.9-dev clang-3.9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -41,7 +41,7 @@ RUN echo "Building zlib" \
     && sha256sum -c checksums.txt \
     && tar xzf zlib-$ZLIB_VERS.tar.gz && cd zlib-$ZLIB_VERS \
     && ./configure --static --archs="-fPIC" --prefix=$PREFIX_DIR \
-    && make && make install \
+    && make -j$(nproc) && make install \
     && cd .. && rm -rf zlib-$ZLIB_VERS.tar.gz zlib-$ZLIB_VERS checksums.txt
 
 RUN echo "Building OpenSSL" \
@@ -55,27 +55,31 @@ RUN echo "Building OpenSSL" \
     && tar xzf openssl-$OPENSSL_VERS.tar.gz && cd openssl-$OPENSSL_VERS \
     && ./Configure $OPENSSL_ARCH -fPIC --prefix=$PREFIX_DIR \
     && make depend \
-    && make && make install \
+    && make -j$(nproc) && make install \
     && cd .. && rm -rf openssl-$OPENSSL_VERS.tar.gz openssl-$OPENSSL_VERS checksums.txt
 
 #####################
 ### Builder stage ###
 #####################
 
+FROM getsentry/sentry-cli:1.47.1 AS sentry-cli
 FROM semaphore-deps AS semaphore-builder
 
+COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 COPY . .
 
+# TODO remove this
 RUN make init-submodules
 
-RUN cargo build --release --locked --all-features --target $BUILD_TARGET
-
-RUN bash -c 'objcopy --only-keep-debug target/${BUILD_TARGET}/release/semaphore{,.debug} \
-    && objcopy --strip-debug --strip-unneeded target/${BUILD_TARGET}/release/semaphore \
-    && objcopy --add-gnu-debuglink target/${BUILD_TARGET}/release/semaphore{.debug,}'
+# BUILD IT!
+RUN make build-linux-release TARGET=${BUILD_TARGET}
 
 RUN cp ./target/$BUILD_TARGET/release/semaphore /bin/semaphore \
     && zip /opt/semaphore-debug.zip target/$BUILD_TARGET/release/semaphore.debug
+
+# Collect source bundle
+RUN sentry-cli difutil bundle-sources ./target/$BUILD_TARGET/release/semaphore.debug \
+    && mv ./target/$BUILD_TARGET/release/semaphore.src.zip /opt/semaphore.src.zip
 
 ###################
 ### Final stage ###
@@ -104,7 +108,7 @@ WORKDIR /work
 EXPOSE 3000
 
 COPY --from=semaphore-builder /bin/semaphore /bin/semaphore
-COPY --from=semaphore-builder /opt/semaphore-debug.zip /opt/semaphore-debug.zip
+COPY --from=semaphore-builder /opt/semaphore-debug.zip /opt/semaphore.src.zip /opt/
 
 COPY ./docker-entrypoint.sh /
 ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,14 +62,11 @@ RUN echo "Building OpenSSL" \
 ### Builder stage ###
 #####################
 
-FROM getsentry/sentry-cli:1.47.1 AS sentry-cli
+FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM semaphore-deps AS semaphore-builder
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 COPY . .
-
-# TODO remove this
-RUN make init-submodules
 
 # BUILD IT!
 RUN make build-linux-release TARGET=${BUILD_TARGET}
@@ -78,7 +75,8 @@ RUN cp ./target/$BUILD_TARGET/release/semaphore /bin/semaphore \
     && zip /opt/semaphore-debug.zip target/$BUILD_TARGET/release/semaphore.debug
 
 # Collect source bundle
-RUN sentry-cli difutil bundle-sources ./target/$BUILD_TARGET/release/semaphore.debug \
+RUN sentry-cli --version \
+    && sentry-cli difutil bundle-sources ./target/$BUILD_TARGET/release/semaphore.debug \
     && mv ./target/$BUILD_TARGET/release/semaphore.src.zip /opt/semaphore.src.zip
 
 ###################

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -24,9 +24,8 @@ docker pull "${DOCKER_IMAGE}"
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/semaphore-debug.zip > semaphore-debug.zip
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/semaphore.src.zip > semaphore.src.zip
 
-# TODO!
 echo 'Uploading debug information and source bundle...'
-sentry-cli upload-dif ./semaphore-debug.zip
+sentry-cli upload-dif ./semaphore-debug.zip ./semaphore.src.zip
 
 echo 'Creating a new deploy in Sentry...'
 sentry-cli releases new "${VERSION}"

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -24,7 +24,8 @@ docker pull "${DOCKER_IMAGE}"
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/semaphore-debug.zip > semaphore-debug.zip
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/semaphore.src.zip > semaphore.src.zip
 
-echo 'Uploading debug information...'
+# TODO!
+echo 'Uploading debug information and source bundle...'
 sentry-cli upload-dif ./semaphore-debug.zip
 
 echo 'Creating a new deploy in Sentry...'

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -20,7 +20,9 @@ fi
 
 echo 'Pulling debug information from semaphore image...'
 docker pull "${DOCKER_IMAGE}"
+
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/semaphore-debug.zip > semaphore-debug.zip
+docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/semaphore.src.zip > semaphore.src.zip
 
 echo 'Uploading debug information...'
 sentry-cli upload-dif ./semaphore-debug.zip


### PR DESCRIPTION
Should work after a new version of sentry-cli  (>1.47.1) is released.