### PR TITLE
fix(general): Fix the glob matcher for strings with newlines

### DIFF
--- a/general/src/filter/common.rs
+++ b/general/src/filter/common.rs
@@ -1,8 +1,35 @@
+use std::borrow::Cow;
 use std::fmt;
 
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use lazycell::AtomicLazyCell;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Escapes the a glob pattern or message for the glob matcher.
+fn escape<'a, S>(message: S) -> Cow<'a, str>
+where
+    S: Into<Cow<'a, str>>,
+{
+    let mut escaped = message.into();
+
+    if escaped.contains('\n') {
+        // The glob matcher cannot deal with newlines. We replace them with the zero byte, which we
+        // view as sufficiently uncommon in regular strings to perform such a match.
+        escaped = Cow::Owned(escaped.as_ref().replace("\n", "\00"))
+    }
+
+    escaped
+}
+
+/// Returns `true` if any of the patterns match the given message.
+///
+/// The message is internally escaped using `escape`.
+fn is_match<'a, S>(globs: &GlobSet, message: S) -> bool
+where
+    S: Into<Cow<'a, str>>,
+{
+    globs.is_match(escape(message).as_ref())
+}
 
 /// A list of patterns for glob matching.
 #[derive(Clone)]
@@ -28,8 +55,11 @@ impl GlobPatterns {
     }
 
     /// Returns `true` if any of the patterns match the given message.
-    pub fn is_match<S: AsRef<str>>(&self, message: S) -> bool {
-        let message = message.as_ref();
+    pub fn is_match<'a, S>(&self, message: S) -> bool
+    where
+        S: Into<Cow<'a, str>>,
+    {
+        let message = message.into();
         if message.is_empty() {
             return false;
         }
@@ -37,18 +67,18 @@ impl GlobPatterns {
         // Parse globs lazily to ensure that this work is not done upon deserialization.
         // Deserialization usually happens in web workers but parsing / matching in CPU pools.
         if let Some(globs) = self.globs.borrow() {
-            return globs.is_match(message);
+            return is_match(globs, message);
         }
 
         // If filling the lazy cell fails, another thread has filled it in the meanwhile. Use the
         // globs to respond right away, instead of borrowing again.
         if let Err(globs) = self.globs.fill(self.parse_globs()) {
-            return globs.is_match(message);
+            return is_match(&globs, message);
         }
 
         // The lazy cell was filled successfully, so it is safe to assume that this cannot panic.
         match self.globs.borrow() {
-            Some(globs) => globs.is_match(message),
+            Some(globs) => is_match(globs, message),
             None => unreachable!(),
         }
     }
@@ -58,7 +88,12 @@ impl GlobPatterns {
         let mut builder = GlobSetBuilder::new();
 
         for pattern in &self.patterns {
-            if let Ok(glob) = GlobBuilder::new(&pattern).case_insensitive(true).build() {
+            let glob_result = GlobBuilder::new(&escape(pattern))
+                .case_insensitive(true)
+                .backslash_escape(true)
+                .build();
+
+            if let Ok(glob) = glob_result {
                 builder.add(glob);
             }
         }
@@ -147,5 +182,69 @@ impl FilterStatKey {
 impl fmt::Display for FilterStatKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! globs {
+        ($($pattern:literal),*) => {
+            GlobPatterns::new(vec![
+                $($pattern.to_string()),*
+            ])
+        };
+    }
+
+    #[test]
+    fn test_match_literal() {
+        let globs = globs!("foo");
+        assert!(globs.is_match("foo"));
+    }
+
+    #[test]
+    fn test_match_negative() {
+        let globs = globs!("foo");
+        assert!(!globs.is_match("nope"));
+    }
+
+    #[test]
+    fn test_match_prefix() {
+        let globs = globs!("foo*");
+        assert!(globs.is_match("foobarblub"));
+    }
+
+    #[test]
+    fn test_match_suffix() {
+        let globs = globs!("*blub");
+        assert!(globs.is_match("foobarblub"));
+    }
+
+    #[test]
+    fn test_match_inner() {
+        let globs = globs!("*bar*");
+        assert!(globs.is_match("foobarblub"));
+    }
+
+    #[test]
+    fn test_match_utf8() {}
+
+    #[test]
+    fn test_match_newline() {
+        let globs = globs!("*foo*");
+        assert!(globs.is_match("foo\n"));
+    }
+
+    #[test]
+    fn test_match_newline_inner() {
+        let globs = globs!("foo*bar");
+        assert!(globs.is_match("foo\nbar"));
+    }
+
+    #[test]
+    fn test_match_newline_pattern() {
+        let globs = globs!("foo*\n*bar");
+        assert!(globs.is_match("foo \n bar"));
     }
 }

--- a/general/src/filter/error_messages.rs
+++ b/general/src/filter/error_messages.rs
@@ -111,6 +111,7 @@ mod tests {
                 false,
             ),
             (None, None, "This is a filtered exception.", false),
+            (None, None, "This is a filtered exception.\n", false),
             (
                 Some("FilteredException"),
                 Some("This is a filtered exception."),

--- a/general/src/filter/error_messages.rs
+++ b/general/src/filter/error_messages.rs
@@ -111,7 +111,6 @@ mod tests {
                 false,
             ),
             (None, None, "This is a filtered exception.", false),
-            (None, None, "This is a filtered exception.\n", false),
             (
                 Some("FilteredException"),
                 Some("This is a filtered exception."),


### PR DESCRIPTION
There is a regression in our message filter that does not handle messages with newlines properly.

As it turns out, `GlobSet` never matches on strings that contain newlines. To fix this, we're now replacing each newline with `\x00` (the zero byte), which is sufficiently uncommon in regular strings so that it won't cause false positives. This is done only on a need basis to avoid intermediate allocations.