### PR TITLE
fix(cabi): Unconditionally free in decode_str

### DIFF
--- a/py/sentry_relay/auth.py
+++ b/py/sentry_relay/auth.py
@@ -46,7 +46,7 @@ class PublicKey(RustObject):
         return json.loads(buf)
 
     def __str__(self):
-        return decode_str(self._methodcall(lib.relay_publickey_to_string), free=True)
+        return decode_str(self._methodcall(lib.relay_publickey_to_string))
 
     def __repr__(self):
         return "<%s %r>" % (self.__class__.__name__, text_type(self))
@@ -63,14 +63,14 @@ class SecretKey(RustObject):
 
     def sign(self, value):
         buf = make_buf(value)
-        return decode_str(self._methodcall(lib.relay_secretkey_sign, buf), free=True)
+        return decode_str(self._methodcall(lib.relay_secretkey_sign, buf))
 
     def pack(self, data):
         packed = json.dumps(data, separators=(",", ":"))
         return packed, self.sign(packed)
 
     def __str__(self):
-        return decode_str(self._methodcall(lib.relay_secretkey_to_string), free=True)
+        return decode_str(self._methodcall(lib.relay_secretkey_to_string))
 
     def __repr__(self):
         return "<%s %r>" % (self.__class__.__name__, text_type(self))

--- a/py/sentry_relay/utils.py
+++ b/py/sentry_relay/utils.py
@@ -78,7 +78,8 @@ def decode_str(s):
             return u""
         return ffi.unpack(s.data, s.len).decode("utf-8", "replace")
     finally:
-        lib.relay_str_free(ffi.addressof(s))
+        if s.owned:
+            lib.relay_str_free(ffi.addressof(s))
 
 
 def encode_str(s, mutable=False):

--- a/py/sentry_relay/utils.py
+++ b/py/sentry_relay/utils.py
@@ -71,15 +71,14 @@ class RustObject(with_metaclass(_NoDict)):
             self._objptr = None
 
 
-def decode_str(s, free=False):
+def decode_str(s):
     """Decodes a SymbolicStr"""
     try:
         if s.len == 0:
             return u""
         return ffi.unpack(s.data, s.len).decode("utf-8", "replace")
     finally:
-        if free:
-            lib.relay_str_free(ffi.addressof(s))
+        lib.relay_str_free(ffi.addressof(s))
 
 
 def encode_str(s, mutable=False):


### PR DESCRIPTION
Fixes a memory leak, since we never called `free=True`. `SymbolicStr` checks ownership internally.