### PR TITLE
feat(filters): Add safari extensions to browser extension filter

### DIFF
--- a/general/src/filter/browser_extensions.rs
+++ b/general/src/filter/browser_extensions.rs
@@ -87,6 +87,7 @@ lazy_static! {
         static\.woopra\.com/js/woopra\.js|
         ^chrome(-extension)?://|                        # Chrome extensions
         ^moz-extension://|                              # Firefox extensions
+        ^safari-extension://|                           # Safari extensions
         127\.0\.0\.1:4001/isrunning|                    # Cacaoweb
         webappstoolbarba\.texthelp\.com/|               # Other
         metrics\.itunes\.apple\.com\.edgesuite\.net/|
@@ -171,6 +172,7 @@ mod tests {
             "chrome-extension://my-extension/or/something",
             "chrome://my-extension/or/something",
             "moz-extension://my-extension/or/something",
+            "safari-extension://my-extension/or/something",
             "127.0.0.1:4001/isrunning",
             "webappstoolbarba.texthelp.com/",
             "http://metrics.itunes.apple.com.edgesuite.net/itunespreview/itunes/browser:firefo",


### PR DESCRIPTION
By popular request. Also adding it on the python side of things, in https://github.com/getsentry/sentry/pull/16304.