### PR TITLE
fix(pii): Better selector grammar

### DIFF
--- a/docs/pii-config/selectors.md
+++ b/docs/pii-config/selectors.md
@@ -14,9 +14,9 @@ You have the possibility to select a region of the event using JSON-path-like sy
 
 You can combine selectors using boolean logic.
 
-* Prefix with `~` to invert the selector. `foo` matches the JSON key `foo`, while `(~foo)` matches everything but `foo`.
-* Build the conjunction (AND) using `&`, such as: `(foo&(~extra.foo))` to match the key `foo` except when inside of `extra`.
-* Build the disjunction (OR) using `|`, such as: `(foo|bar)` to match `foo` or `bar`.
+* Prefix with `!` to invert the selector. `foo` matches the JSON key `foo`, while `(~foo)` matches everything but `foo`.
+* Build the conjunction (AND) using `&&`, such as: `foo && !extra.foo` to match the key `foo` except when inside of `extra`.
+* Build the disjunction (OR) using `||`, such as: `foo || bar` to match `foo` or `bar`.
 
 ## Wildcards
 

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -167,7 +167,7 @@ def test_validate_pii_config():
 
 
 def test_convert_datascrubbing_config():
-    assert sentry_relay.convert_datascrubbing_config(
+    cfg = sentry_relay.convert_datascrubbing_config(
         {
             "scrubData": True,
             "excludeFields": [],
@@ -175,18 +175,9 @@ def test_convert_datascrubbing_config():
             "sensitiveFields": [],
             "scrubDefaults": True,
         }
-    ) == {
-        "applications": {
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
-                "@anything:remove"
-            ],
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
-                "@common:filter"
-            ],
-        },
-        "rules": {},
-        "vars": {"hashKey": None},
-    }
+    )
+
+    assert cfg["applications"]
 
     assert (
         sentry_relay.convert_datascrubbing_config(

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -204,7 +204,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
+            "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted)": [
               "@common:filter"
             ],
             "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
@@ -229,7 +229,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
+            "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted)": [
               "@common:filter"
             ],
             "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
@@ -263,7 +263,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
+            "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted)": [
               "@common:filter",
               "strip-fields"
             ],
@@ -289,7 +289,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted))&(~foobar))": [
+            "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted) && !foobar": [
               "@common:filter"
             ],
             "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
@@ -1202,7 +1202,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
+            "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted)": [
               "@common:filter",
               "strip-fields"
             ],

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -207,7 +207,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
               "@common:filter"
             ],
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+            "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
             ]
           }
@@ -232,7 +232,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted)))": [
               "@common:filter"
             ],
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+            "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
             ]
           }
@@ -267,7 +267,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
               "@common:filter",
               "strip-fields"
             ],
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+            "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
             ]
           }
@@ -292,7 +292,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted))&(~foobar))": [
               "@common:filter"
             ],
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+            "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
             ]
           }
@@ -316,7 +316,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+            "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
             ]
           }
@@ -1206,7 +1206,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
               "@common:filter",
               "strip-fields"
             ],
-            "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+            "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
             ]
           }

--- a/relay-general/src/pii/snapshots/tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/tests__regression_more_odd_keys.snap
@@ -11,7 +11,7 @@ expression: pii_config
     "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted))&(~url)&(~message)&(~'http.request.url')&(~'*url*')&(~'*message*')&(~'*http.request.url*'))": [
       "@common:filter"
     ],
-    "($request.env.REMOTE_ADDR|$user.ip_address|$sdk.client_ip)": [
+    "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
       "@anything:remove"
     ]
   }

