### PR TITLE
build: Prepare for CalVer releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 ---
-minVersion: "0.9.5"
+minVersion: "0.9.6"
 github:
   owner: getsentry
   repo: relay

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,11 +1,11 @@
 ---
-minVersion: "0.8.4"
+minVersion: "0.9.5"
 github:
   owner: getsentry
   repo: relay
 changelogPolicy: simple
+
 targets:
-  - name: pypi
   - name: github
   - name: gh-pages
   - name: registry
@@ -27,10 +27,6 @@ targets:
 
 requireNames:
   - /^gh-pages.zip$/
-  - /^sentry_relay-.*-py2.py3-none-macosx_10_13_x86_64.whl$/
-  - /^sentry_relay-.*-py2.py3-none-manylinux1_i686.whl$/
-  - /^sentry_relay-.*-py2.py3-none-manylinux1_x86_64.whl$/
-  - /^sentry-relay-.*.zip$/
   - /^relay-Darwin-x86_64$/
   - /^relay-Darwin-x86_64-dsym.zip$/
   - /^relay-Linux-x86_64$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
   only:
     - master
     - /^release\/[\d.]+$/
+    - /^release-library\/[\d.]+$/
 
 before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable}
@@ -27,17 +28,15 @@ jobs:
     # STATIC ANALYSIS
     # -------------------------------------
 
-    - name: "check: codestyle"
-      script: make -e style
-
-    - name: "check: lint"
-      script: make -e lint
+    - name: "check: lints"
+      script: make -e style lint
 
     # -------------------------------------
     # RUST TESTS
     # -------------------------------------
 
     - name: "test: relay[linux]"
+      if: NOT branch ~= /^release-library\/[\d.]+$/
       addons:
         apt:
           packages:
@@ -61,10 +60,12 @@ jobs:
     # -------------------------------------
 
     - name: "test: librelay"
+      if: NOT branch ~= /^release\/[\d.]+$/
       script: make -e test-python
 
     - name: "test: librelay[py2]"
       python: "2.7"
+      if: NOT branch ~= /^release\/[\d.]+$/
       script: make -e RELAY_PYTHON_VERSION=python2 test-python
 
     # -------------------------------------
@@ -72,6 +73,7 @@ jobs:
     # -------------------------------------
 
     - name: "integration-test: relay"
+      if: NOT branch ~= /^release-library\/[\d.]+$/
       env:
         - KAFKA_BOOTSTRAP_SERVER="localhost:9092"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,12 +118,17 @@ jobs:
         - zip -r relay-dsym.zip target/release/relay.dSYM
         - zeus upload -t "application/octet-stream" -n relay-Darwin-x86_64-dsym.zip relay-dsym.zip || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
+    - name: "release: docs"
+      if: branch ~= /^release\/[\d.]+$/
+      before_script: npm install -g @zeus-ci/cli
+      script: make -e travis-upload-prose-docs
+
     # -------------------------------------
     # PYTHON RELEASE BUILDS
     # -------------------------------------
 
     - name: "release: librelay[linux-x86]"
-      if: branch ~= /^release\/[\d.]+$/
+      if: branch ~= /^release-library\/[\d.]+$/
       env: BUILD_ARCH=i686
       language: generic
       script:
@@ -132,7 +137,7 @@ jobs:
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
     - name: "release: librelay[linux-x86_64]"
-      if: branch ~= /^release\/[\d.]+$/
+      if: branch ~= /^release-library\/[\d.]+$/
       env: BUILD_ARCH=x86_64
       language: generic
       script:
@@ -141,7 +146,7 @@ jobs:
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
     - name: "release: librelay[macos]"
-      if: branch ~= /^release\/[\d.]+$/
+      if: branch ~= /^release-library\/[\d.]+$/
       os: osx
       language: generic
       osx_image: xcode9.4
@@ -152,15 +157,11 @@ jobs:
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
 
     - name: "release: librelay[sdist]"
