### PR TITLE
fix(general): Avoid scrubbing event errors by default

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -184,7 +184,7 @@ pub struct EventProcessingError {
     pub value: Annotated<Value>,
 
     /// Additional data explaining this error.
-    #[metastructure(additional_properties, pii = "true")]
+    #[metastructure(additional_properties, pii = "maybe")]
     pub other: Object<Value>,
 }
 


### PR DESCRIPTION
Alternatively we can opt these fields out specifically for the legacy scrubbers