### PR TITLE
fix(server): Consume request payloads

### DIFF
--- a/server/src/body/store_body.rs
+++ b/server/src/body/store_body.rs
@@ -95,7 +95,7 @@ impl StoreBody {
         }
 
         // Check the content length first. If we detect an overflow from the content length header,
-        // keep the payload in the request. The `ReadRequestMiddleware` should drain the payload.
+        // keep the payload in the request to drain it correctly in the `ReadRequestMiddleware`.
         if let Some(length) = utils::get_content_length(req) {
             if length > limit {
                 return Self::err(StorePayloadError::Overflow);

--- a/server/src/endpoints/forward.rs
+++ b/server/src/endpoints/forward.rs
@@ -97,8 +97,7 @@ fn forward_upstream(request: &HttpRequest<ServiceState>) -> ResponseFuture<HttpR
         .set_header("Connection", "close")
         .timeout(config.http_timeout());
 
-    ForwardBody::new(request)
-        .limit(limit)
+    ForwardBody::new(request, limit)
         .map_err(Error::from)
         .and_then(move |data| forwarded_request_builder.body(data).map_err(Error::from))
         .and_then(move |request| request.send().map_err(Error::from))

--- a/server/src/endpoints/minidump.rs
+++ b/server/src/endpoints/minidump.rs
@@ -3,6 +3,7 @@ use futures::Future;
 
 use semaphore_general::protocol::EventId;
 
+use crate::body::ForwardBody;
 use crate::endpoints::common::{handle_store_like_request, BadStoreRequest};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::extractors::{EventMeta, StartTime};
@@ -62,9 +63,7 @@ where {
     // minidump can either be transmitted as request body, or as `upload_file_minidump` in a
     // multipart formdata request.
     if MINIDUMP_RAW_CONTENT_TYPES.contains(&request.content_type()) {
-        let future = request
-            .body()
-            .limit(max_payload_size)
+        let future = ForwardBody::new(request, max_payload_size)
             .map_err(|_| BadStoreRequest::InvalidMinidump)
             .and_then(move |data| {
                 validate_minidump(&data)?;

--- a/server/src/endpoints/security_report.rs
+++ b/server/src/endpoints/security_report.rs
@@ -26,8 +26,7 @@ fn extract_envelope(
     max_event_payload_size: usize,
     params: SecurityReportParams,
 ) -> ResponseFuture<Envelope, BadStoreRequest> {
-    let future = StoreBody::new(&request)
-        .limit(max_event_payload_size)
+    let future = StoreBody::new(&request, max_event_payload_size)
         .map_err(BadStoreRequest::PayloadError)
         .and_then(move |data| {
             if data.is_empty() {

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -33,8 +33,7 @@ fn extract_envelope(
     max_event_payload_size: usize,
     content_type: String,
 ) -> ResponseFuture<Envelope, BadStoreRequest> {
-    let future = StoreBody::new(&request)
-        .limit(max_event_payload_size)
+    let future = StoreBody::new(&request, max_event_payload_size)
         .map_err(BadStoreRequest::PayloadError)
         .and_then(move |mut data| {
             if data.is_empty() {

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -3,6 +3,7 @@ mod api;
 mod error_boundary;
 mod multipart;
 mod param_parser;
+mod request;
 mod shutdown;
 mod timer;
 
@@ -14,6 +15,7 @@ pub use self::api::*;
 pub use self::error_boundary::*;
 pub use self::multipart::*;
 pub use self::param_parser::*;
+pub use self::request::*;
 pub use self::shutdown::*;
 pub use self::timer::*;
 

--- a/server/src/utils/request.rs
+++ b/server/src/utils/request.rs
@@ -1,0 +1,9 @@
+use actix_web::{http::header, HttpRequest};
+
+// Resolve the content length from HTTP request headers.
+pub fn get_content_length<S>(req: &HttpRequest<S>) -> Option<usize> {
+    req.headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse().ok())
+}

--- a/server/src/utils/request.rs
+++ b/server/src/utils/request.rs
@@ -1,7 +1,10 @@
-use actix_web::{http::header, HttpRequest};
+use actix_web::{http::header, HttpMessage};
 
 // Resolve the content length from HTTP request headers.
-pub fn get_content_length<S>(req: &HttpRequest<S>) -> Option<usize> {
+pub fn get_content_length<T>(req: &T) -> Option<usize>
+where
+    T: HttpMessage,
+{
     req.headers()
         .get(header::CONTENT_LENGTH)
         .and_then(|h| h.to_str().ok())


### PR DESCRIPTION
Our body implementations move the payload out of the HttpRequest object. Therefore, the `ReadRequestMiddleware` can no longer exhaust the stream once we've started to consume it in our endpoints. 

To avoid broken keep-alive connections, Relay will now fully consume all started streams, or avoid to take the payload in the first place. This currently happens in three places: `ForwardBody`, `StoreBody` and `MultipartEnvelope`. 