### PR TITLE
build(uap-core): Bump to latest version

### DIFF
--- a/relay-general/src/store/normalize/user_agent.rs
+++ b/relay-general/src/store/normalize/user_agent.rs
@@ -225,6 +225,12 @@ mod tests {
             "name": "Mac OS X",
             "version": "10.13.4",
             "type": "os"
+          },
+          "device": {
+            "family": "Mac",
+            "model": "Mac",
+            "brand": "Apple",
+            "type": "device"
           }
         }
         "###);


### PR DESCRIPTION
There's been a handful of updates since Nov 8, 2019.

https://github.com/ua-parser/uap-core/compare/9db18c34f47ee8a30fcd1615ffcbb3ba4e02f287..ec8322ffe14f94d88131cec550705f392085a519