### PR TITLE
ref(server): Simplify module names and remove noop logs

### DIFF
--- a/relay-server/src/utils/redis.rs
+++ b/relay-server/src/utils/redis.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "processing")]
-pub use real_implementation::*;
+pub use real::*;
 
 #[cfg(not(feature = "processing"))]
-pub use noop_implementation::*;
+pub use noop::*;
 
 #[cfg(feature = "processing")]
-mod real_implementation {
+mod real {
     use failure::Fail;
     use r2d2::Pool;
 
@@ -71,7 +71,7 @@ mod real_implementation {
 }
 
 #[cfg(not(feature = "processing"))]
-mod noop_implementation {
+mod noop {
     use failure::Fail;
 
     use relay_config::Config;


### PR DESCRIPTION
This will avoid logs like this:

```
 INFO  relay_server::actors::upstream > upstream relay started
 INFO  relay_server::actors::events   > starting 40 event processing workers
 INFO  relay_server::actors::outcome::no_op_implementation > Fake OutcomeProducer started.
 INFO  relay_server::service                               > spawning http server
 INFO  relay_server::service                               >   listening on: http://127.0.0.1:3000/
```