### PR TITLE
ref(server): Replace Envelope auth with DSN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,7 +2235,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semaphore-general 0.4.62",
- "sentry-types 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3513,7 +3513,7 @@ dependencies = [
 "checksum sentry 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe4ea18f306c959be49f1bea8f3911a454e5d09d2dc43307215729e636bfbf4b"
 "checksum sentry-actix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdf25d31316bdbe2965dfa37ba6073f43a1f40d4530eb84105534c0cc2bf9b0a"
 "checksum sentry-types 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b23e3d9c8c6e4a1523f24df6753c4088bfe16c44a73c8881c1d23c70f28ae280"
-"checksum sentry-types 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b823a70fe8d7cd12eee9bf9af21a1253cef10fcf2e09dc3ee10f76c7457772d"
+"checksum sentry-types 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4934793a0d37dad44b088c66f362cb7a3d0d7b9ba803c56d9ff22e9b92c0cff"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"

--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semaphore-general 0.4.62",
- "sentry-types 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -974,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sentry-types"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1376,7 +1376,7 @@ dependencies = [
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum sentry-types 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b823a70fe8d7cd12eee9bf9af21a1253cef10fcf2e09dc3ee10f76c7457772d"
+"checksum sentry-types 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4934793a0d37dad44b088c66f362cb7a3d0d7b9ba803c56d9ff22e9b92c0cff"
 "checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
 "checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,7 +27,7 @@ num_cpus = "1.10.1"
 parking_lot = "0.9.0"
 rand = "0.6.5"
 regex = "1.2.0"
-sentry-types = "0.12.0"
+sentry-types = "0.12.1"
 sha2 = "0.8.0"
 serde = { version = "1.0.98", features = ["derive"] }
 serde_json = "1.0.40"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -25,6 +25,7 @@ pub use crate::types::*;
 pub use crate::upstream::*;
 pub use crate::utils::*;
 
+pub use sentry_types::protocol::LATEST as PROTOCOL_VERSION;
 pub use sentry_types::{Auth, AuthParseError, Dsn, DsnParseError, Scheme, Uuid};
 
 /// Represents a project ID.

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -213,7 +213,7 @@ impl EventProcessor {
                 }
 
                 let store_config = StoreConfig {
-                    project_id: Some(envelope.project_id()),
+                    project_id: Some(envelope.meta().project_id()),
                     client_ip: envelope.meta().client_addr().map(IpAddr::from),
                     client: envelope.meta().client().map(str::to_owned),
                     key_id,
@@ -517,7 +517,7 @@ impl Handler<HandleEvent> for EventManager {
         } = message;
 
         let event_id = envelope.event_id();
-        let project_id = envelope.project_id();
+        let project_id = envelope.meta().project_id();
         let remote_addr = envelope.meta().client_addr();
         let meta_clone = Arc::new(envelope.meta().clone());
 

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -56,7 +56,7 @@ pub enum RateLimitScope {
 
 impl RateLimitScope {
     fn iter_variants(meta: &EventMeta) -> impl Iterator<Item = RateLimitScope> {
-        iter::once(RateLimitScope::Key(meta.auth().public_key().to_owned()))
+        iter::once(RateLimitScope::Key(meta.public_key().to_owned()))
     }
 }
 
@@ -416,7 +416,7 @@ impl ProjectState {
             // thus we handle events pretending the config is still valid,
             // except queueing events for unknown DSNs as they might have become
             // available in the meanwhile.
-            match self.get_public_key_status(meta.auth().public_key()) {
+            match self.get_public_key_status(meta.public_key()) {
                 PublicKeyStatus::Enabled => EventAction::Accept,
                 PublicKeyStatus::Disabled => EventAction::Discard(DiscardReason::ProjectId),
                 PublicKeyStatus::Unknown => EventAction::Accept,
@@ -437,7 +437,7 @@ impl ProjectState {
             // public keys do not exist and drop events eagerly. proxy mode is
             // an exception, where public keys are backfilled lazily after
             // events are sent to the upstream.
-            match self.get_public_key_status(meta.auth().public_key()) {
+            match self.get_public_key_status(meta.public_key()) {
                 PublicKeyStatus::Enabled => EventAction::Accept,
                 PublicKeyStatus::Disabled => EventAction::Discard(DiscardReason::ProjectId),
                 PublicKeyStatus::Unknown => match config.relay_mode() {

--- a/server/src/endpoints/common.rs
+++ b/server/src/endpoints/common.rs
@@ -156,7 +156,7 @@ where
     let start_time = start_time.into_inner();
 
     // For now, we only handle <= v8 and drop everything else
-    let version = meta.auth().version();
+    let version = meta.version();
     if version > 8 {
         // TODO: Delegate to forward_upstream here
         tryf!(Err(BadStoreRequest::UnsupportedProtocolVersion(version)));

--- a/server/src/endpoints/common.rs
+++ b/server/src/endpoints/common.rs
@@ -11,7 +11,7 @@ use futures::prelude::*;
 use sentry::Hub;
 use sentry_actix::ActixWebHubExt;
 
-use semaphore_common::{metric, tryf, LogError, ProjectId, ProjectIdParseError};
+use semaphore_common::{metric, tryf, LogError};
 use semaphore_general::protocol::EventId;
 
 use crate::actors::events::{QueueEvent, QueueEventError};
@@ -25,9 +25,6 @@ use crate::utils::ApiErrorResponse;
 
 #[derive(Fail, Debug)]
 pub enum BadStoreRequest {
-    #[fail(display = "invalid project path parameter")]
-    BadProject(#[cause] ProjectIdParseError),
-
     #[fail(display = "unsupported protocol version ({})", _0)]
     UnsupportedProtocolVersion(u16),
 
@@ -62,8 +59,6 @@ pub enum BadStoreRequest {
 impl BadStoreRequest {
     fn to_outcome(&self) -> Outcome {
         match self {
-            BadStoreRequest::BadProject(_) => Outcome::Invalid(DiscardReason::ProjectId),
-
             BadStoreRequest::UnsupportedProtocolVersion(_) => {
                 Outcome::Invalid(DiscardReason::AuthVersion)
             }
@@ -157,19 +152,12 @@ where
 
     // For now, we only handle <= v8 and drop everything else
     let version = meta.version();
-    if version > 8 {
+    if version > semaphore_common::PROTOCOL_VERSION {
         // TODO: Delegate to forward_upstream here
         tryf!(Err(BadStoreRequest::UnsupportedProtocolVersion(version)));
     }
 
-    // Make sure we have a project ID. Does not check if the project exists yet
-    let project_id = tryf!(request
-        .match_info()
-        .get("project")
-        .unwrap_or_default()
-        .parse::<ProjectId>()
-        .map_err(BadStoreRequest::BadProject));
-
+    let project_id = meta.project_id();
     let hub = Hub::from_request(&request);
     hub.configure_scope(|scope| {
         scope.set_user(Some(sentry::User {
@@ -214,7 +202,6 @@ where
                     event_manager
                         .send(QueueEvent {
                             envelope,
-                            project_id,
                             project,
                             start_time,
                         })

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -47,7 +47,7 @@ fn extract_envelope(
     // character substitution on the input stream but only if we detect a Python agent.
     //
     // This is done here so that the rest of the code can assume valid JSON.
-    let is_legacy_python_json = meta.auth().client_agent().map_or(false, |agent| {
+    let is_legacy_python_json = meta.client().map_or(false, |agent| {
         agent.starts_with("raven-python/") || agent.starts_with("sentry-python/")
     });
 

--- a/server/src/envelope.rs
+++ b/server/src/envelope.rs
@@ -42,6 +42,7 @@ use failure::Fail;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
+use semaphore_common::ProjectId;
 use semaphore_general::protocol::{EventId, EventType};
 use semaphore_general::types::Value;
 
@@ -321,6 +322,10 @@ impl Envelope {
 
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
+    }
+
+    pub fn project_id(&self) -> ProjectId {
+        self.headers.meta.project_id()
     }
 
     /// Unique identifier of the event associated to this envelope.

--- a/server/src/envelope.rs
+++ b/server/src/envelope.rs
@@ -308,6 +308,7 @@ impl Envelope {
         Ok(envelope)
     }
 
+    /// TODO(ja): Write that envelope data wins over request meta.
     pub fn parse_request(bytes: Bytes, meta: EventMeta) -> Result<Self, EnvelopeError> {
         let mut envelope = Self::parse_bytes(bytes)?;
         envelope.headers.meta.default_to(meta);

--- a/server/src/envelope.rs
+++ b/server/src/envelope.rs
@@ -22,7 +22,7 @@
 //! This is enabled by declaring an explicit length in the item headers. Example:
 //!
 //! ```plain
-//! {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","auth":"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b, sentry_version=7"}
+//! {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn": "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}
 //! {"type":"event","length":41,"content_type":"application/json"}
 //! {"message":"hello world","level":"error"}
 //! {"type":"attachment","length":7,"content_type":"text/plain","filename":"application.log"}
@@ -473,11 +473,11 @@ mod tests {
     use super::*;
 
     fn event_meta() -> EventMeta {
-        let auth = "Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b"
+        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
             .unwrap();
 
-        EventMeta::new(auth)
+        EventMeta::new(dsn)
     }
 
     #[test]
@@ -568,7 +568,7 @@ mod tests {
     #[test]
     fn test_deserialize_envelope_empty() {
         // Without terminating newline after header
-        let bytes = Bytes::from("{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"auth\":\"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b\"}");
+        let bytes = Bytes::from("{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}");
         let envelope = Envelope::parse_bytes(bytes).unwrap();
 
         let event_id = EventId("9ec79c33ec9942ab8353589fcb2e04dc".parse().unwrap());
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn test_deserialize_envelope_empty_newline() {
         // With terminating newline after header
-        let bytes = Bytes::from("{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"auth\":\"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b\"}\n");
+        let bytes = Bytes::from("{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n");
         let envelope = Envelope::parse_bytes(bytes).unwrap();
         assert_eq!(envelope.len(), 0);
     }
@@ -589,7 +589,7 @@ mod tests {
         // With terminating newline after item payload
         let bytes = Bytes::from(
             "\
-             {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"auth\":\"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b\"}\n\
+             {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n\
              {\"type\":\"attachment\",\"length\":0}\n\
              \n\
              {\"type\":\"attachment\",\"length\":0}\n\
@@ -608,7 +608,7 @@ mod tests {
     fn test_deserialize_envelope_multiple_items() {
         // With terminating newline
         let bytes = Bytes::from(&b"\
-            {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"auth\":\"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b\"}\n\
+            {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n\
             {\"type\":\"attachment\",\"length\":10,\"content_type\":\"text/plain\",\"filename\":\"hello.txt\"}\n\
             \xef\xbb\xbfHello\r\n\n\
             {\"type\":\"event\",\"length\":41,\"content_type\":\"application/json\",\"filename\":\"application.log\"}\n\
@@ -647,7 +647,7 @@ mod tests {
         envelope.serialize(&mut buffer).unwrap();
 
         let stringified = String::from_utf8_lossy(&buffer);
-        insta::assert_snapshot!(stringified, @r###"{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","auth":"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b, sentry_version=7"}
+        insta::assert_snapshot!(stringified, @r###"{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","version":7}
 "###);
     }
 
@@ -673,12 +673,12 @@ mod tests {
 
         let stringified = String::from_utf8_lossy(&buffer);
         insta::assert_snapshot!(stringified, @r###"
-        {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","auth":"Sentry sentry_key=e12d836b15bb49d7bbf99e64295d995b, sentry_version=7"}
+        {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","version":7}
         {"type":"event","length":41,"content_type":"application/json"}
         {"message":"hello world","level":"error"}
         {"type":"attachment","length":7,"content_type":"text/plain","filename":"application.log"}
         Hello
-
+        
         "###);
     }
 }

--- a/server/src/extractors/event_meta.rs
+++ b/server/src/extractors/event_meta.rs
@@ -78,22 +78,24 @@ impl EventMeta {
         }
     }
 
-    /// Completes this event meta instance with information from another.
+    /// Overwrites this event meta instance with information from another.
     ///
-    /// All fields that are set in this instance will remain. Only missing fields will be updated if
-    /// they are defined in the other EvenMeta instance.
-    pub fn default_to(&mut self, other: EventMeta) {
-        if self.origin.is_none() {
-            self.origin = other.origin;
+    /// All fields that are not set in the other instance will remain.
+    pub fn merge(&mut self, other: EventMeta) {
+        self.dsn = other.dsn;
+        if let Some(client) = other.client {
+            self.client = Some(client);
         }
-        if self.remote_addr.is_none() {
-            self.remote_addr = other.remote_addr;
+        self.version = other.version;
+        if let Some(origin) = other.origin {
+            self.origin = Some(origin);
         }
-        if self.forwarded_for.is_empty() {
-            self.forwarded_for = other.forwarded_for;
+        if let Some(remote_addr) = other.remote_addr {
+            self.remote_addr = Some(remote_addr);
         }
-        if self.user_agent.is_none() {
-            self.user_agent = other.user_agent;
+        self.forwarded_for = other.forwarded_for;
+        if let Some(user_agent) = other.user_agent {
+            self.user_agent = Some(user_agent);
         }
     }
 

--- a/server/src/extractors/event_meta.rs
+++ b/server/src/extractors/event_meta.rs
@@ -69,12 +69,12 @@ impl EventMeta {
     pub fn new(dsn: Dsn) -> Self {
         EventMeta {
             dsn,
-            client: None,
-            version: default_version(),
-            origin: None,
-            remote_addr: None,
+            client: Some("sentry/client".to_string()),
+            version: 7,
+            origin: Some("http://origin/".parse().unwrap()),
+            remote_addr: Some("192.168.0.1".parse().unwrap()),
             forwarded_for: String::new(),
-            user_agent: None,
+            user_agent: Some("sentry/agent".to_string()),
         }
     }
 

--- a/server/src/extractors/event_meta.rs
+++ b/server/src/extractors/event_meta.rs
@@ -99,27 +99,31 @@ impl EventMeta {
         }
     }
 
-    /// Returns a reference to the auth info
+    /// Returns a reference to the DSN.
+    ///
+    /// The DSN declares the project and auth information and upstream address. When EventMeta is
+    /// constructed from a web request, the DSN is set to point to the upstream host.
     pub fn dsn(&self) -> &Dsn {
         &self.dsn
     }
 
-    /// TODO(ja): Describe
+    /// Returns the project identifier that the DSN points to.
     pub fn project_id(&self) -> ProjectId {
-        // TODO(ja): Fix this in sentry-types
+        // TODO(ja): sentry-types does not expose the DSN at the moment.
         unsafe { std::mem::transmute(self.dsn().project_id()) }
     }
 
-    /// TODO(ja): Describe
+    /// Returns the public key part of the DSN for authentication.
     pub fn public_key(&self) -> &str {
         &self.dsn.public_key()
     }
 
-    /// TODO(ja): Describe
+    /// Returns the client that sent this event (Sentry SDK identifier).
     pub fn client(&self) -> Option<&str> {
         self.client.as_ref().map(String::as_str)
     }
 
+    /// Returns the protocol version of the event payload.
     pub fn version(&self) -> u16 {
         self.version
     }
@@ -157,7 +161,9 @@ impl EventMeta {
         self.user_agent.as_ref().map(String::as_str)
     }
 
-    /// TODO(ja): Describe
+    /// Formats the Sentry authentication header.
+    ///
+    /// This header must be included in store requests.
     pub fn auth_header(&self) -> String {
         let mut auth = format!(
             "Sentry sentry_key={}, sentry_version={}",


### PR DESCRIPTION
Switch Auth in Envelope with DSN. This adds validation of envelope headers when ingesting an envelope in the store endpoint.

At the moment, the auth headers in store requests are still required, but that can be changed in a follow-up.