### PR TITLE
fix(server): Never respond with 429 for minidumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Outcomes from downstream relays were not forwarded upstream. ([#632](https://github.com/getsentry/relay/pull/632))
 - Apply clock drift correction to Release Health sessions and validate timestamps. ([#633](https://github.com/getsentry/relay/pull/633))
 - Apply clock drift correction for timestamps that are too far in the past or future. This fixes a bug where broken transaction timestamps would lead to negative durations. ([#634](https://github.com/getsentry/relay/pull/634))
+- Respond with status code `200 OK` to rate limited minidump and UE4 requests. Third party clients otherwise retry those requests, leading to even more load. ([#646](https://github.com/getsentry/relay/pull/646))
 
 **Internal**:
 

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -54,6 +54,7 @@ fn store_attachment(
         request,
         extract_envelope,
         create_response,
+        true,
     )
 }
 

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -54,6 +54,7 @@ fn store_envelope(
         request,
         extract_envelope,
         create_response,
+        true,
     )
 }
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -188,6 +188,7 @@ fn store_minidump(
         request,
         extract_envelope,
         common::create_text_event_id_response,
+        false, // Never respond with a 429 since clients often retry these
     )
 }
 

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -73,6 +73,7 @@ fn store_security_report(
         request,
         move |data, meta| extract_envelope(data, meta, params.into_inner()),
         |_| create_response(),
+        true,
     )
 }
 

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -132,6 +132,7 @@ fn store_event(
         request,
         extract_envelope,
         move |id| create_response(id, is_get_request),
+        true,
     )
 }
 

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -50,6 +50,7 @@ fn store_unreal(
         // The return here is only useful for consistency because the UE4 crash reporter doesn't
         // care about it.
         common::create_text_event_id_response,
+        false,
     )
 }
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -381,8 +381,6 @@ def test_minidump_ratelimit(
     relay.send_minidump(project_id=42, files=attachments)
     outcomes_consumer.assert_rate_limited("static_disabled_quota")
 
-    # Second minidump returns 429 in endpoint
-    with pytest.raises(HTTPError) as excinfo:
-        relay.send_minidump(project_id=42, files=attachments)
-    assert excinfo.value.response.status_code == 429
+    # Minidumps never return rate limits
+    relay.send_minidump(project_id=42, files=attachments)
     outcomes_consumer.assert_rate_limited("static_disabled_quota")


### PR DESCRIPTION
Many third-party minidump clients retry requests that are not successful, including `429 Too Many Requests`. However, such requests should never be retried. For this reason, always respond with `200 OK` despite rate limits.

This is limited to the `/minidump/` and `/unreal/` endpoints, since Sentry clients as well as community SDKs are expected to obey the rate limit header. 