### PR TITLE
fix(cli): Gen-creds should not try to read existing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,7 +110,10 @@ pub fn extract_config_env_vars() -> OverridableConfig {
 pub fn manage_credentials<'a>(mut config: Config, matches: &ArgMatches<'a>) -> Result<(), Error> {
     // generate completely new credentials
     if let Some(matches) = matches.subcommand_matches("generate") {
-        if config.has_credentials() && !matches.is_present("overwrite") {
+        if !matches.is_present("stdout")
+            && !matches.is_present("overwrite")
+            && config.has_credentials()
+        {
             return Err(err_msg(
                 "aborting because credentials already exist. Pass --overwrite to force.",
             ));


### PR DESCRIPTION
When `--stdout` is passed `generate credentials` still try to read the existing credentials and complain if they exist, requiring `--overwrite` to be passed and failing if the file is not readable. This should not happen with `--stdout` as there's no chance of accidental data loss.