### PR TITLE
feat(envelope): Introduce an item type for transactions

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -65,15 +65,16 @@ impl_str_serde!(EventId);
 
 /// The type of event we're dealing with.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum EventType {
-    Default,
     Error,
     Csp,
     Hpkp,
     ExpectCT,
     ExpectStaple,
     Transaction,
+    #[serde(other)]
+    Default,
 }
 
 /// An error used when parsing `EventType`.

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -218,15 +218,14 @@ impl<'a> NormalizeProcessor<'a> {
 
     /// Infers the `EventType` from the event's interfaces.
     fn infer_event_type(&self, event: &Event) -> EventType {
-        if let Some(ty) = event.ty.value() {
-            return *ty;
+        // The only exception are legacy SDKs send transactions as events. We still support this
+        // temporarily, until all SDKs have been updated to send Envelopes with explicit transaction
+        // items. This fallback is DEPRECATED.
+        if let Some(EventType::Transaction) = event.ty.value() {
+            return EventType::Transaction;
         }
 
-        // port of src/sentry/eventtypes
-        //
-        // the SDKs currently do not describe event types, and we must infer
-        // them from available attributes
-
+        // The SDKs do not describe event types, and we must infer them from available attributes.
         let has_exceptions = event
             .exceptions
             .value()

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -218,10 +218,10 @@ impl<'a> NormalizeProcessor<'a> {
 
     /// Infers the `EventType` from the event's interfaces.
     fn infer_event_type(&self, event: &Event) -> EventType {
-        // The only exception are legacy SDKs send transactions as events. We still support this
-        // temporarily, until all SDKs have been updated to send Envelopes with explicit transaction
-        // items. This fallback is DEPRECATED.
-        if let Some(EventType::Transaction) = event.ty.value() {
+        // The event type may be set explicitly when constructing the event items from specific
+        // items. This is DEPRECATED, and each distinct event type may get its own base class. For
+        // the time being, this is only implemented for transactions, so be specific:
+        if event.ty.value() == Some(&EventType::Transaction) {
             return EventType::Transaction;
         }
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -325,9 +325,10 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
 
     for item in envelope.items() {
         match item.ty() {
-            ItemType::Event | ItemType::SecurityReport | ItemType::FormData => {
-                event_size += item.len()
-            }
+            ItemType::Event
+            | ItemType::Transaction
+            | ItemType::SecurityReport
+            | ItemType::FormData => event_size += item.len(),
             ItemType::Attachment | ItemType::UnrealReport => {
                 if item.len() > config.max_attachment_size() {
                     return false;

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -2,11 +2,11 @@
 
 use actix::prelude::*;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use futures::Future;
 use serde::Serialize;
 
-use relay_general::protocol::EventId;
+use relay_general::protocol::{EventId, EventType};
 
 use crate::body::StoreBody;
 use crate::endpoints::common::{self, BadStoreRequest};
@@ -19,6 +19,64 @@ use crate::service::{ServiceApp, ServiceState};
 static PIXEL: &[u8] =
     b"GIF89a\x01\x00\x01\x00\x00\xff\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x00;";
 
+/// Parses a full `Envelope` request body.
+fn parse_envelope(meta: RequestMeta, data: Bytes) -> Result<Envelope, BadStoreRequest> {
+    // Use `parse_request` here to ensure that we're merging available request headers into the
+    // envelope's headers.
+    Envelope::parse_request(data, meta).map_err(BadStoreRequest::InvalidEnvelope)
+}
+
+/// Parses a JSON event body into an `Envelope`.
+fn parse_event(
+    meta: RequestMeta,
+    content_type: String,
+    mut data: Bytes,
+) -> Result<Envelope, BadStoreRequest> {
+    // Python clients are well known to send crappy JSON in the Sentry world.  The reason
+    // for this is that they send NaN and Infinity as invalid JSON tokens.  The code sentry
+    // server could deal with this but we cannot.  To work around this issue, we run a basic
+    // character substitution on the input stream but only if we detect a Python agent.
+    //
+    // This is done here so that the rest of the code can assume valid JSON.
+    let is_legacy_python_json = meta.client().map_or(false, |agent| {
+        agent.starts_with("raven-python/") || agent.starts_with("sentry-python/")
+    });
+
+    if is_legacy_python_json {
+        let mut data_mut = BytesMut::from(data);
+        json_forensics::translate_slice(&mut data_mut[..]);
+        data = data_mut.freeze();
+    }
+
+    // Ensure that the event has a UUID. It will be returned from this message and from the
+    // incoming store request. To uncouple it from the workload on the processing workers, this
+    // requires to synchronously parse a minimal part of the JSON payload. If the JSON payload
+    // is invalid, processing can be skipped altogether.
+    let minimal = common::minimal_event_from_json(&data)?;
+
+    // Use the request's content type. If the content type is missing, assume "application/json".
+    let content_type = match &content_type {
+        ct if ct.is_empty() => ContentType::Json,
+        _ct => ContentType::from(content_type),
+    };
+
+    // Old SDKs used to send transactions to the store endpoint with an explicit `Transaction` event
+    // type. The processing queue expects those in an explicit item.
+    let item_type = match minimal.ty {
+        EventType::Transaction => ItemType::Transaction,
+        _ => ItemType::Event,
+    };
+
+    let mut event_item = Item::new(item_type);
+    event_item.set_payload(content_type, data);
+
+    let event_id = minimal.id.unwrap_or_else(EventId::new);
+    let mut envelope = Envelope::from_request(Some(event_id), meta);
+    envelope.add_item(event_item);
+
+    Ok(envelope)
+}
+
 fn extract_envelope(
     request: &HttpRequest<ServiceState>,
     meta: RequestMeta,
@@ -28,54 +86,15 @@ fn extract_envelope(
 
     let future = StoreBody::new(&request, max_payload_size)
         .map_err(BadStoreRequest::PayloadError)
-        .and_then(move |mut data| {
+        .and_then(move |data| {
             if data.is_empty() {
                 return Err(BadStoreRequest::EmptyBody);
             }
 
-            // Clients may send full envelopes to /store. In this case, just parse the envelope and assume
-            // that it has sufficient headers. However, we're using `parse_request` here to ensure that
-            // we're merging available request headers into the envelope's headers.
-            if content_type == envelope::CONTENT_TYPE {
-                return Envelope::parse_request(data, meta)
-                    .map_err(BadStoreRequest::InvalidEnvelope);
+            match content_type.as_str() {
+                envelope::CONTENT_TYPE => parse_envelope(meta, data),
+                _ => parse_event(meta, content_type, data),
             }
-
-            // Python clients are well known to send crappy JSON in the Sentry world.  The reason
-            // for this is that they send NaN and Infinity as invalid JSON tokens.  The code sentry
-            // server could deal with this but we cannot.  To work around this issue, we run a basic
-            // character substitution on the input stream but only if we detect a Python agent.
-            //
-            // This is done here so that the rest of the code can assume valid JSON.
-            let is_legacy_python_json = meta.client().map_or(false, |agent| {
-                agent.starts_with("raven-python/") || agent.starts_with("sentry-python/")
-            });
-
-            if is_legacy_python_json {
-                let mut data_mut = BytesMut::from(data);
-                json_forensics::translate_slice(&mut data_mut[..]);
-                data = data_mut.freeze();
-            }
-
-            // Ensure that the event has a UUID. It will be returned from this message and from the
-            // incoming store request. To uncouple it from the workload on the processing workers, this
-            // requires to synchronously parse a minimal part of the JSON payload. If the JSON payload
-            // is invalid, processing can be skipped altogether.
-            let event_id = common::event_id_from_json(&data)?.unwrap_or_else(EventId::new);
-
-            // Use the request's content type. If the content type is missing, assume "application/json".
-            let content_type = match &content_type {
-                ct if ct.is_empty() => ContentType::Json,
-                _ct => ContentType::from(content_type),
-            };
-
-            let mut event_item = Item::new(ItemType::Event);
-            event_item.set_payload(content_type, data);
-
-            let mut envelope = Envelope::from_request(Some(event_id), meta);
-            envelope.add_item(event_item);
-
-            Ok(envelope)
         });
 
     Box::new(future)


### PR DESCRIPTION
Introduces a transaction item type to envelopes and ensures that it is used consistently.

This made the `event_type` item header obsolete, since it's now no longer needed to determine the appropriate action for storing an event.

When ingesting envelopes, it is assumed that the event comes in an `Event` item and transactions come in `transaction` item. To enforce this, the event_type is overridden, when retrieving items from the envelope. In normalization, the transaction event type is then left in place.

The store endpoint needs to be more lenient, however. It checks for the event type in the JSON payload and puts the event into an appropriate item.