### PR TITLE
ref: Selectively log internal errors to stderr

### DIFF
--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -54,7 +54,7 @@ def mini_sentry(request):
     @app.route("/api/666/store/", methods=["POST"])
     def store_internal_error_event():
         sentry.test_failures.append(
-            ("/api/666/store/", AssertionError("Relay sent us event"))
+            ("/api/666/store/", AssertionError("Relay sent us event: {}".format(flask_request.data)))
         )
         return jsonify({"event_id": uuid.uuid4().hex})
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -50,6 +50,11 @@ def test_forced_shutdown(mini_sentry, relay):
     relay.shutdown(sig=signal.SIGINT)
     pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
 
+    (route, error), = mini_sentry.test_failures
+    assert route == '/api/666/store/'
+    assert 'shutdown timer expired' in str(error)
+    mini_sentry.test_failures.clear()
+
 
 @pytest.mark.parametrize("failure_type", ["timeout", "socketerror"])
 def test_query_retry(failure_type, mini_sentry, relay):

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -80,6 +80,10 @@ def test_event_timeout(mini_sentry, relay):
         "formatted": "correct"
     }
     pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+    (route, error), = mini_sentry.test_failures
+    assert route == '/api/666/store/'
+    assert 'configured lifetime' in str(error)
+    mini_sentry.test_failures.clear()
 
 
 def test_rate_limit(mini_sentry, relay):


### PR DESCRIPTION
We're logging quite a few errors now for events that are being filtered or rate limited. Most importantly, actix automatically logs all errors returned from endpoint futures.

This PR changes this, so that errors are logged selectively to stderr if they are considered "server" or "internal" errors, and otherwise either swallowed or logged to INFO.