### PR TITLE
fix(cabi): Consistently free strings obtained from the C-ABI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,9 +15,10 @@
   "rust.cfg_test": true,
   "rust.rustfmt_path": "rustfmt",
   "rust-client.rlsPath": "rls",
+  "rust.all_features": true,
 
   // Python configuration
-  "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
+  "python.pythonPath": ".venv/bin/python",
   "python.linting.enabled": false,
   "python.formatting.provider": "black",
 
@@ -25,6 +26,5 @@
   "[markdown]": {
     "editor.rulers": [80],
     "editor.tabSize": 2
-  },
-  "rust.all_features": true
+  }
 }

--- a/py/sentry_relay/auth.py
+++ b/py/sentry_relay/auth.py
@@ -89,20 +89,18 @@ def generate_relay_id():
 
 
 def create_register_challenge(data, signature, max_age=60 * 15):
-    rv = json.loads(
-        decode_str(
-            rustcall(
-                lib.relay_create_register_challenge,
-                make_buf(data),
-                encode_str(signature),
-                max_age,
-            )
-        )
+    challenge_json = rustcall(
+        lib.relay_create_register_challenge,
+        make_buf(data),
+        encode_str(signature),
+        max_age,
     )
+
+    challenge = json.loads(decode_str(challenge_json, free=True))
     return {
-        "relay_id": uuid.UUID(rv["relay_id"]),
-        "public_key": PublicKey.parse(rv["public_key"]),
-        "token": rv["token"],
+        "relay_id": uuid.UUID(challenge["relay_id"]),
+        "public_key": PublicKey.parse(challenge["public_key"]),
+        "token": challenge["token"],
     }
 
 
@@ -113,15 +111,13 @@ def get_register_response_relay_id(data):
 
 
 def validate_register_response(public_key, data, signature, max_age=60 * 15):
-    rv = json.loads(
-        decode_str(
-            rustcall(
-                lib.relay_validate_register_response,
-                public_key._objptr,
-                make_buf(data),
-                encode_str(signature),
-                max_age,
-            )
-        )
+    response_json = rustcall(
+        lib.relay_validate_register_response,
+        public_key._objptr,
+        make_buf(data),
+        encode_str(signature),
+        max_age,
     )
-    return {"relay_id": uuid.UUID(rv["relay_id"]), "token": rv["token"]}
+
+    response = json.loads(decode_str(response_json, free=True))
+    return {"relay_id": uuid.UUID(response["relay_id"]), "token": response["token"]}

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -34,7 +34,7 @@ def _init_valid_platforms():
 
     valid_platforms = []
     for i in range(int(size_out[0])):
-        valid_platforms.append(decode_str(strings[i]))
+        valid_platforms.append(decode_str(strings[i], free=True))
 
     VALID_PLATFORMS = frozenset(valid_platforms)
 
@@ -43,15 +43,10 @@ _init_valid_platforms()
 
 
 def split_chunks(string, remarks):
-    return json.loads(
-        decode_str(
-            rustcall(
-                lib.relay_split_chunks,
-                encode_str(string),
-                encode_str(json.dumps(remarks)),
-            )
-        )
+    json_chunks = rustcall(
+        lib.relay_split_chunks, encode_str(string), encode_str(json.dumps(remarks)),
     )
+    return json.loads(decode_str(json_chunks, free=True))
 
 
 def meta_with_chunks(data, meta):
@@ -113,7 +108,7 @@ class StoreNormalizer(RustObject):
 
         event = _encode_raw_event(raw_event)
         rv = self._methodcall(lib.relay_store_normalizer_normalize_event, event)
-        return json.loads(decode_str(rv))
+        return json.loads(decode_str(rv, free=True))
 
 
 def _serialize_event(event):
@@ -139,7 +134,7 @@ def scrub_event(config, data):
     event = _encode_raw_event(raw_event)
 
     rv = rustcall(lib.relay_scrub_event, encode_str(config), event)
-    return json.loads(decode_str(rv))
+    return json.loads(decode_str(rv, free=True))
 
 
 def is_glob_match(

--- a/py/sentry_relay/utils.py
+++ b/py/sentry_relay/utils.py
@@ -28,8 +28,8 @@ def rustcall(func, *args):
         return rv
     msg = lib.relay_err_get_last_message()
     cls = exceptions_by_code.get(err, RelayError)
-    exc = cls(decode_str(msg))
-    backtrace = decode_str(lib.relay_err_get_backtrace())
+    exc = cls(decode_str(msg, free=True))
+    backtrace = decode_str(lib.relay_err_get_backtrace(), free=True)
     if backtrace:
         exc.rust_info = backtrace
     raise exc
@@ -72,13 +72,13 @@ class RustObject(with_metaclass(_NoDict)):
 
 
 def decode_str(s, free=False):
-    """Decodes a SymbolicStr"""
+    """Decodes a RelayStr"""
     try:
         if s.len == 0:
             return u""
         return ffi.unpack(s.data, s.len).decode("utf-8", "replace")
     finally:
-        if free:
+        if free and s.owned:
             lib.relay_str_free(ffi.addressof(s))
 
 

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -54,20 +54,50 @@ typedef struct RelaySecretKey RelaySecretKey;
 typedef struct RelayStoreNormalizer RelayStoreNormalizer;
 
 /**
- * Represents a buffer.
+ * A binary buffer of known length.
+ *
+ * If the buffer is owned, indicated by the `owned` flag, the owner must call the `free` function
+ * on this buffer. The convention is:
+ *
+ *  - When obtained as instance through return values, always free the buffer.
+ *  - When obtained as pointer through field access, never free the buffer.
  */
 typedef struct {
+  /**
+   * Pointer to the raw data.
+   */
   uint8_t *data;
+  /**
+   * The length of the buffer pointed to by `data`.
+   */
   uintptr_t len;
+  /**
+   * Indicates that the buffer is owned and must be freed.
+   */
   bool owned;
 } RelayBuf;
 
 /**
- * Represents a string.
+ * A length-prefixed UTF-8 string.
+ *
+ * As opposed to C strings, this string is not null-terminated. If the string is owned, indicated
+ * by the `owned` flag, the owner must call the `free` function on this string. The convention is:
+ *
+ *  - When obtained as instance through return values, always free the string.
+ *  - When obtained as pointer through field access, never free the string.
  */
 typedef struct {
+  /**
+   * Pointer to the UTF-8 encoded string data.
+   */
   char *data;
+  /**
+   * The length of the string pointed to by `data`.
+   */
   uintptr_t len;
+  /**
+   * Indicates that the string is owned and must be freed.
+   */
   bool owned;
 } RelayStr;
 
@@ -80,9 +110,12 @@ typedef struct {
 } RelayKeyPair;
 
 /**
- * Represents a uuid.
+ * A 16-byte UUID.
  */
 typedef struct {
+  /**
+   * UUID bytes in network byte order (big endian).
+   */
   uint8_t data[16];
 } RelayUuid;
 
@@ -226,11 +259,7 @@ RelayStr relay_store_normalizer_normalize_event(RelayStoreNormalizer *normalizer
 void relay_str_free(RelayStr *s);
 
 /**
- * Creates a Relay str from a c string.
- *
- * This sets the string to owned.  In case it's not owned you either have
- * to make sure you are not freeing the memory or you need to set the
- * owned flag to false.
+ * Creates a Relay string from a c string.
  */
 RelayStr relay_str_from_cstr(const char *s);
 
@@ -239,7 +268,7 @@ void relay_test_panic(void);
 bool relay_translate_legacy_python_json(RelayStr *event);
 
 /**
- * Returns true if the uuid is nil
+ * Returns true if the uuid is nil.
  */
 bool relay_uuid_is_nil(const RelayUuid *uuid);
 


### PR DESCRIPTION
We did not consistently call `free=True` on strings returned from the C-ABI. This PR updates docs and adds the flags where appropriate.