### PR TITLE
fix(server): Detect JavaScript SDKs for clock drift

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -694,7 +694,12 @@ impl EventProcessor {
             // TODO: Temporary workaround before processing. Experimental JavaScript SDKs relied on
             // a buggy clock drift correction that assumes the event timestamp is the sent_at date.
             // This should be removed as soon as JS has switched to Envelope-only ingestion.
-            let client = envelope.meta().client().unwrap_or_default();
+            let client = event
+                .client_sdk
+                .value()
+                .and_then(|sdk| sdk.name.as_str())
+                .unwrap_or("");
+
             if envelope.sent_at().is_none()
                 && event_type == Some(EventType::Transaction)
                 && client.starts_with("sentry.javascript")

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -691,19 +691,10 @@ impl EventProcessor {
             // event id. To be defensive, we always overwrite to ensure consistency.
             event.id = Annotated::new(event_id);
 
-            // TODO: Temporary workaround before processing. Experimental JavaScript SDKs relied on
-            // a buggy clock drift correction that assumes the event timestamp is the sent_at date.
-            // This should be removed as soon as JS has switched to Envelope-only ingestion.
-            let client = event
-                .client_sdk
-                .value()
-                .and_then(|sdk| sdk.name.as_str())
-                .unwrap_or("");
-
-            if envelope.sent_at().is_none()
-                && event_type == Some(EventType::Transaction)
-                && client.starts_with("sentry.javascript")
-            {
+            // TODO: Temporary workaround before processing. Experimental SDKs relied on a buggy
+            // clock drift correction that assumes the event timestamp is the sent_at time. This
+            // should be removed as soon as legacy ingestion has been removed.
+            if envelope.sent_at().is_none() && event_type == Some(EventType::Transaction) {
                 if let Some(&event_timestamp) = event.timestamp.value() {
                     envelope.set_sent_at(event_timestamp);
                 }


### PR DESCRIPTION
Turns out that browser SDKs don't send `sentry_client` in the first place, and we need to apply this logic to all legacy SDKs.