### PR TITLE
feat: Bump release parser to 0.5.0

### DIFF
--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -208,14 +208,12 @@ def test_parse_release():
     assert parsed == {
         "build_hash": None,
         "description": "1.0-rc1 (20200101100)",
-        "format": "qualified_versioned",
         "package": "org.example.FooApp",
         "version_parsed": {
             "build_code": "20200101100",
             "components": 2,
             "major": 1,
             "minor": 0,
-            "normalized_build_code": "02020010110000000000000000000000",
             "patch": 0,
             "pre": "rc1",
         },

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -207,11 +207,12 @@ def test_parse_release():
     parsed = sentry_relay.parse_release("org.example.FooApp@1.0rc1+20200101100")
     assert parsed == {
         "build_hash": None,
-        "description": "1.0.0-rc1 (20200101100)",
+        "description": "1.0-rc1 (20200101100)",
         "format": "qualified_versioned",
         "package": "org.example.FooApp",
         "version_parsed": {
             "build_code": "20200101100",
+            "components": 2,
             "major": 1,
             "minor": 0,
             "normalized_build_code": "02020010110000000000000000000000",

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -29,4 +29,4 @@ serde_json = "1.0.40"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
 relay-general = { path = "../relay-general" }
-sentry-release-parser = { version = "0.3.1", features = ["serde"] }
+sentry-release-parser = { version = "0.5.0", features = ["serde"] }


### PR DESCRIPTION
This bumps the release parser to 0.5.0.  This adds support for telling `1.0.0`
apart from `1.0`.  See also https://github.com/getsentry/sentry-release-parser/pull/4