### PR TITLE
ref: Reject invalid transaction events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.49.2"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -218,15 +218,15 @@ dependencies = [
  "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -875,14 +875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,14 +1225,6 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1897,12 +1881,12 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.21.0"
-source = "git+https://github.com/fede1024/rust-rdkafka?rev=0efbcf38150fad9fcd65b5f7f23f488c01248ae8#0efbcf38150fad9fcd65b5f7f23f488c01248ae8"
+source = "git+https://github.com/fede1024/rust-rdkafka#b1a391b3264ca8e0b0e053c6aec7a6db09af3131"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka-sys 1.0.1 (git+https://github.com/fede1024/rust-rdkafka?rev=0efbcf38150fad9fcd65b5f7f23f488c01248ae8)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1910,10 +1894,10 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "1.0.1"
-source = "git+https://github.com/fede1024/rust-rdkafka?rev=0efbcf38150fad9fcd65b5f7f23f488c01248ae8#0efbcf38150fad9fcd65b5f7f23f488c01248ae8"
+version = "1.2.1"
+source = "git+https://github.com/fede1024/rust-rdkafka#b1a391b3264ca8e0b0e053c6aec7a6db09af3131"
 dependencies = [
- "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2056,6 +2040,14 @@ dependencies = [
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc_version"
@@ -2253,7 +2245,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka?rev=0efbcf38150fad9fcd65b5f7f23f488c01248ae8)",
+ "rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka)",
  "redis 0.12.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs?branch=feature/cluster)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3079,7 +3071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "which"
-version = "1.0.5"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3204,7 +3196,7 @@ dependencies = [
 "checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
+"checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
@@ -3280,7 +3272,6 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -3320,7 +3311,6 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
@@ -3393,8 +3383,8 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
-"checksum rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka?rev=0efbcf38150fad9fcd65b5f7f23f488c01248ae8)" = "<none>"
-"checksum rdkafka-sys 1.0.1 (git+https://github.com/fede1024/rust-rdkafka?rev=0efbcf38150fad9fcd65b5f7f23f488c01248ae8)" = "<none>"
+"checksum rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka)" = "<none>"
+"checksum rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka)" = "<none>"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redis 0.12.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs?branch=feature/cluster)" = "<none>"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
@@ -3407,6 +3397,7 @@ dependencies = [
 "checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 "checksum ron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
@@ -3500,7 +3491,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
-"checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
+"checksum which 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240a31163872f7e8e49f35b42b58485e35355b07eb009d9f3686733541339a69"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,12 +1881,12 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.21.0"
-source = "git+https://github.com/fede1024/rust-rdkafka#b1a391b3264ca8e0b0e053c6aec7a6db09af3131"
+source = "git+https://github.com/fede1024/rust-rdkafka?rev=b1a391b3264ca8e0b0e053c6aec7a6db09af3131#b1a391b3264ca8e0b0e053c6aec7a6db09af3131"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka)",
+ "rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka?rev=b1a391b3264ca8e0b0e053c6aec7a6db09af3131)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.2.1"
-source = "git+https://github.com/fede1024/rust-rdkafka#b1a391b3264ca8e0b0e053c6aec7a6db09af3131"
+source = "git+https://github.com/fede1024/rust-rdkafka?rev=b1a391b3264ca8e0b0e053c6aec7a6db09af3131#b1a391b3264ca8e0b0e053c6aec7a6db09af3131"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2245,7 +2245,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka)",
+ "rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka?rev=b1a391b3264ca8e0b0e053c6aec7a6db09af3131)",
  "redis 0.12.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs?branch=feature/cluster)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3383,8 +3383,8 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
-"checksum rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka)" = "<none>"
-"checksum rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka)" = "<none>"
+"checksum rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka?rev=b1a391b3264ca8e0b0e053c6aec7a6db09af3131)" = "<none>"
+"checksum rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka?rev=b1a391b3264ca8e0b0e053c6aec7a6db09af3131)" = "<none>"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redis 0.12.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs?branch=feature/cluster)" = "<none>"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"

--- a/cabi/src/processing.rs
+++ b/cabi/src/processing.rs
@@ -81,7 +81,7 @@ ffi_fn! {
     ) -> Result<SemaphoreStr> {
         let processor = normalizer as *mut StoreProcessor;
         let mut event = Annotated::<Event>::from_json((*event).as_str())?;
-        process_value(&mut event, &mut *processor, ProcessingState::root());
+        process_value(&mut event, &mut *processor, ProcessingState::root())?;
         Ok(SemaphoreStr::from_string(event.to_json()?))
     }
 }

