### PR TITLE
feat(server): Limit maximum rate limits in processing

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -440,6 +440,10 @@ fn default_projectconfig_cache_prefix() -> String {
     "relayconfig".to_owned()
 }
 
+fn default_rate_limit() -> Option<u32> {
+    Some(300) // 5 minutes
+}
+
 /// Controls Sentry-internal event processing.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Processing {
@@ -466,6 +470,9 @@ pub struct Processing {
     /// Prefix to use when looking up project configs in Redis. Defaults to "relayconfig".
     #[serde(default = "default_projectconfig_cache_prefix")]
     pub projectconfig_cache_prefix: String,
+    /// Maximum rate limit to report to clients.
+    #[serde(default = "default_rate_limit")]
+    pub max_rate_limit: Option<u32>,
 }
 
 impl Default for Processing {
@@ -486,6 +493,7 @@ impl Default for Processing {
             redis: Some(Redis::default()),
             attachment_chunk_size: default_chunk_size(),
             projectconfig_cache_prefix: default_projectconfig_cache_prefix(),
+            max_rate_limit: default_rate_limit(),
         }
     }
 }
@@ -986,6 +994,11 @@ impl Config {
     /// Relay is in processing mode.
     pub fn projectconfig_cache_prefix(&self) -> &str {
         &self.values.processing.projectconfig_cache_prefix
+    }
+
+    /// Maximum rate limit to report to clients in seconds.
+    pub fn max_rate_limit(&self) -> Option<u64> {
+        self.values.processing.max_rate_limit.into()
     }
 }
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -998,7 +998,7 @@ impl Config {
 
     /// Maximum rate limit to report to clients in seconds.
     pub fn max_rate_limit(&self) -> Option<u64> {
-        self.values.processing.max_rate_limit.into()
+        self.values.processing.max_rate_limit.map(u32::into)
     }
 }
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use actix::fut::result;
 use actix::prelude::*;
@@ -704,13 +704,13 @@ impl EventManager {
         config: Arc<Config>,
         upstream: Addr<UpstreamRelay>,
         outcome_producer: Addr<OutcomeProducer>,
-        redis: Option<RedisPool>,
+        redis_pool: Option<RedisPool>,
     ) -> Result<Self, ServerError> {
         let thread_count = config.cpu_concurrency();
         log::info!("starting {} event processing workers", thread_count);
 
         #[cfg(not(feature = "processing"))]
-        let _ = redis;
+        let _ = redis_pool;
 
         #[cfg(feature = "processing")]
         let processor = {
@@ -721,7 +721,7 @@ impl EventManager {
                 None => None,
             };
 
-            let rate_limiter = redis.map(RateLimiter::new);
+            let rate_limiter = redis_pool.map(|pool| RateLimiter::new(config.clone(), pool));
 
             SyncArbiter::start(
                 thread_count,
@@ -976,14 +976,11 @@ impl Handler<HandleEnvelope> for EventManager {
                     .and_then(move |result| {
                         result.map_err(move |error| match error {
                             UpstreamRequestError::RateLimited(secs) => {
+                                // TODO: Maybe add a header that tells us the value for
+                                // RateLimitScope?
                                 ProcessingError::RateLimited(RateLimit(
-                                    // TODO: Maybe add a header that tells us the value for
-                                    // RateLimitScope?
                                     RateLimitScope::Key(public_key),
-                                    RetryAfter {
-                                        when: Instant::now() + Duration::from_secs(secs),
-                                        reason_code: None,
-                                    },
+                                    RetryAfter::new(secs),
                                 ))
                             }
                             other => ProcessingError::SendFailed(other),


### PR DESCRIPTION
This PR adds a limit for the maximum rate limit that is reported to clients from processing relays. Along with this, there is a bunch of code cleanup in the rate limiter and tests.

This change is made to avoid false-positives in the false path. Sentry knows the concept of [refunds](https://github.com/getsentry/sentry/blob/72e31a9e7767663f826f60e3b4f4635e62f15d59/src/sentry/tasks/store.py#L501) to revert a rate limit if a previously event is deleted due to discarded groups. Since we do not want to get rid of the fast-path, instead we limit it to _5 minutes_ at max.

Downstream relays and clients do not need to implement this logic. However, they will now also receive the lower retry-after values, and retry sooner.