### PR TITLE
test(integration): Simulate proper auth in publickey tests

### DIFF
--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -44,7 +44,7 @@ class Relay(SentryLike):
 
 @pytest.fixture
 def relay(tmpdir, mini_sentry, request, random_port, background_process, config_dir):
-    def inner(upstream, options=None, prepare=None):
+    def inner(upstream, options=None, prepare=None, external=None):
         host = "127.0.0.1"
         port = random_port()
 
@@ -102,6 +102,11 @@ def relay(tmpdir, mini_sentry, request, random_port, background_process, config_
 
         assert public_key
         assert relay_id
+
+        mini_sentry.known_relays[relay_id] = {
+            "publicKey": public_key,
+            "internal": not external,
+        }
 
         return Relay(
             (host, port), process, upstream, public_key, relay_id, dir, default_opts


### PR DESCRIPTION
When creating a `relay()`, we tell `mini_sentry` about that Relay, and then check for the `internal` flag, as to whether that Relay has access to a certain project config. A test with 3 Relays verifies this behavior:

```
Relay3  -->  Relay2  -->  Relay1  -->  Sentry

> Request project state
             > Verify Relay 3 key
                          > Verify Relay 2 key
                                       > Verify Relay 1
                                       > Verify Relay 2
                                       < Respond with Relay 2
                          > Verify Relay 3
                                       > Verify Relay 3
                                       < Respond with Relay 3
                          < Respond with Relay 3
             > Get project
                          > Get project
                                       > Check Relay1 access
                                       < Respond with project
                          > Check Relay2 access
                          < Respond with project
             > Check Relay 3 access
             < Respond with project
> Process event
...
```