### PR TITLE
fix: Preserve microsecond precision

### DIFF
--- a/general/src/types/impls.rs
+++ b/general/src/types/impls.rs
@@ -468,7 +468,7 @@ impl FromValue for DateTime<Utc> {
             }
             Annotated(Some(Value::F64(ts)), meta) => {
                 let secs = ts as i64;
-                // at this point we probably already loose nanosecond precision, but we deal with
+                // at this point we probably already lose nanosecond precision, but we deal with
                 // this in `datetime_to_timestamp`.
                 let nanos = (ts.fract() * 1_000_000_000f64) as u32;
                 utc_result_to_annotated(Utc.timestamp_opt(secs, nanos), ts, meta)

--- a/general/src/types/impls.rs
+++ b/general/src/types/impls.rs
@@ -403,8 +403,24 @@ impl ToValue for Value {
 }
 
 fn datetime_to_timestamp(dt: DateTime<Utc>) -> f64 {
-    let micros = f64::from(dt.timestamp_subsec_micros()) / 1_000_000f64;
-    ((dt.timestamp() as f64 + micros) * 1000f64).round() / 1000f64
+    // use `timestamp_subsec_nanos` here because all other functions on `DateTime` are built on top
+    // of it, so we only need to do one float division to construct `timestamp`
+    let nanos = f64::from(dt.timestamp_subsec_nanos()) / 1_000_000_000f64;
+    let timestamp = dt.timestamp() as f64 + nanos;
+
+    // f64s cannot store nanoseconds. To verify this just try to fit the current timestamp in
+    // nanoseconds into a 52-bit number (which is the significand of a double).
+    //
+    // Round off to microseconds to not show more decimal points than we know are correct. Anything
+    // else might trick the user into thinking the nanoseconds in those timestamps mean anything.
+    //
+    // This needs to be done regardless of whether the input value was a ISO-formatted string or a
+    // number because it all ends up as a f64 on serialization.
+    //
+    // If we want to support nanoseconds at some point we will probably have to start using strings
+    // everywhere. Even then it's unclear how to deal with it in Python code as a `datetime` cannot
+    // store nanoseconds.
+    (timestamp * 1_000_000f64).round() / 1_000_000f64
 }
 
 fn utc_result_to_annotated<V: ToValue>(
@@ -452,8 +468,10 @@ impl FromValue for DateTime<Utc> {
             }
             Annotated(Some(Value::F64(ts)), meta) => {
                 let secs = ts as i64;
-                let micros = (ts.fract() * 1_000_000f64) as u32;
-                utc_result_to_annotated(Utc.timestamp_opt(secs, micros * 1000), ts, meta)
+                // at this point we probably already loose nanosecond precision, but we deal with
+                // this in `datetime_to_timestamp`.
+                let nanos = (ts.fract() * 1_000_000_000f64) as u32;
+                utc_result_to_annotated(Utc.timestamp_opt(secs, nanos), ts, meta)
             }
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {

--- a/general/tests/snapshots/test_fixtures__dotnet.snap
+++ b/general/tests/snapshots/test_fixtures__dotnet.snap
@@ -171,7 +171,7 @@ modules:
   nbxk3h5b.orp: 0.0.0.0
   netstandard: 2.0.0.0
 platform: csharp
-timestamp: 1532343443.75
+timestamp: 1532343443.750303
 release: e386dfd
 environment: Production
 request:


### PR DESCRIPTION
We used to intentionally round off sub-millisecond digits to make the
normalization diff smaller. However, now we need microsecond precision.
Still round off nanoseconds because it's impossible for them to be
accurate.