--- a/general/derive/src/empty.rs
+++ b/general/derive/src/empty.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use crate::{is_newtype, parse_field_attributes};
 
 pub fn derive_empty(mut s: synstructure::Structure<'_>) -> TokenStream {
-    s.add_bounds(synstructure::AddBounds::Generics);
+    let _ = s.add_bounds(synstructure::AddBounds::Generics);
 
     let is_empty_arms = s.each_variant(|variant| {
         let mut is_tuple_struct = false;

--- a/general/derive/src/lib.rs
+++ b/general/derive/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![allow(clippy::cognitive_complexity)]
+#![deny(unused_must_use)]
 
 mod empty;
 mod process;
@@ -262,7 +263,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
         Err(s) => s,
     };
 
-    s.add_bounds(synstructure::AddBounds::Generics);
+    let _ = s.add_bounds(synstructure::AddBounds::Generics);
 
     let variants = s.variants();
     if variants.len() != 1 {
@@ -594,14 +595,11 @@ impl TypeAttrs {
         if let Some(ref func_name) = self.process_func {
             let func_name = Ident::new(&func_name, Span::call_site());
             quote! {
-                __processor.#func_name(self, __meta, __state)
+                __processor.#func_name(self, __meta, __state)?;
             }
         } else {
             quote! {
-                {
-                    self.process_child_values(__processor, __state);
-                    crate::types::ValueAction::Keep
-                }
+                self.process_child_values(__processor, __state)?;
             }
         }
     }

--- a/general/derive/src/process.rs
+++ b/general/derive/src/process.rs
@@ -35,7 +35,7 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
                 // This is a copy of `funcs::process_value`, due to ownership issues. In particular
                 // we want to pass the same meta twice.
                 //
-                // NOTE: Handling for DiscardValue is slightly different (early-return). This
+                // NOTE: Handling for ProcessingAction is slightly different (early-return). This
                 // should be fine though.
                 let action = __processor.before_process(
                     Some(&*#ident),
@@ -161,7 +161,7 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
                 __meta: &mut crate::types::Meta,
                 __processor: &mut P,
                 __state: &crate::processor::ProcessingState<'_>,
-            ) -> crate::types::ValueAction
+            ) -> crate::types::ProcessingResult
             where
                 P: crate::processor::Processor,
             {
@@ -178,7 +178,7 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
                 &mut self,
                 __processor: &mut P,
                 __state: &crate::processor::ProcessingState<'_>
-            ) -> crate::types::ValueAction
+            ) -> crate::types::ProcessingResult
             where
                 P: crate::processor::Processor,
             {

--- a/general/src/datascrubbing/convert.rs
+++ b/general/src/datascrubbing/convert.rs
@@ -334,7 +334,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -354,7 +354,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -373,7 +373,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -390,7 +390,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -409,7 +409,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -435,7 +435,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = to_pii_config(&scrubbing_config).unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -459,7 +459,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -477,7 +477,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
         // n.b.: This diverges from Python behavior because it would strip a context that is called
         // "secret", not just a string. We accept this difference.
@@ -494,7 +494,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -517,7 +517,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -534,7 +534,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -551,7 +551,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -576,7 +576,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -593,7 +593,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -611,7 +611,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -628,7 +628,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -645,7 +645,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -662,7 +662,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -688,7 +688,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -705,7 +705,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data, @r###"
         {
           "extra": {
@@ -768,7 +768,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -790,11 +790,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         // n.b.: In Rust we rely on store normalization to parse inline JSON
 
         let mut store_processor = StoreProcessor::new(Default::default(), None);
-        process_value(&mut data, &mut store_processor, ProcessingState::root());
+        process_value(&mut data, &mut store_processor, ProcessingState::root()).unwrap();
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data.value().unwrap().request);
     }
 
@@ -816,11 +816,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         // n.b.: In Rust we rely on store normalization to parse inline JSON.
 
         let mut store_processor = StoreProcessor::new(Default::default(), None);
-        process_value(&mut data, &mut store_processor, ProcessingState::root());
+        process_value(&mut data, &mut store_processor, ProcessingState::root()).unwrap();
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data.value().unwrap().request);
     }
 
@@ -837,7 +837,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
         assert_annotated_snapshot!(data, @r###"
         {
@@ -861,7 +861,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -878,7 +878,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -895,7 +895,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -912,7 +912,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -929,7 +929,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -944,7 +944,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -964,7 +964,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -984,7 +984,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -1004,7 +1004,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
         assert_annotated_snapshot!(data, @r###"
         {
@@ -1032,7 +1032,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
         assert_annotated_snapshot!(data, @r###"
         {
@@ -1070,7 +1070,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -1094,7 +1094,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -1126,7 +1126,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -1141,7 +1141,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 
@@ -1194,7 +1194,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(&pii_config);
-        process_value(&mut data, &mut pii_processor, ProcessingState::root());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
 }

--- a/general/src/filter/common.rs
+++ b/general/src/filter/common.rs
@@ -120,6 +120,11 @@ pub enum FilterStatKey {
     // that is why it was commented here and moved to OutcomeInvalidReason enum
     /// note: Not returned by any filters implemented in Rust.
     DiscardedHash,
+
+    /// Event has been discarded due to containing invalid data. This happens very rarely and only
+    /// for events that we really would not know how to process after store (e.g. invalid
+    /// transaction events)
+    InvalidEvent,
 }
 
 impl FilterStatKey {
@@ -134,6 +139,7 @@ impl FilterStatKey {
             FilterStatKey::WebCrawlers => "web-crawlers",
             FilterStatKey::InvalidCsp => "invalid-csp",
             FilterStatKey::DiscardedHash => "discarded-hash",
+            FilterStatKey::InvalidEvent => "invalid-event",
         }
     }
 }

--- a/general/src/lib.rs
+++ b/general/src/lib.rs
@@ -1,6 +1,7 @@
 // Clippy throws errors in situations where a closure is clearly the better way. An example is
 // `Annotated::as_str`, which can't be used directly because it's part of two impl blocks.
 #![allow(clippy::redundant_closure)]
+#![deny(unused_must_use)]
 
 // we use macro_use here because we really consider this to be an internal
 // macro which currently cannot be imported.

--- a/general/src/pii/builtin.rs
+++ b/general/src/pii/builtin.rs
@@ -411,7 +411,7 @@ mod tests {
             let mut root = Annotated::new(FreeformRoot {
                 value: Annotated::new(input),
             });
-            process_value(&mut root, &mut processor, ProcessingState::root());
+            process_value(&mut root, &mut processor, ProcessingState::root()).unwrap();
             let root = root.0.unwrap();
             assert_eq_str!(root.value.value().unwrap(), $output);
             let remarks: Vec<Remark> = $remarks;

--- a/general/src/processor/funcs.rs
+++ b/general/src/processor/funcs.rs
@@ -1,5 +1,5 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::types::{Annotated, ValueAction};
+use crate::types::{Annotated, ProcessingResult};
 
 /// Processes the value using the given processor.
 #[inline]
@@ -7,7 +7,7 @@ pub fn process_value<T, P>(
     annotated: &mut Annotated<T>,
     processor: &mut P,
     state: &ProcessingState<'_>,
-) -> ValueAction
+) -> ProcessingResult
 where
     T: ProcessValue,
     P: Processor,

--- a/general/src/processor/funcs.rs
+++ b/general/src/processor/funcs.rs
@@ -1,5 +1,5 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::types::Annotated;
+use crate::types::{Annotated, ValueAction};
 
 /// Processes the value using the given processor.
 #[inline]
@@ -7,13 +7,18 @@ pub fn process_value<T, P>(
     annotated: &mut Annotated<T>,
     processor: &mut P,
     state: &ProcessingState<'_>,
-) where
+) -> ValueAction
+where
     T: ProcessValue,
     P: Processor,
 {
     let action = processor.before_process(annotated.0.as_ref(), &mut annotated.1, state);
-    annotated.apply(|_, _| action);
+    annotated.apply(|_, _| action)?;
 
-    annotated.apply(|value, meta| ProcessValue::process_value(value, meta, processor, state));
-    processor.after_process(annotated.0.as_ref(), &mut annotated.1, state);
+    annotated.apply(|value, meta| ProcessValue::process_value(value, meta, processor, state))?;
+
+    let action = processor.after_process(annotated.0.as_ref(), &mut annotated.1, state);
+    annotated.apply(|_, _| action)?;
+
+    Ok(())
 }

--- a/general/src/processor/impls.rs
+++ b/general/src/processor/impls.rs
@@ -149,7 +149,11 @@ where
     }
 
     #[inline]
-    fn process_child_values<P>(&mut self, processor: &mut P, state: &ProcessingState<'_>)
+    fn process_child_values<P>(
+        &mut self,
+        processor: &mut P,
+        state: &ProcessingState<'_>,
+    ) -> ValueAction
     where
         P: Processor,
     {
@@ -158,8 +162,10 @@ where
                 element,
                 processor,
                 &state.enter_index(index, state.inner_attrs(), ValueType::for_field(element)),
-            );
+            )?;
         }
+
+        Ok(())
     }
 }
 
@@ -186,7 +192,11 @@ where
     }
 
     #[inline]
-    fn process_child_values<P>(&mut self, processor: &mut P, state: &ProcessingState<'_>)
+    fn process_child_values<P>(
+        &mut self,
+        processor: &mut P,
+        state: &ProcessingState<'_>,
+    ) -> ValueAction
     where
         P: Processor,
     {
@@ -195,8 +205,10 @@ where
                 v,
                 processor,
                 &state.enter_borrowed(k, state.inner_attrs(), ValueType::for_field(v)),
-            );
+            )?;
         }
+
+        Ok(())
     }
 }
 
