### PR TITLE
feat: Healthcheck for processing mode

### DIFF
--- a/server/src/endpoints/healthcheck.rs
+++ b/server/src/endpoints/healthcheck.rs
@@ -15,6 +15,24 @@ struct HealthcheckResponse {
     is_healthy: bool,
 }
 
+impl HealthcheckResponse {
+    fn healthy() -> Self {
+        Self { is_healthy: true }
+    }
+
+    fn unhealthy() -> Self {
+        Self { is_healthy: false }
+    }
+
+    fn into_response(self) -> HttpResponse {
+        if self.is_healthy {
+            HttpResponse::Ok().json(self)
+        } else {
+            HttpResponse::ServiceUnavailable().json(self)
+        }
+    }
+}
+
 #[allow(clippy::needless_pass_by_value)]
 fn healthcheck(state: CurrentServiceState) -> ResponseFuture<HttpResponse, Error> {
     Box::new(
@@ -24,20 +42,35 @@ fn healthcheck(state: CurrentServiceState) -> ResponseFuture<HttpResponse, Error
             .map_err(|_| ())
             .and_then(move |is_authenticated| {
                 if is_authenticated {
-                    Ok(HttpResponse::Ok().json(HealthcheckResponse { is_healthy: true }))
+                    Ok(HealthcheckResponse::healthy().into_response())
                 } else {
                     Err(())
                 }
             })
-            .or_else(|_| {
-                Ok(HttpResponse::ServiceUnavailable()
-                    .json(HealthcheckResponse { is_healthy: false }))
-            }),
+            .or_else(|_| Ok(HealthcheckResponse::unhealthy().into_response())),
     )
 }
 
+#[cfg(feature = "processing")]
+#[allow(clippy::needless_pass_by_value)]
+fn healthcheck_processing(state: CurrentServiceState) -> ResponseFuture<HttpResponse, Error> {
+    if state.config().processing_enabled() {
+        healthcheck(state)
+    } else {
+        Box::new(futures::future::ok(
+            HealthcheckResponse::unhealthy().into_response(),
+        ))
+    }
+}
+
 pub fn configure_scope(scope: Scope<ServiceState>) -> Scope<ServiceState> {
-    scope.resource("/healthcheck/", |r| {
+    let scope = scope.resource("/healthcheck/", |r| {
         r.method(Method::GET).with(healthcheck);
-    })
+    });
+
+    #[cfg(feature = "processing")]
+    let scope = scope.resource("/healthcheck_processing/", |r| {
+        r.method(Method::GET).with(healthcheck_processing);
+    });
+    scope
 }


### PR DESCRIPTION
This new healthcheck will not exist when building relay without "processing" feature, and will return a bad response when processing is disabled.