### PR TITLE
build: Switch to licensed geoip downloads

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,7 @@
   "rust-client.rlsPath": "rls",
 
   // Python configuration
-  "python.pythonPath": "${workspaceFolder}/venv/bin/python",
+  "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
   "python.linting.enabled": false,
   "python.formatting.provider": "black",
 

--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,14 @@ clean-target-dir:
 	@which virtualenv || sudo easy_install virtualenv
 	virtualenv -p $$SEMAPHORE_PYTHON_VERSION .venv
 
+# GNU tar requires `--wildcards`, but bsd tar does not.
+ifneq (, $(findstring GNU tar,$(shell tar --version)))
+wildcards=--wildcards
+endif
+
 # See https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads
 GeoLite2-City.mmdb:
-	@curl https://download.maxmind.com/app/geoip_download\?edition_id=GeoLite2-City\&license_key=${GEOIP_LICENSE}\&suffix=tar.gz | tar xz --to-stdout '*/GeoLite2-City.mmdb' > $@
+	@curl https://download.maxmind.com/app/geoip_download\?edition_id=GeoLite2-City\&license_key=${GEOIP_LICENSE}\&suffix=tar.gz | tar xz --to-stdout $(wildcards) '*/GeoLite2-City.mmdb' > $@
 
 .git/hooks/pre-commit:
 	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,9 @@ clean-target-dir:
 	@which virtualenv || sudo easy_install virtualenv
 	virtualenv -p $$SEMAPHORE_PYTHON_VERSION .venv
 
+# See https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads
 GeoLite2-City.mmdb:
-	@curl http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz | gzip -cd > $@
+	@curl https://download.maxmind.com/app/geoip_download\?edition_id=GeoLite2-City\&license_key=${GEOIP_LICENSE}\&suffix=tar.gz | tar xz --to-stdout '*/GeoLite2-City.mmdb' > $@
 
 .git/hooks/pre-commit:
 	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit


### PR DESCRIPTION
Since Dec 31, 2019, MaxMind requires an account to download the latest version of the geoip database. For more information on the changes, see:

- https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
- https://dev.maxmind.com/geoip/geoip2/geolite2/
