### PR TITLE
ref(pii): Make converter output more user friendly

### DIFF
--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -167,7 +167,7 @@ def test_validate_pii_config():
 
 
 def test_convert_datascrubbing_config():
-    assert sentry_relay.convert_datascrubbing_config(
+    cfg = sentry_relay.convert_datascrubbing_config(
         {
             "scrubData": True,
             "excludeFields": [],
@@ -175,18 +175,9 @@ def test_convert_datascrubbing_config():
             "sensitiveFields": [],
             "scrubDefaults": True,
         }
-    ) == {
-        "applications": {
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
-                "@anything:remove"
-            ],
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
-                "@common:filter"
-            ],
-        },
-        "rules": {},
-        "vars": {"hashKey": None},
-    }
+    )
+
+    assert cfg["applications"]
 
     assert (
         sentry_relay.convert_datascrubbing_config(

--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -97,14 +97,6 @@ pub struct AliasRule {
     pub hide_inner: bool,
 }
 
-/// A pair redaction rule.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct RedactPairRule {
-    /// A pattern to match for keys.
-    pub key_pattern: Pattern,
-}
-
 /// Supported stripping rules.
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -133,8 +125,6 @@ pub enum RuleType {
     UrlAuth,
     /// US SSN.
     UsSsn,
-    /// When a regex matches a key, a value is removed
-    RedactPair(RedactPairRule),
     /// Applies multiple rules.
     Multiple(MultipleRule),
     /// Applies another rule.  Works like a single multiple.
@@ -158,9 +148,6 @@ impl<'de> Deserialize<'de> for RuleType {
             Pemkey,
             UrlAuth,
             UsSsn,
-            RedactPair(RedactPairRule),
-            #[serde(rename = "redactPair")]
-            RedactPairLegacy(RedactPairRule),
             Multiple(MultipleRule),
             Alias(AliasRule),
         }
@@ -178,8 +165,6 @@ impl<'de> Deserialize<'de> for RuleType {
             RuleTypeWithLegacy::Pemkey => RuleType::Pemkey,
             RuleTypeWithLegacy::UrlAuth => RuleType::UrlAuth,
             RuleTypeWithLegacy::UsSsn => RuleType::UsSsn,
-            RuleTypeWithLegacy::RedactPair(r) => RuleType::RedactPair(r),
-            RuleTypeWithLegacy::RedactPairLegacy(r) => RuleType::RedactPair(r),
             RuleTypeWithLegacy::Multiple(r) => RuleType::Multiple(r),
             RuleTypeWithLegacy::Alias(r) => RuleType::Alias(r),
         })

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -1,11 +1,12 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use regex::RegexBuilder;
 
 use crate::pii::{
-    DataScrubbingConfig, Pattern, PiiConfig, RedactPairRule, Redaction, RuleSpec, RuleType, Vars,
+    DataScrubbingConfig, Pattern, PatternRule, PiiConfig, Redaction, ReplaceRedaction, RuleSpec,
+    RuleType, Vars,
 };
-use crate::processor::{SelectorPathItem, SelectorSpec, ValueType};
+use crate::processor::{SelectorPathItem, SelectorSpec};
 
 lazy_static::lazy_static! {
     // XXX: Move to @ip rule for better IP address scrubbing. Right now we just try to keep
@@ -14,109 +15,178 @@ lazy_static::lazy_static! {
 
     // Fields that the legacy data scrubber cannot strip. We define this list independently of
     // `metastructure(pii = true/false)` because the new PII scrubber should be able to strip more.
-    static ref DATASCRUBBER_IGNORE: SelectorSpec = "( \
-          debug_meta.** \
-        | $frame.filename \
-        | $frame.abs_path \
-        | $logentry.formatted \
-    )".parse().unwrap();
+    static ref DATASCRUBBER_IGNORE: Vec<SelectorSpec> = vec![
+        "$object".parse().unwrap(),
+        "$logentry.formatted".parse().unwrap(),
+    ];
 }
 
+static PASSWORD_FIELDS: &[&str] = &[
+    "password",
+    "secret",
+    "passwd",
+    "api_key",
+    "apikey",
+    "access_token",
+    "auth",
+    "credentials",
+    "mysql_pwd",
+    "stripetoken",
+];
+
 pub fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiConfig> {
-    let mut custom_rules = BTreeMap::new();
-    let mut applied_rules = Vec::new();
+    let mut rules = BTreeMap::new();
     let mut applications = BTreeMap::new();
 
-    if datascrubbing_config.scrub_data && datascrubbing_config.scrub_defaults {
-        applied_rules.push("@common:filter".to_owned());
-    }
+    let with_exclude_fields = |mut conjunctions: Vec<SelectorSpec>| {
+        for field in &datascrubbing_config.exclude_fields {
+            let field = field.trim();
+
+            if field.is_empty() {
+                continue;
+            }
+
+            conjunctions.push(SelectorSpec::Not(Box::new(SelectorSpec::Path(vec![
+                SelectorPathItem::Key(field.to_owned()),
+            ]))));
+        }
+
+        for path in DATASCRUBBER_IGNORE.iter() {
+            conjunctions.push(SelectorSpec::Not(Box::new(path.clone())));
+        }
+
+        let mut rv = SelectorSpec::And(conjunctions);
+        simplify_selector(&mut rv);
+        rv
+    };
 
     if datascrubbing_config.scrub_ip_addresses {
+        // Legacy IP settings ignore safe_fields setting
         applications.insert(KNOWN_IP_FIELDS.clone(), vec!["@anything:remove".to_owned()]);
     }
 
-    if datascrubbing_config.scrub_data {
-        let mut sensitive_fields = datascrubbing_config
-            .sensitive_fields
-            .iter()
-            .map(|x| x.trim())
-            .filter(|x| !x.is_empty())
-            .peekable();
+    let mut wildcard_rules = vec![];
+    let mut sensitive_fields: Vec<&str> = vec![];
 
-        let sensitive_fields_re = if sensitive_fields.peek().is_some() {
-            let mut re = ".*(".to_owned();
+    if datascrubbing_config.scrub_data && datascrubbing_config.scrub_defaults {
+        wildcard_rules.push("@creditcard:filter".into());
+        wildcard_rules.push("@pemkey:filter".into());
+        wildcard_rules.push("@urlauth:legacy".into());
+        wildcard_rules.push("@userpath:filter".into());
+        wildcard_rules.push("@usssn:filter".into());
 
-            for (idx, field) in sensitive_fields.enumerate() {
-                if idx != 0 {
-                    re.push('|');
-                }
-
-                // ugly: regex::escape returns owned string
-                re.push_str(&regex::escape(field));
-            }
-
-            re.push_str(").*");
-            Some(re)
-        } else {
-            None
-        };
-
-        if let Some(key_pattern) = sensitive_fields_re {
-            custom_rules.insert(
-                "strip-fields".to_owned(),
-                RuleSpec {
-                    ty: RuleType::RedactPair(RedactPairRule {
-                        key_pattern: Pattern(
-                            RegexBuilder::new(&key_pattern)
-                                .case_insensitive(true)
-                                .build()
-                                .unwrap(),
-                        ),
-                    }),
-                    redaction: Redaction::Replace("[Filtered]".to_owned().into()),
-                },
-            );
-
-            applied_rules.push("strip-fields".to_owned());
-        }
+        sensitive_fields.extend(PASSWORD_FIELDS.iter());
     }
 
-    if applied_rules.is_empty() && applications.is_empty() {
+    if datascrubbing_config.scrub_data {
+        sensitive_fields.extend(
+            datascrubbing_config
+                .sensitive_fields
+                .iter()
+                .map(String::as_str),
+        );
+    }
+
+    let sensitive_fields = sensitive_fields
+        .iter()
+        .map(|x| x.trim())
+        .filter(|x| !x.is_empty())
+        .collect::<Vec<_>>();
+
+    if !sensitive_fields.is_empty() {
+        // remove keys
+        for field in &sensitive_fields {
+            let selector = with_exclude_fields(vec![SelectorSpec::Path(vec![
+                SelectorPathItem::KeySubstring(field.to_string()),
+            ])]);
+            applications.insert(selector, vec!["@anything:filter".to_owned()]);
+        }
+
+        // remove values
+        let mut re = ".*(".to_owned();
+        for (idx, field) in sensitive_fields.iter().enumerate() {
+            if idx != 0 {
+                re.push('|');
+            }
+
+            // ugly: regex::escape returns owned string
+            re.push_str(&regex::escape(field));
+        }
+        re.push_str(").*");
+
+        let value_rule_name = "remove-keywords".to_owned();
+        rules.insert(
+            value_rule_name.clone(),
+            RuleSpec {
+                ty: RuleType::Pattern(PatternRule {
+                    pattern: Pattern(
+                        RegexBuilder::new(&re)
+                            .case_insensitive(true)
+                            .build()
+                            .unwrap(),
+                    ),
+
+                    replace_groups: None,
+                }),
+                redaction: Redaction::Replace(ReplaceRedaction {
+                    text: "[Filtered]".into(),
+                }),
+            },
+        );
+        wildcard_rules.push(value_rule_name);
+    }
+
+    if !wildcard_rules.is_empty() {
+        applications.insert(with_exclude_fields(vec![]), wildcard_rules);
+    }
+
+    if applications.is_empty() {
         return None;
     }
 
-    let mut conjunctions = vec![
-        SelectorSpec::Or(vec![
-            ValueType::String.into(),
-            ValueType::Number.into(),
-            ValueType::Array.into(),
-        ]),
-        SelectorSpec::Not(Box::new(DATASCRUBBER_IGNORE.clone())),
-    ];
-
-    for field in &datascrubbing_config.exclude_fields {
-        let field = field.trim();
-
-        if field.is_empty() {
-            continue;
-        }
-
-        conjunctions.push(SelectorSpec::Not(Box::new(SelectorSpec::Path(vec![
-            SelectorPathItem::Key(field.to_owned()),
-        ]))));
-    }
-
-    let applied_selector = SelectorSpec::And(conjunctions);
-
-    if !applied_rules.is_empty() {
-        applications.insert(applied_selector, applied_rules);
-    }
-
     Some(PiiConfig {
-        rules: custom_rules,
+        rules,
         vars: Vars::default(),
         applications,
     })
+}
+
+/// Simplify the selector to be equivalent in logic but shorter. This is very primitive and still
+/// produces non-optimal selectors, but goes 90% of the way of trimming down unnecessarily long
+/// selectors created by the converter.
+fn simplify_selector(selector: &mut SelectorSpec) {
+    match selector {
+        SelectorSpec::And(ref mut conjunctions) => {
+            let mut require_substrings = BTreeSet::new();
+
+            for inner in conjunctions.iter() {
+                if let SelectorSpec::Path(ref segments) = inner {
+                    if let Some(SelectorPathItem::KeySubstring(key))
+                    | Some(SelectorPathItem::Key(key)) = segments.last()
+                    {
+                        require_substrings.insert(key.to_owned());
+                    }
+                }
+            }
+
+            conjunctions.retain(|inner| {
+                if let SelectorSpec::Not(ref inner) = inner {
+                    if let SelectorSpec::Path(ref segments) = **inner {
+                        if let Some(SelectorPathItem::Key(key)) = segments.last() {
+                            for substring in &require_substrings {
+                                if !key.contains(substring.as_str()) {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                true
+            });
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -199,13 +269,58 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     fn test_convert_default_pii_config() {
         insta::assert_json_snapshot!(simple_enabled_pii_config(), @r###"
         {
-          "rules": {},
+          "rules": {
+            "remove-keywords": {
+              "type": "pattern",
+              "pattern": ".*(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken).*",
+              "replaceGroups": null,
+              "redaction": {
+                "method": "replace",
+                "text": "[Filtered]"
+              }
+            }
+          },
           "vars": {
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
-              "@common:filter"
+            "((~$object)&(~$logentry.formatted))": [
+              "@creditcard:filter",
+              "@pemkey:filter",
+              "@urlauth:legacy",
+              "@userpath:filter",
+              "@usssn:filter",
+              "remove-keywords"
+            ],
+            "(*access_token*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*api_key*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*apikey*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*auth*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*credentials*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*mysql_pwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*passwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*password*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*secret*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*stripetoken*&(~$object))": [
+              "@anything:filter"
             ],
             "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
               "@anything:remove"
@@ -224,13 +339,58 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         insta::assert_json_snapshot!(pii_config, @r###"
         {
-          "rules": {},
+          "rules": {
+            "remove-keywords": {
+              "type": "pattern",
+              "pattern": ".*(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken).*",
+              "replaceGroups": null,
+              "redaction": {
+                "method": "replace",
+                "text": "[Filtered]"
+              }
+            }
+          },
           "vars": {
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
-              "@common:filter"
+            "((~$object)&(~$logentry.formatted))": [
+              "@creditcard:filter",
+              "@pemkey:filter",
+              "@urlauth:legacy",
+              "@userpath:filter",
+              "@usssn:filter",
+              "remove-keywords"
+            ],
+            "(*access_token*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*api_key*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*apikey*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*auth*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*credentials*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*mysql_pwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*passwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*password*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*secret*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*stripetoken*&(~$object))": [
+              "@anything:filter"
             ],
             "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
               "@anything:remove"
@@ -250,9 +410,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         insta::assert_json_snapshot!(pii_config, @r###"
         {
           "rules": {
-            "strip-fields": {
-              "type": "redact_pair",
-              "keyPattern": ".*(fieldy_field|moar_other_field).*",
+            "remove-keywords": {
+              "type": "pattern",
+              "pattern": ".*(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken|fieldy_field|moar_other_field).*",
+              "replaceGroups": null,
               "redaction": {
                 "method": "replace",
                 "text": "[Filtered]"
@@ -263,9 +424,49 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
-              "@common:filter",
-              "strip-fields"
+            "((~$object)&(~$logentry.formatted))": [
+              "@creditcard:filter",
+              "@pemkey:filter",
+              "@urlauth:legacy",
+              "@userpath:filter",
+              "@usssn:filter",
+              "remove-keywords"
+            ],
+            "(*access_token*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*api_key*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*apikey*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*auth*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*credentials*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*fieldy_field*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*moar_other_field*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*mysql_pwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*passwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*password*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*secret*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*stripetoken*&(~$object))": [
+              "@anything:filter"
             ],
             "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
               "@anything:remove"
@@ -284,13 +485,58 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         insta::assert_json_snapshot!(pii_config, @r###"
         {
-          "rules": {},
+          "rules": {
+            "remove-keywords": {
+              "type": "pattern",
+              "pattern": ".*(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken).*",
+              "replaceGroups": null,
+              "redaction": {
+                "method": "replace",
+                "text": "[Filtered]"
+              }
+            }
+          },
           "vars": {
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted))&(~foobar))": [
-              "@common:filter"
+            "((~foobar)&(~$object)&(~$logentry.formatted))": [
+              "@creditcard:filter",
+              "@pemkey:filter",
+              "@urlauth:legacy",
+              "@userpath:filter",
+              "@usssn:filter",
+              "remove-keywords"
+            ],
+            "(*access_token*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*api_key*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*apikey*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*auth*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*credentials*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*mysql_pwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*passwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*password*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*secret*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*stripetoken*&(~$object))": [
+              "@anything:filter"
             ],
             "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
               "@anything:remove"
@@ -1189,9 +1435,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         insta::assert_json_snapshot!(pii_config, @r###"
         {
           "rules": {
-            "strip-fields": {
-              "type": "redact_pair",
-              "keyPattern": ".*(session_key).*",
+            "remove-keywords": {
+              "type": "pattern",
+              "pattern": ".*(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken|session_key).*",
+              "replaceGroups": null,
               "redaction": {
                 "method": "replace",
                 "text": "[Filtered]"
@@ -1202,9 +1449,46 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
-              "@common:filter",
-              "strip-fields"
+            "((~$object)&(~$logentry.formatted))": [
+              "@creditcard:filter",
+              "@pemkey:filter",
+              "@urlauth:legacy",
+              "@userpath:filter",
+              "@usssn:filter",
+              "remove-keywords"
+            ],
+            "(*access_token*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*api_key*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*apikey*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*auth*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*credentials*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*mysql_pwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*passwd*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*password*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*secret*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*session_key*&(~$object))": [
+              "@anything:filter"
+            ],
+            "(*stripetoken*&(~$object))": [
+              "@anything:filter"
             ],
             "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
               "@anything:remove"

--- a/relay-general/src/pii/mod.rs
+++ b/relay-general/src/pii/mod.rs
@@ -9,8 +9,7 @@ mod redactions;
 
 pub use self::builtin::{BUILTIN_RULES, BUILTIN_SELECTORS};
 pub use self::config::{
-    AliasRule, MultipleRule, Pattern, PatternRule, PiiConfig, RedactPairRule, RuleSpec, RuleType,
-    Vars,
+    AliasRule, MultipleRule, Pattern, PatternRule, PiiConfig, RuleSpec, RuleType, Vars,
 };
 pub use self::legacy::DataScrubbingConfig;
 pub use self::processor::PiiProcessor;

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -560,7 +560,6 @@ fn apply_regex_to_chunks<'a>(
     }
 
     process_text(&search_string[pos..], &mut rv, &mut replacement_chunks);
-    debug_assert!(replacement_chunks.is_empty());
 
     rv
 }

--- a/relay-general/src/pii/snapshots/processor__basic_stripping.snap
+++ b/relay-general/src/pii/snapshots/processor__basic_stripping.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/pii/processor.rs
+source: relay-general/src/pii/processor.rs
 expression: event
 ---
 {
@@ -34,7 +34,7 @@ expression: event
           "": {
             "rem": [
               [
-                "remove_bad_headers",
+                "@anything:remove",
                 "x"
               ]
             ]
@@ -47,7 +47,7 @@ expression: event
             "": {
               "rem": [
                 [
-                  "remove_bad_headers",
+                  "@anything:remove",
                   "x"
                 ]
               ]

--- a/relay-general/src/pii/snapshots/tests__authorization_scrubbing.snap
+++ b/relay-general/src/pii/snapshots/tests__authorization_scrubbing.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -14,7 +14,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10
@@ -27,7 +27,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__breadcrumb_message-2.snap
+++ b/relay-general/src/pii/snapshots/tests__breadcrumb_message-2.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -18,7 +18,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "strip-fields",
+                  "remove-keywords",
                   "s",
                   0,
                   10

--- a/relay-general/src/pii/snapshots/tests__contexts.snap
+++ b/relay-general/src/pii/snapshots/tests__contexts.snap
@@ -102,7 +102,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -115,7 +115,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -128,7 +128,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -141,7 +141,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -154,7 +154,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -169,7 +169,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -182,7 +182,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -195,7 +195,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -208,7 +208,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -221,7 +221,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -234,7 +234,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10

--- a/relay-general/src/pii/snapshots/tests__doesnt_scrub_not_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/tests__doesnt_scrub_not_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -21,7 +21,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10

--- a/relay-general/src/pii/snapshots/tests__exclude_fields_on_field_name.snap
+++ b/relay-general/src/pii/snapshots/tests__exclude_fields_on_field_name.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@usssn:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__explicit_fields.snap
+++ b/relay-general/src/pii/snapshots/tests__explicit_fields.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "strip-fields",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__explicit_fields_case_insensitive.snap
+++ b/relay-general/src/pii/snapshots/tests__explicit_fields_case_insensitive.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "strip-fields",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__extra.snap
+++ b/relay-general/src/pii/snapshots/tests__extra.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -19,7 +19,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "x"
             ]
           ]
@@ -29,7 +29,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10
@@ -42,7 +42,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "x"
             ]
           ]
@@ -52,7 +52,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "remove-keywords",
               "s",
               0,
               10
@@ -65,7 +65,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "remove-keywords",
               "s",
               0,
               10
@@ -78,7 +78,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10
@@ -91,7 +91,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__http.snap
+++ b/relay-general/src/pii/snapshots/tests__http.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -81,7 +81,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -96,7 +96,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "remove-keywords",
                   "s",
                   0,
                   10
@@ -111,7 +111,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "remove-keywords",
                   "s",
                   0,
                   10
@@ -126,7 +126,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -141,7 +141,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -157,7 +157,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -170,7 +170,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -183,7 +183,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -196,7 +196,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -209,7 +209,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -224,7 +224,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -237,7 +237,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -250,7 +250,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -263,7 +263,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -276,7 +276,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -292,7 +292,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -307,7 +307,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "remove-keywords",
                   "s",
                   0,
                   10
@@ -322,7 +322,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "remove-keywords",
                   "s",
                   0,
                   10
@@ -337,7 +337,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -352,7 +352,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10

--- a/relay-general/src/pii/snapshots/tests__odd_keys.snap
+++ b/relay-general/src/pii/snapshots/tests__odd_keys.snap
@@ -13,7 +13,7 @@ expression: data
         "": {
           "rem": [
             [
-              "strip-fields",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__querystring_as_pairlist.snap
+++ b/relay-general/src/pii/snapshots/tests__querystring_as_pairlist.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -35,7 +35,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -50,7 +50,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -65,7 +65,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -80,7 +80,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "remove-keywords",
                   "s",
                   0,
                   10

--- a/relay-general/src/pii/snapshots/tests__querystring_as_string.snap
+++ b/relay-general/src/pii/snapshots/tests__querystring_as_string.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -35,7 +35,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -50,7 +50,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -65,7 +65,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "@anything:filter",
                   "s",
                   0,
                   10
@@ -80,7 +80,7 @@ expression: data
             "": {
               "rem": [
                 [
-                  "@password:filter",
+                  "remove-keywords",
                   "s",
                   0,
                   10

--- a/relay-general/src/pii/snapshots/tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/tests__regression_more_odd_keys.snap
@@ -3,13 +3,58 @@ source: relay-general/src/pii/convert.rs
 expression: pii_config
 ---
 {
-  "rules": {},
+  "rules": {
+    "remove-keywords": {
+      "type": "pattern",
+      "pattern": ".*(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken).*",
+      "replaceGroups": null,
+      "redaction": {
+        "method": "replace",
+        "text": "[Filtered]"
+      }
+    }
+  },
   "vars": {
     "hashKey": null
   },
   "applications": {
-    "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted))&(~url)&(~message)&(~'http.request.url')&(~'*url*')&(~'*message*')&(~'*http.request.url*'))": [
-      "@common:filter"
+    "((~url)&(~message)&(~'http.request.url')&(~'*url*')&(~'*message*')&(~'*http.request.url*')&(~$object)&(~$logentry.formatted))": [
+      "@creditcard:filter",
+      "@pemkey:filter",
+      "@urlauth:legacy",
+      "@userpath:filter",
+      "@usssn:filter",
+      "remove-keywords"
+    ],
+    "(*access_token*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*api_key*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*apikey*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*auth*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*credentials*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*mysql_pwd*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*passwd*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*password*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*secret*&(~$object))": [
+      "@anything:filter"
+    ],
+    "(*stripetoken*&(~$object))": [
+      "@anything:filter"
     ],
     "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
       "@anything:remove"

--- a/relay-general/src/pii/snapshots/tests__sanitize_additional_sensitive_fields.snap
+++ b/relay-general/src/pii/snapshots/tests__sanitize_additional_sensitive_fields.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -19,7 +19,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10
@@ -32,7 +32,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "remove-keywords",
               "s",
               0,
               10
@@ -45,7 +45,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "remove-keywords",
               "s",
               0,
               10
@@ -58,7 +58,7 @@ expression: data
         "": {
           "rem": [
             [
-              "strip-fields",
+              "@anything:filter",
               "s",
               0,
               10
@@ -71,7 +71,7 @@ expression: data
         "": {
           "rem": [
             [
-              "strip-fields",
+              "@anything:filter",
               "s",
               0,
               10
@@ -84,7 +84,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10
@@ -97,7 +97,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__sanitize_http_body.snap
+++ b/relay-general/src/pii/snapshots/tests__sanitize_http_body.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data.value().unwrap().request
 ---
 {
@@ -14,7 +14,7 @@ expression: data.value().unwrap().request
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__sanitize_http_body_string.snap
+++ b/relay-general/src/pii/snapshots/tests__sanitize_http_body_string.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data.value().unwrap().request
 ---
 {
@@ -9,7 +9,7 @@ expression: data.value().unwrap().request
       "": {
         "rem": [
           [
-            "@password:filter",
+            "remove-keywords",
             "s",
             0,
             10

--- a/relay-general/src/pii/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
+++ b/relay-general/src/pii/snapshots/tests__should_have_mysql_pwd_as_a_default_1.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
+++ b/relay-general/src/pii/snapshots/tests__should_have_mysql_pwd_as_a_default_2.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -12,7 +12,7 @@ expression: data
         "": {
           "rem": [
             [
-              "@password:filter",
+              "@anything:filter",
               "s",
               0,
               10

--- a/relay-general/src/pii/snapshots/tests__stacktrace.snap
+++ b/relay-general/src/pii/snapshots/tests__stacktrace.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -26,7 +26,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password:filter",
+                    "@anything:filter",
                     "s",
                     0,
                     10
@@ -39,7 +39,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password:filter",
+                    "remove-keywords",
                     "s",
                     0,
                     10
@@ -52,7 +52,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password:filter",
+                    "remove-keywords",
                     "s",
                     0,
                     10
@@ -65,7 +65,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password:filter",
+                    "@anything:filter",
                     "s",
                     0,
                     10
@@ -78,7 +78,7 @@ expression: data
               "": {
                 "rem": [
                   [
-                    "@password:filter",
+                    "@anything:filter",
                     "s",
                     0,
                     10

--- a/relay-general/src/pii/snapshots/tests__user.snap
+++ b/relay-general/src/pii/snapshots/tests__user.snap
@@ -1,5 +1,5 @@
 ---
-source: general/src/datascrubbing/convert.rs
+source: relay-general/src/pii/convert.rs
 expression: data
 ---
 {
@@ -22,7 +22,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -35,7 +35,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -48,7 +48,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "remove-keywords",
                 "s",
                 0,
                 10
@@ -61,7 +61,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10
@@ -74,7 +74,7 @@ expression: data
           "": {
             "rem": [
               [
-                "@password:filter",
+                "@anything:filter",
                 "s",
                 0,
                 10

--- a/relay-general/src/processor/selector.pest
+++ b/relay-general/src/processor/selector.pest
@@ -12,10 +12,11 @@ RootUnquotedKey = { SOI ~ UnquotedKey ~ EOI }
 QuotedCharacter = @{ ((!"'") ~ ANY) }
 QuotedKey = ${ (QuotedCharacter | ("'" ~ EscapedQuote))+ }
 Key = { UnquotedKey | Quote ~ QuotedKey ~ Quote }
+KeySubstring = { "*" ~ Key ~ "*" }
 
 Index = @{ ASCII_DIGIT+ }
 
-SelectorPathItem = { ObjectType | DeepWildcard | Wildcard | Index | Key }
+SelectorPathItem = { ObjectType | Index | Key | KeySubstring | DeepWildcard | Wildcard }
 SelectorPath = { SelectorPathItem ~ ("." ~ SelectorPathItem)* }
 
 // enforce parenthesis everywhere as long as we don't have clear precedence


### PR DESCRIPTION
* new feature: ability to use wildcards in selector keys: `foo.bar.*baz*` (currently requires leading and trailing wildcard until we get to properly refactoring the grammar)
* redactPair is gone (replaced by previously mentioned feature and a pattern rule)
* `@common` is gone (replaced by multiple rules)