### PR TITLE
fix(test): Explicitly close kafka consumer

### DIFF
--- a/integration-test-requirements.txt
+++ b/integration-test-requirements.txt
@@ -2,9 +2,10 @@ pytest
 pytest-localserver
 requests
 flask
+werkzeug==0.15.1
 confluent-kafka
 msgpack
 pytest-rerunfailures
-pytest-xdist
-redis
+pytest-xdist==1.31.0
+redis==3.4.1
 git+https://github.com/untitaker/pytest-sentry#egg=pytest-sentry

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -125,7 +125,12 @@ def kafka_consumer(request, get_topic_name, processing_config):
 
         consumer = kafka.Consumer(settings)
         consumer.subscribe(topics)
-        request.addfinalizer(consumer.unsubscribe)
+
+        def die():
+            consumer.unsubscribe()
+            consumer.close()
+
+        request.addfinalizer(die)
 
         while consumer.poll(timeout=0.1) is not None:
             pass


### PR DESCRIPTION
~We have no idea whether xdist actually forks before importing modules or after, or whether rdkafka is fork-safe. Let's just take the safe route.~

https://github.com/confluentinc/confluent-kafka-python/issues/265