### PR TITLE
fix(store): Validate release names

### DIFF
--- a/relay-general/src/protocol/constants.rs
+++ b/relay-general/src/protocol/constants.rs
@@ -20,4 +20,8 @@ pub const VALID_PLATFORMS: &[&str] = &[
     "ruby",
 ];
 
+/// Invalid environment strings (case sensitive).
 pub const INVALID_ENVIRONMENTS: &[&str] = &["none"];
+
+/// Invalid release version strings (case insensitive).
+pub const INVALID_RELEASES: &[&str] = &["latest", "..", "."];

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -268,7 +268,7 @@ pub struct Event {
     /// Program's release identifier.
     #[metastructure(
         max_chars = "tag_value",  // release ends in tag
-        match_regex = r"^[^\r\n]*\z",
+        match_regex = r"^[^\r\n\f/]*\z",
         required = "false",
         trim_whitespace = "true",
         nonempty = "true",

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -268,7 +268,7 @@ pub struct Event {
     /// Program's release identifier.
     #[metastructure(
         max_chars = "tag_value",  // release ends in tag
-        match_regex = r"^[^\r\n\f/]*\z",
+        match_regex = r"^[^\r\n\f\t/]*\z",
         required = "false",
         trim_whitespace = "true",
         nonempty = "true",

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -24,7 +24,7 @@ mod user_report;
 
 pub use self::breadcrumb::Breadcrumb;
 pub use self::clientsdk::{ClientSdkInfo, ClientSdkPackage};
-pub use self::constants::{INVALID_ENVIRONMENTS, VALID_PLATFORMS};
+pub use self::constants::{INVALID_ENVIRONMENTS, INVALID_RELEASES, VALID_PLATFORMS};
 pub use self::contexts::{
     AppContext, BrowserContext, Context, ContextInner, Contexts, DeviceContext, GpuContext,
     OperationType, OsContext, RuntimeContext, SpanId, SpanStatus, TraceContext, TraceId,


### PR DESCRIPTION
Validates the release name according to this logic:

```py
BAD_RELEASE_CHARS = "\n\f\t/"

def is_valid_version(value):
    return not (
        any(c in value for c in BAD_RELEASE_CHARS)
        or value in (".", "..")
        or not value
        or value.lower() == "latest"
    )
```

Notes:
 - The release field is annotated as `nonempty = "true"`, which corresponds to `not value`.
 - The bad characters are validated with the regex: `^[^\r\n\f/]*\z`