### PR TITLE
fix(filters): Switch to regex-based glob matching

### DIFF
--- a/relay-common/src/glob.rs
+++ b/relay-common/src/glob.rs
@@ -117,6 +117,7 @@ fn test_globs() {
     test_glob!("foo\\hello\\bar.PY", "foo/**/*.py", true, {double_star: true, case_insensitive: true, path_normalize: true});
     test_glob!("foo\nbar", "foo*", false, {});
     test_glob!("foo\nbar", "foo*", true, {allow_newline: true});
+    test_glob!("1.18.4.2153-2aa83397b", "1.18.[0-4].*", true, {});
 
     let mut long_string = std::iter::repeat('x').take(1_000_000).collect::<String>();
     long_string.push_str(".PY");


### PR DESCRIPTION
The "optimized" globset matcher cannot handle ranges, while the regex engine can.

In a follow-up, I'll consolidate the globs exported to Python and the ones defined in filters into a `relay-glob` module that exposes a cleaner Rust interface and move the LRU cache into the C-ABI.