### PR TITLE
feat: Added span status mapping and integer values from otel

### DIFF
--- a/general/Cargo.toml
+++ b/general/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../LICENSE"
 
 [dependencies]
 bytecount = "0.5.1"
-chrono = "0.4.7"
+chrono = { version = "0.4.7", features = ["serde"] }
 cookie = { version = "0.12.0", features = ["percent-encode"] }
 debugid = { version = "0.7.0", features = ["serde"] }
 dynfmt = { version = "0.1.1", features = ["python", "curly"] }

--- a/general/src/protocol/contexts.rs
+++ b/general/src/protocol/contexts.rs
@@ -372,6 +372,8 @@ pub struct TraceContext {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)] // size limit in clickhouse
 pub enum SpanStatus {
+    // XXX: this mapping exists multiple times at the moment.  It's also in the python binding
+    // to semaphore.  This should be cleaned up.
     /// The operation completed successfully.
     ///
     /// HTTP status 100..299 + successful redirects from the 3xx range.

--- a/general/src/protocol/contexts.rs
+++ b/general/src/protocol/contexts.rs
@@ -355,7 +355,7 @@ pub struct TraceContext {
 
     /// Whether the trace failed or succeeded. Currently only used to indicate status of individual
     /// transactions.
-    pub status: Annotated<TraceStatus>,
+    pub status: Annotated<SpanStatus>,
 
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = "true")]
@@ -371,25 +371,25 @@ pub struct TraceContext {
 /// value. We use repr(u8) to statically validate that the trace status has 255 variants at most.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)] // size limit in clickhouse
-pub enum TraceStatus {
+pub enum SpanStatus {
     /// The operation completed successfully.
     ///
     /// HTTP status 100..299 + successful redirects from the 3xx range.
-    Ok,
+    Ok = 0,
 
     /// The operation was cancelled (typically by the user).
-    Cancelled,
+    Cancelled = 1,
 
     /// Unknown. Any non-standard HTTP status code.
     ///
     /// "We do not know whether the transaction failed or succeeded"
-    UnknownError,
+    UnknownError = 2,
 
     /// Client specified an invalid argument. 4xx.
     ///
     /// Note that this differs from FailedPrecondition. InvalidArgument indicates arguments that
     /// are problematic regardless of the state of the system.
-    InvalidArgument,
+    InvalidArgument = 3,
 
     /// Deadline expired before operation could complete.
     ///
@@ -397,60 +397,60 @@ pub enum TraceStatus {
     /// operation has been completed successfully.
     ///
     /// HTTP redirect loops and 504 Gateway Timeout
-    DeadlineExceeded,
+    DeadlineExceeded = 4,
 
     /// 404 Not Found. Some requested entity (file or directory) was not found.
-    NotFound,
+    NotFound = 5,
 
     /// Already exists (409)
     ///
     /// Some entity that we attempted to create already exists.
-    AlreadyExists,
+    AlreadyExists = 6,
 
     /// 403 Forbidden
     ///
     /// The caller does not have permission to execute the specified operation.
-    PermissionDenied,
+    PermissionDenied = 7,
 
     /// 429 Too Many Requests
     ///
     /// Some resource has been exhausted, perhaps a per-user quota or perhaps the entire file
     /// system is out of space.
-    ResourceExhausted,
+    ResourceExhausted = 8,
 
     /// Operation was rejected because the system is not in a state required for the operation's
     /// execution
-    FailedPrecondition,
+    FailedPrecondition = 9,
 
     /// The operation was aborted, typically due to a concurrency issue.
-    Aborted,
+    Aborted = 10,
 
     /// Operation was attempted past the valid range.
-    OutOfRange,
+    OutOfRange = 11,
 
     /// 501 Not Implemented
     ///
     /// Operation is not implemented or not enabled.
-    Unimplemented,
+    Unimplemented = 12,
 
     /// Other/generic 5xx.
-    InternalError,
+    InternalError = 13,
 
     /// 503 Service Unavailable
-    Unavailable,
+    Unavailable = 14,
 
     /// Unrecoverable data loss or corruption
-    DataLoss,
+    DataLoss = 15,
 
     /// 401 Unauthorized (actually does mean unauthenticated according to RFC 7235)
     ///
     /// Prefer PermissionDenied if a user is logged in.
-    Unauthenticated,
+    Unauthenticated = 16,
 }
 
-impl ProcessValue for TraceStatus {}
+impl ProcessValue for SpanStatus {}
 
-impl Empty for TraceStatus {
+impl Empty for SpanStatus {
     #[inline]
     fn is_empty(&self) -> bool {
         false
@@ -458,63 +458,63 @@ impl Empty for TraceStatus {
 }
 
 #[derive(Debug, Fail)]
-#[fail(display = "invalid trace status")]
-pub struct ParseTraceStatusError;
+#[fail(display = "invalid span status")]
+pub struct ParseSpanStatusError;
 
-impl FromStr for TraceStatus {
-    type Err = ParseTraceStatusError;
+impl FromStr for SpanStatus {
+    type Err = ParseSpanStatusError;
 
-    fn from_str(string: &str) -> Result<TraceStatus, Self::Err> {
+    fn from_str(string: &str) -> Result<SpanStatus, Self::Err> {
         Ok(match string {
-            "ok" => TraceStatus::Ok,
-            "success" => TraceStatus::Ok, // Backwards compat with initial schema
-            "deadline_exceeded" => TraceStatus::DeadlineExceeded,
-            "unauthenticated" => TraceStatus::Unauthenticated,
-            "permission_denied" => TraceStatus::PermissionDenied,
-            "not_found" => TraceStatus::NotFound,
-            "resource_exhausted" => TraceStatus::ResourceExhausted,
-            "invalid_argument" => TraceStatus::InvalidArgument,
-            "unimplemented" => TraceStatus::Unimplemented,
-            "unavailable" => TraceStatus::Unavailable,
-            "internal_error" => TraceStatus::InternalError,
-            "failure" => TraceStatus::InternalError, // Backwards compat with initial schema
-            "unknown_error" => TraceStatus::UnknownError,
-            "cancelled" => TraceStatus::Cancelled,
-            "already_exists" => TraceStatus::AlreadyExists,
-            "failed_precondition" => TraceStatus::FailedPrecondition,
-            "aborted" => TraceStatus::Aborted,
-            "out_of_range" => TraceStatus::OutOfRange,
-            "data_loss" => TraceStatus::DataLoss,
-            _ => return Err(ParseTraceStatusError),
+            "ok" => SpanStatus::Ok,
+            "success" => SpanStatus::Ok, // Backwards compat with initial schema
+            "deadline_exceeded" => SpanStatus::DeadlineExceeded,
+            "unauthenticated" => SpanStatus::Unauthenticated,
+            "permission_denied" => SpanStatus::PermissionDenied,
+            "not_found" => SpanStatus::NotFound,
+            "resource_exhausted" => SpanStatus::ResourceExhausted,
+            "invalid_argument" => SpanStatus::InvalidArgument,
+            "unimplemented" => SpanStatus::Unimplemented,
+            "unavailable" => SpanStatus::Unavailable,
+            "internal_error" => SpanStatus::InternalError,
+            "failure" => SpanStatus::InternalError, // Backwards compat with initial schema
+            "unknown_error" => SpanStatus::UnknownError,
+            "cancelled" => SpanStatus::Cancelled,
+            "already_exists" => SpanStatus::AlreadyExists,
+            "failed_precondition" => SpanStatus::FailedPrecondition,
+            "aborted" => SpanStatus::Aborted,
+            "out_of_range" => SpanStatus::OutOfRange,
+            "data_loss" => SpanStatus::DataLoss,
+            _ => return Err(ParseSpanStatusError),
         })
     }
 }
 
-impl fmt::Display for TraceStatus {
+impl fmt::Display for SpanStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            TraceStatus::Ok => write!(f, "ok"),
-            TraceStatus::DeadlineExceeded => write!(f, "deadline_exceeded"),
-            TraceStatus::Unauthenticated => write!(f, "unauthenticated"),
-            TraceStatus::PermissionDenied => write!(f, "permission_denied"),
-            TraceStatus::NotFound => write!(f, "not_found"),
-            TraceStatus::ResourceExhausted => write!(f, "resource_exhausted"),
-            TraceStatus::InvalidArgument => write!(f, "invalid_argument"),
-            TraceStatus::Unimplemented => write!(f, "unimplemented"),
-            TraceStatus::Unavailable => write!(f, "unavailable"),
-            TraceStatus::InternalError => write!(f, "internal_error"),
-            TraceStatus::UnknownError => write!(f, "unknown_error"),
-            TraceStatus::Cancelled => write!(f, "cancelled"),
-            TraceStatus::AlreadyExists => write!(f, "already_exists"),
-            TraceStatus::FailedPrecondition => write!(f, "failed_precondition"),
-            TraceStatus::Aborted => write!(f, "aborted"),
-            TraceStatus::OutOfRange => write!(f, "out_of_range"),
-            TraceStatus::DataLoss => write!(f, "data_loss"),
+            SpanStatus::Ok => write!(f, "ok"),
+            SpanStatus::DeadlineExceeded => write!(f, "deadline_exceeded"),
+            SpanStatus::Unauthenticated => write!(f, "unauthenticated"),
+            SpanStatus::PermissionDenied => write!(f, "permission_denied"),
+            SpanStatus::NotFound => write!(f, "not_found"),
+            SpanStatus::ResourceExhausted => write!(f, "resource_exhausted"),
+            SpanStatus::InvalidArgument => write!(f, "invalid_argument"),
+            SpanStatus::Unimplemented => write!(f, "unimplemented"),
+            SpanStatus::Unavailable => write!(f, "unavailable"),
+            SpanStatus::InternalError => write!(f, "internal_error"),
+            SpanStatus::UnknownError => write!(f, "unknown_error"),
+            SpanStatus::Cancelled => write!(f, "cancelled"),
+            SpanStatus::AlreadyExists => write!(f, "already_exists"),
+            SpanStatus::FailedPrecondition => write!(f, "failed_precondition"),
+            SpanStatus::Aborted => write!(f, "aborted"),
+            SpanStatus::OutOfRange => write!(f, "out_of_range"),
+            SpanStatus::DataLoss => write!(f, "data_loss"),
         }
     }
 }
 
-impl FromValue for TraceStatus {
+impl FromValue for SpanStatus {
     fn from_value(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
@@ -525,6 +525,33 @@ impl FromValue for TraceStatus {
                     Annotated(None, meta)
                 }
             },
+            Annotated(Some(Value::I64(value)), mut meta) => Annotated(
+                Some(match value {
+                    0 => SpanStatus::Ok,
+                    1 => SpanStatus::Cancelled,
+                    2 => SpanStatus::UnknownError,
+                    3 => SpanStatus::InvalidArgument,
+                    4 => SpanStatus::DeadlineExceeded,
+                    5 => SpanStatus::NotFound,
+                    6 => SpanStatus::AlreadyExists,
+                    7 => SpanStatus::PermissionDenied,
+                    8 => SpanStatus::ResourceExhausted,
+                    9 => SpanStatus::FailedPrecondition,
+                    10 => SpanStatus::Aborted,
+                    11 => SpanStatus::OutOfRange,
+                    12 => SpanStatus::Unimplemented,
+                    13 => SpanStatus::InternalError,
+                    14 => SpanStatus::Unavailable,
+                    15 => SpanStatus::DataLoss,
+                    16 => SpanStatus::Unauthenticated,
+                    _ => {
+                        meta.add_error(Error::expected("a trace status"));
+                        meta.set_original_value(Some(value));
+                        return Annotated(None, meta);
+                    }
+                }),
+                meta,
+            ),
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
                 meta.add_error(Error::expected("a string"));
@@ -535,7 +562,7 @@ impl FromValue for TraceStatus {
     }
 }
 
-impl ToValue for TraceStatus {
+impl ToValue for SpanStatus {
     fn to_value(self) -> Value {
         Value::String(self.to_string())
     }
@@ -881,7 +908,7 @@ fn test_trace_context_roundtrip() {
         span_id: Annotated::new(SpanId("fa90fdead5f74052".into())),
         parent_span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
         op: Annotated::new("http".into()),
-        status: Annotated::new(TraceStatus::Ok),
+        status: Annotated::new(SpanStatus::Ok),
         other: {
             let mut map = Object::new();
             map.insert(

--- a/general/src/protocol/mod.rs
+++ b/general/src/protocol/mod.rs
@@ -24,7 +24,7 @@ pub use self::clientsdk::{ClientSdkInfo, ClientSdkPackage};
 pub use self::constants::{INVALID_ENVIRONMENTS, VALID_PLATFORMS};
 pub use self::contexts::{
     AppContext, BrowserContext, Context, ContextInner, Contexts, DeviceContext, OperationType,
-    OsContext, RuntimeContext, SpanId, TraceContext, TraceId, TraceStatus,
+    OsContext, RuntimeContext, SpanId, SpanStatus, TraceContext, TraceId,
 };
 pub use self::debugmeta::{
     AppleDebugImage, DebugImage, DebugMeta, NativeDebugImage, SystemSdkInfo,

--- a/general/src/store/normalize.rs
+++ b/general/src/store/normalize.rs
@@ -12,8 +12,8 @@ use smallvec::SmallVec;
 use crate::processor::{MaxChars, ProcessValue, ProcessingState, Processor};
 use crate::protocol::{
     AsPair, Breadcrumb, ClientSdkInfo, Context, DebugImage, Event, EventId, EventType, Exception,
-    Frame, HeaderName, HeaderValue, Headers, IpAddr, Level, LogEntry, Request, Stacktrace, Tags,
-    TraceContext, TraceStatus, User, INVALID_ENVIRONMENTS, VALID_PLATFORMS,
+    Frame, HeaderName, HeaderValue, Headers, IpAddr, Level, LogEntry, Request, SpanStatus,
+    Stacktrace, Tags, TraceContext, User, INVALID_ENVIRONMENTS, VALID_PLATFORMS,
 };
 use crate::store::{GeoIpLookup, StoreConfig};
 use crate::types::{
@@ -640,7 +640,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         context
             .status
             .value_mut()
-            .get_or_insert(TraceStatus::UnknownError);
+            .get_or_insert(SpanStatus::UnknownError);
         Ok(())
     }
 }

--- a/py/semaphore/consts.py
+++ b/py/semaphore/consts.py
@@ -1,6 +1,6 @@
 from .processing import StoreNormalizer
 
-__all__ = ['SPAN_STATUS_MAPPING']
+__all__ = ["SPAN_STATUS_MAPPING"]
 
 
 def _get_span_status_mapping():
@@ -8,13 +8,9 @@ def _get_span_status_mapping():
     rv = {}
 
     for i in range(255):
-        name = normalizer.normalize_event({
-            'contexts': {
-                'trace': {
-                    'status': i,
-                },
-            },
-        })['contexts']['trace']['status']
+        name = normalizer.normalize_event({"contexts": {"trace": {"status": i,},},})[
+            "contexts"
+        ]["trace"]["status"]
         if name is not None:
             rv[i] = name
 

--- a/py/semaphore/consts.py
+++ b/py/semaphore/consts.py
@@ -1,0 +1,25 @@
+from .processing import StoreNormalizer
+
+__all__ = ['SPAN_STATUS_MAPPING']
+
+
+def _get_span_status_mapping():
+    normalizer = StoreNormalizer()
+    rv = {}
+
+    for i in range(255):
+        name = normalizer.normalize_event({
+            'contexts': {
+                'trace': {
+                    'status': i,
+                },
+            },
+        })['contexts']['trace']['status']
+        if name is not None:
+            rv[i] = name
+
+    return rv
+
+
+SPAN_STATUS_MAPPING = _get_span_status_mapping()
+del _get_span_status_mapping

--- a/py/semaphore/consts.py
+++ b/py/semaphore/consts.py
@@ -1,21 +1,24 @@
-from .processing import StoreNormalizer
-
-__all__ = ["SPAN_STATUS_MAPPING"]
+__all__ = ["SPAN_STATUS_CODE_TO_NAME", "SPAN_STATUS_NAME_TO_CODE"]
 
 
-def _get_span_status_mapping():
-    normalizer = StoreNormalizer()
-    rv = {}
+SPAN_STATUS_CODE_TO_NAME = {
+    0: "ok",
+    1: "cancelled",
+    2: "unknown_error",
+    3: "invalid_argument",
+    4: "deadline_exceeded",
+    5: "not_found",
+    6: "already_exists",
+    7: "permission_denied",
+    8: "resource_exhausted",
+    9: "failed_precondition",
+    10: "aborted",
+    11: "out_of_range",
+    12: "unimplemented",
+    13: "internal_error",
+    14: "unavailable",
+    15: "data_loss",
+    16: "unauthenticated",
+}
 
-    for i in range(255):
-        name = normalizer.normalize_event({"contexts": {"trace": {"status": i,},},})[
-            "contexts"
-        ]["trace"]["status"]
-        if name is not None:
-            rv[i] = name
-
-    return rv
-
-
-SPAN_STATUS_MAPPING = _get_span_status_mapping()
-del _get_span_status_mapping
+SPAN_STATUS_NAME_TO_CODE = dict((v, k) for k, v in SPAN_STATUS_CODE_TO_NAME.items())


### PR DESCRIPTION
I hate that we have no enum derive helpers. At least I tried to avoid having the mapping in another file but that required some really stupid hacks on the python layer.