### PR TITLE
fix(pii): Complete builtin rules set

### DIFF
--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -144,10 +144,7 @@ declare_builtin_rules! {
     };
     "@mac:hash" => RuleSpec {
         ty: RuleType::Mac,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
     };
     "@mac:mask" => RuleSpec {
         ty: RuleType::Mac,

--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -4,11 +4,9 @@ use std::collections::BTreeMap;
 use lazy_static::lazy_static;
 
 use crate::pii::{
-    AliasRule, HashAlgorithm, HashRedaction, MaskRedaction, MultipleRule, PatternRule,
-    RedactPairRule, Redaction, ReplaceRedaction, RuleSpec, RuleType,
+    AliasRule, HashAlgorithm, HashRedaction, MaskRedaction, MultipleRule, PatternRule, Redaction,
+    ReplaceRedaction, RuleSpec, RuleType,
 };
-
-pub static BUILTIN_SELECTORS: &[&str] = &["text", "container"];
 
 macro_rules! declare_builtin_rules {
     ($($rule_id:expr => $spec:expr;)*) => {
@@ -83,16 +81,15 @@ declare_builtin_rules! {
     };
     "@anything:replace" => RuleSpec {
         ty: RuleType::Anything,
-        redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[redacted]".into(),
-        }),
+        redaction: Redaction::Replace(ReplaceRedaction::default()),
     };
     "@anything:hash" => RuleSpec {
         ty: RuleType::Anything,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@anything:mask" => RuleSpec {
+        ty: RuleType::Anything,
+        redaction: Redaction::Mask(MaskRedaction::default()),
     };
 
     // ip rules
@@ -105,10 +102,15 @@ declare_builtin_rules! {
     };
     "@ip:hash" => RuleSpec {
         ty: RuleType::Ip,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@ip:mask" => RuleSpec {
+        ty: RuleType::Ip,
+        redaction: Redaction::Mask(MaskRedaction::default()),
+    };
+    "@ip:remove" => RuleSpec {
+        ty: RuleType::Ip,
+        redaction: Redaction::Remove,
     };
 
     // imei rules
@@ -121,10 +123,15 @@ declare_builtin_rules! {
     };
     "@imei:hash" => RuleSpec {
         ty: RuleType::Imei,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@imei:mask" => RuleSpec {
+        ty: RuleType::Imei,
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@imei:remove" => RuleSpec {
+        ty: RuleType::Imei,
+        redaction: Redaction::Remove,
     };
 
     // mac rules
@@ -135,6 +142,13 @@ declare_builtin_rules! {
             text: "[mac]".into(),
         }),
     };
+    "@mac:hash" => RuleSpec {
+        ty: RuleType::Mac,
+        redaction: Redaction::Hash(HashRedaction {
+            algorithm: HashAlgorithm::HmacSha1,
+            key: None,
+        }),
+    };
     "@mac:mask" => RuleSpec {
         ty: RuleType::Mac,
         redaction: Redaction::Mask(MaskRedaction {
@@ -143,12 +157,9 @@ declare_builtin_rules! {
             range: (Some(9), None),
         }),
     };
-    "@mac:hash" => RuleSpec {
+    "@mac:remove" => RuleSpec {
         ty: RuleType::Mac,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Remove
     };
 
     // uuid rules
@@ -159,6 +170,10 @@ declare_builtin_rules! {
             text: "[uuid]".into(),
         }),
     };
