### PR TITLE
feat(server): Apply quotas per item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
+**Features**:
+
+- Sessions and attachments can be rate limited now. These rate limits apply separately from error events, which means that you can continue to send Release Health sessions while you're out of quota with errors. ([#636](https://github.com/getsentry/relay/pull/636))
+
 **Bug Fixes**:
 
 - Outcomes from downstream relays were not forwarded upstream. ([#632](https://github.com/getsentry/relay/pull/632))
 - Apply clock drift correction to Release Health sessions and validate timestamps. ([#633](https://github.com/getsentry/relay/pull/633))
+
+**Internal**:
+
+- Restructure the envelope and event ingestion paths into a pipeline and apply rate limits to all envelopes. ([#635](https://github.com/getsentry/relay/pull/635), [#636](https://github.com/getsentry/relay/pull/636))
 
 ## 20.6.0
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write;
+use std::fmt::{self, Write};
 
 use relay_quotas::{
     DataCategories, DataCategory, ItemScoping, QuotaScope, RateLimit, RateLimitScope, RateLimits,
@@ -131,6 +131,16 @@ where
         }
     }
 
+    /// Assume an event with the given category, even if no item is present in the envelope.
+    ///
+    /// This ensures that rate limits for the given data category are checked even if there is no
+    /// matching item in the envelope. Other items are handled according to the rules as if the
+    /// event item were present.
+    #[cfg(feature = "processing")]
+    pub fn assume_event(&mut self, category: DataCategory) {
+        self.event_category = Some(category);
+    }
+
     /// Process rate limits for the envelope, removing offending items and returning applied limits.
     pub fn enforce(mut self, envelope: &mut Envelope, scoping: &Scoping) -> Result<RateLimits, E> {
         self.aggregate(envelope);
@@ -204,6 +214,19 @@ where
         }
 
         false
+    }
+}
+
+impl<F> fmt::Debug for EnvelopeLimiter<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EnvelopeLimiter")
+            .field("event_category", &self.event_category)
+            .field("attachment_quantity", &self.attachment_quantity)
+            .field("session_quantity", &self.session_quantity)
+            .field("remove_event", &self.remove_event)
+            .field("remove_attachments", &self.remove_attachments)
+            .field("remove_sessions", &self.remove_sessions)
+            .finish()
     }
 }
 

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -1,4 +1,8 @@
 from datetime import datetime, timedelta, timezone
+import pytest
+from requests.exceptions import HTTPError
+import six
+import uuid
 
 
 def test_session_with_processing(mini_sentry, relay_with_processing, sessions_consumer):
@@ -245,3 +249,82 @@ def test_session_release_required(
     assert sessions_consumer.poll() is None
     assert mini_sentry.test_failures
     mini_sentry.test_failures.clear()
+
+
+def test_session_quotas(mini_sentry, relay_with_processing, sessions_consumer):
+    relay = relay_with_processing()
+    relay.wait_relay_healthcheck()
+
+    sessions_consumer = sessions_consumer()
+
+    project_config = mini_sentry.full_project_config()
+    project_config["config"]["eventRetention"] = 17
+    project_config["config"]["quotas"] = [
+        {
+            "id": "test_rate_limiting_{}".format(uuid.uuid4().hex),
+            "categories": ["session"],
+            "scope": "key",
+            "scopeId": six.text_type(project_config["publicKeys"][0]["numericId"]),
+            "window": 3600,
+            "limit": 5,
+            "reasonCode": "sessions_exceeded",
+        }
+    ]
+    mini_sentry.project_configs[42] = project_config
+
+    timestamp = datetime.now(tz=timezone.utc)
+    started = timestamp - timedelta(hours=1)
+
+    session = {
+        "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
+        "timestamp": timestamp.isoformat(),
+        "started": started.isoformat(),
+        "attrs": {"release": "sentry-test@1.0.0"},
+    }
+
+    for i in range(5):
+        relay.send_session(42, session)
+        sessions_consumer.get_session()
+
+    # Rate limited, but responds with 200 because of deferred processing
+    relay.send_session(42, session)
+    assert sessions_consumer.poll() is None
+
+    with pytest.raises(HTTPError):
+        relay.send_session(42, session)
+    assert sessions_consumer.poll() is None
+
+
+def test_session_disabled(mini_sentry, relay_with_processing, sessions_consumer):
+    relay = relay_with_processing()
+    relay.wait_relay_healthcheck()
+
+    sessions_consumer = sessions_consumer()
+
+    project_config = mini_sentry.full_project_config()
+    project_config["config"]["eventRetention"] = 17
+    project_config["config"]["quotas"] = [
+        {
+            "categories": ["session"],
+            "scope": "key",
+            "scopeId": six.text_type(project_config["publicKeys"][0]["numericId"]),
+            "limit": 0,
+            "reasonCode": "sessions_exceeded",
+        }
+    ]
+    mini_sentry.project_configs[42] = project_config
+
+    timestamp = datetime.now(tz=timezone.utc)
+    started = timestamp - timedelta(hours=1)
+
+    relay.send_session(
+        42,
+        {
+            "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "timestamp": timestamp.isoformat(),
+            "started": started.isoformat(),
+            "attrs": {"release": "sentry-test@1.0.0"},
+        },
+    )
+
+    assert sessions_consumer.poll() is None

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -390,6 +390,39 @@ def test_store_not_normalized(mini_sentry, relay):
     assert event.get("version") is None
 
 
+def make_transaction(event):
+    now = datetime.datetime.utcnow()
+    event.update(
+        {
+            "type": "transaction",
+            "timestamp": now.isoformat(),
+            "start_timestamp": (now - datetime.timedelta(seconds=2)).isoformat(),
+            "spans": [],
+            "contexts": {
+                "trace": {
+                    "op": "hi",
+                    "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                    "span_id": "968cff94913ebb07",
+                }
+            },
+            "transaction": "hi",
+        }
+    )
+    return event
+
+
+def make_error(event):
+    event.update(
+        {
+            "type": "error",
+            "exception": {
+                "values": [{"type": "ValueError", "value": "Should not happen"}]
+            },
+        }
+    )
+    return event
+
+
 @pytest.mark.parametrize("event_type", ["default", "transaction"])
 def test_processing(
     mini_sentry,
@@ -411,30 +444,14 @@ def test_processing(
         events_consumer = transactions_consumer()
 
     # create a unique message so we can make sure we don't test with stale data
-    now = datetime.datetime.utcnow()
-    message_text = "some message {}".format(now.isoformat())
+    message_text = "some message {}".format(uuid.uuid4())
     event = {
         "message": message_text,
         "extra": {"msg_text": message_text},
-        "type": event_type,
-        "timestamp": now.isoformat(),
     }
 
     if event_type == "transaction":
-        event.update(
-            {
-                "start_timestamp": (now - datetime.timedelta(seconds=2)).isoformat(),
-                "spans": [],
-                "contexts": {
-                    "trace": {
-                        "op": "hi",
-                        "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
-                        "span_id": "968cff94913ebb07",
-                    }
-                },
-                "transaction": "hi",
-            }
-        )
+        make_transaction(event)
 
     relay.send_event(42, event)
 
@@ -460,8 +477,14 @@ def test_processing(
     assert event.get("version") is not None
 
 
+@pytest.mark.parametrize("event_type", ["default", "error", "transaction"])
 def test_processing_quotas(
-    mini_sentry, relay_with_processing, outcomes_consumer, events_consumer
+    mini_sentry,
+    relay_with_processing,
+    outcomes_consumer,
+    events_consumer,
+    transactions_consumer,
+    event_type,
 ):
     relay = relay_with_processing({"processing": {"max_rate_limit": 120}})
     relay.wait_relay_healthcheck()
@@ -470,12 +493,15 @@ def test_processing_quotas(
     public_keys = projectconfig["publicKeys"]
     key_id = public_keys[0]["numericId"]
 
+    # Default events are also mapped to "error" by Relay.
+    category = "error" if event_type == "default" else event_type
+
     projectconfig["config"]["quotas"] = [
         {
             "id": "test_rate_limiting_{}".format(uuid.uuid4().hex),
             "scope": "key",
             "scopeId": six.text_type(key_id),
-            "categories": ["error", "default"],
+            "categories": [category],
             "limit": 5,
             "window": 3600,
             "reasonCode": "get_lost",
@@ -489,37 +515,47 @@ def test_processing_quotas(
     }
     public_keys.append(second_key)
 
-    events_consumer = events_consumer()
+    if event_type == "transaction":
+        events_consumer = transactions_consumer()
+    else:
+        events_consumer = events_consumer()
     outcomes_consumer = outcomes_consumer()
 
+    if event_type == "transaction":
+        transform = make_transaction
+    elif event_type == "error":
+        transform = make_error
+    elif event_type == "default":
+        transform = lambda e: e
+
     for i in range(5):
-        relay.send_event(42, {"message": f"regular{i}"})
+        relay.send_event(42, transform({"message": f"regular{i}"}))
 
         event, _ = events_consumer.get_event()
         assert event["logentry"]["formatted"] == f"regular{i}"
 
     # this one will not get a 429 but still get rate limited (silently) because
     # of our caching
-    relay.send_event(42, {"message": "some_message"})
+    relay.send_event(42, transform({"message": "some_message"}))
 
     outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
 
     for _ in range(5):
         with pytest.raises(HTTPError) as excinfo:
-            relay.send_event(42, {"message": "rate_limited"})
+            relay.send_event(42, transform({"message": "rate_limited"}))
         headers = excinfo.value.response.headers
 
         # The rate limit is actually for 1 hour, but we cap at 120s with the
         # max_rate_limit parameter
         retry_after = headers["retry-after"]
         assert int(retry_after) <= 120
-        assert headers["x-sentry-rate-limits"] == "120:default;error:key"
+        assert headers["x-sentry-rate-limits"] == "120:%s:key" % category
         outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
 
     relay.dsn_public_key = second_key["publicKey"]
 
     for i in range(10):
-        relay.send_event(42, {"message": f"otherkey{i}"})
+        relay.send_event(42, transform({"message": f"otherkey{i}"}))
         event, _ = events_consumer.get_event()
 
         assert event["logentry"]["formatted"] == f"otherkey{i}"


### PR DESCRIPTION
Invokes the rate limiter with correct data categories for all items in the envelope, sharing the same code as the rate limiting fast path. 

Based on https://github.com/getsentry/relay/pull/635