### PR TITLE
ref: Rename all references to the github repository

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,7 @@
 minVersion: "0.8.4"
 github:
   owner: getsentry
-  repo: semaphore
+  repo: relay
 changelogPolicy: simple
 targets:
   - name: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@
 
 ## 0.4.58
 
-- Expose globbing code from Semaphore to Python (#288)
+- Expose globbing code from Relay to Python (#288)
 - Normalize before datascrubbing (#290)
 - Evict project caches after some time (#287)
 - Add event size metrics (#286)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
+name = "relay"
 authors = ["Sentry <oss@sentry.io>"]
 description = "An proxy service for Sentry."
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
 exclude = [".vscode/**/*", ".idea/**/*"]
 license-file = "./LICENSE"
-name = "relay"
 readme = "README.md"
 version = "0.4.65"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 
 # Official Sentry Relay
 
-[![Travis](https://travis-ci.com/getsentry/semaphore.svg?branch=master)](https://travis-ci.com/getsentry/semaphore)
+[![Travis](https://travis-ci.com/getsentry/relay.svg?branch=master)](https://travis-ci.com/getsentry/relay)
 [![AppVeyor](https://img.shields.io/appveyor/ci/sentry/sentry-agent.svg)](https://ci.appveyor.com/project/sentry/sentry-agent)
-[![codecov without integration tests](https://codecov.io/gh/getsentry/semaphore/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/semaphore)
-[![GitHub release](https://img.shields.io/github/release/getsentry/semaphore.svg)](https://github.com/getsentry/semaphore/releases/latest)
+[![codecov without integration tests](https://codecov.io/gh/getsentry/relay/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/relay)
+[![GitHub release](https://img.shields.io/github/release/getsentry/relay.svg)](https://github.com/getsentry/relay/releases/latest)
 [![PyPI](https://img.shields.io/pypi/v/semaphore.svg)](https://pypi.python.org/pypi/Semaphore)
-[![license](https://img.shields.io/github/license/getsentry/semaphore.svg)](https://github.com/getsentry/semaphore/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/getsentry/relay.svg)](https://github.com/getsentry/relay/blob/master/LICENSE)
 
 <p align="center">
   <p align="center">
-    <img src="https://github.com/getsentry/semaphore/blob/master/artwork/semaphore.jpg?raw=true" alt="semaphore tower" width="480">
+    <img src="https://github.com/getsentry/relay/blob/master/artwork/semaphore.jpg?raw=true" alt="semaphore tower" width="480">
   </p>
 </p>
 
@@ -24,7 +24,7 @@ The Sentry Relay is a work in progress service that pushes some functionality
 from the Sentry SDKs as well as the Sentry server into a proxy process.
 
 ## Documentation
-The project documentation can be found at: [https://getsentry.github.io/semaphore/](https://getsentry.github.io/semaphore/).
+The project documentation can be found at: [https://getsentry.github.io/relay/](https://getsentry.github.io/relay/).
 
 ## Quickstart
 

--- a/cabi/Cargo.toml
+++ b/cabi/Cargo.toml
@@ -2,8 +2,8 @@
 name = "relay-cabi"
 version = "0.4.65"
 authors = ["Sentry <oss@sentry.io>"]
-homepage = "https://github.com/getsentry/semaphore"
-repository = "https://github.com/getsentry/semaphore"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
 description = "Exposes some internals of the relay to C."
 edition = "2018"
 license-file = "../LICENSE"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
+name = "relay-common"
 authors = ["Sentry <oss@sentry.io>"]
 description = "Common functionality for the sentry relay"
-homepage = "https://github.com/getsentry/semaphore"
-name = "relay-common"
-repository = "https://github.com/getsentry/semaphore"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
 version = "0.4.65"
 edition = "2018"
 license-file = "../LICENSE"

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ from the Sentry SDKs as well as the Sentry server into a proxy process.
 ## Getting started
 
 The Relay server is called `relay`.  Binaries can be downloaded from the
-[GitHub releases page](https://github.com/getsentry/semaphore/releases).  After
+[GitHub releases page](https://github.com/getsentry/relay/releases).  After
 downloading place the binary somewhere on your `PATH` and make it executable.
 
 The `config init` command is provided to initialize the initial config.  The

--- a/general/Cargo.toml
+++ b/general/Cargo.toml
@@ -2,6 +2,8 @@
 name = "relay-general"
 version = "0.4.65"
 authors = ["Sentry <oss@sentry.io>"]
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
 edition = "2018"
 license-file = "../LICENSE"
 

--- a/general/README.md
+++ b/general/README.md
@@ -11,4 +11,4 @@ General is a support library for [Relay].  It implements the annotated Sentry
 protocol that supports metadata to be sent alongside.  It also implements a
 general processing layer.  This is a replacement for the older marshal library.
 
-[Relay]: https://github.com/getsentry/semaphore
+[Relay]: https://github.com/getsentry/relay

--- a/general/derive/Cargo.toml
+++ b/general/derive/Cargo.toml
@@ -2,6 +2,8 @@
 name = "relay-general-derive"
 version = "0.4.65"
 authors = ["Sentry <oss@sentry.io>"]
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
 edition = "2018"
 
 [dependencies]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Sentry Relay
-repo_url: https://github.com/getsentry/semaphore
+repo_url: https://github.com/getsentry/relay
 site_author: Sentry
 theme:
   name: material
@@ -9,14 +9,14 @@ nav:
   - options.md
   - project-config.md
   - PII and datascrubbing:
-    - pii-config/index.md
-    - pii-config/types.md
-    - pii-config/methods.md
+      - pii-config/index.md
+      - pii-config/types.md
+      - pii-config/methods.md
 
   - Architecture:
-    - architecture/index.md
-    - architecture/actors.md
-    - architecture/ingest-event-path.md
+      - architecture/index.md
+      - architecture/actors.md
+      - architecture/ingest-event-path.md
 
 markdown_extensions:
   - admonition: {}

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -4,7 +4,7 @@ set -eu
 #   SENTRY_AUTH_TOKEN: Sentry auth token (https://sentry.io/settings/account/api/auth-tokens/)
 
 VERSION="${1:-}"
-GITHUB_PROJECT="getsentry/semaphore"
+GITHUB_PROJECT="getsentry/relay"
 DOCKER_IMAGE="us.gcr.io/sentryio/semaphore:${VERSION}"
 export SENTRY_ORG="sentry"
 export SENTRY_PROJECT="relay"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
+name = "relay-server"
 authors = ["Sentry <oss@sentry.io>"]
 description = "Server components for the Relay"
-homepage = "https://github.com/getsentry/semaphore"
-name = "relay-server"
-repository = "https://github.com/getsentry/semaphore"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
 version = "0.4.65"
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
Zeus is having issues with the rename, but everything else has been moved.