### PR TITLE
feat(config): Add a configuration for the shutdown timeout

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -349,6 +349,8 @@ struct Limits {
     max_pending_connections: i32,
     /// The maximum number of open connections to Relay.
     max_connections: usize,
+    /// The maximum number of seconds to wait for pending events after receiving a shutdown signal.
+    shutdown_timeout: u64,
 }
 
 impl Default for Limits {
@@ -369,6 +371,7 @@ impl Default for Limits {
             max_connection_rate: 256,
             max_pending_connections: 2048,
             max_connections: 25_000,
+            shutdown_timeout: 10,
         }
     }
 }
@@ -1101,6 +1104,11 @@ impl Config {
     /// The maximum number of pending connects to Relay.
     pub fn max_pending_connections(&self) -> i32 {
         self.values.limits.max_pending_connections
+    }
+
+    /// The maximum number of seconds to wait for pending events after receiving a shutdown signal.
+    pub fn shutdown_timeout(&self) -> Duration {
+        Duration::from_secs(self.values.limits.shutdown_timeout)
     }
 
     /// Returns the number of cores to use for thread pools.

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -7,7 +7,7 @@ use futures::prelude::*;
 
 use relay_config::{Config, RelayMode};
 
-use crate::actors::controller::{Controller, Shutdown, Subscribe};
+use crate::actors::controller::{Controller, Shutdown};
 use crate::actors::upstream::{IsAuthenticated, UpstreamRelay};
 
 pub struct Healthcheck {
@@ -30,7 +30,7 @@ impl Actor for Healthcheck {
     type Context = Context<Self>;
 
     fn started(&mut self, context: &mut Self::Context) {
-        Controller::from_registry().do_send(Subscribe(context.address().recipient()));
+        Controller::subscribe(context.address());
     }
 }
 

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -5,7 +5,7 @@ use futures::prelude::*;
 use relay_common::metric;
 use relay_config::Config;
 
-use crate::actors::controller::{Controller, Shutdown, Subscribe};
+use crate::actors::controller::{Controller, Shutdown};
 use crate::metrics::RelayCounters;
 use crate::service;
 
@@ -27,7 +27,7 @@ impl Actor for Server {
     type Context = Context<Self>;
 
     fn started(&mut self, context: &mut Self::Context) {
-        Controller::from_registry().do_send(Subscribe(context.address().recipient()));
+        Controller::subscribe(context.address());
     }
 }
 

--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -1,8 +1,5 @@
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
 
-/// Shutdown timeout before killing all tasks and dropping queued events.
-pub const SHUTDOWN_TIMEOUT: u16 = 10;
-
 /// Name of the event attachment.
 ///
 /// This is a special attachment that can contain a sentry event payload encoded as message pack.


### PR DESCRIPTION
The shutdown timeout introduces an unconditional delay after receiving the shutdown signal. To configure this, a `shutdown_timeout` option is introduced now that can be overridden in the config.

To achieve this, the `Controller` had to be made configurable. Since it is a `SystemService`, it needs to retain a `Default` impl, which now contains no timeout. When starting the service, the default from the config is filled in.

Along with this goes a small refactor of the `Subscribe` message. Since the usual pattern is always the same, there is now a shorthand `Controller::subscribe(Addr)`.

Ref https://github.com/getsentry/sentry/pull/18426