### PR TITLE
ref(pii): Implement data scrubbing closer to legacy implementation

### DIFF
--- a/cabi/include/semaphore.h
+++ b/cabi/include/semaphore.h
@@ -3,11 +3,12 @@
 #ifndef SEMAPHORE_H_INCLUDED
 #define SEMAPHORE_H_INCLUDED
 
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdbool.h>
 
-/*
+/**
  * Represents all possible error codes
  */
 enum SemaphoreErrorCode {
@@ -24,19 +25,19 @@ typedef uint32_t SemaphoreErrorCode;
 
 typedef struct SemaphoreGeoIpLookup SemaphoreGeoIpLookup;
 
-/*
+/**
  * Represents a public key in semaphore.
  */
 typedef struct SemaphorePublicKey SemaphorePublicKey;
 
-/*
+/**
  * Represents a secret key in semaphore.
  */
 typedef struct SemaphoreSecretKey SemaphoreSecretKey;
 
 typedef struct SemaphoreStoreNormalizer SemaphoreStoreNormalizer;
 
-/*
+/**
  * Represents a buffer.
  */
 typedef struct {
@@ -45,7 +46,7 @@ typedef struct {
   bool owned;
 } SemaphoreBuf;
 
-/*
+/**
  * Represents a string.
  */
 typedef struct {
@@ -54,7 +55,7 @@ typedef struct {
   bool owned;
 } SemaphoreStr;
 
-/*
+/**
  * Represents a key pair from key generation.
  */
 typedef struct {
@@ -62,59 +63,56 @@ typedef struct {
   SemaphoreSecretKey *secret_key;
 } SemaphoreKeyPair;
 
-/*
+/**
  * Represents a uuid.
  */
 typedef struct {
   uint8_t data[16];
 } SemaphoreUuid;
 
-/*
+/**
  * Frees a semaphore buf.
- *
  * If the buffer is marked as not owned then this function does not
  * do anything.
  */
 void semaphore_buf_free(SemaphoreBuf *b);
 
-/*
+/**
  * Creates a challenge from a register request and returns JSON.
  */
 SemaphoreStr semaphore_create_register_challenge(const SemaphoreBuf *data,
                                                  const SemaphoreStr *signature,
                                                  uint32_t max_age);
 
-/*
+/**
  * Clears the last error.
  */
 void semaphore_err_clear(void);
 
-/*
+/**
  * Returns the panic information as string.
  */
 SemaphoreStr semaphore_err_get_backtrace(void);
 
-/*
+/**
  * Returns the last error code.
- *
  * If there is no error, 0 is returned.
  */
 SemaphoreErrorCode semaphore_err_get_last_code(void);
 
-/*
+/**
  * Returns the last error message.
- *
  * If there is no error an empty string is returned.  This allocates new memory
  * that needs to be freed with `semaphore_str_free`.
  */
 SemaphoreStr semaphore_err_get_last_message(void);
 
-/*
+/**
  * Generates a secret, public key pair.
  */
 SemaphoreKeyPair semaphore_generate_key_pair(void);
 
-/*
+/**
  * Randomly generates an relay id
  */
 SemaphoreUuid semaphore_generate_relay_id(void);
@@ -123,40 +121,40 @@ void semaphore_geoip_lookup_free(SemaphoreGeoIpLookup *lookup);
 
 SemaphoreGeoIpLookup *semaphore_geoip_lookup_new(const char *path);
 
-/*
+/**
  * Given just the data from a register response returns the
  * conained relay id without validating the signature.
  */
 SemaphoreUuid semaphore_get_register_response_relay_id(const SemaphoreBuf *data);
 
-/*
+/**
  * Initializes the library
  */
 void semaphore_init(void);
 
-/*
+/**
  * Frees a public key.
  */
 void semaphore_publickey_free(SemaphorePublicKey *spk);
 
-/*
+/**
  * Parses a public key from a string.
  */
 SemaphorePublicKey *semaphore_publickey_parse(const SemaphoreStr *s);
 
-/*
+/**
  * Converts a public key into a string.
  */
 SemaphoreStr semaphore_publickey_to_string(const SemaphorePublicKey *spk);
 
-/*
+/**
  * Verifies a signature
  */
 bool semaphore_publickey_verify(const SemaphorePublicKey *spk,
                                 const SemaphoreBuf *data,
                                 const SemaphoreStr *sig);
 
-/*
+/**
  * Verifies a signature
  */
 bool semaphore_publickey_verify_timestamp(const SemaphorePublicKey *spk,
@@ -164,22 +162,24 @@ bool semaphore_publickey_verify_timestamp(const SemaphorePublicKey *spk,
                                           const SemaphoreStr *sig,
                                           uint32_t max_age);
 
-/*
+SemaphoreStr semaphore_scrub_event(const SemaphoreStr *config, const SemaphoreStr *event);
+
+/**
  * Frees a secret key.
  */
 void semaphore_secretkey_free(SemaphoreSecretKey *spk);
 
-/*
+/**
  * Parses a secret key from a string.
  */
 SemaphoreSecretKey *semaphore_secretkey_parse(const SemaphoreStr *s);
 
-/*
+/**
  * Verifies a signature
  */
 SemaphoreStr semaphore_secretkey_sign(const SemaphoreSecretKey *spk, const SemaphoreBuf *data);
 
-/*
+/**
  * Converts a secret key into a string.
  */
 SemaphoreStr semaphore_secretkey_to_string(const SemaphoreSecretKey *spk);
@@ -194,17 +194,15 @@ SemaphoreStoreNormalizer *semaphore_store_normalizer_new(const SemaphoreStr *con
 SemaphoreStr semaphore_store_normalizer_normalize_event(SemaphoreStoreNormalizer *normalizer,
                                                         const SemaphoreStr *event);
 
-/*
+/**
  * Frees a semaphore str.
- *
  * If the string is marked as not owned then this function does not
  * do anything.
  */
 void semaphore_str_free(SemaphoreStr *s);
 
-/*
+/**
  * Creates a semaphore str from a c string.
- *
  * This sets the string to owned.  In case it's not owned you either have
  * to make sure you are not freeing the memory or you need to set the
  * owned flag to false.
@@ -213,20 +211,19 @@ SemaphoreStr semaphore_str_from_cstr(const char *s);
 
 bool semaphore_translate_legacy_python_json(SemaphoreStr *event);
 
-/*
+/**
  * Returns true if the uuid is nil
  */
 bool semaphore_uuid_is_nil(const SemaphoreUuid *uuid);
 
-/*
+/**
  * Formats the UUID into a string.
- *
  * The string is newly allocated and needs to be released with
  * `semaphore_cstr_free`.
  */
 SemaphoreStr semaphore_uuid_to_str(const SemaphoreUuid *uuid);
 
-/*
+/**
  * Validates a register response.
  */
 SemaphoreStr semaphore_validate_register_response(const SemaphorePublicKey *pk,

--- a/general/src/datascrubbing/convert.rs
+++ b/general/src/datascrubbing/convert.rs
@@ -11,9 +11,9 @@ pub fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiCo
     let mut applied_rules = Vec::new();
 
     if datascrubbing_config.scrub_data && datascrubbing_config.scrub_defaults {
-        applied_rules.push("@common".to_owned());
+        applied_rules.push("@common:filter".to_owned());
     } else if datascrubbing_config.scrub_ip_addresses {
-        applied_rules.push("@ip".to_owned());
+        applied_rules.push("@ip:filter".to_owned());
     }
 
     if datascrubbing_config.scrub_data {
@@ -180,7 +180,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "**": [
-              "@common"
+              "@common:filter"
             ]
           }
         }
@@ -202,7 +202,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "**": [
-              "@common"
+              "@common:filter"
             ]
           }
         }
@@ -233,7 +233,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "**": [
-              "@common",
+              "@common:filter",
               "strip-fields"
             ]
           }
@@ -256,7 +256,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "(~foobar)": [
-              "@common"
+              "@common:filter"
             ]
           }
         }
@@ -1024,7 +1024,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "**": [
-              "@common",
+              "@common:filter",
               "strip-fields"
             ]
           }

