### PR TITLE
feat(server): Apply clock-drift correction in proxy Relays

### DIFF
--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 backoff = "0.1.5"
 cadence = "0.17.1"
-chrono = { version = "0.4.7", optional = true }
+chrono = "0.4.7"
 failure = "0.1.5"
 globset = "0.4.4"
 lazy_static = "1.3.0"

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -9,7 +9,6 @@ pub fn instant_to_system_time(instant: Instant) -> SystemTime {
 }
 
 /// Converts an `Instant` into a `DateTime`.
-#[cfg(feature = "chrono")]
 pub fn instant_to_date_time(instant: Instant) -> chrono::DateTime<chrono::Utc> {
     instant_to_system_time(instant).into()
 }

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -19,7 +19,8 @@ mod schema;
 mod transactions;
 mod trimming;
 
-pub use crate::store::geo::{GeoIpError, GeoIpLookup};
+pub use self::clock_drift::ClockDriftProcessor;
+pub use self::geo::{GeoIpError, GeoIpLookup};
 
 /// The config for store.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -15,7 +15,6 @@ default = ["with_ssl"]
 with_ssl = ["native-tls", "actix-web/tls"]
 processing = [
     "rdkafka",
-    "relay-common/chrono",
     "relay-config/processing",
     "relay-quotas/rate-limiter",
     "relay-redis/impl",

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -697,7 +697,7 @@ impl EventProcessor {
             let client = envelope.meta().client().unwrap_or_default();
             if envelope.sent_at().is_none()
                 && event_type == Some(EventType::Transaction)
-                && client.starts_with("sentry-javascript/")
+                && client.starts_with("sentry.javascript")
             {
                 if let Some(&event_timestamp) = event.timestamp.value() {
                     envelope.set_sent_at(event_timestamp);

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -634,9 +634,13 @@ impl Envelope {
     }
 
     /// When the event has been sent, according to the SDK.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn sent_at(&self) -> Option<DateTime<Utc>> {
         self.headers.sent_at
+    }
+
+    /// Sets the timestamp at which an envelope is sent to the upstream.
+    pub fn set_sent_at(&mut self, sent_at: DateTime<Utc>) {
+        self.headers.sent_at = Some(sent_at);
     }
 
     /// Sets the data retention in days for items in this envelope.


### PR DESCRIPTION
Exposes the `ClockDriftProcessor` and applies it in non-processing mode. This allows for proper clock drift correction even when using proxy Relays that are in remote locations.

This also contains a workaround for the current experimental JavaScript SDK (versions `5.2` - `5.15`), which relies on clock drift correction without `sent_at`. In such a case, the `sent_at` value is inferred from the event's timestamp.