### PR TITLE
fix(server): Configure CORS on all store-like endpoints

### DIFF
--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -60,11 +60,12 @@ fn store_attachment(
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    app.resource(
-        r"/api/{project:\d+}/events/{event_id:[^/]+}/attachments{trailing_slash:/}",
-        |r| {
+    let url_pattern = r"/api/{project:\d+}/events/{event_id:[\w-]+}/attachments{t:/}";
+
+    common::cors(app)
+        .resource(url_pattern, |r| {
             r.name("store-attachment");
             r.method(Method::POST).with(store_attachment);
-        },
-    )
+        })
+        .register()
 }

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -200,8 +200,10 @@ fn store_minidump(
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    app.resource(r"/api/{project:\d+}/minidump{trailing_slash:/?}", |r| {
-        r.name("store-minidump");
-        r.post().with(store_minidump);
-    })
+    common::cors(app)
+        .resource(r"/api/{project:\d+}/minidump{t:/?}", |r| {
+            r.name("store-minidump");
+            r.post().with(store_minidump);
+        })
+        .register()
 }

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -100,18 +100,20 @@ impl pred::Predicate<ServiceState> for SecurityReportFilter {
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    // Default security endpoint
-    app.resource(r"/api/{project:\d+}/security/", |r| {
-        r.name("store-security-report");
-        r.post()
-            .filter(SecurityReportFilter)
-            .with(store_security_report);
-    })
-    // Legacy security endpoint
-    .resource(r"/api/{project:\d+}/csp-report/", |r| {
-        r.name("store-csp-report");
-        r.post()
-            .filter(SecurityReportFilter)
-            .with(store_security_report);
-    })
+    common::cors(app)
+        // Default security endpoint
+        .resource(r"/api/{project:\d+}/security/", |r| {
+            r.name("store-security-report");
+            r.post()
+                .filter(SecurityReportFilter)
+                .with(store_security_report);
+        })
+        // Legacy security endpoint
+        .resource(r"/api/{project:\d+}/csp-report/", |r| {
+            r.name("store-csp-report");
+            r.post()
+                .filter(SecurityReportFilter)
+                .with(store_security_report);
+        })
+        .register()
 }

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -1,7 +1,6 @@
 //! Handles event store requests.
 
 use actix::prelude::*;
-use actix_web::middleware::cors::Cors;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use bytes::BytesMut;
 use futures::Future;
@@ -123,20 +122,7 @@ fn store_event(
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    Cors::for_app(app)
-        .allowed_methods(vec!["POST"])
-        .allowed_headers(vec![
-            "x-sentry-auth",
-            "x-requested-with",
-            "x-forwarded-for",
-            "origin",
-            "referer",
-            "accept",
-            "content-type",
-            "authentication",
-        ])
-        .expose_headers(vec!["X-Sentry-Error", "Retry-After"])
-        .max_age(3600)
+    common::cors(app)
         // Standard store endpoint. Some SDKs send multiple leading or trailing slashes due to bugs
         // in their URL handling. Since actix does not normalize such paths, allow any number of
         // slashes. The trailing slash can also be omitted, optionally.

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -55,8 +55,10 @@ fn store_unreal(
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    app.resource(r"/api/{project:\d+}/unreal/{sentry_key:\w+}/", |r| {
-        r.name("store-unreal");
-        r.post().with(store_unreal);
-    })
+    common::cors(app)
+        .resource(r"/api/{project:\d+}/unreal/{sentry_key:\w+}/", |r| {
+            r.name("store-unreal");
+            r.post().with(store_unreal);
+        })
+        .register()
 }


### PR DESCRIPTION
When porting the store-like endpoints we did not configure CORS. Turns out that at least for the attachments endpoint, CORS is required as browser SDKs are going to send attachments going forward. For consistency, CORS is now added to all store-like endpoints.

In addition to that, two fixes were applied:
- Added the `Authentication` to CORS. Even though it is not used, it was accepted by Sentry.
- Fix the URL pattern for the attachment endpoint `event_id` from `[^/]+` to `[\w-]+` to match Sentry.