### PR TITLE
ref(envelope): Remove "name" from envelope item headers

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -23,8 +23,7 @@ use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::project::{EventAction, GetEventAction, GetScoping};
 use crate::actors::project_cache::{GetProject, ProjectError};
 use crate::body::StorePayloadError;
-use crate::constants::ITEM_NAME_EVENT;
-use crate::envelope::{Envelope, EnvelopeError, ItemType, Items};
+use crate::envelope::{AttachmentType, Envelope, EnvelopeError, ItemType, Items};
 use crate::extractors::{RequestMeta, StartTime};
 use crate::metrics::RelayCounters;
 use crate::service::{ServiceApp, ServiceState};
@@ -256,7 +255,7 @@ pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreReq
 
     if let Some(item) = items
         .iter()
-        .find(|item| item.name() == Some(ITEM_NAME_EVENT))
+        .find(|item| item.attachment_type() == Some(AttachmentType::EventPayload))
     {
         if let Some(event_id) = event_id_from_msgpack(&item.payload())? {
             return Ok(Some(event_id));
@@ -295,6 +294,7 @@ pub fn cors(app: ServiceApp) -> CorsBuilder<ServiceState> {
             "authentication",
             "authorization",
             "content-encoding",
+            "transfer-encoding",
         ])
         .expose_headers(vec![
             "x-sentry-error",

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -39,6 +39,16 @@ fn validate_minidump(data: &[u8]) -> Result<(), BadStoreRequest> {
     Ok(())
 }
 
+fn infer_attachment_type(field_name: Option<&str>) -> AttachmentType {
+    match field_name.unwrap_or("") {
+        self::MINIDUMP_FIELD_NAME => AttachmentType::Minidump,
+        self::ITEM_NAME_BREADCRUMBS1 => AttachmentType::Breadcrumbs,
+        self::ITEM_NAME_BREADCRUMBS2 => AttachmentType::Breadcrumbs,
+        self::ITEM_NAME_EVENT => AttachmentType::EventPayload,
+        _ => AttachmentType::Attachment,
+    }
+}
+
 fn get_embedded_minidump(
     payload: Bytes,
     max_size: usize,
@@ -95,8 +105,7 @@ fn extract_envelope(
                 validate_minidump(&data)?;
 
                 let mut item = Item::new(ItemType::Attachment);
-                item.set_name(MINIDUMP_FIELD_NAME);
-                item.set_payload(ContentType::OctetStream, data);
+                item.set_payload(ContentType::Minidump, data);
                 item.set_filename(MINIDUMP_FILE_NAME);
                 item.set_attachment_type(AttachmentType::Minidump);
 
@@ -110,12 +119,13 @@ fn extract_envelope(
     }
 
     let future = MultipartItems::new(max_multipart_size)
+        .infer_attachment_type(infer_attachment_type)
         .handle_request(request)
         .map_err(BadStoreRequest::InvalidMultipart)
         .and_then(move |mut items| {
             let minidump_index = items
                 .iter()
-                .position(|item| item.name() == Some(MINIDUMP_FIELD_NAME));
+                .position(|item| item.attachment_type() == Some(AttachmentType::Minidump));
 
             let mut minidump_item = match minidump_index {
                 Some(index) => items.swap_remove(index),
@@ -140,15 +150,9 @@ fn extract_envelope(
             let future = get_embedded_minidump(minidump_item.payload(), max_single_size).and_then(
                 move |embedded_opt| {
                     if let Some(embedded) = embedded_opt {
-                        let content_type = minidump_item
-                            .content_type()
-                            .cloned()
-                            .unwrap_or(ContentType::OctetStream);
-
-                        minidump_item.set_payload(content_type, embedded);
+                        minidump_item.set_payload(ContentType::Minidump, embedded);
                     }
 
-                    minidump_item.set_attachment_type(AttachmentType::Minidump);
                     validate_minidump(&minidump_item.payload())?;
                     items.push(minidump_item);
 
@@ -162,18 +166,7 @@ fn extract_envelope(
             let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
             let mut envelope = Envelope::from_request(Some(event_id), meta);
 
-            for mut item in items {
-                let attachment_type = match item.name() {
-                    Some(self::ITEM_NAME_BREADCRUMBS1) => Some(AttachmentType::Breadcrumbs),
-                    Some(self::ITEM_NAME_BREADCRUMBS2) => Some(AttachmentType::Breadcrumbs),
-                    Some(self::ITEM_NAME_EVENT) => Some(AttachmentType::EventPayload),
-                    _ => None,
-                };
-
-                if let Some(ty) = attachment_type {
-                    item.set_attachment_type(ty);
-                }
-
+            for item in items {
                 envelope.add_item(item);
             }
 

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -33,13 +33,13 @@ pub fn expand_unreal_envelope(
 
     for file in crash.files() {
         let (content_type, attachment_type) = match file.ty() {
-            Unreal4FileType::Minidump => (ContentType::OctetStream, AttachmentType::Minidump),
+            Unreal4FileType::Minidump => (ContentType::Minidump, AttachmentType::Minidump),
             Unreal4FileType::AppleCrashReport => {
-                (ContentType::OctetStream, AttachmentType::AppleCrashReport)
+                (ContentType::Text, AttachmentType::AppleCrashReport)
             }
-            Unreal4FileType::Log => (ContentType::OctetStream, AttachmentType::UnrealLogs),
+            Unreal4FileType::Log => (ContentType::Text, AttachmentType::UnrealLogs),
             Unreal4FileType::Config => (ContentType::OctetStream, AttachmentType::Attachment),
-            Unreal4FileType::Context => (ContentType::OctetStream, AttachmentType::UnrealContext),
+            Unreal4FileType::Context => (ContentType::Xml, AttachmentType::UnrealContext),
             Unreal4FileType::Unknown => match file.name() {
                 self::ITEM_NAME_EVENT => (ContentType::MsgPack, AttachmentType::EventPayload),
                 self::ITEM_NAME_BREADCRUMBS1 => (ContentType::MsgPack, AttachmentType::Breadcrumbs),
@@ -49,7 +49,6 @@ pub fn expand_unreal_envelope(
         };
 
         let mut item = Item::new(ItemType::Attachment);
-        item.set_name(file.name());
         item.set_filename(file.name());
         item.set_payload(content_type, file.data());
         item.set_attachment_type(attachment_type);

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -31,8 +31,8 @@ def assert_only_minidump(envelope, assert_payload=True):
     for item in envelope.items:
         item_type = item.headers.get("type")
         if item_type == "attachment":
-            item_name = item.headers.get("name")
-            assert item_name == MINIDUMP_ATTACHMENT_NAME
+            attachment_type = item.headers.get("attachment_type")
+            assert attachment_type == "event.minidump"
             minidump_item = item
 
     assert_minidump(minidump_item, assert_payload=assert_payload)
@@ -114,11 +114,13 @@ def test_minidump_attachments(mini_sentry, relay):
         if item.headers.get("type") != "attachment":
             continue
 
-        name = item.headers.get("name")
-        if name == MINIDUMP_ATTACHMENT_NAME:
+        name = item.headers.get("filename")
+        if name == "minidump.dmp":
             minidump_item = item
-        elif name == "attachment1":
+            assert item.headers.get("attachment_type") == "event.minidump"
+        elif name == "attach1.txt":
             attachment_item = item
+            assert item.headers.get("attachment_type") == "event.attachment"
         else:
             raise AssertionError("Unexpected attachment")
 


### PR DESCRIPTION
Removes the `name` Item header as per updated spec. Relay should not have to rely on that, and instead infer an appropriate attachment type when parsing multipart requests.

`MultipartItems` now has a way to override the attachment type based on the field name.

cc @Swatinem since this was aligned with the Native SDK