### PR TITLE
ref(server): Split event-independent items from envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 - Remove unused `rev` from project state. ([#586](https://github.com/getsentry/relay/pull/586))
 - Add an outcome endpoint for trusted Relays. ([#589](https://github.com/getsentry/relay/pull/589))
 - Emit outcomes for event payloads submitted in attachment files. ([#609](https://github.com/getsentry/relay/pull/609))
+- Split envelopes that contain sessions and other items and ingest them independently. ([#610](https://github.com/getsentry/relay/pull/610))
 
 ## 0.5.9
 

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -697,6 +697,32 @@ impl Envelope {
         self.items.push(item)
     }
 
+    /// Splits the envelope by the given predicate.
+    ///
+    /// The predicate passed to `split_by()` can return `true`, or `false`. If it returns `true` or
+    /// `false` for all items, then this returns `None`. Otherwise, a new envelope is constructed
+    /// with all items that return `true`. Items that return `false` remain in this envelope.
+    ///
+    /// The returned envelope assumes the same headers.
+    pub fn split_by<F>(&mut self, mut f: F) -> Option<Self>
+    where
+        F: FnMut(&Item) -> bool,
+    {
+        let split_count = self.items().filter(|item| f(item)).count();
+        if split_count == self.len() || split_count == 0 {
+            return None;
+        }
+
+        let old_items = std::mem::take(&mut self.items);
+        let (split_items, own_items) = old_items.into_iter().partition(f);
+        self.items = own_items;
+
+        Some(Envelope {
+            headers: self.headers.clone(),
+            items: split_items,
+        })
+    }
+
     /// Serializes this envelope into the given writer.
     pub fn serialize<W>(&self, mut writer: W) -> Result<(), EnvelopeError>
     where
@@ -796,7 +822,7 @@ impl Envelope {
     fn require_termination(slice: &[u8], offset: usize) -> Result<(), EnvelopeError> {
         match slice.get(offset) {
             Some(&b'\n') | None => Ok(()),
-            _ => Err(EnvelopeError::MissingNewline),
+            Some(_) => Err(EnvelopeError::MissingNewline),
         }
     }
 
@@ -1147,5 +1173,49 @@ mod tests {
         Hello
 
         "###);
+    }
+
+    #[test]
+    fn test_split_envelope_none() {
+        let mut envelope = Envelope::from_request(Some(EventId::new()), request_meta());
+        envelope.add_item(Item::new(ItemType::Attachment));
+        envelope.add_item(Item::new(ItemType::Attachment));
+
+        // Does not split when no item matches.
+        let split_opt = envelope.split_by(|item| item.ty() == ItemType::Session);
+        assert!(split_opt.is_none());
+    }
+
+    #[test]
+    fn test_split_envelope_all() {
+        let mut envelope = Envelope::from_request(Some(EventId::new()), request_meta());
+        envelope.add_item(Item::new(ItemType::Session));
+        envelope.add_item(Item::new(ItemType::Session));
+
+        // Does not split when all items match.
+        let split_opt = envelope.split_by(|item| item.ty() == ItemType::Session);
+        assert!(split_opt.is_none());
+    }
+
+    #[test]
+    fn test_split_envelope_some() {
+        let mut envelope = Envelope::from_request(Some(EventId::new()), request_meta());
+        envelope.add_item(Item::new(ItemType::Session));
+        envelope.add_item(Item::new(ItemType::Attachment));
+
+        let split_opt = envelope.split_by(|item| item.ty() == ItemType::Session);
+        let split_envelope = split_opt.expect("split_by returns an Envelope");
+
+        assert_eq!(split_envelope.len(), 1);
+        assert_eq!(split_envelope.event_id(), envelope.event_id());
+
+        // Matching items have moved into the split envelope.
+        for item in split_envelope.items() {
+            assert_eq!(item.ty(), ItemType::Session);
+        }
+
+        for item in envelope.items() {
+            assert_eq!(item.ty(), ItemType::Attachment);
+        }
     }
 }


### PR DESCRIPTION
Splits envelopes into items that require events and items that are independent of events. This helps to optimize the ingestion path for envelopes that only contain sessions.

**Changelog (Internal):** Split envelopes that contain sessions and other items and ingest them independently.

Requires https://github.com/getsentry/relay/pull/609