--- a/general/src/datascrubbing/convert.rs
+++ b/general/src/datascrubbing/convert.rs
@@ -621,7 +621,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     #[test]
     fn test_sanitize_url_7() {
         // Don't be too overly eager within JSON strings an catch the right field.
-        // n.b.: We accept the difference from Python, where "b" is not masked.
         sanitize_url_test(
             r#"{"a":"https://localhost","b":"foo@localhost","c":"pg://matt:pass@localhost/1","d":"lol"}"#,
         );
@@ -643,6 +642,8 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         assert_annotated_snapshot!(data);
     }
 
+    /// Ensure that valid JSON as request body is parsed as such, and that the PII stripping is
+    /// then more granular/sophisticated because we now understand the structure.
     #[test]
     fn test_sanitize_http_body() {
         use crate::store::StoreProcessor;
@@ -667,6 +668,8 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         assert_annotated_snapshot!(data.value().unwrap().request);
     }
 
+    /// Ensure that a request body that cannot be parsed by the store processor gets PII stripped
+    /// nevertheless.
     #[test]
     fn test_sanitize_http_body_string() {
         use crate::store::StoreProcessor;
@@ -680,7 +683,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             .into(),
         );
 
-        // n.b.: In Rust we rely on store normalization to parse inline JSON
+        // n.b.: In Rust we rely on store normalization to parse inline JSON.
 
         let mut store_processor = StoreProcessor::new(Default::default(), None);
         process_value(&mut data, &mut store_processor, ProcessingState::root());

--- a/general/src/datascrubbing/convert.rs
+++ b/general/src/datascrubbing/convert.rs
@@ -55,7 +55,7 @@ pub fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiCo
                                 .unwrap(),
                         ),
                     }),
-                    redaction: Redaction::Replace("[filtered]".to_owned().into()),
+                    redaction: Redaction::Replace("[Filtered]".to_owned().into()),
                 },
             );
 
@@ -224,7 +224,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
               "keyPattern": ".*(fieldy_field|moar_other_field).*",
               "redaction": {
                 "method": "replace",
-                "text": "[filtered]"
+                "text": "[Filtered]"
               }
             }
           },
@@ -1039,7 +1039,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
               "keyPattern": ".*(session_key).*",
               "redaction": {
                 "method": "replace",
-                "text": "[filtered]"
+                "text": "[Filtered]"
               }
             }
           },

--- a/general/src/datascrubbing/snapshots/tests__authorization_scrubbing.snap
+++ b/general/src/datascrubbing/snapshots/tests__authorization_scrubbing.snap
@@ -5,8 +5,8 @@ expression: data
 {
   "extra": {
     "auXth": "foobar",
-    "auth": "[filtered]",
-    "authorization": "[filtered]"
+    "auth": "[Filtered]",
+    "authorization": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__authorization_scrubbing.snap
+++ b/general/src/datascrubbing/snapshots/tests__authorization_scrubbing.snap
@@ -5,8 +5,8 @@ expression: data
 {
   "extra": {
     "auXth": "foobar",
-    "auth": null,
-    "authorization": null
+    "auth": "[filtered]",
+    "authorization": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -15,9 +15,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 6
         }
       },
       "authorization": {
@@ -25,9 +28,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 6
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__authorization_scrubbing.snap
+++ b/general/src/datascrubbing/snapshots/tests__authorization_scrubbing.snap
@@ -14,7 +14,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -24,7 +24,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__breadcrumb_message-2.snap
+++ b/general/src/datascrubbing/snapshots/tests__breadcrumb_message-2.snap
@@ -6,7 +6,7 @@ expression: data
   "breadcrumbs": {
     "values": [
       {
-        "message": "[filtered]"
+        "message": "[Filtered]"
       }
     ]
   },

--- a/general/src/datascrubbing/snapshots/tests__contexts.snap
+++ b/general/src/datascrubbing/snapshots/tests__contexts.snap
@@ -5,12 +5,12 @@ expression: data
 {
   "contexts": {
     "biz": {
-      "a_password_here": "[filtered]",
-      "apiKey": "[filtered]",
-      "api_key": "[filtered]",
+      "a_password_here": "[Filtered]",
+      "apiKey": "[Filtered]",
+      "api_key": "[Filtered]",
       "foo": "bar",
-      "password": "[filtered]",
-      "the_secret": "[filtered]",
+      "password": "[Filtered]",
+      "the_secret": "[Filtered]",
       "type": "biz"
     },
     "secret": null

--- a/general/src/datascrubbing/snapshots/tests__contexts.snap
+++ b/general/src/datascrubbing/snapshots/tests__contexts.snap
@@ -5,12 +5,12 @@ expression: data
 {
   "contexts": {
     "biz": {
-      "a_password_here": null,
-      "apiKey": null,
-      "api_key": null,
+      "a_password_here": "[filtered]",
+      "apiKey": "[filtered]",
+      "api_key": "[filtered]",
       "foo": "bar",
-      "password": null,
-      "the_secret": null,
+      "password": "[filtered]",
+      "the_secret": "[filtered]",
       "type": "biz"
     },
     "secret": null
@@ -23,9 +23,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "apiKey": {
@@ -33,9 +36,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "api_key": {
@@ -43,9 +49,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "password": {
@@ -53,9 +62,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "the_secret": {
@@ -63,9 +75,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         }
       },

--- a/general/src/datascrubbing/snapshots/tests__contexts.snap
+++ b/general/src/datascrubbing/snapshots/tests__contexts.snap
@@ -22,7 +22,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -32,7 +32,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -42,7 +42,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -52,7 +52,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -62,7 +62,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -73,7 +73,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__csp_blocked_uri.snap
+++ b/general/src/datascrubbing/snapshots/tests__csp_blocked_uri.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "csp": {
-    "blocked_uri": "https://example.com/?foo=[creditcard]&bar=baz"
+    "blocked_uri": "https://example.com/?foo=[filtered]&bar=baz"
   },
   "_meta": {
     "csp": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               25,
-              37
+              35
             ]
           ],
           "len": 49

--- a/general/src/datascrubbing/snapshots/tests__csp_blocked_uri.snap
+++ b/general/src/datascrubbing/snapshots/tests__csp_blocked_uri.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "csp": {
-    "blocked_uri": "https://example.com/?foo=[filtered]&bar=baz"
+    "blocked_uri": "https://example.com/?foo=[Filtered]&bar=baz"
   },
   "_meta": {
     "csp": {

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_encrypted_private_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_encrypted_private_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN ENCRYPTED PRIVATE KEY-----\n[pemkey]\n-----END ENCRYPTED PRIVATE KEY-----\"\""
+    "s": "\"\"-----BEGIN ENCRYPTED PRIVATE KEY-----\n[filtered]\n-----END ENCRYPTED PRIVATE KEY-----\"\""
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@pemkey",
+              "@pemkey:filter",
               "s",
               40,
-              48
+              50
             ]
           ],
           "len": 277

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_encrypted_private_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_encrypted_private_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN ENCRYPTED PRIVATE KEY-----\n[filtered]\n-----END ENCRYPTED PRIVATE KEY-----\"\""
+    "s": "\"\"-----BEGIN ENCRYPTED PRIVATE KEY-----\n[Filtered]\n-----END ENCRYPTED PRIVATE KEY-----\"\""
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_private_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_private_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN PRIVATE KEY-----\n[filtered]\n-----END PRIVATE KEY-----\"\""
+    "s": "\"\"-----BEGIN PRIVATE KEY-----\n[Filtered]\n-----END PRIVATE KEY-----\"\""
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_private_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_private_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN PRIVATE KEY-----\n[pemkey]\n-----END PRIVATE KEY-----\"\""
+    "s": "\"\"-----BEGIN PRIVATE KEY-----\n[filtered]\n-----END PRIVATE KEY-----\"\""
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@pemkey",
+              "@pemkey:filter",
               "s",
               30,
-              38
+              40
             ]
           ],
           "len": 252

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_public_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_public_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN PUBLIC KEY-----\n[filtered]\n-----END PUBLIC KEY-----\"\""
+    "s": "\"\"-----BEGIN PUBLIC KEY-----\n[Filtered]\n-----END PUBLIC KEY-----\"\""
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_public_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_public_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN PUBLIC KEY-----\n[pemkey]\n-----END PUBLIC KEY-----\"\""
+    "s": "\"\"-----BEGIN PUBLIC KEY-----\n[filtered]\n-----END PUBLIC KEY-----\"\""
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@pemkey",
+              "@pemkey:filter",
               "s",
               29,
-              37
+              39
             ]
           ],
           "len": 283

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_rsa_private_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_rsa_private_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN RSA PRIVATE KEY-----\n[filtered]\n-----END RSA PRIVATE KEY-----\"\""
+    "s": "\"\"-----BEGIN RSA PRIVATE KEY-----\n[Filtered]\n-----END RSA PRIVATE KEY-----\"\""
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_rsa_private_key.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_rsa_private_key.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "\"\"-----BEGIN RSA PRIVATE KEY-----\n[pemkey]\n-----END RSA PRIVATE KEY-----\"\""
+    "s": "\"\"-----BEGIN RSA PRIVATE KEY-----\n[filtered]\n-----END RSA PRIVATE KEY-----\"\""
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@pemkey",
+              "@pemkey:filter",
               "s",
               34,
-              42
+              44
             ]
           ],
           "len": 260

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_social_security_number.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_social_security_number.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "[filtered]"
+    "s": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__does_sanitize_social_security_number.snap
+++ b/general/src/datascrubbing/snapshots/tests__does_sanitize_social_security_number.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "s": "***-**-****"
+    "s": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@usssn",
-              "m",
+              "@usssn:filter",
+              "s",
               0,
-              11
+              10
             ]
           ],
           "len": 11

