### PR TITLE
build: Build OSX wheels on xcode 9.4

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -27,7 +27,6 @@ targets:
 
 requireNames:
   - /^gh-pages.zip$/
-  - /^sentry_relay-.*-py2.py3-none-macosx_10_11_x86_64.whl$/
   - /^sentry_relay-.*-py2.py3-none-macosx_10_13_x86_64.whl$/
   - /^sentry_relay-.*-py2.py3-none-manylinux1_i686.whl$/
   - /^sentry_relay-.*-py2.py3-none-manylinux1_x86_64.whl$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -28,6 +28,7 @@ targets:
 requireNames:
   - /^gh-pages.zip$/
   - /^sentry_relay-.*-py2.py3-none-macosx_10_11_x86_64.whl$/
+  - /^sentry_relay-.*-py2.py3-none-macosx_10_13_x86_64.whl$/
   - /^sentry_relay-.*-py2.py3-none-manylinux1_i686.whl$/
   - /^sentry_relay-.*-py2.py3-none-manylinux1_x86_64.whl$/
   - /^sentry-relay-.*.zip$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,19 @@ jobs:
         - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
-    - name: "release: librelay[macos]"
+    - name: "release: librelay[macos-10.11]"
+      if: branch ~= /^release\/[\d.]+$/
+      os: osx
+      language: generic
+      osx_image: xcode7.3
+      env: RELAY_PYTHON_VERSION=python
+      script:
+        - sudo easy_install virtualenv
+        - make -e wheel
+        - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
+        - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
+
+    - name: "release: librelay[macos-10.13]"
       if: branch ~= /^release\/[\d.]+$/
       os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ jobs:
       if: branch ~= /^release\/[\d.]+$/
       os: osx
       language: generic
-      osx_image: xcode9.2
+      osx_image: xcode9.4
       env: RELAY_PYTHON_VERSION=python
       script:
         - make -e wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ jobs:
       if: branch ~= /^release\/[\d.]+$/
       os: osx
       language: generic
-      osx_image: xcode7.3
+      osx_image: xcode9.2
       env: RELAY_PYTHON_VERSION=python
       script:
         - make -e wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,26 +145,13 @@ jobs:
         - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
-    - name: "release: librelay[macos-10.11]"
-      if: branch ~= /^release\/[\d.]+$/
-      os: osx
-      language: generic
-      osx_image: xcode7.3
-      env: RELAY_PYTHON_VERSION=python
-      script:
-        - sudo easy_install virtualenv
-        - make -e wheel
-        - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
-        - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
-
-    - name: "release: librelay[macos-10.13]"
+    - name: "release: librelay[macos]"
       if: branch ~= /^release\/[\d.]+$/
       os: osx
       language: generic
       osx_image: xcode9.4
       env: RELAY_PYTHON_VERSION=python
       script:
-        - sudo pip install virtualenv
         - make -e wheel
         - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,7 @@ jobs:
       osx_image: xcode9.4
       env: RELAY_PYTHON_VERSION=python
       script:
+        - sudo pip install virtualenv
         - make -e wheel
         - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ clean-target-dir:
 
 .venv/bin/python: Makefile
 	@rm -rf .venv
-	@which virtualenv || sudo easy_install virtualenv
+	@which virtualenv || sudo pip install virtualenv
 	virtualenv -p $$RELAY_PYTHON_VERSION .venv
 
 # GNU tar requires `--wildcards`, but bsd tar does not.

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ clean-target-dir:
 
 .venv/bin/python: Makefile
 	@rm -rf .venv
+	@which virtualenv || sudo pip install virtualenv
 	virtualenv -p $$RELAY_PYTHON_VERSION .venv
 
 # GNU tar requires `--wildcards`, but bsd tar does not.

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,6 @@ clean-target-dir:
 
 .venv/bin/python: Makefile
 	@rm -rf .venv
-	@which virtualenv || sudo pip install virtualenv
 	virtualenv -p $$RELAY_PYTHON_VERSION .venv
 
 # GNU tar requires `--wildcards`, but bsd tar does not.


### PR DESCRIPTION
There are issues with running xcode 7.3 builds on newer osx. Let's just drop support for older osx.