### PR TITLE
doc(server): Clarify envelope and request metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 - All endpoint metrics now report their proper `route` tag. This applies to `requests`, `requests.duration`, and `responses.status_codes`. Previously, some some endpoints reported an empty route. ([#595](https://github.com/getsentry/relay/pull/595))
 - Properly refresh cached project states based on the configured intervals. Previously, Relay may have gone into an endless refresh cycle if the system clock not accurate, or the state had not been updated in the upstream. ([#596](https://github.com/getsentry/relay/pull/596))
 - Respond with `403 Forbidden` when multiple authentication payloads are sent by the SDK. Previously, Relay would authenticate using one of the payloads and silently ignore the rest. ([#602](https://github.com/getsentry/relay/pull/602))
+- Improve metrics documentation. ([#614](https://github.com/getsentry/relay/pull/614))
 
 **Internal**:
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -390,7 +390,7 @@ mod kafka {
                 .map_err(OutcomeError::SerializationError)?;
 
             metric!(
-                counter(RelayCounters::EventOutcomes) += 1,
+                counter(RelayCounters::Outcomes) += 1,
                 reason = message.outcome.to_reason().unwrap_or(""),
                 outcome = message.outcome.name()
             );

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -479,7 +479,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
 
             self.produce(topic, event_message)?;
             metric!(
-                counter(RelayCounters::ProcessingEventProduced) += 1,
+                counter(RelayCounters::ProcessingMessageProduced) += 1,
                 event_type = "event"
             );
         } else if !attachments.is_empty() {
@@ -493,7 +493,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
 
                 self.produce(topic, attachment_message)?;
                 metric!(
-                    counter(RelayCounters::ProcessingEventProduced) += 1,
+                    counter(RelayCounters::ProcessingMessageProduced) += 1,
                     event_type = "attachment"
                 );
             }

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -156,10 +156,10 @@ impl Future for StoreBody {
             })
             .and_then(|body_opt| {
                 let body = body_opt.ok_or(StorePayloadError::Overflow)?;
-                metric!(histogram(RelayHistograms::EventSizeBytesRaw) = body.len() as u64);
+                metric!(histogram(RelayHistograms::RequestSizeBytesRaw) = body.len() as u64);
                 let decoded = decode_bytes(body.freeze())?;
                 metric!(
-                    histogram(RelayHistograms::EventSizeBytesUncompressed) = decoded.len() as u64
+                    histogram(RelayHistograms::RequestSizeBytesUncompressed) = decoded.len() as u64
                 );
                 Ok(decoded)
             });

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -456,7 +456,7 @@ where
                 })
         }))
         .or_else(move |error: BadStoreRequest| {
-            metric!(counter(RelayCounters::EventRejected) += 1);
+            metric!(counter(RelayCounters::EnvelopeRejected) += 1);
 
             if is_event {
                 outcome_producer.do_send(TrackOutcome {


### PR DESCRIPTION
Clarifies documentation for metrics that include envelopes with items other than events, as well as metrics that measure web requests rather than events.

**Changelog (Bug Fixes)**: Improve metrics documentation.