### PR TITLE
test(pii): Test rough equivalency of custom rule with defaults vs builtin

### DIFF
--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -834,7 +834,7 @@ mod tests {
             input = "John Appleseed 4571234567890111!";
             output = "John Appleseed ****************!";
             remarks = vec![
-                Remark::with_range(RemarkType::Masked, "@creditcard:mask", (15, 31)),
+                Remark::with_range(RemarkType::Masked, "0", (15, 31)),
             ];
         );
         assert_text_rule!(
@@ -848,9 +848,9 @@ mod tests {
         assert_custom_rulespec!(
             rule = "@creditcard:replace";
             input = "John Appleseed 4571234567890111!";
-            output = "John Appleseed [creditcard]!";
+            output = "John Appleseed [Filtered]!";
             remarks = vec![
-                Remark::with_range(RemarkType::Substituted, "@creditcard:replace", (15, 27)),
+                Remark::with_range(RemarkType::Substituted, "0", (15, 25)),
             ];
         );
         assert_text_rule!(
@@ -866,7 +866,7 @@ mod tests {
             input = "John Appleseed 4571234567890111!";
             output = "John Appleseed 68C796A9ED3FB51BF850A11140FCADD8E2D88466!";
             remarks = vec![
-                Remark::with_range(RemarkType::Pseudonymized, "@creditcard:hash", (15, 55)),
+                Remark::with_range(RemarkType::Pseudonymized, "0", (15, 55)),
             ];
         );
     }


### PR DESCRIPTION
We're going to stop emitting builtin rules in the datascrubbing UI to simplify the PII config format and allow for custom placeholders of replace rules. After this PR and https://github.com/getsentry/sentry/pull/19339 is merged that means:

* a "mask creditcard" rule will no longer preserve the last 4 digits
* other "mask" methods no longer skip certain character classes
* "replace" now truly replaces with `[Filtered]` while previously it replaced with `[ip]`, `[mac]` etc. That was not documented behavior and was not the case with all rule types either.
* we could remove builtin rules if we wanted to, as soon as we migrated old configs over

Mask generally sees low adoption so I don't think this is too much of a breaking change.

We can bring back the masking features at a later point, but I don't see big value in having them. I'd much rather expose masking options in the UI.