### PR TITLE
feat(server): Spawn actors into separate arbiters

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -393,8 +393,8 @@ impl EventManager {
 
         #[cfg(feature = "processing")]
         let store_forwarder = if config.processing_enabled() {
-            let store_config = StoreForwarder::configure(config.clone())?;
-            Some(Arbiter::start(move |_| StoreForwarder::new(store_config)))
+            let actor = StoreForwarder::create(config.clone())?;
+            Some(Arbiter::start(move |_| actor))
         } else {
             None
         };

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -393,7 +393,8 @@ impl EventManager {
 
         #[cfg(feature = "processing")]
         let store_forwarder = if config.processing_enabled() {
-            Some(StoreForwarder::create(config.clone())?.start())
+            let store_config = StoreForwarder::configure(config.clone())?;
+            Some(Arbiter::start(move |_| StoreForwarder::new(store_config)))
         } else {
             None
         };

--- a/server/src/actors/outcome.rs
+++ b/server/src/actors/outcome.rs
@@ -163,21 +163,18 @@ mod real_implementation {
 
     use chrono::{DateTime, SecondsFormat, Utc};
     use failure::{Fail, ResultExt};
-    use futures::Future;
-    use rdkafka::{
-        error::KafkaError,
-        producer::{FutureProducer, FutureRecord},
-        ClientConfig,
-    };
+    use rdkafka::error::KafkaError;
+    use rdkafka::producer::{BaseRecord, DefaultProducerContext};
+    use rdkafka::ClientConfig;
     use serde::Serialize;
     use serde_json::Error as SerdeSerializationError;
 
-    use semaphore_common::tryf;
     use semaphore_common::{metric, KafkaTopic};
 
-    use crate::actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
     use crate::service::ServerErrorKind;
-    use crate::utils::{self, SyncFuture, SyncHandle};
+    use crate::utils;
+
+    type ThreadedProducer = rdkafka::producer::ThreadedProducer<DefaultProducerContext>;
 
     impl Outcome {
         /// Returns the name of the outcome as recognized by Sentry.
@@ -291,30 +288,19 @@ mod real_implementation {
 
     #[derive(Fail, Debug)]
     pub enum OutcomeError {
-        #[fail(display = "kafka message send canceled")]
-        Canceled,
         #[fail(display = "failed to send kafka message")]
         SendFailed(KafkaError),
-        #[fail(display = "shutdown timer expired")]
-        Shutdown,
         #[fail(display = "json serialization error")]
         SerializationError(SerdeSerializationError),
     }
 
-    /// A config for the outcome producer that can be sent across threads.
-    pub struct OutcomeProducerConfig {
-        config: Arc<Config>,
-        producer: Option<FutureProducer>,
-    }
-
     pub struct OutcomeProducer {
         config: Arc<Config>,
-        shutdown: SyncHandle,
-        producer: Option<FutureProducer>,
+        producer: Option<ThreadedProducer>,
     }
 
     impl OutcomeProducer {
-        pub fn configure(config: Arc<Config>) -> Result<OutcomeProducerConfig, ServerError> {
+        pub fn create(config: Arc<Config>) -> Result<Self, ServerError> {
             let future_producer = if config.processing_enabled() {
                 let mut client_config = ClientConfig::new();
                 for config_p in config.kafka_config() {
@@ -328,18 +314,10 @@ mod real_implementation {
                 None
             };
 
-            Ok(OutcomeProducerConfig {
+            Ok(Self {
                 config,
                 producer: future_producer,
             })
-        }
-
-        pub fn new(config: OutcomeProducerConfig) -> Self {
-            Self {
-                config: config.config,
-                producer: config.producer,
-                shutdown: SyncHandle::new(),
-            }
         }
     }
 
@@ -347,9 +325,12 @@ mod real_implementation {
         type Context = Context<Self>;
 
         fn started(&mut self, context: &mut Self::Context) {
+            // Set the mailbox size to the size of the event buffer. This is a rough estimate but
+            // should ensure that we're not dropping outcomes unintentionally.
+            let mailbox_size = self.config.event_buffer_size() as usize;
+            context.set_mailbox_capacity(mailbox_size);
+
             log::info!("OutcomeProducer started.");
-            //register with the controller for shutdown notifications
-            Controller::from_registry().do_send(Subscribe(context.address().recipient()));
         }
 
         fn stopped(&mut self, _ctx: &mut Self::Context) {
@@ -358,22 +339,24 @@ mod real_implementation {
     }
 
     impl Handler<TrackOutcome> for OutcomeProducer {
-        type Result = ResponseFuture<(), OutcomeError>;
+        type Result = Result<(), OutcomeError>;
 
         fn handle(&mut self, message: TrackOutcome, _ctx: &mut Self::Context) -> Self::Result {
             log::trace!("Tracking outcome: {:?}", message);
 
             let producer = match self.producer {
                 Some(ref producer) => producer,
-                None => return Box::new(futures::future::ok(())),
+                None => return Ok(()),
             };
 
-            let payload = tryf![serde_json::to_string(&OutcomePayload::from(&message))
-                .map_err(OutcomeError::SerializationError)];
+            let payload = serde_json::to_string(&OutcomePayload::from(&message))
+                .map_err(OutcomeError::SerializationError)?;
 
-            metric!(counter("events.outcomes") +=1,
-                    "reason"=>message.outcome.to_reason().unwrap_or(""),
-                    "outcome"=>message.outcome.name());
+            metric!(
+                counter("events.outcomes") +=1,
+                "reason" => message.outcome.to_reason().unwrap_or(""),
+                "outcome" => message.outcome.name()
+            );
 
             // At the moment, we support outcomes with optional EventId.
             // Here we create a fake EventId, when we don't have the real one, so that we can
@@ -381,40 +364,14 @@ mod real_implementation {
             // kafka consumer groups.
             let key = message.event_id.unwrap_or_else(EventId::new).0;
 
-            let record = FutureRecord::to(self.config.kafka_topic_name(KafkaTopic::Outcomes))
+            let record = BaseRecord::to(self.config.kafka_topic_name(KafkaTopic::Outcomes))
                 .payload(&payload)
                 .key(key.as_bytes().as_ref());
 
-            let future = producer
-                .send(record, 0)
-                .then(|result| match result {
-                    Ok(Ok(_)) => Ok(()),
-                    Ok(Err((kafka_error, _message))) => Err(OutcomeError::SendFailed(kafka_error)),
-                    Err(_) => Err(OutcomeError::Canceled),
-                })
-                .sync(&self.shutdown, OutcomeError::Shutdown);
-
-            Box::new(future)
-        }
-    }
-
-    impl Handler<Shutdown> for OutcomeProducer {
-        type Result = ResponseActFuture<Self, (), TimeoutError>;
-
-        fn handle(&mut self, message: Shutdown, _context: &mut Self::Context) -> Self::Result {
-            let shutdown = match message.timeout {
-                Some(timeout) => self.shutdown.timeout(timeout),
-                None => self.shutdown.now(),
-            };
-
-            let future = shutdown.into_actor(self).and_then(move |_, slf, _ctx| {
-                if let Some(ref producer) = slf.producer {
-                    producer.flush(message.timeout);
-                }
-                actix::fut::ok(())
-            });
-
-            Box::new(future)
+            match producer.send(record) {
+                Ok(_) => Ok(()),
+                Err((kafka_error, _message)) => Err(OutcomeError::SendFailed(kafka_error)),
+            }
         }
     }
 }
@@ -431,17 +388,11 @@ mod no_op_implementation {
     #[derive(Debug)]
     pub enum OutcomeError {}
 
-    pub struct OutcomeProducerConfig;
-
     pub struct OutcomeProducer;
 
     impl OutcomeProducer {
-        pub fn configure(_config: Arc<Config>) -> Result<OutcomeProducerConfig, ServerError> {
-            Ok(OutcomeProducerConfig)
-        }
-
-        pub fn new(_config: OutcomeProducerConfig) -> Self {
-            Self
+        pub fn create(_config: Arc<Config>) -> Result<Self, ServerError> {
+            Ok(Self)
         }
     }
 

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -1059,6 +1059,12 @@ impl Actor for ProjectCache {
     type Context = Context<Self>;
 
     fn started(&mut self, context: &mut Self::Context) {
+        // Set the mailbox size to the size of the event buffer. This is a rough estimate but
+        // should ensure that we're not dropping messages if the main arbiter running this actor
+        // gets hammered a bit.
+        let mailbox_size = self.config.event_buffer_size() as usize;
+        context.set_mailbox_capacity(mailbox_size);
+
         log::info!("project cache started");
         Controller::from_registry().do_send(Subscribe(context.address().recipient()));
 

--- a/server/src/actors/server.rs
+++ b/server/src/actors/server.rs
@@ -5,7 +5,7 @@ use futures::prelude::*;
 use semaphore_common::{metric, Config};
 
 use crate::actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
-use crate::service::{self, ServiceState};
+use crate::service;
 
 pub use crate::service::ServerError;
 
@@ -16,7 +16,7 @@ pub struct Server {
 impl Server {
     pub fn start(config: Config) -> Result<Addr<Self>, ServerError> {
         metric!(counter("server.starting") += 1);
-        let http_server = service::start(ServiceState::start(config)?)?;
+        let http_server = service::start(config)?;
         Ok(Server { http_server }.start())
     }
 }

--- a/server/src/actors/store.rs
+++ b/server/src/actors/store.rs
@@ -7,77 +7,38 @@ use std::time::Instant;
 use actix::prelude::*;
 use bytes::Bytes;
 use failure::{Fail, ResultExt};
-use futures::{future, Future};
 use rdkafka::error::KafkaError;
-use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::producer::{BaseRecord, DefaultProducerContext};
 use rdkafka::ClientConfig;
 use serde::Serialize;
 
 use rmp_serde::encode::Error as SerdeError;
 
-use semaphore_common::{metric, tryf, Config, KafkaTopic};
+use semaphore_common::{metric, Config, KafkaTopic};
 use semaphore_general::protocol::{EventId, EventType};
 
-use crate::actors::controller::{Controller, Shutdown, Subscribe, TimeoutError};
 use crate::envelope::{Envelope, ItemType};
 use crate::service::{ServerError, ServerErrorKind};
-use crate::utils::{instant_to_unix_timestamp, SyncFuture, SyncHandle};
+use crate::utils::instant_to_unix_timestamp;
+
+type ThreadedProducer = rdkafka::producer::ThreadedProducer<DefaultProducerContext>;
 
 #[derive(Fail, Debug)]
 pub enum StoreError {
-    #[fail(display = "kafka message send canceled")]
-    Canceled,
     #[fail(display = "failed to send kafka message")]
     SendFailed(KafkaError),
     #[fail(display = "failed to serialize message")]
     SerializeFailed(SerdeError),
-    #[fail(display = "shutdown timer expired")]
-    Shutdown,
-}
-
-fn produce<T>(
-    producer: &FutureProducer,
-    config: &Config,
-    topic: KafkaTopic,
-    event_id: EventId,
-    message: T,
-) -> ResponseFuture<(), StoreError>
-where
-    T: Serialize,
-{
-    // Use the event id as partition routing key.
-    let key = event_id.0.as_bytes().as_ref();
-
-    let serialized = tryf!(rmp_serde::to_vec_named(&message).map_err(StoreError::SerializeFailed));
-
-    let record = FutureRecord::to(config.kafka_topic_name(topic))
-        .payload(&serialized)
-        .key(key);
-
-    let future = producer.send(record, 0).then(|result| match result {
-        Ok(Ok(_)) => Ok(()),
-        Ok(Err((kafka_error, _message))) => Err(StoreError::SendFailed(kafka_error)),
-        Err(_) => Err(StoreError::Canceled),
-    });
-
-    Box::new(future)
-}
-
-/// A config for the store fowarder that can be sent across threads.
-pub struct StoreForwarderConfig {
-    config: Arc<Config>,
-    producer: Arc<FutureProducer>,
 }
 
 /// Actor for publishing events to Sentry through kafka topics.
 pub struct StoreForwarder {
     config: Arc<Config>,
-    shutdown: SyncHandle,
-    producer: Arc<FutureProducer>,
+    producer: Arc<ThreadedProducer>,
 }
 
 impl StoreForwarder {
-    pub fn configure(config: Arc<Config>) -> Result<StoreForwarderConfig, ServerError> {
+    pub fn create(config: Arc<Config>) -> Result<Self, ServerError> {
         let mut client_config = ClientConfig::new();
         for config_p in config.kafka_config() {
             client_config.set(config_p.name.as_str(), config_p.value.as_str());
@@ -87,17 +48,27 @@ impl StoreForwarder {
             .create()
             .context(ServerErrorKind::KafkaError)?;
 
-        Ok(StoreForwarderConfig {
+        Ok(Self {
             config,
             producer: Arc::new(producer),
         })
     }
 
-    pub fn new(config: StoreForwarderConfig) -> Self {
-        Self {
-            config: config.config,
-            producer: config.producer,
-            shutdown: SyncHandle::new(),
+    fn produce<T>(&self, topic: KafkaTopic, event_id: EventId, message: T) -> Result<(), StoreError>
+    where
+        T: Serialize,
+    {
+        // Use the event id as partition routing key.
+        let key = event_id.0.as_bytes().as_ref();
+
+        let serialized = rmp_serde::to_vec_named(&message).map_err(StoreError::SerializeFailed)?;
+        let record = BaseRecord::to(self.config.kafka_topic_name(topic))
+            .payload(&serialized)
+            .key(key);
+
+        match self.producer.send(record) {
+            Ok(_) => Ok(()),
+            Err((kafka_error, _message)) => Err(StoreError::SendFailed(kafka_error)),
         }
     }
 }
@@ -108,8 +79,12 @@ impl Actor for StoreForwarder {
     type Context = Context<Self>;
 
     fn started(&mut self, context: &mut Self::Context) {
+        // Set the mailbox size to the size of the event buffer. This is a rough estimate but
+        // should ensure that we're not dropping events unintentionally after we've accepted them.
+        let mailbox_size = self.config.event_buffer_size() as usize;
+        context.set_mailbox_capacity(mailbox_size);
+
         log::info!("store forwarder started");
-        Controller::from_registry().do_send(Subscribe(context.address().recipient()));
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
@@ -179,12 +154,9 @@ impl Message for StoreEvent {
 }
 
 impl Handler<StoreEvent> for StoreForwarder {
-    type Result = ResponseFuture<(), StoreError>;
+    type Result = Result<(), StoreError>;
 
     fn handle(&mut self, message: StoreEvent, _ctx: &mut Self::Context) -> Self::Result {
-        let producer = self.producer.clone();
-        let config = self.config.clone();
-
         let StoreEvent {
             envelope,
             start_time,
@@ -202,9 +174,6 @@ impl Handler<StoreEvent> for StoreForwarder {
             KafkaTopic::Events
         };
 
-        let max_chunk_size = self.config.attachment_chunk_size();
-        let mut attachment_futures = Vec::with_capacity(envelope.len());
-
         for (index, item) in envelope.items().enumerate() {
             // Only upload items first.
             if item.ty() != ItemType::Attachment {
@@ -216,7 +185,9 @@ impl Handler<StoreEvent> for StoreForwarder {
             let size = item.len();
 
             while offset == 0 || offset < size {
+                let max_chunk_size = self.config.attachment_chunk_size();
                 let chunk_size = std::cmp::min(max_chunk_size, size - offset);
+
                 let attachment_message = AttachmentKafkaMessage {
                     ty: KafkaMessageType::AttachmentChunk,
                     payload: payload.slice(offset, offset + chunk_size),
@@ -227,22 +198,10 @@ impl Handler<StoreEvent> for StoreForwarder {
                     size,
                 };
 
-                attachment_futures.push(produce(
-                    &producer,
-                    &config,
-                    topic,
-                    event_id,
-                    attachment_message,
-                ));
-
+                self.produce(topic, event_id, attachment_message)?;
                 offset += chunk_size;
             }
         }
-
-        let mut response: ResponseFuture<(), StoreError> = match attachment_futures.len() {
-            0 => Box::new(future::ok(())),
-            _ => Box::new(future::join_all(attachment_futures).map(|_| ())),
-        };
 
         if let Some(event_item) = event_item {
             let event_message = EventKafkaMessage {
@@ -254,31 +213,10 @@ impl Handler<StoreEvent> for StoreForwarder {
                 remote_addr: envelope.meta().client_addr().map(|addr| addr.to_string()),
             };
 
-            let chained_future = response
-                .and_then(move |_| produce(&producer, &config, topic, event_id, event_message))
-                .map(|_| metric!(counter("processing.event.produced") += 1, "type" => "event"));
-
-            response = Box::new(chained_future);
+            self.produce(topic, event_id, event_message)?;
+            metric!(counter("processing.event.produced") += 1, "type" => "event");
         }
 
-        Box::new(response.sync(&self.shutdown, StoreError::Shutdown))
-    }
-}
-
-impl Handler<Shutdown> for StoreForwarder {
-    type Result = ResponseActFuture<Self, (), TimeoutError>;
-
-    fn handle(&mut self, message: Shutdown, _context: &mut Self::Context) -> Self::Result {
-        let shutdown = match message.timeout {
-            Some(timeout) => self.shutdown.timeout(timeout),
-            None => self.shutdown.now(),
-        };
-
-        let future = shutdown.into_actor(self).and_then(move |_, slf, _ctx| {
-            slf.producer.flush(message.timeout);
-            actix::fut::ok(())
-        });
-
-        Box::new(future)
+        Ok(())
     }
 }

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -9,7 +9,7 @@ use failure::{Backtrace, Context, Fail};
 use listenfd::ListenFd;
 use sentry_actix::SentryMiddleware;
 
-use semaphore_common::Config;
+use semaphore_common::{clone, Config};
 
 use crate::actors::events::EventManager;
 use crate::actors::keys::KeyCache;
@@ -112,10 +112,11 @@ pub struct ServiceState {
 
 impl ServiceState {
     /// Starts all services and returns addresses to all of them.
-    pub fn start(config: Config) -> Result<Self, ServerError> {
-        let config = Arc::new(config);
-        let upstream_relay = UpstreamRelay::new(config.clone()).start();
-        let outcome_producer = OutcomeProducer::create(config.clone())?.start();
+    pub fn start(config: Arc<Config>) -> Result<Self, ServerError> {
+        let upstream_relay = Arbiter::start(clone!(config, |_| UpstreamRelay::new(config)));
+
+        let outcome_config = OutcomeProducer::configure(config.clone())?;
+        let outcome_producer = Arbiter::start(move |_| OutcomeProducer::new(outcome_config));
 
         let event_manager = EventManager::create(
             config.clone(),
@@ -283,8 +284,18 @@ where
 /// Given a relay config spawns the server together with all actors and lets them run forever.
 ///
 /// Effectively this boots the server.
-pub fn start(state: ServiceState) -> Result<Recipient<server::StopServer>, ServerError> {
-    let config = state.config();
+pub fn start(config: Config) -> Result<Recipient<server::StopServer>, ServerError> {
+    let config = Arc::new(config);
+
+    // Start the connector before creating the ServiceState. The service state will spawn Arbiters
+    // that immediately start the authentication process. The connector must be available before.
+    let connector = ClientConnector::default()
+        .limit(config.max_concurrent_requests())
+        .start();
+
+    System::current().registry().set(connector);
+
+    let state = ServiceState::start(config.clone())?;
     let mut server = server::new(move || make_app(state.clone()));
     server = server
         .workers(config.cpu_concurrency())
@@ -293,12 +304,6 @@ pub fn start(state: ServiceState) -> Result<Recipient<server::StopServer>, Serve
         .maxconnrate(config.max_connection_rate())
         .backlog(config.max_pending_connections())
         .disable_signals();
-
-    let connector = ClientConnector::default()
-        .limit(config.max_concurrent_requests())
-        .start();
-
-    System::current().registry().set(connector);
 
     server = listen(server, &config)?;
     server = listen_ssl(server, &config)?;

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -115,8 +115,8 @@ impl ServiceState {
     pub fn start(config: Arc<Config>) -> Result<Self, ServerError> {
         let upstream_relay = Arbiter::start(clone!(config, |_| UpstreamRelay::new(config)));
 
-        let outcome_config = OutcomeProducer::configure(config.clone())?;
-        let outcome_producer = Arbiter::start(move |_| OutcomeProducer::new(outcome_config));
+        let outcome_producer = OutcomeProducer::create(config.clone())?;
+        let outcome_producer = Arbiter::start(move |_| outcome_producer);
 
         let event_manager = EventManager::create(
             config.clone(),


### PR DESCRIPTION
This should fix or mitigate slowdowns when the main arbiter is busy or we're running at CPU limits.

Firstly, the main arbiter runs tasks that might potentially take a little longer than intended. These actors are now moved into their own arbiter threads, so that they can run independently:

 - **Upstream**: Serialize upstream queries and parse their responses
 - **OutcomeProducer**: Produce outcomes to Kafka
 - **StoreForwarder**: Produce events and attachments to Kafka

Second, and probably more importantly, it turns out that rdkafka's `FutureProducer` does not produce asynchronously. It may block the event loop until the message is posted. Also, our message producing mechanism includes serializing the payload and allocating intermediate buffers, which might make time. To simplify the implementation, we're now using `ThreadedProducer` directly.