### PR TITLE
meta(LICENSE): Switch to Business Source License 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Sentry <hello@sentry.io>"]
 description = "An proxy service for Sentry."
 exclude = [".vscode/**/*", ".idea/**/*"]
-license = "MIT"
+license-file = "./LICENSE"
 name = "semaphore"
 readme = "README.md"
 version = "0.4.59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Sentry <hello@sentry.io>"]
+authors = ["Sentry <hoss@sentry.io>"]
 description = "An proxy service for Sentry."
 exclude = [".vscode/**/*", ".idea/**/*"]
 license-file = "./LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Sentry <hoss@sentry.io>"]
+authors = ["Sentry <oss@sentry.io>"]
 description = "An proxy service for Sentry."
 exclude = [".vscode/**/*", ".idea/**/*"]
 license-file = "./LICENSE"

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,104 @@
-Copyright (c) 2017 Sentry (https://sentry.io) and individual contributors.
-All rights reserved.
+Business Source License 1.1
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Parameters
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Licensor:             Functional Software, Inc.
+Licensed Work:        Sentry
+                      The Licensed Work is (c) 2019 Functional Software, Inc.
+Additional Use Grant: You may make use of the Licensed Work, provided that you do
+                      not use the Licensed Work for an Application Monitoring
+                      Service.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+                      An "Application Monitoring Service" is a commercial offering
+                      that allows third parties (other than your employees and
+                      contractors) to access the functionality of the Licensed
+                      Work so that such third parties directly benefit from the
+                      error-reporting or application monitoring features of the
+                      Licensed Work.
+
+Change Date:          2022-09-15
+
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Software,
+please visit: https://sentry.io/pricing/
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/cabi/Cargo.toml
+++ b/cabi/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "semaphore-cabi"
 version = "0.4.59"
-license = "MIT"
-authors = ["Sentry <hello@sentry.io>"]
+authors = ["Sentry <oss@sentry.io>"]
 homepage = "https://github.com/getsentry/semaphore"
 repository = "https://github.com/getsentry/semaphore"
 description = "Exposes some internals of the relay to C."
 edition = "2018"
+license-file = "../LICENSE"
 
 [lib]
 name = "semaphore"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-authors = ["Sentry <hello@sentry.io>"]
+authors = ["Sentry <oss@sentry.io>"]
 description = "Common functionality for the sentry relay"
 documentation = "https://docs.rs/semaphore-common"
 homepage = "https://github.com/getsentry/semaphore"
-license = "MIT"
 name = "semaphore-common"
 repository = "https://github.com/getsentry/semaphore"
 version = "0.4.59"
 edition = "2018"
+license-file = "../LICENSE"
 
 [features]
 default = []

--- a/general/Cargo.toml
+++ b/general/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "semaphore-general"
 version = "0.4.59"
-authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
+authors = ["Sentry <oss@sentry.io>"]
 edition = "2018"
+license-file = "../LICENSE"
 
 [dependencies]
 bytecount = "0.5.1"

--- a/py/setup.py
+++ b/py/setup.py
@@ -88,7 +88,7 @@ setup(
     version=version,
     packages=find_packages(),
     author="Sentry",
-    license="MIT",
+    license="BSL-1.1",
     author_email="hello@sentry.io",
     description="A python library to access sentry relay functionality.",
     long_description=readme,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-authors = ["Sentry <hello@sentry.io>"]
+authors = ["Sentry <oss@sentry.io>"]
 description = "Server components for the relay"
 documentation = "https://docs.rs/semaphore-server"
 homepage = "https://github.com/getsentry/semaphore"
-license = "MIT"
 name = "semaphore-server"
 repository = "https://github.com/getsentry/semaphore"
 version = "0.4.59"
 edition = "2018"
 build = "build.rs"
+license-file = "../LICENSE"
 
 [features]
 default = ["with_ssl"]


### PR DESCRIPTION
See the public announcement about this on: https://blog.sentry.io/2019/11/06/relicensing-sentry/