### PR TITLE
fix(server): Require release for sessions

### DIFF
--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use lazy_static::lazy_static;
 
 use crate::pii::{
-    AliasRule, HashAlgorithm, HashRedaction, MaskRedaction, MultipleRule, PatternRule, Redaction,
+    AliasRule, HashRedaction, MaskRedaction, MultipleRule, PatternRule, Redaction,
     ReplaceRedaction, RuleSpec, RuleType,
 };
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -334,7 +334,7 @@ struct SessionKafkaMessage {
     duration: Option<f64>,
     status: SessionStatus,
     errors: u16,
-    release: Option<String>,
+    release: String,
     environment: Option<String>,
     retention_days: u16,
 }

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -139,6 +139,7 @@ def test_session_with_custom_retention(
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),
             "started": timestamp.isoformat(),
+            "attrs": {"release": "sentry-test@1.0.0"},
         },
     )
 
@@ -165,6 +166,7 @@ def test_session_age_discard(mini_sentry, relay_with_processing, sessions_consum
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),
             "started": started.isoformat(),
+            "attrs": {"release": "sentry-test@1.0.0"},
         },
     )
 


### PR DESCRIPTION
The `release` attribute in sessions is required for release health, so discard sessions that do not have it.