### PR TITLE
build(virtualenv): Remove dependency on virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,16 @@ clean-target-dir:
 
 # Dependencies
 
-.venv/bin/python: Makefile
+.venv/bin/python:
 	@rm -rf .venv
-	@which virtualenv || sudo pip install virtualenv
-	virtualenv -p $$RELAY_PYTHON_VERSION .venv
+ifeq ($(TRAVIS)$(basename $(RELAY_PYTHON_VERSION)), python3)
+	@# if (!TRAVIS && python3)
+	$(RELAY_PYTHON_VERSION) -m venv .venv
+else
+	@# if (TRAVIS || python2)
+	@# force use virtualenv in TRAVIS because of https://github.com/travis-ci/travis-ci/issues/8589
+	virtualenv -p $(RELAY_PYTHON_VERSION) .venv
+endif
 
 .git/hooks/pre-commit:
 	@cd .git/hooks && ln -sf ../../scripts/git-precommit-hook.py pre-commit

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ development:
   below for more information).
 - `make all`: Runs all checks and tests. This runs most of the tasks that are
   also performed in CI.
-- `make clean`: Removes all build artifacts, the virtualenv and cached files.
+- `make clean`: Removes all build artifacts, the Python virtual environment and
+  cached files.
 
 ### Building and Running
 
@@ -124,11 +125,11 @@ make test-rust-all
 ```
 
 The integration test suite requires `python`. By default, the integration test
-suite will create a virtualenv, build the Relay binary with processing enabled,
-and run a set of integration tests:
+suite will create a Python virtual environment, build the Relay binary with
+processing enabled, and run a set of integration tests:
 
 ```bash
-# Create a new virtualenv, build Relay and run integration tests
+# Prepare dependencies and run integration tests
 make test-integration
 
 # Build and run a single test manually
@@ -157,9 +158,9 @@ This first requires to expose new functions in the C ABI. For this, refer to the
 [Relay C-ABI readme](relay-cabi/README.md).
 
 We highly recommend to develop and test the python package in a **virtual
-environment**. Once the ABI has been updated and tested, ensure the virtualenv
-is active and install the package, which builds the native library. There are
-two ways to install this:
+environment**. Once the ABI has been updated and tested, ensure the virtual
+environment is active and install the package, which builds the native library.
+There are two ways to install this:
 
 ```bash
 # Install the release build, recommended:
@@ -169,12 +170,12 @@ pip install --editable ./py
 RELAY_DEBUG=1 pip install --editable ./py
 ```
 
-For testing, we use ubiquitous `pytest`. Again, ensure that your virtualenv is
-active and the latest version of the native library has been installed. Then,
-run:
+For testing, we use ubiquitous `pytest`. Again, ensure that your virtual
+environment is active and the latest version of the native library has been
+installed. Then, run:
 
 ```bash
-# Create a new virtualenv, install the release build and run tests
+# Prepare dependencies and run tests
 make test-python
 
 # Run a single test manually

--- a/tests/load-tests/Makefile
+++ b/tests/load-tests/Makefile
@@ -38,7 +38,13 @@ setup-deps: setup-venv
 setup-venv: .venv/bin/python
 .PHONY: setup-venv
 
-.venv/bin/python: Makefile
+.venv/bin/python:
 	@rm -rf .venv
-	@which virtualenv || sudo easy_install virtualenv
-	virtualenv -p $$PYTHON_VERSION .venv
+ifeq ($(TRAVIS)$(basename $(PYTHON_VERSION)), python3)
+	@# if (!TRAVIS && python3)
+	$(PYTHON_VERSION) -m venv .venv
+else
+	@# if (TRAVIS || python2)
+	@# force use virtualenv in TRAVIS because of https://github.com/travis-ci/travis-ci/issues/8589
+	virtualenv -p $(PYTHON_VERSION) .venv
+endif


### PR DESCRIPTION
We use Python 3 and it has the `venv` module built-in, what allow us to
require one less dependency on developer machines.

As a plus, remove a usage of `sudo` in the Makefile.