### PR TITLE
feat: Per-key quotas

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -24,7 +24,7 @@ use crate::actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
 use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
 use crate::actors::project::{
     EventAction, GetEventAction, GetProjectId, GetProjectState, Project, ProjectError,
-    ProjectState, RetryAfter,
+    ProjectState, RateLimited, RetryAfter, RetryAfterScope,
 };
 use crate::actors::upstream::{SendRequest, UpstreamRelay, UpstreamRequestError};
 use crate::extractors::EventMeta;
@@ -79,7 +79,7 @@ enum ProcessingError {
     StoreFailed(#[cause] StoreError),
 
     #[fail(display = "sending failed due to rate limit: {:?}", _0)]
-    RateLimited(RetryAfter),
+    RateLimited(RateLimited),
 
     #[fail(display = "failed to apply quotas")]
     QuotasFailed(#[cause] QuotasError),
@@ -197,7 +197,11 @@ impl EventProcessor {
                     .map_err(ProcessingError::QuotasFailed)?;
 
                 if let Some(retry_after) = rate_limit {
-                    return Err(ProcessingError::RateLimited(retry_after));
+                    // TODO: Use quota prefix to determine scope
+                    return Err(ProcessingError::RateLimited(RateLimited(
+                        RetryAfterScope::Key(key_config.public_key.clone()),
+                        retry_after,
+                    )));
                 }
             }
         }
@@ -572,6 +576,8 @@ impl Handler<HandleEvent> for EventManager {
                             return Box::new(Ok(()).into_future()) as ResponseFuture<_, _>;
                         }
 
+                        let public_key = meta.auth().public_key().to_string();
+
                         log::trace!("sending event to sentry endpoint {}", event_id);
                         let request = SendRequest::post(format!("/api/{}/store/", project_id))
                             .build(move |builder| {
@@ -592,10 +598,15 @@ impl Handler<HandleEvent> for EventManager {
                             .and_then(move |result| {
                                 result.map_err(move |error| match error {
                                     UpstreamRequestError::RateLimited(secs) => {
-                                        ProcessingError::RateLimited(RetryAfter {
-                                            when: Instant::now() + Duration::from_secs(secs),
-                                            reason_code: None,
-                                        })
+                                        ProcessingError::RateLimited(RateLimited(
+                                            // TODO: Maybe add a header that tells us the value for
+                                            // RetryAfterScope?
+                                            RetryAfterScope::Key(public_key),
+                                            RetryAfter {
+                                                when: Instant::now() + Duration::from_secs(secs),
+                                                reason_code: None,
+                                            }
+                                        ))
                                     }
                                     other => ProcessingError::SendFailed(other),
                                 })

--- a/server/src/actors/outcome.rs
+++ b/server/src/actors/outcome.rs
@@ -14,7 +14,7 @@ use semaphore_common::Config;
 use semaphore_general::filter::FilterStatKey;
 use semaphore_general::protocol::EventId;
 
-use crate::actors::project::RateLimited;
+use crate::actors::project::RateLimit;
 use crate::ServerError;
 
 // Choose the outcome module implementation (either the real one or the fake, no-op one).
@@ -64,7 +64,7 @@ pub enum Outcome {
     Filtered(FilterStatKey),
 
     /// The event has been rate limited.
-    RateLimited(RateLimited),
+    RateLimited(RateLimit),
 
     /// The event has been discarded because of invalid data.
     Invalid(DiscardReason),
@@ -155,9 +155,7 @@ mod real_implementation {
                 Outcome::Accepted => None,
                 Outcome::Invalid(discard_reason) => Some(discard_reason.name()),
                 Outcome::Filtered(filter_key) => Some(filter_key.name()),
-                Outcome::RateLimited(rate_limited) => {
-                    rate_limited.1.reason_code.as_ref().map(String::as_str)
-                }
+                Outcome::RateLimited(rate_limit) => rate_limit.reason_code(),
                 Outcome::Abuse => None,
             }
         }

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -16,7 +16,7 @@ use semaphore_common::{metric, tryf, ProjectId, ProjectIdParseError};
 use semaphore_general::protocol::EventId;
 
 use crate::actors::events::{EventError, QueueEvent};
-use crate::actors::project::{EventAction, GetEventAction, GetProject, ProjectError, RetryAfter};
+use crate::actors::project::{EventAction, GetEventAction, GetProject, ProjectError, RateLimited};
 use crate::body::{StoreBody, StorePayloadError};
 use crate::extractors::{EventMeta, StartTime};
 use crate::service::{ServiceApp, ServiceState};
@@ -45,7 +45,7 @@ pub enum BadStoreRequest {
     PayloadError(#[cause] StorePayloadError),
 
     #[fail(display = "event rejected due to rate limit: {:?}", _0)]
-    RateLimited(RetryAfter),
+    RateLimited(RateLimited),
 
     #[fail(display = "event submission rejected with_reason:{:?}", _0)]
     EventRejected(DiscardReason),
@@ -56,7 +56,7 @@ impl ResponseError for BadStoreRequest {
         let body = ApiErrorResponse::from_fail(self);
 
         match self {
-            BadStoreRequest::RateLimited(retry_after) => {
+            BadStoreRequest::RateLimited(RateLimited(_, retry_after)) => {
                 // For rate limits, we return a special status code and indicate the client to hold
                 // off until the rate limit period has expired. Currently, we only support the
                 // delay-seconds variant of the Rate-Limit header.

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -16,7 +16,7 @@ use semaphore_common::{metric, tryf, ProjectId, ProjectIdParseError};
 use semaphore_general::protocol::EventId;
 
 use crate::actors::events::{EventError, QueueEvent};
-use crate::actors::project::{EventAction, GetEventAction, GetProject, ProjectError, RateLimited};
+use crate::actors::project::{EventAction, GetEventAction, GetProject, ProjectError, RateLimit};
 use crate::body::{StoreBody, StorePayloadError};
 use crate::extractors::{EventMeta, StartTime};
 use crate::service::{ServiceApp, ServiceState};
@@ -45,7 +45,7 @@ pub enum BadStoreRequest {
     PayloadError(#[cause] StorePayloadError),
 
     #[fail(display = "event rejected due to rate limit: {:?}", _0)]
-    RateLimited(RateLimited),
+    RateLimited(RateLimit),
 
     #[fail(display = "event submission rejected with_reason:{:?}", _0)]
     EventRejected(DiscardReason),
@@ -80,7 +80,7 @@ impl ResponseError for BadStoreRequest {
         let body = ApiErrorResponse::from_fail(self);
 
         match self {
-            BadStoreRequest::RateLimited(RateLimited(_, retry_after)) => {
+            BadStoreRequest::RateLimited(RateLimit(_, retry_after)) => {
                 // For rate limits, we return a special status code and indicate the client to hold
                 // off until the rate limit period has expired. Currently, we only support the
                 // delay-seconds variant of the Rate-Limit header.

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -10,6 +10,8 @@ session = requests.session()
 class SentryLike(object):
     _healthcheck_passed = False
 
+    dsn_public_key = "31a5a894b4524f74a9a8d0e27e21ba91"
+
     @property
     def url(self):
         return "http://{}:{}".format(*self.server_address)
@@ -35,10 +37,6 @@ class SentryLike(object):
 
     def __repr__(self):
         return "<{}({})>".format(self.__class__.__name__, repr(self.upstream))
-
-    @property
-    def dsn_public_key(self):
-        return "31a5a894b4524f74a9a8d0e27e21ba91"
 
     @property
     def dsn(self):

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -272,13 +272,16 @@ def test_quotas(mini_sentry, relay_with_processing, kafka_consumer):
 
     mini_sentry.project_configs[42] = projectconfig = mini_sentry.full_project_config()
     public_keys = projectconfig['publicKeys']
-    single_key, = public_keys
-    single_key['quotas'] = quotas = [{
+    limited_key, = public_keys
+    limited_key['quotas'] = quotas = [{
         "prefix": "test_rate_limiting_{}".format(uuid.uuid4().hex),
         "limit": 5,
-        "window": 60,
+        "window": 3600,
         "reason_code": "get_lost"
     }]
+
+    second_key = {"publicKey": "31a5a894b4524f74a9a8d0e27e21ba92", "isEnabled": True, "numericId": 1234, "quotas": []}
+    public_keys.append(second_key)
 
     consumer = kafka_consumer("events")
 
@@ -292,3 +295,13 @@ def test_quotas(mini_sentry, relay_with_processing, kafka_consumer):
 
     message = consumer.poll(timeout=20)
     assert message is None
+
+    relay.dsn_public_key = second_key["publicKey"]
+
+    for _ in range(10):
+        relay.send_event(42, {"message": "some_message2"})
+
+    for _ in range(5):
+        message = consumer.poll(timeout=20)
+        assert message is not None
+        assert message.error() is None


### PR DESCRIPTION
When we rate limit a key through Redis, do not rate limit the entire
project. Store rate limits in ProjectState per-key.