### PR TITLE
fix(server): Validate session timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## Unreleased
 
-**Features**:
-
 **Bug Fixes**:
-- Outcomes from downstream relays were not forwarded upstream. ([#632](https://github.com/getsentry/relay/pull/632))
 
-**Internal**:
+- Outcomes from downstream relays were not forwarded upstream. ([#632](https://github.com/getsentry/relay/pull/632))
+- Apply clock drift correction to Release Health sessions and validate timestamps. ([#633](https://github.com/getsentry/relay/pull/633))
 
 ## 20.6.0
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -652,6 +652,10 @@ fn default_max_secs_in_past() -> u32 {
     30 * 24 * 3600 // 30 days
 }
 
+fn default_max_session_secs_in_past() -> u32 {
+    5 * 24 * 3600 // 5 days
+}
+
 fn default_chunk_size() -> ByteSize {
     ByteSize::from_megabytes(1)
 }
@@ -678,6 +682,9 @@ pub struct Processing {
     /// Maximum age of ingested events. Older events will be adjusted to `now()`.
     #[serde(default = "default_max_secs_in_past")]
     pub max_secs_in_past: u32,
+    /// Maximum age of ingested sessions. Older sessions will be dropped.
+    #[serde(default = "default_max_session_secs_in_past")]
+    pub max_session_secs_in_past: u32,
     /// Kafka producer configurations.
     pub kafka_config: Vec<KafkaConfigParam>,
     /// Kafka topic names.
@@ -705,6 +712,7 @@ impl Default for Processing {
             geoip_path: None,
             max_secs_in_future: 0,
             max_secs_in_past: 0,
+            max_session_secs_in_past: 0,
             kafka_config: Vec::new(),
             topics: TopicNames::default(),
             redis: None,
@@ -1322,7 +1330,9 @@ impl Config {
         self.values.processing.geoip_path.as_deref()
     }
 
-    /// Maximum future timestamp of ingested events.
+    /// Maximum future timestamp of ingested data.
+    ///
+    /// Events past this timestamp will be adjusted to `now()`. Sessions will be dropped.
     pub fn max_secs_in_future(&self) -> i64 {
         self.values.processing.max_secs_in_future.into()
     }
@@ -1330,6 +1340,11 @@ impl Config {
     /// Maximum age of ingested events. Older events will be adjusted to `now()`.
     pub fn max_secs_in_past(&self) -> i64 {
         self.values.processing.max_secs_in_past.into()
+    }
+
+    /// Maximum age of ingested sessions. Older sessions will be dropped.
+    pub fn max_session_secs_in_past(&self) -> i64 {
+        self.values.processing.max_session_secs_in_past.into()
     }
 
     /// The list of Kafka configuration parameters.

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::protocol::Event;
+use crate::protocol::{Event, SessionUpdate};
 use crate::types::{Error, ErrorKind, Meta, ProcessingResult, Timestamp};
 
 /// The minimum clock drift for correction to apply.
@@ -91,6 +91,19 @@ impl ClockDriftProcessor {
         Self {
             received_at,
             correction,
+        }
+    }
+
+    /// Returns `true` if the clocks are significantly drifted.
+    pub fn is_drifted(&self) -> bool {
+        self.correction.is_some()
+    }
+
+    /// Processes the given session.
+    pub fn process_session(&self, session: &mut SessionUpdate) {
+        if let Some(correction) = self.correction {
+            session.timestamp = session.timestamp + correction.drift;
+            session.started = session.started + correction.drift;
         }
     }
 }

--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -25,8 +25,3 @@ pub const UNREAL_USER_HEADER: &str = "unreal_user_id";
 /// The default retention for events if the server does not specify a value in project
 /// configurations.
 pub const DEFAULT_EVENT_RETENTION: u16 = 90;
-
-/// The maximum age of an ingested session in days. Session updates for sessions older than this
-/// will be discarded.
-#[cfg_attr(not(feature = "processing"), allow(dead_code))]
-pub const MAX_SESSION_DAYS: u8 = 5;


### PR DESCRIPTION
Adds clock drift correction and validates session timestamps. Previously, only the `started` timestamp was validated. 

The maximum session age was previously hardcoded and can now be configured via processing settings. As part of this, the validation code has moved into the `EventProcessor`, where all other normalization code is executed.