--- a/general/src/datascrubbing/snapshots/tests__doesnt_scrub_not_scrubbed.snap
+++ b/general/src/datascrubbing/snapshots/tests__doesnt_scrub_not_scrubbed.snap
@@ -21,7 +21,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]

--- a/general/src/datascrubbing/snapshots/tests__doesnt_scrub_not_scrubbed.snap
+++ b/general/src/datascrubbing/snapshots/tests__doesnt_scrub_not_scrubbed.snap
@@ -5,7 +5,7 @@ expression: data
 {
   "extra": {
     "test1": {
-      "is_authenticated": "[filtered]"
+      "is_authenticated": "[Filtered]"
     },
     "test2": {
       "is_authenticated": "null"

--- a/general/src/datascrubbing/snapshots/tests__doesnt_scrub_not_scrubbed.snap
+++ b/general/src/datascrubbing/snapshots/tests__doesnt_scrub_not_scrubbed.snap
@@ -5,7 +5,7 @@ expression: data
 {
   "extra": {
     "test1": {
-      "is_authenticated": null
+      "is_authenticated": "[filtered]"
     },
     "test2": {
       "is_authenticated": "null"
@@ -22,9 +22,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 6
           }
         }
       }

--- a/general/src/datascrubbing/snapshots/tests__exclude_fields_on_field_name.snap
+++ b/general/src/datascrubbing/snapshots/tests__exclude_fields_on_field_name.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "password": "[filtered]"
+    "password": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__exclude_fields_on_field_name.snap
+++ b/general/src/datascrubbing/snapshots/tests__exclude_fields_on_field_name.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "password": null
+    "password": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -13,9 +13,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 11
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__exclude_fields_on_field_name.snap
+++ b/general/src/datascrubbing/snapshots/tests__exclude_fields_on_field_name.snap
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__explicit_fields.snap
+++ b/general/src/datascrubbing/snapshots/tests__explicit_fields.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "mystuff": "[filtered]"
+    "mystuff": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__explicit_fields.snap
+++ b/general/src/datascrubbing/snapshots/tests__explicit_fields.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "mystuff": null
+    "mystuff": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -13,9 +13,12 @@ expression: data
           "rem": [
             [
               "strip-fields",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 3
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__explicit_fields_case_insensitive.snap
+++ b/general/src/datascrubbing/snapshots/tests__explicit_fields_case_insensitive.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "MYSTUFF": "[filtered]"
+    "MYSTUFF": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__explicit_fields_case_insensitive.snap
+++ b/general/src/datascrubbing/snapshots/tests__explicit_fields_case_insensitive.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "MYSTUFF": null
+    "MYSTUFF": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -13,9 +13,12 @@ expression: data
           "rem": [
             [
               "strip-fields",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 3
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__extra.snap
+++ b/general/src/datascrubbing/snapshots/tests__extra.snap
@@ -17,7 +17,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -27,7 +27,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -37,7 +37,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -47,7 +47,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -57,7 +57,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__extra.snap
+++ b/general/src/datascrubbing/snapshots/tests__extra.snap
@@ -4,12 +4,12 @@ expression: data
 ---
 {
   "extra": {
-    "a_password_here": "[filtered]",
-    "apiKey": "[filtered]",
-    "api_key": "[filtered]",
+    "a_password_here": "[Filtered]",
+    "apiKey": "[Filtered]",
+    "api_key": "[Filtered]",
     "foo": "bar",
-    "password": "[filtered]",
-    "the_secret": "[filtered]"
+    "password": "[Filtered]",
+    "the_secret": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__extra.snap
+++ b/general/src/datascrubbing/snapshots/tests__extra.snap
@@ -4,12 +4,12 @@ expression: data
 ---
 {
   "extra": {
-    "a_password_here": null,
-    "apiKey": null,
-    "api_key": null,
+    "a_password_here": "[filtered]",
+    "apiKey": "[filtered]",
+    "api_key": "[filtered]",
     "foo": "bar",
-    "password": null,
-    "the_secret": null
+    "password": "[filtered]",
+    "the_secret": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -18,9 +18,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       },
       "apiKey": {
@@ -28,9 +31,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 10
         }
       },
       "api_key": {
@@ -38,9 +44,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 10
         }
       },
       "password": {
@@ -48,9 +57,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       },
       "the_secret": {
@@ -58,9 +70,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__http.snap
+++ b/general/src/datascrubbing/snapshots/tests__http.snap
@@ -5,25 +5,25 @@ expression: data
 {
   "request": {
     "data": {
-      "a_password_here": null,
-      "apiKey": null,
-      "api_key": null,
+      "a_password_here": "[filtered]",
+      "apiKey": "[filtered]",
+      "api_key": "[filtered]",
       "foo": "bar",
-      "password": null,
-      "the_secret": null
+      "password": "[filtered]",
+      "the_secret": "[filtered]"
     },
     "cookies": [
       [
         "a_password_here",
-        null
+        "[filtered]"
       ],
       [
         "apiKey",
-        null
+        "[filtered]"
       ],
       [
         "api_key",
-        null
+        "[filtered]"
       ],
       [
         "foo",
@@ -31,25 +31,25 @@ expression: data
       ],
       [
         "password",
-        null
+        "[filtered]"
       ],
       [
         "the_secret",
-        null
+        "[filtered]"
       ]
     ],
     "headers": [
       [
         "A_password_here",
-        null
+        "[filtered]"
       ],
       [
         "ApiKey",
-        null
+        "[filtered]"
       ],
       [
         "Api_key",
-        null
+        "[filtered]"
       ],
       [
         "Foo",
@@ -57,20 +57,20 @@ expression: data
       ],
       [
         "Password",
-        null
+        "[filtered]"
       ],
       [
         "The_secret",
-        null
+        "[filtered]"
       ]
     ],
     "env": {
-      "a_password_here": null,
-      "apiKey": null,
-      "api_key": null,
+      "a_password_here": "[filtered]",
+      "apiKey": "[filtered]",
+      "api_key": "[filtered]",
       "foo": "bar",
-      "password": null,
-      "the_secret": null
+      "password": "[filtered]",
+      "the_secret": "[filtered]"
     }
   },
   "_meta": {
@@ -82,9 +82,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -94,9 +97,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 10
             }
           }
         },
@@ -106,9 +112,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 10
             }
           }
         },
@@ -118,9 +127,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -130,9 +142,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         }
@@ -143,9 +158,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "apiKey": {
@@ -153,9 +171,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "api_key": {
@@ -163,9 +184,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "password": {
@@ -173,9 +197,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "the_secret": {
@@ -183,9 +210,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         }
       },
@@ -195,9 +225,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "apiKey": {
@@ -205,9 +238,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "api_key": {
@@ -215,9 +251,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "password": {
@@ -225,9 +264,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "the_secret": {
@@ -235,9 +277,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         }
       },
@@ -248,9 +293,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -260,9 +308,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 10
             }
           }
         },
@@ -272,9 +323,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 10
             }
           }
         },
@@ -284,9 +338,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -296,9 +353,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         }

--- a/general/src/datascrubbing/snapshots/tests__http.snap
+++ b/general/src/datascrubbing/snapshots/tests__http.snap
@@ -81,7 +81,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -93,7 +93,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -105,7 +105,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -117,7 +117,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -129,7 +129,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -142,7 +142,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -152,7 +152,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -162,7 +162,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -172,7 +172,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -182,7 +182,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -194,7 +194,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -204,7 +204,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -214,7 +214,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -224,7 +224,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -234,7 +234,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -247,7 +247,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -259,7 +259,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -271,7 +271,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -283,7 +283,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -295,7 +295,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]

