### PR TITLE
feat(server): Discard session updates older than 5 days

### DIFF
--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -28,3 +28,7 @@ pub const UNREAL_USER_HEADER: &str = "unreal_user_id";
 /// The default retention for events if the server does not specify a value in project
 /// configurations.
 pub const DEFAULT_EVENT_RETENTION: u16 = 90;
+
+/// The maximum age of an ingested session in days. Session updates for sessions older than this
+/// will be discarded.
+pub const MAX_SESSION_DAYS: u8 = 5;

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timedelta, timezone
+
+
 def test_session_with_processing(mini_sentry, relay_with_processing, sessions_consumer):
     relay = relay_with_processing()
     relay.wait_relay_healthcheck()
 
     sessions_consumer = sessions_consumer()
+
+    timestamp = datetime.now(tz=timezone.utc)
+    started = timestamp - timedelta(hours=1)
 
     mini_sentry.project_configs[42] = mini_sentry.full_project_config()
     relay.send_session(
@@ -11,8 +17,8 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "did": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
             "seq": 42,
-            "timestamp": "2020-02-07T15:17:00Z",
-            "started": "2020-02-07T14:16:00Z",
+            "timestamp": timestamp.isoformat(),
+            "started": started.isoformat(),
             "sample_rate": 2.0,
             "duration": 1947.49,
             "status": "exited",
@@ -33,8 +39,8 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
         "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
         "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
         "seq": 42,
-        "timestamp": 1581088620.0,
-        "started": 1581084960.0,
+        "timestamp": timestamp.timestamp(),
+        "started": started.timestamp(),
         "sample_rate": 2.0,
         "duration": 1947.49,
         "status": "exited",
@@ -59,14 +65,40 @@ def test_session_with_custom_retention(
     project_config["config"]["eventRetention"] = 17
     mini_sentry.project_configs[42] = project_config
 
+    timestamp = datetime.now(tz=timezone.utc)
     relay.send_session(
         42,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
-            "timestamp": "2020-02-07T15:17:00Z",
-            "started": "2020-02-07T14:16:00Z",
+            "timestamp": timestamp.isoformat(),
+            "started": timestamp.isoformat(),
         },
     )
 
     session = sessions_consumer.get_session()
     assert session["retention_days"] == 17
+
+
+def test_session_age_discard(mini_sentry, relay_with_processing, sessions_consumer):
+    relay = relay_with_processing()
+    relay.wait_relay_healthcheck()
+
+    sessions_consumer = sessions_consumer()
+
+    project_config = mini_sentry.full_project_config()
+    project_config["config"]["eventRetention"] = 17
+    mini_sentry.project_configs[42] = project_config
+
+    timestamp = datetime.now(tz=timezone.utc)
+    started = timestamp - timedelta(days=5, hours=1)
+
+    relay.send_session(
+        42,
+        {
+            "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "timestamp": timestamp.isoformat(),
+            "started": started.isoformat(),
+        },
+    )
+
+    assert sessions_consumer.poll() is None


### PR DESCRIPTION
Discards updates of sessions older than 5 days, as indicated by their `started` attribute. 