### PR TITLE
ref: Lower dfa_size_limit for user-provided regexes

### DIFF
--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
-use regex::RegexBuilder;
-
+use crate::pii::config::regex_from_user_input;
 use crate::pii::{
     DataScrubbingConfig, Pattern, PiiConfig, RedactPairRule, Redaction, RuleSpec, RuleType, Vars,
 };
@@ -67,7 +66,7 @@ pub fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiCo
                 RuleSpec {
                     ty: RuleType::RedactPair(RedactPairRule {
                         key_pattern: Pattern(
-                            RegexBuilder::new(&key_pattern)
+                            regex_from_user_input(&key_pattern)
                                 .case_insensitive(true)
                                 .build()
                                 .unwrap(),


### PR DESCRIPTION
This should help a bit with keeping memory usage in check

dfa_size_limit is very high by default, and it's a per-thread limit. My suspicion is that we do not actually leak infinite memory, just up to `<huge number>`
