### PR TITLE
feat(server): Implement an HTTP outcomes producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 
 **Internal**:
 
+- Add support for Outcomes generation in non processing relays.([#592](https://github.com/getsentry/relay/pull/592))
 - Ignore non-Rust folders for faster rebuilding and testing. ([#578](https://github.com/getsentry/relay/pull/578))
 - Invalid session payloads are now logged for SDK debugging. ([#584](https://github.com/getsentry/relay/pull/584), [#591](https://github.com/getsentry/relay/pull/591))
 - Remove unused `rev` from project state. ([#586](https://github.com/getsentry/relay/pull/586))

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -354,6 +354,12 @@ pub struct Relay {
     /// Controls whether outcomes will be emitted when processing is disabled.
     /// Processing relays always emit outcomes (for backwards compatibility).
     pub emit_outcomes: bool,
+    /// The maximum number of outcomes that are batched before being sent
+    /// via http to the upstream (only applies to non processing relays)
+    pub max_outcome_batch_size: usize,
+    /// The maximum time interval (in milliseconds) that an outcome may be batched
+    /// via http to the upstream (only applies to non processing relays)
+    pub max_outcome_interval_millsec: u64,
 }
 
 impl Default for Relay {
@@ -367,6 +373,8 @@ impl Default for Relay {
             tls_identity_path: None,
             tls_identity_password: None,
             emit_outcomes: false,
+            max_outcome_batch_size: 1000,
+            max_outcome_interval_millsec: 500,
         }
     }
 }
@@ -838,7 +846,7 @@ impl Config {
                 "true" | "1" => processing.enabled = true,
                 "false" | "0" | "" => processing.enabled = false,
                 _ => {
-                    return Err(ConfigError::new(ConfigErrorKind::InvalidValue).field("processing"))
+                    return Err(ConfigError::new(ConfigErrorKind::InvalidValue).field("processing"));
                 }
             }
         }
@@ -1045,6 +1053,16 @@ impl Config {
     /// Returns the emit_outcomes flag
     pub fn emit_outcomes(&self) -> bool {
         self.values.relay.emit_outcomes
+    }
+
+    /// Returns the maximum number of outcomes that are batched before being sent
+    pub fn max_outcome_batch_size(&self) -> usize {
+        self.values.relay.max_outcome_batch_size
+    }
+
+    /// Returns the maximum interval (in milliseconds) that an outcome may be batched
+    pub fn max_outcome_interval_millsec(&self) -> u64 {
+        self.values.relay.max_outcome_interval_millsec
     }
 
     /// Returns the log level.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -715,18 +715,18 @@ pub struct Outcomes {
     pub emit_outcomes: bool,
     /// The maximum number of outcomes that are batched before being sent
     /// via http to the upstream (only applies to non processing relays)
-    pub max_batch_size: usize,
+    pub batch_size: usize,
     /// The maximum time interval (in milliseconds) that an outcome may be batched
     /// via http to the upstream (only applies to non processing relays)
-    pub max_interval: u64,
+    pub batch_interval: u64,
 }
 
 impl Default for Outcomes {
     fn default() -> Self {
         Outcomes {
             emit_outcomes: false,
-            max_batch_size: 1000,
-            max_interval: 500,
+            batch_size: 1000,
+            batch_interval: 500,
         }
     }
 }
@@ -1071,13 +1071,13 @@ impl Config {
     }
 
     /// Returns the maximum number of outcomes that are batched before being sent
-    pub fn max_outcome_batch_size(&self) -> usize {
-        self.values.outcomes.max_batch_size
+    pub fn outcome_batch_size(&self) -> usize {
+        self.values.outcomes.batch_size
     }
 
     /// Returns the maximum interval that an outcome may be batched
-    pub fn max_outcome_interval(&self) -> Duration {
-        Duration::from_millis(self.values.outcomes.max_interval)
+    pub fn outcome_batch_interval(&self) -> Duration {
+        Duration::from_millis(self.values.outcomes.batch_interval)
     }
 
     /// Returns the log level.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -715,18 +715,18 @@ pub struct Outcomes {
     pub emit_outcomes: bool,
     /// The maximum number of outcomes that are batched before being sent
     /// via http to the upstream (only applies to non processing relays)
-    pub max_outcome_batch_size: usize,
+    pub max_batch_size: usize,
     /// The maximum time interval (in milliseconds) that an outcome may be batched
     /// via http to the upstream (only applies to non processing relays)
-    pub max_outcome_interval_millsec: u64,
+    pub max_interval: u64,
 }
 
 impl Default for Outcomes {
     fn default() -> Self {
         Outcomes {
             emit_outcomes: false,
-            max_outcome_batch_size: 1000,
-            max_outcome_interval_millsec: 500,
+            max_batch_size: 1000,
+            max_interval: 500,
         }
     }
 }
@@ -1072,12 +1072,12 @@ impl Config {
 
     /// Returns the maximum number of outcomes that are batched before being sent
     pub fn max_outcome_batch_size(&self) -> usize {
-        self.values.outcomes.max_outcome_batch_size
+        self.values.outcomes.max_batch_size
     }
 
     /// Returns the maximum interval that an outcome may be batched
     pub fn max_outcome_interval(&self) -> Duration {
-        Duration::from_millis(self.values.outcomes.max_outcome_interval_millsec)
+        Duration::from_millis(self.values.outcomes.max_interval)
     }
 
     /// Returns the log level.

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -202,6 +202,39 @@ pub enum DiscardReason {
     ProcessUnreal,
 }
 
+impl Outcome {
+    /// Returns the name of the outcome as recognized by Sentry.
+    fn name(&self) -> &'static str {
+        match self {
+            Outcome::Accepted => "accepted",
+            Outcome::Filtered(_) => "filtered",
+            Outcome::RateLimited(_) => "rate_limited",
+            Outcome::Invalid(_) => "invalid",
+            Outcome::Abuse => "abuse",
+        }
+    }
+
+    fn to_outcome_id(&self) -> u8 {
+        match self {
+            Outcome::Accepted => 0,
+            Outcome::Filtered(_) => 1,
+            Outcome::RateLimited(_) => 2,
+            Outcome::Invalid(_) => 3,
+            Outcome::Abuse => 4,
+        }
+    }
+
+    fn to_reason(&self) -> Option<&str> {
+        match self {
+            Outcome::Accepted => None,
+            Outcome::Invalid(discard_reason) => Some(discard_reason.name()),
+            Outcome::Filtered(filter_key) => Some(filter_key.name()),
+            Outcome::RateLimited(code_opt) => code_opt.as_ref().map(|code| code.as_str()),
+            Outcome::Abuse => None,
+        }
+    }
+}
+
 impl DiscardReason {
     pub fn name(self) -> &'static str {
         match self {
@@ -240,8 +273,7 @@ impl DiscardReason {
 pub struct TrackRawOutcome {
     /// The timespan of the event outcome.
     timestamp: String,
-    /// Organization id.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Organization id.#[serde(default, skip_serializing_if = "Option::is_none")]
     org_id: Option<u64>,
     /// Project id.
     project_id: ProjectId,
@@ -250,14 +282,12 @@ pub struct TrackRawOutcome {
     key_id: Option<u64>,
     /// The outcome.
     outcome: u8,
-    /// Reason for the outcome.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Reason for the outcome.#[serde(default, skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
     /// The event id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event_id: Option<EventId>,
-    /// The client ip address.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The client ip address.#[serde(default, skip_serializing_if = "Option::is_none")]
     remote_addr: Option<String>,
 }
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -202,39 +202,6 @@ pub enum DiscardReason {
     ProcessUnreal,
 }
 
-impl Outcome {
-    /// Returns the name of the outcome as recognized by Sentry.
-    fn name(&self) -> &'static str {
-        match self {
-            Outcome::Accepted => "accepted",
-            Outcome::Filtered(_) => "filtered",
-            Outcome::RateLimited(_) => "rate_limited",
-            Outcome::Invalid(_) => "invalid",
-            Outcome::Abuse => "abuse",
-        }
-    }
-
-    fn to_outcome_id(&self) -> u8 {
-        match self {
-            Outcome::Accepted => 0,
-            Outcome::Filtered(_) => 1,
-            Outcome::RateLimited(_) => 2,
-            Outcome::Invalid(_) => 3,
-            Outcome::Abuse => 4,
-        }
-    }
-
-    fn to_reason(&self) -> Option<&str> {
-        match self {
-            Outcome::Accepted => None,
-            Outcome::Invalid(discard_reason) => Some(discard_reason.name()),
-            Outcome::Filtered(filter_key) => Some(filter_key.name()),
-            Outcome::RateLimited(code_opt) => code_opt.as_ref().map(|code| code.as_str()),
-            Outcome::Abuse => None,
-        }
-    }
-}
-
 impl DiscardReason {
     pub fn name(self) -> &'static str {
         match self {
@@ -273,7 +240,8 @@ impl DiscardReason {
 pub struct TrackRawOutcome {
     /// The timespan of the event outcome.
     timestamp: String,
-    /// Organization id.#[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Organization id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     org_id: Option<u64>,
     /// Project id.
     project_id: ProjectId,
@@ -282,12 +250,14 @@ pub struct TrackRawOutcome {
     key_id: Option<u64>,
     /// The outcome.
     outcome: u8,
-    /// Reason for the outcome.#[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Reason for the outcome.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
     /// The event id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event_id: Option<EventId>,
-    /// The client ip address.#[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The client ip address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     remote_addr: Option<String>,
 }
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -325,7 +325,7 @@ impl OutcomeProducer {
         // or already called (if we are called by a timeout)
         self.send_outcomes_future = None;
 
-        if self.unsent_outcomes.len() == 0 {
+        if self.unsent_outcomes.is_empty() {
             log::warn!("unexpected send_batch scheduled with no outcomes to send.");
             return;
         }

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -4,6 +4,8 @@
 //! must be emitted in the entire ingestion pipeline. Since Relay is only one part in this pipeline,
 //! outcomes may not be emitted if the event is accepted.
 
+use std::borrow::Cow;
+use std::mem;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -33,9 +35,6 @@ pub use self::processing::*;
 pub type OutcomeProducer = processing::ProcessingOutcomeProducer;
 #[cfg(not(feature = "processing"))]
 pub type OutcomeProducer = HttpOutcomeProducer;
-
-use std::borrow::Cow;
-use std::mem;
 
 /// Defines the structure of the HTTP outcomes requests
 #[derive(Deserialize, Serialize, Debug, Default)]

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -546,14 +546,14 @@ impl HttpOutcomeProducer {
     ) -> Result<(), OutcomeError> {
         log::trace!("Batching outcome");
         self.unsent_outcomes.push(message);
-        if self.unsent_outcomes.len() >= self.config.max_outcome_batch_size() {
+        if self.unsent_outcomes.len() >= self.config.outcome_batch_size() {
             if let Some(pending_flush_handle) = self.pending_flush_handle {
                 context.cancel_future(pending_flush_handle);
             }
             self.send_batch(context)
         } else if self.pending_flush_handle.is_none() {
             self.pending_flush_handle =
-                Some(context.run_later(self.config.max_outcome_interval(), Self::send_batch));
+                Some(context.run_later(self.config.outcome_batch_interval(), Self::send_batch));
         }
 
         Ok(())

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -380,7 +380,7 @@ mod processing {
                     .context(ServerErrorKind::KafkaError)?;
                 (Some(future_producer), None)
             } else {
-                let http_producer = HttpOutcomeProducer::create(config.clone(), upstream.clone())
+                let http_producer = HttpOutcomeProducer::create(config.clone(), upstream)
                     .map(|producer| producer.start())
                     .map_err(|error| {
                         log::error!("Failed to start http producer: {}", LogError(&error));

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -16,7 +16,6 @@ mod outcomes;
 mod project_configs;
 mod public_keys;
 mod security_report;
-mod statics;
 mod store;
 mod unreal;
 
@@ -29,6 +28,7 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
         // Web API routes pointing to /api/0
         .configure(project_configs::configure_app)
         .configure(public_keys::configure_app)
+        .configure(outcomes::configure_app)
         // Ingestion routes pointing to /api/<project_id>/
         .configure(store::configure_app)
         .configure(envelope::configure_app)
@@ -36,7 +36,6 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
         .configure(minidump::configure_app)
         .configure(attachments::configure_app)
         .configure(unreal::configure_app)
-        .configure(outcomes::configure_app)
         // `forward` must be last as it creates a wildcard proxy
         .configure(forward::configure_app)
 }

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -16,6 +16,7 @@ mod outcomes;
 mod project_configs;
 mod public_keys;
 mod security_report;
+mod statics;
 mod store;
 mod unreal;
 

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -1,40 +1,33 @@
-use actix::ResponseFuture;
-use actix_web::{HttpResponse, ResponseError};
-use failure::Fail;
-use futures::prelude::*;
-use serde::Deserialize;
+use actix_web::HttpResponse;
+use serde::{Deserialize, Serialize};
 
 use crate::actors::outcome::OutcomePayload;
 use crate::extractors::{CurrentServiceState, SignedJson};
 use crate::service::ServiceApp;
 
+/// Defines the structure of the HTTP outcomes requests
 #[derive(Deserialize, Debug)]
-pub struct SendOutcomes {
+struct SendOutcomes {
     pub outcomes: Vec<OutcomePayload>,
 }
 
-fn send_outcomes(
-    state: CurrentServiceState,
-    body: SignedJson<SendOutcomes>,
-) -> ResponseFuture<HttpResponse, OutcomeProcessingError> {
+/// Defines the structure of the HTTP outcomes responses for successful requests
+#[derive(Serialize, Debug)]
+struct OutcomesResponse {
+    // nothing yet, future features will go here
+}
+
+fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> HttpResponse {
     if !body.relay.internal {
-        return Box::new(futures::future::ok(HttpResponse::Unauthorized().into()));
+        return HttpResponse::Unauthorized().finish();
     }
     if !state.config().emit_outcomes() {
-        return Box::new(futures::future::ok(HttpResponse::Forbidden().into()));
+        return HttpResponse::Forbidden().finish();
     }
-    let requests: Vec<_> = body
-        .inner
-        .outcomes
-        .iter()
-        .map(|o| state.outcome_producer().send(o.clone()))
-        .collect();
-
-    Box::new(
-        futures::future::join_all(requests)
-            .map_err(|_| OutcomeProcessingError)
-            .map(|_| HttpResponse::Ok().into()),
-    )
+    for outcome in body.inner.outcomes {
+        state.outcome_producer().do_send(outcome);
+    }
+    HttpResponse::Ok().json(OutcomesResponse {})
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
@@ -42,14 +35,4 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
         r.name("relay-outcomes");
         r.post().with(send_outcomes);
     })
-}
-
-#[derive(Fail, Debug)]
-#[fail(display = "An error occurred.")]
-struct OutcomeProcessingError;
-
-impl ResponseError for OutcomeProcessingError {
-    fn error_response(&self) -> HttpResponse {
-        HttpResponse::InternalServerError().into()
-    }
 }

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -1,22 +1,8 @@
 use actix_web::HttpResponse;
-use serde::{Deserialize, Serialize};
 
-use crate::actors::outcome::TrackRawOutcome;
+use crate::actors::outcome::{SendOutcomes, SendOutcomesResponse};
 use crate::extractors::{CurrentServiceState, SignedJson};
 use crate::service::ServiceApp;
-
-/// Defines the structure of the HTTP outcomes requests
-#[derive(Deserialize, Debug, Default)]
-#[serde(default)]
-struct SendOutcomes {
-    pub outcomes: Vec<TrackRawOutcome>,
-}
-
-/// Defines the structure of the HTTP outcomes responses for successful requests
-#[derive(Serialize, Debug)]
-struct OutcomesResponse {
-    // nothing yet, future features will go here
-}
 
 fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> HttpResponse {
     if !body.relay.internal || !state.config().emit_outcomes() {
@@ -25,7 +11,7 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
     for outcome in body.inner.outcomes {
         state.outcome_producer().do_send(outcome);
     }
-    HttpResponse::Accepted().json(OutcomesResponse {})
+    HttpResponse::Accepted().json(SendOutcomesResponse {})
 }
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -121,7 +121,7 @@ impl ServiceState {
     pub fn start(config: Arc<Config>) -> Result<Self, ServerError> {
         let upstream_relay = Arbiter::start(clone!(config, |_| UpstreamRelay::new(config)));
 
-        let outcome_producer = OutcomeProducer::create(config.clone())?;
+        let outcome_producer = OutcomeProducer::create(config.clone(), upstream_relay.clone())?;
         let outcome_producer = Arbiter::start(move |_| outcome_producer);
 
         let redis_pool = match config.redis() {

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -160,8 +160,9 @@ def mini_sentry(request):
         if relay_id not in authenticated_relays:
             abort(403, "relay not registered")
 
-        outcomes_batch = flask_request.json()
+        outcomes_batch = flask_request.json
         sentry.captured_outcomes.put(outcomes_batch)
+        return jsonify({})
 
     @app.errorhandler(500)
     def fail(e):

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -19,6 +19,7 @@ class Sentry(SentryLike):
         self.app = app
         self.project_configs = {}
         self.captured_events = Queue()
+        self.captured_outcomes = Queue()
         self.test_failures = []
         self.upstream = None
         self.hits = {}
@@ -152,6 +153,16 @@ def mini_sentry(request):
                 relays[id] = relay
 
         return jsonify(public_keys=keys, relays=relays)
+
+    @app.route("/api/0/relays/outcomes", methods=["POST"])
+    def outcomes():
+        relay_id = flask_request.headers["x-sentry-relay-id"]
+        if relay_id not in authenticated_relays:
+            abort(403, "relay not registered")
+
+        outcomes_batch = flask_request.json()
+        sentry.captured_outcomes.put(outcomes_batch)
+
 
     @app.errorhandler(500)
     def fail(e):

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -154,7 +154,7 @@ def mini_sentry(request):
 
         return jsonify(public_keys=keys, relays=relays)
 
-    @app.route("/api/0/relays/outcomes", methods=["POST"])
+    @app.route("/api/0/relays/outcomes/", methods=["POST"])
     def outcomes():
         relay_id = flask_request.headers["x-sentry-relay-id"]
         if relay_id not in authenticated_relays:
@@ -162,7 +162,6 @@ def mini_sentry(request):
 
         outcomes_batch = flask_request.json()
         sentry.captured_outcomes.put(outcomes_batch)
-
 
     @app.errorhandler(500)
     def fail(e):

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1,8 +1,11 @@
 import datetime
 import json
+import uuid
+
+import time
 
 
-def test_outcomes(relay_with_processing, kafka_consumer, mini_sentry):
+def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry):
     relay = relay_with_processing()
     relay.wait_relay_healthcheck()
     outcomes = kafka_consumer("outcomes")
@@ -53,3 +56,81 @@ def test_outcomes(relay_with_processing, kafka_consumer, mini_sentry):
         "remote_addr": "127.0.0.1",
     }
     assert outcome == expected
+
+
+def _send_event(relay):
+    event_id = uuid.uuid1().hex
+    message_text = "some message {}".format(datetime.datetime.now())
+    relay.send_event(
+        42,
+        {
+            "event_id": event_id,
+            "message": message_text,
+            "extra": {"msg_text": message_text},
+        },
+    )
+    return event_id
+
+
+def test_outcomes_non_processing(relay, relay_with_processing, mini_sentry):
+    config = {
+        "relay": {
+            "emit_outcomes": True,
+            "max_outcome_batch_size": 1,
+            "max_outcome_interval_millsec": 1,
+        }
+    }
+
+    relay = relay(mini_sentry, config)
+    relay.wait_relay_healthcheck()
+    # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
+    mini_sentry.project_configs[42] = None
+
+    event_ids = []
+    for i in range(1):
+        event_id = _send_event(relay)
+        event_ids.append(event_id)
+
+    events = mini_sentry.captured_events
+
+    assert events.empty()  # no events received since all have been for an invalid project id
+    outcomes = mini_sentry.captured_outcomes
+    assert outcomes.qsize() == 1
+
+
+def test_outcomes_non_processing_batching(relay, mini_sentry):
+    config = {
+        "relay": {
+            "emit_outcomes": True,
+            "max_outcome_batch_size": 3,
+            "max_outcome_interval_millsec": 3600 * 1000,  # an hour
+        }
+    }
+
+    relay = relay(config)
+    relay.wait_relay_healthcheck()
+    # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
+    mini_sentry.project_configs[42] = None
+
+    event_ids = []
+    for i in range(2):
+        event_id = _send_event(relay)
+        event_ids.append(event_id)
+
+    # nothing should be sent at this time
+    outcomes = mini_sentry.captured_outcomes
+    assert outcomes.qsize() == 0
+
+    event_id = _send_event(relay)
+    event_ids.append(event_id)
+
+    # now we should have received a batch with all the events
+    outcomes = mini_sentry.captured_outcomes
+    assert outcomes.qsize() == 1
+
+    outcomes_batch = outcomes.get(block=False)
+
+    outcomes = outcomes_batch.get("outcomes")
+    assert len(outcomes) == 3
+    actual_event_ids = [ outcome.get("event_id") for outcome in outcomes]
+    assert event_ids == actual_event_ids

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -93,7 +93,8 @@ def test_outcomes_non_processing(relay, relay_with_processing, mini_sentry):
 
     events = mini_sentry.captured_events
 
-    assert events.empty()  # no events received since all have been for an invalid project id
+    # no events received since all have been for an invalid project id
+    assert events.empty()
     outcomes = mini_sentry.captured_outcomes
     assert outcomes.qsize() == 1
 
@@ -132,5 +133,5 @@ def test_outcomes_non_processing_batching(relay, mini_sentry):
 
     outcomes = outcomes_batch.get("outcomes")
     assert len(outcomes) == 3
-    actual_event_ids = [ outcome.get("event_id") for outcome in outcomes]
+    actual_event_ids = [outcome.get("event_id") for outcome in outcomes]
     assert event_ids == actual_event_ids

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1,8 +1,11 @@
-import datetime
+from datetime import datetime
 import json
 import uuid
+from queue import Empty
 
 import time
+
+HOUR_MILLISEC = 1000 * 3600
 
 
 def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry):
@@ -12,7 +15,7 @@ def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry)
     # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
     mini_sentry.project_configs[42] = None
 
-    message_text = "some message {}".format(datetime.datetime.now())
+    message_text = "some message {}".format(datetime.now())
     event_id = "11122233344455566677788899900011"
     relay.send_event(
         42,
@@ -22,10 +25,10 @@ def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry)
             "extra": {"msg_text": message_text},
         },
     )
-    start = datetime.datetime.utcnow()
+    start = datetime.utcnow()
     # polling first message can take a few good seconds
     outcome = outcomes.poll(timeout=20)
-    end = datetime.datetime.utcnow()
+    end = datetime.utcnow()
 
     assert outcome is not None
     outcome = outcome.value()
@@ -43,7 +46,7 @@ def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry)
     timestamp = outcome.get("timestamp")
     del outcome["timestamp"]
     assert timestamp is not None
-    event_emission = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    event_emission = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
     assert start <= event_emission <= end
     # reconstruct the expected message without timestamp
     expected = {
@@ -60,21 +63,28 @@ def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry)
 
 def _send_event(relay):
     event_id = uuid.uuid1().hex
-    message_text = "some message {}".format(datetime.datetime.now())
-    relay.send_event(
-        42,
-        {
-            "event_id": event_id,
-            "message": message_text,
-            "extra": {"msg_text": message_text},
-        },
-    )
+    message_text = "some message {}".format(datetime.now())
+    event_body = {
+        "event_id": event_id,
+        "message": message_text,
+        "extra": {"msg_text": message_text},
+    }
+
+    try:
+        relay.send_event(42, event_body)
+    except:
+        pass
     return event_id
 
 
 def test_outcomes_non_processing(relay, relay_with_processing, mini_sentry):
+    """
+    Test basic outcome functionality.
+    Send one event that generates an outcome and verify that we get an outcomes batch
+    with all necessary information set.
+    """
     config = {
-        "relay": {
+        "outcomes": {
             "emit_outcomes": True,
             "max_outcome_batch_size": 1,
             "max_outcome_interval_millsec": 1,
@@ -86,52 +96,144 @@ def test_outcomes_non_processing(relay, relay_with_processing, mini_sentry):
     # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
     mini_sentry.project_configs[42] = None
 
-    event_ids = []
-    for i in range(1):
-        event_id = _send_event(relay)
-        event_ids.append(event_id)
+    event_id = _send_event(relay)
 
-    events = mini_sentry.captured_events
+    outcomes_batch = mini_sentry.captured_outcomes.get(timeout=0.2)
+    assert mini_sentry.captured_outcomes.qsize() == 0  # we had only one batch
+
+    outcomes = outcomes_batch.get("outcomes")
+    assert len(outcomes) == 1
+
+    outcome = outcomes[0]
+
+    timestamp = outcome.get("timestamp")
+    del outcome["timestamp"]  # 'timestamp': '2020-06-03T16:18:59.259447Z'
+
+    expected_outcome = {
+        "project_id": 42,
+        "outcome": 3,  # invalid
+        "reason": "project_id",  # missing project id
+        "event_id": event_id,
+        "remote_addr": "127.0.0.1",
+    }
+    assert outcome == expected_outcome
 
     # no events received since all have been for an invalid project id
-    assert events.empty()
-    outcomes = mini_sentry.captured_outcomes
-    assert outcomes.qsize() == 1
+    assert mini_sentry.captured_events.empty()
 
 
-def test_outcomes_non_processing_batching(relay, mini_sentry):
+def test_outcomes_not_sent_when_disabled(relay, mini_sentry):
+    """
+    Set batching to a very short interval and verify that we don't receive any outcome
+    when we disable outcomes.
+    """
     config = {
-        "relay": {
-            "emit_outcomes": True,
-            "max_outcome_batch_size": 3,
-            "max_outcome_interval_millsec": 3600 * 1000,  # an hour
+        "outcomes": {
+            "emit_outcomes": False,
+            "max_outcome_batch_size": 1,
+            "max_outcome_interval_millsec": 1,
         }
     }
 
-    relay = relay(config)
+    relay = relay(mini_sentry, config)
     relay.wait_relay_healthcheck()
     # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
     mini_sentry.project_configs[42] = None
 
-    event_ids = []
-    for i in range(2):
+    try:
+        outcomes_batch = mini_sentry.captured_outcomes.get(timeout=0.2)
+        assert False  # we should not be here ( previous call should have failed)
+    except Empty:
+        pass  # we do expect not to get anything since we have outcomes disabled
+
+
+def test_outcomes_non_processing_max_batch_time(relay, mini_sentry):
+    """
+    Test that outcomes are not batched more than max specified time.
+    Send events at an  interval longer than max_batch_time and expect
+    not to have them batched although we have a very large batch size.
+    """
+    events_to_send = 3
+    config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "max_outcome_batch_size": 1000,  # a huge batch size
+            "max_outcome_interval_millsec": 1,  # very short batch time
+        }
+    }
+    relay = relay(mini_sentry, config)
+    relay.wait_relay_healthcheck()
+    # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
+    mini_sentry.project_configs[42] = None
+
+    event_ids = set()
+    # send one less events than the batch size (and check we don't send anything)
+    for i in range(events_to_send):
         event_id = _send_event(relay)
-        event_ids.append(event_id)
+        event_ids.add(event_id)
+        time.sleep(0.002)  # sleep more than the batch time
+
+    # we should get one batch per event sent
+    batches = []
+    for batch_id in range(events_to_send):
+        batch = mini_sentry.captured_outcomes.get(timeout=0.2)
+        batches.append(batch)
+
+    # verify that the batches contain one outcome each and the event_ids are ok
+    for batch in batches:
+        outcomes = batch.get("outcomes")
+        assert len(outcomes) == 1  # one outcome per batch
+        assert outcomes[0].get("event_id") in event_ids  # a known event id
+
+
+def test_outcomes_non_processing_batching(relay, mini_sentry):
+    """
+    Test that outcomes are batched according to max size.
+    Send max_outcome_batch_size events with a very large max_batch_time and expect all
+    to come in one batch.
+    """
+    batch_size = 3
+    config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "max_outcome_batch_size": batch_size,
+            "max_outcome_interval_millsec": HOUR_MILLISEC,  # batch every hour
+        }
+    }
+
+    relay = relay(mini_sentry, config)
+    relay.wait_relay_healthcheck()
+    # hack mini_sentry configures project 42 (remove the configuration so that we get an error for project 42)
+    mini_sentry.project_configs[42] = None
+
+    event_ids = set()
+    # send one less events than the batch size (and check we don't send anything)
+    for i in range(batch_size - 1):
+        event_id = _send_event(relay)
+        event_ids.add(event_id)
 
     # nothing should be sent at this time
-    outcomes = mini_sentry.captured_outcomes
-    assert outcomes.qsize() == 0
+    try:
+        mini_sentry.captured_outcomes.get(timeout=0.2)
+        assert False  # the request should timeout, there is no outcome coming
+    except Empty:
+        pass  # yes we expect to timout since there should not be any outcome sent yet
 
     event_id = _send_event(relay)
-    event_ids.append(event_id)
+    event_ids.add(event_id)
 
-    # now we should have received a batch with all the events
-    outcomes = mini_sentry.captured_outcomes
-    assert outcomes.qsize() == 1
-
-    outcomes_batch = outcomes.get(block=False)
+    # now we should be getting a batch
+    outcomes_batch = mini_sentry.captured_outcomes.get(timeout=0.2)
+    # we should have received only one outcomes batch (check nothing left)
+    assert mini_sentry.captured_outcomes.qsize() == 0
 
     outcomes = outcomes_batch.get("outcomes")
-    assert len(outcomes) == 3
-    actual_event_ids = [outcome.get("event_id") for outcome in outcomes]
-    assert event_ids == actual_event_ids
+    assert len(outcomes) == batch_size
+
+    received_event_ids = [outcome.get("event_id") for outcome in outcomes]
+
+    for event_id in received_event_ids:
+        assert event_id in event_ids  # the outcome is one of those we sent
+
+    # no events received since all have been for an invalid project id
+    assert mini_sentry.captured_events.empty()

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -86,8 +86,8 @@ def test_outcomes_non_processing(relay, relay_with_processing, mini_sentry):
     config = {
         "outcomes": {
             "emit_outcomes": True,
-            "max_outcome_batch_size": 1,
-            "max_outcome_interval_millsec": 1,
+            "max_batch_size": 1,
+            "max_interval": 1,
         }
     }
 
@@ -130,8 +130,8 @@ def test_outcomes_not_sent_when_disabled(relay, mini_sentry):
     config = {
         "outcomes": {
             "emit_outcomes": False,
-            "max_outcome_batch_size": 1,
-            "max_outcome_interval_millsec": 1,
+            "max_batch_size": 1,
+            "max_interval": 1,
         }
     }
 
@@ -157,8 +157,8 @@ def test_outcomes_non_processing_max_batch_time(relay, mini_sentry):
     config = {
         "outcomes": {
             "emit_outcomes": True,
-            "max_outcome_batch_size": 1000,  # a huge batch size
-            "max_outcome_interval_millsec": 1,  # very short batch time
+            "max_batch_size": 1000,  # a huge batch size
+            "max_interval": 1,  # very short batch time
         }
     }
     relay = relay(mini_sentry, config)
@@ -171,7 +171,7 @@ def test_outcomes_non_processing_max_batch_time(relay, mini_sentry):
     for i in range(events_to_send):
         event_id = _send_event(relay)
         event_ids.add(event_id)
-        time.sleep(0.002)  # sleep more than the batch time
+        time.sleep(0.005)  # sleep more than the batch time
 
     # we should get one batch per event sent
     batches = []
@@ -196,8 +196,8 @@ def test_outcomes_non_processing_batching(relay, mini_sentry):
     config = {
         "outcomes": {
             "emit_outcomes": True,
-            "max_outcome_batch_size": batch_size,
-            "max_outcome_interval_millsec": HOUR_MILLISEC,  # batch every hour
+            "max_batch_size": batch_size,
+            "max_interval": HOUR_MILLISEC,  # batch every hour
         }
     }
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -84,11 +84,7 @@ def test_outcomes_non_processing(relay, relay_with_processing, mini_sentry):
     with all necessary information set.
     """
     config = {
-        "outcomes": {
-            "emit_outcomes": True,
-            "max_batch_size": 1,
-            "max_interval": 1,
-        }
+        "outcomes": {"emit_outcomes": True, "batch_size": 1, "batch_interval": 1,}
     }
 
     relay = relay(mini_sentry, config)
@@ -128,11 +124,7 @@ def test_outcomes_not_sent_when_disabled(relay, mini_sentry):
     when we disable outcomes.
     """
     config = {
-        "outcomes": {
-            "emit_outcomes": False,
-            "max_batch_size": 1,
-            "max_interval": 1,
-        }
+        "outcomes": {"emit_outcomes": False, "batch_size": 1, "batch_interval": 1,}
     }
 
     relay = relay(mini_sentry, config)
@@ -157,8 +149,8 @@ def test_outcomes_non_processing_max_batch_time(relay, mini_sentry):
     config = {
         "outcomes": {
             "emit_outcomes": True,
-            "max_batch_size": 1000,  # a huge batch size
-            "max_interval": 1,  # very short batch time
+            "batch_size": 1000,  # a huge batch size
+            "batch_interval": 1,  # very short batch time
         }
     }
     relay = relay(mini_sentry, config)
@@ -196,8 +188,8 @@ def test_outcomes_non_processing_batching(relay, mini_sentry):
     config = {
         "outcomes": {
             "emit_outcomes": True,
-            "max_batch_size": batch_size,
-            "max_interval": HOUR_MILLISEC,  # batch every hour
+            "batch_size": batch_size,
+            "batch_interval": HOUR_MILLISEC,  # batch every hour
         }
     }
 


### PR DESCRIPTION
Relay installations that use the full (all features) binary may be configured to operate with processing disabled.
When operating with processing disabled they should forward the outcomes to the http endpoint of the upstream instead
of placing them on the outcomes kafka topic.