### PR TITLE
ci(travis): Disable rust caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ python: "3.6"
 
 cache:
   directories:
-    - cabi/target
     - py/venv
-    - $HOME/.cargo
-    - $TRAVIS_BUILD_DIR/target
-  timeout: 1200
 
 git:
   depth: 1


### PR DESCRIPTION
At the moment, we're spending roughly 10 minutes downloading or uploading caches per build. Turns out this is oftentimes slower than just rebuilding. Additionally, we've had one case where the cache corrupts and then fails all subsequent builds.

Let's disable caches and rebuild clean every time.