### PR TITLE
fix(projects): Use correct metrics for project caches

### DIFF
--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -907,7 +907,9 @@ impl ProjectCache {
                         slf.backoff.reset();
 
                         // count number of project states returned (via http requests)
-                        metric!(counter("project_state.received") += response.configs.len() as i64);
+                        metric!(
+                            histogram("project_state.received") = response.configs.len() as u64
+                        );
                         for (id, channel) in batch {
                             let state = response
                                 .configs

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -879,7 +879,7 @@ impl ProjectCache {
         self.updates
             .retain(|update| !batch.contains_key(&update.project_id));
         self.updates
-            .extend(batch.keys().copied().map(ProjectUpdate::new));
+            .extend(batch_ids.iter().copied().map(ProjectUpdate::new));
 
         metric!(timer("project_state.eviction.duration") = eviction_start.elapsed());
         metric!(counter("project_state.request.size") += batch.len() as i64);

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -838,16 +838,16 @@ impl ProjectCache {
 
         let eviction_start = Instant::now();
 
-        let to_fetch: Vec<_> = self
+        let batch_ids: Vec<_> = self
             .state_channels
             .keys()
             .copied()
             .take(self.config.query_batch_size())
             .collect();
 
-        let batch: HashMap<_, _> = to_fetch
-            .into_iter()
-            .map(|id| (id, self.state_channels.remove(&id).unwrap()))
+        let batch: HashMap<_, _> = batch_ids
+            .iter()
+            .map(|id| (*id, self.state_channels.remove(id).unwrap()))
             .collect();
 
         log::debug!(
@@ -886,7 +886,7 @@ impl ProjectCache {
         metric!(histogram("project_cache.size") = self.state_channels.len() as u64);
 
         let request = GetProjectStates {
-            projects: batch.keys().copied().collect(),
+            projects: batch_ids,
             #[cfg(feature = "processing")]
             full_config: self.config.processing_enabled(),
         };

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -883,7 +883,7 @@ impl ProjectCache {
 
         metric!(timer("project_state.eviction.duration") = eviction_start.elapsed());
         metric!(counter("project_state.request.size") += batch.len() as i64);
-        metric!(histogram("project_cache.size") = self.state_channels.len() as u64);
+        metric!(histogram("project_state.request.pending") = self.state_channels.len() as u64);
 
         let request = GetProjectStates {
             projects: batch_ids,
@@ -927,7 +927,8 @@ impl ProjectCache {
                             // have been pushed in the meanwhile. We will retry again shortly.
                             slf.state_channels.extend(batch);
                             metric!(
-                                histogram("project_cache.size") = slf.state_channels.len() as u64
+                                histogram("project_state.request.pending") =
+                                    slf.state_channels.len() as u64
                             );
                         }
                     }


### PR DESCRIPTION
- Ensures that the eviction timer also covers mutations of the `state_channels` field
- Uses histogram metrics instead of counters where applicable
- Fixes the `"x/y projects"` debug message