### PR TITLE
fix: Bump eventmanager's mailbox size

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -414,7 +414,11 @@ impl EventManager {
 impl Actor for EventManager {
     type Context = Context<Self>;
 
-    fn started(&mut self, _ctx: &mut Self::Context) {
+    fn started(&mut self, context: &mut Self::Context) {
+        // Set the mailbox size to the size of the event buffer. This is a rough estimate but
+        // should ensure that we're not dropping events unintentionally after we've accepted them.
+        let mailbox_size = self.config.event_buffer_size() as usize;
+        context.set_mailbox_capacity(mailbox_size);
         log::info!("event manager started");
     }
 


### PR DESCRIPTION
This looks the same in any other actor that is somehow involved in
event processing.