### PR TITLE
fix(readme): Update status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
 # Official Sentry Relay
 
 [![Travis](https://travis-ci.com/getsentry/relay.svg?branch=master)](https://travis-ci.com/getsentry/relay)
-[![AppVeyor](https://img.shields.io/appveyor/ci/sentry/sentry-agent.svg)](https://ci.appveyor.com/project/sentry/sentry-agent)
-[![codecov without integration tests](https://codecov.io/gh/getsentry/relay/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/relay)
+[![AppVeyor](https://img.shields.io/appveyor/ci/sentry/relay.svg)](https://ci.appveyor.com/project/sentry/relay)
 [![GitHub release](https://img.shields.io/github/release/getsentry/relay.svg)](https://github.com/getsentry/relay/releases/latest)
 [![PyPI](https://img.shields.io/pypi/v/sentry-relay.svg)](https://pypi.python.org/pypi/sentry-relay)
-[![license](https://img.shields.io/github/license/getsentry/relay.svg)](https://github.com/getsentry/relay/blob/master/LICENSE)
 
 <p align="center">
   <p align="center">


### PR DESCRIPTION
Updates status badges on top of the readme file:

- AppVeyor project has been renamed, this points to the new project now.
- Codecov is no longer updated (for 4 months now), so it is removed.
- GitHub doesn't recognize the BSL license, so this badge is gone, too.