### PR TITLE
fix(server): Allow base64 encoded JSON payloads

### DIFF
--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -189,6 +189,10 @@ fn decode_bytes<B: Into<Bytes> + AsRef<[u8]>>(body: B) -> Result<Bytes, StorePay
     // TODO: Switch to a streaming decoder
     // see https://github.com/alicemaz/rust-base64/pull/56
     let binary_body = base64::decode(&body).map_err(StorePayloadError::Decode)?;
+    if binary_body.starts_with(b"{") {
+        return Ok(binary_body.into());
+    }
+
     let mut decode_stream = ZlibDecoder::new(binary_body.as_slice());
     let mut bytes = vec![];
     decode_stream


### PR DESCRIPTION
Sentry also supported base64 encoded JSON payloads in addition to base64 encoded zlib streams. This was not ported to Relay yet. Apparently, a community-maintained Grails plugin makes use of this, so we're adding it back to provide backwards compatibility. 

For reference, the code in Sentry runs (simplified):
```py
def decompress(value):
    return zlib.decompress(base64.b64decode(value))


def decode_and_decompress_data(encoded_data):
    try:
        return decompress(encoded_data).decode("utf-8")
    except zlib.error:
        return base64.b64decode(encoded_data).decode("utf-8")
```


Ref https://forum.sentry.io/t/trouble-with-raven-and-base64/8809