### PR TITLE
build: remove unused build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,6 @@ ARG DOCKER_ARCH
 ARG BUILD_ARCH=x86_64
 ARG OPENSSL_ARCH=linux-x86_64
 
-ENV DOCKER_ARCH=${DOCKER_ARCH}
-ENV BUILD_ARCH=${BUILD_ARCH}
-ENV OPENSSL_ARCH=${OPENSSL_ARCH}
-
-ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
-ENV OPENSSL_DIR=/usr/local/build/$BUILD_TARGET
-ENV OPENSSL_STATIC=1
-
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     curl build-essential git zip \
@@ -26,8 +18,10 @@ RUN apt-get update \
 
 WORKDIR /work
 
-ENV PREFIX_DIR="$OPENSSL_DIR"
-ENV LIBS_DIR="/home/rust/libs"
+ENV DOCKER_ARCH=${DOCKER_ARCH} \
+    BUILD_ARCH=${BUILD_ARCH} \
+    BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu \
+    LIBS_DIR="/home/rust/libs"
 
 RUN echo "Building zlib" \
     && ZLIB_VERS=1.2.11 \
@@ -41,6 +35,11 @@ RUN echo "Building zlib" \
     && ./configure --static --archs="-fPIC" --prefix=$PREFIX_DIR \
     && make -j$(nproc) && make install \
     && cd .. && rm -rf zlib-$ZLIB_VERS.tar.gz zlib-$ZLIB_VERS checksums.txt
+
+ENV PREFIX_DIR="$OPENSSL_DIR" \
+    OPENSSL_ARCH=${OPENSSL_ARCH} \
+    OPENSSL_DIR=/usr/local/build/${BUILD_TARGET} \
+    OPENSSL_STATIC=1
 
 RUN echo "Building OpenSSL" \
     && OPENSSL_VERS=1.0.2s \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ ENV OPENSSL_STATIC=1
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     curl build-essential git zip \
-    # For librdkafka
-    libclang-3.9-dev clang-3.9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,14 @@ ARG DOCKER_ARCH
 ARG BUILD_ARCH=x86_64
 ARG OPENSSL_ARCH=linux-x86_64
 
+ENV DOCKER_ARCH=${DOCKER_ARCH}
+ENV BUILD_ARCH=${BUILD_ARCH}
+ENV OPENSSL_ARCH=${OPENSSL_ARCH}
+
+ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
+ENV OPENSSL_DIR=/usr/local/build/$BUILD_TARGET
+ENV OPENSSL_STATIC=1
+
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     curl build-essential git zip \
@@ -18,10 +26,8 @@ RUN apt-get update \
 
 WORKDIR /work
 
-ENV DOCKER_ARCH=${DOCKER_ARCH} \
-    BUILD_ARCH=${BUILD_ARCH} \
-    BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu \
-    LIBS_DIR="/home/rust/libs"
+ENV PREFIX_DIR="$OPENSSL_DIR"
+ENV LIBS_DIR="/home/rust/libs"
 
 RUN echo "Building zlib" \
     && ZLIB_VERS=1.2.11 \
@@ -35,11 +41,6 @@ RUN echo "Building zlib" \
     && ./configure --static --archs="-fPIC" --prefix=$PREFIX_DIR \
     && make -j$(nproc) && make install \
     && cd .. && rm -rf zlib-$ZLIB_VERS.tar.gz zlib-$ZLIB_VERS checksums.txt
-
-ENV PREFIX_DIR="$OPENSSL_DIR" \
-    OPENSSL_ARCH=${OPENSSL_ARCH} \
-    OPENSSL_DIR=/usr/local/build/${BUILD_TARGET} \
-    OPENSSL_STATIC=1
 
 RUN echo "Building OpenSSL" \
     && OPENSSL_VERS=1.0.2s \


### PR DESCRIPTION
These build dependencies were introduced here: https://github.com/getsentry/relay/commit/1940cc8176f12d4ead3292801eb093d08e77428d#diff-3254677a7917c6c01f55212f86c57fbfR26

Not sure the exact version of confluent-kakfa at the time, but I see you now have `confluent-kafka==1.3.0`, which ships as a wheel with librdkafka precompiled. Discovered here: https://github.com/getsentry/snuba/pull/1003

(Also, 1.3.0 doesn't match the version run in sentry saas, or snuba - not sure if that's an issue.)