### PR TITLE
ref: Set _relay_processed to true

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -199,7 +199,7 @@ impl EventProcessor {
                     // TODO: Remove this once cutover is complete.
                     event.other.insert(
                         "_relay_processed".to_owned(),
-                        Annotated::new(Value::Bool(false)),
+                        Annotated::new(Value::Bool(true)),
                     );
                 }
             }


### PR DESCRIPTION
The `_relay_processed` flag is set to `false`. While this still uniquely identifies that Relay has touched this event, it is confusing. Setting to `true` instead.