### PR TITLE
feat: Implement a grace period for project config fetches

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -329,6 +329,9 @@ impl Default for Http {
 struct Cache {
     /// The cache timeout for project configurations in seconds.
     project_expiry: u32,
+    /// Continue using project state this many seconds after cache expiry while a new state is
+    /// being fetched. This is added on top of `project_expiry` and `miss_expiry`. Default is 0.
+    project_grace_period: u32,
     /// The cache timeout for downstream relay info (public keys) in seconds.
     relay_expiry: u32,
     /// The cache timeout for events (store) before dropping them.
@@ -351,8 +354,9 @@ impl Default for Cache {
     fn default() -> Self {
         Cache {
             project_expiry: 300, // 5 minutes
-            relay_expiry: 3600,  // 1 hour
-            event_expiry: 600,   // 10 minutes
+            project_grace_period: 0,
+            relay_expiry: 3600, // 1 hour
+            event_expiry: 600,  // 10 minutes
             event_buffer_size: 1000,
             miss_expiry: 60,     // 1 minute
             batch_interval: 100, // 100ms
@@ -812,6 +816,11 @@ impl Config {
     /// Returns the expiry timeout for cached misses before trying to refetch.
     pub fn cache_miss_expiry(&self) -> Duration {
         Duration::from_secs(self.values.cache.miss_expiry.into())
+    }
+
+    /// Returns the grace period for project caches.
+    pub fn project_grace_period(&self) -> Duration {
+        Duration::from_secs(self.values.cache.project_grace_period.into())
     }
 
     /// Returns the number of seconds during which batchable queries are collected before sending

--- a/server/src/actors/project.rs
+++ b/server/src/actors/project.rs
@@ -705,9 +705,9 @@ impl Handler<GetEventAction> for Project {
                 .map(move |state| state.get_event_action(project_id, &message.meta, &config))
         } else {
             self.get_or_fetch_state(context);
-            // Fetching is not permitted (as part of the store request). In case the state is not
-            // cached, assume that the event can be accepted. The EventManager will later fetch the
-            // project state and reevaluate the event action.
+            // message.fetch == false: Fetching must not block the store request. In case the state
+            // is not cached, assume that the event can be accepted. The EventManager will later
+            // reevaluate the event action using the fetched project state.
             Response::ok(self.state().map_or(EventAction::Accept, |state| {
                 state.get_event_action(project_id, &message.meta, &self.config)
             }))


### PR DESCRIPTION
This should help with queued up events of high-volume projects.