+    "@uuid:hash" => RuleSpec {
+        ty: RuleType::Uuid,
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
     "@uuid:mask" => RuleSpec {
         ty: RuleType::Uuid,
         redaction: Redaction::Mask(MaskRedaction {
@@ -167,24 +182,13 @@ declare_builtin_rules! {
             range: (None, None),
         }),
     };
-    "@uuid:hash" => RuleSpec {
+    "@uuid:remove" => RuleSpec {
         ty: RuleType::Uuid,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Remove,
     };
 
     // email rules
     "@email" => rule_alias!("@email:replace");
-    "@email:mask" => RuleSpec {
-        ty: RuleType::Email,
-        redaction: Redaction::Mask(MaskRedaction {
-            mask_char: '*',
-            chars_to_ignore: ".@".into(),
-            range: (None, None),
-        }),
-    };
     "@email:replace" => RuleSpec {
         ty: RuleType::Email,
         redaction: Redaction::Replace(ReplaceRedaction {
@@ -193,14 +197,33 @@ declare_builtin_rules! {
     };
     "@email:hash" => RuleSpec {
         ty: RuleType::Email,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@email:mask" => RuleSpec {
+        ty: RuleType::Email,
+        redaction: Redaction::Mask(MaskRedaction {
+            mask_char: '*',
+            chars_to_ignore: ".@".into(),
+            range: (None, None),
         }),
+    };
+    "@email:remove" => RuleSpec {
+        ty: RuleType::Email,
+        redaction: Redaction::Remove,
     };
 
     // creditcard rules
     "@creditcard" => rule_alias!("@creditcard:replace");
+    "@creditcard:hash" => RuleSpec {
+        ty: RuleType::Creditcard,
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@creditcard:replace" => RuleSpec {
+        ty: RuleType::Creditcard,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[creditcard]".into(),
+        }),
+    };
     "@creditcard:mask" => RuleSpec {
         ty: RuleType::Creditcard,
         redaction: Redaction::Mask(MaskRedaction {
@@ -209,24 +232,15 @@ declare_builtin_rules! {
             range: (None, Some(-4)),
         }),
     };
-    "@creditcard:replace" => RuleSpec {
-        ty: RuleType::Creditcard,
-        redaction: Redaction::Replace(ReplaceRedaction {
-            text: "[creditcard]".into(),
-        }),
-    };
     "@creditcard:filter" => RuleSpec {
         ty: RuleType::Creditcard,
         redaction: Redaction::Replace(ReplaceRedaction {
             text: "[Filtered]".into(),
         }),
     };
-    "@creditcard:hash" => RuleSpec {
+    "@creditcard:remove" => RuleSpec {
         ty: RuleType::Creditcard,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Remove
     };
 
     // pem rules
@@ -245,10 +259,15 @@ declare_builtin_rules! {
     };
     "@pemkey:hash" => RuleSpec {
         ty: RuleType::Pemkey,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@pemkey:mask" => RuleSpec {
+        ty: RuleType::Pemkey,
+        redaction: Redaction::Mask(MaskRedaction::default()),
+    };
+    "@pemkey:remove" => RuleSpec {
+        ty: RuleType::Pemkey,
+        redaction: Redaction::Remove
     };
 
     // url secrets
@@ -259,6 +278,18 @@ declare_builtin_rules! {
             text: "[auth]".into(),
         }),
     };
+    "@urlauth:hash" => RuleSpec {
+        ty: RuleType::UrlAuth,
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@urlauth:mask" => RuleSpec {
+        ty: RuleType::UrlAuth,
+        redaction: Redaction::Mask(MaskRedaction::default()),
+    };
+    "@urlauth:remove" => RuleSpec {
+        ty: RuleType::UrlAuth,
+        redaction: Redaction::Remove,
+    };
     "@urlauth:legacy" => RuleSpec {
         ty: RuleType::Pattern(PatternRule {
             // Regex copied from legacy Sentry `URL_PASSWORD_RE`
@@ -267,13 +298,6 @@ declare_builtin_rules! {
         }),
         redaction: Redaction::Replace(ReplaceRedaction {
             text: "[Filtered]".into(),
-        }),
-    };
-    "@urlauth:hash" => RuleSpec {
-        ty: RuleType::UrlAuth,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
         }),
     };
 
@@ -301,10 +325,11 @@ declare_builtin_rules! {
     };
     "@usssn:hash" => RuleSpec {
         ty: RuleType::UsSsn,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@usssn:remove" => RuleSpec {
+        ty: RuleType::UsSsn,
+        redaction: Redaction::Remove,
     };
 
     // user path rules
@@ -315,28 +340,43 @@ declare_builtin_rules! {
             text: "[user]".into(),
         }),
     };
+    "@userpath:mask" => RuleSpec {
+        ty: RuleType::Userpath,
+        redaction: Redaction::Mask(MaskRedaction::default()),
+    };
     "@userpath:hash" => RuleSpec {
         ty: RuleType::Userpath,
-        redaction: Redaction::Hash(HashRedaction {
-            algorithm: HashAlgorithm::HmacSha1,
-            key: None,
-        }),
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@userpath:remove" => RuleSpec {
+        ty: RuleType::Userpath,
+        redaction: Redaction::Remove,
     };
 
     // password field removal
     "@password" => rule_alias!("@password:remove");
     "@password:filter" => RuleSpec {
-        ty: RuleType::RedactPair(RedactPairRule {
-            key_pattern: r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)".into(),
-        }),
+        ty: RuleType::Password,
         redaction: Redaction::Replace(ReplaceRedaction {
             text: "[Filtered]".into(),
         }),
     };
