### PR TITLE
feat: Implement individual attachment endpoint

### DIFF
--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -40,25 +40,6 @@ use {
     semaphore_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
 };
 
-/// Name of the event attachment.
-///
-/// This is a special attachment that can contain a sentry event payload encoded as message pack.
-const ITEM_NAME_EVENT: &str = "__sentry-event";
-
-/// Name of the breadcrumb attachment (1).
-///
-/// This is a special attachment that can contain breadcrumbs encoded as message pack. There can be
-/// two attachments that the SDK may use as swappable buffers. Both attachments will be merged and
-/// truncated to the maxmimum number of allowed attachments.
-const ITEM_NAME_BREADCRUMBS1: &str = "__sentry-breadcrumbs1";
-
-/// Name of the breadcrumb attachment (2).
-///
-/// This is a special attachment that can contain breadcrumbs encoded as message pack. There can be
-/// two attachments that the SDK may use as swappable buffers. Both attachments will be merged and
-/// truncated to the maxmimum number of allowed attachments.
-const ITEM_NAME_BREADCRUMBS2: &str = "__sentry-breadcrumbs2";
-
 #[derive(Debug, Fail)]
 pub enum QueueEventError {
     #[fail(display = "Too many events (max_concurrent_events reached)")]
@@ -360,48 +341,62 @@ impl EventProcessor {
     ///  3. Attachments `__sentry-event` and `__sentry-breadcrumbs1/2`.
     ///  4. A multipart form data body.
     ///  5. If none match, an empty default Event.
-    fn extract_event(&self, envelope: &mut Envelope) -> Result<Annotated<Event>, ProcessingError> {
+    fn extract_event(
+        &self,
+        envelope: &mut Envelope,
+    ) -> Result<Option<Annotated<Event>>, ProcessingError> {
         // Remove all items first, and then process them. After this function returns, only
         // attachments can remain in the envelope. The event will be added again at the end of
         // `process_event`.
         let event_item = envelope.take_item_by_type(ItemType::Event);
         let security_item = envelope.take_item_by_type(ItemType::SecurityReport);
+
         let form_item = envelope.take_item_by_type(ItemType::FormData);
-        let attachment_item = envelope.take_item_by_name(ITEM_NAME_EVENT);
-        let breadcrumbs_item1 = envelope.take_item_by_name(ITEM_NAME_BREADCRUMBS1);
-        let breadcrumbs_item2 = envelope.take_item_by_name(ITEM_NAME_BREADCRUMBS2);
+        let attachment_item = envelope.take_item_by_attachment_type(AttachmentType::Event);
+        let breadcrumbs_item1 = envelope.take_item_by_attachment_type(AttachmentType::Breadcrumb);
+        let breadcrumbs_item2 = envelope.take_item_by_attachment_type(AttachmentType::Breadcrumb);
 
         if let Some(item) = event_item {
             log::trace!("processing json event {}", envelope.event_id());
-            return metric!(timer("event_processing.deserialize"), {
-                self.event_from_json_payload(item)
-            });
+            return Ok(Some(metric!(timer("event_processing.deserialize"), {
+                self.event_from_json_payload(item)?
+            })));
         }
 
         if let Some(item) = security_item {
             log::trace!("processing security report {}", envelope.event_id());
-            return self.event_from_security_report(item);
+            return Ok(Some(self.event_from_security_report(item)?));
         }
 
         if attachment_item.is_some() || breadcrumbs_item1.is_some() || breadcrumbs_item2.is_some() {
             log::trace!("extracting attached event data {}", envelope.event_id());
-            return Self::event_from_attachments(
+            return Ok(Some(Self::event_from_attachments(
                 &self.config,
                 attachment_item,
                 breadcrumbs_item1,
                 breadcrumbs_item2,
-            );
+            )?));
         }
 
         if let Some(item) = form_item {
             log::trace!("extracting form data {}", envelope.event_id());
             let mut value = SerdeValue::Object(Default::default());
             self.merge_formdata(&mut value, item);
-            return Ok(Annotated::deserialize_with_meta(value).unwrap_or_default());
+            return Ok(Some(
+                Annotated::deserialize_with_meta(value).unwrap_or_default(),
+            ));
         }
 
-        log::trace!("creating empty event {}", envelope.event_id());
-        Ok(Annotated::new(Event::default()))
+        if envelope
+            .get_item_by_attachment_type(AttachmentType::Minidump)
+            .is_none()
+        {
+            log::trace!("creating no event for envelope {}", envelope.event_id());
+            Ok(None)
+        } else {
+            log::trace!("creating empty event for envelope {}", envelope.event_id());
+            Ok(Some(Annotated::default()))
+        }
     }
 
     #[cfg(feature = "processing")]
@@ -498,7 +493,10 @@ impl EventProcessor {
 
         // Extract the event from the envelope. This removes all items from the envelope that should
         // not be forwarded, including the event item itself.
-        let mut event = self.extract_event(&mut envelope)?;
+        let mut event = match self.extract_event(&mut envelope)? {
+            Some(event) => event,
+            None => return Ok(ProcessEventResponse { envelope }),
+        };
 
         // `extract_event` must remove all items other than attachments from the envelope. Once the
         // envelope is processed, an `Event` item will be added to the envelope again. Only
@@ -761,6 +759,7 @@ impl Handler<HandleEvent> for EventManager {
         } = message;
 
         let event_id = envelope.event_id();
+        let is_event = envelope.get_item_by_type(ItemType::Event).is_some();
         let project_id = envelope.meta().project_id();
         let remote_addr = envelope.meta().client_addr();
         let meta_clone = Arc::new(envelope.meta().clone());
@@ -800,7 +799,7 @@ impl Handler<HandleEvent> for EventManager {
                 #[cfg(feature = "processing")]
                 {
                     if let Some(store_forwarder) = store_forwarder {
-                        log::trace!("sending event to kafka {}", event_id);
+                        log::trace!("sending envelope to kafka {}", event_id);
                         let future = store_forwarder
                             .send(StoreEvent {
                                 envelope,
@@ -873,6 +872,11 @@ impl Handler<HandleEvent> for EventManager {
             .timeout(self.config.event_buffer_expiry(), ProcessingError::Timeout)
             .map(|_, _, _| metric!(counter("event.accepted") += 1))
             .map_err(clone!(project, captured_events, |error, _, _| {
+                // Do not track outcomes or capture events for non-event envelopes (such as
+                // individual attachments)
+                if !is_event {
+                    return;
+                }
                 // if we are in capture mode, we stash away the event instead of
                 // forwarding it.
                 if capture {

--- a/server/src/actors/events.rs
+++ b/server/src/actors/events.rs
@@ -352,9 +352,9 @@ impl EventProcessor {
         let security_item = envelope.take_item_by_type(ItemType::SecurityReport);
 
         let form_item = envelope.take_item_by_type(ItemType::FormData);
-        let attachment_item = envelope.take_item_by_attachment_type(AttachmentType::Event);
-        let breadcrumbs_item1 = envelope.take_item_by_attachment_type(AttachmentType::Breadcrumb);
-        let breadcrumbs_item2 = envelope.take_item_by_attachment_type(AttachmentType::Breadcrumb);
+        let attachment_item = envelope.take_item_by_attachment_type(AttachmentType::MsgpackEvent);
+        let breadcrumbs_item1 = envelope.take_item_by_attachment_type(AttachmentType::Breadcrumbs);
+        let breadcrumbs_item2 = envelope.take_item_by_attachment_type(AttachmentType::Breadcrumbs);
 
         if let Some(item) = event_item {
             log::trace!("processing json event {}", envelope.event_id());

--- a/server/src/actors/outcome.rs
+++ b/server/src/actors/outcome.rs
@@ -161,6 +161,9 @@ pub enum DiscardReason {
     /// [Relay] An envelope was submitted with two items that need to be unique.
     DuplicateItem,
 
+    /// [Relay] User specified an unparseable event ID as part of an attachment endpoint request.
+    InvalidEventId,
+
     /// [All] An error in Relay caused event ingestion to fail. This is the catch-all and usually
     /// indicates bugs in Relay, rather than an expected failure.
     Internal,
@@ -247,6 +250,7 @@ mod real_implementation {
                 DiscardReason::ProjectState => "project_state",
                 DiscardReason::DuplicateItem => "duplicate_item",
                 DiscardReason::Internal => "internal",
+                DiscardReason::InvalidEventId => "invalid_event_id",
             }
         }
     }

--- a/server/src/actors/store.rs
+++ b/server/src/actors/store.rs
@@ -211,9 +211,12 @@ impl Handler<StoreEvent> for StoreForwarder {
         } = message;
 
         let event_id = envelope.event_id();
-        let event_item = envelope.get_item_by_type(ItemType::Event);
+        let event_item = envelope.get_item_by(|item| item.ty() == ItemType::Event);
 
-        let topic = if envelope.get_item_by_type(ItemType::Attachment).is_some() {
+        let topic = if envelope
+            .get_item_by(|item| item.ty() == ItemType::Attachment)
+            .is_some()
+        {
             KafkaTopic::Attachments
         } else if event_item.and_then(|x| x.event_type()) == Some(EventType::Transaction) {
             KafkaTopic::Transactions

--- a/server/src/actors/store.rs
+++ b/server/src/actors/store.rs
@@ -232,7 +232,6 @@ impl Handler<StoreEvent> for StoreForwarder {
                 continue;
             }
 
-            // TODO(jauer): This needs to be unique within the event.
             let id = Uuid::new_v4().to_string();
 
             let mut chunk_index = 0;

--- a/server/src/actors/store.rs
+++ b/server/src/actors/store.rs
@@ -14,7 +14,7 @@ use serde::{ser::Error, Serialize};
 
 use rmp_serde::encode::Error as SerdeError;
 
-use semaphore_common::{metric, Config, KafkaTopic, ProjectId};
+use semaphore_common::{metric, Config, KafkaTopic, ProjectId, Uuid};
 use semaphore_general::protocol::{EventId, EventType};
 
 use crate::envelope::{AttachmentType, Envelope, ItemType};
@@ -226,14 +226,14 @@ impl Handler<StoreEvent> for StoreForwarder {
 
         let mut attachments = Vec::new();
 
-        for (index, item) in envelope.items().enumerate() {
+        for item in envelope.items() {
             // Only upload items first.
             if item.ty() != ItemType::Attachment {
                 continue;
             }
 
             // TODO(jauer): This needs to be unique within the event.
-            let id = index.to_string();
+            let id = Uuid::new_v4().to_string();
 
             let mut chunk_index = 0;
             let mut offset = 0;

--- a/server/src/endpoints/attachments.rs
+++ b/server/src/endpoints/attachments.rs
@@ -57,6 +57,7 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
     app.resource(
         r"/api/{project:\d+}/events/{event_id:[^/]+}/attachments{trailing_slash:/}",
         |r| {
+            r.name("store-attachment");
             r.method(Method::POST).with(store_attachment);
         },
     )

--- a/server/src/endpoints/attachments.rs
+++ b/server/src/endpoints/attachments.rs
@@ -45,6 +45,7 @@ fn store_attachment(
 
     Box::new(handle_store_like_request(
         meta,
+        false,
         start_time,
         request,
         move |data, meta| extract_envelope(data, meta, attachment_size),

--- a/server/src/endpoints/attachments.rs
+++ b/server/src/endpoints/attachments.rs
@@ -1,0 +1,62 @@
+use actix_web::{actix::ResponseFuture, http::Method, HttpRequest, HttpResponse};
+use futures::Future;
+
+use semaphore_common::tryf;
+use semaphore_general::protocol::EventId;
+
+use crate::actors::outcome::DiscardReason;
+use crate::endpoints::common::{handle_store_like_request, BadStoreRequest};
+use crate::envelope::Envelope;
+use crate::extractors::{EventMeta, StartTime};
+use crate::service::{ServiceApp, ServiceState};
+use crate::utils::MultipartEnvelope;
+
+fn extract_envelope(
+    request: &HttpRequest<ServiceState>,
+    meta: EventMeta,
+    max_payload_size: usize,
+) -> ResponseFuture<Envelope, BadStoreRequest> {
+    let event_id = tryf!(request
+        .match_info()
+        .get("event_id")
+        .unwrap_or_default()
+        .parse::<EventId>()
+        .map_err(|_| BadStoreRequest::EventRejected(DiscardReason::InvalidEventId)));
+
+    let envelope = Envelope::from_request(event_id, meta);
+
+    let future = MultipartEnvelope::new(envelope, max_payload_size)
+        .handle_request(request)
+        .map_err(BadStoreRequest::InvalidMultipart);
+
+    Box::new(future)
+}
+
+fn create_response(_: EventId) -> HttpResponse {
+    HttpResponse::Created().finish()
+}
+
+fn store_attachment(
+    meta: EventMeta,
+    start_time: StartTime,
+    request: HttpRequest<ServiceState>,
+) -> ResponseFuture<HttpResponse, BadStoreRequest> {
+    let attachment_size = request.state().config().max_attachment_payload_size();
+
+    Box::new(handle_store_like_request(
+        meta,
+        start_time,
+        request,
+        move |data, meta| extract_envelope(data, meta, attachment_size),
+        create_response,
+    ))
+}
+
+pub fn configure_app(app: ServiceApp) -> ServiceApp {
+    app.resource(
+        r"/api/{project:\d+}/events/{event_id:[^/]+}/attachments{trailing_slash:/}",
+        |r| {
+            r.method(Method::POST).with(store_attachment);
+        },
+    )
+}

--- a/server/src/endpoints/common.rs
+++ b/server/src/endpoints/common.rs
@@ -19,7 +19,7 @@ use crate::actors::events::{QueueEvent, QueueEventError};
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::project::{EventAction, GetEventAction, GetProject, ProjectError, RateLimit};
 use crate::body::StorePayloadError;
-use crate::envelope::{Envelope, EnvelopeError};
+use crate::envelope::{Envelope, EnvelopeError, ItemType};
 use crate::extractors::{EventMeta, StartTime};
 use crate::service::ServiceState;
 use crate::utils::{ApiErrorResponse, MultipartError};
@@ -191,15 +191,20 @@ where
 
     let cloned_meta = Arc::new(meta.clone());
     let event_id = Rc::new(Mutex::new(None));
+    let is_event = Rc::new(Mutex::new(true));
 
     let future = project_manager
         .send(GetProject { id: project_id })
         .map_err(BadStoreRequest::ScheduleFailed)
-        .and_then(clone!(event_id, |project| {
+        .and_then(clone!(event_id, is_event, |project| {
             extract_envelope(&request, meta)
                 .into_future()
                 .and_then(clone!(project, |envelope| {
                     *event_id.lock() = Some(envelope.event_id());
+
+                    if envelope.get_item_by_type(ItemType::Event).is_none() {
+                        *is_event.lock() = false;
+                    }
 
                     project
                         .send(GetEventAction::cached(cloned_meta))
@@ -231,15 +236,17 @@ where
         .or_else(move |error: BadStoreRequest| {
             metric!(counter("event.rejected") += 1);
 
-            outcome_producer.do_send(TrackOutcome {
-                timestamp: start_time,
-                project_id,
-                org_id: None,
-                key_id: None,
-                outcome: error.to_outcome(),
-                event_id: *event_id.lock(),
-                remote_addr,
-            });
+            if *is_event.lock() {
+                outcome_producer.do_send(TrackOutcome {
+                    timestamp: start_time,
+                    project_id,
+                    org_id: None,
+                    key_id: None,
+                    outcome: error.to_outcome(),
+                    event_id: *event_id.lock(),
+                    remote_addr,
+                });
+            }
 
             let response = error.error_response();
             if response.status().is_server_error() {

--- a/server/src/endpoints/minidump.rs
+++ b/server/src/endpoints/minidump.rs
@@ -15,6 +15,25 @@ use crate::utils::MultipartEnvelope;
 /// Sentry requires
 const MINIDUMP_FIELD_NAME: &str = "upload_file_minidump";
 
+/// Name of the event attachment.
+///
+/// This is a special attachment that can contain a sentry event payload encoded as message pack.
+const ITEM_NAME_EVENT: &str = "__sentry-event";
+
+/// Name of the breadcrumb attachment (1).
+///
+/// This is a special attachment that can contain breadcrumbs encoded as message pack. There can be
+/// two attachments that the SDK may use as swappable buffers. Both attachments will be merged and
+/// truncated to the maxmimum number of allowed attachments.
+const ITEM_NAME_BREADCRUMBS1: &str = "__sentry-breadcrumbs1";
+
+/// Name of the breadcrumb attachment (2).
+///
+/// This is a special attachment that can contain breadcrumbs encoded as message pack. There can be
+/// two attachments that the SDK may use as swappable buffers. Both attachments will be merged and
+/// truncated to the maxmimum number of allowed attachments.
+const ITEM_NAME_BREADCRUMBS2: &str = "__sentry-breadcrumbs2";
+
 /// File name for a standalone minidump upload.
 ///
 /// In contrast to the field name, this is used when a standalone minidump is uploaded not in a
@@ -92,6 +111,19 @@ where {
                     item.set_attachment_type(AttachmentType::Minidump);
                 }
                 None => return Err(BadStoreRequest::MissingMinidump),
+            }
+
+            for field_name in &[ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2] {
+                if let Some(item) = envelope.get_item_by_mut(|item| item.name() == Some(field_name))
+                {
+                    item.set_attachment_type(AttachmentType::Breadcrumb);
+                }
+            }
+
+            if let Some(item) =
+                envelope.get_item_by_mut(|item| item.name() == Some(ITEM_NAME_EVENT))
+            {
+                item.set_attachment_type(AttachmentType::Event);
             }
 
             Ok(envelope)

--- a/server/src/endpoints/minidump.rs
+++ b/server/src/endpoints/minidump.rs
@@ -134,7 +134,7 @@ where {
     let future = MultipartEnvelope::new(envelope, max_payload_size)
         .handle_request(request)
         .map_err(BadStoreRequest::InvalidMultipart)
-        .and_then(|mut envelope| {
+        .and_then(move |mut envelope| {
             let mut minidump_item =
                 match envelope.take_item_by(|item| item.name() == Some(MINIDUMP_FIELD_NAME)) {
                     Some(item) => item,
@@ -175,6 +175,9 @@ where {
                 },
             );
 
+            Box::new(future)
+        })
+        .and_then(move |mut envelope| {
             for field_name in &[ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2] {
                 if let Some(item) = envelope.get_item_by_mut(|item| item.name() == Some(field_name))
                 {

--- a/server/src/endpoints/minidump.rs
+++ b/server/src/endpoints/minidump.rs
@@ -149,6 +149,7 @@ fn store_minidump(
 
     Box::new(handle_store_like_request(
         meta,
+        true,
         start_time,
         request,
         move |data, meta| extract_envelope(data, meta, event_size),

--- a/server/src/endpoints/minidump.rs
+++ b/server/src/endpoints/minidump.rs
@@ -116,14 +116,14 @@ where {
             for field_name in &[ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2] {
                 if let Some(item) = envelope.get_item_by_mut(|item| item.name() == Some(field_name))
                 {
-                    item.set_attachment_type(AttachmentType::Breadcrumb);
+                    item.set_attachment_type(AttachmentType::Breadcrumbs);
                 }
             }
 
             if let Some(item) =
                 envelope.get_item_by_mut(|item| item.name() == Some(ITEM_NAME_EVENT))
             {
-                item.set_attachment_type(AttachmentType::Event);
+                item.set_attachment_type(AttachmentType::MsgpackEvent);
             }
 
             Ok(envelope)

--- a/server/src/endpoints/mod.rs
+++ b/server/src/endpoints/mod.rs
@@ -7,6 +7,7 @@ use actix_web::HttpResponse;
 
 use crate::service::ServiceApp;
 
+mod attachments;
 mod common;
 mod events;
 mod forward;
@@ -30,6 +31,7 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
     .configure(store::configure_app)
     .configure(security_report::configure_app)
     .configure(minidump::configure_app)
+    .configure(attachments::configure_app)
     // `forward` must be last as it creates a wildcard proxy
     .configure(forward::configure_app)
 }

--- a/server/src/endpoints/security_report.rs
+++ b/server/src/endpoints/security_report.rs
@@ -69,6 +69,7 @@ fn store_security_report(
     let event_size = request.state().config().max_event_payload_size();
     Box::new(handle_store_like_request(
         meta,
+        true,
         start_time,
         request,
         move |data, meta| extract_envelope(data, meta, event_size, params.into_inner()),

--- a/server/src/endpoints/store.rs
+++ b/server/src/endpoints/store.rs
@@ -123,6 +123,10 @@ fn store_event(
 
     Box::new(handle_store_like_request(
         meta,
+        // XXX: This is wrong. In case of external relays, store can receive event-less envelopes.
+        // We need to fix this before external relays go live or we will create outcomes and rate
+        // limits for individual attachment requests.
+        true,
         start_time,
         request,
         move |data, meta| extract_envelope(data, meta, event_size, content_type),

--- a/server/src/envelope.rs
+++ b/server/src/envelope.rs
@@ -494,21 +494,6 @@ impl Envelope {
         self.items().find(|item| pred(item))
     }
 
-    /// Returns the first item that matches the given `ItemType`.
-    pub fn get_item_by_type(&self, ty: ItemType) -> Option<&Item> {
-        self.get_item_by(|item| item.ty() == ty)
-    }
-
-    /// Returns the first item that matches the given `AttachmentType`.
-    pub fn get_item_by_attachment_type(&self, ty: AttachmentType) -> Option<&Item> {
-        self.get_item_by(|item| item.attachment_type() == Some(ty))
-    }
-
-    /// Returns the first item that matches the given name.
-    pub fn get_item_by_name(&self, name: &str) -> Option<&Item> {
-        self.get_item_by(|item| item.name() == Some(name))
-    }
-
     /// Returns the an option with a mutable reference to the first item that matches
     /// the predicate, or None if the predicate is not matched by any item.
     pub fn get_item_by_mut<F>(&mut self, mut pred: F) -> Option<&mut Item>
@@ -525,25 +510,6 @@ impl Envelope {
     {
         let index = self.items.iter().position(cond);
         index.map(|index| self.items.swap_remove(index))
-    }
-
-    /// Removes and returns the first item that matches the given `ItemType`.
-    ///
-    /// This swaps the last item with the item being removed.
-    pub fn take_item_by_type(&mut self, ty: ItemType) -> Option<Item> {
-        self.take_item_by(|item| item.ty() == ty)
-    }
-
-    /// Removes and returns the first item that matches the given `AttachmentType`.
-    ///
-    /// This swaps the last item with the item being removed.
-    pub fn take_item_by_attachment_type(&mut self, ty: AttachmentType) -> Option<Item> {
-        self.take_item_by(|item| item.attachment_type() == Some(ty))
-    }
-
-    /// Removes and returns the first item that matches the given name.
-    pub fn take_item_by_name(&mut self, name: &str) -> Option<Item> {
-        self.take_item_by(|item| item.name() == Some(name))
     }
 
     /// Adds a new item to this envelope.
@@ -729,12 +695,14 @@ mod tests {
         envelope.add_item(item2);
 
         let taken = envelope
-            .take_item_by_type(ItemType::Attachment)
+            .take_item_by(|item| item.ty() == ItemType::Attachment)
             .expect("should return some item");
 
         assert_eq!(taken.filename(), Some("item1"));
 
-        assert!(envelope.take_item_by_type(ItemType::Event).is_none());
+        assert!(envelope
+            .take_item_by(|item| item.ty() == ItemType::Event)
+            .is_none());
     }
 
     #[test]

--- a/server/src/envelope.rs
+++ b/server/src/envelope.rs
@@ -179,15 +179,15 @@ pub enum AttachmentType {
     #[allow(dead_code)]
     AppleCrashReport,
 
-    #[serde(rename = "event.event")]
+    #[serde(rename = "event.msgpackevent")]
     /// A msgpack-encoded event submitted as part of minidump uploads.
-    Event,
+    MsgpackEvent,
 
-    #[serde(rename = "event.breadcrumb")]
+    #[serde(rename = "event.breadcrumbs")]
     /// This is a special attachment that can contain breadcrumbs encoded as message pack. There can be
     /// two attachments that the SDK may use as swappable buffers. Both attachments will be merged and
     /// truncated to the maxmimum number of allowed attachments.
-    Breadcrumb,
+    Breadcrumbs,
 }
 
 impl Default for AttachmentType {

--- a/server/src/envelope.rs
+++ b/server/src/envelope.rs
@@ -178,6 +178,16 @@ pub enum AttachmentType {
     #[serde(rename = "event.applecrashreport")]
     #[allow(dead_code)]
     AppleCrashReport,
+
+    #[serde(rename = "event.event")]
+    /// A msgpack-encoded event submitted as part of minidump uploads.
+    Event,
+
+    #[serde(rename = "event.breadcrumb")]
+    /// This is a special attachment that can contain breadcrumbs encoded as message pack. There can be
+    /// two attachments that the SDK may use as swappable buffers. Both attachments will be merged and
+    /// truncated to the maxmimum number of allowed attachments.
+    Breadcrumb,
 }
 
 impl Default for AttachmentType {
@@ -489,6 +499,11 @@ impl Envelope {
         self.get_item_by(|item| item.ty() == ty)
     }
 
+    /// Returns the first item that matches the given `AttachmentType`.
+    pub fn get_item_by_attachment_type(&self, ty: AttachmentType) -> Option<&Item> {
+        self.get_item_by(|item| item.attachment_type() == Some(ty))
+    }
+
     /// Returns the first item that matches the given name.
     pub fn get_item_by_name(&self, name: &str) -> Option<&Item> {
         self.get_item_by(|item| item.name() == Some(name))
@@ -517,6 +532,13 @@ impl Envelope {
     /// This swaps the last item with the item being removed.
     pub fn take_item_by_type(&mut self, ty: ItemType) -> Option<Item> {
         self.take_item_by(|item| item.ty() == ty)
+    }
+
+    /// Removes and returns the first item that matches the given `AttachmentType`.
+    ///
+    /// This swaps the last item with the item being removed.
+    pub fn take_item_by_attachment_type(&mut self, ty: AttachmentType) -> Option<Item> {
+        self.take_item_by(|item| item.attachment_type() == Some(ty))
     }
 
     /// Removes and returns the first item that matches the given name.

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -162,7 +162,6 @@ class SentryLike(object):
 
     def send_minidump(self, project_id, params=None, files=None):
         """
-
         :param project_id: the project id
         :param params: a list of tuples (param_name, param_value)
         :param files: a list of triples (param_name, file_name, file_content)
@@ -191,6 +190,28 @@ class SentryLike(object):
 
         response.raise_for_status()
         return response
+
+    def send_attachments(self, project_id, event_id, files):
+        files = {
+            name: (file_name, file_content)
+            for (name, file_name, file_content) in files
+        }
+        response = self.post(
+            "/api/{}/events/{}/attachments/".format(project_id, event_id),
+            headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+                "X-Sentry-Auth": (
+                    "Sentry sentry_version=5, sentry_timestamp=1535376240291, "
+                    "sentry_client=raven-node/2.6.3, "
+                    "sentry_key={}".format(self.dsn_public_key)
+                ),
+            },
+            files=files
+        )
+        response.raise_for_status()
+        return response
+
 
     def request(self, method, path, **kwargs):
         assert path.startswith("/")

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -193,8 +193,7 @@ class SentryLike(object):
 
     def send_attachments(self, project_id, event_id, files):
         files = {
-            name: (file_name, file_content)
-            for (name, file_name, file_content) in files
+            name: (file_name, file_content) for (name, file_name, file_content) in files
         }
         response = self.post(
             "/api/{}/events/{}/attachments/".format(project_id, event_id),
@@ -207,11 +206,10 @@ class SentryLike(object):
                     "sentry_key={}".format(self.dsn_public_key)
                 ),
             },
-            files=files
+            files=files,
         )
         response.raise_for_status()
         return response
-
 
     def request(self, method, path, **kwargs):
         assert path.startswith("/")

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -209,5 +209,5 @@ class AttachmentsConsumer(EventsConsumer):
         assert message.error() is None
 
         v = msgpack.unpackb(message.value(), raw=False, use_list=False)
-        assert v['type'] == 'attachment', v['type']
+        assert v["type"] == "attachment", v["type"]
         return v

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -195,10 +195,19 @@ class EventsConsumer(ConsumerBase):
 
 class AttachmentsConsumer(EventsConsumer):
     def get_attachment_chunk(self):
-        event = self.poll()
-        assert event is not None
-        assert event.error() is None
+        message = self.poll()
+        assert message is not None
+        assert message.error() is None
 
-        v = msgpack.unpackb(event.value(), raw=False, use_list=False)
+        v = msgpack.unpackb(message.value(), raw=False, use_list=False)
         assert v["type"] == "attachment_chunk", v["type"]
         return v["payload"], v
+
+    def get_individual_attachment(self):
+        message = self.poll()
+        assert message is not None
+        assert message.error() is None
+
+        v = msgpack.unpackb(message.value(), raw=False, use_list=False)
+        assert v['type'] == 'attachment', v['type']
+        return v

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -2,6 +2,7 @@ import pytest
 
 from requests.exceptions import HTTPError
 
+
 def test_attachments_with_processing(
     mini_sentry, relay_with_processing, attachments_consumer, outcomes_consumer
 ):
@@ -14,23 +15,24 @@ def test_attachments_with_processing(
 
     event_id = "515539018c9b4260a6f999572f1661ee"
 
-    response = relay.send_attachments(proj_id, event_id, [
-        ("att_1", "foo.txt", b"heavens no"),
-        ("att_2", "bar.txt", b"hell yeah"),
-    ])
+    response = relay.send_attachments(
+        proj_id,
+        event_id,
+        [("att_1", "foo.txt", b"heavens no"), ("att_2", "bar.txt", b"hell yeah"),],
+    )
 
     attachment_contents = {}
     attachment_num_chunks = {}
 
     while set(attachment_contents.values()) != {b"heavens no", b"hell yeah"}:
         chunk, v = attachments_consumer.get_attachment_chunk()
-        attachment_contents[v['id']] = attachment_contents.get(v['id'], b"") + chunk
-        num_chunks = 1 + attachment_num_chunks.get(v['id'], 0)
-        assert v['chunk_index'] == num_chunks - 1
-        attachment_num_chunks[v['id']] = num_chunks
+        attachment_contents[v["id"]] = attachment_contents.get(v["id"], b"") + chunk
+        num_chunks = 1 + attachment_num_chunks.get(v["id"], 0)
+        assert v["chunk_index"] == num_chunks - 1
+        attachment_num_chunks[v["id"]] = num_chunks
 
-    assert attachment_contents['0'] == b'heavens no'
-    assert attachment_contents['1'] == b'hell yeah'
+    assert attachment_contents["0"] == b"heavens no"
+    assert attachment_contents["1"] == b"hell yeah"
 
     attachment = attachments_consumer.get_individual_attachment()
     attachment2 = attachments_consumer.get_individual_attachment()
@@ -39,10 +41,10 @@ def test_attachments_with_processing(
         "type": "attachment",
         "attachment": {
             "attachment_type": "event.attachment",
-            "chunks": attachment_num_chunks['0'],
+            "chunks": attachment_num_chunks["0"],
             "content_type": "application/octet-stream",
             "id": "0",
-            "name": "foo.txt"
+            "name": "foo.txt",
         },
         "event_id": event_id,
         "project_id": 42,
@@ -51,10 +53,10 @@ def test_attachments_with_processing(
         "type": "attachment",
         "attachment": {
             "attachment_type": "event.attachment",
-            "chunks": attachment_num_chunks['1'],
+            "chunks": attachment_num_chunks["1"],
             "content_type": "application/octet-stream",
             "id": "1",
-            "name": "bar.txt"
+            "name": "bar.txt",
         },
         "event_id": event_id,
         "project_id": 42,
@@ -70,9 +72,9 @@ def test_attachments_with_processing(
     # We need to send in an invalid event because successful ones do not
     # produce outcomes (not in Relay)
     with pytest.raises(HTTPError):
-        relay.send_event(42, b'bogus')
+        relay.send_event(42, b"bogus")
 
     outcome = outcomes_consumer.get_outcome()
-    assert outcome['event_id'] == None, outcome
-    assert outcome['outcome'] == 3
-    assert outcome['reason'] == 'payload'
+    assert outcome["event_id"] == None, outcome
+    assert outcome["outcome"] == 3
+    assert outcome["reason"] == "payload"

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -22,17 +22,22 @@ def test_attachments_with_processing(
     )
 
     attachment_contents = {}
+    attachment_ids = []
     attachment_num_chunks = {}
 
     while set(attachment_contents.values()) != {b"heavens no", b"hell yeah"}:
         chunk, v = attachments_consumer.get_attachment_chunk()
         attachment_contents[v["id"]] = attachment_contents.get(v["id"], b"") + chunk
+        if v['id'] not in attachment_ids:
+            attachment_ids.append(v['id'])
         num_chunks = 1 + attachment_num_chunks.get(v["id"], 0)
         assert v["chunk_index"] == num_chunks - 1
         attachment_num_chunks[v["id"]] = num_chunks
 
-    assert attachment_contents["0"] == b"heavens no"
-    assert attachment_contents["1"] == b"hell yeah"
+    id1, id2 = attachment_ids
+
+    assert attachment_contents[id1] == b"heavens no"
+    assert attachment_contents[id2] == b"hell yeah"
 
     attachment = attachments_consumer.get_individual_attachment()
     attachment2 = attachments_consumer.get_individual_attachment()
@@ -41,9 +46,9 @@ def test_attachments_with_processing(
         "type": "attachment",
         "attachment": {
             "attachment_type": "event.attachment",
-            "chunks": attachment_num_chunks["0"],
+            "chunks": attachment_num_chunks[id1],
             "content_type": "application/octet-stream",
-            "id": "0",
+            "id": id1,
             "name": "foo.txt",
         },
         "event_id": event_id,
@@ -53,9 +58,9 @@ def test_attachments_with_processing(
         "type": "attachment",
         "attachment": {
             "attachment_type": "event.attachment",
-            "chunks": attachment_num_chunks["1"],
+            "chunks": attachment_num_chunks[id2],
             "content_type": "application/octet-stream",
-            "id": "1",
+            "id": id2,
             "name": "bar.txt",
         },
         "event_id": event_id,

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -28,8 +28,8 @@ def test_attachments_with_processing(
     while set(attachment_contents.values()) != {b"heavens no", b"hell yeah"}:
         chunk, v = attachments_consumer.get_attachment_chunk()
         attachment_contents[v["id"]] = attachment_contents.get(v["id"], b"") + chunk
-        if v['id'] not in attachment_ids:
-            attachment_ids.append(v['id'])
+        if v["id"] not in attachment_ids:
+            attachment_ids.append(v["id"])
         num_chunks = 1 + attachment_num_chunks.get(v["id"], 0)
         assert v["chunk_index"] == num_chunks - 1
         attachment_num_chunks[v["id"]] = num_chunks

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -1,0 +1,78 @@
+import pytest
+
+from requests.exceptions import HTTPError
+
+def test_attachments_with_processing(
+    mini_sentry, relay_with_processing, attachments_consumer, outcomes_consumer
+):
+    proj_id = 42
+    relay = relay_with_processing()
+    relay.wait_relay_healthcheck()
+    mini_sentry.project_configs[proj_id] = mini_sentry.full_project_config()
+    attachments_consumer = attachments_consumer()
+    outcomes_consumer = outcomes_consumer()
+
+    event_id = "515539018c9b4260a6f999572f1661ee"
+
+    response = relay.send_attachments(proj_id, event_id, [
+        ("att_1", "foo.txt", b"heavens no"),
+        ("att_2", "bar.txt", b"hell yeah"),
+    ])
+
+    attachment_contents = {}
+    attachment_num_chunks = {}
+
+    while set(attachment_contents.values()) != {b"heavens no", b"hell yeah"}:
+        chunk, v = attachments_consumer.get_attachment_chunk()
+        attachment_contents[v['id']] = attachment_contents.get(v['id'], b"") + chunk
+        num_chunks = 1 + attachment_num_chunks.get(v['id'], 0)
+        assert v['chunk_index'] == num_chunks - 1
+        attachment_num_chunks[v['id']] = num_chunks
+
+    assert attachment_contents['0'] == b'heavens no'
+    assert attachment_contents['1'] == b'hell yeah'
+
+    attachment = attachments_consumer.get_individual_attachment()
+    attachment2 = attachments_consumer.get_individual_attachment()
+
+    assert attachment == {
+        "type": "attachment",
+        "attachment": {
+            "attachment_type": "event.attachment",
+            "chunks": attachment_num_chunks['0'],
+            "content_type": "application/octet-stream",
+            "id": "0",
+            "name": "foo.txt"
+        },
+        "event_id": event_id,
+        "project_id": 42,
+    }
+    assert attachment2 == {
+        "type": "attachment",
+        "attachment": {
+            "attachment_type": "event.attachment",
+            "chunks": attachment_num_chunks['1'],
+            "content_type": "application/octet-stream",
+            "id": "1",
+            "name": "bar.txt"
+        },
+        "event_id": event_id,
+        "project_id": 42,
+    }
+
+    # We want to check that no outcome has been created for the attachment
+    # upload.
+    #
+    # Send an unrelated event in, and assert that it is the first item we can
+    # poll from outcomes for. While not 100% correct due to partitioning, it's
+    # way faster than waiting n seconds to see if nothing else is in outcomes.
+    #
+    # We need to send in an invalid event because successful ones do not
+    # produce outcomes (not in Relay)
+    with pytest.raises(HTTPError):
+        relay.send_event(42, b'bogus')
+
+    outcome = outcomes_consumer.get_outcome()
+    assert outcome['event_id'] == None, outcome
+    assert outcome['outcome'] == 3
+    assert outcome['reason'] == 'payload'

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -172,6 +172,7 @@ def test_minidump_with_processing(
     num_chunks = 0
 
     while attachment != b"MDMPminidump content":
+        print("ATTACHMENT", attachment)
         chunk, v = attachments_consumer.get_attachment_chunk()
         attachment += chunk
         num_chunks += 1

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -170,10 +170,12 @@ def test_minidump_with_processing(
 
     attachment = b""
     num_chunks = 0
+    attachment_id = None
 
     while attachment != b"MDMPminidump content":
         print("ATTACHMENT", attachment)
         chunk, v = attachments_consumer.get_attachment_chunk()
+        attachment_id = attachment_id or v['id']
         attachment += chunk
         num_chunks += 1
 
@@ -184,7 +186,7 @@ def test_minidump_with_processing(
 
     assert list(v["attachments"]) == [
         {
-            "id": "0",
+            "id": attachment_id,
             "name": "minidump.txt",
             "content_type": "application/octet-stream",
             "attachment_type": "event.minidump",

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -200,7 +200,7 @@ def test_minidump_with_processing(
     while attachment != b"MDMPminidump content":
         print("ATTACHMENT", attachment)
         chunk, v = attachments_consumer.get_attachment_chunk()
-        attachment_id = attachment_id or v['id']
+        attachment_id = attachment_id or v["id"]
         attachment += chunk
         num_chunks += 1
 


### PR DESCRIPTION
* Refactor special attachment handling for minidumps such that the "special names" are probed in the endpoint instead of the event actor. This is necessary such that we do not treat *individual* attachments with "special" names as actually special. (`__sentry_event` as attachment should only have meaning when part of a minidump upload, not as an attachment upload).

  Breadcrumbs and messagepack-encoded whatevers are now treated more like the minidump itself: There is a custom attachment type assigned in the endpoint, and later in the event processor we merge everything into one event. That means we need to introduce attachment types for breadcrumb buffers and attached event payloads.

  Note that this means we now have events represented as `itemtype=event` and `itemtype=attachment, attachmenttype=event.event`, where the latter is a msgpack-encoded payload, while the former is a regular json-event

* `extract_event` now returns an `Option<Annotated<Event>>`, and based on `None`-ness we skip over certain code such as rate limiting. We refactor a bit of code to check for the existence of an `itemtype=event` item to decide whether to apply event processing and to send outcomes.

* Implement the attachment endpoint itself which just calls `handle_store_like_request` but produces an envelope without event.