### PR TITLE
fix: Use camelcase for quotas

### DIFF
--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -571,6 +571,7 @@ mod __quota_serialization {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RedisQuota {
     /// How many events should be accepted within the window.
     ///
@@ -597,6 +598,7 @@ pub struct RedisQuota {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RejectAllQuota {
     /// Some string identifier that will be part of the 429 Rate Limit Exceeded response if it
     /// comes to that.

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -286,7 +286,7 @@ def test_quotas(mini_sentry, relay_with_processing, outcomes_consumer, events_co
             "prefix": "test_rate_limiting_{}".format(uuid.uuid4().hex),
             "limit": 5,
             "window": 3600,
-            "reason_code": "get_lost",
+            "reasonCode": "get_lost",
         }
     ]
 


### PR DESCRIPTION
Relay saw a missing `reason_code` (which is interpreted as no reason code) and a superfluous `reasonCode` (which it just discarded). Therefore it never reported a reason as part of a outcome:rate_limited