### PR TITLE
feat: Add Session Aggregates as new Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724), [#785](https://github.com/getsentry/relay/pull/785))
 - Add support for scrubbing UTF-16 data in attachments ([#742](https://github.com/getsentry/relay/pull/742), [#784](https://github.com/getsentry/relay/pull/784), [#787](https://github.com/getsentry/relay/pull/787))
 - Add upstream request metric. ([#793](https://github.com/getsentry/relay/pull/793))
+- Add a new `session_aggregates` ItemType which contains aggregated session numbers. ([#523](https://github.com/getsentry/relay/pull/523))
 
 **Bug Fixes**:
 

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -50,7 +50,9 @@ pub use self::request::{Cookies, HeaderName, HeaderValue, Headers, Query, Reques
 #[cfg(feature = "jsonschema")]
 pub use self::schema::event_json_schema;
 pub use self::security_report::{Csp, ExpectCt, ExpectStaple, Hpkp, SecurityReportType};
-pub use self::session::{ParseSessionStatusError, SessionAttributes, SessionStatus, SessionUpdate};
+pub use self::session::{
+    ParseSessionStatusError, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
+};
 pub use self::span::Span;
 pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrace};
 pub use self::tags::{TagEntry, Tags};

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -197,12 +197,12 @@ impl SessionAggregates {
                 continue;
             };
             return Some(SessionUpdate {
-                session_id: Uuid::nil(),
+                session_id: Uuid::new_v4(),
                 distinct_id: item.distinct_id.clone(),
                 sequence: 0,
                 init: true,
                 timestamp: Utc::now(),
-                started: item.started.clone(),
+                started: item.started,
                 duration: None,
                 status,
                 errors,
@@ -347,10 +347,11 @@ mod tests {
 
         let mut settings = insta::Settings::new();
         settings.add_redaction(".timestamp", "[TS]");
+        settings.add_redaction(".sid", "[SID]");
         settings.bind(|| {
             insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
             ---
-            sid: 00000000-0000-0000-0000-000000000000
+            sid: "[SID]"
             did: some-user
             seq: 0
             init: true
@@ -366,7 +367,7 @@ mod tests {
             "###);
             insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
             ---
-            sid: 00000000-0000-0000-0000-000000000000
+            sid: "[SID]"
             did: ~
             seq: 0
             init: true
@@ -382,7 +383,7 @@ mod tests {
             "###);
             insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
             ---
-            sid: 00000000-0000-0000-0000-000000000000
+            sid: "[SID]"
             did: ~
             seq: 0
             init: true
@@ -398,7 +399,7 @@ mod tests {
             "###);
             insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
             ---
-            sid: 00000000-0000-0000-0000-000000000000
+            sid: "[SID]"
             did: ~
             seq: 0
             init: true

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -673,6 +673,7 @@ impl EventProcessor {
 
             // session data is never considered as part of deduplication
             ItemType::Session => false,
+            ItemType::SessionAggregates => false,
         }
     }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -168,7 +168,7 @@ impl StoreForwarder {
         };
 
         if aggregates.num_sessions() as usize > MAX_EXPLODED_SESSIONS {
-            warn!("exploded session items from aggregate exceed threshold");
+            log::warn!("exploded session items from aggregate exceed threshold");
         }
 
         for session in aggregates.into_updates_iter().take(MAX_EXPLODED_SESSIONS) {

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -348,6 +348,8 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
                 attachments_size += item.len()
             }
             ItemType::Session => session_count += 1,
+            // TODO: extract the actual session counts from the aggregates
+            ItemType::SessionAggregates => session_count += 1,
             ItemType::UserReport => (),
         }
     }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -91,6 +91,8 @@ pub enum ItemType {
     UserReport,
     /// Session update data.
     Session,
+    /// Aggregated session data.
+    SessionAggregates,
 }
 
 impl ItemType {
@@ -118,6 +120,7 @@ impl fmt::Display for ItemType {
             Self::UnrealReport => write!(f, "unreal report"),
             Self::UserReport => write!(f, "user feedback"),
             Self::Session => write!(f, "session"),
+            Self::SessionAggregates => write!(f, "session aggregates"),
         }
     }
 }
@@ -500,7 +503,7 @@ impl Item {
             ItemType::FormData => false,
 
             // The remaining item types cannot carry event payloads.
-            ItemType::UserReport | ItemType::Session => false,
+            ItemType::UserReport | ItemType::Session | ItemType::SessionAggregates => false,
         }
     }
 
@@ -518,6 +521,7 @@ impl Item {
             ItemType::UnrealReport => true,
             ItemType::UserReport => true,
             ItemType::Session => false,
+            ItemType::SessionAggregates => false,
         }
     }
 }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -88,6 +88,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Attachment if item.creates_event() => Some(DataCategory::Error),
         ItemType::Attachment => None,
         ItemType::Session => None,
+        ItemType::SessionAggregates => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
     }


### PR DESCRIPTION
This adds a more efficient envelope item for sending lots of sessions up that happened in the same minute.

Right now they are exploded in relay, but in the future they will be stored directly as-is