### PR TITLE
 ref(protocol): Rename unknown_error to unknown, step 1

### DIFF
--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -22,3 +22,4 @@ SPAN_STATUS_CODE_TO_NAME = {
 }
 
 SPAN_STATUS_NAME_TO_CODE = dict((v, k) for k, v in SPAN_STATUS_CODE_TO_NAME.items())
+SPAN_STATUS_NAME_TO_CODE['unknown'] = SPAN_STATUS_NAME_TO_CODE['unknown_error']

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -22,4 +22,4 @@ SPAN_STATUS_CODE_TO_NAME = {
 }
 
 SPAN_STATUS_NAME_TO_CODE = dict((v, k) for k, v in SPAN_STATUS_CODE_TO_NAME.items())
-SPAN_STATUS_NAME_TO_CODE['unknown'] = SPAN_STATUS_NAME_TO_CODE['unknown_error']
+SPAN_STATUS_NAME_TO_CODE["unknown"] = SPAN_STATUS_NAME_TO_CODE["unknown_error"]

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -524,7 +524,7 @@ impl fmt::Display for SpanStatus {
             SpanStatus::Unimplemented => write!(f, "unimplemented"),
             SpanStatus::Unavailable => write!(f, "unavailable"),
             SpanStatus::InternalError => write!(f, "internal_error"),
-            // TODO: Switch this to "unknown" once snuba is updated
+            // TODO: Switch this to "unknown" once snuba is updated on saas and singletenant
             SpanStatus::Unknown => write!(f, "unknown_error"),
             SpanStatus::Cancelled => write!(f, "cancelled"),
             SpanStatus::AlreadyExists => write!(f, "already_exists"),

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -404,7 +404,7 @@ pub enum SpanStatus {
     /// Unknown. Any non-standard HTTP status code.
     ///
     /// "We do not know whether the transaction failed or succeeded"
-    UnknownError = 2,
+    Unknown = 2,
 
     /// Client specified an invalid argument. 4xx.
     ///
@@ -499,7 +499,7 @@ impl FromStr for SpanStatus {
             "unavailable" => SpanStatus::Unavailable,
             "internal_error" => SpanStatus::InternalError,
             "failure" => SpanStatus::InternalError, // Backwards compat with initial schema
-            "unknown_error" => SpanStatus::UnknownError,
+            "unknown" | "unknown_error" => SpanStatus::Unknown,
             "cancelled" => SpanStatus::Cancelled,
             "already_exists" => SpanStatus::AlreadyExists,
             "failed_precondition" => SpanStatus::FailedPrecondition,
@@ -524,7 +524,8 @@ impl fmt::Display for SpanStatus {
             SpanStatus::Unimplemented => write!(f, "unimplemented"),
             SpanStatus::Unavailable => write!(f, "unavailable"),
             SpanStatus::InternalError => write!(f, "internal_error"),
-            SpanStatus::UnknownError => write!(f, "unknown_error"),
+            // TODO: Switch this to "unknown" once snuba is updated
+            SpanStatus::Unknown => write!(f, "unknown_error"),
             SpanStatus::Cancelled => write!(f, "cancelled"),
             SpanStatus::AlreadyExists => write!(f, "already_exists"),
             SpanStatus::FailedPrecondition => write!(f, "failed_precondition"),
@@ -550,7 +551,7 @@ impl FromValue for SpanStatus {
                 Some(match value {
                     0 => SpanStatus::Ok,
                     1 => SpanStatus::Cancelled,
-                    2 => SpanStatus::UnknownError,
+                    2 => SpanStatus::Unknown,
                     3 => SpanStatus::InvalidArgument,
                     4 => SpanStatus::DeadlineExceeded,
                     5 => SpanStatus::NotFound,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -655,7 +655,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         context
             .status
             .value_mut()
-            .get_or_insert(SpanStatus::UnknownError);
+            .get_or_insert(SpanStatus::Unknown);
         Ok(())
     }
 }


### PR DESCRIPTION
This still does not change the canonical output format but makes sure all mappings accept `unknown` as well. I will cut a release after this, bump the dependency in Snuba and create a follow-up PR to change the canonical format.