### PR TITLE
ref(pii): Use aho-corasick to improve selector matching performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.6"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1048,7 +1048,7 @@ name = "globset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bstr 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2159,7 +2159,7 @@ name = "regex"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2182,6 +2182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "relay"
 version = "0.5.5"
 dependencies = [
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2271,6 +2272,7 @@ dependencies = [
 name = "relay-general"
 version = "0.5.5"
 dependencies = [
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3664,7 +3666,7 @@ dependencies = [
 "checksum actix_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4300e9431455322ae393d43a2ba1ef96b8080573c0fc23b196219efedfb6ba69"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum anylog 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b3677680d7f74e87066850ba07976ad03296b6ec4e17bddef05564438ffb86e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ relay-general = { path = "relay-general" }
 sentry = { version = "0.18.0", features = ["with_debug_meta"] }
 serde = "1.0.98"
 serde_json = "1.0.40"
-aho-corasick = "0.7.9"
+aho-corasick = "0.7.10"
 
 [target."cfg(not(windows))".dependencies]
 openssl-probe = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ relay-general = { path = "relay-general" }
 sentry = { version = "0.18.0", features = ["with_debug_meta"] }
 serde = "1.0.98"
 serde_json = "1.0.40"
+aho-corasick = "0.7.9"
 
 [target."cfg(not(windows))".dependencies]
 openssl-probe = "0.1.2"

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -35,6 +35,7 @@ uaparser = { version = "0.3.3", optional = true }
 url = "2.0.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 relay-common = { path = "../relay-common" }
+aho-corasick = "0.7.10"
 
 [dev-dependencies]
 difference = "2.0.0"

--- a/relay-general/src/pii/compiledconfig.rs
+++ b/relay-general/src/pii/compiledconfig.rs
@@ -1,30 +1,64 @@
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 
 use crate::pii::builtin::BUILTIN_RULES_MAP;
 use crate::pii::{PiiConfig, Redaction, RuleSpec, RuleType};
-use crate::processor::SelectorSpec;
+use crate::processor::{SelectorPathItem, SelectorSpec};
+
+type Application = (SelectorSpec, BTreeSet<RuleRef>);
 
 /// A representation of `PiiConfig` that is more (CPU-)efficient for use in `PiiProcessor`. It is
 /// lossy in the sense that it cannot be consumed by downstream relays, so both versions have to be
 /// kept around.
 #[derive(Debug, Clone)]
 pub struct CompiledPiiConfig {
-    pub(super) applications: Vec<(SelectorSpec, BTreeSet<RuleRef>)>,
+    pub(super) key_applications: Vec<Vec<Application>>,
+    pub(super) key_patterns: AhoCorasick,
+    pub(super) non_key_applications: Vec<Application>,
 }
 
 impl CompiledPiiConfig {
     pub fn new(config: &PiiConfig) -> Self {
-        let mut applications = Vec::new();
+        let mut key_applications = BTreeMap::new();
+        let mut non_key_applications = Vec::new();
+
         for (selector, rules) in &config.applications {
+            // XXX(markus): Flatten into applications
             let mut rule_set = BTreeSet::default();
             for rule_id in rules {
                 collect_rules(config, &mut rule_set, &rule_id, None);
             }
-            applications.push((selector.clone(), rule_set));
+
+            let mut pushed = false;
+
+            for substring in get_substrings(selector) {
+                key_applications
+                    .entry(substring)
+                    .or_insert_with(Vec::new)
+                    .push((selector.clone(), rule_set.clone()));
+                pushed = true;
+            }
+
+            if !pushed {
+                non_key_applications.push((selector.clone(), rule_set.clone()));
+            }
         }
 
-        CompiledPiiConfig { applications }
+        let key_patterns = key_applications.keys().cloned().collect::<Vec<_>>();
+        let key_patterns = AhoCorasickBuilder::new()
+            .auto_configure(&key_patterns)
+            .ascii_case_insensitive(true)
+            .build(key_patterns);
+
+        let key_applications = key_applications.into_iter().map(|(_k, v)| v).collect();
+
+        CompiledPiiConfig {
+            key_applications,
+            key_patterns,
+            non_key_applications,
+        }
     }
 }
 
@@ -81,6 +115,39 @@ fn collect_rules(
             rules.insert(rule);
         }
     }
+}
+
+fn get_substrings(selector: &SelectorSpec) -> BTreeSet<&str> {
+    let mut rv = BTreeSet::new();
+    let mut stack = vec![(None, selector)];
+
+    while let Some((parent, selector)) = stack.pop() {
+        macro_rules! handle_unknown {
+            () => {
+                if let Some(&SelectorSpec::Or(_)) = parent {
+                    return BTreeSet::new();
+                }
+            };
+        }
+
+        match *selector {
+            SelectorSpec::Path(ref items) => {
+                if let Some(SelectorPathItem::Key(ref key)) = items.last() {
+                    rv.insert(key.as_str());
+                } else {
+                    handle_unknown!();
+                }
+            }
+            SelectorSpec::And(ref inner) | SelectorSpec::Or(ref inner) => {
+                for subselector in inner {
+                    stack.push((Some(selector), subselector));
+                }
+            }
+            SelectorSpec::Not(_) => handle_unknown!(),
+        }
+    }
+
+    rv
 }
 
 /// Reference to a PII rule.

--- a/relay-general/src/pii/compiledconfig.rs
+++ b/relay-general/src/pii/compiledconfig.rs
@@ -25,7 +25,6 @@ impl CompiledPiiConfig {
         let mut non_key_applications = Vec::new();
 
         for (selector, rules) in &config.applications {
-            // XXX(markus): Flatten into applications
             let mut rule_set = BTreeSet::default();
             for rule_id in rules {
                 collect_rules(config, &mut rule_set, &rule_id, None);

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -1082,7 +1082,8 @@ fn test_impossible_selector() {
         ..Default::default()
     });
 
-    let mut processor = PiiProcessor::new(&config);
+    let compiled = config.compiled();
+    let mut processor = PiiProcessor::new(&compiled);
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
     assert_annotated_snapshot!(event);
 }
@@ -1112,7 +1113,8 @@ fn test_weird_wildcard_selectors() {
         ..Default::default()
     });
 
-    let mut processor = PiiProcessor::new(&config);
+    let compiled = config.compiled();
+    let mut processor = PiiProcessor::new(&compiled);
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
     assert_annotated_snapshot!(event);
 }

--- a/relay-general/src/pii/snapshots/processor__impossible_selector.snap
+++ b/relay-general/src/pii/snapshots/processor__impossible_selector.snap
@@ -1,0 +1,9 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: event
+---
+{
+  "extra": {
+    "myvalue": "foobar"
+  }
+}

--- a/relay-general/src/pii/snapshots/processor__weird_wildcard_selectors.snap
+++ b/relay-general/src/pii/snapshots/processor__weird_wildcard_selectors.snap
@@ -1,0 +1,23 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: event
+---
+{
+  "extra": {
+    "myvalue": null
+  },
+  "_meta": {
+    "extra": {
+      "myvalue": {
+        "": {
+          "rem": [
+            [
+              "@anything:remove",
+              "x"
+            ]
+          ]
+        }
+      }
+    }
+  }
+}

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -496,7 +496,7 @@ pub struct Path<'a>(&'a ProcessingState<'a>);
 impl<'a> Path<'a> {
     /// Returns the current key if there is one
     #[inline]
-    pub fn key(&self) -> Option<&str> {
+    pub fn key(&self) -> Option<&'a str> {
         PathItem::key(self.0.path_item()?)
     }
 


### PR DESCRIPTION
This is in preparation for bringing back #499. We had to revert this PR because it attempted to kill our use of redactpair by swapping it out for multiple selectors. Instead of having a single selector with a redactpair rule containing `a|b|c|d|e|f`, #499 generated selectors `*a*`, `*b*`, `*c*`, `*d*`, `*e*`, `*f*`, which make the entire processor run 5x slower.

Right now our PII processor takes time with a *lower-bound* of `<size of
event> * <amount of applications/selectors>`, because `iter_rules()` is
linear: We iterate through all applications/selectors for each key we
look at in the event.

We do not improve the upper bound here, but using aho-corasick is much
faster than calling `Path::matches_selector` everytime, and lets us skip
over most selectors.
