### PR TITLE
ref(store): Add remote_addr to the Kafka message

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -547,6 +547,7 @@ impl Handler<HandleEvent> for EventManager {
                                         event_id,
                                         start_time,
                                         project_id,
+                                        remote_addr,
                                     })
                                     .map_err(ProcessingError::ScheduleFailed)
                                     .and_then(move |result| {

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -238,6 +238,8 @@ def test_when_processing_is_enabled_relay_normalizes_events_and_puts_them_in_kaf
     assert event_id is not None
     project_id = v.get('project_id')
     assert project_id is not None
+    remote_addr = v.get('remote_addr')
+    assert remote_addr is not None
 
     event = json.load(io.BytesIO(payload))
 


### PR DESCRIPTION
Adds `remote_addr` to `StoreEvent` and the Kafka message.

This will be required to emit the `event_accepted` signal in Sentry. See https://github.com/getsentry/sentry/pull/14863