### PR TITLE
build: Fix google cloud build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,4 +203,4 @@ GeoLite2-City.mmdb:
 	@curl https://download.maxmind.com/app/geoip_download\?edition_id=GeoLite2-City\&license_key=${GEOIP_LICENSE}\&suffix=tar.gz | tar xz --to-stdout $(wildcards) '*/GeoLite2-City.mmdb' > $@
 
 .git/hooks/pre-commit:
-	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit || echo "WARNING: There is no git hooks directory"
+	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit

--- a/Makefile
+++ b/Makefile
@@ -203,4 +203,4 @@ GeoLite2-City.mmdb:
 	@curl https://download.maxmind.com/app/geoip_download\?edition_id=GeoLite2-City\&license_key=${GEOIP_LICENSE}\&suffix=tar.gz | tar xz --to-stdout $(wildcards) '*/GeoLite2-City.mmdb' > $@
 
 .git/hooks/pre-commit:
-	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit
+	@cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit

--- a/Makefile
+++ b/Makefile
@@ -203,4 +203,4 @@ GeoLite2-City.mmdb:
 	@curl https://download.maxmind.com/app/geoip_download\?edition_id=GeoLite2-City\&license_key=${GEOIP_LICENSE}\&suffix=tar.gz | tar xz --to-stdout $(wildcards) '*/GeoLite2-City.mmdb' > $@
 
 .git/hooks/pre-commit:
-	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit
+	cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit || echo "WARNING: There is no git hooks directory"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   # GCB only fetches a source archive, but the build requires an actual git repo
   - name: gcr.io/cloud-builders/git
-    args: ['clone', 'https://github.com/getsentry/relay.git']
+    args: ['clone', 'https://github.com/getsentry/relay.git', '.']
 
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,8 @@
 steps:
+  # GCB only fetches a source archive, but the build requires an actual git repo
+  - name: gcr.io/cloud-builders/git
+    args: ['clone', 'https://github.com/getsentry/relay.git']
+
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,9 +10,7 @@ steps:
         git init
         git remote add origin https://github.com/getsentry/$REPO_NAME.git
         git fetch --depth=1 origin $COMMIT_SHA
-        git reset --hard FETCH_HEAD
         git config -f .gitmodules submodule.core.url https://github.com/getsentry/$REPO_NAME.git
-        git submodule update --init
 
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,9 @@ steps:
         git init
         git remote add origin https://github.com/getsentry/$REPO_NAME.git
         git fetch --depth=1 origin $COMMIT_SHA
+        git reset --hard FETCH_HEAD
+        git config -f .gitmodules submodule.core.url https://github.com/getsentry/$REPO_NAME.git
+        git submodule update --init
 
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,7 @@ steps:
         git init
         git remote add origin https://github.com/getsentry/$REPO_NAME.git
         git fetch --depth=1 origin $COMMIT_SHA
+        git reset --hard FETCH_HEAD
         git config -f .gitmodules submodule.core.url https://github.com/getsentry/$REPO_NAME.git
 
   - name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,13 @@
 steps:
   # GCB only fetches a source archive, but the build requires an actual git repo
-  - name: gcr.io/cloud-builders/git
-    args: ['clone', 'https://github.com/getsentry/relay.git', '.']
+  - name: "gcr.io/cloud-builders/git"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        git init
+        git remote add origin git@github.com:/getsentry/$REPO_NAME.git
+        git fetch --depth=1 origin $COMMIT_SHA
 
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - "-c"
       - |
         git init
-        git remote add origin git@github.com:/getsentry/$REPO_NAME.git
+        git remote add origin https://github.com/getsentry/$REPO_NAME.git
         git fetch --depth=1 origin $COMMIT_SHA
 
   - name: "gcr.io/cloud-builders/docker"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,7 @@
 steps:
-  # GCB only fetches a source archive, but the build requires an actual git repo
+  # GCB only fetches a source archive, but the build requires an actual git repo. Note that the
+  # clone behavior changed multiple times between 2017 and 2019 and might not be stable.
+  # See: https://github.com/GoogleCloudPlatform/cloud-builders/issues/236#issuecomment-558991730
   - name: "gcr.io/cloud-builders/git"
     entrypoint: "bash"
     args:


### PR DESCRIPTION
GCB no longer clones the repository but downloads a source archive. Relay requires submodules to build, for which reason we need to initialize the git repo before building.