### PR TITLE
feat(server): Support the legacy store endpoint

### DIFF
--- a/server/src/actors/mod.rs
+++ b/server/src/actors/mod.rs
@@ -47,6 +47,7 @@ pub mod healthcheck;
 pub mod keys;
 pub mod outcome;
 pub mod project;
+pub mod project_keys;
 pub mod server;
 pub mod upstream;
 

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -127,7 +127,7 @@ impl Project {
         self.manager
             .send(FetchProjectState { id })
             .into_actor(self)
-            .and_then(move |state_result, slf, _ctx| {
+            .map(move |state_result, slf, _ctx| {
                 slf.state_channel = None;
                 slf.is_local = state_result
                     .as_ref()
@@ -139,8 +139,6 @@ impl Project {
                     log::debug!("project {} state updated", id);
                     sender.send(state.clone()).ok();
                 }
-
-                fut::ok(())
             })
             .drop_err()
             .spawn(context);

--- a/server/src/actors/project_keys.rs
+++ b/server/src/actors/project_keys.rs
@@ -68,6 +68,10 @@ impl ProjectIdChannel {
     }
 }
 
+/// Reverse lookup for project keys.
+///
+/// This is used for the legacy store endpoint (`/api/store/`) to resolve the project id from a
+/// public key.
 pub struct ProjectKeyLookup {
     config: Arc<Config>,
     upstream: Addr<UpstreamRelay>,
@@ -163,7 +167,12 @@ impl Handler<GetProjectId> for ProjectKeyLookup {
                 let channel = ProjectIdChannel::new();
                 let receiver = channel.receiver();
                 entry.insert(channel);
+
+                // Fetch each project id individually. The result is cached indefinitely and those
+                // requests only happen infrequently. Since the store endpoint waits on this result,
+                // we need to execute as fast as possible.
                 self.fetch_project_id(key, context);
+
                 receiver
             }
         };

--- a/server/src/actors/project_keys.rs
+++ b/server/src/actors/project_keys.rs
@@ -1,0 +1,174 @@
+use std::borrow::Cow;
+use std::collections::hash_map::{Entry, HashMap};
+use std::sync::Arc;
+
+use actix::fut;
+use actix::prelude::*;
+use actix_web::http::Method;
+use failure::Fail;
+use futures::{future::Shared, sync::oneshot, Future};
+use serde::{Deserialize, Serialize};
+
+use semaphore_common::{Config, LogError, ProjectId};
+
+use crate::actors::upstream::{SendQuery, UpstreamQuery, UpstreamRelay};
+
+type ProjectKey = String;
+
+#[derive(Clone, Copy, Debug, Fail)]
+#[fail(display = "failed to fetch project id for project key")]
+pub struct ProjectKeyError;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GetProjectIds {
+    pub public_keys: Vec<ProjectKey>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetProjectIdsResponse {
+    pub project_ids: HashMap<ProjectKey, Option<ProjectId>>,
+}
+
+impl UpstreamQuery for GetProjectIds {
+    type Response = GetProjectIdsResponse;
+
+    fn method(&self) -> Method {
+        Method::POST
+    }
+
+    fn path(&self) -> Cow<'static, str> {
+        Cow::Borrowed("/api/0/relays/projectids/")
+    }
+}
+
+#[derive(Debug)]
+struct ProjectIdChannel {
+    sender: oneshot::Sender<Option<ProjectId>>,
+    receiver: Shared<oneshot::Receiver<Option<ProjectId>>>,
+}
+
+impl ProjectIdChannel {
+    pub fn new() -> Self {
+        let (sender, receiver) = oneshot::channel();
+
+        Self {
+            sender,
+            receiver: receiver.shared(),
+        }
+    }
+
+    pub fn send(self, project_id: Option<ProjectId>) {
+        self.sender.send(project_id).ok();
+    }
+
+    pub fn receiver(&self) -> Shared<oneshot::Receiver<Option<ProjectId>>> {
+        self.receiver.clone()
+    }
+}
+
+pub struct ProjectKeyLookup {
+    config: Arc<Config>,
+    upstream: Addr<UpstreamRelay>,
+    project_ids: HashMap<ProjectKey, Option<ProjectId>>,
+    id_channels: HashMap<ProjectKey, ProjectIdChannel>,
+}
+
+impl ProjectKeyLookup {
+    pub fn new(config: Arc<Config>, upstream: Addr<UpstreamRelay>) -> Self {
+        Self {
+            config,
+            upstream,
+            project_ids: HashMap::new(),
+            id_channels: HashMap::new(),
+        }
+    }
+
+    fn fetch_project_id(&mut self, public_key: ProjectKey, context: &mut Context<Self>) {
+        log::debug!("fetching project id for public key {}", public_key);
+        let public_keys = vec![public_key];
+
+        let request = GetProjectIds {
+            public_keys: public_keys.clone(),
+        };
+
+        self.upstream
+            .send(SendQuery(request))
+            .into_actor(self)
+            .then(move |result, slf, _context| {
+                let mut project_ids = match result {
+                    Ok(Ok(response)) => response.project_ids,
+                    Ok(Err(upstream_err)) => {
+                        log::error!("error fetching project ids: {}", LogError(&upstream_err));
+                        HashMap::new()
+                    }
+                    Err(mailbox_err) => {
+                        log::error!("error fetching project ids: {}", LogError(&mailbox_err));
+                        HashMap::new()
+                    }
+                };
+
+                for key in public_keys {
+                    let project_id = project_ids.remove(&key).and_then(|opt| opt);
+                    if let Some(channel) = slf.id_channels.remove(&key) {
+                        channel.send(project_id);
+                    }
+                    slf.project_ids.insert(key, project_id);
+                }
+
+                fut::ok(())
+            })
+            .spawn(context);
+    }
+}
+
+impl Actor for ProjectKeyLookup {
+    type Context = Context<Self>;
+
+    fn started(&mut self, context: &mut Self::Context) {
+        // Set the mailbox size to the size of the event buffer. This is a rough estimate but
+        // should ensure that we're not dropping messages if the main arbiter running this actor
+        // gets hammered a bit.
+        let mailbox_size = self.config.event_buffer_size() as usize;
+        context.set_mailbox_capacity(mailbox_size);
+
+        log::info!("project cache started");
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        log::info!("project cache stopped");
+    }
+}
+
+pub struct GetProjectId(pub ProjectKey);
+
+impl Message for GetProjectId {
+    type Result = Result<Option<ProjectId>, ProjectKeyError>;
+}
+
+impl Handler<GetProjectId> for ProjectKeyLookup {
+    type Result = Response<Option<ProjectId>, ProjectKeyError>;
+
+    fn handle(&mut self, message: GetProjectId, context: &mut Context<Self>) -> Self::Result {
+        let key = message.0;
+
+        if let Some(project_id) = self.project_ids.get(&key) {
+            return Response::reply(Ok(*project_id));
+        }
+
+        let channel = match self.id_channels.entry(key.clone()) {
+            Entry::Occupied(entry) => entry.get().receiver(),
+            Entry::Vacant(entry) => {
+                let channel = ProjectIdChannel::new();
+                let receiver = channel.receiver();
+                entry.insert(channel);
+                self.fetch_project_id(key, context);
+                receiver
+            }
+        };
+
+        let response = channel.map(|shared| *shared).map_err(|_| ProjectKeyError);
+        Response::r#async(response)
+    }
+}

--- a/server/src/endpoints/public_keys.rs
+++ b/server/src/endpoints/public_keys.rs
@@ -20,6 +20,11 @@ fn get_public_keys(
     Box::new(future)
 }
 
+/// Registers the Relay public keys endpoint.
+///
+/// Note that this has nothing to do with Sentry public keys, which refer to the public key portion
+/// of a DSN used for authenticating event submission. This endpoint is for Relay's public keys,
+/// which authenticate entire Relays.
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
     app.resource("/api/0/relays/publickeys/", |r| {
         r.method(Method::POST).with(get_public_keys);

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -148,7 +148,13 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
         ])
         .expose_headers(vec!["X-Sentry-Error", "Retry-After"])
         .max_age(3600)
-        .resource(r"/api/{project:\d+}/store{trailing_slash:/*}", |r| {
+        .resource(r"/api/{project:\d+}/store{t:/*}", |r| {
+            // .resource(r"{l:/+}api/{project:\d+}/store{t:/*}", |r| {
+            r.method(Method::POST).with(store_event);
+            r.method(Method::GET).with(store_event);
+        })
+        .resource(r"/api/store{trailing_slash:/*}", |r| {
+            // .resource(r"{l:/+}api/store{trailing_slash:/*}", |r| {
             r.method(Method::POST).with(store_event);
             r.method(Method::GET).with(store_event);
         })

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -133,7 +133,6 @@ fn store_event(
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    // XXX: does not handle the legacy /api/store/ endpoint
     Cors::for_app(app)
         .allowed_methods(vec!["POST"])
         .allowed_headers(vec![
@@ -148,13 +147,17 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
         ])
         .expose_headers(vec!["X-Sentry-Error", "Retry-After"])
         .max_age(3600)
-        .resource(r"/api/{project:\d+}/store{t:/*}", |r| {
-            // .resource(r"{l:/+}api/{project:\d+}/store{t:/*}", |r| {
+        // Standard store endpoint. Some SDKs send multiple leading or trailing slashes due to bugs
+        // in their URL handling. Since actix does not normalize such paths, allow any number of
+        // slashes. The trailing slash can also be omitted, optionally.
+        .resource(r"/{l:/*}api/{project:\d+}/store{t:/*}", |r| {
             r.method(Method::POST).with(store_event);
             r.method(Method::GET).with(store_event);
         })
-        .resource(r"/api/store{trailing_slash:/*}", |r| {
-            // .resource(r"{l:/+}api/store{trailing_slash:/*}", |r| {
+        // Legacy store path. Since it is missing the project parameter, the `EventMeta` extractor
+        // will use `ProjectKeyLookup` to map the public key to a project id before handling the
+        // request.
+        .resource(r"/{l:/*}api/store{t:/*}", |r| {
             r.method(Method::POST).with(store_event);
             r.method(Method::GET).with(store_event);
         })

--- a/server/src/extractors/event_meta.rs
+++ b/server/src/extractors/event_meta.rs
@@ -225,7 +225,6 @@ fn parse_header_url<T>(req: &HttpRequest<T>, header: header::HeaderName) -> Opti
 fn extract_event_meta(
     request: &HttpRequest<ServiceState>,
 ) -> ResponseFuture<EventMeta, BadEventMeta> {
-    // println!("XXXXXXXXXXXXXXXXX    extracting meta now");
     let auth = tryf!(auth_from_request(request));
 
     let version = auth.version();
@@ -292,7 +291,6 @@ impl FromRequest<ServiceState> for EventMeta {
     type Result = AsyncResult<Self, actix_web::Error>;
 
     fn from_request(request: &HttpRequest<ServiceState>, _cfg: &Self::Config) -> Self::Result {
-        // println!("XXXXXXXXXXXXXXXX       eventmeta fromrequest");
         AsyncResult::from(Ok(extract_event_meta(request)))
     }
 }

--- a/server/src/extractors/event_meta.rs
+++ b/server/src/extractors/event_meta.rs
@@ -1,13 +1,19 @@
 use std::net::IpAddr;
 
+use actix::ResponseFuture;
+use actix_web::dev::AsyncResult;
 use actix_web::http::header;
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use failure::Fail;
+use futures::{future, Future};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use semaphore_common::{Auth, AuthParseError, Dsn, DsnParseError, ProjectId, ProjectIdParseError};
+use semaphore_common::{
+    tryf, Auth, AuthParseError, Dsn, DsnParseError, ProjectId, ProjectIdParseError,
+};
 
+use crate::actors::project_keys::GetProjectId;
 use crate::extractors::ForwardedFor;
 use crate::service::ServiceState;
 use crate::utils::ApiErrorResponse;
@@ -22,11 +28,23 @@ pub enum BadEventMeta {
 
     #[fail(display = "bad sentry DSN")]
     BadDsn(#[fail(cause)] DsnParseError),
+
+    #[fail(display = "bad project key: project does not exist")]
+    BadProjectKey,
+
+    #[fail(display = "could not schedule event processing")]
+    ScheduleFailed,
 }
 
 impl ResponseError for BadEventMeta {
     fn error_response(&self) -> HttpResponse {
-        HttpResponse::BadRequest().json(&ApiErrorResponse::from_fail(self))
+        let mut builder = match *self {
+            Self::ScheduleFailed => HttpResponse::ServiceUnavailable(),
+            Self::BadProjectKey => HttpResponse::Unauthorized(),
+            _ => HttpResponse::BadRequest(),
+        };
+
+        builder.json(&ApiErrorResponse::from_fail(self))
     }
 }
 
@@ -204,21 +222,49 @@ fn parse_header_url<T>(req: &HttpRequest<T>, header: header::HeaderName) -> Opti
         })
 }
 
-impl FromRequest<ServiceState> for EventMeta {
-    type Config = ();
-    type Result = Result<Self, BadEventMeta>;
+fn extract_event_meta(
+    request: &HttpRequest<ServiceState>,
+) -> ResponseFuture<EventMeta, BadEventMeta> {
+    // println!("XXXXXXXXXXXXXXXXX    extracting meta now");
+    let auth = tryf!(auth_from_request(request));
 
-    fn from_request(request: &HttpRequest<ServiceState>, _cfg: &Self::Config) -> Self::Result {
-        let project_id = request
-            .match_info()
-            .get("project")
-            .unwrap_or_default()
-            .parse::<ProjectId>()
-            .map_err(BadEventMeta::BadProject)?;
+    let version = auth.version();
+    let client = auth.client_agent().map(str::to_owned);
+    let origin = parse_header_url(request, header::ORIGIN)
+        .or_else(|| parse_header_url(request, header::REFERER));
+    let remote_addr = request.peer_addr().map(|peer| peer.ip());
+    let forwarded_for = ForwardedFor::from(request).into_inner();
+    let user_agent = request
+        .headers()
+        .get(header::USER_AGENT)
+        .and_then(|h| h.to_str().ok())
+        .map(str::to_owned);
 
-        let auth = auth_from_request(request)?;
+    let state = request.state();
+    let config = state.config();
 
-        let config = request.state().config();
+    let project_future = match request.match_info().get("project") {
+        Some(s) => {
+            // The project_id was declared in the URL. Use it directly.
+            let id_result = s.parse::<ProjectId>().map_err(BadEventMeta::BadProject);
+            Box::new(future::result(id_result)) as ResponseFuture<_, _>
+        }
+        None => {
+            // The legacy endpoint (/api/store) was hit without a project id. Fetch the project
+            // id from the key lookup. Since this is the uncommon case, block the request until the
+            // project id is here.
+            let future = state
+                .key_lookup()
+                .send(GetProjectId(auth.public_key().to_owned()))
+                .map_err(|_| BadEventMeta::ScheduleFailed)
+                .and_then(|result| result.map_err(|_| BadEventMeta::ScheduleFailed))
+                .and_then(|opt| opt.ok_or(BadEventMeta::BadProjectKey));
+
+            Box::new(future) as ResponseFuture<_, _>
+        }
+    };
+
+    Box::new(project_future.and_then(move |project_id| {
         let upstream = config.upstream_descriptor();
 
         let dsn_string = format!(
@@ -231,17 +277,22 @@ impl FromRequest<ServiceState> for EventMeta {
 
         Ok(EventMeta {
             dsn: dsn_string.parse().map_err(BadEventMeta::BadDsn)?,
-            version: auth.version(),
-            client: auth.client_agent().map(str::to_owned),
-            origin: parse_header_url(request, header::ORIGIN)
-                .or_else(|| parse_header_url(request, header::REFERER)),
-            remote_addr: request.peer_addr().map(|peer| peer.ip()),
-            forwarded_for: ForwardedFor::from(request).into_inner(),
-            user_agent: request
-                .headers()
-                .get(header::USER_AGENT)
-                .and_then(|h| h.to_str().ok())
-                .map(str::to_owned),
+            version,
+            client,
+            origin,
+            remote_addr,
+            forwarded_for,
+            user_agent,
         })
+    }))
+}
+
+impl FromRequest<ServiceState> for EventMeta {
+    type Config = ();
+    type Result = AsyncResult<Self, actix_web::Error>;
+
+    fn from_request(request: &HttpRequest<ServiceState>, _cfg: &Self::Config) -> Self::Result {
+        // println!("XXXXXXXXXXXXXXXX       eventmeta fromrequest");
+        AsyncResult::from(Ok(extract_event_meta(request)))
     }
 }

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -16,6 +16,7 @@ use crate::actors::healthcheck::Healthcheck;
 use crate::actors::keys::KeyCache;
 use crate::actors::outcome::OutcomeProducer;
 use crate::actors::project::ProjectCache;
+use crate::actors::project_keys::ProjectKeyLookup;
 use crate::actors::upstream::UpstreamRelay;
 use crate::constants::SHUTDOWN_TIMEOUT;
 use crate::endpoints;
@@ -108,6 +109,7 @@ pub struct ServiceState {
     project_cache: Addr<ProjectCache>,
     upstream_relay: Addr<UpstreamRelay>,
     event_manager: Addr<EventManager>,
+    key_lookup: Addr<ProjectKeyLookup>,
     outcome_producer: Addr<OutcomeProducer>,
     healthcheck: Addr<Healthcheck>,
 }
@@ -130,6 +132,7 @@ impl ServiceState {
 
         Ok(ServiceState {
             config: config.clone(),
+            key_lookup: ProjectKeyLookup::new(config.clone(), upstream_relay.clone()).start(),
             upstream_relay: upstream_relay.clone(),
             key_cache: KeyCache::new(config.clone(), upstream_relay.clone()).start(),
             project_cache: ProjectCache::new(config.clone(), upstream_relay.clone()).start(),
@@ -157,6 +160,11 @@ impl ServiceState {
     /// Returns the current event manager.
     pub fn event_manager(&self) -> Addr<EventManager> {
         self.event_manager.clone()
+    }
+
+    /// Returns project id lookup for project keys.
+    pub fn key_lookup(&self) -> Addr<ProjectKeyLookup> {
+        self.key_lookup.clone()
     }
 
     pub fn outcome_producer(&self) -> Addr<OutcomeProducer> {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -58,7 +58,12 @@ pub fn init_logging(config: &Config) {
         dsn: config
             .sentry_dsn()
             .map(|dsn| dsn.to_string().parse().unwrap()),
-        in_app_include: vec!["semaphore_common::", "semaphore_server::", "semaphore::"],
+        in_app_include: vec![
+            "semaphore_common::",
+            "semaphore_general::",
+            "semaphore_server::",
+            "semaphore::",
+        ],
         release: sentry::release_name!(),
         ..Default::default()
     });
@@ -79,6 +84,7 @@ pub fn init_logging(config: &Config) {
                 "INFO,\
                  actix_web::pipeline=DEBUG,\
                  semaphore_common=DEBUG,\
+                 semaphore_general=DEBUG,\
                  semaphore_server=DEBUG,\
                  semaphore=DEBUG"
             }
@@ -86,6 +92,7 @@ pub fn init_logging(config: &Config) {
                 "INFO,\
                  actix_web::pipeline=DEBUG,\
                  semaphore_common=TRACE,\
+                 semaphore_general=TRACE,\
                  semaphore_server=TRACE,\
                  semaphore=TRACE"
             }

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -115,7 +115,7 @@ class SentryLike(object):
             "config": {**basic["config"], **full["config"]},
         }
 
-    def send_event(self, project_id, payload=None, headers=None):
+    def send_event(self, project_id, payload=None, headers=None, legacy=False):
         if payload is None:
             payload = {"message": "Hello, World!"}
 
@@ -136,7 +136,12 @@ class SentryLike(object):
             **(headers or {}),
         }
 
-        response = self.post("/api/%s/store/" % project_id, headers=headers, **kwargs,)
+        if legacy:
+            url = "/api/store/"
+        else:
+            url = "/api/%s/store/" % project_id
+
+        response = self.post(url, headers=headers, **kwargs)
         response.raise_for_status()
 
     def send_security_report(

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -107,7 +107,9 @@ def mini_sentry(request):
     def get_project_ids():
         project_ids = {}
         for public_key in flask_request.json["publicKeys"]:
-            project_ids[public_key] = _get_project_id(public_key, sentry.project_configs)
+            project_ids[public_key] = _get_project_id(
+                public_key, sentry.project_configs
+            )
         return jsonify(projectIds=project_ids)
 
     @app.route("/api/0/relays/projectconfigs/", methods=["POST"])

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -22,6 +22,17 @@ def test_store(mini_sentry, relay_chain):
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
 
+def test_legacy_store(mini_sentry, relay_chain):
+    relay = relay_chain()
+    mini_sentry.project_configs[42] = relay.basic_project_config()
+    relay.wait_relay_healthcheck()
+
+    relay.send_event(42, legacy=True)
+    event = mini_sentry.captured_events.get(timeout=1).get_event()
+
+    assert event["logentry"] == {"formatted": "Hello, World!"}
+
+
 def test_store_node_base64(mini_sentry, relay_chain):
     relay = relay_chain()
     relay.wait_relay_healthcheck()


### PR DESCRIPTION
This PR adds support for the legacy store endpoint `/api/store/`. Since it does not contain a project id, we have to perform reverse lookup of project ids.

This endpoint is rarely hit, so we perform this lookup as part of the request handler. The result (project id) is cached in an actor, and subsequent lookups will be fast.

This requires a new endpoint in Sentry.