--- a/general/src/datascrubbing/snapshots/tests__http.snap
+++ b/general/src/datascrubbing/snapshots/tests__http.snap
@@ -5,25 +5,25 @@ expression: data
 {
   "request": {
     "data": {
-      "a_password_here": "[filtered]",
-      "apiKey": "[filtered]",
-      "api_key": "[filtered]",
+      "a_password_here": "[Filtered]",
+      "apiKey": "[Filtered]",
+      "api_key": "[Filtered]",
       "foo": "bar",
-      "password": "[filtered]",
-      "the_secret": "[filtered]"
+      "password": "[Filtered]",
+      "the_secret": "[Filtered]"
     },
     "cookies": [
       [
         "a_password_here",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "apiKey",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "api_key",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "foo",
@@ -31,25 +31,25 @@ expression: data
       ],
       [
         "password",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "the_secret",
-        "[filtered]"
+        "[Filtered]"
       ]
     ],
     "headers": [
       [
         "A_password_here",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "ApiKey",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "Api_key",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "Foo",
@@ -57,20 +57,20 @@ expression: data
       ],
       [
         "Password",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "The_secret",
-        "[filtered]"
+        "[Filtered]"
       ]
     ],
     "env": {
-      "a_password_here": "[filtered]",
-      "apiKey": "[filtered]",
-      "api_key": "[filtered]",
+      "a_password_here": "[Filtered]",
+      "apiKey": "[Filtered]",
+      "api_key": "[Filtered]",
       "foo": "bar",
-      "password": "[filtered]",
-      "the_secret": "[filtered]"
+      "password": "[Filtered]",
+      "the_secret": "[Filtered]"
     }
   },
   "_meta": {

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist.snap
@@ -11,19 +11,19 @@ expression: data
       ],
       [
         "password",
-        null
+        "[filtered]"
       ],
       [
         "the_secret",
-        null
+        "[filtered]"
       ],
       [
         "a_password_here",
-        null
+        "[filtered]"
       ],
       [
         "api_key",
-        null
+        "[filtered]"
       ]
     ]
   },
@@ -36,9 +36,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -48,9 +51,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -60,9 +66,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -72,9 +81,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 10
             }
           }
         }

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist.snap
@@ -11,19 +11,19 @@ expression: data
       ],
       [
         "password",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "the_secret",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "a_password_here",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "api_key",
-        "[filtered]"
+        "[Filtered]"
       ]
     ]
   },

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist.snap
@@ -35,7 +35,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -47,7 +47,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -59,7 +59,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -71,7 +71,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist_with_partials.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist_with_partials.snap
@@ -11,7 +11,7 @@ expression: data
       ],
       [
         "password",
-        null
+        "[filtered]"
       ],
       [
         "baz",
@@ -28,9 +28,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 0
             }
           }
         }

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist_with_partials.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist_with_partials.snap
@@ -27,7 +27,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist_with_partials.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_pairlist_with_partials.snap
@@ -11,7 +11,7 @@ expression: data
       ],
       [
         "password",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "baz",

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_string.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_string.snap
@@ -11,19 +11,19 @@ expression: data
       ],
       [
         "password",
-        null
+        "[filtered]"
       ],
       [
         "the_secret",
-        null
+        "[filtered]"
       ],
       [
         "a_password_here",
-        null
+        "[filtered]"
       ],
       [
         "api_key",
-        null
+        "[filtered]"
       ]
     ]
   },
