### PR TITLE
ref: Mmap maxminddb by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2287,6 +2288,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maxminddb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -499,6 +499,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -507,6 +508,15 @@ dependencies = [
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-integer"
@@ -933,6 +943,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maxminddb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1331,6 +1342,7 @@ dependencies = [
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maxminddb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9412a854bf1355d1ff92ef6ffe557dcc4a866e20cdffc7d3fc082174dba7436e"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"

--- a/general/Cargo.toml
+++ b/general/Cargo.toml
@@ -18,7 +18,7 @@ ipnetwork = "0.14.0"
 itertools = "0.8.0"
 lazycell = "1.2.1"
 lazy_static = "1.3.0"
-maxminddb = "0.13.0"
+maxminddb = { version = "0.13.0", features = ["mmap"], optional = true }
 num-traits = "0.2.8"
 regex = "1.2.0"
 semaphore-general-derive = { path = "derive" }
@@ -33,6 +33,7 @@ url = "2.0.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 pest = "2.1.1"
 pest_derive = "2.1.0"
+memmap = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 difference = "2.0.0"
@@ -40,4 +41,4 @@ insta = { version = "0.11.0", features =  ["ron", "redactions"] }
 
 [features]
 bench = []
-default = ["uaparser"]
+default = ["uaparser", "maxminddb", "memmap"]

--- a/general/Cargo.toml
+++ b/general/Cargo.toml
@@ -18,7 +18,7 @@ ipnetwork = "0.14.0"
 itertools = "0.8.0"
 lazycell = "1.2.1"
 lazy_static = "1.3.0"
-maxminddb = { version = "0.13.0", features = ["mmap"], optional = true }
+maxminddb = "0.13.0"
 num-traits = "0.2.8"
 regex = "1.2.0"
 semaphore-general-derive = { path = "derive" }
@@ -41,4 +41,5 @@ insta = { version = "0.11.0", features =  ["ron", "redactions"] }
 
 [features]
 bench = []
-default = ["uaparser", "maxminddb", "memmap"]
+mmap = ["maxminddb/mmap", "memmap"]
+default = ["uaparser", "mmap"]

--- a/general/src/store/geo.rs
+++ b/general/src/store/geo.rs
@@ -4,10 +4,10 @@ use std::path::Path;
 use crate::protocol::Geo;
 use crate::types::Annotated;
 
-#[cfg(feature = "memmap")]
+#[cfg(feature = "mmap")]
 type ReaderType = memmap::Mmap;
 
-#[cfg(not(feature = "memmap"))]
+#[cfg(not(feature = "mmap"))]
 type ReaderType = Vec<u8>;
 
 /// A geo ip lookup helper based on maxmind db files.
@@ -19,7 +19,11 @@ impl GeoIpLookup {
     where
         P: AsRef<Path>,
     {
-        Ok(GeoIpLookup(maxminddb::Reader::open_mmap(path)?))
+        #[cfg(feature = "mmap")]
+        let reader = maxminddb::Reader::open_mmap(path)?;
+        #[cfg(not(feature = "mmap"))]
+        let reader = maxminddb::Reader::open_readfile(path)?;
+        Ok(GeoIpLookup(reader))
     }
 
     /// Looks up an IP address.

--- a/general/src/store/geo.rs
+++ b/general/src/store/geo.rs
@@ -4,8 +4,14 @@ use std::path::Path;
 use crate::protocol::Geo;
 use crate::types::Annotated;
 
+#[cfg(feature = "memmap")]
+type ReaderType = memmap::Mmap;
+
+#[cfg(not(feature = "memmap"))]
+type ReaderType = Vec<u8>;
+
 /// A geo ip lookup helper based on maxmind db files.
-pub struct GeoIpLookup(maxminddb::Reader<Vec<u8>>);
+pub struct GeoIpLookup(maxminddb::Reader<ReaderType>);
 
 impl GeoIpLookup {
     /// Opens a maxminddb file by path.
@@ -13,7 +19,7 @@ impl GeoIpLookup {
     where
         P: AsRef<Path>,
     {
-        Ok(GeoIpLookup(maxminddb::Reader::open_readfile(path)?))
+        Ok(GeoIpLookup(maxminddb::Reader::open_mmap(path)?))
     }
 
     /// Looks up an IP address.


### PR DESCRIPTION
Those databases are quite large (~200mb). Mmapping is also what the Python code did.

I put this behind a feature flag because the memmap crate likely doesn't compile to wasm, and I still want to use this inside piinguin.