### PR TITLE
fix(envelope): Detect attachments that create events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 - Invalid session payloads are now logged for SDK debugging. ([#584](https://github.com/getsentry/relay/pull/584), [#591](https://github.com/getsentry/relay/pull/591))
 - Remove unused `rev` from project state. ([#586](https://github.com/getsentry/relay/pull/586))
 - Add an outcome endpoint for trusted Relays. ([#589](https://github.com/getsentry/relay/pull/589))
+- Emit outcomes for event payloads submitted in attachment files. ([#609](https://github.com/getsentry/relay/pull/609))
 
 ## 0.5.9
 

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -443,7 +443,8 @@ impl Item {
             | ItemType::SecurityReport
             | ItemType::UnrealReport => true,
 
-            // Attachments are only event items if they are crash reports.
+            // Attachments are only event items if they are crash reports or if they carry partial
+            // event payloads. Plain attachments never create event payloads.
             ItemType::Attachment => match self.attachment_type().unwrap_or_default() {
                 AttachmentType::AppleCrashReport
                 | AttachmentType::Minidump

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -445,13 +445,18 @@ impl Item {
 
             // Attachments are only event items if they are crash reports.
             ItemType::Attachment => match self.attachment_type().unwrap_or_default() {
-                AttachmentType::AppleCrashReport | AttachmentType::Minidump => true,
-                _ => false,
+                AttachmentType::AppleCrashReport
+                | AttachmentType::Minidump
+                | AttachmentType::EventPayload
+                | AttachmentType::Breadcrumbs => true,
+                AttachmentType::Attachment
+                | AttachmentType::UnrealContext
+                | AttachmentType::UnrealLogs => false,
             },
 
-            // Form data items may contain partial event payloads, but those are only ever valid if they
-            // occur together with an explicit event item, such as a minidump or apple crash report. For
-            // this reason, FormData alone does not constitute an event item.
+            // Form data items may contain partial event payloads, but those are only ever valid if
+            // they occur together with an explicit event item, such as a minidump or apple crash
+            // report. For this reason, FormData alone does not constitute an event item.
             ItemType::FormData => false,
 
             // The remaining item types cannot carry event payloads.


### PR DESCRIPTION
In addition to crash reports, the `__sentry-event` and `__sentry-breadcrumb*` attachments also create event payloads, and should therefore emit outcomes in Relay. This patch ensure that `Item::creates_event` correctly detects these, which is used in `EventManager`.

**Changelog (Internal)**: Emit outcomes for event payloads submitted in attachment files.