@@ -36,9 +36,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -48,9 +51,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -60,9 +66,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 5
             }
           }
         },
@@ -72,9 +81,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 10
             }
           }
         }

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_string.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_string.snap
@@ -11,19 +11,19 @@ expression: data
       ],
       [
         "password",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "the_secret",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "a_password_here",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "api_key",
-        "[filtered]"
+        "[Filtered]"
       ]
     ]
   },

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_string.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_string.snap
@@ -35,7 +35,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -47,7 +47,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -59,7 +59,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]
@@ -71,7 +71,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_string_with_partials.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_string_with_partials.snap
@@ -11,7 +11,7 @@ expression: data
       ],
       [
         "password",
-        null
+        "[filtered]"
       ],
       [
         "baz",
@@ -28,9 +28,12 @@ expression: data
               "rem": [
                 [
                   "@password:filter",
-                  "x"
+                  "s",
+                  0,
+                  10
                 ]
-              ]
+              ],
+              "len": 0
             }
           }
         }

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_string_with_partials.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_string_with_partials.snap
@@ -27,7 +27,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password",
+                  "@password:filter",
                   "x"
                 ]
               ]

--- a/general/src/datascrubbing/snapshots/tests__querystring_as_string_with_partials.snap
+++ b/general/src/datascrubbing/snapshots/tests__querystring_as_string_with_partials.snap
@@ -11,7 +11,7 @@ expression: data
       ],
       [
         "password",
-        "[filtered]"
+        "[Filtered]"
       ],
       [
         "baz",

--- a/general/src/datascrubbing/snapshots/tests__sanitize_additional_sensitive_fields.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_additional_sensitive_fields.snap
@@ -19,7 +19,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -29,7 +29,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -39,7 +39,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -69,7 +69,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]
@@ -79,7 +79,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__sanitize_additional_sensitive_fields.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_additional_sensitive_fields.snap
@@ -4,14 +4,14 @@ expression: data
 ---
 {
   "extra": {
-    "a_password_here": "[filtered]",
-    "apiKey": "[filtered]",
-    "api_key": "[filtered]",
-    "fieldy_field": "[filtered]",
+    "a_password_here": "[Filtered]",
+    "apiKey": "[Filtered]",
+    "api_key": "[Filtered]",
+    "fieldy_field": "[Filtered]",
     "foo": "bar",
-    "moar_other_field": "[filtered]",
-    "password": "[filtered]",
-    "the_secret": "[filtered]"
+    "moar_other_field": "[Filtered]",
+    "password": "[Filtered]",
+    "the_secret": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_additional_sensitive_fields.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_additional_sensitive_fields.snap
@@ -4,14 +4,14 @@ expression: data
 ---
 {
   "extra": {
-    "a_password_here": null,
-    "apiKey": null,
-    "api_key": null,
-    "fieldy_field": null,
+    "a_password_here": "[filtered]",
+    "apiKey": "[filtered]",
+    "api_key": "[filtered]",
+    "fieldy_field": "[filtered]",
     "foo": "bar",
-    "moar_other_field": null,
-    "password": null,
-    "the_secret": null
+    "moar_other_field": "[filtered]",
+    "password": "[filtered]",
+    "the_secret": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -20,9 +20,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       },
       "apiKey": {
@@ -30,9 +33,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 10
         }
       },
       "api_key": {
@@ -40,9 +46,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 10
         }
       },
       "fieldy_field": {
@@ -50,9 +59,12 @@ expression: data
           "rem": [
             [
               "strip-fields",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       },
       "moar_other_field": {
@@ -60,9 +72,12 @@ expression: data
           "rem": [
             [
               "strip-fields",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 13
         }
       },
       "password": {
@@ -70,9 +85,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       },
       "the_secret": {
@@ -80,9 +98,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[filtered]"
+    "foo": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[creditcard]"
+    "foo": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               0,
-              12
+              10
             ]
           ],
           "len": 16

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_amex.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_amex.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[filtered]"
+    "foo": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_amex.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_amex.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[creditcard]"
+    "foo": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               0,
-              12
+              10
             ]
           ],
           "len": 15

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_discover.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_discover.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[filtered]"
+    "foo": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_discover.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_discover.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[creditcard]"
+    "foo": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               0,
-              12
+              10
             ]
           ],
           "len": 16

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_mastercard.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_mastercard.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[filtered]"
+    "foo": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_mastercard.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_mastercard.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[creditcard]"
+    "foo": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               0,
-              12
+              10
             ]
           ],
           "len": 16

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_visa.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_visa.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[filtered]"
+    "foo": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_visa.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_visa.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "[creditcard]"
+    "foo": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               0,
-              12
+              10
             ]
           ],
           "len": 16

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "'[creditcard]'"
+    "foo": "'[filtered]'"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               1,
-              13
+              11
             ]
           ],
           "len": 18

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "'[filtered]'"
+    "foo": "'[Filtered]'"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo [creditcard]"
+    "foo": "foo [filtered]"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@creditcard",
+              "@creditcard:filter",
               "s",
               4,
-              16
+              14
             ]
           ],
           "len": 20

--- a/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_credit_card_within_value_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo [filtered]"
+    "foo": "foo [Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
@@ -5,7 +5,7 @@ expression: data.value().unwrap().request
 {
   "data": {
     "email": "zzzz@gmail.com",
-    "password": "[filtered]"
+    "password": "[Filtered]"
   },
   "inferred_content_type": "application/json",
   "_meta": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
@@ -4,7 +4,7 @@ expression: data.value().unwrap().request
 ---
 {
   "data": {
-    "email": "[email]",
+    "email": "[filtered]",
     "password": null
   },
   "inferred_content_type": "application/json",
@@ -14,10 +14,10 @@ expression: data.value().unwrap().request
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               0,
-              7
+              10
             ]
           ],
           "len": 14
