### PR TITLE
build(docker): Build all features for the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,14 @@ RUN echo "Building OpenSSL" \
 FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM semaphore-deps AS semaphore-builder
 
+ARG SEMAPHORE_FEATURES=with_ssl,processing
+ENV SEMAPHORE_FEATURES=${SEMAPHORE_FEATURES}
+
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 COPY . .
 
 # BUILD IT!
-RUN make build-linux-release TARGET=${BUILD_TARGET}
+RUN make build-linux-release TARGET=${BUILD_TARGET} SEMAPHORE_FEATURES=${SEMAPHORE_FEATURES}
 
 RUN cp ./target/$BUILD_TARGET/release/semaphore /bin/semaphore \
     && zip /opt/semaphore-debug.zip target/$BUILD_TARGET/release/semaphore.debug

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL=/bin/bash
 export SEMAPHORE_PYTHON_VERSION := python3
+export SEMAPHORE_FEATURES := with_ssl
 
 all: check test
 .PHONY: all
@@ -21,7 +22,7 @@ build: setup-git
 .PHONY: build
 
 release: setup-git
-	@cargo +stable build --release --locked --features with_ssl
+	@cargo +stable build --release --locked --features ${SEMAPHORE_FEATURES}
 .PHONY: release
 
 docker: setup-git
@@ -29,7 +30,7 @@ docker: setup-git
 .PHONY: docker
 
 build-linux-release: setup-git
-	cargo build --release --locked --features with_ssl --target=${TARGET}
+	cargo build --release --locked --features ${SEMAPHORE_FEATURES} --target=${TARGET}
 	objcopy --only-keep-debug target/${TARGET}/release/semaphore{,.debug}
 	objcopy --strip-debug --strip-unneeded target/${TARGET}/release/semaphore
 	objcopy --add-gnu-debuglink target/${TARGET}/release/semaphore{.debug,}

--- a/scripts/docker-build-linux.sh
+++ b/scripts/docker-build-linux.sh
@@ -33,7 +33,7 @@ DOCKER_RUN_OPTS="
 
 # And now build the project
 docker run $DOCKER_RUN_OPTS \
-  make build-linux-release
+  make build-linux-release SEMAPHORE_FEATURES="${SEMAPHORE_FEATURES}"
 
 # Smoke test
 docker run $DOCKER_RUN_OPTS \


### PR DESCRIPTION
Fixes a regression in #244 which caused the docker build to miss the processing feature.

In the future, we'll distribute two containers: One for regular Relays, and one for relays with processing enabled.
