### PR TITLE
build(cloudbuild): Push images to Docker Hub too

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,12 +57,23 @@ steps:
     args: ['--help']
     id: "smoke test"
 
-  # Only tag "latest" when on master
   - name: 'gcr.io/cloud-builders/docker'
+    secretEnv: ['DOCKER_PASSWORD']
     entrypoint: 'bash'
     args:
+    - '-e'
     - '-c'
-    - '[[ "$BRANCH_NAME" == "master" ]] && docker push us.gcr.io/$PROJECT_ID/relay:latest || true'
+    - |
+      # Only push to Docker Hub from master
+      [ "$BRANCH_NAME" != "master" ] && exit 0
+      docker push us.gcr.io/$PROJECT_ID/relay:latest
+      echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
+      docker tag us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA getsentry/relay:$SHORT_SHA
+      docker push getsentry/relay:$SHORT_SHA
+      docker tag us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA getsentry/relay:$COMMIT_SHA
+      docker push getsentry/relay:$COMMIT_SHA
+      docker tag us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA getsentry/relay:latest
+      docker push getsentry/relay:latest
 
 images:
   [
@@ -73,3 +84,12 @@ timeout: 3600s
 options:
   # Run on bigger machines
   machineType: 'N1_HIGHCPU_8'
+secrets:
+- kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
+  secretEnv:
+    # This is a personal access token for the sentrybuilder account, encrypted using the
+    # short guide at http://bit.ly/2Pg6uw9
+    DOCKER_PASSWORD: |
+      CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
+      TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
+      QcMK


### PR DESCRIPTION
Ported from https://github.com/getsentry/symbolicator/blob/master/cloudbuild.yaml