### PR TITLE
fix: Fix serialization of attachment type enum

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from .fixtures.processing import (
     events_consumer,
     outcomes_consumer,
     transactions_consumer,
+    attachments_consumer,
 )  # noqa
 
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -173,6 +173,10 @@ def events_consumer(kafka_consumer):
 def transactions_consumer(kafka_consumer):
     return lambda: EventsConsumer(kafka_consumer("transactions"))
 
+@pytest.fixture
+def attachments_consumer(kafka_consumer):
+    return lambda: AttachmentsConsumer(kafka_consumer("attachments"))
+
 
 class EventsConsumer(ConsumerBase):
     def __init__(self, consumer):
@@ -186,3 +190,14 @@ class EventsConsumer(ConsumerBase):
         v = msgpack.unpackb(event.value(), raw=False, use_list=False)
         assert v["type"] == "event"
         return json.loads(v["payload"].decode("utf8")), v
+
+
+class AttachmentsConsumer(EventsConsumer):
+    def get_attachment_chunk(self):
+        event = self.poll()
+        assert event is not None
+        assert event.error() is None
+
+        v = msgpack.unpackb(event.value(), raw=False, use_list=False)
+        assert v["type"] == "attachment_chunk", v['type']
+        return v["payload"], v

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -173,6 +173,7 @@ def events_consumer(kafka_consumer):
 def transactions_consumer(kafka_consumer):
     return lambda: EventsConsumer(kafka_consumer("transactions"))
 
+
 @pytest.fixture
 def attachments_consumer(kafka_consumer):
     return lambda: AttachmentsConsumer(kafka_consumer("attachments"))
@@ -199,5 +200,5 @@ class AttachmentsConsumer(EventsConsumer):
         assert event.error() is None
 
         v = msgpack.unpackb(event.value(), raw=False, use_list=False)
-        assert v["type"] == "attachment_chunk", v['type']
+        assert v["type"] == "attachment_chunk", v["type"]
         return v["payload"], v

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -179,7 +179,7 @@ def test_minidump_with_processing(
     event, v = attachments_consumer.get_event()
 
     assert event["platform"] == "native"
-    assert event["exception"]["value"][0]["mechanism"]["type"] == "minidump"
+    assert event["exception"]["values"][0]["mechanism"]["type"] == "minidump"
 
     assert list(v["attachments"]) == [
         {

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -154,7 +154,9 @@ def test_minidump_endpoint_accepts_doubly_nested_formdata(mini_sentry, relay):
     assert mini_dump.headers.get("name") == MINIDUMP_ATTACHMENT_NAME
 
 
-def test_minidump_with_processing(mini_sentry, relay_with_processing, attachments_consumer):
+def test_minidump_with_processing(
+    mini_sentry, relay_with_processing, attachments_consumer
+):
     proj_id = 42
     relay = relay_with_processing()
     relay.wait_relay_healthcheck()
@@ -163,9 +165,7 @@ def test_minidump_with_processing(mini_sentry, relay_with_processing, attachment
 
     relay.send_minidump(
         project_id=proj_id,
-        files=(
-            ("upload_file_minidump", "minidump.txt", "MDMPminidump content"),
-        ),
+        files=(("upload_file_minidump", "minidump.txt", "MDMPminidump content"),),
     )
 
     attachment = b""
@@ -178,7 +178,8 @@ def test_minidump_with_processing(mini_sentry, relay_with_processing, attachment
 
     event, v = attachments_consumer.get_event()
 
-    assert event['platform'] == 'native'
+    assert event["platform"] == "native"
+    assert event["exception"]["value"][0]["mechanism"]["type"] == "minidump"
 
     assert list(v["attachments"]) == [
         {


### PR DESCRIPTION
To save space, `rmp-serde` serializes enums with a proprietary encoding instead of using the string representation. This is not compatible with Sentry, so we force it to string now.