-    "@password:remove" => RuleSpec {
-        ty: RuleType::RedactPair(RedactPairRule {
-            key_pattern: r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)".into(),
+    "@password:hash" => RuleSpec {
+        ty: RuleType::Password,
+        redaction: Redaction::Hash(HashRedaction::default()),
+    };
+    "@password:replace" => RuleSpec {
+        ty: RuleType::Password,
+        redaction: Redaction::Replace(ReplaceRedaction {
+            text: "[password]".into(),
         }),
+    };
+    "@password:mask" => RuleSpec {
+        ty: RuleType::Password,
+        redaction: Redaction::Mask(MaskRedaction::default()),
+    };
+    "@password:remove" => RuleSpec {
+        ty: RuleType::Password,
         redaction: Redaction::Remove,
     };
 }
@@ -350,6 +390,8 @@ mod tests {
     use crate::pii::processor::PiiProcessor;
     use crate::processor::{process_value, ProcessingState, ValueType};
     use crate::types::{Annotated, Remark, RemarkType};
+
+    use super::{BUILTIN_RULES, BUILTIN_RULES_MAP};
 
     #[derive(Clone, Debug, PartialEq, Empty, FromValue, ProcessValue, ToValue)]
     struct FreeformRoot {
@@ -778,5 +820,35 @@ HdmUCGvfKiF2CodxyLon1XkK8pX+Ap86MbJhluqK
                 Remark::with_range(RemarkType::Pseudonymized, "@userpath:hash", (15, 55)),
             ];
         );
+    }
+
+    #[test]
+    fn test_builtin_rules_completeness() {
+        // Test that all combinations of ruletype and redactionmethod work, because that's what the
+        // UI assumes.
+        //
+        // Note: Keep these lists in sync with what is defined and exposed in the UI, not what we
+        // define internally.
+        for rule_type in &[
+            "creditcard",
+            "password",
+            "ip",
+            "imei",
+            "email",
+            "uuid",
+            "pemkey",
+            "urlauth",
+            "usssn",
+            "userpath",
+            "mac",
+            "anything",
+        ] {
+            for redaction_method in &["mask", "remove", "hash", "replace"] {
+                let key = format!("@{}:{}", rule_type, redaction_method);
+                println!("looking up {}", key);
+                assert!(BUILTIN_RULES.contains(&key.as_str()));
+                assert!(BUILTIN_RULES_MAP.contains_key(key.as_str()));
+            }
+        }
     }
 }

