### PR TITLE
ref(protocol): Update session schema

### DIFF
--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -93,7 +93,7 @@ fn default_sequence() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs()
+        .as_millis() as u64
 }
 
 fn default_sample_rate() -> f32 {
@@ -107,9 +107,6 @@ fn is_default_sample_rate(rate: &f32) -> bool {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionUpdate {
-    /// Unique identifier of this update event.
-    #[serde(rename = "id", default = "Uuid::new_v4")]
-    pub update_id: Uuid,
     /// The session identifier.
     #[serde(rename = "sid")]
     pub session_id: Uuid,
@@ -175,7 +172,6 @@ mod tests {
 }"#;
 
         let output = r#"{
-  "id": "94ecab99-184a-45ee-ac18-6ed2c2c2e9f2",
   "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
   "did": "8333339f-5675-4f89-a9a0-1c935255ab58",
   "seq": 4711,
@@ -185,7 +181,6 @@ mod tests {
 }"#;
 
         let update = SessionUpdate {
-            update_id: "94ecab99-184a-45ee-ac18-6ed2c2c2e9f2".parse().unwrap(),
             session_id: "8333339f-5675-4f89-a9a0-1c935255ab58".parse().unwrap(),
             distinct_id: "8333339f-5675-4f89-a9a0-1c935255ab58".parse().unwrap(),
             sequence: 4711, // this would be a timestamp instead
@@ -197,9 +192,7 @@ mod tests {
             attributes: SessionAttributes::default(),
         };
 
-        // Since the update_id is defaulted randomly, ensure that it matches.
         let mut parsed = SessionUpdate::parse(json.as_bytes()).unwrap();
-        parsed.update_id = update.update_id;
 
         // Sequence is defaulted to the current timestamp. Override for snapshot.
         assert_eq!(parsed.sequence, default_sequence());
@@ -212,7 +205,6 @@ mod tests {
     #[test]
     fn test_session_roundtrip() {
         let json = r#"{
-  "id": "94ecab99-184a-45ee-ac18-6ed2c2c2e9f2",
   "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
   "did": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
   "seq": 42,
@@ -231,7 +223,6 @@ mod tests {
 }"#;
 
         let update = SessionUpdate {
-            update_id: "94ecab99-184a-45ee-ac18-6ed2c2c2e9f2".parse().unwrap(),
             session_id: "8333339f-5675-4f89-a9a0-1c935255ab58".parse().unwrap(),
             distinct_id: "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf".parse().unwrap(),
             sequence: 42,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -156,13 +156,6 @@ impl StoreForwarder {
             return Ok(());
         }
 
-        let status = match session.status {
-            SessionStatus::Ok => 0,
-            SessionStatus::Exited => 1,
-            SessionStatus::Crashed => 2,
-            SessionStatus::Abnormal => 3,
-        };
-
         let message = KafkaMessage::Session(SessionKafkaMessage {
             org_id,
             project_id,
@@ -173,7 +166,7 @@ impl StoreForwarder {
             started: session.started.to_rfc3339(),
             sample_rate: session.sample_rate,
             duration: session.duration.unwrap_or(0.0),
-            status,
+            status: session.status,
             os: session.attributes.os,
             os_version: session.attributes.os_version,
             device_family: session.attributes.device_family,
@@ -316,7 +309,7 @@ struct SessionKafkaMessage {
     started: String,
     sample_rate: f32,
     duration: f64,
-    status: u8,
+    status: SessionStatus,
     os: Option<String>,
     os_version: Option<String>,
     device_family: Option<String>,

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -8,7 +8,6 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
     relay.send_session(
         42,
         {
-            "id": "94ecab99-184a-45ee-ac18-6ed2c2c2e9f2",
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "did": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
             "seq": 42,
@@ -31,7 +30,6 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
     assert session == {
         "org_id": 1,
         "project_id": 42,
-        "event_id": "94ecab99-184a-45ee-ac18-6ed2c2c2e9f2",
         "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
         "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
         "seq": 42,
@@ -45,5 +43,5 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
         "device_family": "iPhone12,3",
         "release": "sentry-test@1.0.0",
         "environment": "production",
-        "retention_days": None,
+        "retention_days": 90,
     }

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -37,7 +37,7 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
         "started": "2020-02-07T14:16:00+00:00",
         "sample_rate": 2.0,
         "duration": 1947.49,
-        "status": 1,
+        "status": "exited",
         "os": "iOS",
         "os_version": "13.3.1",
         "device_family": "iPhone12,3",


### PR DESCRIPTION
- Removes the session event id
- Partitions the kafka topic by session id
- Removes minute precision for timestamps
- Makes the `seq` default epoch milliseconds instead of seconds
- Adds a hard-coded default of `90` for `retention_days` (will be fetched from project config later)
- Serialize session status as string instead of integer into Kafka