### PR TITLE
feat(general): Add schema for success metrics

### DIFF
--- a/relay-general/src/protocol/metrics.rs
+++ b/relay-general/src/protocol/metrics.rs
@@ -117,8 +117,8 @@ pub struct Metrics {
     /// Example: malformed/unparseable debug information files.
     ///
     /// This metric is measured in Sentry and should be reported in all processing tasks.
-    #[metastructure(field = "error.processing")]
-    pub error_processing: Annotated<bool>,
+    #[metastructure(field = "flag.error.processing")]
+    pub flag_error_processing: Annotated<bool>,
 
     /// Whether there has been a processing error that almost certainly renders the event
     /// unusuable.
@@ -127,8 +127,8 @@ pub struct Metrics {
     /// context data and attachments, and we already billed the user anyway.
     ///
     /// This metric is measured in Sentry and should be reported in all processing tasks.
-    #[metastructure(field = "fatal.processing")]
-    pub fatal_processing: Annotated<bool>,
+    #[metastructure(field = "flag.fatal.processing")]
+    pub flag_fatal_processing: Annotated<bool>,
 }
 
 // Do not process Metrics

--- a/relay-general/src/protocol/metrics.rs
+++ b/relay-general/src/protocol/metrics.rs
@@ -117,8 +117,8 @@ pub struct Metrics {
     /// Example: malformed/unparseable debug information files.
     ///
     /// This metric is measured in Sentry and should be reported in all processing tasks.
-    #[metastructure(field = "flag.error.processing")]
-    pub flag_error_processing: Annotated<bool>,
+    #[metastructure(field = "flag.processing.error")]
+    pub flag_processing_error: Annotated<bool>,
 
     /// Whether there has been a processing error that almost certainly renders the event
     /// unusuable.
@@ -127,8 +127,8 @@ pub struct Metrics {
     /// context data and attachments, and we already billed the user anyway.
     ///
     /// This metric is measured in Sentry and should be reported in all processing tasks.
-    #[metastructure(field = "flag.fatal.processing")]
-    pub flag_fatal_processing: Annotated<bool>,
+    #[metastructure(field = "flag.processing.fatal")]
+    pub flag_processing_fatal: Annotated<bool>,
 }
 
 // Do not process Metrics

--- a/relay-general/src/protocol/metrics.rs
+++ b/relay-general/src/protocol/metrics.rs
@@ -111,6 +111,24 @@ pub struct Metrics {
     /// This metric is measured in Sentry and reported in the javascript processing task.
     #[metastructure(field = "ms.processing.sourcemaps")]
     pub ms_processing_sourcemaps: Annotated<u64>,
+
+    /// Whether there has been a processing error that likely impacts the usefulness of an event.
+    ///
+    /// Example: malformed/unparseable debug information files.
+    ///
+    /// This metric is measured in Sentry and should be reported in all processing tasks.
+    #[metastructure(field = "error.processing")]
+    pub error_processing: Annotated<bool>,
+
+    /// Whether there has been a processing error that almost certainly renders the event
+    /// unusuable.
+    ///
+    /// Example: Minidump could not be parsed, but we do not drop the event as it may still contain
+    /// context data and attachments, and we already billed the user anyway.
+    ///
+    /// This metric is measured in Sentry and should be reported in all processing tasks.
+    #[metastructure(field = "fatal.processing")]
+    pub fatal_processing: Annotated<bool>,
 }
 
 // Do not process Metrics


### PR DESCRIPTION
This serves only documentation purposes. Adds metrics for errors and failures in the processing pipeline.

Used in https://github.com/getsentry/sentry/pull/19068