### PR TITLE
ref(server): Replace async keyword in function name

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -472,7 +472,7 @@ impl Project {
             .map(|shared| (*shared).clone())
             .map_err(|_| ProjectError::FetchFailed);
 
-        Response::r#async(future)
+        Response::future(future)
     }
 
     fn fetch_state(

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -270,6 +270,6 @@ impl Handler<FetchProjectState> for ProjectCache {
             Box::new(fetch_redis)
         });
 
-        Response::r#async(future)
+        Response::future(future)
     }
 }

--- a/relay-server/src/actors/project_keys.rs
+++ b/relay-server/src/actors/project_keys.rs
@@ -15,6 +15,7 @@ use relay_config::Config;
 
 use crate::actors::upstream::{SendQuery, UpstreamQuery, UpstreamRelay};
 use crate::metrics::{RelayCounters, RelayTimers};
+use crate::utils::Response;
 
 type ProjectKey = String;
 
@@ -186,6 +187,6 @@ impl Handler<GetProjectId> for ProjectKeyLookup {
         };
 
         let response = channel.map(|shared| *shared).map_err(|_| ProjectKeyError);
-        Response::r#async(response)
+        Response::future(response)
     }
 }

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -219,7 +219,7 @@ impl RelayCache {
             .map(move |key| (relay_id, (*key).clone()))
             .map_err(|_| KeyError::FetchFailed);
 
-        Response::r#async(receiver)
+        Response::future(receiver)
     }
 }
 
@@ -343,7 +343,7 @@ impl Handler<GetRelays> for RelayCache {
 
         for id in message.relay_ids {
             match self.get_or_fetch_info(id, context) {
-                Response::Async(fut) => {
+                Response::Future(fut) => {
                     futures.push(fut);
                 }
                 Response::Reply(Ok((id, key))) => {
@@ -364,6 +364,6 @@ impl Handler<GetRelays> for RelayCache {
             GetRelaysResult { relays }
         });
 
-        Response::r#async(future)
+        Response::future(future)
     }
 }


### PR DESCRIPTION
The `async` keyword has been reserved since Rust Edition 2018 and requires literal escaping in identifiers. Instead of that, we can use a non-reserved name.

No changelog entry.