### PR TITLE
fix: Remove broken appveyor caching

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,10 +5,6 @@ branches:
     - master
     - /^release\/.*$/
 
-cache:
-  - "target"
-  - '%USERPROFILE%\.cargo'
-
 build:
   verbosity: minimal
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 python: "3.7"
 os: linux
 
-cache:
-  directories:
-    - py/venv
-
 git:
   depth: 1
 


### PR DESCRIPTION
Currently all of our builds hang bc it takes forever to unzip on cache download.

Also travis was caching a nonexistent dir.