@@ -27,7 +27,7 @@ expression: data.value().unwrap().request
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
@@ -4,25 +4,12 @@ expression: data.value().unwrap().request
 ---
 {
   "data": {
-    "email": "[filtered]",
+    "email": "zzzz@gmail.com",
     "password": null
   },
   "inferred_content_type": "application/json",
   "_meta": {
     "data": {
-      "email": {
-        "": {
-          "rem": [
-            [
-              "@email:filter",
-              "s",
-              0,
-              10
-            ]
-          ],
-          "len": 14
-        }
-      },
       "password": {
         "": {
           "rem": [

--- a/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_http_body.snap
@@ -5,7 +5,7 @@ expression: data.value().unwrap().request
 {
   "data": {
     "email": "zzzz@gmail.com",
-    "password": null
+    "password": "[filtered]"
   },
   "inferred_content_type": "application/json",
   "_meta": {
@@ -15,9 +15,12 @@ expression: data.value().unwrap().request
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 5
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__sanitize_http_body_string.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_http_body_string.snap
@@ -3,7 +3,7 @@ source: general/src/datascrubbing/convert.rs
 expression: data.value().unwrap().request
 ---
 {
-  "data": "[filtered]",
+  "data": "[Filtered]",
   "_meta": {
     "data": {
       "": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_http_body_string.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_http_body_string.snap
@@ -1,0 +1,22 @@
+---
+source: general/src/datascrubbing/convert.rs
+expression: data.value().unwrap().request
+---
+{
+  "data": "[filtered]",
+  "_meta": {
+    "data": {
+      "": {
+        "rem": [
+          [
+            "@password:filter",
+            "s",
+            0,
+            10
+          ]
+        ],
+        "len": 48
+      }
+    }
+  }
+}

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "pg://matt:[email]/1"
+    "foo": "pg://matt:[filtered]/1"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               10,
-              17
+              20
             ]
           ],
           "len": 26

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "pg://matt:[filtered]/1"
+    "foo": "pg://matt:[filtered]@localhost/1"
   },
   "_meta": {
     "extra": {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
               10,
               20

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "pg://matt:[filtered]@localhost/1"
+    "foo": "pg://matt:[Filtered]@localhost/1"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo 'redis://redis:[filtered]:6379/0' bar"
+    "foo": "foo 'redis://redis:[filtered]@localhost:6379/0' bar"
   },
   "_meta": {
     "extra": {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
               19,
               29

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo 'redis://redis:[email]:6379/0' bar"
+    "foo": "foo 'redis://redis:[filtered]:6379/0' bar"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               19,
-              26
+              29
             ]
           ],
           "len": 44

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo 'redis://redis:[filtered]@localhost:6379/0' bar"
+    "foo": "foo 'redis://redis:[Filtered]@localhost:6379/0' bar"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_3.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_3.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "'redis://redis:[email]:6379/0'"
+    "foo": "'redis://redis:[filtered]:6379/0'"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               15,
-              22
+              25
             ]
           ],
           "len": 36

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_3.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_3.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "'redis://redis:[filtered]@localhost:6379/0'"
+    "foo": "'redis://redis:[Filtered]@localhost:6379/0'"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_3.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_3.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "'redis://redis:[filtered]:6379/0'"
+    "foo": "'redis://redis:[filtered]@localhost:6379/0'"
   },
   "_meta": {
     "extra": {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
               15,
               25

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_4.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_4.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo redis://redis:[email]:6379/0 bar"
+    "foo": "foo redis://redis:[filtered]:6379/0 bar"
   },
   "_meta": {
     "extra": {
@@ -12,10 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               18,
-              25
+              28
             ]
           ],
           "len": 42

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_4.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_4.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo redis://redis:[filtered]@localhost:6379/0 bar"
+    "foo": "foo redis://redis:[Filtered]@localhost:6379/0 bar"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_4.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_4.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo redis://redis:[filtered]:6379/0 bar"
+    "foo": "foo redis://redis:[filtered]@localhost:6379/0 bar"
   },
   "_meta": {
     "extra": {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
               18,
               28

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_5.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_5.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo redis://redis:[email]:6379/0 bar pg://matt:[email]/1"
+    "foo": "foo redis://redis:[filtered]:6379/0 bar pg://matt:[filtered]/1"
   },
   "_meta": {
     "extra": {
@@ -12,16 +12,16 @@ expression: data
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               18,
-              25
+              28
             ],
             [
-              "@email",
+              "@email:filter",
               "s",
-              47,
-              54
+              50,
+              60
             ]
           ],
           "len": 68

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_5.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_5.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo redis://redis:[filtered]:6379/0 bar pg://matt:[filtered]/1"
+    "foo": "foo redis://redis:[filtered]@localhost:6379/0 bar pg://matt:[filtered]@localhost/1"
   },
   "_meta": {
     "extra": {
@@ -12,16 +12,16 @@ expression: data
         "": {
           "rem": [
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
               18,
               28
             ],
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
-              50,
-              60
+              60,
+              70
             ]
           ],
           "len": 68

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_5.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_5.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "foo redis://redis:[filtered]@localhost:6379/0 bar pg://matt:[filtered]@localhost/1"
+    "foo": "foo redis://redis:[Filtered]@localhost:6379/0 bar pg://matt:[Filtered]@localhost/1"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_7.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_7.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "{\"a\":\"https://localhost\",\"b\":\"[filtered]\",\"c\":\"pg://matt:[filtered]/1\",\"d\":\"lol\"}"
+    "foo": "{\"a\":\"https://localhost\",\"b\":\"foo@localhost\",\"c\":\"pg://matt:[filtered]@localhost/1\",\"d\":\"lol\"}"
   },
   "_meta": {
     "extra": {
@@ -12,16 +12,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@email:filter",
+              "@urlauth:legacy",
               "s",
-              30,
-              40
-            ],
-            [
-              "@email:filter",
-              "s",
-              57,
-              67
+              60,
+              70
             ]
           ],
           "len": 88

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_7.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_7.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "{\"a\":\"https://localhost\",\"b\":\"[email]\",\"c\":\"pg://matt:[email]/1\",\"d\":\"lol\"}"
+    "foo": "{\"a\":\"https://localhost\",\"b\":\"[filtered]\",\"c\":\"pg://matt:[filtered]/1\",\"d\":\"lol\"}"
   },
   "_meta": {
     "extra": {
@@ -12,16 +12,16 @@ expression: data
         "": {
           "rem": [
             [
-              "@email",
+              "@email:filter",
               "s",
               30,
-              37
+              40
             ],
             [
-              "@email",
+              "@email:filter",
               "s",
-              54,
-              61
+              57,
+              67
             ]
           ],
           "len": 88

--- a/general/src/datascrubbing/snapshots/tests__sanitize_url_7.snap
+++ b/general/src/datascrubbing/snapshots/tests__sanitize_url_7.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "foo": "{\"a\":\"https://localhost\",\"b\":\"foo@localhost\",\"c\":\"pg://matt:[filtered]@localhost/1\",\"d\":\"lol\"}"
+    "foo": "{\"a\":\"https://localhost\",\"b\":\"foo@localhost\",\"c\":\"pg://matt:[Filtered]@localhost/1\",\"d\":\"lol\"}"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "MYSQL_PWD": null
+    "MYSQL_PWD": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -13,9 +13,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 7
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
+++ b/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "MYSQL_PWD": "[filtered]"
+    "MYSQL_PWD": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "mysql_pwd": "[filtered]"
+    "mysql_pwd": "[Filtered]"
   },
   "_meta": {
     "extra": {

--- a/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password",
+              "@password:filter",
               "x"
             ]
           ]

--- a/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
+++ b/general/src/datascrubbing/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "extra": {
-    "mysql_pwd": null
+    "mysql_pwd": "[filtered]"
   },
   "_meta": {
     "extra": {
@@ -13,9 +13,12 @@ expression: data
           "rem": [
             [
               "@password:filter",
-              "x"
+              "s",
+              0,
+              10
             ]
-          ]
+          ],
+          "len": 7
         }
       }
     }

--- a/general/src/datascrubbing/snapshots/tests__stacktrace.snap
+++ b/general/src/datascrubbing/snapshots/tests__stacktrace.snap
@@ -7,12 +7,12 @@ expression: data
     "frames": [
       {
         "vars": {
-          "a_password_here": null,
-          "apiKey": null,
-          "api_key": null,
+          "a_password_here": "[filtered]",
+          "apiKey": "[filtered]",
+          "api_key": "[filtered]",
           "foo": "bar",
-          "password": null,
-          "the_secret": null
+          "password": "[filtered]",
+          "the_secret": "[filtered]"
         }
       }
     ]
@@ -27,9 +27,12 @@ expression: data
                 "rem": [
                   [
                     "@password:filter",
-                    "x"
+                    "s",
+                    0,
+                    10
                   ]
-                ]
+                ],
+                "len": 5
               }
             },
             "apiKey": {
@@ -37,9 +40,12 @@ expression: data
                 "rem": [
                   [
                     "@password:filter",
-                    "x"
+                    "s",
+                    0,
+                    10
                   ]
-                ]
+                ],
+                "len": 10
               }
             },
             "api_key": {
@@ -47,9 +53,12 @@ expression: data
                 "rem": [
                   [
                     "@password:filter",
-                    "x"
+                    "s",
+                    0,
+                    10
                   ]
-                ]
+                ],
+                "len": 10
               }
             },
             "password": {
@@ -57,9 +66,12 @@ expression: data
                 "rem": [
                   [
                     "@password:filter",
-                    "x"
+                    "s",
+                    0,
+                    10
                   ]
-                ]
+                ],
+                "len": 5
               }
             },
             "the_secret": {
@@ -67,9 +79,12 @@ expression: data
                 "rem": [
                   [
                     "@password:filter",
-                    "x"
+                    "s",
+                    0,
+                    10
                   ]
-                ]
+                ],
+                "len": 5
               }
             }
           }

