### PR TITLE
feat(server): Add explicit route names to request metrics

### DIFF
--- a/server/src/endpoints/events.rs
+++ b/server/src/endpoints/events.rs
@@ -36,6 +36,7 @@ fn get_captured_event(
 
 pub fn configure_scope(scope: Scope<ServiceState>) -> Scope<ServiceState> {
     scope.resource("/events/{event_id}/", |r| {
+        r.name("internal-events");
         r.method(Method::GET).with(get_captured_event);
     })
 }

--- a/server/src/endpoints/forward.rs
+++ b/server/src/endpoints/forward.rs
@@ -129,9 +129,15 @@ fn forward_upstream(request: &HttpRequest<ServiceState>) -> ResponseFuture<HttpR
 }
 
 /// Registers this endpoint in the actix-web app.
+///
+/// NOTE: This endpoint registers a catch-all handler on `/api`. Register this endpoint last, since
+/// no routes can be registered afterwards!
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
     // We only forward API requests so that relays cannot be used to surf sentry's frontend. The
     // "/api/" path is special as it is actually a web UI endpoint.
-    app.resource("/api/", |r| r.f(|_| HttpResponse::NotFound()))
-        .handler("/api", forward_upstream)
+    app.resource("/api/", |r| {
+        r.name("api-root");
+        r.f(|_| HttpResponse::NotFound())
+    })
+    .handler("/api", forward_upstream)
 }

--- a/server/src/endpoints/healthcheck.rs
+++ b/server/src/endpoints/healthcheck.rs
@@ -1,6 +1,6 @@
 //! A simple healthcheck endpoint for the relay.
 use ::actix::prelude::*;
-use actix_web::{http::Method, Error, HttpResponse, Scope};
+use actix_web::{Error, HttpResponse, Scope};
 use futures::prelude::*;
 use serde::Serialize;
 
@@ -64,9 +64,11 @@ fn liveness_healthcheck(state: CurrentServiceState) -> ResponseFuture<HttpRespon
 pub fn configure_scope(scope: Scope<ServiceState>) -> Scope<ServiceState> {
     scope
         .resource("/healthcheck/ready/", |r| {
-            r.method(Method::GET).with(readiness_healthcheck);
+            r.name("internal-healthcheck-ready");
+            r.get().with(readiness_healthcheck);
         })
         .resource("/healthcheck/live/", |r| {
-            r.method(Method::GET).with(liveness_healthcheck)
+            r.name("internal-healthcheck-live");
+            r.get().with(liveness_healthcheck);
         })
 }

