### PR TITLE
fix(server): Return status code 415 on wrong content type

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -44,6 +44,9 @@ pub enum BadStoreRequest {
     #[fail(display = "empty request body")]
     EmptyBody,
 
+    #[fail(display = "unsupported content type, expected {}", _0)]
+    InvalidContentType(&'static str),
+
     #[fail(display = "invalid JSON data")]
     InvalidJson(#[cause] serde_json::Error),
 
@@ -93,6 +96,7 @@ impl BadStoreRequest {
             }
 
             BadStoreRequest::EmptyBody => Outcome::Invalid(DiscardReason::NoData),
+            BadStoreRequest::InvalidContentType(_) => Outcome::Invalid(DiscardReason::ContentType),
             BadStoreRequest::InvalidJson(_) => Outcome::Invalid(DiscardReason::InvalidJson),
             BadStoreRequest::InvalidMsgpack(_) => Outcome::Invalid(DiscardReason::InvalidMsgpack),
             BadStoreRequest::InvalidMultipart(_) => {
@@ -179,6 +183,9 @@ impl ResponseError for BadStoreRequest {
             }
             BadStoreRequest::PayloadError(StorePayloadError::Overflow) => {
                 HttpResponse::PayloadTooLarge().json(&body)
+            }
+            BadStoreRequest::InvalidContentType(_) => {
+                HttpResponse::UnsupportedMediaType().json(&body)
             }
             _ => {
                 // In all other cases, we indicate a generic bad request to the client and render

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -1,15 +1,15 @@
 //! Handles envelope store requests.
 
 use actix::prelude::*;
-use actix_web::{pred, HttpRequest, HttpResponse};
-use futures::Future;
+use actix_web::{HttpMessage, HttpRequest, HttpResponse};
+use futures::{future, Future};
 use serde::Serialize;
 
 use relay_general::protocol::EventId;
 
 use crate::body::StoreBody;
 use crate::endpoints::common::{self, BadStoreRequest};
-use crate::envelope::{self, Envelope};
+use crate::envelope::{self, ContentType, Envelope};
 use crate::extractors::{RequestMeta, StartTime};
 use crate::service::{ServiceApp, ServiceState};
 
@@ -47,6 +47,12 @@ fn store_envelope(
     start_time: StartTime,
     request: HttpRequest<ServiceState>,
 ) -> ResponseFuture<HttpResponse, BadStoreRequest> {
+    if request.content_type() != ContentType::Envelope {
+        return Box::new(future::err(BadStoreRequest::InvalidContentType(
+            envelope::CONTENT_TYPE,
+        )));
+    }
+
     common::handle_store_like_request(
         meta,
         true,
@@ -61,9 +67,7 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
     common::cors(app)
         .resource(r"/api/{project:\d+}/envelope/", |r| {
             r.name("store-envelope");
-            r.post()
-                .filter(pred::Header("content-type", envelope::CONTENT_TYPE))
-                .with(store_envelope);
+            r.post().with(store_envelope);
         })
         .register()
 }

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -47,10 +47,12 @@ fn store_envelope(
     start_time: StartTime,
     request: HttpRequest<ServiceState>,
 ) -> ResponseFuture<HttpResponse, BadStoreRequest> {
-    if request.content_type() != ContentType::Envelope {
-        return Box::new(future::err(BadStoreRequest::InvalidContentType(
-            envelope::CONTENT_TYPE,
-        )));
+    let content_type = request.content_type();
+    if content_type != ContentType::Envelope {
+        return Box::new(future::err(BadStoreRequest::InvalidContentType {
+            provided: content_type.to_owned(),
+            accepted: envelope::CONTENT_TYPE,
+        }));
     }
 
     common::handle_store_like_request(


### PR DESCRIPTION
Predicate filters on the envelope endpoint cause `404` responses if the `content-type` requirement is not met. Instead of this, the endpoint now returns a more descriptive status code. 

Additionally, content types are compared case insensitive according to the standard.

cc @rhcarvalho 