### PR TITLE
fix: Add missing .NET 4.8 patches

### DIFF
--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -56,6 +56,8 @@ fn normalize_runtime_context(runtime: &mut RuntimeContext) {
                     "461814" => Some("4.7.2".to_string()),
                     "528040" => Some("4.8".to_string()),
                     "528049" => Some("4.8".to_string()),
+                    "528209" => Some("4.8".to_string()),
+                    "528372" => Some("4.8".to_string()),
                     _ => None,
                 };
 


### PR DESCRIPTION
Adds support on the server to display the correct version. Related to: https://github.com/getsentry/sentry-dotnet/issues/443 even though it doesn't solve it since `Sentry.PlatformAbstractions` can also be patched before resolving.