--- a/general/src/datascrubbing/snapshots/tests__stacktrace.snap
+++ b/general/src/datascrubbing/snapshots/tests__stacktrace.snap
@@ -7,12 +7,12 @@ expression: data
     "frames": [
       {
         "vars": {
-          "a_password_here": "[filtered]",
-          "apiKey": "[filtered]",
-          "api_key": "[filtered]",
+          "a_password_here": "[Filtered]",
+          "apiKey": "[Filtered]",
+          "api_key": "[Filtered]",
           "foo": "bar",
-          "password": "[filtered]",
-          "the_secret": "[filtered]"
+          "password": "[Filtered]",
+          "the_secret": "[Filtered]"
         }
       }
     ]

--- a/general/src/datascrubbing/snapshots/tests__stacktrace.snap
+++ b/general/src/datascrubbing/snapshots/tests__stacktrace.snap
@@ -26,7 +26,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password",
+                    "@password:filter",
                     "x"
                   ]
                 ]
@@ -36,7 +36,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password",
+                    "@password:filter",
                     "x"
                   ]
                 ]
@@ -46,7 +46,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password",
+                    "@password:filter",
                     "x"
                   ]
                 ]
@@ -56,7 +56,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password",
+                    "@password:filter",
                     "x"
                   ]
                 ]
@@ -66,7 +66,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password",
+                    "@password:filter",
                     "x"
                   ]
                 ]

--- a/general/src/datascrubbing/snapshots/tests__user.snap
+++ b/general/src/datascrubbing/snapshots/tests__user.snap
@@ -6,12 +6,12 @@ expression: data
   "user": {
     "username": "secret",
     "data": {
-      "a_password_here": null,
-      "apiKey": null,
-      "api_key": null,
+      "a_password_here": "[filtered]",
+      "apiKey": "[filtered]",
+      "api_key": "[filtered]",
       "foo": "bar",
-      "password": null,
-      "the_secret": null
+      "password": "[filtered]",
+      "the_secret": "[filtered]"
     }
   },
   "_meta": {
@@ -22,9 +22,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "apiKey": {
@@ -32,9 +35,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "api_key": {
@@ -42,9 +48,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 10
           }
         },
         "password": {
@@ -52,9 +61,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         },
         "the_secret": {
@@ -62,9 +74,12 @@ expression: data
             "rem": [
               [
                 "@password:filter",
-                "x"
+                "s",
+                0,
+                10
               ]
-            ]
+            ],
+            "len": 5
           }
         }
       }

--- a/general/src/datascrubbing/snapshots/tests__user.snap
+++ b/general/src/datascrubbing/snapshots/tests__user.snap
@@ -6,12 +6,12 @@ expression: data
   "user": {
     "username": "secret",
     "data": {
-      "a_password_here": "[filtered]",
-      "apiKey": "[filtered]",
-      "api_key": "[filtered]",
+      "a_password_here": "[Filtered]",
+      "apiKey": "[Filtered]",
+      "api_key": "[Filtered]",
       "foo": "bar",
-      "password": "[filtered]",
-      "the_secret": "[filtered]"
+      "password": "[Filtered]",
+      "the_secret": "[Filtered]"
     }
   },
   "_meta": {

--- a/general/src/datascrubbing/snapshots/tests__user.snap
+++ b/general/src/datascrubbing/snapshots/tests__user.snap
@@ -21,7 +21,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -31,7 +31,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -41,7 +41,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -51,7 +51,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]
@@ -61,7 +61,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password",
+                "@password:filter",
                 "x"
               ]
             ]

--- a/general/src/pii/builtin.rs
+++ b/general/src/pii/builtin.rs
@@ -61,6 +61,24 @@ declare_builtin_rules! {
         redaction: Redaction::Default,
         ..Default::default()
     };
+    // legacy data scrubbing equivalent
+    "@common:filter" => RuleSpec {
+        ty: RuleType::Multiple(MultipleRule {
+            rules: vec![
+                "@ip:filter".into(),
+                "@email:filter".into(),
+                "@creditcard:filter".into(),
+                "@pemkey:filter".into(),
+                "@urlauth:filter".into(),
+                "@userpath:filter".into(),
+                "@password:filter".into(),
+                "@usssn:filter".into(),
+            ],
+            hide_inner: false,
+        }),
+        redaction: Redaction::Default,
+        ..Default::default()
+    };
 
     // anything
     "@anything" => rule_alias!("@anything:replace");
@@ -91,6 +109,13 @@ declare_builtin_rules! {
         ty: RuleType::Ip,
         redaction: Redaction::Replace(ReplaceRedaction {
             text: "[ip]".into(),
+        }),
+        ..Default::default()
+    };
+    "@ip:filter" => RuleSpec {
+        ty: RuleType::Ip,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
         }),
         ..Default::default()
     };
@@ -193,6 +218,13 @@ declare_builtin_rules! {
         }),
         ..Default::default()
     };
+    "@email:filter" => RuleSpec {
+        ty: RuleType::Email,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
+        }),
+        ..Default::default()
+    };
     "@email:hash" => RuleSpec {
         ty: RuleType::Email,
         redaction: Redaction::Hash(HashRedaction {
@@ -220,6 +252,13 @@ declare_builtin_rules! {
         }),
         ..Default::default()
     };
+    "@creditcard:filter" => RuleSpec {
+        ty: RuleType::Creditcard,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
+        }),
+        ..Default::default()
+    };
     "@creditcard:hash" => RuleSpec {
         ty: RuleType::Creditcard,
         redaction: Redaction::Hash(HashRedaction {
@@ -235,6 +274,13 @@ declare_builtin_rules! {
         ty: RuleType::Pemkey,
         redaction: Redaction::Replace(ReplaceRedaction {
             text: "[pemkey]".into(),
+        }),
+        ..Default::default()
+    };
+    "@pemkey:filter" => RuleSpec {
+        ty: RuleType::Pemkey,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
         }),
         ..Default::default()
     };
@@ -256,6 +302,13 @@ declare_builtin_rules! {
         }),
         ..Default::default()
     };
