### PR TITLE
fix(setup): Disable stacktraces in log integration

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -176,6 +176,7 @@ pub fn init_logging(config: &Config) {
         Some(log),
         sentry::integrations::log::LoggerOptions {
             global_filter: Some(global_filter),
+            attach_stacktraces: config.enable_backtraces(),
             ..Default::default()
         },
     );


### PR DESCRIPTION
Turns out that the sentry log integration defaulted to attaching stack traces, not honoring the `RUST_BACKTRACE` flag. We can consider to fix this separately, but for now, pass the flag explicitly down to the integration.