### PR TITLE
fix: blacklist "none" as a possible environment name

### DIFF
--- a/general/src/protocol/constants.rs
+++ b/general/src/protocol/constants.rs
@@ -19,3 +19,5 @@ pub const VALID_PLATFORMS: &[&str] = &[
     "python",
     "ruby",
 ];
+
+pub const INVALID_ENVIRONMENTS: &[&str] = &["none"];

--- a/general/src/protocol/mod.rs
+++ b/general/src/protocol/mod.rs
@@ -21,7 +21,7 @@ mod user;
 
 pub use self::breadcrumb::Breadcrumb;
 pub use self::clientsdk::{ClientSdkInfo, ClientSdkPackage};
-pub use self::constants::VALID_PLATFORMS;
+pub use self::constants::{INVALID_ENVIRONMENTS, VALID_PLATFORMS};
 pub use self::contexts::{
     AppContext, BrowserContext, Context, ContextInner, Contexts, DeviceContext, OperationType,
     OsContext, RuntimeContext, SpanId, TraceContext, TraceId,


### PR DESCRIPTION
- This is because there's an app [function](https://github.com/getsentry/sentry/blob/master/src/sentry/models/environment.py#L107) that uses the string "none" from a URL path segment (case-sensitive) to represent the empty string environment name.