### PR TITLE
fix(server): Make status codes consistent with Sentry

### DIFF
--- a/server/src/actors/outcome.rs
+++ b/server/src/actors/outcome.rs
@@ -161,9 +161,6 @@ pub enum DiscardReason {
     /// [Relay] An envelope was submitted with two items that need to be unique.
     DuplicateItem,
 
-    /// [Relay] User specified an unparseable event ID as part of an attachment endpoint request.
-    InvalidEventId,
-
     /// [All] An error in Relay caused event ingestion to fail. This is the catch-all and usually
     /// indicates bugs in Relay, rather than an expected failure.
     Internal,
@@ -250,7 +247,6 @@ mod real_implementation {
                 DiscardReason::ProjectState => "project_state",
                 DiscardReason::DuplicateItem => "duplicate_item",
                 DiscardReason::Internal => "internal",
-                DiscardReason::InvalidEventId => "invalid_event_id",
             }
         }
     }

--- a/server/src/endpoints/attachments.rs
+++ b/server/src/endpoints/attachments.rs
@@ -4,7 +4,6 @@ use futures::Future;
 use semaphore_common::tryf;
 use semaphore_general::protocol::EventId;
 
-use crate::actors::outcome::DiscardReason;
 use crate::endpoints::common::{handle_store_like_request, BadStoreRequest};
 use crate::envelope::Envelope;
 use crate::extractors::{EventMeta, StartTime};
@@ -21,7 +20,7 @@ fn extract_envelope(
         .get("event_id")
         .unwrap_or_default()
         .parse::<EventId>()
-        .map_err(|_| BadStoreRequest::EventRejected(DiscardReason::InvalidEventId)));
+        .map_err(|_| BadStoreRequest::InvalidEventId));
 
     let envelope = Envelope::from_request(event_id, meta);
 

--- a/server/src/endpoints/common.rs
+++ b/server/src/endpoints/common.rs
@@ -64,6 +64,10 @@ pub enum BadStoreRequest {
 
     #[fail(display = "event submission rejected with_reason: {:?}", _0)]
     EventRejected(DiscardReason),
+
+    /// User specified an unparseable event ID as part of an attachment endpoint request.
+    #[fail(display = "invalid event id")]
+    InvalidEventId,
 }
 
 impl BadStoreRequest {
@@ -102,6 +106,9 @@ impl BadStoreRequest {
             }
 
             BadStoreRequest::RateLimited(retry_after) => Outcome::RateLimited(retry_after.clone()),
+
+            // should actually never create an outcome
+            BadStoreRequest::InvalidEventId => Outcome::Invalid(DiscardReason::Internal),
         }
     }
 }

--- a/server/src/endpoints/common.rs
+++ b/server/src/endpoints/common.rs
@@ -134,6 +134,12 @@ impl ResponseError for BadStoreRequest {
                 // client. It might retry event submission at a later time.
                 HttpResponse::ServiceUnavailable().json(&body)
             }
+            BadStoreRequest::EventRejected(_) => {
+                // The event has been discarded, which is generally indicated with a 403 error.
+                // Originally, Sentry also used this status code for event filters, but these are
+                // now executed asynchronously in `EventProcessor`.
+                HttpResponse::Forbidden().json(&body)
+            }
             _ => {
                 // In all other cases, we indicate a generic bad request to the client and render
                 // the cause. This was likely the client's fault.

--- a/server/src/extractors/event_meta.rs
+++ b/server/src/extractors/event_meta.rs
@@ -42,9 +42,11 @@ pub enum BadEventMeta {
 impl ResponseError for BadEventMeta {
     fn error_response(&self) -> HttpResponse {
         let mut builder = match *self {
+            Self::MissingAuth | Self::BadProjectKey | Self::BadAuth(_) => {
+                HttpResponse::Unauthorized()
+            }
+            Self::BadProject(_) | Self::BadDsn(_) => HttpResponse::BadRequest(),
             Self::ScheduleFailed => HttpResponse::ServiceUnavailable(),
-            Self::BadProjectKey => HttpResponse::Unauthorized(),
-            _ => HttpResponse::BadRequest(),
         };
 
         builder.json(&ApiErrorResponse::from_fail(self))

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -3,6 +3,23 @@ import pytest
 from requests.exceptions import HTTPError
 
 
+def test_attachments_400(
+    mini_sentry, relay_with_processing, attachments_consumer, outcomes_consumer
+):
+    proj_id = 42
+    relay = relay_with_processing()
+    relay.wait_relay_healthcheck()
+    mini_sentry.project_configs[proj_id] = mini_sentry.full_project_config()
+    attachments_consumer = attachments_consumer()
+
+    event_id = "123abc"
+
+    with pytest.raises(HTTPError) as excinfo:
+        relay.send_attachments(proj_id, event_id, [])
+
+    assert excinfo.value.response.status_code == 400
+
+
 def test_attachments_with_processing(
     mini_sentry, relay_with_processing, attachments_consumer, outcomes_consumer
 ):


### PR DESCRIPTION
This should restore the 401 and 403 status codes as in Sentry.