### PR TITLE
ref: Use rc instead of arc

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -522,7 +523,7 @@ impl Handler<HandleEvent> for EventManager {
         let remote_addr = envelope.meta().client_addr();
         let meta_clone = Arc::new(envelope.meta().clone());
 
-        let org_id_for_err = Arc::new(Mutex::new(None::<u64>));
+        let org_id_for_err = Rc::new(Mutex::new(None::<u64>));
 
         metric!(set("unique_projects") = project_id as i64);
 

--- a/server/src/endpoints/common.rs
+++ b/server/src/endpoints/common.rs
@@ -1,5 +1,6 @@
 //! Common facilities for ingesting events through store-like endpoints.
 
+use std::rc::Rc;
 use std::sync::Arc;
 
 use actix::prelude::*;
@@ -174,7 +175,7 @@ where
     let remote_addr = meta.client_addr();
 
     let cloned_meta = Arc::new(meta.clone());
-    let event_id = Arc::new(Mutex::new(None));
+    let event_id = Rc::new(Mutex::new(None));
 
     let future = project_manager
         .send(GetProject { id: project_id })


### PR DESCRIPTION
The future does not have to be `Send` so we can get away with `Rc` here. This is almost no improvement since it's atomic increment vs regular increment.