### PR TITLE
fix(server): Forward outcomes in processing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Apply clock drift correction for timestamps that are too far in the past or future. This fixes a bug where broken transaction timestamps would lead to negative durations. ([#634](https://github.com/getsentry/relay/pull/634))
 - Respond with status code `200 OK` to rate limited minidump and UE4 requests. Third party clients otherwise retry those requests, leading to even more load. ([#646](https://github.com/getsentry/relay/pull/646), [#647](https://github.com/getsentry/relay/pull/647))
 - Ingested unreal crash reports no longer have a `misc_primary_cpu_brand` key with GPU information set in the Unreal context. ([#650](https://github.com/getsentry/relay/pull/650))
+- Fix ingestion of forwarded outcomes in processing Relays. Previously, `emit_outcomes` had to be set explicitly to enable this. ([#653](https://github.com/getsentry/relay/pull/653))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1094,9 +1094,12 @@ impl Config {
         self.values.relay.tls_identity_password.as_deref()
     }
 
-    /// Returns the emit_outcomes flag
+    /// Returns whether this Relay should emit outcomes.
+    ///
+    /// This is `true` either if `outcomes.emit_outcomes` is explicitly enabled, or if this Relay is
+    /// in processing mode.
     pub fn emit_outcomes(&self) -> bool {
-        self.values.outcomes.emit_outcomes
+        self.values.outcomes.emit_outcomes || self.values.processing.enabled
     }
 
     /// Returns the maximum number of outcomes that are batched before being sent

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -154,16 +154,6 @@ def mini_sentry(request):
 
         return jsonify(public_keys=keys, relays=relays)
 
-    @app.route("/api/0/relays/outcomes/", methods=["POST"])
-    def outcomes():
-        relay_id = flask_request.headers["x-sentry-relay-id"]
-        if relay_id not in authenticated_relays:
-            abort(403, "relay not registered")
-
-        outcomes_batch = flask_request.json
-        sentry.captured_outcomes.put(outcomes_batch)
-        return jsonify({})
-
     @app.errorhandler(500)
     def fail(e):
         sentry.test_failures.append((flask_request.url, e))

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -154,6 +154,20 @@ def mini_sentry(request):
 
         return jsonify(public_keys=keys, relays=relays)
 
+    @app.route("/api/0/relays/outcomes/", methods=["POST"])
+    def outcomes():
+        """
+        Mock endpoint for outcomes. SENTRY DOES NOT IMPLEMENT THIS ENDPOINT! This is just used to
+        verify Relay's batching behavior.
+        """
+        relay_id = flask_request.headers["x-sentry-relay-id"]
+        if relay_id not in authenticated_relays:
+            abort(403, "relay not registered")
+
+        outcomes_batch = flask_request.json
+        sentry.captured_outcomes.put(outcomes_batch)
+        return jsonify({})
+
     @app.errorhandler(500)
     def fail(e):
         sentry.test_failures.append((flask_request.url, e))

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -10,7 +10,9 @@ import time
 HOUR_MILLISEC = 1000 * 3600
 
 
-def test_outcomes_processing(relay_with_processing, kafka_consumer, mini_sentry, outcomes_consumer):
+def test_outcomes_processing(
+    relay_with_processing, kafka_consumer, mini_sentry, outcomes_consumer
+):
     """
     Tests outcomes are sent to the kafka outcome topic
 


### PR DESCRIPTION
The outcome endpoint checks for `emit_outcomes`, which needs to return `true` in processing mode. This allows all components in Relay to check a single flag.

https://github.com/getsentry/relay/blob/bc3e7709527ff4edb272dcd03274246d0f4240d2/relay-server/src/endpoints/outcomes.rs#L8-L10