-      if: branch ~= /^release\/[\d.]+$/
+      if: branch ~= /^release-library\/[\d.]+$/
       script:
         - make -e sdist
         - npm install -g @zeus-ci/cli || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
         - zeus upload -t "application/zip+wheel" py/dist/* || [[ ! "$TRAVIS_BRANCH" =~ ^release/ ]]
-
-    - name: "docs"
-      before_script: npm install -g @zeus-ci/cli
-      script: make -e travis-upload-prose-docs
 
 notifications:
   webhooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,18 @@
 
 ## 0.5.9
 
-**Relay**:
-
-- New explicit envelope endpoint. Envelopes no longer need to be sent with the
-  right content type (to cater to browser JS).
-- Introduce an item type for transactions.
+- Relay has a logo now!
+- New explicit `envelope/` endpoint. Envelopes no longer need to be sent with
+  the right `content-type` header (to cater to browser JS).
+- Introduce an Envelope item type for transactions.
 - Support environment variables and CLI arguments instead of command line parameters.
-- Return status 415 on wrong content types.
-- Normalize double-slashes in requests more aggressively.
+- Return status `415` on wrong content types.
+- Normalize double-slashes in request URLs more aggressively.
 - Add an option to generate credentials on stdout.
-- Ability to serve project configs from Relay to downstream Relays with proper
-  permission checking.
-- Relay has a logo now.
 
-**Store**:
+**Internal**:
 
+- Serve project configs to downstream Relays with proper permission checking.
 - PII: Make and/or selectors specific.
 - Add a browser filter for IE 11.
 - Changes to release parsing.
@@ -24,18 +21,16 @@
 
 ## 0.5.8
 
-**Store**:
+**Internal**:
 
 - Fix a bug where exception values and the device name were not PII-strippable.
 
 ## 0.5.7
 
-**Relay**:
-
 - Docker images are now also pushed to Docker Hub.
 - New helper function to generate PII selectors from event data.
 
-**Store**:
+**Internal**:
 
 - Release is now a required attribute for session data.
 - `unknown` can now be used in place of `unknown_error` for span statuses. A
@@ -44,8 +39,6 @@
 
 ## 0.5.6
 
-**Relay**:
-
 - Fix a bug where Relay would stop processing events if Sentry is down for only a short time.
 - Improvements to architecture documentation.
 - Initial support for rate limiting by event type ("scoped quotas")
@@ -53,28 +46,26 @@
 - Fix a bug where it was not permitted to send content-encoding as part of a
   CORS request to store.
 
-**Store**:
+**Internal**:
 
-- Minor updates to PII processing: Aliases for value types (`$error` instead of
-  `$exception` to be in sync with Discover column naming) and adding a default
-  for replace-redactions.
+- PII processing: Aliases for value types (`$error` instead of `$exception` to
+  be in sync with Discover column naming) and adding a default for
+  replace-redactions.
 - It is now valid to send transactions and spans without `op` set, in which
   case a default value will be inserted.
 
 ## 0.5.5
 
-**Store**:
+- Suppress verbose DNS lookup logs.
+
+**Internal**:
 
 - Small performance improvements in datascrubbing config converter.
 - New, C-style selector syntax (old one still works)
 
-**Relay**:
-
-- Suppress verbose DNS lookup logs.
-
 ## 0.5.4
 
-**Store**:
+**Internal**:
 
 - Add event contexts to `pii=maybe`.
 - Fix parsing of msgpack breadcrumbs in Rust store.
@@ -83,28 +74,19 @@
 
 ## 0.5.3
 
-**Relay**:
-
 - Properly strip the linux binary to reduce its size
 - Allow base64 encoded JSON event payloads (#466)
 - Fix multipart requests without trailing newline (#465)
 - Support for ingesting session updates (#449)
 
-**Store**:
+**Internal**:
 
 - Validate release names during event ingestion (#479)
 - Add browser extension filter (#470)
 - Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if explicitly addressed.
 - Add way to scrub filepaths in a way that does not break processing.
 
-**Python**:
-
-- Add missing errors for JSON parsing and release validation (#478)
-- Expose more datascrubbing utils (#464)
-
 ## 0.5.2
-
-**Relay**:
 
 - Fix trivial Redis-related crash when running in non-processing mode.
 - Limit the maximum retry-after of a rate limit. This is necessary because of
@@ -113,7 +95,7 @@
   you have that parameter set to a high number you may see increased memory
   consumption.
 
-**Store**:
+**Internal**:
 
 - Misc bugfixes in PII processor. Those bugs do not affect the legacy data scrubber exposed in Python.
 - Polishing documentation around PII configuration format.
@@ -121,38 +103,27 @@
 
 ## 0.5.1
 
-**Relay**:
-
 - Ability to fetch project configuration from Redis as additional caching layer.
 - Fix a few bugs in release filters.
 - Fix a few bugs in minidumps endpoint with processing enabled.
 
-**Python**:
-
-- Bump xcode version from 7.3 to 9.4, dropping wheel support for some older OS X versions.
-- New function `validate_pii_config`.
-
-**Store**:
+**Internal**:
 
 - Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
 - Ability to correct some clock drift and wrong system time in transaction events.
 
 ## 0.5.0
 
-**Relay**:
-
 - The binary has been renamed to `relay`.
 - Updated documentation for metrics.
 
-**Python**:
+**Internal**:
 
 - The package is now called `sentry-relay`.
 - Renamed all `Semaphore*` types to `Relay*`.
 - Fixed memory leaks in processing functions.
 
 ## 0.4.65
-
-**Relay**:
 
 - Implement the Minidump endpoint.
 - Implement the Attachment endpoint.
@@ -168,25 +139,16 @@
 - Use _mmap_ to load the GeoIP database to improve the memory footprint.
 - Revert back to the system memory allocator.
 
-**Store**:
+**Internal**:
 
 - Preserve microsecond precision in all time stamps.
 - Record event ids in all outcomes.
 - Updates to event processing metrics.
 - Add span status mapping from open telemetry.
 
-**Python**:
-
-- Fix glob-matching of newline characters.
-
 ## 0.4.64
 
-- Added newline support for general glob code.
-- Added span status mapping to python library.
-
-**Relay**:
-
-- Switched to jemalloc.
+- Switched to `jemalloc` as global allocator.
 - Introduce separate outcome reason for invalid events.
 - Always consume request bodies to the end.
 - Implemented minidump ingestion.
@@ -194,7 +156,12 @@
 
 ## 0.4.63
 
-**Store**:
+- Refactor healthchecks into two: Liveness and readiness (see code comments for
+  explanation for now).
+- Allow multiple trailing slashes on store endpoint, e.g. `/api/42/store///`.
+- Internal refactor to prepare for envelopes format.
+
+**Internal**:
 
 - Fix a bug where glob-matching in filters did not behave correctly when the
   to-be-matched string contained newlines.
@@ -203,46 +170,32 @@
 - Raise a dedicated Python exception type for invalid transaction events. Also
   do not report that error to Sentry from Relay.
 
-**Relay**:
-
-- Refactor healthchecks into two: Liveness and readiness (see code comments for
-  explanation for now).
-- Allow multiple trailing slashes on store endpoint, e.g. `/api/42/store///`.
-- Internal refactor to prepare for envelopes format.
-
 ## 0.4.62
-
-**Event schema**:
-
-- Spec out values of `event.contexts.trace.status`.
-- `none` is now no longer a valid environment name.
-- Do no longer drop transaction events in renormalization.
-
-**Store**:
 
 - Various performance improvements.
 
 ## 0.4.61
+
+**Internal**:
 
 - Add `thread.errored` attribute (#306).
 
 ## 0.4.60
 
 - License is now BSL instead of MIT (#301).
-
-**Store**:
-
-- Transaction events with negative duration are now rejected (#291).
-- Fix a panic when normalizing certain dates.
-
-**Relay**:
-
 - Improve internal metrics and logging (#296, #297, #298).
 - Fix unbounded requests to Sentry for project configs (#295, #300).
 - Fix rejected responses from Sentry due to size limit (#303).
 - Expose more options for configuring request concurrency limits (#311).
 
+**Internal**:
+
+- Transaction events with negative duration are now rejected (#291).
+- Fix a panic when normalizing certain dates.
+
 ## 0.4.59
+
+**Internal**:
 
 - Fix: Normalize legacy stacktrace attributes (#292)
 - Fix: Validate platform attributes in Relay (#294)
@@ -250,57 +203,57 @@
 
 ## 0.4.58
 
-- Expose globbing code from Relay to Python (#288)
-- Normalize before datascrubbing (#290)
 - Evict project caches after some time (#287)
-- Add event size metrics (#286)
 - Selectively log internal errors to stderr (#285)
-- Do not ignore `process_value` result in `scrub_event` (#284)
+- Add an error boundary to parsing project states (#281)
+
+**Internal**:
+
+- Add event size metrics (#286)
+- Normalize before datascrubbing (#290)
 - Add a config value for thread counts (#283)
 - Refactor outcomes for parity with Sentry (#282)
-- Add an error boundary to parsing project states (#281)
-- Remove warning and add comment for temporary attribute
 - Add flag that relay processed an event (#279)
 
 ## 0.4.57
 
-**Store**:
+**Internal**:
 
 - Stricter validation of transaction events.
 
 ## 0.4.56
 
-**Store**:
+**Internal**:
 
 - Fix a panic in trimming.
 
 ## 0.4.55
 
-**Store**:
+**Internal**:
 
 - Fix more bugs in datascrubbing converter.
 
 ## 0.4.54
 
-**Store**:
+**Internal**:
 
 - Fix more bugs in datascrubbing converter.
 
 ## 0.4.53
 
-**Store**:
+**Internal**:
 
 - Fix more bugs in datascrubbing converter.
 
 ## 0.4.52
 
-**Store**:
+**Internal**:
 
 - Fix more bugs in datascrubbing converter.
 
 ## 0.4.51
 
-**Store**:
+**Internal**:
 
 - Fix a few bugs in datascrubbing converter.
 - Accept trailing slashes.
@@ -311,36 +264,31 @@
 
 ## 0.4.50
 
-**Store**:
+**Internal**:
 
 - Fix bug where IP scrubbers were applied even when not enabled.
 
 ## 0.4.49
 
-**Python**
-
-- Fix handling of panics in CABI/Python bindings.
+- Internal changes.
 
 ## 0.4.48
 
-**Store**:
+**Internal**:
 
-- Fix various bugs in the datascrubber and PII processing code to get closer to behavior of the Python implementation.
+- Fix various bugs in the datascrubber and PII processing code to get closer to
+  behavior of the Python implementation.
 
 ## 0.4.47
 
-**Normalization**:
-
-- Fix encoding issue in the Python layer of event normalization.
-
-**Store**:
+**Internal**:
 
 - Various work on re-implementing Sentry's `/api/X/store` endpoint in Relay.
   Relay can now apply rate limits based on Redis and emit the correct outcomes.
 
 ## 0.4.46
 
-**Normalization**:
+**Internal**:
 
 - Resolved a regression in IP address normalization. The new behavior is closer to a line-by-line port of the old Python code.
 
@@ -372,113 +320,158 @@
 
 ## 0.4.41
 
-**Normalization**:
+- Support extended project configuration.
 
+**Internal**:
+
+- Implement event filtering rules.
+- Add basic support for Sentry-internal event ingestion.
 - Parse and normalize user agent strings.
 
-**Relay**:
-
-- Add basic support for Sentry-internal event ingestion.
-- Support extended project configuration.
-- Implement event filtering rules.
-
 ## 0.4.40
+
+**Internal**:
 
 - Restrict ranges of timestamps to prevent overflows in Python code and UI.
 
 ## 0.4.39
 
+**Internal**:
+
 - Fix a bug where stacktrace trimming was not applied during renormalization.
 
 ## 0.4.38
+
+**Internal**:
 
 - Added typed spans to Event.
 
 ## 0.4.37
 
+**Internal**:
+
 - Added `orig_in_app` to frame data.
 
 ## 0.4.36
 
+**Internal**:
+
 - Add new .NET versions for context normalization.
 
 ## 0.4.35
+
+**Internal**:
 
 - Fix bug where thread's stacktraces were not normalized.
 - Fix bug where a string at max depth of a databag was stringified again.
 
 ## 0.4.34
 
+**Internal**:
+
 - Added `data` attribute to frames.
 - Added a way to override other trimming behavior in Python normalizer binding.
 
 ## 0.4.33
 
-- Smaller protocol adjustments related to rolling out re-normalization in Rust.
+**Internal**:
+
 - Plugin-provided context types should now work properly again.
 
 ## 0.4.32
+
+**Internal**:
 
 - Removed `function_name` field from frame and added `raw_function`.
 
 ## 0.4.31
 
+**Internal**:
+
 - Add trace context type.
 
 ## 0.4.30
+
+**Internal**:
 
 - Make exception messages/values larger to allow for foreign stacktrace data to be attached.
 
 ## 0.4.29
 
+**Internal**:
+
 - Added `function_name` field to frame.
 
 ## 0.4.28
 
+**Internal**:
+
 - Add missing context type for sessionstack.
 
 ## 0.4.27
+
+**Internal**:
 
 - Increase frame vars size again! Byte size was fine, but max depth
   was way too small.
 
 ## 0.4.26
 
+**Internal**:
+
 - Reduce frame vars size.
 
 ## 0.4.25
+
+**Internal**:
 
 - Add missing trimming to frame vars.
 
 ## 0.4.24
 
+**Internal**:
+
 - Reject non-http/https `help_urls` in exception mechanisms.
 
 ## 0.4.23
+
+**Internal**:
 
 - Add basic truncation to event meta to prevent payload size from spiralling out of control.
 
 ## 0.4.22
 
+**Internal**:
+
 - Added grouping enhancements to protocol.
 
 ## 0.4.21
+
+**Internal**:
 
 - Updated debug image interface with more attributes.
 
 ## 0.4.20
 
+**Internal**:
+
 - Added support for `lang` frame and stacktrace attribute.
 
 ## 0.4.19
+
+**Internal**:
 
 - Slight changes to allow replacing more normalization code in Sentry with Rust.
 
 ## 0.4.18
 
+**Internal**:
+
 - Allow much larger payloads in the extra attribute.
 
 ## 0.4.17
+
+**Internal**:
 
 - Added support for protocol changes related to upcoming sentry SDK features.
   In particular the `none` event type was added.

--- a/README.md
+++ b/README.md
@@ -202,3 +202,14 @@ The password for the `.pfx` file is `password`.
 ### Release Management
 
 We use [craft](https://github.com/getsentry/craft) to release new versions.
+There are two separate projects to publish:
+
+- **Relay binary** is released from the root folder. Run `craft prepare` and
+  `craft publish` in that directory to create a release build and publish it,
+  respectively. We use [Calendar Versioning](https://calver.org/) and coordinate
+  releases with Sentry.
+
+- **Relay Python library** along with the C-ABI are released from the `py/`
+  subfolder. Change into that directory and run `craft prepare` and `craft
+  publish`. We use [Semantic Versioning](https://semver.org/) and release during
+  the development cycle.

--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -1,5 +1,5 @@
 ---
-minVersion: "0.9.5"
+minVersion: "0.9.6"
 github:
   owner: getsentry
   repo: relay

--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -1,0 +1,24 @@
+---
+minVersion: "0.9.5"
+github:
+  owner: getsentry
+  repo: relay
+changelogPolicy: simple
+preReleaseCommand: ../scripts/bump-library.sh
+releaseBranchPrefix: release-library
+
+targets:
+  - name: pypi
+  - name: gcs
+    bucket: sentry-sdk-assets
+    includeNames: /^(sentry-relay|sentry_relay).*(.whl|.zip)$/
+    paths:
+      - path: /librelay/{{version}}/
+        metadata:
+          cacheControl: "public, max-age=2592000"
+
+requireNames:
+  - /^sentry_relay-.*-py2.py3-none-macosx_10_13_x86_64.whl$/
+  - /^sentry_relay-.*-py2.py3-none-manylinux1_i686.whl$/
+  - /^sentry_relay-.*-py2.py3-none-manylinux1_x86_64.whl$/
+  - /^sentry-relay-.*.zip$/

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,0 +1,467 @@
+# Changelog
+
+## 0.5.9
+
+- PII: Make and/or selectors specific.
+- Add a browser filter for IE 11.
+- Changes to release parsing.
+- PII: Expose event values as part of generated selector suggestions.
+
+## 0.5.8
+
+- Fix a bug where exception values and the device name were not PII-strippable.
+
+## 0.5.7
+
+- Release is now a required attribute for session data.
+- `unknown` can now be used in place of `unknown_error` for span statuses. A
+  future release will change the canonical format from `unknown_error` to
+  `unknown`.
+
+## 0.5.6
+
+- Minor updates to PII processing: Aliases for value types (`$error` instead of
+  `$exception` to be in sync with Discover column naming) and adding a default
+  for replace-redactions.
+- It is now valid to send transactions and spans without `op` set, in which
+  case a default value will be inserted.
+
+## 0.5.5
+
+- Small performance improvements in datascrubbing config converter.
+- New, C-style selector syntax (old one still works)
+
+## 0.5.4
+
+- Add event contexts to `pii=maybe`.
+- Fix parsing of msgpack breadcrumbs in Rust store.
+- Envelopes sent to Rust store can omit the DSN in headers.
+- Ability to quote/escape special characters in selectors in PII configs.
+
+## 0.5.3
+
+- Validate release names during event ingestion (#479)
+- Add browser extension filter (#470)
+- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if explicitly addressed.
+- Add way to scrub filepaths in a way that does not break processing.
+- Add missing errors for JSON parsing and release validation (#478)
+- Expose more datascrubbing utils (#464)
+
+## 0.5.2
+
+- Misc bugfixes in PII processor. Those bugs do not affect the legacy data scrubber exposed in Python.
+- Polishing documentation around PII configuration format.
+- Signal codes in mach mechanism are no longer required.
+
+## 0.5.1
+
+- Bump xcode version from 7.3 to 9.4, dropping wheel support for some older OS X versions.
+- New function `validate_pii_config`.
+- Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
+- Ability to correct some clock drift and wrong system time in transaction events.
+
+## 0.5.0
+
+- The package is now called `sentry-relay`.
+- Renamed all `Semaphore*` types to `Relay*`.
+- Fixed memory leaks in processing functions.
+
+## 0.4.65
+
+- Preserve microsecond precision in all time stamps.
+- Record event ids in all outcomes.
+- Updates to event processing metrics.
+- Add span status mapping from open telemetry.
+- Fix glob-matching of newline characters.
+
+## 0.4.64
+
+- Added newline support for general glob code.
+- Added span status mapping to python library.
+
+## 0.4.63
+
+- Fix a bug where glob-matching in filters did not behave correctly when the
+  to-be-matched string contained newlines.
+- Add `moz-extension:` as scheme for browser extensions (filtering out Firefox
+  addons).
+- Raise a dedicated Python exception type for invalid transaction events. Also
+  do not report that error to Sentry from Relay.
+
+## 0.4.62
+
+- Spec out values of `event.contexts.trace.status`.
+- `none` is now no longer a valid environment name.
+- Do no longer drop transaction events in renormalization.
+- Various performance improvements.
+
+## 0.4.61
+
+- Add `thread.errored` attribute (#306).
+
+## 0.4.60
+
+- License is now BSL instead of MIT (#301).
+- Transaction events with negative duration are now rejected (#291).
+- Fix a panic when normalizing certain dates.
+
+## 0.4.59
+
+- Fix: Normalize legacy stacktrace attributes (#292)
+- Fix: Validate platform attributes (#294)
+
+## 0.4.58
+
+- Expose globbing code from Relay to Python (#288)
+- Normalize before datascrubbing (#290)
+- Selectively log internal errors to stderr (#285)
+- Do not ignore `process_value` result in `scrub_event` (#284)
+
+## 0.4.57
+
+- Stricter validation of transaction events
+
+## 0.4.56
+
+- Fix a panic in trimming
+
+## 0.4.55
+
+- Fix more bugs in datascrubbing converter
+
+## 0.4.54
+
+- Fix more bugs in datascrubbing converter
+
+## 0.4.53
+
+- Fix more bugs in datascrubbing converter
+
+## 0.4.52
+
+- Fix more bugs in datascrubbing converter
+
+## 0.4.51
+
+- Fix a few bugs in datascrubbing converter
+- Fix a panic on overflowing timestamps
+
+## 0.4.50
+
+- Fix bug where IP scrubbers were applied even when not enabled
+
+## 0.4.49
+
+- Fix handling of panics in CABI/Python bindings
+
+## 0.4.48
+
+- Fix various bugs in the datascrubber and PII processing code to get closer to behavior of the Python implementation.
+
+## 0.4.47
+
+- Fix encoding issue in the Python layer of event normalization.
+
+## 0.4.46
+
+- Resolved a regression in IP address normalization. The new behavior is closer to a line-by-line port of the old Python code.
+
+## 0.4.45
+
+- Resolved an issue where GEO IP data was not always infered.
+
+## 0.4.44
+
+- Only take the user IP address from the store request's IP for certain platforms. This restores the behavior of the old Python code.
+
+## 0.4.43
+
+- Bump size of breadcrumbs
+- Workaround for an issue where we would not parse OS information from User Agent when SDK had already sent OS information.
+
+## 0.4.42
+
+- Fix normalization of version strings from user agents.
+
+## 0.4.41
+
+- Parse and normalize user agent strings.
+
+## 0.4.40
+
+- Restrict ranges of timestamps to prevent overflows in Python code and UI.
+
+## 0.4.39
+
+- Fix a bug where stacktrace trimming was not applied during renormalization.
+
+## 0.4.38
+
+- Added typed spans to `Event`.
+
+## 0.4.37
+
+- Added `orig_in_app` to frame data.
+
+## 0.4.36
+
+- Add new .NET versions for context normalization.
+
+## 0.4.35
+
+- Fix bug where thread's stacktraces were not normalized.
+- Fix bug where a string at max depth of a databag was stringified again.
+
+## 0.4.34
+
+- Added `data` attribute to frames.
+- Added a way to override other trimming behavior in Python normalizer binding.
+
+## 0.4.33
+
+- Smaller protocol adjustments related to rolling out re-normalization in Rust.
+- Plugin-provided context types should now work properly again.
+
+## 0.4.32
+
+- Removed `function_name` field from frame and added `raw_function`.
+
+## 0.4.31
+
+- Add trace context type.
+
+## 0.4.30
+
+- Make exception messages/values larger to allow for foreign stacktrace data to be attached.
+
+## 0.4.29
+
+- Added `function_name` field to frame.
+
+## 0.4.28
+
+- Add missing context type for sessionstack.
+
+## 0.4.27
+
+- Increase frame vars size again! Byte size was fine, but max depth
+  was way too small.
+
+## 0.4.26
+
+- Reduce frame vars size.
+
+## 0.4.25
+
+- Add missing trimming to frame vars.
+
+## 0.4.24
+
+- Reject non-http/https `help_urls` in exception mechanisms (#192)
+
+## 0.4.23
+
+- Add basic truncation to event meta to prevent payload size from spiralling out of control.
+
+## 0.4.22
+
+- Improve the grouping protocol config (#190)
+
+## 0.4.21
+
+- Add new debug image variants (#188)
+- Trim release and environment (#184)
+
+## 0.4.20
+
+- Alias level critical as fatal (#182)
+- Add device properties from Java/.NET SDKs (#185)
+- Add `lang` to frame and stacktrace (#186)
+
+## 0.4.19
+
+- Add mode for renormalization (#181)
+
+## 0.4.18
+
+- Restore the original behavior with supporting very large values in extra
+  (#180)
+
+## 0.4.17
+
+- Add untyped spans for tracing (#179)
+- Add the `none` event type
+
+## 0.4.16
+
+- Add support for synthetic mechanism markers (#177)
+
+## 0.4.15
+
+- Fix processors: Do not create `path_item` in `enter_nothing`
+
+## 0.4.14
+
+- Rename `template_info` to template
+- Add two new untyped context types: `gpu`, `monitors`
+- Rewrite `derive(ProcessValue)` to use `Structure::each_variant` (#175)
+
+## 0.4.13
+
+- Allow arrays as header values (#176)
+- Swap `python-json-read-adapter` to git dependency
+
+## 0.4.12
+
+- Run json.dumps at max depth in databag (#174)
+
+## 0.4.11
+
+- Get oshint case-insensitively
+
+## 0.4.10
+
+- Trim `time_spent` to max value of db column
+
+## 0.4.9
+
+- Trim containers one level before max_depth (#173)
+- Unconditionally overwrite `received`
+
+## 0.4.8
+
+- Fix bugs in array trimming, more code comments (#172)
+
+## 0.4.7
+
+- Deal with surrogate escapes in python bindings
+
+## 0.4.6
+
+- Reject exceptions with empty type and value (#170)
+- Validate remote_addr before backfilling into user (#171)
+
+## 0.4.5
+
+- Adjust limits to fit values into db (#167)
+- Environment is 64 chars in db
+- Normalize macOS (#168)
+- Use right maxchars for `transaction`, `dist`, `release`
+- Do not add error to invalid url
+
+## 0.4.4
+
+- Reject unknown debug images (#163)
+- Include original_value in `Meta::eq` (#164)
+- Emit correct expectations for common types (#162)
+- Permit invalid emails in user interface (#161)
+- Drop long tags correctly (#165)
+- Do not skip null values in pairlists (#166)
+
+## 0.4.3
+
+- Fix broken sdk_info parsing (#156)
+- Add basic snapshot tests for normalize and event parsing (#154)
+- Context trimming (#153)
+- Coerce PHP frame vars array to object (#159)
+
+## 0.4.2
+
+- Remove content-type params
+- Dont attempt to free() if python is shutting down
+- Improve cookie header normalizations (#151)
+- Implement LogEntry formatting (#152)
+- Deduplicate tags (#155)
+- Treat empty paths like no paths in frame normalization
+- Remove cookie header when explicit cookies are given
+
+## 0.4.1
+
+- Do not remove empty cookies or headers (#138)
+- Skip more empty containers (#139)
+- Make `request.header` values lenient (#145)
+- Remove internal tags when backfilling (#146)
+- Implement advanced context normalization (#140)
+- Retain additional properties in contexts (#141)
+- Implement very lenient URL parsing (#147)
+- Do not require breadcrumb timestamps (#144)
+- Reject tags with long keys (#149)
+
+## 0.4.0
+
+- Add new options max_concurrent_events (#134)
+- Dont move stacktrace before normalizing it (#135)
+- Fix broken repr and crash when shutting down python
+- Port slim_frame_data (#137)
+- Special treatment for ellipsis in URLs
+- Parse request bodies
+
+## 0.3.0
+
+- Changed PII stripping rule format to permit path selectors when applying
+  rules. This means that now `$string` refers to strings for instance and
+  `user.id` refers to the `id` field in the `user` attribute of the event.
+  Temporarily support for old rules is retained.
+
+## 0.2.7
+
+- Minor fixes to be closer to Python. Ability to disable trimming of objects,
+  arrays and strings.
+
+## 0.2.6
+
+- Fix bug where PII stripping would remove containers without leaving any
+  metadata about the retraction.
+- Fix bug where old `redactPair` rules would stop working.
+
+## 0.2.5
+
+- Rewrite of PII stripping logic. This brings potentially breaking changes to
+  the semantics of PII configs. Most importantly field types such as
+  `"freeform"` and `"databag"` are gone, right now there is only `"container"`
+  and `"text"`. All old field types should have become an alias for `"text"`,
+  but take extra care in ensuring your PII rules still work.
+
+- Minor fixes to be closer to Python.
+
+## 0.2.4
+
+- Remove stray print statement.
+
+## 0.2.3
+
+- Fix main performance issues.
+
+## 0.2.2
+
+- Fix segfault when trying to process contexts.
+- Fix trimming state "leaking" between interfaces, leading to excessive trimming.
+- Don't serialize empty arrays and objects (with a few exceptions).
+
+## 0.2.1
+
+- Expose CABI for normalizing event data.
+
+## 0.2.0
+
+- Updated event processing: Events from older SDKs are now supported. Also,
+  we've fixed some bugs along the line.
+- Introduced full support for PII stripping.
+
+## 0.1.3
+
+- Added support for metadata format
+
+## 0.1.2
+
+- Update dependencies
+
+## 0.1.1
+
+- Rename "sentry-relay" to "semaphore"
+- Use new features from Rust 1.26
+- Prepare Python builds (#20)
+
+## 0.1.0
+
+An initial release of the library.

--- a/scripts/bump-library.sh
+++ b/scripts/bump-library.sh
@@ -11,6 +11,6 @@ echo "Current version: ${OLD_VERSION}"
 echo "Bumping version: ${NEW_VERSION}"
 
 VERSION_RE=${VERSION//\./\\.}
-find . -name Cargo.toml -not -path './relay-cabi/*' -exec sed -i '' -e "1,/^version/ s/^version.*/version = \"${NEW_VERSION}\"/" {} \;
+sed -i '' -e "1,/^version/ s/^version.*/version = \"${NEW_VERSION}\"/" relay-cabi/Cargo.toml
 
-cargo update -p relay
+cargo update -p relay-common --manifest-path ./relay-cabi/Cargo.toml


### PR DESCRIPTION
Separates the Relay application binary from the library used by Sentry:

- **Relay binary** is released from the root folder. Run `craft prepare` and `craft publish` in that directory to create a release build and publish it, respectively. We use [Calendar Versioning](https://calver.org/) and coordinate releases with Sentry.

- **Relay Python library** along with the C-ABI are released from the `py/` subfolder. Change into that directory and run `craft prepare` and `craft publish`. We use [Semantic Versioning](https://semver.org/) and release during the development cycle.

Craft configuration, changelogs and builds are fully separated so that releases can run independently.

Requires https://github.com/getsentry/craft/pull/86