### PR TITLE
feat: Correct clock drift in transaction events

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -453,6 +453,7 @@ impl EventProcessor {
             is_renormalize: Some(false),
             remove_other: Some(true),
             normalize_user_agent: Some(true),
+            sent_at: envelope.meta().sent_at(),
         };
 
         let mut store_processor = StoreProcessor::new(store_config, geoip_lookup);

--- a/relay-server/src/extractors/event_meta.rs
+++ b/relay-server/src/extractors/event_meta.rs
@@ -192,7 +192,7 @@ impl EventMeta {
     }
 
     /// When the event has been sent, according to the SDK.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code)]
+    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn sent_at(&self) -> Option<DateTime<Utc>> {
         self.sent_at
     }

--- a/relay-server/src/extractors/event_meta.rs
+++ b/relay-server/src/extractors/event_meta.rs
@@ -5,6 +5,7 @@ use actix::ResponseFuture;
 use actix_web::dev::AsyncResult;
 use actix_web::http::header;
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
+use chrono::{DateTime, Utc};
 use failure::Fail;
 use futures::{future, Future};
 use serde::{Deserialize, Serialize};
@@ -86,6 +87,10 @@ pub struct EventMeta {
     /// The user agent that sent this event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     user_agent: Option<String>,
+
+    /// When the event has been sent, according to the SDK.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sent_at: Option<DateTime<Utc>>,
 }
 
 impl EventMeta {
@@ -99,6 +104,7 @@ impl EventMeta {
             remote_addr: Some("192.168.0.1".parse().unwrap()),
             forwarded_for: String::new(),
             user_agent: Some("sentry/agent".to_string()),
+            sent_at: None,
         }
     }
 
@@ -183,6 +189,12 @@ impl EventMeta {
     /// the SDK that sent the event.
     pub fn user_agent(&self) -> Option<&str> {
         self.user_agent.as_ref().map(String::as_str)
+    }
+
+    /// When the event has been sent, according to the SDK.
+    #[allow(dead_code)] // This is only used in processing.
+    pub fn sent_at(&self) -> Option<DateTime<Utc>> {
+        self.sent_at
     }
 
     /// Formats the Sentry authentication header.
@@ -312,6 +324,7 @@ fn extract_event_meta(
             remote_addr,
             forwarded_for,
             user_agent,
+            sent_at: None, // We only support this via envelopes
         })
     }))
 }

--- a/relay-server/src/extractors/event_meta.rs
+++ b/relay-server/src/extractors/event_meta.rs
@@ -192,7 +192,7 @@ impl EventMeta {
     }
 
     /// When the event has been sent, according to the SDK.
-    #[allow(dead_code)] // This is only used in processing.
+    #[cfg_attr(not(feature = "processing"), allow(dead_code)]
     pub fn sent_at(&self) -> Option<DateTime<Utc>> {
         self.sent_at
     }


### PR DESCRIPTION
We could do this for error events as well, but let's see how this plays out in APM first. Maybe it's a stupid idea.