### PR TITLE
fix(server): Fix parsing of msgpack breadcrumbs

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1168,7 +1168,7 @@ mod tests {
 
         for (date, message) in breadcrumbs {
             let mut breadcrumb = BTreeMap::new();
-            breadcrumb.insert("message", message.to_string());
+            breadcrumb.insert("message", (*message).to_string());
             if let Some(date) = date {
                 breadcrumb.insert("timestamp", date.to_rfc3339());
             }

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -70,8 +70,8 @@ def test_minidump_attachments(mini_sentry, relay):
     mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
 
     event = {"event_id": "2dd132e467174db48dbaddabd3cbed57", "user": {"id": "123"}}
-    breadcrumbs1 = [{"timestamp": 1461185755, "message": "A",}]
-    breadcrumbs2 = [{"timestamp": 1461185750, "message": "B",}]
+    breadcrumbs1 = {"timestamp": 1461185755, "message": "A",}
+    breadcrumbs2 = {"timestamp": 1461185750, "message": "B",}
 
     sentry_event = msgpack.packb(event)
     sentry_breadcrumbs1 = msgpack.packb(breadcrumbs1)

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -70,8 +70,14 @@ def test_minidump_attachments(mini_sentry, relay):
     mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
 
     event = {"event_id": "2dd132e467174db48dbaddabd3cbed57", "user": {"id": "123"}}
-    breadcrumbs1 = {"timestamp": 1461185755, "message": "A",}
-    breadcrumbs2 = {"timestamp": 1461185750, "message": "B",}
+    breadcrumbs1 = {
+        "timestamp": 1461185755,
+        "message": "A",
+    }
+    breadcrumbs2 = {
+        "timestamp": 1461185750,
+        "message": "B",
+    }
 
     sentry_event = msgpack.packb(event)
     sentry_breadcrumbs1 = msgpack.packb(breadcrumbs1)


### PR DESCRIPTION
This fixes two bugs in handling msgpack attachments:
1. Empty files no longer create an error (leading to the event being discarded). Instead, they create an empty event
2. Breadcrumb attachments actually contain multiple msgpack payloads and not a single list. Instead of deserializing an array, this now invokes the deserializer multiple times, similar to the JSON deserializer. Along with this fix, tests have been fixed.

Most importantly, this PR updates the tests for breadcrumb attachments to use correct fixtures. Along with this, tests have been cleaned up a little further. 

I have verified with `sentry-native@0.1.4` that this now correctly ingests breadcrumbs in events.