### PR TITLE
docs(docker): Prefer Docker Hub for the image

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,12 +42,12 @@ If you moved your config folder somewhere else, you can use the `--config` optio
 
 ### Running in Docker
 
-Docker image for `relay` can be found at `us.gcr.io/sentryio/relay`.
+Docker image for `relay` can be found at [`getsentry/relay`](https://hub.docker.com/r/getsentry/relay/).
 
 For example, you can start the latest version of `relay` as follows:
 
 ```sh
-docker run -v $(pwd)/configs/:/etc/relay/ us.gcr.io/sentryio/relay run --config /etc/relay
+docker run -v $(pwd)/configs/:/etc/relay/ getsentry/relay run --config /etc/relay
 ```
 
 The command assumes that Relay's configuration (`config.yml` and


### PR DESCRIPTION
Switch from `us.gcr.io/sentryio/relay` to `getsentry/relay` for the Docker image as Docker Hub is more available around the world and easier to maintain with all our tags.

This is a follow up to https://github.com/getsentry/onpremise/pull/462#issuecomment-623071425