### PR TITLE
ref(server): Move sent_at to envelope implementation

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -455,7 +455,7 @@ impl EventProcessor {
             is_renormalize: Some(false),
             remove_other: Some(true),
             normalize_user_agent: Some(true),
-            sent_at: envelope.meta().sent_at(),
+            sent_at: envelope.sent_at(),
         };
 
         let mut store_processor = StoreProcessor::new(store_config, geoip_lookup);

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -5,7 +5,6 @@ use actix::ResponseFuture;
 use actix_web::dev::AsyncResult;
 use actix_web::http::header;
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
-use chrono::{DateTime, Utc};
 use failure::Fail;
 use futures::{future, Future};
 use serde::{Deserialize, Serialize};
@@ -88,10 +87,6 @@ pub struct RequestMeta {
     /// The user agent that sent this event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     user_agent: Option<String>,
-
-    /// When the event has been sent, according to the SDK.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    sent_at: Option<DateTime<Utc>>,
 }
 
 impl RequestMeta {
@@ -105,7 +100,6 @@ impl RequestMeta {
             remote_addr: Some("192.168.0.1".parse().unwrap()),
             forwarded_for: String::new(),
             user_agent: Some("sentry/agent".to_string()),
-            sent_at: None,
         }
     }
 
@@ -127,9 +121,6 @@ impl RequestMeta {
         self.forwarded_for = other.forwarded_for;
         if let Some(user_agent) = other.user_agent {
             self.user_agent = Some(user_agent);
-        }
-        if let Some(sent_at) = other.sent_at {
-            self.sent_at = Some(sent_at);
         }
     }
 
@@ -193,12 +184,6 @@ impl RequestMeta {
     /// the SDK that sent the event.
     pub fn user_agent(&self) -> Option<&str> {
         self.user_agent.as_ref().map(String::as_str)
-    }
-
-    /// When the event has been sent, according to the SDK.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
-    pub fn sent_at(&self) -> Option<DateTime<Utc>> {
-        self.sent_at
     }
 
     /// Formats the Sentry authentication header.
@@ -328,7 +313,6 @@ fn extract_event_meta(
             remote_addr,
             forwarded_for,
             user_agent,
-            sent_at: None, // We only support this via envelopes
         })
     }))
 }


### PR DESCRIPTION
Since `sent_at` is not transferred in the request but as a literal envelope header, this is being moved now.