@@ -234,6 +246,7 @@ macro_rules! process_tuple {
             #[inline]
             #[allow(non_snake_case, unused_assignments)]
             fn process_child_values<P>(&mut self, processor: &mut P, state: &ProcessingState<'_>)
+                -> ValueAction
             where
                 P: Processor,
             {
@@ -241,9 +254,11 @@ macro_rules! process_tuple {
                 let mut index = 0;
 
                 $(
-                    process_value($name, processor, &state.enter_index(index, state.inner_attrs(), ValueType::for_field($name)));
+                    process_value($name, processor, &state.enter_index(index, state.inner_attrs(), ValueType::for_field($name)))?;
                     index += 1;
                 )*
+
+                Ok(())
             }
         }
     };

--- a/general/src/processor/impls.rs
+++ b/general/src/processor/impls.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
-use crate::types::{Annotated, Array, Meta, Object, ValueAction};
+use crate::types::{Annotated, Array, Meta, Object, ProcessingResult};
 
 impl ProcessValue for String {
     #[inline]
@@ -16,7 +16,7 @@ impl ProcessValue for String {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -36,7 +36,7 @@ impl ProcessValue for bool {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -56,7 +56,7 @@ impl ProcessValue for u64 {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -76,7 +76,7 @@ impl ProcessValue for i64 {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -96,7 +96,7 @@ impl ProcessValue for f64 {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -116,7 +116,7 @@ impl ProcessValue for DateTime<Utc> {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -141,7 +141,7 @@ where
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -153,7 +153,7 @@ where
         &mut self,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -184,7 +184,7 @@ where
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -196,7 +196,7 @@ where
         &mut self,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -227,7 +227,7 @@ where
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -246,7 +246,7 @@ macro_rules! process_tuple {
             #[inline]
             #[allow(non_snake_case, unused_assignments)]
             fn process_child_values<P>(&mut self, processor: &mut P, state: &ProcessingState<'_>)
-                -> ValueAction
+                -> ProcessingResult
             where
                 P: Processor,
             {

--- a/general/src/processor/traits.rs
+++ b/general/src/processor/traits.rs
@@ -4,7 +4,7 @@
 use std::fmt::Debug;
 
 use crate::processor::{process_value, ProcessingState, ValueType};
-use crate::types::{FromValue, Meta, Timestamp, ToValue, ValueAction};
+use crate::types::{FromValue, Meta, ProcessingResult, Timestamp, ToValue};
 
 macro_rules! process_method {
     ($name: ident, $ty:ident $(::$path:ident)*) => {
@@ -18,7 +18,7 @@ macro_rules! process_method {
             value: &mut $ty $(::$path)* <$($param),*>,
             meta: &mut Meta,
             state: &ProcessingState<'_>,
-        ) -> ValueAction
+        ) -> ProcessingResult
         where
             $($param: ProcessValue),*
             $(, $param_req_key : $param_req_trait)*
@@ -37,7 +37,7 @@ pub trait Processor: Sized {
         value: Option<&T>,
         meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ pub trait Processor: Sized {
         value: Option<&T>,
         meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         Ok(())
     }
 
@@ -92,7 +92,7 @@ pub trait Processor: Sized {
         &mut self,
         other: &mut crate::types::Object<crate::types::Value>,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         for (key, value) in other {
             process_value(
                 value,
@@ -121,7 +121,7 @@ pub trait ProcessValue: FromValue + ToValue + Debug {
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -134,7 +134,7 @@ pub trait ProcessValue: FromValue + ToValue + Debug {
         &mut self,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {

--- a/general/src/protocol/contexts.rs
+++ b/general/src/protocol/contexts.rs
@@ -778,7 +778,7 @@ fn test_multiple_contexts_roundtrip() {
 fn test_context_processing() {
     use crate::processor::{ProcessingState, Processor};
     use crate::protocol::Event;
-    use crate::types::{Meta, ValueAction};
+    use crate::types::{Meta, ProcessingResult};
 
     let mut event = Annotated::new(Event {
         contexts: Annotated::new(Contexts({
@@ -807,7 +807,7 @@ fn test_context_processing() {
             _value: &mut Context,
             _meta: &mut Meta,
             _state: &ProcessingState<'_>,
-        ) -> ValueAction {
+        ) -> ProcessingResult {
             self.called = true;
             Ok(())
         }

--- a/general/src/protocol/contexts.rs
+++ b/general/src/protocol/contexts.rs
@@ -809,11 +809,11 @@ fn test_context_processing() {
             _state: &ProcessingState<'_>,
         ) -> ValueAction {
             self.called = true;
-            ValueAction::default()
+            Ok(())
         }
     }
 
     let mut processor = FooProcessor { called: false };
-    crate::processor::process_value(&mut event, &mut processor, ProcessingState::root());
+    crate::processor::process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
     assert!(processor.called);
 }

--- a/general/src/protocol/types.rs
+++ b/general/src/protocol/types.rs
@@ -279,14 +279,20 @@ where
         processor.process_pairlist(self, meta, state)
     }
 
-    fn process_child_values<P>(&mut self, processor: &mut P, state: &ProcessingState<'_>)
+    fn process_child_values<P>(
+        &mut self,
+        processor: &mut P,
+        state: &ProcessingState<'_>,
+    ) -> ValueAction
     where
         P: Processor,
     {
         for (idx, pair) in self.0.iter_mut().enumerate() {
             let state = state.enter_index(idx, state.inner_attrs(), ValueType::for_field(pair));
-            process_value(pair, processor, &state);
+            process_value(pair, processor, &state)?;
         }
+
+        Ok(())
     }
 }
 

--- a/general/src/protocol/types.rs
+++ b/general/src/protocol/types.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
 use crate::types::{
-    Annotated, Array, Empty, Error, ErrorKind, FromValue, Meta, Object, SkipSerialization, ToValue,
-    Value, ValueAction,
+    Annotated, Array, Empty, Error, ErrorKind, FromValue, Meta, Object, ProcessingResult,
+    SkipSerialization, ToValue, Value,
 };
 
 /// A array like wrapper used in various places.
@@ -272,7 +272,7 @@ where
         meta: &mut Meta,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {
@@ -283,7 +283,7 @@ where
         &mut self,
         processor: &mut P,
         state: &ProcessingState<'_>,
-    ) -> ValueAction
+    ) -> ProcessingResult
     where
         P: Processor,
     {

--- a/general/src/store/event_error.rs
+++ b/general/src/store/event_error.rs
@@ -20,7 +20,7 @@ impl Processor for EmitEventErrors {
         state: &ProcessingState<'_>,
     ) -> ValueAction {
         if !meta.has_errors() {
-            return ValueAction::Keep;
+            return Ok(());
         }
 
         // Only append the original value to the first error if there are multiple.
@@ -38,7 +38,7 @@ impl Processor for EmitEventErrors {
             });
         }
 
-        ValueAction::Keep
+        Ok(())
     }
 
     fn process_event(
@@ -47,7 +47,7 @@ impl Processor for EmitEventErrors {
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ValueAction {
-        event.process_child_values(self, state);
+        event.process_child_values(self, state)?;
 
         if !self.errors.is_empty() {
             event
@@ -56,7 +56,7 @@ impl Processor for EmitEventErrors {
                 .extend(self.errors.drain(..).map(Annotated::from));
         }
 
-        ValueAction::Keep
+        Ok(())
     }
 }
 
@@ -74,7 +74,8 @@ fn test_no_errors() {
         &mut event,
         &mut EmitEventErrors::new(),
         ProcessingState::root(),
-    );
+    )
+    .unwrap();
 
     assert_eq_dbg!(event.value().unwrap().errors.value(), None);
 }
@@ -90,7 +91,8 @@ fn test_top_level_errors() {
         &mut event,
         &mut EmitEventErrors::new(),
         ProcessingState::root(),
-    );
+    )
+    .unwrap();
 
     assert_eq_dbg!(
         *event.value().unwrap().errors.value().unwrap(),
@@ -121,7 +123,8 @@ fn test_errors_in_other() {
         &mut event,
         &mut EmitEventErrors::new(),
         ProcessingState::root(),
-    );
+    )
+    .unwrap();
 
     assert_eq_dbg!(
         *event.value().unwrap().errors.value().unwrap(),
@@ -150,7 +153,8 @@ fn test_nested_errors() {
         &mut event,
         &mut EmitEventErrors::new(),
         ProcessingState::root(),
-    );
+    )
+    .unwrap();
 
     assert_eq_dbg!(
         *event.value().unwrap().errors.value().unwrap(),
@@ -177,7 +181,8 @@ fn test_multiple_errors() {
         &mut event,
         &mut EmitEventErrors::new(),
         ProcessingState::root(),
-    );
+    )
+    .unwrap();
 
     assert_eq_dbg!(
         *event.value().unwrap().errors.value().unwrap(),
@@ -213,7 +218,8 @@ fn test_original_value() {
         &mut event,
         &mut EmitEventErrors::new(),
         ProcessingState::root(),
-    );
+    )
+    .unwrap();
 
     assert_eq_dbg!(
         *event.value().unwrap().errors.value().unwrap(),

--- a/general/src/store/event_error.rs
+++ b/general/src/store/event_error.rs
@@ -1,6 +1,6 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
 use crate::protocol::{Event, EventProcessingError};
-use crate::types::{Annotated, Meta, ValueAction};
+use crate::types::{Annotated, Meta, ProcessingResult};
 
 pub struct EmitEventErrors {
     errors: Vec<EventProcessingError>,
@@ -18,7 +18,7 @@ impl Processor for EmitEventErrors {
         _: Option<&T>,
         meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         if !meta.has_errors() {
             return Ok(());
         }
@@ -46,7 +46,7 @@ impl Processor for EmitEventErrors {
         event: &mut Event,
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         event.process_child_values(self, state)?;
 
         if !self.errors.is_empty() {

--- a/general/src/store/legacy.rs
+++ b/general/src/store/legacy.rs
@@ -4,7 +4,7 @@ use debugid::DebugId;
 
 use crate::processor::{ProcessingState, Processor};
 use crate::protocol::{DebugImage, NativeDebugImage};
-use crate::types::{Annotated, Meta, Object, ValueAction};
+use crate::types::{Annotated, Meta, Object, ProcessingResult};
 
 /// Converts legacy data structures to current format.
 pub struct LegacyProcessor;
@@ -15,7 +15,7 @@ impl Processor for LegacyProcessor {
         image: &mut DebugImage,
         _meta: &mut Meta,
         _state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         if let DebugImage::Apple(ref mut apple) = image {
             let native = NativeDebugImage {
                 code_id: Annotated::empty(),

--- a/general/src/store/legacy.rs
+++ b/general/src/store/legacy.rs
@@ -33,6 +33,6 @@ impl Processor for LegacyProcessor {
             *image = DebugImage::MachO(Box::new(native));
         }
 
-        ValueAction::Keep
+        Ok(())
     }
 }

--- a/general/src/store/mod.rs
+++ b/general/src/store/mod.rs
@@ -15,6 +15,7 @@ mod legacy;
 mod normalize;
 mod remove_other;
 mod schema;
+mod transactions;
 mod trimming;
 
 pub use crate::store::geo::GeoIpLookup;
@@ -103,6 +104,9 @@ impl<'a> Processor for StoreProcessor<'a> {
             // Trim large strings and databags down
             trimming::TrimmingProcessor::new().process_event(event, meta, state)?;
         }
+
+        // internally noops for non-transaction events
+        transactions::TransactionsProcessor.process_event(event, meta, state)?;
 
         Ok(())
     }

--- a/general/src/store/mod.rs
+++ b/general/src/store/mod.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use crate::processor::{ProcessingState, Processor};
 use crate::protocol::{Event, IpAddr};
-use crate::types::{Meta, ValueAction};
+use crate::types::{Meta, ProcessingResult};
 
 mod event_error;
 mod geo;
@@ -75,7 +75,7 @@ impl<'a> Processor for StoreProcessor<'a> {
         event: &mut Event,
         meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         // Convert legacy data structures to current format
         legacy::LegacyProcessor.process_event(event, meta, state)?;
 

--- a/general/src/store/normalize/logentry.rs
+++ b/general/src/store/normalize/logentry.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use dynfmt::{Argument, Format, FormatArgs, PythonFormat, SimpleCurlyFormat};
 
 use crate::protocol::LogEntry;
-use crate::types::{Annotated, Empty, Error, Meta, Value, ValueAction};
+use crate::types::{Annotated, DiscardValue, Empty, Error, Meta, Value, ValueAction};
 
 impl FormatArgs for Value {
     fn get_index(&self, index: usize) -> Result<Option<Argument<'_>>, ()> {
@@ -50,12 +50,12 @@ fn format_message<'f>(format: &'f str, params: &Value) -> Option<String> {
 pub fn normalize_logentry(logentry: &mut LogEntry, meta: &mut Meta) -> ValueAction {
     // An empty logentry should just be skipped during serialization. No need for an error.
     if logentry.is_empty() {
-        return ValueAction::Keep;
+        return Ok(());
     }
 
     if logentry.formatted.value().is_none() && logentry.message.value().is_none() {
         meta.add_error(Error::invalid("no message present"));
-        return ValueAction::DeleteSoft;
+        return Err(DiscardValue::DeleteSoft);
     }
 
     if let Some(params) = logentry.params.value() {
@@ -77,7 +77,7 @@ pub fn normalize_logentry(logentry: &mut LogEntry, meta: &mut Meta) -> ValueActi
         logentry.formatted = std::mem::replace(&mut logentry.message, Annotated::empty());
     }
 
-    ValueAction::Keep
+    Ok(())
 }
 
 #[cfg(test)]
@@ -190,7 +190,7 @@ fn test_empty_missing_message() {
 
     assert_eq_dbg!(
         normalize_logentry(&mut logentry, &mut meta),
-        ValueAction::DeleteSoft
+        Err(DiscardValue::DeleteSoft)
     );
     assert!(meta.has_errors());
 }
@@ -200,9 +200,6 @@ fn test_empty_logentry() {
     let mut logentry = LogEntry::default();
     let mut meta = Meta::default();
 
-    assert_eq_dbg!(
-        normalize_logentry(&mut logentry, &mut meta),
-        ValueAction::Keep
-    );
+    assert_eq_dbg!(normalize_logentry(&mut logentry, &mut meta), Ok(()));
     assert!(!meta.has_errors());
 }

--- a/general/src/store/normalize/mechanism.rs
+++ b/general/src/store/normalize/mechanism.rs
@@ -1,5 +1,5 @@
 use crate::protocol::{Context, ContextInner, Event, Mechanism};
-use crate::types::{Annotated, DiscardValue, Error, ValueAction};
+use crate::types::{Annotated, Error, ProcessingAction, ProcessingResult};
 
 #[cfg(test)]
 use crate::protocol::{CError, MachException, MechanismMeta, PosixSignal};
@@ -595,13 +595,13 @@ impl OsHint {
 }
 
 /// Normalizes the exception mechanism in place.
-pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) -> ValueAction {
+pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) -> ProcessingResult {
     mechanism.help_link.apply(|value, meta| {
         if value.starts_with("http://") || value.starts_with("https://") {
             Ok(())
         } else {
             meta.add_error(Error::expected("http URL"));
-            Err(DiscardValue::DeleteSoft)
+            Err(ProcessingAction::DeleteValueSoft)
         }
     })?;
 

--- a/general/src/store/normalize/mechanism.rs
+++ b/general/src/store/normalize/mechanism.rs
@@ -1,5 +1,5 @@
 use crate::protocol::{Context, ContextInner, Event, Mechanism};
-use crate::types::{Annotated, Error, ValueAction};
+use crate::types::{Annotated, DiscardValue, Error, ValueAction};
 
 #[cfg(test)]
 use crate::protocol::{CError, MachException, MechanismMeta, PosixSignal};
@@ -595,19 +595,19 @@ impl OsHint {
 }
 
 /// Normalizes the exception mechanism in place.
-pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) {
+pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) -> ValueAction {
     mechanism.help_link.apply(|value, meta| {
         if value.starts_with("http://") || value.starts_with("https://") {
-            ValueAction::Keep
+            Ok(())
         } else {
             meta.add_error(Error::expected("http URL"));
-            ValueAction::DeleteSoft
+            Err(DiscardValue::DeleteSoft)
         }
-    });
+    })?;
 
     let meta = match mechanism.meta.value_mut() {
         Some(meta) => meta,
-        None => return,
+        None => return Ok(()),
     };
 
     if let Some(os_hint) = os_hint {
@@ -649,6 +649,8 @@ pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) {
             }
         }
     }
+
+    Ok(())
 }
 
 #[test]
@@ -660,7 +662,7 @@ fn test_normalize_missing() {
 
     let old_mechanism = mechanism.clone();
 
-    normalize_mechanism(&mut mechanism, None);
+    normalize_mechanism(&mut mechanism, None).unwrap();
 
     assert_eq!(mechanism, old_mechanism);
 }
@@ -679,7 +681,7 @@ fn test_normalize_errno() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, Some(OsHint::Linux));
+    normalize_mechanism(&mut mechanism, Some(OsHint::Linux)).unwrap();
 
     let errno = mechanism.meta.value().unwrap().errno.value().unwrap();
     assert_eq!(
@@ -705,7 +707,7 @@ fn test_normalize_errno_override() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, Some(OsHint::Linux));
+    normalize_mechanism(&mut mechanism, Some(OsHint::Linux)).unwrap();
 
     let errno = mechanism.meta.value().unwrap().errno.value().unwrap();
     assert_eq!(
@@ -731,7 +733,7 @@ fn test_normalize_errno_fail() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, None);
+    normalize_mechanism(&mut mechanism, None).unwrap();
 
     let errno = mechanism.meta.value().unwrap().errno.value().unwrap();
     assert_eq!(
@@ -758,7 +760,7 @@ fn test_normalize_signal() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, Some(OsHint::Darwin));
+    normalize_mechanism(&mut mechanism, Some(OsHint::Darwin)).unwrap();
 
     let signal = mechanism.meta.value().unwrap().signal.value().unwrap();
     assert_eq!(
@@ -786,7 +788,7 @@ fn test_normalize_partial_signal() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, Some(OsHint::Linux));
+    normalize_mechanism(&mut mechanism, Some(OsHint::Linux)).unwrap();
 
     let signal = mechanism.meta.value().unwrap().signal.value().unwrap();
 
@@ -816,7 +818,7 @@ fn test_normalize_signal_override() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, Some(OsHint::Linux));
+    normalize_mechanism(&mut mechanism, Some(OsHint::Linux)).unwrap();
 
     let signal = mechanism.meta.value().unwrap().signal.value().unwrap();
 
@@ -846,7 +848,7 @@ fn test_normalize_signal_fail() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut mechanism, None);
+    normalize_mechanism(&mut mechanism, None).unwrap();
 
     let signal = mechanism.meta.value().unwrap().signal.value().unwrap();
 
@@ -879,7 +881,7 @@ fn test_normalize_mach() {
     // We do not need SDK information here because mach exceptions only
     // occur on Darwin
 
-    normalize_mechanism(&mut mechanism, None);
+    normalize_mechanism(&mut mechanism, None).unwrap();
 
     let mach_exception = mechanism
         .meta
@@ -919,7 +921,7 @@ fn test_normalize_mach_override() {
     // We do not need SDK information here because mach exceptions only
     // occur on Darwin
 
-    normalize_mechanism(&mut mechanism, None);
+    normalize_mechanism(&mut mechanism, None).unwrap();
 
     let mach_exception = mechanism
         .meta
@@ -958,7 +960,7 @@ fn test_normalize_mach_fail() {
     // We do not need SDK information here because mach exceptions only
     // occur on Darwin
 
-    normalize_mechanism(&mut mechanism, None);
+    normalize_mechanism(&mut mechanism, None).unwrap();
 
     let mach_exception = mechanism
         .meta
@@ -989,7 +991,7 @@ fn test_normalize_http_url() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut good_mechanism, None);
+    normalize_mechanism(&mut good_mechanism, None).unwrap();
     assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(good_mechanism)), @r###"
     {
       "type": "generic",
@@ -1003,7 +1005,7 @@ fn test_normalize_http_url() {
         ..Default::default()
     };
 
-    normalize_mechanism(&mut bad_mechanism, None);
+    normalize_mechanism(&mut bad_mechanism, None).unwrap();
     assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(bad_mechanism)), @r###"
     {
       "type": "generic",

--- a/general/src/store/normalize/request.rs
+++ b/general/src/store/normalize/request.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use url::Url;
 
 use crate::protocol::{Query, Request};
-use crate::types::{Annotated, DiscardValue, ErrorKind, Meta, Value, ValueAction};
+use crate::types::{Annotated, ErrorKind, Meta, ProcessingAction, ProcessingResult, Value};
 
 const ELLIPSIS: char = '\u{2026}';
 
@@ -76,12 +76,12 @@ fn normalize_url(request: &mut Request) {
     };
 }
 
-fn normalize_method(method: &mut String, meta: &mut Meta) -> ValueAction {
+fn normalize_method(method: &mut String, meta: &mut Meta) -> ProcessingResult {
     method.make_ascii_uppercase();
 
     if !meta.has_errors() && !METHOD_RE.is_match(&method) {
         meta.add_error(ErrorKind::InvalidData);
-        return Err(DiscardValue::DeleteSoft);
+        return Err(ProcessingAction::DeleteValueSoft);
     }
 
     Ok(())
@@ -180,7 +180,7 @@ fn normalize_cookies(request: &mut Request) {
     }
 }
 
-pub fn normalize_request(request: &mut Request) -> ValueAction {
+pub fn normalize_request(request: &mut Request) -> ProcessingResult {
     request.method.apply(normalize_method)?;
     normalize_url(request);
     normalize_data(request);

--- a/general/src/store/normalize/request.rs
+++ b/general/src/store/normalize/request.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use url::Url;
 
 use crate::protocol::{Query, Request};
-use crate::types::{Annotated, ErrorKind, Meta, Value, ValueAction};
+use crate::types::{Annotated, DiscardValue, ErrorKind, Meta, Value, ValueAction};
 
 const ELLIPSIS: char = '\u{2026}';
 
@@ -81,10 +81,10 @@ fn normalize_method(method: &mut String, meta: &mut Meta) -> ValueAction {
 
     if !meta.has_errors() && !METHOD_RE.is_match(&method) {
         meta.add_error(ErrorKind::InvalidData);
-        return ValueAction::DeleteSoft;
+        return Err(DiscardValue::DeleteSoft);
     }
 
-    ValueAction::Keep
+    Ok(())
 }
 /// Decodes an urlencoded body.
 fn urlencoded_from_str(raw: &str) -> Option<Value> {
@@ -180,11 +180,12 @@ fn normalize_cookies(request: &mut Request) {
     }
 }
 
-pub fn normalize_request(request: &mut Request) {
-    request.method.apply(normalize_method);
+pub fn normalize_request(request: &mut Request) -> ValueAction {
+    request.method.apply(normalize_method)?;
     normalize_url(request);
     normalize_data(request);
     normalize_cookies(request);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -200,7 +201,7 @@ fn test_url_truncation() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.url.as_str(), Some("http://example.com/path"));
 }
 
@@ -212,7 +213,7 @@ fn test_url_truncation_reversed() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.url.as_str(), Some("http://example.com/path"));
 }
 
@@ -223,7 +224,7 @@ fn test_url_with_ellipsis() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.url.as_str(), Some("http://example.com/path..."));
 }
 
@@ -236,7 +237,7 @@ fn test_url_with_qs_and_fragment() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(
         request,
@@ -259,7 +260,7 @@ fn test_url_only_path() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(
         request,
         Request {
@@ -276,7 +277,7 @@ fn test_url_punycoded() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(
         request,
@@ -301,7 +302,7 @@ fn test_url_precedence() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(
         request,
@@ -326,7 +327,7 @@ fn test_query_string_empty_value() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(
         request,
@@ -354,7 +355,7 @@ fn test_cookies_in_header() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(
         request.cookies,
@@ -393,7 +394,7 @@ fn test_cookies_in_header_dont_override_cookies() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(
         request.cookies,
@@ -414,7 +415,7 @@ fn test_method_invalid() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(request.method.value(), None);
 }
@@ -426,7 +427,7 @@ fn test_method_valid() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
 
     assert_eq_dbg!(request.method.as_str(), Some("POST"));
 }
@@ -444,7 +445,7 @@ fn test_infer_json() {
         Annotated::from(Value::String("bar".into())),
     );
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(
         request.inferred_content_type.as_str(),
         Some("application/json")
@@ -465,7 +466,7 @@ fn test_broken_json_with_fallback() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.inferred_content_type.as_str(), Some("text/plain"));
     assert_eq_dbg!(request.data.as_str(), Some(r#"{"foo":"b"#));
 }
@@ -477,7 +478,7 @@ fn test_broken_json_without_fallback() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.inferred_content_type.value(), None);
     assert_eq_dbg!(request.data.as_str(), Some(r#"{"foo":"b"#));
 }
@@ -495,7 +496,7 @@ fn test_infer_url_encoded() {
         Annotated::from(Value::String("bar".into())),
     );
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(
         request.inferred_content_type.as_str(),
         Some("application/x-www-form-urlencoded")
@@ -510,7 +511,7 @@ fn test_infer_url_false_positive() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.inferred_content_type.value(), None);
     assert_eq_dbg!(request.data.as_str(), Some("dGU="));
 }
@@ -522,7 +523,7 @@ fn test_infer_url_encoded_base64() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.inferred_content_type.value(), None);
     assert_eq_dbg!(request.data.as_str(), Some("dA=="));
 }
@@ -534,7 +535,7 @@ fn test_infer_xml() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.inferred_content_type.value(), None);
     assert_eq_dbg!(request.data.as_str(), Some("<?xml version=\"1.0\" ?>"));
 }
@@ -546,7 +547,7 @@ fn test_infer_binary() {
         ..Request::default()
     };
 
-    normalize_request(&mut request);
+    normalize_request(&mut request).unwrap();
     assert_eq_dbg!(request.inferred_content_type.value(), None);
     assert_eq_dbg!(request.data.as_str(), Some("\u{001f}1\u{0000}\u{0000}"));
 }

--- a/general/src/store/normalize/stacktrace.rs
+++ b/general/src/store/normalize/stacktrace.rs
@@ -3,7 +3,7 @@ use std::mem;
 use url::Url;
 
 use crate::protocol::{Frame, RawStacktrace};
-use crate::types::{Annotated, Empty, Meta, ValueAction};
+use crate::types::{Annotated, Empty, Meta, ProcessingResult};
 
 fn is_url(filename: &str) -> bool {
     filename.starts_with("file:")
@@ -12,7 +12,7 @@ fn is_url(filename: &str) -> bool {
         || filename.starts_with("applewebdata:")
 }
 
-pub fn process_stacktrace(stacktrace: &mut RawStacktrace, _meta: &mut Meta) -> ValueAction {
+pub fn process_stacktrace(stacktrace: &mut RawStacktrace, _meta: &mut Meta) -> ProcessingResult {
     // This processing is only done for non raw frames (i.e. not for exception.raw_stacktrace).
     if let Some(frames) = stacktrace.frames.value_mut() {
         for frame in frames.iter_mut() {
@@ -23,7 +23,7 @@ pub fn process_stacktrace(stacktrace: &mut RawStacktrace, _meta: &mut Meta) -> V
     Ok(())
 }
 
-pub fn process_non_raw_frame(frame: &mut Frame, _meta: &mut Meta) -> ValueAction {
+pub fn process_non_raw_frame(frame: &mut Frame, _meta: &mut Meta) -> ProcessingResult {
     if frame.abs_path.value().is_empty() {
         frame.abs_path = mem::replace(&mut frame.filename, Annotated::empty());
     }

--- a/general/src/store/remove_other.rs
+++ b/general/src/store/remove_other.rs
@@ -1,6 +1,6 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
 use crate::protocol::Event;
-use crate::types::{Annotated, ErrorKind, Meta, Object, Value, ValueAction};
+use crate::types::{Annotated, ErrorKind, Meta, Object, ProcessingResult, Value};
 
 pub struct RemoveOtherProcessor;
 
@@ -9,7 +9,7 @@ impl Processor for RemoveOtherProcessor {
         &mut self,
         other: &mut Object<Value>,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         // Drop unknown attributes at all levels without error messages, unless `retain = "true"`
         // was specified explicitly on the field.
         if !state.attrs().retain {
@@ -24,7 +24,7 @@ impl Processor for RemoveOtherProcessor {
         event: &mut Event,
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         // Move the current map out so we don't clear it in `process_other`
         let mut other = std::mem::replace(&mut event.other, Default::default());
 

--- a/general/src/store/transactions.rs
+++ b/general/src/store/transactions.rs
@@ -1,0 +1,689 @@
+use crate::processor::{ProcessValue, ProcessingState, Processor};
+use crate::protocol::{Context, ContextInner, Contexts, Event, EventType, Span};
+use crate::types::{Annotated, DiscardValue, Meta, ValueAction};
+
+pub struct TransactionsProcessor;
+
+impl Processor for TransactionsProcessor {
+    fn process_event(
+        &mut self,
+        event: &mut Event,
+        _meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ValueAction {
+        if event.ty.value() != Some(&EventType::Transaction) {
+            return Ok(());
+        }
+
+        if event.timestamp.value().is_none() {
+            // This invariant should be already guaranteed for regular error events.
+            return Err(DiscardValue::InvalidEvent(
+                "timestamp hard-required for transaction events",
+            ));
+        }
+
+        // XXX: Maybe copy timestamp over?
+        if event.start_timestamp.value().is_none() {
+            return Err(DiscardValue::InvalidEvent(
+                "start_timestamp hard-required for transaction events",
+            ));
+        }
+
+        if let Some(Contexts(ref contexts)) = event.contexts.value() {
+            match contexts.get("trace").and_then(Annotated::value) {
+                Some(ContextInner(Context::Trace(ref trace_context))) => {
+                    if trace_context.trace_id.value().is_none() {
+                        return Err(DiscardValue::InvalidEvent(
+                            "trace context is missing trace_id",
+                        ));
+                    }
+
+                    if trace_context.span_id.value().is_none() {
+                        return Err(DiscardValue::InvalidEvent(
+                            "trace context is missing span_id",
+                        ));
+                    }
+
+                    if trace_context.op.value().is_none() {
+                        return Err(DiscardValue::InvalidEvent("trace context is missing op"));
+                    }
+                }
+                Some(_) => {
+                    return Err(DiscardValue::InvalidEvent(
+                        "context at event.contexts.trace must be of type trace.",
+                    ));
+                }
+                None => {
+                    return Err(DiscardValue::InvalidEvent(
+                        "trace context hard-required for transaction events",
+                    ));
+                }
+            }
+        } else {
+            return Err(DiscardValue::InvalidEvent(
+                "trace context hard-required for transaction events",
+            ));
+        }
+
+        if let Some(spans) = event.spans.value() {
+            for span in spans {
+                if span.value().is_none() {
+                    return Err(DiscardValue::InvalidEvent(
+                        "spans must be valid in transaction event",
+                    ));
+                }
+            }
+        }
+
+        event.process_child_values(self, state)?;
+
+        Ok(())
+    }
+
+    fn process_span(
+        &mut self,
+        span: &mut Span,
+        _meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ValueAction {
+        // XXX: Maybe do the same as event.timestamp?
+        if span.timestamp.value().is_none() {
+            return Err(DiscardValue::InvalidEvent("span is missing timestamp"));
+        }
+
+        // XXX: Maybe copy timestamp over?
+        if span.start_timestamp.value().is_none() {
+            return Err(DiscardValue::InvalidEvent(
+                "span is missing start_timestamp",
+            ));
+        }
+
+        if span.trace_id.value().is_none() {
+            return Err(DiscardValue::InvalidEvent("span is missing trace_id"));
+        }
+
+        if span.span_id.value().is_none() {
+            return Err(DiscardValue::InvalidEvent("span is missing span_id"));
+        }
+
+        if span.op.value().is_none() {
+            return Err(DiscardValue::InvalidEvent("span is missing op"));
+        }
+
+        span.process_child_values(self, state)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::processor::process_value;
+    use crate::protocol::{SpanId, TraceContext, TraceId};
+    use crate::types::Object;
+    use chrono::offset::TimeZone;
+    use chrono::Utc;
+
+    #[test]
+    fn test_skips_non_transaction_events() {
+        let mut event = Annotated::new(Event::default());
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+        assert!(event.value().is_some());
+    }
+
+    #[test]
+    fn test_discards_when_missing_timestamp() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "timestamp hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_when_missing_start_timestamp() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "start_timestamp hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_contexts_map() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "trace context hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_context() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts(Object::new())),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "trace context hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_null_context() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert("trace".to_owned(), Annotated::empty());
+                contexts
+            })),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "trace context hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_trace_id_in_context() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "trace context is missing trace_id"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_span_id_in_context() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "trace context is missing span_id"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_op_in_context() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent("trace context is missing op"))
+        );
+    }
+
+    #[test]
+    fn test_allows_transaction_event_without_span_list() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            ..Default::default()
+        });
+
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+        assert!(event.value().is_some());
+    }
+
+    #[test]
+    fn test_allows_transaction_event_with_empty_span_list() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![]),
+            ..Default::default()
+        });
+
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+        assert!(event.value().is_some());
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_nulled_out_span() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::empty()]),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "spans must be valid in transaction event"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_timestamp() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent("span is missing timestamp"))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_start_timestamp() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent(
+                "span is missing start_timestamp"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_trace_id() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent("span is missing trace_id"))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_span_id() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent("span is missing span_id"))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_op() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq_dbg!(
+            process_value(
+                &mut event,
+                &mut TransactionsProcessor,
+                ProcessingState::root()
+            ),
+            Err(DiscardValue::InvalidEvent("span is missing op"))
+        );
+    }
+
+    #[test]
+    fn test_allows_valid_transaction_event_with_spans() {
+        let mut event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
+                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                op: Annotated::new("db.statement".to_owned()),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert!(event.value().is_some());
+    }
+}

--- a/general/src/types/mod.rs
+++ b/general/src/types/mod.rs
@@ -11,7 +11,7 @@ mod traits;
 mod value;
 
 pub use self::annotated::{
-    Annotated, DiscardValue, MetaMap, MetaTree, SerializableAnnotated, ValueAction,
+    Annotated, MetaMap, MetaTree, ProcessingAction, ProcessingResult, SerializableAnnotated,
 };
 pub use self::impls::SerializePayload;
 pub use self::meta::{Error, ErrorKind, Meta, Range, Remark, RemarkType};

--- a/general/src/types/mod.rs
+++ b/general/src/types/mod.rs
@@ -10,7 +10,9 @@ mod meta;
 mod traits;
 mod value;
 
-pub use self::annotated::{Annotated, MetaMap, MetaTree, SerializableAnnotated, ValueAction};
+pub use self::annotated::{
+    Annotated, DiscardValue, MetaMap, MetaTree, SerializableAnnotated, ValueAction,
+};
 pub use self::impls::SerializePayload;
 pub use self::meta::{Error, ErrorKind, Meta, Range, Remark, RemarkType};
 pub use self::traits::{Empty, FromValue, SkipSerialization, ToValue};

--- a/general/tests/test_derive.rs
+++ b/general/tests/test_derive.rs
@@ -19,9 +19,9 @@ impl Processor for RecordingProcessor {
     ) -> ValueAction {
         self.0.push(format!("process_value({})", state.path()));
         self.0.push("before_process_child_values".to_string());
-        value.process_child_values(self, state);
+        value.process_child_values(self, state)?;
         self.0.push("after_process_child_values".to_string());
-        ValueAction::Keep
+        Ok(())
     }
 
     fn process_string(
@@ -31,7 +31,7 @@ impl Processor for RecordingProcessor {
         state: &ProcessingState<'_>,
     ) -> ValueAction {
         self.0.push(format!("process_string({})", state.path()));
-        ValueAction::Keep
+        Ok(())
     }
 
     fn process_header_name(
@@ -43,9 +43,9 @@ impl Processor for RecordingProcessor {
         self.0
             .push(format!("process_header_name({})", state.path()));
         self.0.push("before_process_child_values".to_string());
-        value.process_child_values(self, state);
+        value.process_child_values(self, state)?;
         self.0.push("after_process_child_values".to_string());
-        ValueAction::Keep
+        Ok(())
     }
 }
 
@@ -58,7 +58,8 @@ fn test_enums_processor_calls() {
         &mut value,
         &mut processor,
         &ProcessingState::root().enter_static("foo", None, None),
-    );
+    )
+    .unwrap();
 
     // Assert that calling `process_child_values` does not recurse. This is surprising and slightly
     // undesirable for processors, but not a big deal and easy to implement.
@@ -82,7 +83,8 @@ fn test_simple_newtype() {
         &mut value,
         &mut processor,
         &ProcessingState::root().enter_static("foo", None, None),
-    );
+    )
+    .unwrap();
 
     // Assert that calling `process_child_values` does not recurse. This is surprising and slightly
     // undesirable for processors, but not a big deal and easy to implement.

--- a/general/tests/test_derive.rs
+++ b/general/tests/test_derive.rs
@@ -5,8 +5,8 @@ use semaphore_general::processor::Processor;
 use semaphore_general::protocol::HeaderName;
 use semaphore_general::types::Annotated;
 use semaphore_general::types::Meta;
+use semaphore_general::types::ProcessingResult;
 use semaphore_general::types::Value;
-use semaphore_general::types::ValueAction;
 
 struct RecordingProcessor(Vec<String>);
 
@@ -16,7 +16,7 @@ impl Processor for RecordingProcessor {
         value: &mut Value,
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         self.0.push(format!("process_value({})", state.path()));
         self.0.push("before_process_child_values".to_string());
         value.process_child_values(self, state)?;
@@ -29,7 +29,7 @@ impl Processor for RecordingProcessor {
         _value: &mut String,
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         self.0.push(format!("process_string({})", state.path()));
         Ok(())
     }
@@ -39,7 +39,7 @@ impl Processor for RecordingProcessor {
         value: &mut HeaderName,
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
-    ) -> ValueAction {
+    ) -> ProcessingResult {
         self.0
             .push(format!("process_header_name({})", state.path()));
         self.0.push("before_process_child_values".to_string());

--- a/general/tests/test_fixtures.rs
+++ b/general/tests/test_fixtures.rs
@@ -43,7 +43,7 @@ macro_rules! event_snapshot {
         let mut config = StoreConfig::default();
         config.valid_platforms = VALID_PLATOFORMS.clone();
         let mut processor = StoreProcessor::new(config, None);
-        process_value(&mut event, &mut processor, ProcessingState::root());
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
         assert_yaml_snapshot!(SerializableAnnotated(&event), {
             ".received" => "[received]",
             ".timestamp" => "[timestamp]"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,8 +33,7 @@ native-tls = { version = "0.2.3", optional = true }
 num_cpus = "1.10.1"
 parking_lot = "0.9.0"
 r2d2 = { version = "0.8.5", optional = true }
-# https://github.com/fede1024/rust-rdkafka/issues/125
-rdkafka = { version = "0.21.0", git = "https://github.com/fede1024/rust-rdkafka", optional = true, rev = "0efbcf38150fad9fcd65b5f7f23f488c01248ae8" }
+rdkafka = { version = "0.21.0", git = "https://github.com/fede1024/rust-rdkafka", optional = true }
 redis = { version = "0.12.1-alpha.0", git = "https://github.com/mitsuhiko/redis-rs", optional = true, branch = "feature/cluster", features = ["cluster", "r2d2"] }
 regex = "1.2.0"
 rmp-serde = { version = "0.13.7", optional = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,7 +33,7 @@ native-tls = { version = "0.2.3", optional = true }
 num_cpus = "1.10.1"
 parking_lot = "0.9.0"
 r2d2 = { version = "0.8.5", optional = true }
-rdkafka = { version = "0.21.0", git = "https://github.com/fede1024/rust-rdkafka", optional = true }
+rdkafka = { version = "0.21.0", git = "https://github.com/fede1024/rust-rdkafka", optional = true, rev = "b1a391b3264ca8e0b0e053c6aec7a6db09af3131" }
 redis = { version = "0.12.1-alpha.0", git = "https://github.com/mitsuhiko/redis-rs", optional = true, branch = "feature/cluster", features = ["cluster", "r2d2"] }
 regex = "1.2.0"
 rmp-serde = { version = "0.13.7", optional = true }

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -17,7 +17,7 @@ use semaphore_general::filter::FilterStatKey;
 use semaphore_general::pii::PiiProcessor;
 use semaphore_general::processor::{process_value, ProcessingState};
 use semaphore_general::protocol::{Event, EventId};
-use semaphore_general::types::{Annotated, DiscardValue};
+use semaphore_general::types::{Annotated, ProcessingAction};
 use serde_json;
 
 use crate::actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
@@ -54,7 +54,7 @@ enum ProcessingError {
     InvalidJson(#[cause] serde_json::Error),
 
     #[fail(display = "invalid event")]
-    InvalidEvent(#[cause] DiscardValue),
+    InvalidEvent(#[cause] ProcessingAction),
 
     #[fail(display = "could not schedule project fetch")]
     ScheduleFailed(#[cause] MailboxError),

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -664,6 +664,7 @@ impl RetryAfter {
 pub struct RateLimit(pub RateLimitScope, pub RetryAfter);
 
 impl RateLimit {
+    #[cfg(feature = "processing")]
     pub fn reason_code(&self) -> Option<&str> {
         Some(&self.1.reason_code.as_ref()?)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -319,12 +319,12 @@ pub fn process_event<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
     let mut event = EventV8::from_json_bytes(&event_json[..])?;
     if let Some(ref pii_config) = pii_config {
         let mut processor = PiiProcessor::new(pii_config);
-        process_value(&mut event, &mut processor, ProcessingState::root());
+        process_value(&mut event, &mut processor, ProcessingState::root())?;
     };
 
     if matches.is_present("store") {
         let mut processor = StoreProcessor::new(Default::default(), None);
-        process_value(&mut event, &mut processor, ProcessingState::root());
+        process_value(&mut event, &mut processor, ProcessingState::root())?;
     }
 
     if matches.is_present("debug") {


### PR DESCRIPTION
* Introduce a much stricter transaction event schema, using a separate processor:

  * for trace context and spans, trace_id/span_id/op is required
  * there must be a trace context present under `event.contexts.trace` for transaction events
  * start_timestamp and timestamp are required for both spans and the event

* For the processor to be able to reject an entire event (and not just a local value) we need a separate valueaction variant.
* Refactor valueaction to be a result that works with `try!() / x?`.
* The top-level `process_value` function is now fallible.