### PR TITLE
feat(server): Support broken encoding in form data

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -38,7 +38,7 @@ use {
     crate::quotas::{QuotasError, RateLimiter},
     crate::service::ServerErrorKind,
     failure::ResultExt,
-    relay_filter::{should_filter, FilterStatKey},
+    relay_filter::FilterStatKey,
     relay_general::protocol::IpAddr,
     relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
 };
@@ -441,6 +441,7 @@ impl EventProcessor {
             return Ok((event, len));
         }
 
+        log::trace!("no event in envelope");
         Ok((Annotated::empty(), 0))
     }
 
@@ -489,7 +490,7 @@ impl EventProcessor {
             let client_ip = envelope.meta().client_addr();
             let filter_settings = &project_state.config.filter_settings;
             let filter_result = metric!(timer(RelayTimers::EventProcessingFiltering), {
-                should_filter(event, client_ip, filter_settings)
+                relay_filter::should_filter(event, client_ip, filter_settings)
             });
 
             if let Err(reason) = filter_result {

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -200,10 +200,10 @@ fn consume_item(
 
             content.items.push(item);
         } else if let Some(field_name) = field_name {
-            match std::str::from_utf8(&data) {
-                Ok(value) => content.form_data.append(field_name, value),
-                Err(_failure) => log::trace!("invalid text value in multipart item"),
-            }
+            // Ensure to decode this safely to match Django's POST data behavior. This allows us to
+            // process sentry event payloads even if they contain invalid encoding.
+            let string = String::from_utf8_lossy(&data);
+            content.form_data.append(field_name, &string);
         } else {
             log::trace!("multipart content without name or file_name");
         }

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -90,12 +90,7 @@ class SentryLike(object):
             "organizationId": 1,
             "config": {
                 "excludeFields": [],
-                "filterSettings": {
-                    "browser-extensions": {"isEnabled": True},
-                    "web-crawlers": {"isEnabled": True},
-                    "localhost": {"isEnabled": False},
-                    "legacy-browsers": {"isEnabled": True, "options": ["ie_pre_9"]},
-                },
+                "filterSettings": {},
                 "scrubIpAddresses": False,
                 "sensitiveFields": [],
                 "scrubDefaults": True,

--- a/tests/load-tests/relay_load_tests/fake_sentry.py
+++ b/tests/load-tests/relay_load_tests/fake_sentry.py
@@ -105,12 +105,7 @@ class Sentry(object):
             "organizationId": 1,
             "config": {
                 "excludeFields": [],
-                "filterSettings": {
-                    "browser-extensions": {"isEnabled": True},
-                    "web-crawlers": {"isEnabled": True},
-                    "localhost": {"isEnabled": False},
-                    "legacy-browsers": {"isEnabled": True, "options": ["ie_pre_9"]},
-                },
+                "filterSettings": {},
                 "scrubIpAddresses": False,
                 "sensitiveFields": [],
                 "scrubDefaults": True,


### PR DESCRIPTION
Turns out that Django applied lossy decoding on form data items. Since the downside is to lose full sentry payloads if we don't apply lossy decoding, we accept the occasional allocation.