### PR TITLE
fix: Normalize before datascrubbing

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -144,14 +144,6 @@ impl EventProcessor {
             event.id = Annotated::new(message.event_id);
         }
 
-        metric!(timer("event_processing.pii"), {
-            for pii_config in message.project_state.config.pii_configs() {
-                let mut processor = PiiProcessor::new(pii_config);
-                process_value(&mut event, &mut processor, ProcessingState::root())
-                    .map_err(ProcessingError::InvalidEvent)?;
-            }
-        });
-
         #[cfg(feature = "processing")]
         {
             if self.config.processing_enabled() {
@@ -237,6 +229,14 @@ impl EventProcessor {
                 }
             }
         }
+
+        metric!(timer("event_processing.pii"), {
+            for pii_config in message.project_state.config.pii_configs() {
+                let mut processor = PiiProcessor::new(pii_config);
+                process_value(&mut event, &mut processor, ProcessingState::root())
+                    .map_err(ProcessingError::InvalidEvent)?;
+            }
+        });
 
         let data = metric! {timer("event_processing.serialization"), {
             event


### PR DESCRIPTION
This probably didn't cause any problems, but it's better to run datascrubbers after rate limits have been applied