### PR TITLE
feat: Set default transaction name

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -227,7 +227,7 @@ pub struct Event {
     pub culprit: Annotated<String>,
 
     /// Transaction name of the event.
-    #[metastructure(max_chars = "culprit")]
+    #[metastructure(max_chars = "culprit", trim_whitespace = "true")]
     pub transaction: Annotated<String>,
 
     /// Time since the start of the transaction until the error occurred.

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -198,7 +198,7 @@ mod tests {
     fn new_test_event() -> Annotated<Event> {
         let start = Utc.ymd(2000, 1, 1).and_hms(0, 0, 0);
         let end = Utc.ymd(2000, 1, 1).and_hms(0, 0, 10);
-        return Annotated::new(Event {
+        Annotated::new(Event {
             ty: Annotated::new(EventType::Transaction),
             transaction: Annotated::new("/".to_owned()),
             start_timestamp: Annotated::new(start),

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -41,7 +41,9 @@ impl Processor for TransactionsProcessor {
         // SDKs should avoid sending empty transaction names, setting a more contextual default
         // value when possible.
         if event.transaction.value().map_or(true, |s| s.is_empty()) {
-            event.transaction = Annotated::new("<unlabeled transaction>".to_owned())
+            event
+                .transaction
+                .set_value(Some("<unlabeled transaction>".to_owned()))
         }
 
         match (event.start_timestamp.value(), event.timestamp.value_mut()) {
@@ -227,7 +229,7 @@ mod tests {
                 ..Default::default()
             })]),
             ..Default::default()
-        });
+        })
     }
 
     #[test]

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -35,6 +35,15 @@ impl Processor for TransactionsProcessor {
             return Ok(());
         }
 
+        // The transaction name is expected to be non-empty by downstream services (e.g. Snuba), but
+        // Relay doesn't reject events missing the transaction name. Instead, a default transaction
+        // name is given, similar to how Sentry gives an "<unlabeled event>" title to error events.
+        // SDKs should avoid sending empty transaction names, setting a more contextual default
+        // value when possible.
+        if event.transaction.value().map_or(true, |s| s.is_empty()) {
+            event.transaction = Annotated::new("<unlabeled transaction>".to_owned())
+        }
+
         match (event.start_timestamp.value(), event.timestamp.value_mut()) {
             (Some(start), Some(end)) => {
                 if *end < *start {
@@ -185,6 +194,41 @@ mod tests {
     use crate::processor::process_value;
     use crate::protocol::{Contexts, SpanId, TraceContext, TraceId};
     use crate::types::Object;
+
+    fn new_test_event() -> Annotated<Event> {
+        let start = Utc.ymd(2000, 1, 1).and_hms(0, 0, 0);
+        let end = Utc.ymd(2000, 1, 1).and_hms(0, 0, 10);
+        return Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("/".to_owned()),
+            start_timestamp: Annotated::new(start),
+            timestamp: Annotated::new(end),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert(
+                    "trace".to_owned(),
+                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
+                        trace_id: Annotated::new(TraceId(
+                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
+                        )),
+                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                        op: Annotated::new("http.server".to_owned()),
+                        ..Default::default()
+                    })))),
+                );
+                contexts
+            })),
+            spans: Annotated::new(vec![Annotated::new(Span {
+                start_timestamp: Annotated::new(start),
+                timestamp: Annotated::new(end),
+                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                op: Annotated::new("db.statement".to_owned()),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+    }
 
     #[test]
     fn test_skips_non_transaction_events() {
@@ -378,6 +422,7 @@ mod tests {
 
         let mut event = Annotated::new(Event {
             ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("/".to_owned()),
             timestamp: Annotated::new(end),
             start_timestamp: Annotated::new(start),
             contexts: Annotated::new(Contexts({
@@ -404,6 +449,7 @@ mod tests {
         assert_annotated_snapshot!(event, @r###"
         {
           "type": "transaction",
+          "transaction": "/",
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -691,6 +737,7 @@ mod tests {
 
         let mut event = Annotated::new(Event {
             ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("/".to_owned()),
             timestamp: Annotated::new(end),
             start_timestamp: Annotated::new(start),
             contexts: Annotated::new(Contexts({
@@ -726,6 +773,7 @@ mod tests {
         assert_annotated_snapshot!(event, @r###"
         {
           "type": "transaction",
+          "transaction": "/",
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -751,44 +799,39 @@ mod tests {
 
     #[test]
     fn test_allows_valid_transaction_event_with_spans() {
-        let mut event = Annotated::new(Event {
-            ty: Annotated::new(EventType::Transaction),
-            timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
-            start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
-            contexts: Annotated::new(Contexts({
-                let mut contexts = Object::new();
-                contexts.insert(
-                    "trace".to_owned(),
-                    Annotated::new(ContextInner(Context::Trace(Box::new(TraceContext {
-                        trace_id: Annotated::new(TraceId(
-                            "4c79f60c11214eb38604f4ae0781bfb2".into(),
-                        )),
-                        span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
-                        op: Annotated::new("http.server".to_owned()),
-                        ..Default::default()
-                    })))),
-                );
-                contexts
-            })),
-            spans: Annotated::new(vec![Annotated::new(Span {
-                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
-                start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
-                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
-                span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
-                op: Annotated::new("db.statement".to_owned()),
-                ..Default::default()
-            })]),
-            ..Default::default()
-        });
+        let mut event = new_test_event();
+        let end = *event.value().unwrap().timestamp.value().unwrap();
 
-        process_value(
-            &mut event,
-            &mut TransactionsProcessor::new(None),
-            ProcessingState::root(),
-        )
-        .unwrap();
+        let mut processor = TransactionsProcessor::new(None);
+        processor.now = end;
 
-        assert!(event.value().is_some());
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+        assert_annotated_snapshot!(event, @r###"
+        {
+          "type": "transaction",
+          "transaction": "/",
+          "timestamp": 946684810.0,
+          "start_timestamp": 946684800.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "http.server",
+              "type": "trace"
+            }
+          },
+          "spans": [
+            {
+              "timestamp": 946684810.0,
+              "start_timestamp": 946684800.0,
+              "op": "db.statement",
+              "span_id": "fa90fdead5f74053",
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2"
+            }
+          ]
+        }
+        "###);
     }
 
     #[test]
@@ -870,5 +913,93 @@ mod tests {
             *event.value().unwrap().start_timestamp.value().unwrap(),
             end
         ); // shift by 1 day == end
+    }
+
+    #[test]
+    fn test_defaults_transaction_name_when_missing() {
+        let mut event = new_test_event();
+        let end = *event.value().unwrap().timestamp.value().unwrap();
+
+        event
+            .apply(|event, _| {
+                event.transaction.set_value(None);
+                Ok(())
+            })
+            .unwrap();
+
+        let mut processor = TransactionsProcessor::new(None);
+        processor.now = end;
+
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+        assert_annotated_snapshot!(event, @r###"
+        {
+          "type": "transaction",
+          "transaction": "<unlabeled transaction>",
+          "timestamp": 946684810.0,
+          "start_timestamp": 946684800.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "http.server",
+              "type": "trace"
+            }
+          },
+          "spans": [
+            {
+              "timestamp": 946684810.0,
+              "start_timestamp": 946684800.0,
+              "op": "db.statement",
+              "span_id": "fa90fdead5f74053",
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2"
+            }
+          ]
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_defaults_transaction_name_when_empty() {
+        let mut event = new_test_event();
+        let end = *event.value().unwrap().timestamp.value().unwrap();
+
+        event
+            .apply(|event, _| {
+                event.transaction.set_value(Some("".to_owned()));
+                Ok(())
+            })
+            .unwrap();
+
+        let mut processor = TransactionsProcessor::new(None);
+        processor.now = end;
+
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+        assert_annotated_snapshot!(event, @r###"
+        {
+          "type": "transaction",
+          "transaction": "<unlabeled transaction>",
+          "timestamp": 946684810.0,
+          "start_timestamp": 946684800.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "http.server",
+              "type": "trace"
+            }
+          },
+          "spans": [
+            {
+              "timestamp": 946684810.0,
+              "start_timestamp": 946684800.0,
+              "op": "db.statement",
+              "span_id": "fa90fdead5f74053",
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2"
+            }
+          ]
+        }
+        "###);
     }
 }


### PR DESCRIPTION
Trim whitespace from transaction name and set a default name if the
transaction attribute is missing or is the empty string.

This fixes bad behavior in Snuba / Discover searches as transactions
without name are not searchable nor visible in the list of transactions,
and a more visible problem being no text in links in the Performance
view in the Sentry UI.