### PR TITLE
fix(general): Avoid a race condition in lazy cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,6 @@ dependencies = [
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json-forensics 0.1.0 (git+https://github.com/getsentry/rust-json-forensics)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,7 +26,6 @@ failure = "0.1.5"
 flate2 = "1.0.9"
 futures = "0.1.28"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
-lazycell = "1.2.1"
 lazy_static = "1.3.0"
 listenfd = "0.3.3"
 log = "0.4.8"


### PR DESCRIPTION
Not proud of this.

`AtomicLazyCell` does not have a single function to get or insert an element. Instead, one has to call `fill` manually, which either returns `Ok`, or `Err` if someone else filled it already. Filling internally works like this:
 1. Acquire an atomic lock
 2. Fill the value
 3. Release the atomic lock

We need to account for the time between 1 and 2, in which `Err` is returned, but the cell is not filled yet.