### PR TITLE
doc: Improve introduction to pii config format

### DIFF
--- a/docs/pii-config/index.md
+++ b/docs/pii-config/index.md
@@ -1,6 +1,10 @@
 # PII Configuration
 
-The following document explores the syntax and semantics of PII configs for Relay. To get started with PII configs, it's recommended to use [_Piinguin_](https://getsentry.github.io/piinguin) and refer back to this document when needed.
+The following document explores the syntax and semantics of the new
+datascrubbing ("PII") configuration consumed by
+[Relay](https://github.com/getsentry/relay).
+
+This type of configuration is supposed to eventually replace our existing [server-side data scrubbing feature](https://docs.sentry.io/data-management/sensitive-data/#server-side-scrubbing). **We are currently beta-testing this feature on `sentry.io`**. If you are interested in gaining early access to this feature, please refer to [this issue](https://github.com/getsentry/relay/issues/453) or contact us at `markus@sentry.io`.
 
 ## A basic example
 


### PR DESCRIPTION
This is directly linked from the Sentry UI at the moment, make sure users have all the necessary context here.