+    "@urlauth:filter" => RuleSpec {
+        ty: RuleType::UrlAuth,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
+        }),
+        ..Default::default()
+    };
     "@urlauth:hash" => RuleSpec {
         ty: RuleType::UrlAuth,
         redaction: Redaction::Hash(HashRedaction {
@@ -271,6 +324,13 @@ declare_builtin_rules! {
         ty: RuleType::UsSsn,
         redaction: Redaction::Replace(ReplaceRedaction {
             text: "[us-ssn]".into(),
+        }),
+        ..Default::default()
+    };
+    "@usssn:filter" => RuleSpec {
+        ty: RuleType::UsSsn,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
         }),
         ..Default::default()
     };
@@ -312,6 +372,15 @@ declare_builtin_rules! {
 
     // password field removal
     "@password" => rule_alias!("@password:remove");
+    "@password:filter" => RuleSpec {
+        ty: RuleType::RedactPair(RedactPairRule {
+            key_pattern: r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)".into(),
+        }),
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[filtered]".into(),
+        }),
+        ..Default::default()
+    };
     "@password:remove" => RuleSpec {
         ty: RuleType::RedactPair(RedactPairRule {
             key_pattern: r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)".into(),

--- a/general/src/pii/builtin.rs
+++ b/general/src/pii/builtin.rs
@@ -114,7 +114,7 @@ declare_builtin_rules! {
     "@ip:filter" => RuleSpec {
         ty: RuleType::Ip,
         redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[filtered]".into(),
+            text: "[Filtered]".into(),
         }),
         ..Default::default()
     };
@@ -247,7 +247,7 @@ declare_builtin_rules! {
     "@creditcard:filter" => RuleSpec {
         ty: RuleType::Creditcard,
         redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[filtered]".into(),
+            text: "[Filtered]".into(),
         }),
         ..Default::default()
     };
@@ -272,7 +272,7 @@ declare_builtin_rules! {
     "@pemkey:filter" => RuleSpec {
         ty: RuleType::Pemkey,
         redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[filtered]".into(),
+            text: "[Filtered]".into(),
         }),
         ..Default::default()
     };
@@ -301,7 +301,7 @@ declare_builtin_rules! {
             replace_groups: Some([2].iter().copied().collect()),
         }),
         redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[filtered]".into(),
+            text: "[Filtered]".into(),
         }),
         ..Default::default()
     };
@@ -326,7 +326,7 @@ declare_builtin_rules! {
     "@usssn:filter" => RuleSpec {
         ty: RuleType::UsSsn,
         redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[filtered]".into(),
+            text: "[Filtered]".into(),
         }),
         ..Default::default()
     };
@@ -373,7 +373,7 @@ declare_builtin_rules! {
             key_pattern: r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)".into(),
         }),
         redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[filtered]".into(),
+            text: "[Filtered]".into(),
         }),
         ..Default::default()
     };

--- a/py/semaphore/processing.py
+++ b/py/semaphore/processing.py
@@ -5,7 +5,7 @@ from semaphore._lowlevel import lib, ffi
 from semaphore.utils import encode_str, decode_str, rustcall, RustObject, attached_refs
 
 
-__all__ = ["split_chunks", "meta_with_chunks", "StoreNormalizer", "GeoIpLookup"]
+__all__ = ["split_chunks", "meta_with_chunks", "StoreNormalizer", "GeoIpLookup", "scrub_event"]
 
 
 def split_chunks(string, remarks):
@@ -75,11 +75,34 @@ class StoreNormalizer(RustObject):
 
     def normalize_event(self, event=None, raw_event=None):
         if raw_event is None:
-            raw_event = json.dumps(event, ensure_ascii=False)
-            if isinstance(raw_event, text_type):
-                raw_event = raw_event.encode("utf-8", errors="replace")
+            raw_event = _serialize_event(event)
 
-        event = encode_str(raw_event, mutable=True)
-        rustcall(lib.semaphore_translate_legacy_python_json, event)
+        event = _encode_raw_event(raw_event)
         rv = self._methodcall(lib.semaphore_store_normalizer_normalize_event, event)
         return json.loads(decode_str(rv))
+
+
+def _serialize_event(event):
+    raw_event = json.dumps(event, ensure_ascii=False)
+    if isinstance(raw_event, text_type):
+        raw_event = raw_event.encode("utf-8", errors="replace")
+    return raw_event
+
+
+def _encode_raw_event(raw_event):
+    event = encode_str(raw_event, mutable=True)
+    rustcall(lib.semaphore_translate_legacy_python_json, event)
+    return event
+
+
+def scrub_event(config, data):
+    if not config:
+        return data
+
+    config = json.dumps(config)
+
+    raw_event = _serialize_event(data)
+    event = _encode_raw_event(raw_event)
+
+    rv = rustcall(lib.semaphore_scrub_event, encode_str(config), event)
+    return json.loads(decode_str(rv))

--- a/py/semaphore/processing.py
+++ b/py/semaphore/processing.py
@@ -5,7 +5,13 @@ from semaphore._lowlevel import lib, ffi
 from semaphore.utils import encode_str, decode_str, rustcall, RustObject, attached_refs
 
 
-__all__ = ["split_chunks", "meta_with_chunks", "StoreNormalizer", "GeoIpLookup", "scrub_event"]
+__all__ = [
+    "split_chunks",
+    "meta_with_chunks",
+    "StoreNormalizer",
+    "GeoIpLookup",
+    "scrub_event",
+]
 
 
 def split_chunks(string, remarks):

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -138,10 +138,10 @@ def test_data_scrubbing_default_config():
     assert scrubbed == {
         "extra": {
             "foo": "bar",
-            "password": None,
-            "the_secret": None,
-            "a_password_here": None,
-            "api_key": None,
-            "apiKey": None,
+            "password": "[filtered]",
+            "the_secret": "[filtered]",
+            "a_password_here": "[filtered]",
+            "api_key": "[filtered]",
+            "apiKey": "[filtered]",
         }
     }

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -123,6 +123,7 @@ def test_data_scrubbing_disabled_config():
     scrubbed = semaphore.scrub_event(config, event)
     assert event == scrubbed
 
+
 def test_data_scrubbing_default_config():
     event = {"extra": PII_VARS}
     config = {

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -139,10 +139,10 @@ def test_data_scrubbing_default_config():
     assert scrubbed == {
         "extra": {
             "foo": "bar",
-            "password": "[filtered]",
-            "the_secret": "[filtered]",
-            "a_password_here": "[filtered]",
-            "api_key": "[filtered]",
-            "apiKey": "[filtered]",
+            "password": "[Filtered]",
+            "the_secret": "[Filtered]",
+            "a_password_here": "[Filtered]",
+            "api_key": "[Filtered]",
+            "apiKey": "[Filtered]",
         }
     }


### PR DESCRIPTION
Changes data scrubbing in Relay to be closer to what Sentry currently does. 

- Introduces `:filter` or `:legacy` rules that replace values with `[Filtered]` instead of more specific place holders
- Changes `RedactPair` rules to apply their action on the entire value, rather than just the match.
- Ensures that replacement of `RedactPair` rules actually works, rather than always removing the value.
- Exposes data scrubbing via the C-FFI layer to Python.

cc @lobsterkatie 