### PR TITLE
build(gha): Add skip_prepare option for manual triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
           with:
             token: ${{ secrets.GH_SENTRY_BOT_PAT }}
         - uses: getsentry/craft@master
+          if: ${{ !github.event.client_payload.skip_prepare }}
           with:
             action: prepare
             version: ${{ github.event.client_payload.version || steps.calver.outputs.version }}


### PR DESCRIPTION
Sometimes the builds for release branches fail due to flaky tests. When this happens, to be able to run the release GitHub Action, we need to delete the release branch, and start over which means a lot of waiting, especially for already passed builds.

This PR adds a `skip_prepare` option that can be used on [manual triggers](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) allowing us to just run `publish` without the already successful `prepare` step.