### PR TITLE
feat: Add _skip_projects list for testing

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt;
 use std::fs;
@@ -355,7 +355,7 @@ pub struct Relay {
     /// Password for the PKCS12 archive.
     pub tls_identity_password: Option<String>,
     /// Events for these projects will not be forwarded
-    pub _skip_projects: Option<HashSet<u64>>,
+    pub _skip_projects: Option<BTreeSet<u64>>,
 }
 
 impl Default for Relay {
@@ -1398,7 +1398,7 @@ impl Config {
     }
 
     /// Events for these projects will not be forwarded
-    pub fn skipped_projects(&self) -> Option<&HashSet<u64>> {
+    pub fn skipped_projects(&self) -> Option<&BTreeSet<u64>> {
         self.values.relay._skip_projects.as_ref()
     }
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::env;
 use std::fmt;
 use std::fs;
@@ -354,6 +354,8 @@ pub struct Relay {
     pub tls_identity_path: Option<PathBuf>,
     /// Password for the PKCS12 archive.
     pub tls_identity_password: Option<String>,
+    /// Events for these projects will not be forwarded
+    pub _skip_projects: Option<HashSet<u64>>,
 }
 
 impl Default for Relay {
@@ -366,6 +368,7 @@ impl Default for Relay {
             tls_port: None,
             tls_identity_path: None,
             tls_identity_password: None,
+            _skip_projects: None,
         }
     }
 }
@@ -1392,6 +1395,11 @@ impl Config {
     /// Emits flags for rate limited attachments. Disabled by default.
     pub fn emit_attachment_rate_limit_flag(&self) -> bool {
         self.values.processing._attachment_flag
+    }
+
+    /// Events for these projects will not be forwarded
+    pub fn skipped_projects(&self) -> Option<&HashSet<u64>> {
+        self.values.relay._skip_projects.as_ref()
     }
 }
 

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -229,6 +229,8 @@ pub enum RelayCounters {
     /// We are scanning our in-memory project cache for stale entries. This counter is incremented
     /// before doing the expensive operation.
     EvictingStaleProjectCaches,
+    /// Counts the number of events that were skipped based on the list of test projects
+    EnvelopeSkippedProject,
 }
 
 impl CounterMetric for RelayCounters {
@@ -250,6 +252,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
+            RelayCounters::EnvelopeSkippedProject => "event.skipped_project",
         }
     }
 }

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -94,8 +94,8 @@ def mini_sentry(request):
         )
         return jsonify({"event_id": uuid.uuid4().hex})
 
-    @app.route("/api/42/store/", methods=["POST"])
-    def store_event():
+    @app.route("/api/<project_id>/store/", methods=["POST"])
+    def store_event(project_id=None):
         if flask_request.headers.get("Content-Encoding", "") == "gzip":
             data = gzip.decompress(flask_request.data)
         else:
@@ -109,10 +109,6 @@ def mini_sentry(request):
 
         sentry.captured_events.put(envelope)
         return jsonify({"event_id": uuid.uuid4().hex})
-
-    @app.route("/api/<project>/store/", methods=["POST"])
-    def store_event_catchall(project):
-        raise AssertionError(f"Unknown project: {project}")
 
     @app.route("/api/0/relays/projectids/", methods=["POST"])
     def get_project_ids():


### PR DESCRIPTION
This is not an official feature (yet?), but we basically want to use this for testing external-internal relay connectivity by sending a steam of events, but without actually processing them (i.e. sending to Kafka or to the configured upstream).