### PR TITLE
fix: Actually attempt to parse url for host matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "relay-general 0.4.65",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -16,6 +16,7 @@ lazycell = "1.2.1"
 regex = "1.2.0"
 relay-general = { path = "../relay-general" }
 serde = { version = "1.0.98", features = ["derive"] }
+url = "2.0.0"
 
 [dev-dependencies]
 insta = "0.12.0"


### PR DESCRIPTION
This is how Sentry behaves. We want `http://localhost:8080` to be filtered out. Duh.