--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -132,6 +132,8 @@ pub enum RuleType {
     UrlAuth,
     /// US SSN.
     UsSsn,
+    /// Keys that look like passwords
+    Password,
     /// When a regex matches a key, a value is removed
     RedactPair(RedactPairRule),
     /// Applies multiple rules.
@@ -157,6 +159,7 @@ impl<'de> Deserialize<'de> for RuleType {
             Pemkey,
             UrlAuth,
             UsSsn,
+            Password,
             RedactPair(RedactPairRule),
             #[serde(rename = "redactPair")]
             RedactPairLegacy(RedactPairRule),
@@ -178,6 +181,7 @@ impl<'de> Deserialize<'de> for RuleType {
             RuleTypeWithLegacy::UrlAuth => RuleType::UrlAuth,
             RuleTypeWithLegacy::UsSsn => RuleType::UsSsn,
             RuleTypeWithLegacy::RedactPair(r) => RuleType::RedactPair(r),
+            RuleTypeWithLegacy::Password => RuleType::Password,
             RuleTypeWithLegacy::RedactPairLegacy(r) => RuleType::RedactPair(r),
             RuleTypeWithLegacy::Multiple(r) => RuleType::Multiple(r),
             RuleTypeWithLegacy::Alias(r) => RuleType::Alias(r),

--- a/relay-general/src/pii/mod.rs
+++ b/relay-general/src/pii/mod.rs
@@ -8,7 +8,7 @@ mod legacy;
 mod processor;
 mod redactions;
 
-pub use self::builtin::{BUILTIN_RULES, BUILTIN_SELECTORS};
+pub use self::builtin::BUILTIN_RULES;
 pub use self::compiledconfig::CompiledPiiConfig;
 pub use self::config::{
     AliasRule, MultipleRule, Pattern, PatternRule, PiiConfig, RedactPairRule, RuleSpec, RuleType,

--- a/relay-general/src/pii/redactions.rs
+++ b/relay-general/src/pii/redactions.rs
@@ -26,17 +26,30 @@ fn default_mask_char() -> char {
     '*'
 }
 
+fn default_replace_text() -> String {
+    "[Filtered]".into()
+}
+
 /// Replaces a value with a specific string.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplaceRedaction {
     /// The replacement string.
+    #[serde(default = "default_replace_text")]
     pub text: String,
 }
 
 impl From<String> for ReplaceRedaction {
     fn from(text: String) -> ReplaceRedaction {
         ReplaceRedaction { text }
+    }
+}
+
+impl Default for ReplaceRedaction {
+    fn default() -> Self {
+        ReplaceRedaction {
+            text: default_replace_text(),
+        }
     }
 }
 
@@ -55,6 +68,16 @@ pub struct MaskRedaction {
     pub range: (Option<i32>, Option<i32>),
 }
 
+impl Default for MaskRedaction {
+    fn default() -> Self {
+        MaskRedaction {
+            mask_char: default_mask_char(),
+            chars_to_ignore: String::new(),
+            range: (None, None),
+        }
+    }
+}
+
 /// Replaces the value with a hash
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -63,7 +86,17 @@ pub struct HashRedaction {
     #[serde(default)]
     pub algorithm: HashAlgorithm,
     /// The secret key (if not to use the default)
+    #[serde(default)]
     pub key: Option<String>,
+}
+
+impl Default for HashRedaction {
+    fn default() -> Self {
+        HashRedaction {
+            algorithm: HashAlgorithm::default(),
+            key: None,
+        }
+    }
 }
 
 /// Defines how replacements happen.

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__replace_debugmeta_path.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__replace_debugmeta_path.snap
@@ -7,7 +7,7 @@ expression: event
     "images": [
       {
         "code_id": "59b0d8f3183000",
-        "code_file": "[redacted]\\ntdll.dll",
+        "code_file": "[Filtered]\\ntdll.dll",
         "debug_id": "971f98e5-ce60-41ff-b2d7-235bbeb34578-1",
         "debug_file": "wntdll.pdb",
         "arch": "arm64",

--- a/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -191,9 +191,9 @@ request:
     - - ".AspNetCore.Antiforgery._2NlYY4B078"
       - CfDJ8ChafIEN-7pHv152tZrpaC_lvW7hdfN_EdO5t5Zh63rpzWqqsA5O2nEyfM5KDfb0QyrEiEK_I3phDQyTPdGKKImqEXWHWHjLJyUU8VRQNNsFvKgwyLiiOc1mDPNxlDbsXhWV44nuF4SzFe9gy9mm_g0
     - - wcsid
-      - "[redacted]"
+      - "[Filtered]"
     - - hblid
-      - "[redacted]"
+      - "[Filtered]"
     - - _okdetect
       - "{[ok detect token],\"proto\":\"http:\",\"host\":\"localhost:4040\"}"
     - - olfsk
@@ -220,13 +220,13 @@ request:
     - - Host
       - "localhost:62919"
     - - MS-ASPNETCORE-TOKEN
-      - "[redacted]"
+      - "[Filtered]"
     - - Origin
       - "http://localhost:62919"
     - - Referer
       - "http://localhost:62919/"
     - - User-Agent
-      - "[redacted]"
+      - "[Filtered]"
     - - X-Original-For
       - "127.0.0.1:50788"
     - - X-Original-Proto


### PR DESCRIPTION
* All combinations of rule types and redaction methods that we expose in the UI now actually work. This was an outstanding bug.
* Bring back `replace` with a default value for the replacement text.  The value for `@anything:replace` changes from `[redacted]` to `[Filtered]`, which is a change we can do because `replace` is not exposed to the user anyway.
* password has been promoted to a ruletype, this makes rule definitions simpler, deduplicates a regex and should make it easier to remove redactpair in the future.