### PR TITLE
build: Bump release parser to 0.6.0

### DIFF
--- a/relay-cabi/Cargo.lock
+++ b/relay-cabi/Cargo.lock
@@ -967,6 +967,7 @@ version = "0.5.9"
 dependencies = [
  "backoff",
  "cadence",
+ "chrono",
  "failure",
  "globset",
  "lazy_static",
@@ -1065,9 +1066,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry-release-parser"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59caafcf5d0662504ad1a1184ba75975704f1b16d4d2ce877ed8e3e8cf61933f"
+checksum = "5e3922f28bac40e0edf372875bb64836bfe22013f5dd1b241846fec2ad6dca28"
 dependencies = [
  "lazy_static",
  "regex",

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -29,4 +29,4 @@ serde_json = "1.0.40"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
 relay-general = { path = "../relay-general" }
-sentry-release-parser = { version = "0.5.0", features = ["serde"] }
+sentry-release-parser = { version = "0.6.0", features = ["serde"] }


### PR DESCRIPTION
This fixes a bug in the release parser.