### PR TITLE
fix(server): Emit outcomes with key_id

### DIFF
--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Duration, Utc};
 
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::protocol::{Context, ContextInner, Contexts, Event, EventType, Span};
+use crate::protocol::{ContextInner, Contexts, Event, EventType, Span};
 use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Timestamp};
 
 pub struct TransactionsProcessor {

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Duration, Utc};
 
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::protocol::{ContextInner, Contexts, Event, EventType, Span};
+use crate::protocol::{Context, ContextInner, Event, EventType, Span};
 use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Timestamp};
 
 pub struct TransactionsProcessor {
@@ -178,11 +178,13 @@ impl Processor for TransactionsProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::processor::process_value;
-    use crate::protocol::{SpanId, TraceContext, TraceId};
-    use crate::types::Object;
+
     use chrono::offset::TimeZone;
     use chrono::Utc;
+
+    use crate::processor::process_value;
+    use crate::protocol::{Contexts, SpanId, TraceContext, TraceId};
+    use crate::types::Object;
 
     #[test]
     fn test_skips_non_transaction_events() {

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -264,7 +264,11 @@ impl ProjectState {
         matches_any_origin(Some(origin.as_str()), &allowed)
     }
 
-    /// TODO(ja): Doc this
+    /// Returns `Scoping` information for this project state.
+    ///
+    /// This scoping amends `RequestMeta::get_partial_scoping` by adding organization and key info.
+    /// The processor must fetch the full scoping before attempting to rate limit with partial
+    /// scoping.
     pub fn get_scoping(&self, meta: &RequestMeta) -> Scoping {
         let mut scoping = meta.get_partial_scoping();
 

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -12,6 +12,7 @@ use url::Url;
 use relay_common::{
     tryf, Auth, Dsn, ParseAuthError, ParseDsnError, ParseProjectIdError, ProjectId,
 };
+use relay_quotas::Scoping;
 
 use crate::actors::project_keys::GetProjectId;
 use crate::extractors::ForwardedFor;
@@ -181,6 +182,16 @@ impl RequestMeta {
         }
 
         auth
+    }
+
+    /// TODO(ja): Doc this
+    pub fn get_partial_scoping(&self) -> Scoping {
+        Scoping {
+            organization_id: 0,
+            project_id: self.project_id(),
+            public_key: self.public_key().to_owned(),
+            key_id: None,
+        }
     }
 }
 

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -184,7 +184,10 @@ impl RequestMeta {
         auth
     }
 
-    /// TODO(ja): Doc this
+    /// Returns scoping information from the request.
+    ///
+    /// The scoping returned from this function is not complete since it lacks info from the Project
+    /// state. To fetch full scoping information, invoke the `GetScoping` message on `Project`.
     pub fn get_partial_scoping(&self) -> Scoping {
         Scoping {
             organization_id: 0,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use relay_quotas::{
-    DataCategories, DataCategory, ItemScoping, QuotaScope, RateLimit, RateLimitScope, RateLimits,
+    DataCategories, DataCategory, QuotaScope, RateLimit, RateLimitScope, RateLimits, Scoping,
 };
 
 /// Name of the rate limits header.
@@ -32,7 +32,7 @@ pub fn format_rate_limits(rate_limits: &RateLimits) -> String {
 }
 
 /// Parses the `X-Sentry-Rate-Limits` header.
-pub fn parse_rate_limits(scoping: &ItemScoping, string: &str) -> RateLimits {
+pub fn parse_rate_limits(scoping: &Scoping, string: &str) -> RateLimits {
     let mut rate_limits = RateLimits::new();
 
     for limit in string.split(',') {
@@ -111,8 +111,7 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_rate_limits() {
-        let scoping = ItemScoping {
-            category: DataCategory::Unknown, // irrelevant for this test
+        let scoping = Scoping {
             organization_id: 42,
             project_id: ProjectId::new(21),
             public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
@@ -126,8 +125,7 @@ mod tests {
 
     #[test]
     fn test_parse_rate_limits() {
-        let scoping = ItemScoping {
-            category: DataCategory::Unknown, // irrelevant for this test
+        let scoping = Scoping {
             organization_id: 42,
             project_id: ProjectId::new(21),
             public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -166,10 +166,12 @@ class OutcomesConsumer(ConsumerBase):
         assert outcome.error() is None
         return json.loads(outcome.value())
 
-    def assert_rate_limited(self, reason):
+    def assert_rate_limited(self, reason, key_id=None):
         outcome = self.get_outcome()
         assert outcome["outcome"] == 2, outcome
         assert outcome["reason"] == reason
+        if key_id is not None:
+            assert outcome["key_id"] == key_id
 
     def assert_dropped_internal(self):
         outcome = self.get_outcome()

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -347,8 +347,9 @@ def test_minidump_ratelimit(mini_sentry, relay_with_processing, outcomes_consume
     relay.wait_relay_healthcheck()
 
     project_config = mini_sentry.project_configs[42] = mini_sentry.full_project_config()
-    (key_config,) = project_config["publicKeys"]
-    key_config["quotas"] = [{"limit": 0, "reasonCode": "static_disabled_quota",}]
+    project_config["config"]["quotas"] = [
+        {"limit": 0, "reasonCode": "static_disabled_quota",}
+    ]
 
     outcomes_consumer = outcomes_consumer()
     attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content")]

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -39,9 +39,15 @@ def test_local_project_config(mini_sentry, relay):
     relay.config_dir.join("projects").join("42.json").write(
         json.dumps({"disabled": True})
     )
-    time.sleep(5)
+    time.sleep(2)
 
-    relay.send_event(42)
+    try:
+        # This may or may not respond with 403, depending on how quickly the future to fetch project
+        # states executes.
+        relay.send_event(42)
+    except HTTPError:
+        pass
+
     pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
 
 


### PR DESCRIPTION
Computes `Scoping` information (organization, project and key) in central places of request handling and passes it through the pipeline. This allows to emit the `key_id` outcome field. Scoping is now computed in the following places:

 - At the beginning of the web request, and then updated when getting project information.
 - At the beginning of envelope handling, and then upated when fetching full project config.
 - For smaller signatures, again in `EventProcessor::enforce_quotas`.

To facilitate this, scoping has been split into item-agnostic `Scoping` and specific `ItemScoping` for rate limiting.