### PR TITLE
fix(server): Preserve streams for invalid multipart content-type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ api-docs: setup-git
 .PHONY: api-docs
 
 prose-docs: .venv/bin/python extract-doc
-	.venv/bin/pip install -U mkdocs mkdocs-material pygments pymdown-extensions Jinja2
+	.venv/bin/pip install -U mkdocs markdown==3.1.1 mkdocs-material pygments pymdown-extensions Jinja2
 	.venv/bin/mkdocs build
 	touch site/.nojekyll
 .PHONY: prose-docs


### PR DESCRIPTION
This is a bare minimum fix to avoid connection resets if the `Content-Type` header is malformed.

For context: Some Android devices are sending us a form-data boundary that is not properly quoted:

```
content-type: multipart/form-data; boundary====1580990334284===
```

We still correctly reject those requests, but now also consume the stream.