### PR TITLE
ref(server): Restructure endpoints to report correct metrics

### DIFF
--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -1,13 +1,13 @@
 //! Returns captured events.
 
 use ::actix::prelude::*;
-use actix_web::{http::Method, HttpResponse, Path, Scope};
+use actix_web::{http::Method, HttpResponse, Path};
 use futures::future::Future;
 
 use crate::actors::events::GetCapturedEvent;
 use crate::envelope;
 use crate::extractors::CurrentServiceState;
-use crate::service::ServiceState;
+use crate::service::ServiceApp;
 
 use relay_general::protocol::EventId;
 
@@ -34,8 +34,8 @@ fn get_captured_event(
     Box::new(future)
 }
 
-pub fn configure_scope(scope: Scope<ServiceState>) -> Scope<ServiceState> {
-    scope.resource("/events/{event_id}/", |r| {
+pub fn configure_app(app: ServiceApp) -> ServiceApp {
+    app.resource("/api/relay/events/{event_id}/", |r| {
         r.name("internal-events");
         r.method(Method::GET).with(get_captured_event);
     })

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -14,6 +14,7 @@ use relay_common::GlobMatcher;
 use relay_config::Config;
 
 use crate::body::ForwardBody;
+use crate::endpoints::statics;
 use crate::extractors::ForwardedFor;
 use crate::service::{ServiceApp, ServiceState};
 
@@ -138,7 +139,7 @@ pub fn configure_app(app: ServiceApp) -> ServiceApp {
     // "/api/" path is special as it is actually a web UI endpoint.
     app.resource("/api/", |r| {
         r.name("api-root");
-        r.f(|_| HttpResponse::NotFound())
+        r.f(statics::not_found)
     })
     .handler("/api", forward_upstream)
 }

--- a/relay-server/src/endpoints/healthcheck.rs
+++ b/relay-server/src/endpoints/healthcheck.rs
@@ -1,11 +1,11 @@
 //! A simple healthcheck endpoint for the relay.
 use ::actix::prelude::*;
-use actix_web::{Error, HttpResponse, Scope};
+use actix_web::{Error, HttpResponse};
 use futures::prelude::*;
 use serde::Serialize;
 
 use crate::extractors::CurrentServiceState;
-use crate::service::ServiceState;
+use crate::service::ServiceApp;
 
 use crate::actors::healthcheck::IsHealthy;
 
@@ -61,14 +61,13 @@ fn liveness_healthcheck(state: CurrentServiceState) -> ResponseFuture<HttpRespon
     healthcheck_impl(state, IsHealthy::Liveness)
 }
 
-pub fn configure_scope(scope: Scope<ServiceState>) -> Scope<ServiceState> {
-    scope
-        .resource("/healthcheck/ready/", |r| {
-            r.name("internal-healthcheck-ready");
-            r.get().with(readiness_healthcheck);
-        })
-        .resource("/healthcheck/live/", |r| {
-            r.name("internal-healthcheck-live");
-            r.get().with(liveness_healthcheck);
-        })
+pub fn configure_app(app: ServiceApp) -> ServiceApp {
+    app.resource("/api/relay/healthcheck/ready/", |r| {
+        r.name("internal-healthcheck-ready");
+        r.get().with(readiness_healthcheck);
+    })
+    .resource("/api/relay/healthcheck/live/", |r| {
+        r.name("internal-healthcheck-live");
+        r.get().with(liveness_healthcheck);
+    })
 }

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -3,8 +3,6 @@
 //! This module contains implementations for all supported relay endpoints, as well as a generic
 //! `forward` endpoint that sends unknown requests to the upstream.
 
-use actix_web::HttpResponse;
-
 use crate::service::ServiceApp;
 
 mod attachments;
@@ -17,25 +15,26 @@ mod minidump;
 mod project_configs;
 mod public_keys;
 mod security_report;
+mod statics;
 mod store;
 mod unreal;
 
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
-    app.scope("/api/relay", |mut scope| {
-        scope = healthcheck::configure_scope(scope);
-        scope = events::configure_scope(scope);
-
-        // never forward /api/relay, as that prefix is used for stuff like healthchecks
-        scope.default_resource(|r| r.f(|_| HttpResponse::NotFound()))
-    })
-    .configure(project_configs::configure_app)
-    .configure(public_keys::configure_app)
-    .configure(store::configure_app)
-    .configure(envelope::configure_app)
-    .configure(security_report::configure_app)
-    .configure(minidump::configure_app)
-    .configure(attachments::configure_app)
-    .configure(unreal::configure_app)
-    // `forward` must be last as it creates a wildcard proxy
-    .configure(forward::configure_app)
+    app
+        // Internal routes pointing to /api/relay
+        .configure(healthcheck::configure_app)
+        .configure(events::configure_app)
+        .handler("/api/relay", statics::not_found)
+        // Web API routes pointing to /api/0
+        .configure(project_configs::configure_app)
+        .configure(public_keys::configure_app)
+        // Ingestion routes pointing to /api/<project_id>/
+        .configure(store::configure_app)
+        .configure(envelope::configure_app)
+        .configure(security_report::configure_app)
+        .configure(minidump::configure_app)
+        .configure(attachments::configure_app)
+        .configure(unreal::configure_app)
+        // `forward` must be last as it creates a wildcard proxy
+        .configure(forward::configure_app)
 }

--- a/relay-server/src/endpoints/statics.rs
+++ b/relay-server/src/endpoints/statics.rs
@@ -1,0 +1,10 @@
+use actix_web::{HttpRequest, HttpResponse};
+
+use crate::service::ServiceState;
+
+/// An endpoint function that always responds with `404 Not Found`.
+///
+/// This function has a signature compatible with `App::handler` and `Resource::f`.
+pub fn not_found(_: &HttpRequest<ServiceState>) -> HttpResponse {
+    HttpResponse::NotFound().finish()
+}


### PR DESCRIPTION
Instead of using `App::scope`, this creates all endpoints directly on the App.
Scopes internally create an unnamed resource, which would report wrong to in the
metrics middleware.

Additionally, all endpoints now declare their full URL.

