### PR TITLE
build(cargo): Ignore non-Rust folders for rebuilding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,21 @@ authors = ["Sentry <oss@sentry.io>"]
 description = "An proxy service for Sentry."
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"
-exclude = [".vscode/**/*", ".idea/**/*"]
 license-file = "./LICENSE"
 readme = "README.md"
 version = "0.5.9"
 edition = "2018"
 build = "build.rs"
 publish = false
+exclude = [
+    ".idea/**",
+    ".vscode/**",
+    "artwork/**",
+    "py/**",
+    "docs/**",
+    "scripts/**",
+    "tests/**",
+]
 
 [workspace]
 


### PR DESCRIPTION
Rebuild only if one of the source files of Relay changes. Updates to the integration tests, artwork, docs and scripts do not require to rebuild the binary. This helps to speed up iterations in testing.