### PR TITLE
doc(architecture): Add a disclaimer on outdated docs

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,3 +1,15 @@
 # Architecture
 
-This subsection contains internal docs that are useful for development and operation of Relay
+This subsection contains internal docs that are useful for development and
+operation of Relay.
+
+> **Important Note**: Relay is undergoing extensive internal restructuring. This
+> includes:
+>
+>  - The introduction of _Envelopes_ for event ingestion.
+>  - Updated rate limits to handle items different from each other.
+>  - Changes to the project configuration and fetching mechanism.
+>  - Optimizations in the rate limiting fast path.
+>
+> Once these changes are completed, this document will be updated with new
+> descriptions about event ingestion and the architecture.


### PR DESCRIPTION
Most of these docs seem redundant, as they are also described in code.
The code comments should be the source of truth, so most of these docs
can be removed. Due to the restructuring into separate crates, the docs
generated by `cargo doc` can be consumed better.