### PR TITLE
ref(server): Retain exception values for minidumps [ISSUE-932]

### DIFF
--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -140,7 +140,7 @@ mod tests {
 
     fn get_event_with_exception_value(val: &str) -> Event {
         let ex = Exception {
-            value: Annotated::from(JsonLenientString::from(val.to_string())),
+            value: Annotated::from(JsonLenientString::from(val)),
             ..Exception::default()
         };
 

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -736,7 +736,13 @@ impl FromValue for JsonLenientString {
 
 impl From<String> for JsonLenientString {
     fn from(value: String) -> Self {
-        JsonLenientString(value)
+        Self(value)
+    }
+}
+
+impl From<&'_ str> for JsonLenientString {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
     }
 }
 


### PR DESCRIPTION
Minidump ingestion always creates a placeholder exception with the `minidump` mechanism, which triggers processing of the minidump. This drops all attached exception information from the SDK.

Instead of overwriting existing information, we can retain it here.

Partially resolves https://github.com/getsentry/relay/issues/4972