--- a/relay-general/src/pii/snapshots/tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/tests__regression_more_odd_keys.snap
@@ -8,7 +8,7 @@ expression: pii_config
     "hashKey": null
   },
   "applications": {
-    "(($string|$number|$array)&(~(debug_meta.**|$frame.filename|$frame.abs_path|$logentry.formatted))&(~url)&(~message)&(~'http.request.url')&(~'*url*')&(~'*message*')&(~'*http.request.url*'))": [
+    "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
       "@common:filter"
     ],
     "$request.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [

--- a/relay-general/src/processor/selector.pest
+++ b/relay-general/src/processor/selector.pest
@@ -5,6 +5,9 @@ Wildcard = @{ "*" }
 DeepWildcard = @{ "**" }
 
 Quote = _{ "'" }
+And = _{ "&&" | "&" }
+Or = _{ "||" | "|" }
+Not = _{ "~" | "!" }
 EscapedQuote = @{ "'" }
 
 UnquotedKey = @{ (ASCII_ALPHANUMERIC | "-" | "_") + }
@@ -18,12 +21,9 @@ Index = @{ ASCII_DIGIT+ }
 SelectorPathItem = { ObjectType | DeepWildcard | Wildcard | Index | Key }
 SelectorPath = { SelectorPathItem ~ ("." ~ SelectorPathItem)* }
 
-// enforce parenthesis everywhere as long as we don't have clear precedence
-// rules, such that we can introduce them without breaking existing configs.
-
-AndSelector = { "(" ~ Selector ~ ("&" ~ Selector)+ ~ ")" }
-OrSelector = { "(" ~ Selector ~ ("|" ~ Selector)+ ~ ")" }
-NotSelector = { "(~" ~ Selector ~ ")" }
-Selector = { NotSelector | AndSelector | OrSelector | "(" ~ Selector ~ ")" | SelectorPath }
-RootSelector = { SOI ~ Selector ~ EOI }
-
+ParenthesisOrPath = { "(" ~ OrSelector ~ ")" | SelectorPath }
+NotSelector = { Not ~ ParenthesisOrPath }
+MaybeNotSelector = { NotSelector | ParenthesisOrPath } 
+AndSelector = { MaybeNotSelector ~ (And ~ MaybeNotSelector)* }
+OrSelector = { AndSelector ~ (Or ~ AndSelector)* }
+RootSelector = { SOI ~ OrSelector ~ EOI }

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -114,26 +114,51 @@ impl fmt::Display for SelectorSpec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SelectorSpec::And(ref xs) => {
-                write!(f, "(")?;
                 for (idx, x) in xs.iter().enumerate() {
                     if idx > 0 {
-                        write!(f, "&")?;
+                        write!(f, " && ")?;
                     }
-                    write!(f, "{}", x)?;
+
+                    let needs_parens = match *x {
+                        SelectorSpec::And(_) => false,
+                        SelectorSpec::Or(_) => true,
+                        SelectorSpec::Not(_) => false,
+                        SelectorSpec::Path(_) => false,
+                    };
+
+                    if needs_parens {
+                        write!(f, "({})", x)?;
+                    } else {
+                        write!(f, "{}", x)?;
+                    }
                 }
-                write!(f, ")")?;
             }
             SelectorSpec::Or(ref xs) => {
-                write!(f, "(")?;
                 for (idx, x) in xs.iter().enumerate() {
                     if idx > 0 {
-                        write!(f, "|")?;
+                        write!(f, " || ")?;
                     }
+
+                    // OR has weakest precedence, so everything else binds stronger and does not
+                    // need parens
+
                     write!(f, "{}", x)?;
                 }
-                write!(f, ")")?;
             }
-            SelectorSpec::Not(ref x) => write!(f, "(~{})", x)?,
+            SelectorSpec::Not(ref x) => {
+                let needs_parens = match **x {
+                    SelectorSpec::And(_) => true,
+                    SelectorSpec::Or(_) => true,
+                    SelectorSpec::Not(_) => true,
+                    SelectorSpec::Path(_) => false,
+                };
+
+                if needs_parens {
+                    write!(f, "!({})", x)?;
+                } else {
+                    write!(f, "!{}", x)?;
+                }
+            }
             SelectorSpec::Path(ref path) => {
                 for (idx, item) in path.iter().enumerate() {
                     if idx > 0 {
@@ -187,8 +212,30 @@ impl From<ValueType> for SelectorSpec {
 }
 
 fn handle_selector(pair: Pair<Rule>) -> Result<SelectorSpec, InvalidSelectorError> {
+    fn map_multiple_or_inner<F>(
+        pair: Pair<Rule>,
+        f: F,
+    ) -> Result<SelectorSpec, InvalidSelectorError>
+    where
+        F: Fn(Vec<SelectorSpec>) -> SelectorSpec,
+    {
+        let mut iter = pair.into_inner().map(handle_selector).peekable();
+        let first = iter.next().unwrap()?;
+        if iter.peek().is_none() {
+            Ok(first)
+        } else {
+            let mut items = vec![first];
+            for item in iter {
+                items.push(item?);
+            }
+            Ok(f(items))
+        }
+    }
+
     match pair.as_rule() {
-        Rule::Selector => handle_selector(pair.into_inner().next().unwrap()),
+        Rule::ParenthesisOrPath | Rule::MaybeNotSelector => {
+            handle_selector(pair.into_inner().next().unwrap())
+        }
         Rule::SelectorPath => {
             let mut used_deep_wildcard = false;
             let items = pair
@@ -208,16 +255,8 @@ fn handle_selector(pair: Pair<Rule>) -> Result<SelectorSpec, InvalidSelectorErro
 
             Ok(SelectorSpec::Path(items))
         }
-        Rule::AndSelector => Ok(SelectorSpec::And(
-            pair.into_inner()
-                .map(handle_selector)
-                .collect::<Result<_, _>>()?,
-        )),
-        Rule::OrSelector => Ok(SelectorSpec::Or(
-            pair.into_inner()
-                .map(handle_selector)
-                .collect::<Result<_, _>>()?,
-        )),
+        Rule::AndSelector => map_multiple_or_inner(pair, SelectorSpec::And),
+        Rule::OrSelector => map_multiple_or_inner(pair, SelectorSpec::Or),
         Rule::NotSelector => Ok(SelectorSpec::Not(Box::new(handle_selector(
             pair.into_inner().next().unwrap(),
         )?))),
@@ -271,4 +310,17 @@ fn handle_key(pair: Pair<Rule>) -> Result<String, InvalidSelectorError> {
 
 fn key_needs_quoting(key: &str) -> bool {
     SelectorParser::parse(Rule::RootUnquotedKey, key).is_err()
+}
+
+#[test]
+fn test_roundtrip() {
+    fn check_roundtrip(s: &str) {
+        assert_eq!(SelectorSpec::from_str(s).unwrap().to_string(), s);
+    }
+
+    check_roundtrip("!(!a)");
+    check_roundtrip("!a || !b");
+    check_roundtrip("!a && !b");
+    check_roundtrip("!(a && !b)");
+    check_roundtrip("!(a && b)");
 }


### PR DESCRIPTION
Reintroduction of #501

With #502 I reverted two PRs because I was not sure which of them caused the production impact and we just wanted to get master back to being safe. I believe this may be safe to bring back while we look into the memory leak.

There is potential for increased CPU consumption, in that case there is an obvious way forward with PrecClimber.