### PR TITLE
feat(server): Enforce attachment size in rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Internal**:
 
 - Restructure the envelope and event ingestion paths into a pipeline and apply rate limits to all envelopes. ([#635](https://github.com/getsentry/relay/pull/635), [#636](https://github.com/getsentry/relay/pull/636))
+- Pass the combined size of all attachments in an envelope to the Redis rate limiter as quantity to enforce attachment quotas. ([#639](https://github.com/getsentry/relay/pull/639))
 
 ## 20.6.0
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -912,8 +912,8 @@ impl EventProcessor {
 
         // When invoking the rate limiter, capture if the event item has been rate limited to also
         // remove it from the processing state eventually.
-        let mut envelope_limiter = EnvelopeLimiter::new(|item_scope, _quantity| {
-            let limits = rate_limiter.is_rate_limited(quotas, item_scope)?;
+        let mut envelope_limiter = EnvelopeLimiter::new(|item_scope, quantity| {
+            let limits = rate_limiter.is_rate_limited(quotas, item_scope, quantity)?;
             remove_event ^= Some(item_scope.category) == category && limits.is_limited();
             Ok(limits)
         });

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -171,6 +171,7 @@ def test_attachments_quotas(
     mini_sentry, relay_with_processing, attachments_consumer, outcomes_consumer,
 ):
     event_id = "515539018c9b4260a6f999572f1661ee"
+    attachment_body = b"blabla"
 
     relay = relay_with_processing()
     relay.wait_relay_healthcheck()
@@ -181,17 +182,19 @@ def test_attachments_quotas(
             "id": "test_rate_limiting_{}".format(uuid.uuid4().hex),
             "categories": ["attachment"],
             "window": 3600,
-            "limit": 5,  # TODO: Test attachment size quota once implemented
+            "limit": 5 * len(attachment_body),
             "reasonCode": "attachments_exceeded",
         }
     ]
 
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
-    attachments = [("att_1", "foo.txt", b"blabla")]
+    attachments = [("att_1", "foo.txt", attachment_body)]
 
     for i in range(5):
-        relay.send_attachments(42, event_id, [("att_1", "%s.txt" % i, b"")])
+        relay.send_attachments(42, event_id, [("att_1", "%s.txt" % i, attachment_body)])
+        chunk, _ = attachments_consumer.get_attachment_chunk()
+        assert chunk == attachment_body
         attachment = attachments_consumer.get_individual_attachment()
         assert attachment["attachment"]["name"] == "%s.txt" % i
 


### PR DESCRIPTION
Passes the combined size of all attachments in an envelope to the Redis rate limiter as `quantity`. As a result, either all attachments are retained or dropped atomically.

The LUA script now accepts a third argument per quota which is the quantity. Similarly, the `RedisRateLimiter` requires callers to pass a quantity in, which is supplied by `EnvelopeLimiter`.