### PR TITLE
ref(server): Log sessions with invalid UTF8

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -164,11 +164,8 @@ impl StoreForwarder {
                         if let Some(client) = client {
                             scope.set_tag("sdk", client);
                         }
-                        if let Ok(payload) = std::str::from_utf8(&item.payload()) {
-                            scope.set_extra("session", payload.into());
-                        } else {
-                            scope.set_extra("session", "<invalid utf8>".into());
-                        }
+                        let payload = item.payload();
+                        scope.set_extra("session", String::from_utf8_lossy(&payload).into());
                     },
                     || {
                         // Skip gracefully here to allow sending other messages.


### PR DESCRIPTION
Instead of just logging `<invalid utf8>`, log the partially decoded session payload for debbuging purposes.