### PR TITLE
feat(quotas): Check quota units before applying them

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -353,6 +353,12 @@ impl ProjectState {
             }
         }
     }
+
+    /// Validates data in this project state and removes values that are partially invalid.
+    pub fn sanitize(mut self) -> Self {
+        self.config.quotas.retain(Quota::is_valid);
+        self
+    }
 }
 
 /// Represents a public key received from the projectconfig endpoint.

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -120,7 +120,7 @@ fn load_local_states(projects_path: &Path) -> io::Result<HashMap<ProjectId, Arc<
         };
 
         let state = serde_json::from_reader(io::BufReader::new(fs::File::open(path)?))?;
-        states.insert(id, Arc::new(state));
+        states.insert(id, Arc::new(ProjectState::sanitize(state)));
     }
 
     Ok(states)

--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -80,7 +80,7 @@ impl Handler<FetchOptionalProjectState> for RedisProjectSource {
         _ctx: &mut Self::Context,
     ) -> Self::Result {
         match self.get_config(message.id) {
-            Ok(x) => x.map(Arc::new),
+            Ok(x) => x.map(ProjectState::sanitize).map(Arc::new),
             Err(e) => {
                 log::error!("Failed to fetch project from Redis: {}", LogError(&e));
                 None

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -217,7 +217,7 @@ impl UpstreamProjectSource {
                                     })
                                     .unwrap_or_else(ProjectState::missing);
 
-                                channel.send(state);
+                                channel.send(state.sanitize());
                             }
                         }
                         Err(error) => {

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -475,6 +475,7 @@ def test_processing_quotas(
             "id": "test_rate_limiting_{}".format(uuid.uuid4().hex),
             "scope": "key",
             "scopeId": six.text_type(key_id),
+            "categories": ["error", "default"],
             "limit": 5,
             "window": 3600,
             "reasonCode": "get_lost",
@@ -512,7 +513,7 @@ def test_processing_quotas(
         # max_rate_limit parameter
         retry_after = headers["retry-after"]
         assert int(retry_after) <= 120
-        assert headers["x-sentry-rate-limits"] == "120::key"
+        assert headers["x-sentry-rate-limits"] == "120:default;error:key"
         outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
 
     relay.dsn_public_key = second_key["publicKey"]


### PR DESCRIPTION
This checks and removes quotas that Relay cannot handle to avoid invalid counting. Particularly, this checks that counted quotas only apply to data categories with the same unit to avoid invalid counters. Units are:

- "count" for all events
- "bytes" for attachments
- "batches" for sessions (for the time)

Counted quotas are all quotas except for those with a limit of `0`. Such quotas may apply to all categories regardless of their units, since they are never counted and statically rejected.