### PR TITLE
feat(server): Set retention for session events

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -548,6 +548,12 @@ impl EventProcessor {
             };
         }
 
+        // Set the event retention. Effectively, this value will only be available in processing
+        // mode when the full project config is queried from the upstream.
+        if let Some(retention) = message.project_state.config.event_retention {
+            envelope.set_retention(retention);
+        }
+
         // Unreal endpoint puts the whole request into an item. This is done to make the endpoint
         // fast. For envelopes containing an Unreal request, we will look into the unreal item and
         // expand it so it can be consumed like any other event (e.g. `__sentry-event`). External

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -72,6 +72,9 @@ pub struct ProjectConfig {
     /// Configuration for data scrubbers.
     #[serde(skip_serializing_if = "DataScrubbingConfig::is_disabled")]
     pub datascrubbing_settings: DataScrubbingConfig,
+    /// Maximum event retention for the organization.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_retention: Option<u16>,
 }
 
 impl Default for ProjectConfig {
@@ -83,6 +86,7 @@ impl Default for ProjectConfig {
             grouping_config: None,
             filter_settings: FiltersConfig::default(),
             datascrubbing_settings: DataScrubbingConfig::default(),
+            event_retention: None,
         }
     }
 }
@@ -717,6 +721,7 @@ impl RetryAfter {
     }
 
     /// Returns the optional reason for this rate limit.
+    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn reason_code(&self) -> Option<&str> {
         self.reason_code.as_deref()
     }

--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -24,3 +24,7 @@ pub const ITEM_NAME_BREADCRUMBS2: &str = "__sentry-breadcrumb2";
 
 /// Envelope header used to store the UE4 user id.
 pub const UNREAL_USER_HEADER: &str = "unreal_user_id";
+
+/// The default retention for events if the server does not specify a value in project
+/// configurations.
+pub const DEFAULT_EVENT_RETENTION: u16 = 90;

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -4,7 +4,7 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
 
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
     relay.send_session(
         42,
         {
@@ -45,3 +45,38 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
         "environment": "production",
         "retention_days": 90,
     }
+
+
+def test_session_with_custom_retention(mini_sentry, relay_with_processing, sessions_consumer):
+    relay = relay_with_processing()
+    relay.wait_relay_healthcheck()
+
+    sessions_consumer = sessions_consumer()
+
+    project_config = mini_sentry.full_project_config()
+    project_config["config"]["eventRetention"] = 17
+    mini_sentry.project_configs[42] = project_config
+
+    relay.send_session(
+        42,
+        {
+            "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "did": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+            "seq": 42,
+            "timestamp": "2020-02-07T15:17:00Z",
+            "started": "2020-02-07T14:16:00Z",
+            "sample_rate": 2.0,
+            "duration": 1947.49,
+            "status": "exited",
+            "attrs": {
+                "os": "iOS",
+                "os_version": "13.3.1",
+                "device_family": "iPhone12,3",
+                "release": "sentry-test@1.0.0",
+                "environment": "production",
+            },
+        },
+    )
+
+    session = sessions_consumer.get_session()
+    assert session["retention_days"] == 17

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -47,7 +47,9 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
     }
 
 
-def test_session_with_custom_retention(mini_sentry, relay_with_processing, sessions_consumer):
+def test_session_with_custom_retention(
+    mini_sentry, relay_with_processing, sessions_consumer
+):
     relay = relay_with_processing()
     relay.wait_relay_healthcheck()
 
@@ -61,20 +63,8 @@ def test_session_with_custom_retention(mini_sentry, relay_with_processing, sessi
         42,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
-            "did": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
-            "seq": 42,
             "timestamp": "2020-02-07T15:17:00Z",
             "started": "2020-02-07T14:16:00Z",
-            "sample_rate": 2.0,
-            "duration": 1947.49,
-            "status": "exited",
-            "attrs": {
-                "os": "iOS",
-                "os_version": "13.3.1",
-                "device_family": "iPhone12,3",
-                "release": "sentry-test@1.0.0",
-                "environment": "production",
-            },
         },
     )
 


### PR DESCRIPTION
This fills the missing `retention_days` from the `eventRetention` project configuration option.