--- a/server/src/endpoints/minidump.rs
+++ b/server/src/endpoints/minidump.rs
@@ -1,4 +1,4 @@
-use actix_web::{actix::ResponseFuture, http::Method, HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{actix::ResponseFuture, HttpMessage, HttpRequest, HttpResponse};
 use futures::Future;
 
 use semaphore_general::protocol::EventId;
@@ -126,6 +126,7 @@ fn store_minidump(
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
     app.resource(r"/api/{project:\d+}/minidump{trailing_slash:/?}", |r| {
-        r.method(Method::POST).with(store_minidump);
+        r.name("store-minidump");
+        r.post().with(store_minidump);
     })
 }

--- a/server/src/endpoints/project_configs.rs
+++ b/server/src/endpoints/project_configs.rs
@@ -1,5 +1,5 @@
-use ::actix::prelude::*;
-use actix_web::{http::Method, Error, Json};
+use actix::prelude::*;
+use actix_web::{Error, Json};
 use futures::{future, Future};
 
 use crate::actors::project::{
@@ -53,6 +53,7 @@ fn get_project_configs(
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
     app.resource("/api/0/relays/projectconfigs/", |r| {
-        r.method(Method::POST).with(get_project_configs);
+        r.name("relay-projectconfigs");
+        r.post().with(get_project_configs);
     })
 }

--- a/server/src/endpoints/public_keys.rs
+++ b/server/src/endpoints/public_keys.rs
@@ -1,5 +1,5 @@
-use ::actix::ResponseFuture;
-use actix_web::{http::Method, Error, Json};
+use actix::ResponseFuture;
+use actix_web::{Error, Json};
 use futures::prelude::*;
 
 use crate::actors::keys::{GetPublicKeys, GetPublicKeysResult};
@@ -27,6 +27,7 @@ fn get_public_keys(
 /// which authenticate entire Relays.
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
     app.resource("/api/0/relays/publickeys/", |r| {
-        r.method(Method::POST).with(get_public_keys);
+        r.name("relay-publickeys");
+        r.post().with(get_public_keys);
     })
 }

--- a/server/src/endpoints/security_report.rs
+++ b/server/src/endpoints/security_report.rs
@@ -1,7 +1,6 @@
 //! Endpoints for security reports.
 
 use actix_web::actix::ResponseFuture;
-use actix_web::http::Method;
 use actix_web::{pred, HttpRequest, HttpResponse, Query, Request};
 use futures::Future;
 use serde::Deserialize;
@@ -100,15 +99,17 @@ impl pred::Predicate<ServiceState> for SecurityReportFilter {
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
+    // Default security endpoint
     app.resource(r"/api/{project:\d+}/security/", |r| {
-        //hook security endpoint
-        r.method(Method::POST)
+        r.name("store-security-report");
+        r.post()
             .filter(SecurityReportFilter)
             .with(store_security_report);
     })
+    // Legacy security endpoint
     .resource(r"/api/{project:\d+}/csp-report/", |r| {
-        //legacy security endpoint
-        r.method(Method::POST)
+        r.name("store-csp-report");
+        r.post()
             .filter(SecurityReportFilter)
             .with(store_security_report);
     })

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -1,7 +1,6 @@
 //! Handles event store requests.
 
 use actix::prelude::*;
-use actix_web::http::Method;
 use actix_web::middleware::cors::Cors;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use bytes::BytesMut;
@@ -150,15 +149,17 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
         // in their URL handling. Since actix does not normalize such paths, allow any number of
         // slashes. The trailing slash can also be omitted, optionally.
         .resource(r"/{l:/*}api/{project:\d+}/store{t:/*}", |r| {
-            r.method(Method::POST).with(store_event);
-            r.method(Method::GET).with(store_event);
+            r.name("store-default");
+            r.post().with(store_event);
+            r.get().with(store_event);
         })
         // Legacy store path. Since it is missing the project parameter, the `EventMeta` extractor
         // will use `ProjectKeyLookup` to map the public key to a project id before handling the
         // request.
         .resource(r"/{l:/*}api/store{t:/*}", |r| {
-            r.method(Method::POST).with(store_event);
-            r.method(Method::GET).with(store_event);
+            r.name("store-legacy");
+            r.post().with(store_event);
+            r.get().with(store_event);
         })
         .register()
 }

--- a/server/src/middlewares.rs
+++ b/server/src/middlewares.rs
@@ -27,7 +27,11 @@ impl StartTime {
 impl<S> Middleware<S> for Metrics {
     fn start(&self, req: &HttpRequest<S>) -> Result<Started, Error> {
         req.extensions_mut().insert(StartTime(Instant::now()));
-        metric!(counter("requests") += 1, "route" => req.resource().name());
+        metric!(
+            counter("requests") += 1,
+            "route" => req.resource().name(),
+            "method" => req.method().as_str()
+        );
         Ok(Started::Done)
     }
 
@@ -36,12 +40,14 @@ impl<S> Middleware<S> for Metrics {
 
         metric!(
             timer("requests.duration") = start_time.elapsed(),
-            "route" => req.resource().name()
+            "route" => req.resource().name(),
+            "method" => req.method().as_str()
         );
         metric!(
             counter("responses.status_codes") += 1,
             "status_code" => &resp.status().as_str(),
-            "route" => req.resource().name()
+            "route" => req.resource().name(),
+            "method" => req.method().as_str()
         );
 
         Finished::Done

--- a/server/src/middlewares.rs
+++ b/server/src/middlewares.rs
@@ -27,13 +27,23 @@ impl StartTime {
 impl<S> Middleware<S> for Metrics {
     fn start(&self, req: &HttpRequest<S>) -> Result<Started, Error> {
         req.extensions_mut().insert(StartTime(Instant::now()));
+        metric!(counter("requests") += 1, "route" => req.resource().name());
         Ok(Started::Done)
     }
 
     fn finish(&self, req: &HttpRequest<S>, resp: &HttpResponse) -> Finished {
         let start_time = req.extensions().get::<StartTime>().unwrap().0;
-        metric!(timer("requests.duration") = start_time.elapsed());
-        metric!(counter("responses.status_codes") += 1, "status_code" => &resp.status().as_str());
+
+        metric!(
+            timer("requests.duration") = start_time.elapsed(),
+            "route" => req.resource().name()
+        );
+        metric!(
+            counter("responses.status_codes") += 1,
+            "status_code" => &resp.status().as_str(),
+            "route" => req.resource().name()
+        );
+
         Finished::Done
     }
 }


### PR DESCRIPTION
Assigns each route a name and logs it with request metrics in the middleware. Additionally, the new `requests` metric now counts the number of incoming request (per route). This also helps us to detect requests on legacy endpoints.

The schema is `{scope}-{endpoint}`. It's slightly inconsistent with dashes, but it should be quite clear what each endpoint does when looking at it in the metrics dashboard.