### PR TITLE
ref(server): Remove envelope content-type validation

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -44,12 +44,6 @@ pub enum BadStoreRequest {
     #[fail(display = "empty request body")]
     EmptyBody,
 
-    #[fail(display = "unsupported content type '{}', expected '{}'", _0, _1)]
-    InvalidContentType {
-        provided: String,
-        accepted: &'static str,
-    },
-
     #[fail(display = "invalid JSON data")]
     InvalidJson(#[cause] serde_json::Error),
 
@@ -99,9 +93,6 @@ impl BadStoreRequest {
             }
 
             BadStoreRequest::EmptyBody => Outcome::Invalid(DiscardReason::NoData),
-            BadStoreRequest::InvalidContentType { .. } => {
-                Outcome::Invalid(DiscardReason::ContentType)
-            }
             BadStoreRequest::InvalidJson(_) => Outcome::Invalid(DiscardReason::InvalidJson),
             BadStoreRequest::InvalidMsgpack(_) => Outcome::Invalid(DiscardReason::InvalidMsgpack),
             BadStoreRequest::InvalidMultipart(_) => {
@@ -188,9 +179,6 @@ impl ResponseError for BadStoreRequest {
             }
             BadStoreRequest::PayloadError(StorePayloadError::Overflow) => {
                 HttpResponse::PayloadTooLarge().json(&body)
-            }
-            BadStoreRequest::InvalidContentType { .. } => {
-                HttpResponse::UnsupportedMediaType().json(&body)
             }
             _ => {
                 // In all other cases, we indicate a generic bad request to the client and render

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -1,15 +1,15 @@
 //! Handles envelope store requests.
 
 use actix::prelude::*;
-use actix_web::{HttpMessage, HttpRequest, HttpResponse};
-use futures::{future, Future};
+use actix_web::{HttpRequest, HttpResponse};
+use futures::Future;
 use serde::Serialize;
 
 use relay_general::protocol::EventId;
 
 use crate::body::StoreBody;
 use crate::endpoints::common::{self, BadStoreRequest};
-use crate::envelope::{self, ContentType, Envelope};
+use crate::envelope::Envelope;
 use crate::extractors::{RequestMeta, StartTime};
 use crate::service::{ServiceApp, ServiceState};
 
@@ -47,14 +47,6 @@ fn store_envelope(
     start_time: StartTime,
     request: HttpRequest<ServiceState>,
 ) -> ResponseFuture<HttpResponse, BadStoreRequest> {
-    let content_type = request.content_type();
-    if !content_type.is_empty() && content_type != ContentType::Envelope {
-        return Box::new(future::err(BadStoreRequest::InvalidContentType {
-            provided: content_type.to_owned(),
-            accepted: envelope::CONTENT_TYPE,
-        }));
-    }
-
     common::handle_store_like_request(
         meta,
         true,

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -48,7 +48,7 @@ fn store_envelope(
     request: HttpRequest<ServiceState>,
 ) -> ResponseFuture<HttpResponse, BadStoreRequest> {
     let content_type = request.content_type();
-    if content_type != ContentType::Envelope {
+    if !content_type.is_empty() && content_type != ContentType::Envelope {
         return Box::new(future::err(BadStoreRequest::InvalidContentType {
             provided: content_type.to_owned(),
             accepted: envelope::CONTENT_TYPE,


### PR DESCRIPTION
This allows browser SDKs to send envelopes without a preflight request.