### PR TITLE
fix(protocol): Add missing legacy alias for stacktrace

### DIFF
--- a/general/src/protocol/event.rs
+++ b/general/src/protocol/event.rs
@@ -302,6 +302,7 @@ pub struct Event {
 
     /// Deprecated event stacktrace.
     #[metastructure(skip_serialization = "empty")]
+    #[metastructure(legacy_alias = "sentry.interfaces.Stacktrace")]
     pub stacktrace: Annotated<Stacktrace>,
 
     /// Simplified template error location information.


### PR DESCRIPTION
The legacy alias for stacktrace has always been missing in `general`.