### PR TITLE
fix: Always report test failures on master to sentry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ branches:
 before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable}
   - export PATH=~/.cargo/bin/:$PATH
+  - [ "$TRAVIS_BRANCH" != "master" ] || export PYTEST_SENTRY_ALWAYS_REPORT=1
 
 install: skip
 


### PR DESCRIPTION
pytest-sentry will report tests that have been observed to be flaky within a single test run. However, we have tests that work on the PR branch but fail in master. Let's additionally report every test failure on master.

This should help with debugging flaky builds. Unfortunately Travis deletes logs when a job is restarted, but if we still have data in Sentry maybe that helps.