### PR TITLE
 fix(store): Use clock drift normalizer to correct all timestamp issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Outcomes from downstream relays were not forwarded upstream. ([#632](https://github.com/getsentry/relay/pull/632))
 - Apply clock drift correction to Release Health sessions and validate timestamps. ([#633](https://github.com/getsentry/relay/pull/633))
+- Apply clock drift correction for timestamps that are too far in the past or future. This fixes a bug where broken transaction timestamps would lead to negative durations.
 
 ## 20.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Outcomes from downstream relays were not forwarded upstream. ([#632](https://github.com/getsentry/relay/pull/632))
 - Apply clock drift correction to Release Health sessions and validate timestamps. ([#633](https://github.com/getsentry/relay/pull/633))
-- Apply clock drift correction for timestamps that are too far in the past or future. This fixes a bug where broken transaction timestamps would lead to negative durations.
+- Apply clock drift correction for timestamps that are too far in the past or future. This fixes a bug where broken transaction timestamps would lead to negative durations. ([#634](https://github.com/getsentry/relay/pull/634))
 
 ## 20.6.0
 

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -72,6 +72,8 @@ impl ClockDriftProcessor {
         }
     }
 
+    /// Use the given error kind for the attached eventerror instead of the default
+    /// `ErrorKind::ClockDrift`.
     pub fn error_kind(mut self, kind: ErrorKind) -> Self {
         self.kind = kind;
         self

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -129,7 +129,7 @@ impl Processor for ClockDriftProcessor {
             let timestamp_meta = event.timestamp.meta_mut();
             timestamp_meta.add_error(Error::with(ErrorKind::InvalidData, |e| {
                 let mut reason = format!(
-                    "clock drift: all timestamps adjusted by {}. Reason: {}",
+                    "{}: all timestamps adjusted by {}",
                     HumanDuration(correction.drift),
                     self.reason
                 );

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -1,6 +1,3 @@
-use std::fmt;
-use std::fmt::Write;
-
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 
 use crate::processor::{ProcessValue, ProcessingState, Processor};
@@ -32,28 +29,6 @@ impl ClockCorrection {
     }
 }
 
-/// Prints a duration with minimum precision.
-///
-/// Uses days if the duration is at least 1 day, otherwise falls back to hours and then seconds.
-/// Also supports negative durations.
-#[derive(Clone, Copy, Debug)]
-struct HumanDuration(SignedDuration);
-
-impl fmt::Display for HumanDuration {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let days = self.0.num_days();
-        if days.abs() == 1 {
-            write!(f, "{} day", days)
-        } else if days != 0 {
-            write!(f, "{} days", days)
-        } else if self.0.num_hours() != 0 {
-            write!(f, "{}h", self.0.num_hours())
-        } else {
-            write!(f, "{}s", self.0.num_seconds())
-        }
-    }
-}
-
 /// Corrects clock drift based on the sender's and receivers timestamps.
 ///
 /// Clock drift correction applies to all timestamps in the event protocol. This includes especially
@@ -76,7 +51,7 @@ impl fmt::Display for HumanDuration {
 pub struct ClockDriftProcessor {
     received_at: DateTime<Utc>,
     correction: Option<ClockCorrection>,
-    reason: &'static str,
+    kind: ErrorKind,
 }
 
 impl ClockDriftProcessor {
@@ -93,12 +68,12 @@ impl ClockDriftProcessor {
         Self {
             received_at,
             correction,
-            reason: "Detected bad client clock",
+            kind: ErrorKind::ClockDrift,
         }
     }
 
-    pub fn reason(mut self, reason: &'static str) -> Self {
-        self.reason = reason;
+    pub fn error_kind(mut self, kind: ErrorKind) -> Self {
+        self.kind = kind;
         self
     }
 
@@ -127,16 +102,9 @@ impl Processor for ClockDriftProcessor {
             event.process_child_values(self, state)?;
 
             let timestamp_meta = event.timestamp.meta_mut();
-            timestamp_meta.add_error(Error::with(ErrorKind::InvalidData, |e| {
-                let mut reason = format!(
-                    "{}: all timestamps adjusted by {}",
-                    HumanDuration(correction.drift),
-                    self.reason
-                );
-
-                e.insert("reason", reason);
-                e.insert("sdk_time", correction.sent_at.to_string());
-                e.insert("server_time", self.received_at.to_string());
+            timestamp_meta.add_error(Error::with(self.kind.clone(), |e| {
+                e.insert("sdk_time", correction.sent_at.to_rfc3339());
+                e.insert("server_time", self.received_at.to_rfc3339());
             }));
         }
 

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -148,7 +148,7 @@ impl<'a> NormalizeProcessor<'a> {
         })?;
 
         ClockDriftProcessor::new(sent_at, received_at)
-            .reason("Timestamp out of bounds.")
+            .reason("timestamp out of bounds")
             .process_event(event, meta, state)?;
 
         if event.timestamp.value().is_none() {

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -15,7 +15,7 @@ use crate::protocol::{
     Frame, HeaderName, HeaderValue, Headers, IpAddr, Level, LogEntry, Request, SpanStatus,
     Stacktrace, Tags, TraceContext, User, INVALID_ENVIRONMENTS, INVALID_RELEASES, VALID_PLATFORMS,
 };
-use crate::store::{GeoIpLookup, StoreConfig};
+use crate::store::{ClockDriftProcessor, GeoIpLookup, StoreConfig};
 use crate::types::{
     Annotated, Empty, Error, ErrorKind, FromValue, Meta, Object, ProcessingAction,
     ProcessingResult, Value,
@@ -118,27 +118,40 @@ impl<'a> NormalizeProcessor<'a> {
     }
 
     /// Validates the timestamp range and sets a default value.
-    fn normalize_timestamps(&self, event: &mut Event) -> ProcessingResult {
+    fn normalize_timestamps(
+        &self,
+        event: &mut Event,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
         let received_at = self.config.received_at.unwrap_or_else(Utc::now);
         event.received = Annotated::new(received_at);
+
+        let mut sent_at = None;
 
         event.timestamp.apply(|timestamp, meta| {
             if let Some(secs) = self.config.max_secs_in_future {
                 if *timestamp > received_at + Duration::seconds(secs) {
                     meta.add_error(ErrorKind::FutureTimestamp);
-                    return Err(ProcessingAction::DeleteValueSoft);
+                    sent_at = Some(*timestamp);
+                    return Ok(());
                 }
             }
 
             if let Some(secs) = self.config.max_secs_in_past {
                 if *timestamp < received_at - Duration::seconds(secs) {
                     meta.add_error(ErrorKind::PastTimestamp);
-                    return Err(ProcessingAction::DeleteValueSoft);
+                    sent_at = Some(*timestamp);
+                    return Ok(());
                 }
             }
 
             Ok(())
         })?;
+
+        ClockDriftProcessor::new(sent_at, received_at)
+            .reason("Timestamp out of bounds.")
+            .process_event(event, meta, state)?;
 
         if event.timestamp.value().is_none() {
             event.timestamp.set_value(Some(received_at));
@@ -398,7 +411,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
     fn process_event(
         &mut self,
         event: &mut Event,
-        _meta: &mut Meta,
+        meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
         // Process security reports first to ensure all props.
@@ -466,7 +479,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
 
         // Normalize connected attributes and interfaces
         self.normalize_release_dist(event);
-        self.normalize_timestamps(event)?;
+        self.normalize_timestamps(event, meta, state)?;
         self.normalize_event_tags(event)?;
         self.normalize_exceptions(event)?;
         self.normalize_user_agent(event);
@@ -1474,6 +1487,61 @@ fn test_grouping_config() {
       "received": "[received]",
       "grouping_config": {
         "id": "legacy:1234-12-12",
+      },
+    }
+    "###);
+}
+
+#[test]
+fn test_future_timestamp() {
+    use crate::types::SerializableAnnotated;
+
+    use chrono::TimeZone;
+    use insta::assert_ron_snapshot;
+
+    let mut event = Annotated::new(Event {
+        timestamp: Annotated::new(Utc.ymd(2000, 1, 2).and_hms(0, 0, 0)),
+        ..Default::default()
+    });
+
+    let mut processor = NormalizeProcessor::new(
+        Arc::new(StoreConfig {
+            received_at: Some(Utc.ymd(2000, 1, 3).and_hms(0, 0, 0)),
+            max_secs_in_past: Some(0),
+            max_secs_in_future: Some(0),
+            ..Default::default()
+        }),
+        None,
+    );
+    process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+    assert_ron_snapshot!(SerializableAnnotated(&event), {
+        ".event_id" => "[event-id]",
+    }, @r###"
+    {
+      "event_id": "[event-id]",
+      "level": "error",
+      "type": "default",
+      "logger": "",
+      "platform": "other",
+      "timestamp": 946857600,
+      "received": 946944000,
+      "_meta": {
+        "timestamp": {
+          "": Meta(Some(MetaInner(
+            err: [
+              "past_timestamp",
+              [
+                "invalid_data",
+                {
+                  "reason": "clock drift: all timestamps adjusted by 1 day. Reason: Timestamp out of bounds.",
+                  "sdk_time": "2000-01-02 00:00:00 UTC",
+                  "server_time": "2000-01-03 00:00:00 UTC",
+                },
+              ],
+            ],
+          ))),
+        },
       },
     }
     "###);

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -132,7 +132,6 @@ impl<'a> NormalizeProcessor<'a> {
         event.timestamp.apply(|timestamp, meta| {
             if let Some(secs) = self.config.max_secs_in_future {
                 if *timestamp > received_at + Duration::seconds(secs) {
-                    meta.add_error(ErrorKind::FutureTimestamp);
                     sent_at = Some(*timestamp);
                     return Ok(());
                 }
@@ -140,7 +139,6 @@ impl<'a> NormalizeProcessor<'a> {
 
             if let Some(secs) = self.config.max_secs_in_past {
                 if *timestamp < received_at - Duration::seconds(secs) {
-                    meta.add_error(ErrorKind::PastTimestamp);
                     sent_at = Some(*timestamp);
                     return Ok(());
                 }

--- a/relay-general/src/types/meta.rs
+++ b/relay-general/src/types/meta.rs
@@ -151,10 +151,10 @@ pub enum ErrorKind {
     /// This value was too long and removed entirely.
     ValueTooLong,
 
+    /// Clock-drift of the SDK has been corrected in all timestamps.
+    ClockDrift,
+
     /// The timestamp is too old.
-    /// XXX: This and FutureTimestamp is only used in minidump processing because we generate
-    /// timestamps for minidump events at a later point. Ideally we would use the same kind of
-    /// timestamp correction for minidumps.
     PastTimestamp,
 
     /// The timestamp lies in the future, likely due to clock drift.
@@ -190,20 +190,8 @@ impl ErrorKind {
             ErrorKind::ValueTooLong => "value_too_long",
             ErrorKind::PastTimestamp => "past_timestamp",
             ErrorKind::FutureTimestamp => "future_timestamp",
+            ErrorKind::ClockDrift => "clock_drift",
             ErrorKind::Unknown(error) => &error,
-        }
-    }
-
-    /// Returns a human readable description of this error kind.
-    pub fn description(&self) -> &'static str {
-        match self {
-            ErrorKind::InvalidData => "Discarded invalid data",
-            ErrorKind::MissingAttribute => "Missing value for required attribute",
-            ErrorKind::InvalidAttribute => "Discarded unknown attribute",
-            ErrorKind::ValueTooLong => "Discarded value exceeding maximum length",
-            ErrorKind::PastTimestamp => "Invalid timestamp (too old)",
-            ErrorKind::FutureTimestamp => "Invalid timestamp (in future)",
-            ErrorKind::Unknown(_) => "Unknown error",
         }
     }
 }

--- a/relay-general/src/types/meta.rs
+++ b/relay-general/src/types/meta.rs
@@ -152,6 +152,9 @@ pub enum ErrorKind {
     ValueTooLong,
 
     /// The timestamp is too old.
+    /// XXX: This and FutureTimestamp is only used in minidump processing because we generate
+    /// timestamps for minidump events at a later point. Ideally we would use the same kind of
+    /// timestamp correction for minidumps.
     PastTimestamp,
 
     /// The timestamp lies in the future, likely due to clock drift.


### PR DESCRIPTION
We encountered an issue, where a transaction that has no "regular clock drift", but still a timestamp far in the future/past, would get its `timestamp` adjusted but not its `start_timestamp`, leading to negative durations. This PR fixes that issues.