### PR TITLE
meta: Add unreleased changes to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+We have switched to [CalVer](https://calver.org/)! Relay's version is always in
+line with the latest version of [Sentry](https://github.com/getsentry/sentry).
+
+**Features**:
+
+- Proxy and managed Relays now apply clock drift correction based on the
+  `sent_at` header emitted by SDKs. (#581)
+
+**Bug Fixes**:
+
+- Clock drift correction no longer considers the transaction timestamp as
+  baseline for SDKs using Envelopes. Instead, only the dedicated `sent_at`
+  Envelope header is used. (#580)
+- The `http.timeout` setting is now applied to all requests, including event
+  submission. Previously, events were exempt. (#588)
+- All endpoint metrics now report their proper `route` tag. This applies to
+  `requests`, `requests.duration`, and `responses.status_codes`. Previously,
+  some some endpoints reported an empty route. (#595)
+- Properly refresh cached project states based on the configured intervals.
+  Previously, Relay may have gone into an endless refresh cycle if the system
+  clock not accurate, or the state had not been updated in the upstream. (#596)
+- Respond with `403 Forbidden` when multiple authentication payloads are sent by
+  the SDK. Previously, Relay would authenticate using one of the payloads and
+  silently ignore the rest. (#602)
+
+**Internal**:
+
+- Ignore non-Rust folders for faster rebuilding and testing. (#578)
+- Invalid session payloads are now logged for SDK debugging. (#584, #591)
+- Remove unused `rev` from project state. (#586)
+- Add an outcome endpoint for trusted Relays. (#589)
+
 ## 0.5.9
 
 - Relay has a logo now!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,56 +2,33 @@
 
 ## Unreleased
 
-We have switched to [CalVer](https://calver.org/)! Relay's version is always in
-line with the latest version of [Sentry](https://github.com/getsentry/sentry).
+We have switched to [CalVer](https://calver.org/)! Relay's version is always in line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Features**:
 
-- Proxy and managed Relays now apply clock drift correction based on the
-  `sent_at` header emitted by SDKs.
-  ([#581](https://github.com/getsentry/relay/pull/581))
+- Proxy and managed Relays now apply clock drift correction based on the `sent_at` header emitted by SDKs. ([#581](https://github.com/getsentry/relay/pull/581))
 
 **Bug Fixes**:
 
-- Clock drift correction no longer considers the transaction timestamp as
-  baseline for SDKs using Envelopes. Instead, only the dedicated `sent_at`
-  Envelope header is used. ([#580](https://github.com/getsentry/relay/pull/580))
-- The `http.timeout` setting is now applied to all requests, including event
-  submission. Previously, events were exempt.
-  ([#588](https://github.com/getsentry/relay/pull/588))
-- All endpoint metrics now report their proper `route` tag. This applies to
-  `requests`, `requests.duration`, and `responses.status_codes`. Previously,
-  some some endpoints reported an empty route.
-  ([#595](https://github.com/getsentry/relay/pull/595))
-- Properly refresh cached project states based on the configured intervals.
-  Previously, Relay may have gone into an endless refresh cycle if the system
-  clock not accurate, or the state had not been updated in the upstream.
-  ([#596](https://github.com/getsentry/relay/pull/596))
-- Respond with `403 Forbidden` when multiple authentication payloads are sent by
-  the SDK. Previously, Relay would authenticate using one of the payloads and
-  silently ignore the rest.
-  ([#602](https://github.com/getsentry/relay/pull/602))
+- Clock drift correction no longer considers the transaction timestamp as baseline for SDKs using Envelopes. Instead, only the dedicated `sent_at` Envelope header is used. ([#580](https://github.com/getsentry/relay/pull/580))
+- The `http.timeout` setting is now applied to all requests, including event submission. Previously, events were exempt. ([#588](https://github.com/getsentry/relay/pull/588))
+- All endpoint metrics now report their proper `route` tag. This applies to `requests`, `requests.duration`, and `responses.status_codes`. Previously, some some endpoints reported an empty route. ([#595](https://github.com/getsentry/relay/pull/595))
+- Properly refresh cached project states based on the configured intervals. Previously, Relay may have gone into an endless refresh cycle if the system clock not accurate, or the state had not been updated in the upstream. ([#596](https://github.com/getsentry/relay/pull/596))
+- Respond with `403 Forbidden` when multiple authentication payloads are sent by the SDK. Previously, Relay would authenticate using one of the payloads and silently ignore the rest. ([#602](https://github.com/getsentry/relay/pull/602))
 
 **Internal**:
 
-- Ignore non-Rust folders for faster rebuilding and testing.
-  ([#578](https://github.com/getsentry/relay/pull/578))
-- Invalid session payloads are now logged for SDK debugging.
-  ([#584](https://github.com/getsentry/relay/pull/584),
-  [#591](https://github.com/getsentry/relay/pull/591))
-- Remove unused `rev` from project state.
-  ([#586](https://github.com/getsentry/relay/pull/586))
-- Add an outcome endpoint for trusted Relays.
-  ([#589](https://github.com/getsentry/relay/pull/589))
+- Ignore non-Rust folders for faster rebuilding and testing. ([#578](https://github.com/getsentry/relay/pull/578))
+- Invalid session payloads are now logged for SDK debugging. ([#584](https://github.com/getsentry/relay/pull/584), [#591](https://github.com/getsentry/relay/pull/591))
+- Remove unused `rev` from project state. ([#586](https://github.com/getsentry/relay/pull/586))
+- Add an outcome endpoint for trusted Relays. ([#589](https://github.com/getsentry/relay/pull/589))
 
 ## 0.5.9
 
 - Relay has a logo now!
-- New explicit `envelope/` endpoint. Envelopes no longer need to be sent with
-  the right `content-type` header (to cater to browser JS).
+- New explicit `envelope/` endpoint. Envelopes no longer need to be sent with the right `content-type` header (to cater to browser JS).
 - Introduce an Envelope item type for transactions.
-- Support environment variables and CLI arguments instead of command line
-  parameters.
+- Support environment variables and CLI arguments instead of command line parameters.
 - Return status `415` on wrong content types.
 - Normalize double-slashes in request URLs more aggressively.
 - Add an option to generate credentials on stdout.
@@ -78,27 +55,20 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 **Internal**:
 
 - Release is now a required attribute for session data.
-- `unknown` can now be used in place of `unknown_error` for span statuses. A
-  future release will change the canonical format from `unknown_error` to
-  `unknown`.
+- `unknown` can now be used in place of `unknown_error` for span statuses. A future release will change the canonical format from `unknown_error` to `unknown`.
 
 ## 0.5.6
 
-- Fix a bug where Relay would stop processing events if Sentry is down for only
-  a short time.
+- Fix a bug where Relay would stop processing events if Sentry is down for only a short time.
 - Improvements to architecture documentation.
 - Initial support for rate limiting by event type ("scoped quotas")
 - Fix a bug where `key_id` was omitted from outcomes created by Relay.
-- Fix a bug where it was not permitted to send content-encoding as part of a
-  CORS request to store.
+- Fix a bug where it was not permitted to send content-encoding as part of a CORS request to store.
 
 **Internal**:
 
-- PII processing: Aliases for value types (`$error` instead of `$exception` to
-  be in sync with Discover column naming) and adding a default for
-  replace-redactions.
-- It is now valid to send transactions and spans without `op` set, in which case
-  a default value will be inserted.
+- PII processing: Aliases for value types (`$error` instead of `$exception` to be in sync with Discover column naming) and adding a default for replace-redactions.
+- It is now valid to send transactions and spans without `op` set, in which case a default value will be inserted.
 
 ## 0.5.5
 
@@ -121,36 +91,26 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 ## 0.5.3
 
 - Properly strip the linux binary to reduce its size
-- Allow base64 encoded JSON event payloads
-  ([#466](https://github.com/getsentry/relay/pull/466))
-- Fix multipart requests without trailing newline
-  ([#465](https://github.com/getsentry/relay/pull/465))
-- Support for ingesting session updates
-  ([#449](https://github.com/getsentry/relay/pull/449))
+- Allow base64 encoded JSON event payloads ([#466](https://github.com/getsentry/relay/pull/466))
+- Fix multipart requests without trailing newline ([#465](https://github.com/getsentry/relay/pull/465))
+- Support for ingesting session updates ([#449](https://github.com/getsentry/relay/pull/449))
 
 **Internal**:
 
-- Validate release names during event ingestion
-  ([#479](https://github.com/getsentry/relay/pull/479))
-- Add browser extension filter
-  ([#470](https://github.com/getsentry/relay/pull/470))
-- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if
-  explicitly addressed.
+- Validate release names during event ingestion ([#479](https://github.com/getsentry/relay/pull/479))
+- Add browser extension filter ([#470](https://github.com/getsentry/relay/pull/470))
+- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if explicitly addressed.
 - Add way to scrub filepaths in a way that does not break processing.
 
 ## 0.5.2
 
 - Fix trivial Redis-related crash when running in non-processing mode.
-- Limit the maximum retry-after of a rate limit. This is necessary because of
-  the "Delete and ignore future events" feature in Sentry.
-- Project caches are now evicted after `project_grace_period` has passed. If you
-  have that parameter set to a high number you may see increased memory
-  consumption.
+- Limit the maximum retry-after of a rate limit. This is necessary because of the "Delete and ignore future events" feature in Sentry.
+- Project caches are now evicted after `project_grace_period` has passed. If you have that parameter set to a high number you may see increased memory consumption.
 
 **Internal**:
 
-- Misc bugfixes in PII processor. Those bugs do not affect the legacy data
-  scrubber exposed in Python.
+- Misc bugfixes in PII processor. Those bugs do not affect the legacy data scrubber exposed in Python.
 - Polishing documentation around PII configuration format.
 - Signal codes in mach mechanism are no longer required.
 
@@ -162,10 +122,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Fix a bug in the PII processor that would always remove the entire string on
-  `pattern` rules.
-- Ability to correct some clock drift and wrong system time in transaction
-  events.
+- Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
+- Ability to correct some clock drift and wrong system time in transaction events.
 
 ## 0.5.0
 
@@ -184,8 +142,7 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 - Implement the Attachment endpoint.
 - Implement the legacy Store endpoint.
 - Support a plain `Authorization` header in addition to `X-Sentry-Auth`.
-- Simplify the shutdown logic. Relay now always takes a fixed configurable time
-  to shut down.
+- Simplify the shutdown logic. Relay now always takes a fixed configurable time to shut down.
 - Fix healthchecks in _Static_ mode.
 - Fix internal handling of event attachments.
 - Fix partial reads of request bodies resulting in a broken connection.
@@ -211,19 +168,15 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 ## 0.4.63
 
-- Refactor healthchecks into two: Liveness and readiness (see code comments for
-  explanation for now).
+- Refactor healthchecks into two: Liveness and readiness (see code comments for explanation for now).
 - Allow multiple trailing slashes on store endpoint, e.g. `/api/42/store///`.
 - Internal refactor to prepare for envelopes format.
 
 **Internal**:
 
-- Fix a bug where glob-matching in filters did not behave correctly when the
-  to-be-matched string contained newlines.
-- Add `moz-extension:` as scheme for browser extensions (filtering out Firefox
-  addons).
-- Raise a dedicated Python exception type for invalid transaction events. Also
-  do not report that error to Sentry from Relay.
+- Fix a bug where glob-matching in filters did not behave correctly when the to-be-matched string contained newlines.
+- Add `moz-extension:` as scheme for browser extensions (filtering out Firefox addons).
+- Raise a dedicated Python exception type for invalid transaction events. Also do not report that error to Sentry from Relay.
 
 ## 0.4.62
 
@@ -233,62 +186,42 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Add `thread.errored` attribute
-  ([#306](https://github.com/getsentry/relay/pull/306)).
+- Add `thread.errored` attribute ([#306](https://github.com/getsentry/relay/pull/306)).
 
 ## 0.4.60
 
-- License is now BSL instead of MIT
-  ([#301](https://github.com/getsentry/relay/pull/301)).
-- Improve internal metrics and logging
-  ([#296](https://github.com/getsentry/relay/pull/296),
-  [#297](https://github.com/getsentry/relay/pull/297),
-  [#298](https://github.com/getsentry/relay/pull/298)).
-- Fix unbounded requests to Sentry for project configs
-  ([#295](https://github.com/getsentry/relay/pull/295),
-  [#300](https://github.com/getsentry/relay/pull/300)).
-- Fix rejected responses from Sentry due to size limit
-  ([#303](https://github.com/getsentry/relay/pull/303)).
-- Expose more options for configuring request concurrency limits
-  ([#311](https://github.com/getsentry/relay/pull/311)).
+- License is now BSL instead of MIT ([#301](https://github.com/getsentry/relay/pull/301)).
+- Improve internal metrics and logging ([#296](https://github.com/getsentry/relay/pull/296), [#297](https://github.com/getsentry/relay/pull/297), [#298](https://github.com/getsentry/relay/pull/298)).
+- Fix unbounded requests to Sentry for project configs ([#295](https://github.com/getsentry/relay/pull/295), [#300](https://github.com/getsentry/relay/pull/300)).
+- Fix rejected responses from Sentry due to size limit ([#303](https://github.com/getsentry/relay/pull/303)).
+- Expose more options for configuring request concurrency limits ([#311](https://github.com/getsentry/relay/pull/311)).
 
 **Internal**:
 
-- Transaction events with negative duration are now rejected
-  ([#291](https://github.com/getsentry/relay/pull/291)).
+- Transaction events with negative duration are now rejected ([#291](https://github.com/getsentry/relay/pull/291)).
 - Fix a panic when normalizing certain dates.
 
 ## 0.4.59
 
 **Internal**:
 
-- Fix: Normalize legacy stacktrace attributes
-  ([#292](https://github.com/getsentry/relay/pull/292))
-- Fix: Validate platform attributes in Relay
-  ([#294](https://github.com/getsentry/relay/pull/294))
-- Flip the flag that indicates Relay processing
-  ([#293](https://github.com/getsentry/relay/pull/293))
+- Fix: Normalize legacy stacktrace attributes ([#292](https://github.com/getsentry/relay/pull/292))
+- Fix: Validate platform attributes in Relay ([#294](https://github.com/getsentry/relay/pull/294))
+- Flip the flag that indicates Relay processing ([#293](https://github.com/getsentry/relay/pull/293))
 
 ## 0.4.58
 
-- Evict project caches after some time
-  ([#287](https://github.com/getsentry/relay/pull/287))
-- Selectively log internal errors to stderr
-  ([#285](https://github.com/getsentry/relay/pull/285))
-- Add an error boundary to parsing project states
-  ([#281](https://github.com/getsentry/relay/pull/281))
+- Evict project caches after some time ([#287](https://github.com/getsentry/relay/pull/287))
+- Selectively log internal errors to stderr ([#285](https://github.com/getsentry/relay/pull/285))
+- Add an error boundary to parsing project states ([#281](https://github.com/getsentry/relay/pull/281))
 
 **Internal**:
 
 - Add event size metrics ([#286](https://github.com/getsentry/relay/pull/286))
-- Normalize before datascrubbing
-  ([#290](https://github.com/getsentry/relay/pull/290))
-- Add a config value for thread counts
-  ([#283](https://github.com/getsentry/relay/pull/283))
-- Refactor outcomes for parity with Sentry
-  ([#282](https://github.com/getsentry/relay/pull/282))
-- Add flag that relay processed an event
-  ([#279](https://github.com/getsentry/relay/pull/279))
+- Normalize before datascrubbing ([#290](https://github.com/getsentry/relay/pull/290))
+- Add a config value for thread counts ([#283](https://github.com/getsentry/relay/pull/283))
+- Refactor outcomes for parity with Sentry ([#282](https://github.com/getsentry/relay/pull/282))
+- Add flag that relay processed an event ([#279](https://github.com/getsentry/relay/pull/279))
 
 ## 0.4.57
 
@@ -351,22 +284,19 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Fix various bugs in the datascrubber and PII processing code to get closer to
-  behavior of the Python implementation.
+- Fix various bugs in the datascrubber and PII processing code to get closer to behavior of the Python implementation.
 
 ## 0.4.47
 
 **Internal**:
 
-- Various work on re-implementing Sentry's `/api/X/store` endpoint in Relay.
-  Relay can now apply rate limits based on Redis and emit the correct outcomes.
+- Various work on re-implementing Sentry's `/api/X/store` endpoint in Relay. Relay can now apply rate limits based on Redis and emit the correct outcomes.
 
 ## 0.4.46
 
 **Internal**:
 
-- Resolved a regression in IP address normalization. The new behavior is closer
-  to a line-by-line port of the old Python code.
+- Resolved a regression in IP address normalization. The new behavior is closer to a line-by-line port of the old Python code.
 
 ## 0.4.45
 
@@ -378,16 +308,14 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Normalization**:
 
-- Only take the user IP address from the store request's IP for certain
-  platforms. This restores the behavior of the old Python code.
+- Only take the user IP address from the store request's IP for certain platforms. This restores the behavior of the old Python code.
 
 ## 0.4.43
 
 **Normalization**:
 
 - Bump size of breadcrumbs.
-- Workaround for an issue where we would not parse OS information from User
-  Agent when SDK had already sent OS information.
+- Workaround for an issue where we would not parse OS information from User Agent when SDK had already sent OS information.
 - Further work on Sentry-internal event ingestion.
 
 ## 0.4.42
@@ -472,8 +400,7 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Make exception messages/values larger to allow for foreign stacktrace data to
-  be attached.
+- Make exception messages/values larger to allow for foreign stacktrace data to be attached.
 
 ## 0.4.29
 
@@ -491,8 +418,7 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Increase frame vars size again! Byte size was fine, but max depth was way too
-  small.
+- Increase frame vars size again! Byte size was fine, but max depth was way too small.
 
 ## 0.4.26
 
@@ -516,8 +442,7 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Add basic truncation to event meta to prevent payload size from spiralling out
-  of control.
+- Add basic truncation to event meta to prevent payload size from spiralling out of control.
 
 ## 0.4.22
 
@@ -553,88 +478,71 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Added support for protocol changes related to upcoming sentry SDK features. In
-  particular the `none` event type was added.
+- Added support for protocol changes related to upcoming sentry SDK features. In particular the `none` event type was added.
 
 ## 0.4.16
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.15
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.14
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.13
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.12
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.11
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.10
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.9
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.8
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.7
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.6
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.5
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.4
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.3
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.2
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.1
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 ## 0.4.0
 
@@ -644,88 +552,65 @@ Introducing new Relay modes:
 - `static`: Static configuration for known projects in the file system.
 - `managed`: Fetch configurations dynamically from Sentry and update them.
 
-The default Relay mode is `managed`. Users upgrading from previous versions will
-automatically activate the `managed` mode. To change this setting, add
-`relay.mode` to `config.yml` or run `semaphore config init` from the command
-line.
+The default Relay mode is `managed`. Users upgrading from previous versions will automatically activate the `managed` mode. To change this setting, add `relay.mode` to `config.yml` or run `semaphore config init` from the command line.
 
-**Breaking Change**: If Relay was used without credentials, the mode needs to be
-set to `proxy`. The default `managed` mode requires credentials.
+**Breaking Change**: If Relay was used without credentials, the mode needs to be set to `proxy`. The default `managed` mode requires credentials.
 
-For more information on Relay modes, see the [documentation
-page](https://docs.sentry.io/data-management/relay/options/).
+For more information on Relay modes, see the [documentation page](https://docs.sentry.io/data-management/relay/options/).
 
 ### Configuration Changes
 
-- Added `cache.event_buffer_size` to control the maximum number of events that
-  are buffered in case of network issues or high rates of incoming events.
-- Added `limits.max_concurrent_requests` to limit the number of connections that
-  this Relay will use to communicate with the upstream.
-- Internal error reporting is now disabled by default. To opt in, set
-  `sentry.enabled`.
+- Added `cache.event_buffer_size` to control the maximum number of events that are buffered in case of network issues or high rates of incoming events.
+- Added `limits.max_concurrent_requests` to limit the number of connections that this Relay will use to communicate with the upstream.
+- Internal error reporting is now disabled by default. To opt in, set `sentry.enabled`.
 
 ### Bugfixes
 
-- Fix a bug that caused events to get unconditionally dropped after five
-  seconds, regardless of the `cache.event_expiry` configuration.
+- Fix a bug that caused events to get unconditionally dropped after five seconds, regardless of the `cache.event_expiry` configuration.
 - Fix a memory leak in Relay's internal error reporting.
 
 ## 0.3.0
 
-- Changed PII stripping rule format to permit path selectors when applying
-  rules. This means that now `$string` refers to strings for instance and
-  `user.id` refers to the `id` field in the `user` attribute of the event.
-  Temporarily support for old rules is retained.
+- Changed PII stripping rule format to permit path selectors when applying rules. This means that now `$string` refers to strings for instance and `user.id` refers to the `id` field in the `user` attribute of the event. Temporarily support for old rules is retained.
 
 ## 0.2.7
 
-- store: Minor fixes to be closer to Python. Ability to disable trimming of
-  objects, arrays and strings.
+- store: Minor fixes to be closer to Python. Ability to disable trimming of objects, arrays and strings.
 
 ## 0.2.6
 
-- Fix bug where PII stripping would remove containers without leaving any
-  metadata about the retraction.
+- Fix bug where PII stripping would remove containers without leaving any metadata about the retraction.
 - Fix bug where old `redactPair` rules would stop working.
 
 ## 0.2.5
 
-- Rewrite of PII stripping logic. This brings potentially breaking changes to
-  the semantics of PII configs. Most importantly field types such as
-  `"freeform"` and `"databag"` are gone, right now there is only `"container"`
-  and `"text"`. All old field types should have become an alias for `"text"`,
-  but take extra care in ensuring your PII rules still work.
+- Rewrite of PII stripping logic. This brings potentially breaking changes to the semantics of PII configs. Most importantly field types such as `"freeform"` and `"databag"` are gone, right now there is only `"container"` and `"text"`. All old field types should have become an alias for `"text"`, but take extra care in ensuring your PII rules still work.
 
 - store: Minor fixes to be closer to Python.
 
 ## 0.2.4
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 - store: Remove stray print statement.
 
 ## 0.2.3
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 - store: Fix main performance issues.
 
 ## 0.2.2
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 - store: Fix segfault when trying to process contexts.
-- store: Fix trimming state "leaking" between interfaces, leading to excessive
-  trimming.
+- store: Fix trimming state "leaking" between interfaces, leading to excessive trimming.
 - store: Don't serialize empty arrays and objects (with a few exceptions).
 
 ## 0.2.1
 
-For users of relay, nothing changed at all. This is a release to test embedding
-some Rust code in Sentry itself.
+For users of relay, nothing changed at all. This is a release to test embedding some Rust code in Sentry itself.
 
 - `libsemaphore`: Expose CABI for normalizing event data.
 
@@ -734,31 +619,18 @@ some Rust code in Sentry itself.
 Our first major iteration on Relay has landed!
 
 - User documentation is now hosted at <https://docs.sentry.io/relay/>.
-- SSL support is now included by default. Just configure a [TLS
-  identity](https://docs.sentry.io/relay/options/#relaytls_identity_path) and
-  you're set.
-- Updated event processing: Events from older SDKs are now supported. Also,
-  we've fixed some bugs along the line.
-- Introduced full support for PII stripping. See [PII
-  Configuration](https://docs.sentry.io/relay/pii-config/) for instructions.
-- Configure with static project settings. Relay will skip querying project
-  states from Sentry and use your provided values instead. See [Project
-  Configuration](https://docs.sentry.io/relay/project-config/) for a full guide.
-- Relay now also acts as a proxy for certain API requests. This allows it to
-  receive CSP reports and Minidump crash reports, among others. It also sets
-  `X-Forwarded-For` and includes a Relay signature header.
+- SSL support is now included by default. Just configure a [TLS identity](https://docs.sentry.io/relay/options/#relaytls_identity_path) and you're set.
+- Updated event processing: Events from older SDKs are now supported. Also, we've fixed some bugs along the line.
+- Introduced full support for PII stripping. See [PII Configuration](https://docs.sentry.io/relay/pii-config/) for instructions.
+- Configure with static project settings. Relay will skip querying project states from Sentry and use your provided values instead. See [Project Configuration](https://docs.sentry.io/relay/project-config/) for a full guide.
+- Relay now also acts as a proxy for certain API requests. This allows it to receive CSP reports and Minidump crash reports, among others. It also sets `X-Forwarded-For` and includes a Relay signature header.
 
 Besides that, there are many technical changes, including:
 
-- Major rewrite of the internals. Relay no longer requires a special endpoint
-  for sending events to upstream Sentry and processes events individually with
-  less delay than before.
-- The executable will exit with a non-zero exit code on startup errors. This
-  makes it easier to catch configuration errors.
-- Removed `libsodium` as a production dependency, greatly simplifying
-  requirements for the runtime environment.
-- Greatly improved logging and metrics. Be careful with the `DEBUG` and `TRACE`
-  levels, as they are **very** verbose now.
+- Major rewrite of the internals. Relay no longer requires a special endpoint for sending events to upstream Sentry and processes events individually with less delay than before.
+- The executable will exit with a non-zero exit code on startup errors. This makes it easier to catch configuration errors.
+- Removed `libsodium` as a production dependency, greatly simplifying requirements for the runtime environment.
+- Greatly improved logging and metrics. Be careful with the `DEBUG` and `TRACE` levels, as they are **very** verbose now.
 - Improved docker containers.
 
 ## 0.1.3
@@ -774,8 +646,7 @@ Besides that, there are many technical changes, including:
 
 - Rename "sentry-relay" to "semaphore"
 - Use new features from Rust 1.26
-- Prepare binary and Python builds
-  ([#20](https://github.com/getsentry/relay/pull/20))
+- Prepare binary and Python builds ([#20](https://github.com/getsentry/relay/pull/20))
 - Add Dockerfile ([#23](https://github.com/getsentry/relay/pull/23))
 
 ## 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,41 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 **Features**:
 
 - Proxy and managed Relays now apply clock drift correction based on the
-  `sent_at` header emitted by SDKs. (#581)
+  `sent_at` header emitted by SDKs.
+  ([#581](https://github.com/getsentry/relay/pull/581))
 
 **Bug Fixes**:
 
 - Clock drift correction no longer considers the transaction timestamp as
   baseline for SDKs using Envelopes. Instead, only the dedicated `sent_at`
-  Envelope header is used. (#580)
+  Envelope header is used. ([#580](https://github.com/getsentry/relay/pull/580))
 - The `http.timeout` setting is now applied to all requests, including event
-  submission. Previously, events were exempt. (#588)
+  submission. Previously, events were exempt.
+  ([#588](https://github.com/getsentry/relay/pull/588))
 - All endpoint metrics now report their proper `route` tag. This applies to
   `requests`, `requests.duration`, and `responses.status_codes`. Previously,
-  some some endpoints reported an empty route. (#595)
+  some some endpoints reported an empty route.
+  ([#595](https://github.com/getsentry/relay/pull/595))
 - Properly refresh cached project states based on the configured intervals.
   Previously, Relay may have gone into an endless refresh cycle if the system
-  clock not accurate, or the state had not been updated in the upstream. (#596)
+  clock not accurate, or the state had not been updated in the upstream.
+  ([#596](https://github.com/getsentry/relay/pull/596))
 - Respond with `403 Forbidden` when multiple authentication payloads are sent by
   the SDK. Previously, Relay would authenticate using one of the payloads and
-  silently ignore the rest. (#602)
+  silently ignore the rest.
+  ([#602](https://github.com/getsentry/relay/pull/602))
 
 **Internal**:
 
-- Ignore non-Rust folders for faster rebuilding and testing. (#578)
-- Invalid session payloads are now logged for SDK debugging. (#584, #591)
-- Remove unused `rev` from project state. (#586)
-- Add an outcome endpoint for trusted Relays. (#589)
+- Ignore non-Rust folders for faster rebuilding and testing.
+  ([#578](https://github.com/getsentry/relay/pull/578))
+- Invalid session payloads are now logged for SDK debugging.
+  ([#584](https://github.com/getsentry/relay/pull/584),
+  [#591](https://github.com/getsentry/relay/pull/591))
+- Remove unused `rev` from project state.
+  ([#586](https://github.com/getsentry/relay/pull/586))
+- Add an outcome endpoint for trusted Relays.
+  ([#589](https://github.com/getsentry/relay/pull/589))
 
 ## 0.5.9
 
@@ -40,7 +50,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 - New explicit `envelope/` endpoint. Envelopes no longer need to be sent with
   the right `content-type` header (to cater to browser JS).
 - Introduce an Envelope item type for transactions.
-- Support environment variables and CLI arguments instead of command line parameters.
+- Support environment variables and CLI arguments instead of command line
+  parameters.
 - Return status `415` on wrong content types.
 - Normalize double-slashes in request URLs more aggressively.
 - Add an option to generate credentials on stdout.
@@ -73,7 +84,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 ## 0.5.6
 
-- Fix a bug where Relay would stop processing events if Sentry is down for only a short time.
+- Fix a bug where Relay would stop processing events if Sentry is down for only
+  a short time.
 - Improvements to architecture documentation.
 - Initial support for rate limiting by event type ("scoped quotas")
 - Fix a bug where `key_id` was omitted from outcomes created by Relay.
@@ -85,8 +97,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 - PII processing: Aliases for value types (`$error` instead of `$exception` to
   be in sync with Discover column naming) and adding a default for
   replace-redactions.
-- It is now valid to send transactions and spans without `op` set, in which
-  case a default value will be inserted.
+- It is now valid to send transactions and spans without `op` set, in which case
+  a default value will be inserted.
 
 ## 0.5.5
 
@@ -109,15 +121,21 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 ## 0.5.3
 
 - Properly strip the linux binary to reduce its size
-- Allow base64 encoded JSON event payloads (#466)
-- Fix multipart requests without trailing newline (#465)
-- Support for ingesting session updates (#449)
+- Allow base64 encoded JSON event payloads
+  ([#466](https://github.com/getsentry/relay/pull/466))
+- Fix multipart requests without trailing newline
+  ([#465](https://github.com/getsentry/relay/pull/465))
+- Support for ingesting session updates
+  ([#449](https://github.com/getsentry/relay/pull/449))
 
 **Internal**:
 
-- Validate release names during event ingestion (#479)
-- Add browser extension filter (#470)
-- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if explicitly addressed.
+- Validate release names during event ingestion
+  ([#479](https://github.com/getsentry/relay/pull/479))
+- Add browser extension filter
+  ([#470](https://github.com/getsentry/relay/pull/470))
+- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if
+  explicitly addressed.
 - Add way to scrub filepaths in a way that does not break processing.
 
 ## 0.5.2
@@ -125,13 +143,14 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 - Fix trivial Redis-related crash when running in non-processing mode.
 - Limit the maximum retry-after of a rate limit. This is necessary because of
   the "Delete and ignore future events" feature in Sentry.
-- Project caches are now evicted after `project_grace_period` has passed. If
-  you have that parameter set to a high number you may see increased memory
+- Project caches are now evicted after `project_grace_period` has passed. If you
+  have that parameter set to a high number you may see increased memory
   consumption.
 
 **Internal**:
 
-- Misc bugfixes in PII processor. Those bugs do not affect the legacy data scrubber exposed in Python.
+- Misc bugfixes in PII processor. Those bugs do not affect the legacy data
+  scrubber exposed in Python.
 - Polishing documentation around PII configuration format.
 - Signal codes in mach mechanism are no longer required.
 
@@ -143,8 +162,10 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
-- Ability to correct some clock drift and wrong system time in transaction events.
+- Fix a bug in the PII processor that would always remove the entire string on
+  `pattern` rules.
+- Ability to correct some clock drift and wrong system time in transaction
+  events.
 
 ## 0.5.0
 
@@ -212,42 +233,62 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Add `thread.errored` attribute (#306).
+- Add `thread.errored` attribute
+  ([#306](https://github.com/getsentry/relay/pull/306)).
 
 ## 0.4.60
 
-- License is now BSL instead of MIT (#301).
-- Improve internal metrics and logging (#296, #297, #298).
-- Fix unbounded requests to Sentry for project configs (#295, #300).
-- Fix rejected responses from Sentry due to size limit (#303).
-- Expose more options for configuring request concurrency limits (#311).
+- License is now BSL instead of MIT
+  ([#301](https://github.com/getsentry/relay/pull/301)).
+- Improve internal metrics and logging
+  ([#296](https://github.com/getsentry/relay/pull/296),
+  [#297](https://github.com/getsentry/relay/pull/297),
+  [#298](https://github.com/getsentry/relay/pull/298)).
+- Fix unbounded requests to Sentry for project configs
+  ([#295](https://github.com/getsentry/relay/pull/295),
+  [#300](https://github.com/getsentry/relay/pull/300)).
+- Fix rejected responses from Sentry due to size limit
+  ([#303](https://github.com/getsentry/relay/pull/303)).
+- Expose more options for configuring request concurrency limits
+  ([#311](https://github.com/getsentry/relay/pull/311)).
 
 **Internal**:
 
-- Transaction events with negative duration are now rejected (#291).
+- Transaction events with negative duration are now rejected
+  ([#291](https://github.com/getsentry/relay/pull/291)).
 - Fix a panic when normalizing certain dates.
 
 ## 0.4.59
 
 **Internal**:
 
-- Fix: Normalize legacy stacktrace attributes (#292)
-- Fix: Validate platform attributes in Relay (#294)
-- Flip the flag that indicates Relay processing (#293)
+- Fix: Normalize legacy stacktrace attributes
+  ([#292](https://github.com/getsentry/relay/pull/292))
+- Fix: Validate platform attributes in Relay
+  ([#294](https://github.com/getsentry/relay/pull/294))
+- Flip the flag that indicates Relay processing
+  ([#293](https://github.com/getsentry/relay/pull/293))
 
 ## 0.4.58
 
-- Evict project caches after some time (#287)
-- Selectively log internal errors to stderr (#285)
-- Add an error boundary to parsing project states (#281)
+- Evict project caches after some time
+  ([#287](https://github.com/getsentry/relay/pull/287))
+- Selectively log internal errors to stderr
+  ([#285](https://github.com/getsentry/relay/pull/285))
+- Add an error boundary to parsing project states
+  ([#281](https://github.com/getsentry/relay/pull/281))
 
 **Internal**:
 
-- Add event size metrics (#286)
-- Normalize before datascrubbing (#290)
-- Add a config value for thread counts (#283)
-- Refactor outcomes for parity with Sentry (#282)
-- Add flag that relay processed an event (#279)
+- Add event size metrics ([#286](https://github.com/getsentry/relay/pull/286))
+- Normalize before datascrubbing
+  ([#290](https://github.com/getsentry/relay/pull/290))
+- Add a config value for thread counts
+  ([#283](https://github.com/getsentry/relay/pull/283))
+- Refactor outcomes for parity with Sentry
+  ([#282](https://github.com/getsentry/relay/pull/282))
+- Add flag that relay processed an event
+  ([#279](https://github.com/getsentry/relay/pull/279))
 
 ## 0.4.57
 
@@ -324,7 +365,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Resolved a regression in IP address normalization. The new behavior is closer to a line-by-line port of the old Python code.
+- Resolved a regression in IP address normalization. The new behavior is closer
+  to a line-by-line port of the old Python code.
 
 ## 0.4.45
 
@@ -336,14 +378,16 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Normalization**:
 
-- Only take the user IP address from the store request's IP for certain platforms. This restores the behavior of the old Python code.
+- Only take the user IP address from the store request's IP for certain
+  platforms. This restores the behavior of the old Python code.
 
 ## 0.4.43
 
 **Normalization**:
 
 - Bump size of breadcrumbs.
-- Workaround for an issue where we would not parse OS information from User Agent when SDK had already sent OS information.
+- Workaround for an issue where we would not parse OS information from User
+  Agent when SDK had already sent OS information.
 - Further work on Sentry-internal event ingestion.
 
 ## 0.4.42
@@ -428,7 +472,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Make exception messages/values larger to allow for foreign stacktrace data to be attached.
+- Make exception messages/values larger to allow for foreign stacktrace data to
+  be attached.
 
 ## 0.4.29
 
@@ -446,8 +491,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Increase frame vars size again! Byte size was fine, but max depth
-  was way too small.
+- Increase frame vars size again! Byte size was fine, but max depth was way too
+  small.
 
 ## 0.4.26
 
@@ -471,7 +516,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Add basic truncation to event meta to prevent payload size from spiralling out of control.
+- Add basic truncation to event meta to prevent payload size from spiralling out
+  of control.
 
 ## 0.4.22
 
@@ -507,8 +553,8 @@ line with the latest version of [Sentry](https://github.com/getsentry/sentry).
 
 **Internal**:
 
-- Added support for protocol changes related to upcoming sentry SDK features.
-  In particular the `none` event type was added.
+- Added support for protocol changes related to upcoming sentry SDK features. In
+  particular the `none` event type was added.
 
 ## 0.4.16
 
@@ -672,7 +718,8 @@ For users of relay, nothing changed at all. This is a release to test embedding
 some Rust code in Sentry itself.
 
 - store: Fix segfault when trying to process contexts.
-- store: Fix trimming state "leaking" between interfaces, leading to excessive trimming.
+- store: Fix trimming state "leaking" between interfaces, leading to excessive
+  trimming.
 - store: Don't serialize empty arrays and objects (with a few exceptions).
 
 ## 0.2.1
@@ -720,15 +767,16 @@ Besides that, there are many technical changes, including:
 
 ## 0.1.2
 
-- JSON logging (#32)
+- JSON logging ([#32](https://github.com/getsentry/relay/pull/32))
 - Update dependencies
 
 ## 0.1.1
 
 - Rename "sentry-relay" to "semaphore"
 - Use new features from Rust 1.26
-- Prepare binary and Python builds (#20)
-- Add Dockerfile (#23)
+- Prepare binary and Python builds
+  ([#20](https://github.com/getsentry/relay/pull/20))
+- Add Dockerfile ([#23](https://github.com/getsentry/relay/pull/23))
 
 ## 0.1.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add SpanStatus to span struct (#603)
+
 ## 0.5.10
 
 - Set default transaction name (#576)

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,16 +2,24 @@
 
 ## Unreleased
 
-- Add SpanStatus to span struct (#603)
+- Add SpanStatus to span struct
+  ([#603](https://github.com/getsentry/relay/pull/603))
 
 ## 0.5.10
 
-- Set default transaction name (#576)
-- Apply clock drift correction based on received_at (#580, #582)
-- Add AWS Security Scanner to web crawlers (#577)
-- Do not default transactions to level error (#585)
-- Update `sentry-release-parser` to 0.6.0 (#590)
-- Add schema for success metrics (failed and errored processing) (#593)
+- Set default transaction name
+  ([#576](https://github.com/getsentry/relay/pull/576))
+- Apply clock drift correction based on received_at
+  ([#580](https://github.com/getsentry/relay/pull/580),
+  [#582](https://github.com/getsentry/relay/pull/582))
+- Add AWS Security Scanner to web crawlers
+  ([#577](https://github.com/getsentry/relay/pull/577))
+- Do not default transactions to level error
+  ([#585](https://github.com/getsentry/relay/pull/585))
+- Update `sentry-release-parser` to 0.6.0
+  ([#590](https://github.com/getsentry/relay/pull/590))
+- Add schema for success metrics (failed and errored processing)
+  ([#593](https://github.com/getsentry/relay/pull/593))
 
 ## 0.5.9
 
@@ -36,8 +44,8 @@
 - Minor updates to PII processing: Aliases for value types (`$error` instead of
   `$exception` to be in sync with Discover column naming) and adding a default
   for replace-redactions.
-- It is now valid to send transactions and spans without `op` set, in which
-  case a default value will be inserted.
+- It is now valid to send transactions and spans without `op` set, in which case
+  a default value will be inserted.
 
 ## 0.5.5
 
@@ -53,25 +61,34 @@
 
 ## 0.5.3
 
-- Validate release names during event ingestion (#479)
-- Add browser extension filter (#470)
-- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if explicitly addressed.
+- Validate release names during event ingestion
+  ([#479](https://github.com/getsentry/relay/pull/479))
+- Add browser extension filter
+  ([#470](https://github.com/getsentry/relay/pull/470))
+- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if
+  explicitly addressed.
 - Add way to scrub filepaths in a way that does not break processing.
-- Add missing errors for JSON parsing and release validation (#478)
-- Expose more datascrubbing utils (#464)
+- Add missing errors for JSON parsing and release validation
+  ([#478](https://github.com/getsentry/relay/pull/478))
+- Expose more datascrubbing utils
+  ([#464](https://github.com/getsentry/relay/pull/464))
 
 ## 0.5.2
 
-- Misc bugfixes in PII processor. Those bugs do not affect the legacy data scrubber exposed in Python.
+- Misc bugfixes in PII processor. Those bugs do not affect the legacy data
+  scrubber exposed in Python.
 - Polishing documentation around PII configuration format.
 - Signal codes in mach mechanism are no longer required.
 
 ## 0.5.1
 
-- Bump xcode version from 7.3 to 9.4, dropping wheel support for some older OS X versions.
+- Bump xcode version from 7.3 to 9.4, dropping wheel support for some older OS X
+  versions.
 - New function `validate_pii_config`.
-- Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
-- Ability to correct some clock drift and wrong system time in transaction events.
+- Fix a bug in the PII processor that would always remove the entire string on
+  `pattern` rules.
+- Ability to correct some clock drift and wrong system time in transaction
+  events.
 
 ## 0.5.0
 
@@ -110,25 +127,34 @@
 
 ## 0.4.61
 
-- Add `thread.errored` attribute (#306).
+- Add `thread.errored` attribute
+  ([#306](https://github.com/getsentry/relay/pull/306)).
 
 ## 0.4.60
 
-- License is now BSL instead of MIT (#301).
-- Transaction events with negative duration are now rejected (#291).
+- License is now BSL instead of MIT
+  ([#301](https://github.com/getsentry/relay/pull/301)).
+- Transaction events with negative duration are now rejected
+  ([#291](https://github.com/getsentry/relay/pull/291)).
 - Fix a panic when normalizing certain dates.
 
 ## 0.4.59
 
-- Fix: Normalize legacy stacktrace attributes (#292)
-- Fix: Validate platform attributes (#294)
+- Fix: Normalize legacy stacktrace attributes
+  ([#292](https://github.com/getsentry/relay/pull/292))
+- Fix: Validate platform attributes
+  ([#294](https://github.com/getsentry/relay/pull/294))
 
 ## 0.4.58
 
-- Expose globbing code from Relay to Python (#288)
-- Normalize before datascrubbing (#290)
-- Selectively log internal errors to stderr (#285)
-- Do not ignore `process_value` result in `scrub_event` (#284)
+- Expose globbing code from Relay to Python
+  ([#288](https://github.com/getsentry/relay/pull/288))
+- Normalize before datascrubbing
+  ([#290](https://github.com/getsentry/relay/pull/290))
+- Selectively log internal errors to stderr
+  ([#285](https://github.com/getsentry/relay/pull/285))
+- Do not ignore `process_value` result in `scrub_event`
+  ([#284](https://github.com/getsentry/relay/pull/284))
 
 ## 0.4.57
 
@@ -169,7 +195,8 @@
 
 ## 0.4.48
 
-- Fix various bugs in the datascrubber and PII processing code to get closer to behavior of the Python implementation.
+- Fix various bugs in the datascrubber and PII processing code to get closer to
+  behavior of the Python implementation.
 
 ## 0.4.47
 
@@ -177,7 +204,8 @@
 
 ## 0.4.46
 
-- Resolved a regression in IP address normalization. The new behavior is closer to a line-by-line port of the old Python code.
+- Resolved a regression in IP address normalization. The new behavior is closer
+  to a line-by-line port of the old Python code.
 
 ## 0.4.45
 
@@ -185,12 +213,14 @@
 
 ## 0.4.44
 
-- Only take the user IP address from the store request's IP for certain platforms. This restores the behavior of the old Python code.
+- Only take the user IP address from the store request's IP for certain
+  platforms. This restores the behavior of the old Python code.
 
 ## 0.4.43
 
 - Bump size of breadcrumbs
-- Workaround for an issue where we would not parse OS information from User Agent when SDK had already sent OS information.
+- Workaround for an issue where we would not parse OS information from User
+  Agent when SDK had already sent OS information.
 
 ## 0.4.42
 
@@ -245,7 +275,8 @@
 
 ## 0.4.30
 
-- Make exception messages/values larger to allow for foreign stacktrace data to be attached.
+- Make exception messages/values larger to allow for foreign stacktrace data to
+  be attached.
 
 ## 0.4.29
 
@@ -257,8 +288,8 @@
 
 ## 0.4.27
 
-- Increase frame vars size again! Byte size was fine, but max depth
-  was way too small.
+- Increase frame vars size again! Byte size was fine, but max depth was way too
+  small.
 
 ## 0.4.26
 
@@ -270,44 +301,55 @@
 
 ## 0.4.24
 
-- Reject non-http/https `help_urls` in exception mechanisms (#192)
+- Reject non-http/https `help_urls` in exception mechanisms
+  ([#192](https://github.com/getsentry/relay/pull/192))
 
 ## 0.4.23
 
-- Add basic truncation to event meta to prevent payload size from spiralling out of control.
+- Add basic truncation to event meta to prevent payload size from spiralling out
+  of control.
 
 ## 0.4.22
 
-- Improve the grouping protocol config (#190)
+- Improve the grouping protocol config
+  ([#190](https://github.com/getsentry/relay/pull/190))
 
 ## 0.4.21
 
-- Add new debug image variants (#188)
-- Trim release and environment (#184)
+- Add new debug image variants
+  ([#188](https://github.com/getsentry/relay/pull/188))
+- Trim release and environment
+  ([#184](https://github.com/getsentry/relay/pull/184))
 
 ## 0.4.20
 
-- Alias level critical as fatal (#182)
-- Add device properties from Java/.NET SDKs (#185)
-- Add `lang` to frame and stacktrace (#186)
+- Alias level critical as fatal
+  ([#182](https://github.com/getsentry/relay/pull/182))
+- Add device properties from Java/.NET SDKs
+  ([#185](https://github.com/getsentry/relay/pull/185))
+- Add `lang` to frame and stacktrace
+  ([#186](https://github.com/getsentry/relay/pull/186))
 
 ## 0.4.19
 
-- Add mode for renormalization (#181)
+- Add mode for renormalization
+  ([#181](https://github.com/getsentry/relay/pull/181))
 
 ## 0.4.18
 
 - Restore the original behavior with supporting very large values in extra
-  (#180)
+  ([#180](https://github.com/getsentry/relay/pull/180))
 
 ## 0.4.17
 
-- Add untyped spans for tracing (#179)
+- Add untyped spans for tracing
+  ([#179](https://github.com/getsentry/relay/pull/179))
 - Add the `none` event type
 
 ## 0.4.16
 
-- Add support for synthetic mechanism markers (#177)
+- Add support for synthetic mechanism markers
+  ([#177](https://github.com/getsentry/relay/pull/177))
 
 ## 0.4.15
 
@@ -317,16 +359,19 @@
 
 - Rename `template_info` to template
 - Add two new untyped context types: `gpu`, `monitors`
-- Rewrite `derive(ProcessValue)` to use `Structure::each_variant` (#175)
+- Rewrite `derive(ProcessValue)` to use `Structure::each_variant`
+  ([#175](https://github.com/getsentry/relay/pull/175))
 
 ## 0.4.13
 
-- Allow arrays as header values (#176)
+- Allow arrays as header values
+  ([#176](https://github.com/getsentry/relay/pull/176))
 - Swap `python-json-read-adapter` to git dependency
 
 ## 0.4.12
 
-- Run json.dumps at max depth in databag (#174)
+- Run json.dumps at max depth in databag
+  ([#174](https://github.com/getsentry/relay/pull/174))
 
 ## 0.4.11
 
@@ -338,12 +383,14 @@
 
 ## 0.4.9
 
-- Trim containers one level before max_depth (#173)
+- Trim containers one level before max_depth
+  ([#173](https://github.com/getsentry/relay/pull/173))
 - Unconditionally overwrite `received`
 
 ## 0.4.8
 
-- Fix bugs in array trimming, more code comments (#172)
+- Fix bugs in array trimming, more code comments
+  ([#172](https://github.com/getsentry/relay/pull/172))
 
 ## 0.4.7
 
@@ -351,61 +398,85 @@
 
 ## 0.4.6
 
-- Reject exceptions with empty type and value (#170)
-- Validate remote_addr before backfilling into user (#171)
+- Reject exceptions with empty type and value
+  ([#170](https://github.com/getsentry/relay/pull/170))
+- Validate remote_addr before backfilling into user
+  ([#171](https://github.com/getsentry/relay/pull/171))
 
 ## 0.4.5
 
-- Adjust limits to fit values into db (#167)
+- Adjust limits to fit values into db
+  ([#167](https://github.com/getsentry/relay/pull/167))
 - Environment is 64 chars in db
-- Normalize macOS (#168)
+- Normalize macOS ([#168](https://github.com/getsentry/relay/pull/168))
 - Use right maxchars for `transaction`, `dist`, `release`
 - Do not add error to invalid url
 
 ## 0.4.4
 
-- Reject unknown debug images (#163)
-- Include original_value in `Meta::eq` (#164)
-- Emit correct expectations for common types (#162)
-- Permit invalid emails in user interface (#161)
-- Drop long tags correctly (#165)
-- Do not skip null values in pairlists (#166)
+- Reject unknown debug images
+  ([#163](https://github.com/getsentry/relay/pull/163))
+- Include original_value in `Meta::eq`
+  ([#164](https://github.com/getsentry/relay/pull/164))
+- Emit correct expectations for common types
+  ([#162](https://github.com/getsentry/relay/pull/162))
+- Permit invalid emails in user interface
+  ([#161](https://github.com/getsentry/relay/pull/161))
+- Drop long tags correctly ([#165](https://github.com/getsentry/relay/pull/165))
+- Do not skip null values in pairlists
+  ([#166](https://github.com/getsentry/relay/pull/166))
 
 ## 0.4.3
 
-- Fix broken sdk_info parsing (#156)
-- Add basic snapshot tests for normalize and event parsing (#154)
-- Context trimming (#153)
-- Coerce PHP frame vars array to object (#159)
+- Fix broken sdk_info parsing
+  ([#156](https://github.com/getsentry/relay/pull/156))
+- Add basic snapshot tests for normalize and event parsing
+  ([#154](https://github.com/getsentry/relay/pull/154))
+- Context trimming ([#153](https://github.com/getsentry/relay/pull/153))
+- Coerce PHP frame vars array to object
+  ([#159](https://github.com/getsentry/relay/pull/159))
 
 ## 0.4.2
 
 - Remove content-type params
 - Dont attempt to free() if python is shutting down
-- Improve cookie header normalizations (#151)
-- Implement LogEntry formatting (#152)
-- Deduplicate tags (#155)
+- Improve cookie header normalizations
+  ([#151](https://github.com/getsentry/relay/pull/151))
+- Implement LogEntry formatting
+  ([#152](https://github.com/getsentry/relay/pull/152))
+- Deduplicate tags ([#155](https://github.com/getsentry/relay/pull/155))
 - Treat empty paths like no paths in frame normalization
 - Remove cookie header when explicit cookies are given
 
 ## 0.4.1
 
-- Do not remove empty cookies or headers (#138)
-- Skip more empty containers (#139)
-- Make `request.header` values lenient (#145)
-- Remove internal tags when backfilling (#146)
-- Implement advanced context normalization (#140)
-- Retain additional properties in contexts (#141)
-- Implement very lenient URL parsing (#147)
-- Do not require breadcrumb timestamps (#144)
-- Reject tags with long keys (#149)
+- Do not remove empty cookies or headers
+  ([#138](https://github.com/getsentry/relay/pull/138))
+- Skip more empty containers
+  ([#139](https://github.com/getsentry/relay/pull/139))
+- Make `request.header` values lenient
+  ([#145](https://github.com/getsentry/relay/pull/145))
+- Remove internal tags when backfilling
+  ([#146](https://github.com/getsentry/relay/pull/146))
+- Implement advanced context normalization
+  ([#140](https://github.com/getsentry/relay/pull/140))
+- Retain additional properties in contexts
+  ([#141](https://github.com/getsentry/relay/pull/141))
+- Implement very lenient URL parsing
+  ([#147](https://github.com/getsentry/relay/pull/147))
+- Do not require breadcrumb timestamps
+  ([#144](https://github.com/getsentry/relay/pull/144))
+- Reject tags with long keys
+  ([#149](https://github.com/getsentry/relay/pull/149))
 
 ## 0.4.0
 
-- Add new options max_concurrent_events (#134)
-- Dont move stacktrace before normalizing it (#135)
+- Add new options max_concurrent_events
+  ([#134](https://github.com/getsentry/relay/pull/134))
+- Dont move stacktrace before normalizing it
+  ([#135](https://github.com/getsentry/relay/pull/135))
 - Fix broken repr and crash when shutting down python
-- Port slim_frame_data (#137)
+- Port slim_frame_data ([#137](https://github.com/getsentry/relay/pull/137))
 - Special treatment for ellipsis in URLs
 - Parse request bodies
 
@@ -448,7 +519,8 @@
 ## 0.2.2
 
 - Fix segfault when trying to process contexts.
-- Fix trimming state "leaking" between interfaces, leading to excessive trimming.
+- Fix trimming state "leaking" between interfaces, leading to excessive
+  trimming.
 - Don't serialize empty arrays and objects (with a few exceptions).
 
 ## 0.2.1
@@ -473,7 +545,7 @@
 
 - Rename "sentry-relay" to "semaphore"
 - Use new features from Rust 1.26
-- Prepare Python builds (#20)
+- Prepare Python builds ([#20](https://github.com/getsentry/relay/pull/20))
 
 ## 0.1.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,24 +2,16 @@
 
 ## Unreleased
 
-- Add SpanStatus to span struct
-  ([#603](https://github.com/getsentry/relay/pull/603))
+- Add SpanStatus to span struct ([#603](https://github.com/getsentry/relay/pull/603))
 
 ## 0.5.10
 
-- Set default transaction name
-  ([#576](https://github.com/getsentry/relay/pull/576))
-- Apply clock drift correction based on received_at
-  ([#580](https://github.com/getsentry/relay/pull/580),
-  [#582](https://github.com/getsentry/relay/pull/582))
-- Add AWS Security Scanner to web crawlers
-  ([#577](https://github.com/getsentry/relay/pull/577))
-- Do not default transactions to level error
-  ([#585](https://github.com/getsentry/relay/pull/585))
-- Update `sentry-release-parser` to 0.6.0
-  ([#590](https://github.com/getsentry/relay/pull/590))
-- Add schema for success metrics (failed and errored processing)
-  ([#593](https://github.com/getsentry/relay/pull/593))
+- Set default transaction name ([#576](https://github.com/getsentry/relay/pull/576))
+- Apply clock drift correction based on received_at ([#580](https://github.com/getsentry/relay/pull/580), [#582](https://github.com/getsentry/relay/pull/582))
+- Add AWS Security Scanner to web crawlers ([#577](https://github.com/getsentry/relay/pull/577))
+- Do not default transactions to level error ([#585](https://github.com/getsentry/relay/pull/585))
+- Update `sentry-release-parser` to 0.6.0 ([#590](https://github.com/getsentry/relay/pull/590))
+- Add schema for success metrics (failed and errored processing) ([#593](https://github.com/getsentry/relay/pull/593))
 
 ## 0.5.9
 
@@ -35,17 +27,12 @@
 ## 0.5.7
 
 - Release is now a required attribute for session data.
-- `unknown` can now be used in place of `unknown_error` for span statuses. A
-  future release will change the canonical format from `unknown_error` to
-  `unknown`.
+- `unknown` can now be used in place of `unknown_error` for span statuses. A future release will change the canonical format from `unknown_error` to `unknown`.
 
 ## 0.5.6
 
-- Minor updates to PII processing: Aliases for value types (`$error` instead of
-  `$exception` to be in sync with Discover column naming) and adding a default
-  for replace-redactions.
-- It is now valid to send transactions and spans without `op` set, in which case
-  a default value will be inserted.
+- Minor updates to PII processing: Aliases for value types (`$error` instead of `$exception` to be in sync with Discover column naming) and adding a default for replace-redactions.
+- It is now valid to send transactions and spans without `op` set, in which case a default value will be inserted.
 
 ## 0.5.5
 
@@ -61,34 +48,25 @@
 
 ## 0.5.3
 
-- Validate release names during event ingestion
-  ([#479](https://github.com/getsentry/relay/pull/479))
-- Add browser extension filter
-  ([#470](https://github.com/getsentry/relay/pull/470))
-- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if
-  explicitly addressed.
+- Validate release names during event ingestion ([#479](https://github.com/getsentry/relay/pull/479))
+- Add browser extension filter ([#470](https://github.com/getsentry/relay/pull/470))
+- Add `pii=maybe`, a new kind of event schema field that can only be scrubbed if explicitly addressed.
 - Add way to scrub filepaths in a way that does not break processing.
-- Add missing errors for JSON parsing and release validation
-  ([#478](https://github.com/getsentry/relay/pull/478))
-- Expose more datascrubbing utils
-  ([#464](https://github.com/getsentry/relay/pull/464))
+- Add missing errors for JSON parsing and release validation ([#478](https://github.com/getsentry/relay/pull/478))
+- Expose more datascrubbing utils ([#464](https://github.com/getsentry/relay/pull/464))
 
 ## 0.5.2
 
-- Misc bugfixes in PII processor. Those bugs do not affect the legacy data
-  scrubber exposed in Python.
+- Misc bugfixes in PII processor. Those bugs do not affect the legacy data scrubber exposed in Python.
 - Polishing documentation around PII configuration format.
 - Signal codes in mach mechanism are no longer required.
 
 ## 0.5.1
 
-- Bump xcode version from 7.3 to 9.4, dropping wheel support for some older OS X
-  versions.
+- Bump xcode version from 7.3 to 9.4, dropping wheel support for some older OS X versions.
 - New function `validate_pii_config`.
-- Fix a bug in the PII processor that would always remove the entire string on
-  `pattern` rules.
-- Ability to correct some clock drift and wrong system time in transaction
-  events.
+- Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
+- Ability to correct some clock drift and wrong system time in transaction events.
 
 ## 0.5.0
 
@@ -111,12 +89,9 @@
 
 ## 0.4.63
 
-- Fix a bug where glob-matching in filters did not behave correctly when the
-  to-be-matched string contained newlines.
-- Add `moz-extension:` as scheme for browser extensions (filtering out Firefox
-  addons).
-- Raise a dedicated Python exception type for invalid transaction events. Also
-  do not report that error to Sentry from Relay.
+- Fix a bug where glob-matching in filters did not behave correctly when the to-be-matched string contained newlines.
+- Add `moz-extension:` as scheme for browser extensions (filtering out Firefox addons).
+- Raise a dedicated Python exception type for invalid transaction events. Also do not report that error to Sentry from Relay.
 
 ## 0.4.62
 
@@ -127,34 +102,25 @@
 
 ## 0.4.61
 
-- Add `thread.errored` attribute
-  ([#306](https://github.com/getsentry/relay/pull/306)).
+- Add `thread.errored` attribute ([#306](https://github.com/getsentry/relay/pull/306)).
 
 ## 0.4.60
 
-- License is now BSL instead of MIT
-  ([#301](https://github.com/getsentry/relay/pull/301)).
-- Transaction events with negative duration are now rejected
-  ([#291](https://github.com/getsentry/relay/pull/291)).
+- License is now BSL instead of MIT ([#301](https://github.com/getsentry/relay/pull/301)).
+- Transaction events with negative duration are now rejected ([#291](https://github.com/getsentry/relay/pull/291)).
 - Fix a panic when normalizing certain dates.
 
 ## 0.4.59
 
-- Fix: Normalize legacy stacktrace attributes
-  ([#292](https://github.com/getsentry/relay/pull/292))
-- Fix: Validate platform attributes
-  ([#294](https://github.com/getsentry/relay/pull/294))
+- Fix: Normalize legacy stacktrace attributes ([#292](https://github.com/getsentry/relay/pull/292))
+- Fix: Validate platform attributes ([#294](https://github.com/getsentry/relay/pull/294))
 
 ## 0.4.58
 
-- Expose globbing code from Relay to Python
-  ([#288](https://github.com/getsentry/relay/pull/288))
-- Normalize before datascrubbing
-  ([#290](https://github.com/getsentry/relay/pull/290))
-- Selectively log internal errors to stderr
-  ([#285](https://github.com/getsentry/relay/pull/285))
-- Do not ignore `process_value` result in `scrub_event`
-  ([#284](https://github.com/getsentry/relay/pull/284))
+- Expose globbing code from Relay to Python ([#288](https://github.com/getsentry/relay/pull/288))
+- Normalize before datascrubbing ([#290](https://github.com/getsentry/relay/pull/290))
+- Selectively log internal errors to stderr ([#285](https://github.com/getsentry/relay/pull/285))
+- Do not ignore `process_value` result in `scrub_event` ([#284](https://github.com/getsentry/relay/pull/284))
 
 ## 0.4.57
 
@@ -195,8 +161,7 @@
 
 ## 0.4.48
 
-- Fix various bugs in the datascrubber and PII processing code to get closer to
-  behavior of the Python implementation.
+- Fix various bugs in the datascrubber and PII processing code to get closer to behavior of the Python implementation.
 
 ## 0.4.47
 
@@ -204,8 +169,7 @@
 
 ## 0.4.46
 
-- Resolved a regression in IP address normalization. The new behavior is closer
-  to a line-by-line port of the old Python code.
+- Resolved a regression in IP address normalization. The new behavior is closer to a line-by-line port of the old Python code.
 
 ## 0.4.45
 
@@ -213,14 +177,12 @@
 
 ## 0.4.44
 
-- Only take the user IP address from the store request's IP for certain
-  platforms. This restores the behavior of the old Python code.
+- Only take the user IP address from the store request's IP for certain platforms. This restores the behavior of the old Python code.
 
 ## 0.4.43
 
 - Bump size of breadcrumbs
-- Workaround for an issue where we would not parse OS information from User
-  Agent when SDK had already sent OS information.
+- Workaround for an issue where we would not parse OS information from User Agent when SDK had already sent OS information.
 
 ## 0.4.42
 
@@ -275,8 +237,7 @@
 
 ## 0.4.30
 
-- Make exception messages/values larger to allow for foreign stacktrace data to
-  be attached.
+- Make exception messages/values larger to allow for foreign stacktrace data to be attached.
 
 ## 0.4.29
 
@@ -288,8 +249,7 @@
 
 ## 0.4.27
 
-- Increase frame vars size again! Byte size was fine, but max depth was way too
-  small.
+- Increase frame vars size again! Byte size was fine, but max depth was way too small.
 
 ## 0.4.26
 
@@ -301,55 +261,43 @@
 
 ## 0.4.24
 
-- Reject non-http/https `help_urls` in exception mechanisms
-  ([#192](https://github.com/getsentry/relay/pull/192))
+- Reject non-http/https `help_urls` in exception mechanisms ([#192](https://github.com/getsentry/relay/pull/192))
 
 ## 0.4.23
 
-- Add basic truncation to event meta to prevent payload size from spiralling out
-  of control.
+- Add basic truncation to event meta to prevent payload size from spiralling out of control.
 
 ## 0.4.22
 
-- Improve the grouping protocol config
-  ([#190](https://github.com/getsentry/relay/pull/190))
+- Improve the grouping protocol config ([#190](https://github.com/getsentry/relay/pull/190))
 
 ## 0.4.21
 
-- Add new debug image variants
-  ([#188](https://github.com/getsentry/relay/pull/188))
-- Trim release and environment
-  ([#184](https://github.com/getsentry/relay/pull/184))
+- Add new debug image variants ([#188](https://github.com/getsentry/relay/pull/188))
+- Trim release and environment ([#184](https://github.com/getsentry/relay/pull/184))
 
 ## 0.4.20
 
-- Alias level critical as fatal
-  ([#182](https://github.com/getsentry/relay/pull/182))
-- Add device properties from Java/.NET SDKs
-  ([#185](https://github.com/getsentry/relay/pull/185))
-- Add `lang` to frame and stacktrace
-  ([#186](https://github.com/getsentry/relay/pull/186))
+- Alias level critical as fatal ([#182](https://github.com/getsentry/relay/pull/182))
+- Add device properties from Java/.NET SDKs ([#185](https://github.com/getsentry/relay/pull/185))
+- Add `lang` to frame and stacktrace ([#186](https://github.com/getsentry/relay/pull/186))
 
 ## 0.4.19
 
-- Add mode for renormalization
-  ([#181](https://github.com/getsentry/relay/pull/181))
+- Add mode for renormalization ([#181](https://github.com/getsentry/relay/pull/181))
 
 ## 0.4.18
 
-- Restore the original behavior with supporting very large values in extra
-  ([#180](https://github.com/getsentry/relay/pull/180))
+- Restore the original behavior with supporting very large values in extra ([#180](https://github.com/getsentry/relay/pull/180))
 
 ## 0.4.17
 
-- Add untyped spans for tracing
-  ([#179](https://github.com/getsentry/relay/pull/179))
+- Add untyped spans for tracing ([#179](https://github.com/getsentry/relay/pull/179))
 - Add the `none` event type
 
 ## 0.4.16
 
-- Add support for synthetic mechanism markers
-  ([#177](https://github.com/getsentry/relay/pull/177))
+- Add support for synthetic mechanism markers ([#177](https://github.com/getsentry/relay/pull/177))
 
 ## 0.4.15
 
@@ -359,19 +307,16 @@
 
 - Rename `template_info` to template
 - Add two new untyped context types: `gpu`, `monitors`
-- Rewrite `derive(ProcessValue)` to use `Structure::each_variant`
-  ([#175](https://github.com/getsentry/relay/pull/175))
+- Rewrite `derive(ProcessValue)` to use `Structure::each_variant` ([#175](https://github.com/getsentry/relay/pull/175))
 
 ## 0.4.13
 
-- Allow arrays as header values
-  ([#176](https://github.com/getsentry/relay/pull/176))
+- Allow arrays as header values ([#176](https://github.com/getsentry/relay/pull/176))
 - Swap `python-json-read-adapter` to git dependency
 
 ## 0.4.12
 
-- Run json.dumps at max depth in databag
-  ([#174](https://github.com/getsentry/relay/pull/174))
+- Run json.dumps at max depth in databag ([#174](https://github.com/getsentry/relay/pull/174))
 
 ## 0.4.11
 
@@ -383,14 +328,12 @@
 
 ## 0.4.9
 
-- Trim containers one level before max_depth
-  ([#173](https://github.com/getsentry/relay/pull/173))
+- Trim containers one level before max_depth ([#173](https://github.com/getsentry/relay/pull/173))
 - Unconditionally overwrite `received`
 
 ## 0.4.8
 
-- Fix bugs in array trimming, more code comments
-  ([#172](https://github.com/getsentry/relay/pull/172))
+- Fix bugs in array trimming, more code comments ([#172](https://github.com/getsentry/relay/pull/172))
 
 ## 0.4.7
 
@@ -398,15 +341,12 @@
 
 ## 0.4.6
 
-- Reject exceptions with empty type and value
-  ([#170](https://github.com/getsentry/relay/pull/170))
-- Validate remote_addr before backfilling into user
-  ([#171](https://github.com/getsentry/relay/pull/171))
+- Reject exceptions with empty type and value ([#170](https://github.com/getsentry/relay/pull/170))
+- Validate remote_addr before backfilling into user ([#171](https://github.com/getsentry/relay/pull/171))
 
 ## 0.4.5
 
-- Adjust limits to fit values into db
-  ([#167](https://github.com/getsentry/relay/pull/167))
+- Adjust limits to fit values into db ([#167](https://github.com/getsentry/relay/pull/167))
 - Environment is 64 chars in db
 - Normalize macOS ([#168](https://github.com/getsentry/relay/pull/168))
 - Use right maxchars for `transaction`, `dist`, `release`
@@ -414,67 +354,46 @@
 
 ## 0.4.4
 
-- Reject unknown debug images
-  ([#163](https://github.com/getsentry/relay/pull/163))
-- Include original_value in `Meta::eq`
-  ([#164](https://github.com/getsentry/relay/pull/164))
-- Emit correct expectations for common types
-  ([#162](https://github.com/getsentry/relay/pull/162))
-- Permit invalid emails in user interface
-  ([#161](https://github.com/getsentry/relay/pull/161))
+- Reject unknown debug images ([#163](https://github.com/getsentry/relay/pull/163))
+- Include original_value in `Meta::eq` ([#164](https://github.com/getsentry/relay/pull/164))
+- Emit correct expectations for common types ([#162](https://github.com/getsentry/relay/pull/162))
+- Permit invalid emails in user interface ([#161](https://github.com/getsentry/relay/pull/161))
 - Drop long tags correctly ([#165](https://github.com/getsentry/relay/pull/165))
-- Do not skip null values in pairlists
-  ([#166](https://github.com/getsentry/relay/pull/166))
+- Do not skip null values in pairlists ([#166](https://github.com/getsentry/relay/pull/166))
 
 ## 0.4.3
 
-- Fix broken sdk_info parsing
-  ([#156](https://github.com/getsentry/relay/pull/156))
-- Add basic snapshot tests for normalize and event parsing
-  ([#154](https://github.com/getsentry/relay/pull/154))
+- Fix broken sdk_info parsing ([#156](https://github.com/getsentry/relay/pull/156))
+- Add basic snapshot tests for normalize and event parsing ([#154](https://github.com/getsentry/relay/pull/154))
 - Context trimming ([#153](https://github.com/getsentry/relay/pull/153))
-- Coerce PHP frame vars array to object
-  ([#159](https://github.com/getsentry/relay/pull/159))
+- Coerce PHP frame vars array to object ([#159](https://github.com/getsentry/relay/pull/159))
 
 ## 0.4.2
 
 - Remove content-type params
 - Dont attempt to free() if python is shutting down
-- Improve cookie header normalizations
-  ([#151](https://github.com/getsentry/relay/pull/151))
-- Implement LogEntry formatting
-  ([#152](https://github.com/getsentry/relay/pull/152))
+- Improve cookie header normalizations ([#151](https://github.com/getsentry/relay/pull/151))
+- Implement LogEntry formatting ([#152](https://github.com/getsentry/relay/pull/152))
 - Deduplicate tags ([#155](https://github.com/getsentry/relay/pull/155))
 - Treat empty paths like no paths in frame normalization
 - Remove cookie header when explicit cookies are given
 
 ## 0.4.1
 
-- Do not remove empty cookies or headers
-  ([#138](https://github.com/getsentry/relay/pull/138))
-- Skip more empty containers
-  ([#139](https://github.com/getsentry/relay/pull/139))
-- Make `request.header` values lenient
-  ([#145](https://github.com/getsentry/relay/pull/145))
-- Remove internal tags when backfilling
-  ([#146](https://github.com/getsentry/relay/pull/146))
-- Implement advanced context normalization
-  ([#140](https://github.com/getsentry/relay/pull/140))
-- Retain additional properties in contexts
-  ([#141](https://github.com/getsentry/relay/pull/141))
-- Implement very lenient URL parsing
-  ([#147](https://github.com/getsentry/relay/pull/147))
-- Do not require breadcrumb timestamps
-  ([#144](https://github.com/getsentry/relay/pull/144))
-- Reject tags with long keys
-  ([#149](https://github.com/getsentry/relay/pull/149))
+- Do not remove empty cookies or headers ([#138](https://github.com/getsentry/relay/pull/138))
+- Skip more empty containers ([#139](https://github.com/getsentry/relay/pull/139))
+- Make `request.header` values lenient ([#145](https://github.com/getsentry/relay/pull/145))
+- Remove internal tags when backfilling ([#146](https://github.com/getsentry/relay/pull/146))
+- Implement advanced context normalization ([#140](https://github.com/getsentry/relay/pull/140))
+- Retain additional properties in contexts ([#141](https://github.com/getsentry/relay/pull/141))
+- Implement very lenient URL parsing ([#147](https://github.com/getsentry/relay/pull/147))
+- Do not require breadcrumb timestamps ([#144](https://github.com/getsentry/relay/pull/144))
+- Reject tags with long keys ([#149](https://github.com/getsentry/relay/pull/149))
 
 ## 0.4.0
 
-- Add new options max_concurrent_events
-  ([#134](https://github.com/getsentry/relay/pull/134))
-- Dont move stacktrace before normalizing it
-  ([#135](https://github.com/getsentry/relay/pull/135))
+- Add new options max_concurrent_events ([#134](https://github.com/getsentry/relay/pull/134))
+- Dont move stacktrace before normalizing it ([#135](https://github.com/getsentry/relay/pull/135))
 - Fix broken repr and crash when shutting down python
 - Port slim_frame_data ([#137](https://github.com/getsentry/relay/pull/137))
 - Special treatment for ellipsis in URLs
@@ -482,29 +401,20 @@
 
 ## 0.3.0
 
-- Changed PII stripping rule format to permit path selectors when applying
-  rules. This means that now `$string` refers to strings for instance and
-  `user.id` refers to the `id` field in the `user` attribute of the event.
-  Temporarily support for old rules is retained.
+- Changed PII stripping rule format to permit path selectors when applying rules. This means that now `$string` refers to strings for instance and `user.id` refers to the `id` field in the `user` attribute of the event. Temporarily support for old rules is retained.
 
 ## 0.2.7
 
-- Minor fixes to be closer to Python. Ability to disable trimming of objects,
-  arrays and strings.
+- Minor fixes to be closer to Python. Ability to disable trimming of objects, arrays and strings.
 
 ## 0.2.6
 
-- Fix bug where PII stripping would remove containers without leaving any
-  metadata about the retraction.
+- Fix bug where PII stripping would remove containers without leaving any metadata about the retraction.
 - Fix bug where old `redactPair` rules would stop working.
 
 ## 0.2.5
 
-- Rewrite of PII stripping logic. This brings potentially breaking changes to
-  the semantics of PII configs. Most importantly field types such as
-  `"freeform"` and `"databag"` are gone, right now there is only `"container"`
-  and `"text"`. All old field types should have become an alias for `"text"`,
-  but take extra care in ensuring your PII rules still work.
+- Rewrite of PII stripping logic. This brings potentially breaking changes to the semantics of PII configs. Most importantly field types such as `"freeform"` and `"databag"` are gone, right now there is only `"container"` and `"text"`. All old field types should have become an alias for `"text"`, but take extra care in ensuring your PII rules still work.
 
 - Minor fixes to be closer to Python.
 
@@ -519,8 +429,7 @@
 ## 0.2.2
 
 - Fix segfault when trying to process contexts.
-- Fix trimming state "leaking" between interfaces, leading to excessive
-  trimming.
+- Fix trimming state "leaking" between interfaces, leading to excessive trimming.
 - Don't serialize empty arrays and objects (with a few exceptions).
 
 ## 0.2.1
@@ -529,8 +438,7 @@
 
 ## 0.2.0
 
-- Updated event processing: Events from older SDKs are now supported. Also,
-  we've fixed some bugs along the line.
+- Updated event processing: Events from older SDKs are now supported. Also, we've fixed some bugs along the line.
 - Introduced full support for PII stripping.
 
 ## 0.1.3


### PR DESCRIPTION
Adds unreleased changes to the changelog. For now, changes are grouped into the following sections:

- "Features": New or enhanced features relevant to users or the public behavior of Relay.
- "Bug Fixes": Fixes for the public behavior of Relay or that impact usage.
- "Internal": Both changes and bug fixes only relevant to the processing mode, trusted Relay operation.

Public behavior is mostly scoped to server features such as endpoints, compression, rate limits and caching behavior. Data scrubbing is explicitly included in this feature set. Explicitly excluded are store normalization and features only for trusted Relays.

This prepares for the `auto` changeset policy in craft: https://github.com/getsentry/craft/pull/93.