### PR TITLE
ref(server): Prepare for per-item rate limits

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -17,9 +17,10 @@ use relay_quotas::{DataCategory, Quota, RateLimits, Scoping};
 
 use crate::actors::outcome::DiscardReason;
 use crate::actors::project_cache::{FetchProjectState, ProjectCache, ProjectError};
+use crate::envelope::Envelope;
 use crate::extractors::RequestMeta;
 use crate::metrics::RelayCounters;
-use crate::utils::Response;
+use crate::utils::{ActorResponse, Response};
 
 /// The current status of a project state. Return value of `ProjectState::outdated`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -294,11 +295,18 @@ impl ProjectState {
         scoping
     }
 
-    /// Determines whether the given event should be accepted or dropped.
-    pub fn get_event_action(&self, meta: &RequestMeta, config: &Config) -> EventAction {
+    /// Determines whether the given request should be accepted or discarded.
+    ///
+    /// Returns `Ok(())` if the request should be accepted. Returns `Err(DiscardReason)` if the
+    /// request should be discarded, by indicating the reason. The checks preformed for this are:
+    ///
+    ///  - Allowed origin headers
+    ///  - Disabled or unknown projects
+    ///  - Disabled project keys (DSN)
+    pub fn check_request(&self, meta: &RequestMeta, config: &Config) -> Result<(), DiscardReason> {
         // Try to verify the request origin with the project config.
         if !self.is_valid_origin(meta.origin()) {
-            return EventAction::Discard(DiscardReason::Cors);
+            return Err(DiscardReason::Cors);
         }
 
         if self.outdated(config) == Outdated::HardOutdated {
@@ -310,20 +318,20 @@ impl ProjectState {
             // except queueing events for unknown DSNs as they might have become
             // available in the meanwhile.
             match self.get_public_key_status(meta.public_key()) {
-                PublicKeyStatus::Enabled => EventAction::Accept,
-                PublicKeyStatus::Disabled => EventAction::Discard(DiscardReason::ProjectId),
-                PublicKeyStatus::Unknown => EventAction::Accept,
+                PublicKeyStatus::Enabled => Ok(()),
+                PublicKeyStatus::Disabled => Err(DiscardReason::ProjectId),
+                PublicKeyStatus::Unknown => Ok(()),
             }
         } else {
             // if we recorded an invalid project state response from the upstream (i.e. parsing
             // failed), discard the event with a s
             if self.invalid() {
-                return EventAction::Discard(DiscardReason::ProjectState);
+                return Err(DiscardReason::ProjectState);
             }
 
             // only drop events if we know for sure the project is disabled.
             if self.disabled() {
-                return EventAction::Discard(DiscardReason::ProjectId);
+                return Err(DiscardReason::ProjectId);
             }
 
             // since the config has been fetched recently, we assume unknown
@@ -331,11 +339,11 @@ impl ProjectState {
             // an exception, where public keys are backfilled lazily after
             // events are sent to the upstream.
             match self.get_public_key_status(meta.public_key()) {
-                PublicKeyStatus::Enabled => EventAction::Accept,
-                PublicKeyStatus::Disabled => EventAction::Discard(DiscardReason::ProjectId),
+                PublicKeyStatus::Enabled => Ok(()),
+                PublicKeyStatus::Disabled => Err(DiscardReason::ProjectId),
                 PublicKeyStatus::Unknown => match config.relay_mode() {
-                    RelayMode::Proxy => EventAction::Accept,
-                    _ => EventAction::Discard(DiscardReason::ProjectId),
+                    RelayMode::Proxy => Ok(()),
+                    _ => Err(DiscardReason::ProjectId),
                 },
             }
         }
@@ -510,6 +518,37 @@ impl Project {
             None => meta.get_partial_scoping(),
         }
     }
+
+    fn check_envelope(
+        &mut self,
+        envelope: Envelope,
+        scoping: &Scoping,
+    ) -> Result<CheckedEnvelope, DiscardReason> {
+        if let Some(state) = self.state() {
+            state.check_request(envelope.meta(), &self.config)?;
+        }
+
+        self.rate_limits.clean_expired();
+
+        // TODO: Apply rate limits no non-event items once implemented.
+        let rate_limits = self.rate_limits.check(scoping.item(DataCategory::Error));
+        let envelope = if rate_limits.is_limited() {
+            None
+        } else {
+            Some(envelope)
+        };
+
+        Ok(CheckedEnvelope {
+            envelope,
+            rate_limits,
+        })
+    }
+
+    fn check_envelope_scoped(&mut self, message: CheckEnvelope) -> CheckEnvelopeResponse {
+        let scoping = self.get_scoping(message.envelope.meta());
+        let result = self.check_envelope(message.envelope, &scoping);
+        CheckEnvelopeResponse { result, scoping }
+    }
 }
 
 impl Actor for Project {
@@ -524,6 +563,9 @@ impl Actor for Project {
     }
 }
 
+/// Returns the project state.
+///
+/// The project state is fetched if it is missing or outdated.
 pub struct GetProjectState;
 
 impl Message for GetProjectState {
@@ -538,86 +580,78 @@ impl Handler<GetProjectState> for Project {
     }
 }
 
-pub struct GetScoping {
-    meta: Arc<RequestMeta>,
+/// Checks the envelope against project configuration and rate limits.
+///
+/// When `fetched`, then the project state is ensured to be up to date. When `cached`, an outdated
+/// project state may be used, or otherwise the envelope is passed through unaltered.
+///
+/// To check the envelope, this runs:
+///  - Validate origins and public keys
+///  - Quotas with a limit of `0`
+///  - Cached rate limits
+#[derive(Debug)]
+pub struct CheckEnvelope {
+    envelope: Envelope,
     fetch: bool,
 }
 
-impl GetScoping {
-    pub fn fetched(meta: Arc<RequestMeta>) -> Self {
-        Self { meta, fetch: true }
+impl CheckEnvelope {
+    /// Fetches the project state and checks the envelope.
+    pub fn fetched(envelope: Envelope) -> Self {
+        Self {
+            envelope,
+            fetch: true,
+        }
     }
 
-    pub fn cached(meta: Arc<RequestMeta>) -> Self {
-        Self { meta, fetch: false }
-    }
-}
-
-impl Message for GetScoping {
-    type Result = Result<Scoping, ProjectError>;
-}
-
-impl Handler<GetScoping> for Project {
-    type Result = Response<Scoping, ProjectError>;
-
-    fn handle(&mut self, message: GetScoping, context: &mut Self::Context) -> Self::Result {
-        if message.fetch {
-            // Project state fetching is allowed, so ensure the state is fetched and up-to-date.
-            // This will return synchronously if the state is still cached.
-            self.get_or_fetch_state(context)
-                .map(move |state| state.get_scoping(&message.meta))
-        } else {
-            self.get_or_fetch_state(context);
-            // message.fetch == false: Fetching must not block the store request. The EventManager
-            // will later fetch the project state.
-            Response::ok(self.get_scoping(&message.meta))
+    /// Uses a cached project state and checks the envelope.
+    pub fn cached(envelope: Envelope) -> Self {
+        Self {
+            envelope,
+            fetch: false,
         }
     }
 }
 
-pub struct GetEventAction {
-    meta: Arc<RequestMeta>,
+/// A checked envelope and associated rate limits.
+///
+/// Items violating the rate limits have been removed from the envelope. If all items are removed
+/// from the envelope, `None` is returned in place of the envelope.
+#[derive(Debug)]
+pub struct CheckedEnvelope {
+    pub envelope: Option<Envelope>,
+    pub rate_limits: RateLimits,
 }
 
-impl GetEventAction {
-    pub fn new(meta: Arc<RequestMeta>) -> Self {
-        GetEventAction { meta }
-    }
+/// Scoping information along with a checked envelope.
+#[derive(Debug)]
+pub struct CheckEnvelopeResponse {
+    pub result: Result<CheckedEnvelope, DiscardReason>,
+    pub scoping: Scoping,
 }
 
-/// Indicates what should happen to events based on their meta data.
-#[derive(Clone, Debug)]
-pub enum EventAction {
-    /// The event should be discarded.
-    Discard(DiscardReason),
-    /// The event should be discarded and the client should back off for some time.
-    RateLimit(RateLimits),
-    /// The event should be processed and sent to upstream.
-    Accept,
+impl Message for CheckEnvelope {
+    type Result = Result<CheckEnvelopeResponse, ProjectError>;
 }
 
-impl Message for GetEventAction {
-    type Result = EventAction;
-}
+impl Handler<CheckEnvelope> for Project {
+    type Result = ActorResponse<Self, CheckEnvelopeResponse, ProjectError>;
 
-impl Handler<GetEventAction> for Project {
-    type Result = MessageResult<GetEventAction>;
-
-    fn handle(&mut self, message: GetEventAction, _context: &mut Self::Context) -> Self::Result {
-        let scoping = self.get_scoping(&message.meta);
-        let rate_limits = self.rate_limits.check(scoping.item(DataCategory::Error));
-
-        let event_action = if rate_limits.is_limited() {
-            EventAction::RateLimit(rate_limits)
+    fn handle(&mut self, message: CheckEnvelope, context: &mut Self::Context) -> Self::Result {
+        if message.fetch {
+            // Project state fetching is allowed, so ensure the state is fetched and up-to-date.
+            // This will return synchronously if the state is still cached.
+            self.get_or_fetch_state(context)
+                .into_actor()
+                .map(self, context, move |_, slf, _ctx| {
+                    slf.check_envelope_scoped(message)
+                })
         } else {
-            // If the state is not loaded, we're probably in a preflight request. `EventManager`
-            // ensures to load the state before calling this function.
-            self.state().map_or(EventAction::Accept, |state| {
-                state.get_event_action(&message.meta, &self.config)
-            })
-        };
-
-        MessageResult(event_action)
+            self.get_or_fetch_state(context);
+            // message.fetch == false: Fetching must not block the store request. The EventManager
+            // will later fetch the project state.
+            ActorResponse::ok(self.check_envelope_scoped(message))
+        }
     }
 }
 

--- a/relay-server/src/utils/actix.rs
+++ b/relay-server/src/utils/actix.rs
@@ -1,4 +1,5 @@
 use ::actix::dev::{MessageResponse, ResponseChannel};
+use ::actix::fut::IntoActorFuture;
 use ::actix::prelude::*;
 use futures::prelude::*;
 
@@ -58,6 +59,81 @@ where
                     tx.send(res);
                 }
             }
+        }
+    }
+}
+
+pub enum ActorResponse<A, T, E> {
+    Reply(Result<T, E>),
+    Future(ResponseActFuture<A, T, E>),
+}
+
+impl<A, T, E> ActorResponse<A, T, E> {
+    pub fn ok(value: T) -> Self {
+        ActorResponse::Reply(Ok(value))
+    }
+
+    pub fn reply(result: Result<T, E>) -> Self {
+        ActorResponse::Reply(result)
+    }
+
+    pub fn future<F>(future: F) -> Self
+    where
+        A: Actor,
+        F: IntoActorFuture<Actor = A, Item = T, Error = E>,
+        F::Future: 'static,
+    {
+        ActorResponse::Future(Box::new(future.into_future()))
+    }
+}
+
+impl<A: Actor, T: 'static, E: 'static> ActorResponse<A, T, E> {
+    pub fn map<U, F: 'static>(
+        self,
+        actor: &mut A,
+        ctx: &mut <A as Actor>::Context,
+        f: F,
+    ) -> ActorResponse<A, U, E>
+    where
+        F: FnOnce(T, &mut A, &mut <A as Actor>::Context) -> U,
+    {
+        match self {
+            ActorResponse::Reply(result) => ActorResponse::reply(result.map(|t| f(t, actor, ctx))),
+            ActorResponse::Future(future) => ActorResponse::future(future.map(f)),
+        }
+    }
+}
+
+impl<A, M, T: 'static, E: 'static> MessageResponse<A, M> for ActorResponse<A, T, E>
+where
+    A: Actor,
+    M: Message<Result = Result<T, E>>,
+    A::Context: AsyncContext<A>,
+{
+    fn handle<R: ResponseChannel<M>>(self, context: &mut A::Context, tx: Option<R>) {
+        match self {
+            ActorResponse::Future(fut) => {
+                context.spawn(fut.then(move |res, _, _| {
+                    if let Some(tx) = tx {
+                        tx.send(res);
+                    }
+                    fut::ok(())
+                }));
+            }
+            ActorResponse::Reply(res) => {
+                if let Some(tx) = tx {
+                    tx.send(res);
+                }
+            }
+        }
+    }
+}
+
+impl<T: 'static, E: 'static> Response<T, E> {
+    pub fn into_actor<A: Actor>(self) -> ActorResponse<A, T, E> {
+        match self {
+            Response::Reply(result) => ActorResponse::Reply(result),
+            Response::Future(future) => ActorResponse::Future(Box::new(fut::wrap_future(future))),
         }
     }
 }


### PR DESCRIPTION
Prepares ingestion for partial rate limits per item:

- `GetEventAction` has been changed into `CheckEnvelope`, which applies rate limits and can remove offending items. At the time, rate limits still apply atomically. See the TODO for the location where partial rate limiting will be implemented.
- If partial rate limits apply, the envelope is still processed. At the end, the rate limits are emitted.

No changelog entry.