### PR TITLE
build(gha): Add automated CalVer releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,9 +1,9 @@
 ---
-minVersion: "0.9.6"
+minVersion: "0.10.0"
 github:
   owner: getsentry
   repo: relay
-changelogPolicy: simple
+changelogPolicy: auto
 
 targets:
   - name: github
@@ -24,6 +24,9 @@ targets:
       - path: /relay/latest/
         metadata:
           cacheControl: "public, max-age=600"
+  - name: docker
+    source: us.gcr.io/sentryio/relay
+    target: getsentry/relay
 
 requireNames:
   - /^gh-pages.zip$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -4,6 +4,8 @@ github:
   owner: getsentry
   repo: relay
 changelogPolicy: auto
+statusProvider:
+  name: github
 
 targets:
   - name: github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ on:
   repository_dispatch:
     types: [release]
   schedule:
-    - cron:  '0 0 15 * *'
+    # We want the release to be at 9-10am Pacific Time
+    # We also want it to be 1 hour before the on-prem release
+    - cron:  '0 17 15 * *'
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,8 @@ jobs:
             action: publish
             version: ${{ github.event.client_payload.version || steps.calver.outputs.version }}
             dry_run: ${{ github.event.client_payload.dry_run }}
+            github_api_token: ${{ secrets.GH_SENTRY_BOT_PAT }}
+            zeues_api_token: ${{ secrets.ZEUS_API_TOKEN }}
+            gcs_target_creds: ${{ secrets.CRAFT_GCS_TARGET_CREDS_JSON }}
+            docker_username: 'sentrybuilder'
+            docker_password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+on:
+  repository_dispatch:
+    types: [release]
+  schedule:
+    - cron:  '0 0 15 * *'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+        - id: calver
+          if: ${{ !github.event.client_payload.version }}
+          run: echo "::set-output name=version::$(date +'%y.%-m.0')"
+        - uses: actions/checkout@v2
+        - uses: getsentry/craft-action@master
+          with:
+            action: prepare
+            version: ${{ github.event.client_payload.version || steps.calver.outputs.version }}
+            dry_run: ${{ github.event.client_payload.dry_run }}
+        - uses: getsentry/craft-action@master
+          with:
+            action: publish
+            version: ${{ github.event.client_payload.version || steps.calver.outputs.version }}
+            dry_run: ${{ github.event.client_payload.dry_run }}


### PR DESCRIPTION
See getsentry/craft#95 and getsentry/onpremise#539.

Does the following:

- Add Docker target to Craft config
- Switch `changelogPolicy` to `auto` in Craft config
- Add manual and scheduled GitHub action for CalVer releases
- Add GitHub status provider 