### PR TITLE
fix(processors/pii): Do not remove entire value with pattern rules

### DIFF
--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -58,6 +58,12 @@ impl PartialEq for Pattern {
     }
 }
 
+fn replace_groups_default() -> Option<BTreeSet<u8>> {
+    let mut set = BTreeSet::new();
+    set.insert(0);
+    Some(set)
+}
+
 /// A rule that matches a regex pattern.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -65,6 +71,7 @@ pub struct PatternRule {
     /// The regular expression to apply.
     pub pattern: Pattern,
     /// The match group indices to replace.
+    #[serde(default = "replace_groups_default")]
     pub replace_groups: Option<BTreeSet<u8>>,
 }
 

--- a/relay-general/src/pii/snapshots/processor__redact_custom_pattern.snap
+++ b/relay-general/src/pii/snapshots/processor__redact_custom_pattern.snap
@@ -1,0 +1,26 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: event
+---
+{
+  "extra": {
+    "myvalue": "asdbar"
+  },
+  "_meta": {
+    "extra": {
+      "myvalue": {
+        "": {
+          "rem": [
+            [
+              "myrule",
+              "s",
+              0,
+              3
+            ]
+          ],
+          "len": 6
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In #263 we change the semantics of replace_groups which then goes on to affect every single `RuleType::Pattern` rule.