### PR TITLE
fix(unreal): Do not serialize broken misc_primary_cpu_brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Apply clock drift correction to Release Health sessions and validate timestamps. ([#633](https://github.com/getsentry/relay/pull/633))
 - Apply clock drift correction for timestamps that are too far in the past or future. This fixes a bug where broken transaction timestamps would lead to negative durations. ([#634](https://github.com/getsentry/relay/pull/634))
 - Respond with status code `200 OK` to rate limited minidump and UE4 requests. Third party clients otherwise retry those requests, leading to even more load. ([#646](https://github.com/getsentry/relay/pull/646), [#647](https://github.com/getsentry/relay/pull/647))
+- Ingested unreal crash reports no longer have a `misc_primary_cpu_brand` key with GPU information set in the Unreal context. ([#650](https://github.com/getsentry/relay/pull/650))
 
 **Internal**:
 

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
@@ -51,7 +51,6 @@ expression: event.to_json_pretty().unwrap()
       "misc_cpu_vendor": "GenuineIntel",
       "misc_number_of_cores": 6,
       "misc_number_of_cores_inc_hyperthread": 6,
-      "misc_primary_cpu_brand": "Parallels Display Adapter (WDDM)",
       "platform_name": "WindowsNoEditor",
       "portable_call_stack": "YetAnother 0x00000000544e0000 + 703394 YetAnother 0x00000000544e0000 + 281f2ee YetAnother 0x00000000544e0000 + 2a26dd3 YetAnother 0x00000000544e0000 + 2a4f984 YetAnother 0x00000000544e0000 + 355e77e YetAnother 0x00000000544e0000 + 3576186 YetAnother 0x00000000544e0000 + 8acc56 YetAnother 0x00000000544e0000 + 8acf00 YetAnother 0x00000000544e0000 + 35c121d YetAnother 0x00000000544e0000 + 35cfb58 YetAnother 0x00000000544e0000 + 2eb082f YetAnother 0x00000000544e0000 + 2eb984f YetAnother 0x00000000544e0000 + 2d1cd39 YetAnother 0x00000000544e0000 + 325258 YetAnother 0x00000000544e0000 + 334e4c YetAnother 0x00000000544e0000 + 334eaa YetAnother 0x00000000544e0000 + 3429e6 YetAnother 0x00000000544e0000 + 44e73c6 KERNEL32 0x000000000fd40000 + 13034 ntdll 0x0000000010060000 + 71471",
       "process_id": 9444,

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -175,6 +175,11 @@ fn merge_unreal_context(event: &mut Event, context: Unreal4Context) {
         }
     }
 
+    // Clear this property. It's a duplicate of misc_primary_gpu_brand and only exists because
+    // somebody made a typo once while mapping the GPU data from unrealcontext in symbolic, and we
+    // tried to fix this in a backwards-compatible way by retaining both properties.
+    runtime_props.misc_primary_cpu_brand = None;
+
     if let Some(gpu_brand) = runtime_props.misc_primary_gpu_brand.take() {
         let gpu_context = contexts.get_or_insert_with(GpuContext::default_key(), || {
             Context::Gpu(Box::new(GpuContext::default()))


### PR DESCRIPTION
`misc_primary_cpu_brand` is a typo and was meant to be named `misc_primary_gpu_brand`. Due to compat, symbolic exposes both. We pop one key (moving it into another more structured context), but not the other.

Always clear both keys such that no misleading information is exposed.