### PR TITLE
chore(filters): Add browser extension filter

### DIFF
--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -78,7 +78,7 @@ lazy_static! {
         # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
         plugin\.setSuspendState\sis\snot\sa\sfunction|
         # Chrome extension message passing failure
-        Extension context invalidated
+        Extension\scontext\sinvalidated
     "#
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex");

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -76,7 +76,7 @@ lazy_static! {
         null\sis\snot\san\sobject\s\(evaluating\s'elt.parentNode'\)|
         # Dragon Web Extension from Nuance Communications
         # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
-        plugin\.setSuspendState\sis\snot\sa\sfunction
+        plugin\.setSuspendState\sis\snot\sa\sfunction|
         # Chrome extension message passing failure
         Extension context invalidated
     "#

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -77,6 +77,8 @@ lazy_static! {
         # Dragon Web Extension from Nuance Communications
         # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
         plugin\.setSuspendState\sis\snot\sa\sfunction
+        # Chrome extension message passing failure
+        Extension context invalidated
     "#
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex");
@@ -197,7 +199,6 @@ mod tests {
         let exceptions = [
             "what does conduitPage even do",
             "null is not an object (evaluating 'elt.parentNode')",
-            "plugin.setSuspendState is not a function",
             "some error on top.GLOBALS",
             "biiig problem on originalCreateNotification",
             "canvas.contentDocument",
@@ -215,6 +216,7 @@ mod tests {
             "conduitPage",
             "null is not an object (evaluating 'elt.parentNode')",
             "plugin.setSuspendState is not a function",
+            "Extension context invalidated",
         ];
 
         for exc_value in &exceptions {


### PR DESCRIPTION
As discussed at length [here](https://github.com/getsentry/sentry-javascript/issues/2380) and [here](https://github.com/getsentry/sentry-javascript/pull/2429), `Extension context invalidated` errors (which result from an extension not being able to communicate with its injected scripts, or vice versa) have lately been spamming a subset of our customers. This filters them out.

(It also removes a duplicate entry from the related test.)