### PR TITLE
fix: Add (larger) query response size limit

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -258,8 +258,6 @@ struct Limits {
     /// The total number of threads spawned will roughly be `2 * max_thread_count + 1`. Defaults to
     /// the number of logical CPU cores on the host.
     max_thread_count: usize,
-    /// The maximum size of a projectconfig query response. Defaults to 10MB
-    max_query_response_size: ByteSize,
 }
 
 impl Default for Limits {
@@ -271,7 +269,6 @@ impl Default for Limits {
             max_api_file_upload_size: ByteSize::from_megabytes(40),
             max_api_chunk_upload_size: ByteSize::from_megabytes(100),
             max_thread_count: num_cpus::get(),
-            max_query_response_size: ByteSize::from_megabytes(10),
         }
     }
 }
@@ -824,11 +821,6 @@ impl Config {
     /// Returns the maximum size of a project config query.
     pub fn query_batch_size(&self) -> usize {
         self.values.cache.batch_size
-    }
-
-    /// Returns the maximum size of a project config query's response in MB.
-    pub fn max_query_response_size(&self) -> usize {
-        self.values.limits.max_query_response_size.as_bytes() as usize
     }
 
     /// Return the Sentry DSN if reporting to Sentry is enabled.

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -258,6 +258,8 @@ struct Limits {
     /// The total number of threads spawned will roughly be `2 * max_thread_count + 1`. Defaults to
     /// the number of logical CPU cores on the host.
     max_thread_count: usize,
+    /// The maximum size of a projectconfig query response. Defaults to 10MB
+    max_query_response_size: ByteSize,
 }
 
 impl Default for Limits {
@@ -269,6 +271,7 @@ impl Default for Limits {
             max_api_file_upload_size: ByteSize::from_megabytes(40),
             max_api_chunk_upload_size: ByteSize::from_megabytes(100),
             max_thread_count: num_cpus::get(),
+            max_query_response_size: ByteSize::from_megabytes(10),
         }
     }
 }
@@ -821,6 +824,11 @@ impl Config {
     /// Returns the maximum size of a project config query.
     pub fn query_batch_size(&self) -> usize {
         self.values.cache.batch_size
+    }
+
+    /// Returns the maximum size of a project config query's response in MB.
+    pub fn max_query_response_size(&self) -> usize {
+        self.values.limits.max_query_response_size.as_bytes() as usize
     }
 
     /// Return the Sentry DSN if reporting to Sentry is enabled.

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -166,7 +166,7 @@ impl UpstreamRelay {
 
         let (json, signature) = credentials.secret_key.pack(query);
 
-        let max_response_size = self.config.max_query_response_size();
+        let max_response_size = self.config.max_api_payload_size();
 
         let future = self
             .send_request(method, path, |builder| {

--- a/server/src/actors/upstream.rs
+++ b/server/src/actors/upstream.rs
@@ -166,6 +166,8 @@ impl UpstreamRelay {
 
         let (json, signature) = credentials.secret_key.pack(query);
 
+        let max_response_size = self.config.max_query_response_size();
+
         let future = self
             .send_request(method, path, |builder| {
                 builder
@@ -174,7 +176,11 @@ impl UpstreamRelay {
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(json)
             })
-            .and_then(|r| r.json().map_err(UpstreamRequestError::InvalidJson));
+            .and_then(move |r| {
+                r.json()
+                    .limit(max_response_size)
+                    .map_err(UpstreamRequestError::InvalidJson)
+            });
 
         Box::new(future)
     }


### PR DESCRIPTION
actix by default would discard anything above 256kb, let's bump that to 10Mb and make it configurable