### PR TITLE
fix: Impose a limit on the projectconfig query size

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -258,6 +258,10 @@ struct Limits {
     /// The total number of threads spawned will roughly be `2 * max_thread_count + 1`. Defaults to
     /// the number of logical CPU cores on the host.
     max_thread_count: usize,
+    /// The maximum number of project configs to fetch from Sentry at once. Defaults to 3000.
+    ///
+    /// `cache.batch_interval` controls how quickly batches are sent, this controls the batch size.
+    max_query_batch_size: usize,
 }
 
 impl Default for Limits {
@@ -269,6 +273,7 @@ impl Default for Limits {
             max_api_file_upload_size: ByteSize::from_megabytes(40),
             max_api_chunk_upload_size: ByteSize::from_megabytes(100),
             max_thread_count: num_cpus::get(),
+            max_query_batch_size: 3000,
         }
     }
 }
@@ -811,6 +816,11 @@ impl Config {
     /// Returns the number of cores to use for thread pools.
     pub fn cpu_concurrency(&self) -> usize {
         self.values.limits.max_thread_count
+    }
+
+    /// Returns the maximum size of a project config query.
+    pub fn max_query_batch_size(&self) -> usize {
+        self.values.limits.max_query_batch_size
     }
 
     /// Return the Sentry DSN if reporting to Sentry is enabled.

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -311,7 +311,7 @@ struct Cache {
     miss_expiry: u32,
     /// The buffer timeout for batched queries before sending them upstream in ms.
     batch_interval: u32,
-    /// The maximum number of project configs to fetch from Sentry at once. Defaults to 3000.
+    /// The maximum number of project configs to fetch from Sentry at once. Defaults to 500.
     ///
     /// `cache.batch_interval` controls how quickly batches are sent, this controls the batch size.
     batch_size: usize,
@@ -328,7 +328,7 @@ impl Default for Cache {
             event_buffer_size: 1000,
             miss_expiry: 60,     // 1 minute
             batch_interval: 100, // 100ms
-            batch_size: 3000,
+            batch_size: 500,
             file_interval: 10, // 10 seconds
         }
     }

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -848,10 +848,10 @@ impl ProjectCache {
             .collect();
 
         log::debug!(
-            "updating project states for {} projects (attempt {}, {} additional states pending)",
+            "updating project states for {}/{} projects (attempt {})",
             channels.len(),
+            self.state_channels.len(),
             self.backoff.attempt(),
-            self.state_channels.len()
         );
 
         metric!(counter("project_state.request.size") += channels.len() as i64);


### PR DESCRIPTION
We have observed that under high load, relay will attempt to fetch a large number of projects within a single request. This request will inevitably fail, so all channels are returned to the state_channels map and the next request will be even bigger.

Add some metrics and add a limit on the request size. This is a quick fix which will likely be insufficient for full mitigation (we should limit the amount of retries maybe?), but should be enough to get us going for now.

Follow-up:

* Limit attempts per entry in state_channels (preferrably using deadline ts)
* Randomly sample from state_channels instead of just using `take(..)`