### PR TITLE
fix(server): Refresh projects based on internal timestamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
     - master
     - /^release\/[\d.]+$/
     - /^release-library\/[\d.]+$/
-    - tmp/project-logs
 
 before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
     - master
     - /^release\/[\d.]+$/
     - /^release-library\/[\d.]+$/
+    - tmp/project-logs
 
 before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable}


### PR DESCRIPTION
The `last_fetch` timestamp in project configs is set when it is written into the cache in Sentry. Since this timestamp may be arbitrarily old, this will force Relays to constantly refresh all project caches. While this is not such a big deal internally, since those requests go to a cache, it creates too much load for external Relays. Also, these time stamps are subject to clock drift and should not be trusted.

As such, the `last_fetch` timestamp has no useful semantics. Instead, the instant of loading the `ProjectState` should be used to determine the last fetch.

Since fetching projects is now a fast operation (both internally and externally), the overcomplicated logic for creating jitter is no longer appropriate. Instead, a simple time-based backoff for refreshes is absolutely sufficient.

Reverts https://github.com/getsentry/relay/pull/277