### PR TITLE
ref(server): Build pipeline-like control flow for processing

### DIFF
--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -88,10 +88,6 @@ impl<'a> Processor for StoreProcessor<'a> {
         legacy::LegacyProcessor.process_event(event, meta, state)?;
 
         if !is_renormalize {
-            let received_at = self.config.received_at.unwrap_or_else(Utc::now);
-            clock_drift::ClockDriftProcessor::new(self.config.sent_at, received_at)
-                .process_event(event, meta, state)?;
-
             // internally noops for non-transaction events
             // TODO: Parts of this processor should probably be a filter once Relay is store so we
             // can revert some changes to ProcessingAction

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -76,6 +76,9 @@ enum ProcessingError {
     #[fail(display = "duplicate {} in event", _0)]
     DuplicateItem(ItemType),
 
+    #[fail(display = "failed to extract event payload")]
+    NoEventPayload,
+
     #[fail(display = "could not schedule project fetch")]
     ScheduleFailed(#[cause] MailboxError),
 
@@ -128,6 +131,7 @@ impl ProcessingError {
             Self::InvalidSecurityReport(_) => Some(Outcome::Invalid(DiscardReason::SecurityReport)),
             Self::InvalidTransaction => Some(Outcome::Invalid(DiscardReason::InvalidTransaction)),
             Self::DuplicateItem(_) => Some(Outcome::Invalid(DiscardReason::DuplicateItem)),
+            Self::NoEventPayload => Some(Outcome::Invalid(DiscardReason::NoEventPayload)),
             Self::RateLimited(ref rate_limits) => rate_limits
                 .longest()
                 .map(|r| Outcome::RateLimited(r.reason_code.clone())),
@@ -157,6 +161,78 @@ impl ProcessingError {
 
 type ExtractedEvent = (Annotated<Event>, usize);
 
+/// A state container for envelope processing.
+#[derive(Debug)]
+struct ProcessEnvelopeState {
+    /// The envelope.
+    ///
+    /// The pipeline can mutate the envelope and remove or add items. In particular, event items are
+    /// removed at the beginning of event processing and re-added in the end.
+    envelope: Envelope,
+
+    /// The extracted event payload.
+    ///
+    /// For Envelopes without event payloads, this contains `Annotated::empty`. If a single item has
+    /// `creates_event`, the event is required and the pipeline errors if no payload can be
+    /// extracted.
+    event: Annotated<Event>,
+
+    /// Partial metrics of the Event during construction.
+    ///
+    /// The pipeline stages can add to this metrics objects. In `finalize_event`, the metrics are
+    /// persisted into the Event. All modifications afterwards will have no effect.
+    metrics: Metrics,
+
+    /// Rate limits returned in processing mode.
+    ///
+    /// The rate limiter is invoked in processing mode, after which the resulting limits are stored
+    /// in this field. Note that there can be rate limits even if the envelope still carries items.
+    ///
+    /// These are always empty in non-processing mode, since the rate limiter is not invoked.
+    rate_limits: RateLimits,
+
+    /// The state of the project that this envelope belongs to.
+    project_state: Arc<ProjectState>,
+
+    /// UTC date time converted from the `start_time` instant.
+    received_at: DateTime<Utc>,
+}
+
+impl ProcessEnvelopeState {
+    /// Returns whether any item in the envelope creates an event.
+    ///
+    /// This is used to branch into the event processing pipeline. If this function returns false,
+    /// only rate limits are executed.
+    fn creates_event(&self) -> bool {
+        self.envelope.items().any(Item::creates_event)
+    }
+
+    /// Returns true if there is an event in the processing state.
+    ///
+    /// The event was previously removed from the Envelope. This returns false if there was an
+    /// invalid event item.
+    fn has_event(&self) -> bool {
+        self.event.value().is_some()
+    }
+
+    /// Returns the event type if there is an event.
+    ///
+    /// If the event does not have a type, `Some(EventType::Default)` is assumed. If, in contrast, there
+    /// is no event, `None` is returned.
+    fn event_type(&self) -> Option<EventType> {
+        self.event
+            .value()
+            .map(|event| event.ty.value().copied().unwrap_or_default())
+    }
+
+    /// Removes the event payload from this processing state.
+    #[cfg(feature = "processing")]
+    fn remove_event(&mut self) {
+        self.event = Annotated::empty();
+    }
+}
+
+/// Synchronous service for processing envelopes.
 struct EventProcessor {
     config: Arc<Config>,
     #[cfg(feature = "processing")]
@@ -184,61 +260,140 @@ impl EventProcessor {
         Self { config }
     }
 
-    /// Writes a placeholder to indicate that this event has an associated minidump or an apple
-    /// crash report.
+    /// Validates all sessions in the envelope, if any.
     ///
-    /// This will indicate to the ingestion pipeline that this event will need to be processed. The
-    /// payload can be checked via `is_minidump_event`.
+    /// Sessions are removed from the envelope if they contain invalid JSON or if their timestamps
+    /// are out of range after clock drift correction.
+    fn process_sessions(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let envelope = &mut state.envelope;
+        let received = state.received_at;
+
+        let project_id = envelope.meta().project_id().value();
+        let clock_drift_processor = ClockDriftProcessor::new(envelope.sent_at(), received);
+        let client = envelope.meta().client().map(str::to_owned);
+
+        envelope.retain_items(|item| {
+            if item.ty() != ItemType::Session {
+                return true;
+            }
+
+            let mut changed = false;
+            let payload = item.payload();
+
+            let mut session = match SessionUpdate::parse(&payload) {
+                Ok(session) => session,
+                Err(error) => {
+                    return sentry::with_scope(
+                        |scope| {
+                            scope.set_tag("project", project_id);
+                            if let Some(ref client) = client {
+                                scope.set_tag("sdk", client);
+                            }
+                            scope.set_extra("session", String::from_utf8_lossy(&payload).into());
+                        },
+                        || {
+                            // Skip gracefully here to allow sending other sessions.
+                            log::error!("failed to store session: {}", LogError(&error));
+                            false
+                        },
+                    );
+                }
+            };
+
+            if session.sequence == u64::max_value() {
+                log::trace!("skipping session due to sequence overflow");
+                return false;
+            }
+
+            if clock_drift_processor.is_drifted() {
+                log::trace!("applying clock drift correction to session");
+                clock_drift_processor.process_session(&mut session);
+                changed = true;
+            }
+
+            if session.timestamp < session.started {
+                log::trace!("fixing session timestamp to {}", session.timestamp);
+                session.timestamp = session.started;
+                changed = true;
+            }
+
+            let max_age = Duration::seconds(self.config.max_session_secs_in_past());
+            if (received - session.started) > max_age || (received - session.timestamp) > max_age {
+                log::trace!("skipping session older than {} days", max_age.num_days());
+                return false;
+            }
+
+            let max_future = Duration::seconds(self.config.max_secs_in_future());
+            if (session.started - received) > max_age || (session.timestamp - received) > max_age {
+                log::trace!(
+                    "skipping session more than {}s in the future",
+                    max_future.num_seconds()
+                );
+                return false;
+            }
+
+            if changed {
+                let json_string = match serde_json::to_string(&session) {
+                    Ok(json) => json,
+                    Err(_) => return false,
+                };
+
+                item.set_payload(ContentType::Json, json_string);
+            }
+
+            true
+        });
+
+        Ok(())
+    }
+
+    /// Creates and initializes the processing state.
+    ///
+    /// This applies defaults to the envelope and initializes empty rate limits.
+    fn prepare_state(
+        &self,
+        message: ProcessEnvelope,
+    ) -> Result<ProcessEnvelopeState, ProcessingError> {
+        let ProcessEnvelope {
+            mut envelope,
+            project_state,
+            start_time,
+        } = message;
+
+        // Set the event retention. Effectively, this value will only be available in processing
+        // mode when the full project config is queried from the upstream.
+        if let Some(retention) = project_state.config.event_retention {
+            envelope.set_retention(retention);
+        }
+
+        Ok(ProcessEnvelopeState {
+            envelope,
+            event: Annotated::empty(),
+            metrics: Metrics::default(),
+            rate_limits: RateLimits::new(),
+            project_state,
+            received_at: relay_common::instant_to_date_time(start_time),
+        })
+    }
+
+    /// Expands Unreal 4 items inside an envelope.
+    ///
+    /// If the envelope does NOT contain an `UnrealReport` item, it doesn't do anything. If the envelope
+    /// contains an `UnrealReport` item, it removes it from the envelope and inserts new items for each
+    /// of its contents.
+    ///
+    /// After this, the `EventProcessor` should be able to process the envelope the same way it
+    /// processes any other envelopes.
     #[cfg(feature = "processing")]
-    fn write_native_placeholder(&self, event: &mut Annotated<Event>, is_minidump: bool) {
-        use relay_general::protocol::{Exception, JsonLenientString, Level, Mechanism};
+    fn expand_unreal(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let envelope = &mut state.envelope;
 
-        let event = event.get_or_insert_with(Event::default);
+        if let Some(item) = envelope.take_item_by(|item| item.ty() == ItemType::UnrealReport) {
+            utils::expand_unreal_envelope(item, envelope)
+                .map_err(ProcessingError::InvalidUnrealReport)?;
+        }
 
-        // Events must be native platform.
-        let platform = event.platform.value_mut();
-        *platform = Some("native".to_string());
-
-        // Assume that this minidump is the result of a crash and assign the fatal
-        // level. Note that the use of `setdefault` here doesn't generally allow the
-        // user to override the minidump's level as processing will overwrite it
-        // later.
-        event.level.get_or_insert_with(|| Level::Fatal);
-
-        // Create a placeholder exception. This signals normalization that this is an
-        // error event and also serves as a placeholder if processing of the minidump
-        // fails.
-        let exceptions = event
-            .exceptions
-            .value_mut()
-            .get_or_insert_with(Values::default)
-            .values
-            .value_mut()
-            .get_or_insert_with(Vec::new);
-
-        exceptions.clear(); // clear previous errors if any
-
-        let (type_name, value, mechanism_type) = if is_minidump {
-            ("Minidump", "Invalid Minidump", "minidump")
-        } else {
-            (
-                "AppleCrashReport",
-                "Invalid Apple Crash Report",
-                "applecrashreport",
-            )
-        };
-
-        exceptions.push(Annotated::new(Exception {
-            ty: Annotated::new(type_name.to_string()),
-            value: Annotated::new(JsonLenientString(value.to_string())),
-            mechanism: Annotated::new(Mechanism {
-                ty: Annotated::from(mechanism_type.to_string()),
-                handled: Annotated::from(false),
-                synthetic: Annotated::from(true),
-                ..Mechanism::default()
-            }),
-            ..Exception::default()
-        }));
+        Ok(())
     }
 
     fn event_from_json_payload(
@@ -422,6 +577,31 @@ impl EventProcessor {
         Ok((event, len))
     }
 
+    /// Checks for duplicate items in an envelope.
+    ///
+    /// An item is considered duplicate if it was not removed by sanitation in `process_event` and
+    /// `extract_event`. This partially depends on the `processing_enabled` flag.
+    fn is_duplicate(&self, item: &Item) -> bool {
+        match item.ty() {
+            // These should always be removed by `extract_event`:
+            ItemType::Event => true,
+            ItemType::Transaction => true,
+            ItemType::Security => true,
+            ItemType::FormData => true,
+            ItemType::RawSecurity => true,
+
+            // These should be removed conditionally:
+            ItemType::UnrealReport => self.config.processing_enabled(),
+
+            // These may be forwarded to upstream / store:
+            ItemType::Attachment => false,
+            ItemType::UserReport => false,
+
+            // session data is never considered as part of deduplication
+            ItemType::Session => false,
+        }
+    }
+
     /// Extracts the primary event payload from an envelope.
     ///
     /// The event is obtained from only one source in the following precedence:
@@ -430,9 +610,9 @@ impl EventProcessor {
     ///  3. Attachments `__sentry-event` and `__sentry-breadcrumb1/2`.
     ///  4. A multipart form data body.
     ///  5. If none match, `Annotated::empty()`.
-    ///
-    /// The return value is a tuple of the extracted event and the original ingested size.
-    fn extract_event(&self, envelope: &mut Envelope) -> Result<ExtractedEvent, ProcessingError> {
+    fn extract_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let envelope = &mut state.envelope;
+
         // Remove all items first, and then process them. After this function returns, only
         // attachments can remain in the envelope. The event will be added again at the end of
         // `process_event`.
@@ -443,45 +623,37 @@ impl EventProcessor {
         let form_item = envelope.take_item_by(|item| item.ty() == ItemType::FormData);
         let attachment_item = envelope
             .take_item_by(|item| item.attachment_type() == Some(AttachmentType::EventPayload));
-        let breadcrumbs_item1 = envelope
+        let breadcrumbs1 = envelope
             .take_item_by(|item| item.attachment_type() == Some(AttachmentType::Breadcrumbs));
-        let breadcrumbs_item2 = envelope
+        let breadcrumbs2 = envelope
             .take_item_by(|item| item.attachment_type() == Some(AttachmentType::Breadcrumbs));
 
-        if let Some(item) = event_item.or(security_item) {
+        // Event items can never occur twice in an envelope.
+        if let Some(duplicate) = envelope.get_item_by(|item| self.is_duplicate(item)) {
+            return Err(ProcessingError::DuplicateItem(duplicate.ty()));
+        }
+
+        let (event, event_len) = if let Some(item) = event_item.or(security_item) {
             log::trace!("processing json event");
-            return Ok(metric!(timer(RelayTimers::EventProcessingDeserialize), {
+            metric!(timer(RelayTimers::EventProcessingDeserialize), {
                 // Event items can never include transactions, so retain the event type and let
                 // inference deal with this during store normalization.
                 self.event_from_json_payload(item, None)?
-            }));
-        }
-
-        if let Some(item) = transaction_item {
+            })
+        } else if let Some(item) = transaction_item {
             log::trace!("processing json transaction");
-            return Ok(metric!(timer(RelayTimers::EventProcessingDeserialize), {
+            metric!(timer(RelayTimers::EventProcessingDeserialize), {
                 // Transaction items can only contain transaction events. Force the event type to
                 // hint to normalization that we're dealing with a transaction now.
                 self.event_from_json_payload(item, Some(EventType::Transaction))?
-            }));
-        }
-
-        if let Some(item) = raw_security_item {
+            })
+        } else if let Some(item) = raw_security_item {
             log::trace!("processing security report");
-            return Ok(self.event_from_security_report(item)?);
-        }
-
-        if attachment_item.is_some() || breadcrumbs_item1.is_some() || breadcrumbs_item2.is_some() {
+            self.event_from_security_report(item)?
+        } else if attachment_item.is_some() || breadcrumbs1.is_some() || breadcrumbs2.is_some() {
             log::trace!("extracting attached event data");
-            return Ok(Self::event_from_attachments(
-                &self.config,
-                attachment_item,
-                breadcrumbs_item1,
-                breadcrumbs_item2,
-            )?);
-        }
-
-        if let Some(item) = form_item {
+            Self::event_from_attachments(&self.config, attachment_item, breadcrumbs1, breadcrumbs2)?
+        } else if let Some(item) = form_item {
             log::trace!("extracting form data");
             let len = item.len();
 
@@ -489,70 +661,172 @@ impl EventProcessor {
             self.merge_formdata(&mut value, item);
             let event = Annotated::deserialize_with_meta(value).unwrap_or_default();
 
-            return Ok((event, len));
-        }
-
-        log::trace!("no event in envelope");
-        Ok((Annotated::empty(), 0))
-    }
-
-    #[cfg(feature = "processing")]
-    fn enforce_quotas(
-        &self,
-        envelope: &Envelope,
-        state: &ProjectState,
-    ) -> Result<(), ProcessingError> {
-        let rate_limiter = match self.rate_limiter.as_ref() {
-            Some(rate_limiter) => rate_limiter,
-            None => return Ok(()),
+            (event, len)
+        } else {
+            log::trace!("no event in envelope");
+            (Annotated::empty(), 0)
         };
 
-        let quotas = state.config.quotas.as_slice();
-        if quotas.is_empty() {
-            return Ok(());
-        }
+        state.event = event;
+        state.metrics.bytes_ingested_event = Annotated::new(event_len as u64);
 
-        // Fetch scoping again from the project state. This is a rather cheap operation at this
-        // point and it is easier than passing scoping through all layers of `process_envelope`.
-        let scoping = state.get_scoping(envelope.meta());
+        Ok(())
+    }
 
-        let rate_limits = metric!(timer(RelayTimers::EventProcessingRateLimiting), {
-            rate_limiter
-                .is_rate_limited(quotas, scoping.item(DataCategory::Error))
-                .map_err(ProcessingError::QuotasFailed)?
-        });
+    /// Extracts event information from an unreal context.
+    ///
+    /// If the event does not contain an unreal context, this function does not perform any action.
+    /// If there was no event payload prior to this function, it is created.
+    #[cfg(feature = "processing")]
+    fn process_unreal(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        utils::process_unreal_envelope(&mut state.event, &mut state.envelope)
+            .map_err(ProcessingError::InvalidUnrealReport)
+    }
 
-        if rate_limits.is_limited() {
-            return Err(ProcessingError::RateLimited(rate_limits));
+    /// Writes a placeholder to indicate that this event has an associated minidump or an apple
+    /// crash report.
+    ///
+    /// This will indicate to the ingestion pipeline that this event will need to be processed. The
+    /// payload can be checked via `is_minidump_event`.
+    #[cfg(feature = "processing")]
+    fn write_native_placeholder(&self, event: &mut Annotated<Event>, is_minidump: bool) {
+        use relay_general::protocol::{Exception, JsonLenientString, Level, Mechanism};
+
+        let event = event.get_or_insert_with(Event::default);
+
+        // Events must be native platform.
+        let platform = event.platform.value_mut();
+        *platform = Some("native".to_string());
+
+        // Assume that this minidump is the result of a crash and assign the fatal
+        // level. Note that the use of `setdefault` here doesn't generally allow the
+        // user to override the minidump's level as processing will overwrite it
+        // later.
+        event.level.get_or_insert_with(|| Level::Fatal);
+
+        // Create a placeholder exception. This signals normalization that this is an
+        // error event and also serves as a placeholder if processing of the minidump
+        // fails.
+        let exceptions = event
+            .exceptions
+            .value_mut()
+            .get_or_insert_with(Values::default)
+            .values
+            .value_mut()
+            .get_or_insert_with(Vec::new);
+
+        exceptions.clear(); // clear previous errors if any
+
+        let (type_name, value, mechanism_type) = if is_minidump {
+            ("Minidump", "Invalid Minidump", "minidump")
+        } else {
+            (
+                "AppleCrashReport",
+                "Invalid Apple Crash Report",
+                "applecrashreport",
+            )
+        };
+
+        exceptions.push(Annotated::new(Exception {
+            ty: Annotated::new(type_name.to_string()),
+            value: Annotated::new(JsonLenientString(value.to_string())),
+            mechanism: Annotated::new(Mechanism {
+                ty: Annotated::from(mechanism_type.to_string()),
+                handled: Annotated::from(false),
+                synthetic: Annotated::from(true),
+                ..Mechanism::default()
+            }),
+            ..Exception::default()
+        }));
+    }
+
+    /// Adds processing placeholders for special attachments.
+    ///
+    /// If special attachments are present in the envelope, this adds placeholder payloads to the
+    /// event. This indicates to the pipeline that the event needs special processing.
+    ///
+    /// If the event payload was empty before, it is created.
+    #[cfg(feature = "processing")]
+    fn create_placeholders(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let envelope = &mut state.envelope;
+
+        let minidump_attachment =
+            envelope.get_item_by(|item| item.attachment_type() == Some(AttachmentType::Minidump));
+        let apple_crash_report_attachment = envelope
+            .get_item_by(|item| item.attachment_type() == Some(AttachmentType::AppleCrashReport));
+
+        if let Some(item) = minidump_attachment {
+            state.metrics.bytes_ingested_event_minidump = Annotated::new(item.len() as u64);
+            self.write_native_placeholder(&mut state.event, true);
+        } else if let Some(item) = apple_crash_report_attachment {
+            state.metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
+            self.write_native_placeholder(&mut state.event, false);
         }
 
         Ok(())
     }
 
-    fn fast_process_event(
-        &self,
-        event: &mut Annotated<Event>,
-        envelope: &Envelope,
-        received_at: DateTime<Utc>,
-    ) -> Result<(), ProcessingError> {
-        let sent_at = envelope.sent_at();
-        let mut processor = relay_general::store::ClockDriftProcessor::new(sent_at, received_at);
+    fn finalize_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let is_transaction = state.event_type() == Some(EventType::Transaction);
+        let envelope = &mut state.envelope;
 
-        process_value(event, &mut processor, ProcessingState::root())
+        let event = match state.event.value_mut() {
+            Some(event) => event,
+            None if !self.config.processing_enabled() => return Ok(()),
+            None => return Err(ProcessingError::NoEventPayload),
+        };
+
+        // Event id is set statically in the ingest path.
+        let event_id = envelope.event_id().unwrap_or_default();
+        debug_assert!(!event_id.is_nil());
+
+        // Ensure that the event id in the payload is consistent with the envelope. If an event
+        // id was ingested, this will already be the case. Otherwise, this will insert a new
+        // event id. To be defensive, we always overwrite to ensure consistency.
+        event.id = Annotated::new(event_id);
+
+        // In processing mode, also write metrics into the event. Most metrics have already been
+        // collected at this state, except for the combined size of all attachments.
+        if self.config.processing_enabled() {
+            let attachment_size = envelope
+                .items()
+                .filter(|item| item.attachment_type() == Some(AttachmentType::Attachment))
+                .map(|item| item.len() as u64)
+                .sum::<u64>();
+
+            if attachment_size > 0 {
+                state.metrics.bytes_ingested_event_attachment = Annotated::new(attachment_size);
+            }
+
+            event._metrics = Annotated::new(std::mem::take(&mut state.metrics));
+        }
+
+        // TODO: Temporary workaround before processing. Experimental SDKs relied on a buggy
+        // clock drift correction that assumes the event timestamp is the sent_at time. This
+        // should be removed as soon as legacy ingestion has been removed.
+        let sent_at = match envelope.sent_at() {
+            Some(sent_at) => Some(sent_at),
+            None if is_transaction => event.timestamp.value().copied(),
+            None => None,
+        };
+
+        let mut processor = ClockDriftProcessor::new(sent_at, state.received_at);
+        process_value(&mut state.event, &mut processor, ProcessingState::root())
             .map_err(|_| ProcessingError::InvalidTransaction)?;
 
         Ok(())
     }
 
     #[cfg(feature = "processing")]
-    fn store_process_event(
-        &self,
-        event: &mut Annotated<Event>,
-        envelope: &Envelope,
-        project_state: &ProjectState,
-        received_at: DateTime<Utc>,
-    ) -> Result<(), ProcessingError> {
-        let geoip_lookup = self.geoip_lookup.as_deref();
+    fn store_process_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let ProcessEnvelopeState {
+            ref envelope,
+            ref mut event,
+            ref project_state,
+            received_at,
+            ..
+        } = *state;
+
         let key_id = project_state
             .get_public_key_config(&envelope.meta().public_key())
             .and_then(|k| Some(k.numeric_id?.to_string()));
@@ -579,320 +853,154 @@ impl EventProcessor {
             received_at: Some(received_at),
         };
 
-        let mut store_processor = StoreProcessor::new(store_config, geoip_lookup);
+        let mut store_processor = StoreProcessor::new(store_config, self.geoip_lookup.as_deref());
         metric!(timer(RelayTimers::EventProcessingProcess), {
             process_value(event, &mut store_processor, ProcessingState::root())
                 .map_err(|_| ProcessingError::InvalidTransaction)?;
         });
 
-        // Event filters assume a normalized event. Unfortunately, this requires us to run
-        // expensive normalization first.
-        if let Some(event) = event.value_mut() {
-            let client_ip = envelope.meta().client_addr();
-            let filter_settings = &project_state.config.filter_settings;
-            let filter_result = metric!(timer(RelayTimers::EventProcessingFiltering), {
-                relay_filter::should_filter(event, client_ip, filter_settings)
-            });
+        Ok(())
+    }
 
-            if let Err(reason) = filter_result {
-                // If the event should be filtered, no more processing is needed
-                return Err(ProcessingError::EventFiltered(reason));
-            }
+    #[cfg(feature = "processing")]
+    fn filter_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let event = match state.event.value_mut() {
+            Some(event) => event,
+            None => return Err(ProcessingError::NoEventPayload),
+        };
+
+        let client_ip = state.envelope.meta().client_addr();
+        let filter_settings = &state.project_state.config.filter_settings;
+
+        metric!(timer(RelayTimers::EventProcessingFiltering), {
+            relay_filter::should_filter(event, client_ip, filter_settings)
+                .map_err(ProcessingError::EventFiltered)
+        })
+    }
+
+    #[cfg(feature = "processing")]
+    fn enforce_quotas(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        // TODO: Enforce quotas for all envelope items. For now, only consider Envelopes with events
+        // and assume the `Error` data category.
+        if state.event_type().is_none() {
+            return Ok(());
         }
 
-        // Run rate limiting after normalizing the event and running all filters. If the event is
-        // dropped or filtered for a different reason before that, it should not count against
-        // quotas. Also, this allows to reduce the number of requests to the rate limiter (currently
-        // implemented in Redis).
-        self.enforce_quotas(envelope, project_state)?;
+        let rate_limiter = match self.rate_limiter.as_ref() {
+            Some(rate_limiter) => rate_limiter,
+            None => return Ok(()),
+        };
+
+        let project_state = &state.project_state;
+        let quotas = project_state.config.quotas.as_slice();
+        if quotas.is_empty() {
+            return Ok(());
+        }
+
+        // Fetch scoping again from the project state. This is a rather cheap operation at this
+        // point and it is easier than passing scoping through all layers of `process_envelope`.
+        let scoping = project_state.get_scoping(state.envelope.meta());
+
+        state.rate_limits = metric!(timer(RelayTimers::EventProcessingRateLimiting), {
+            rate_limiter
+                .is_rate_limited(quotas, scoping.item(DataCategory::Error))
+                .map_err(ProcessingError::QuotasFailed)?
+        });
+
+        if state.rate_limits.is_limited() {
+            state.remove_event();
+        }
 
         Ok(())
     }
 
-    /// Checks for duplicate items in an envelope.
+    /// Apply data privacy rules to the event payload.
     ///
-    /// An item is considered duplicate if it was not removed by sanitation in `process_event` and
-    /// `extract_event`. This partially depends on the `processing_enabled` flag.
-    fn is_duplicate(&self, item: &Item) -> bool {
-        match item.ty() {
-            // These should always be removed by `extract_event`:
-            ItemType::Event => true,
-            ItemType::Transaction => true,
-            ItemType::Security => true,
-            ItemType::FormData => true,
-            ItemType::RawSecurity => true,
+    /// This uses both the general `datascrubbing_settings`, as well as the the PII rules.
+    fn scrub_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let event = &mut state.event;
+        let config = &state.project_state.config;
 
-            // These should be removed conditionally:
-            ItemType::UnrealReport => self.config.processing_enabled(),
+        metric!(timer(RelayTimers::EventProcessingPii), {
+            if let Some(ref config) = config.pii_config {
+                let compiled = config.compiled();
+                let mut processor = PiiProcessor::new(&compiled);
+                process_value(event, &mut processor, ProcessingState::root())
+                    .map_err(ProcessingError::ProcessingFailed)?;
+            }
 
-            // These may be forwarded to upstream / store:
-            ItemType::Attachment => false,
-            ItemType::UserReport => false,
+            if let Some(ref config) = *config.datascrubbing_settings.pii_config() {
+                let compiled = config.compiled();
+                let mut processor = PiiProcessor::new(&compiled);
+                process_value(event, &mut processor, ProcessingState::root())
+                    .map_err(ProcessingError::ProcessingFailed)?;
+            }
+        });
 
-            // session data is never considered as part of deduplication
-            ItemType::Session => false,
-        }
+        Ok(())
     }
 
-    /// Validates all sessions in the envelope, if any.
-    ///
-    /// Sessions are removed from the envelope if they contain invalid JSON or if their timestamps
-    /// are out of range after clock drift correction.
-    fn process_sessions(&self, envelope: &mut Envelope, received: DateTime<Utc>) {
-        let project_id = envelope.meta().project_id().value();
-        let clock_drift_processor = ClockDriftProcessor::new(envelope.sent_at(), received);
-        let client = envelope.meta().client().map(str::to_owned);
-
-        envelope.retain_items(|item| {
-            if item.ty() != ItemType::Session {
-                return true;
-            }
-
-            let mut changed = false;
-            let payload = item.payload();
-
-            let mut session = match SessionUpdate::parse(&payload) {
-                Ok(session) => session,
-                Err(error) => {
-                    return sentry::with_scope(
-                        |scope| {
-                            scope.set_tag("project", project_id);
-                            if let Some(ref client) = client {
-                                scope.set_tag("sdk", client);
-                            }
-                            scope.set_extra("session", String::from_utf8_lossy(&payload).into());
-                        },
-                        || {
-                            // Skip gracefully here to allow sending other sessions.
-                            log::error!("failed to store session: {}", LogError(&error));
-                            false
-                        },
-                    );
-                }
-            };
-
-            if session.sequence == u64::max_value() {
-                log::trace!("skipping session due to sequence overflow");
-                return false;
-            }
-
-            if clock_drift_processor.is_drifted() {
-                log::trace!("applying clock drift correction to session");
-                clock_drift_processor.process_session(&mut session);
-                changed = true;
-            }
-
-            if session.timestamp < session.started {
-                log::trace!("fixing session timestamp to {}", session.timestamp);
-                session.timestamp = session.started;
-                changed = true;
-            }
-
-            let max_age = Duration::seconds(self.config.max_session_secs_in_past());
-            if (received - session.started) > max_age || (received - session.timestamp) > max_age {
-                log::trace!("skipping session older than {} days", max_age.num_days());
-                return false;
-            }
-
-            let max_future = Duration::seconds(self.config.max_secs_in_future());
-            if (session.started - received) > max_age || (session.timestamp - received) > max_age {
-                log::trace!(
-                    "skipping session more than {}s in the future",
-                    max_future.num_seconds()
-                );
-                return false;
-            }
-
-            if changed {
-                let json_string = match serde_json::to_string(&session) {
-                    Ok(json) => json,
-                    Err(_) => return false,
-                };
-
-                item.set_payload(ContentType::Json, json_string);
-            }
-
-            true
+    fn serialize_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+        let data = metric!(timer(RelayTimers::EventProcessingSerialization), {
+            state
+                .event
+                .to_json()
+                .map_err(ProcessingError::SerializeFailed)?
         });
+
+        let event_type = state.event_type().unwrap_or_default();
+        let mut event_item = Item::new(ItemType::from_event_type(event_type));
+        event_item.set_payload(ContentType::Json, data);
+        state.envelope.add_item(event_item);
+
+        Ok(())
     }
 
     fn process(
         &self,
         message: ProcessEnvelope,
     ) -> Result<ProcessEnvelopeResponse, ProcessingError> {
-        #[allow(unused_variables)]
-        let ProcessEnvelope {
-            mut envelope,
-            project_state,
-            start_time,
-        } = message;
-
         macro_rules! if_processing {
-            ($block:block) => {
+            ($if_true:block $(, $if_not:block)?) => {
                 #[cfg(feature = "processing")] {
-                    if self.config.processing_enabled() $block
+                    if self.config.processing_enabled() $if_true
                 }
             };
         }
 
-        // Set the event retention. Effectively, this value will only be available in processing
-        // mode when the full project config is queried from the upstream.
-        if let Some(retention) = project_state.config.event_retention {
-            envelope.set_retention(retention);
-        }
+        let mut state = self.prepare_state(message)?;
+        self.process_sessions(&mut state)?;
 
-        let received_at = relay_common::instant_to_date_time(start_time);
-        self.process_sessions(&mut envelope, received_at);
-
-        // Fast path for envelopes without event items or items that can create events. Such
-        // envelopes only require rate limiting in processing mode and can be passed through without
-        // processing enabled.
-        if !envelope.items().any(Item::creates_event) {
-            // TODO: Apply rate limits no non-event items once implemented.
-            return Ok(ProcessEnvelopeResponse { envelope });
-        }
-
-        // When queueing the envelope, it should have been split up into event-related items and
-        // non-event items. This allows us to bail early if the event is filtered or rate limited
-        // without dealing with other items (such as sessions).
-        debug_assert!(envelope.items().all(Item::requires_event));
-
-        // Unreal endpoint puts the whole request into an item. This is done to make the endpoint
-        // fast. For envelopes containing an Unreal request, we will look into the unreal item and
-        // expand it so it can be consumed like any other event (e.g. `__sentry-event`). External
-        // Relays should leave this as-is.
-        if_processing!({
-            if let Some(item) = envelope.take_item_by(|item| item.ty() == ItemType::UnrealReport) {
-                utils::expand_unreal_envelope(item, &mut envelope)
-                    .map_err(ProcessingError::InvalidUnrealReport)?;
-            }
-        });
-
-        // Carry metrics on event sizes through the entire normalization process. Without
-        // processing, this value is unused and will be optimized away. Note how we need to extract
-        // sizes at different stages of processing and apply them after `store_process_event`.
-        let mut _metrics = Metrics::default();
-
-        // Extract the event from the envelope. This removes all items from the envelope that should
-        // not be forwarded, including the event item itself.
-        let (mut event, event_len) = self.extract_event(&mut envelope)?;
-        #[allow(unused_mut)]
-        let mut event_type = event.value().and_then(|e| e.ty.value()).copied();
-        _metrics.bytes_ingested_event = Annotated::new(event_len as u64);
-
-        // `extract_event` must remove all unique items from the envelope. Once the envelope is
-        // processed, an `Event` item will be added to the envelope again. All additional items will
-        // count as duplicates.
-        if let Some(duplicate) = envelope.get_item_by(|item| self.is_duplicate(item)) {
-            return Err(ProcessingError::DuplicateItem(duplicate.ty()));
-        }
-
-        if_processing!({
-            // This envelope may contain UE4 crash report information, which needs to be patched on
-            // the event returned from `extract_event`.
-            utils::process_unreal_envelope(&mut event, &mut envelope)
-                .map_err(ProcessingError::InvalidUnrealReport)?;
-
-            // If special attachments are present in the envelope, add placeholder payloads to the
-            // event. This indicates to the pipeline that the event needs special processing.
-            let minidump_attachment = envelope
-                .get_item_by(|item| item.attachment_type() == Some(AttachmentType::Minidump));
-            let apple_crash_report_attachment = envelope.get_item_by(|item| {
-                item.attachment_type() == Some(AttachmentType::AppleCrashReport)
+        if state.creates_event() {
+            if_processing!({
+                self.expand_unreal(&mut state)?;
             });
 
-            if let Some(item) = minidump_attachment {
-                _metrics.bytes_ingested_event_minidump = Annotated::new(item.len() as u64);
-                self.write_native_placeholder(&mut event, true);
-            } else if let Some(item) = apple_crash_report_attachment {
-                _metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
-                self.write_native_placeholder(&mut event, false);
-            }
+            self.extract_event(&mut state)?;
 
-            let attachment_size = envelope
-                .items()
-                .filter(|item| item.attachment_type() == Some(AttachmentType::Attachment))
-                .map(|item| item.len())
-                .sum::<usize>();
+            if_processing!({
+                self.process_unreal(&mut state)?;
+                self.create_placeholders(&mut state)?;
+            });
 
-            if attachment_size > 0 {
-                _metrics.bytes_ingested_event_attachment = Annotated::new(attachment_size as u64);
-            }
-        });
+            self.finalize_event(&mut state)?;
 
-        if let Some(event) = event.value_mut() {
-            // Event id is set statically in the ingest path.
-            let event_id = envelope.event_id().unwrap_or_default();
-            debug_assert!(!event_id.is_nil());
-
-            // Ensure that the event id in the payload is consistent with the envelope. If an event
-            // id was ingested, this will already be the case. Otherwise, this will insert a new
-            // event id. To be defensive, we always overwrite to ensure consistency.
-            event.id = Annotated::new(event_id);
-
-            // TODO: Temporary workaround before processing. Experimental SDKs relied on a buggy
-            // clock drift correction that assumes the event timestamp is the sent_at time. This
-            // should be removed as soon as legacy ingestion has been removed.
-            if envelope.sent_at().is_none() && event_type == Some(EventType::Transaction) {
-                if let Some(&event_timestamp) = event.timestamp.value() {
-                    envelope.set_sent_at(event_timestamp);
-                }
-            }
-        } else {
-            // If we have an envelope without event at this point, we are done with processing. This
-            // envelope only contains attachments or user reports. We should not run filters or
-            // apply rate limits.
-            log::trace!("no event for envelope, skipping processing");
-            return Ok(ProcessEnvelopeResponse { envelope });
+            if_processing!({
+                self.store_process_event(&mut state)?;
+                self.filter_event(&mut state)?;
+            });
         }
 
-        if !self.config.processing_enabled() {
-            self.fast_process_event(&mut event, &envelope, received_at)?;
-        }
-        // else
         if_processing!({
-            self.store_process_event(&mut event, &envelope, &project_state, received_at)?;
-
-            if let Some(event) = event.value_mut() {
-                event_type = event.ty.value().copied();
-
-                // Write metrics into the fully processed event. This ensures that whatever happens
-                // during processing is overwritten at last.
-                event._metrics = Annotated::new(_metrics);
-            }
+            self.enforce_quotas(&mut state)?;
         });
 
-        // Run PII stripping last since normalization can add PII (e.g. IP addresses).
-        metric!(timer(RelayTimers::EventProcessingPii), {
-            if let Some(ref config) = project_state.config.pii_config {
-                let compiled = config.compiled();
-                let mut processor = PiiProcessor::new(&compiled);
-                process_value(&mut event, &mut processor, ProcessingState::root())
-                    .map_err(ProcessingError::ProcessingFailed)?;
-            }
+        if state.has_event() {
+            self.scrub_event(&mut state)?;
+            self.serialize_event(&mut state)?;
+        }
 
-            if let Some(ref config) = *project_state.config.datascrubbing_settings.pii_config() {
-                let compiled = config.compiled();
-
-                let mut processor = PiiProcessor::new(&compiled);
-                process_value(&mut event, &mut processor, ProcessingState::root())
-                    .map_err(ProcessingError::ProcessingFailed)?;
-            }
-        });
-
-        // We're done now. Serialize the event back into JSON and put it in an envelope so that it
-        // can be sent to the upstream or processing queue.
-        let data = metric!(timer(RelayTimers::EventProcessingSerialization), {
-            event.to_json().map_err(ProcessingError::SerializeFailed)?
-        });
-
-        // Add the normalized event back to the envelope. All the other items are attachments.
-        let item_type = ItemType::from_event_type(event_type.unwrap_or_default());
-        let mut event_item = Item::new(item_type);
-        event_item.set_payload(ContentType::Json, data);
-        envelope.add_item(event_item);
-
-        Ok(ProcessEnvelopeResponse { envelope })
+        Ok(ProcessEnvelopeResponse::from(state))
     }
 }
 
@@ -908,7 +1016,17 @@ struct ProcessEnvelope {
 
 #[cfg_attr(not(feature = "processing"), allow(dead_code))]
 struct ProcessEnvelopeResponse {
-    envelope: Envelope,
+    envelope: Option<Envelope>,
+    rate_limits: RateLimits,
+}
+
+impl From<ProcessEnvelopeState> for ProcessEnvelopeResponse {
+    fn from(state: ProcessEnvelopeState) -> Self {
+        Self {
+            envelope: Some(state.envelope).filter(|e| !e.is_empty()),
+            rate_limits: state.rate_limits,
+        }
+    }
 }
 
 impl Message for ProcessEnvelope {
@@ -1169,9 +1287,21 @@ impl Handler<HandleEnvelope> for EventManager {
                     .map_err(ProcessingError::ScheduleFailed)
                     .flatten()
             })
-            .and_then(clone!(captured_events, scoping, |processed| {
-                let mut envelope = processed.envelope;
+            .and_then(clone!(project, |processed| {
+                let rate_limits = processed.rate_limits;
 
+                // Processing returned new rate limits. Cache them on the project to avoid expensive
+                // processing while the limit is active.
+                if rate_limits.is_limited() {
+                    project.do_send(UpdateRateLimits(rate_limits.clone()));
+                }
+
+                match processed.envelope {
+                    Some(envelope) => Ok(envelope),
+                    None => Err(ProcessingError::RateLimited(rate_limits)),
+                }
+            }))
+            .and_then(clone!(captured_events, scoping, |mut envelope| {
                 #[cfg(feature = "processing")]
                 {
                     if let Some(store_forwarder) = store_forwarder {
@@ -1240,6 +1370,7 @@ impl Handler<HandleEnvelope> for EventManager {
                         result.map_err(move |error| match error {
                             UpstreamRequestError::RateLimited(upstream_limits) => {
                                 let limits = upstream_limits.scope(&scoping.borrow());
+                                project.do_send(UpdateRateLimits(limits.clone()));
                                 ProcessingError::RateLimited(limits)
                             }
                             other => ProcessingError::SendFailed(other),
@@ -1253,12 +1384,6 @@ impl Handler<HandleEnvelope> for EventManager {
             .map(|_, _, _| metric!(counter(RelayCounters::EnvelopeAccepted) += 1))
             .map_err(move |error, slf, _| {
                 metric!(counter(RelayCounters::EnvelopeRejected) += 1);
-
-                // Rate limits need special handling: Cache them on the project to avoid
-                // expensive processing while the limit is active.
-                if let ProcessingError::RateLimited(ref rate_limits) = error {
-                    project.do_send(UpdateRateLimits(rate_limits.clone()));
-                }
 
                 // if we are in capture mode, we stash away the event instead of
                 // forwarding it.

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -215,6 +215,9 @@ pub enum DiscardReason {
     /// [Relay] An envelope was submitted with two items that need to be unique.
     DuplicateItem,
 
+    /// [Relay] An event envelope was submitted but no payload could be extracted.
+    NoEventPayload,
+
     /// [All] An error in Relay caused event ingestion to fail. This is the catch-all and usually
     /// indicates bugs in Relay, rather than an expected failure.
     Internal,
@@ -252,6 +255,7 @@ impl DiscardReason {
             DiscardReason::InvalidEnvelope => "invalid_envelope",
             DiscardReason::ProjectState => "project_state",
             DiscardReason::DuplicateItem => "duplicate_item",
+            DiscardReason::NoEventPayload => "no_event_payload",
             DiscardReason::Internal => "internal",
         }
     }


### PR DESCRIPTION
Refactors the envelope and event processing code by splitting the main processing function into mostly independent pipeline steps that all operate on a state. The state is mutated by each function, which can be thought of as passing it from one pipeline step to the next.

From the top-level process function, it becomes immediately clear, which actions are applied with processing and which are skipped. The stages only required for processing are conditionally compiled.

There is no change in Relay's behavior. However, there are a few changes internally:

- The flow for rate limiting is different. The function `enforce_quotas` is called on every envelope in the pipeline. This prepares the pipeline for rate limiting of items other than events. At the moment, it skips all envelopes without events and still assumes `DataCategory::Error` for all events.
- Clock drift correction now runs unconditionally and has been removed from the store normalize processor.
- Processing mode errors if no event payload can be extracted from items that should create an event. This includes minidumps with their placeholders.
- Rate limits are still sent to the project for caching. However, these messages have moved from the global error handler into the processing and upstream branches. This means that cached rate limits no longer update the project.