### PR TITLE
chore: Port some missing filter tests

### DIFF
--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -70,8 +70,6 @@ mod tests {
 
     #[test]
     fn test_filter_banned_user_agents() {
-        let calypso_crawler = "Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36";
-
         let user_agents = [
             "Mediapartners-Google",
             "AdsBot-Google",
@@ -95,7 +93,7 @@ mod tests {
             "pingdom",
             "lyticsbot",
             "AWS Security Scanner",
-            calypso_crawler,
+            "Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36",
             "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
             "Slack-ImgProxy 0.19 (+https://api.slack.com/robots)",
             "Slackbot 1.0(+https://api.slack.com/robots)",
@@ -119,16 +117,14 @@ mod tests {
 
     #[test]
     fn test_dont_filter_normal_user_agents() {
-        let google_api = "APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)";
-        let mozilla = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36";
         let normal_user_agents = [
             "some user agent",
             "IE",
             "ie",
             "opera",
             "safari",
-            google_api,
-            mozilla,
+            "APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)",
+            "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
         ];
         for user_agent in &normal_user_agents {
             let event = testutils::get_event_with_user_agent(user_agent);

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -93,6 +93,15 @@ mod tests {
             "pingdom",
             "lyticsbot",
             "AWS Security Scanner",
+
+            "Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36",
+"Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
+"Slack-ImgProxy 0.19 (+https://api.slack.com/robots)",
+"Slackbot 1.0(+https://api.slack.com/robots)",
+"Twitterbot/1.0",
+"FeedFetcher-Google; (+http://www.google.com/feedfetcher.html)",
+            "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+"AdsBot-Google (+http://www.google.com/adsbot.html)"
         ];
 
         for banned_user_agent in &user_agents {
@@ -109,7 +118,10 @@ mod tests {
 
     #[test]
     fn test_dont_filter_normal_user_agents() {
-        for user_agent in &["some user agent", "IE", "ie", "opera", "safari"] {
+        for user_agent in &["some user agent", "IE", "ie", "opera", "safari", 
+"APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)",
+"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+        ] {
             let event = testutils::get_event_with_user_agent(user_agent);
             let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
             assert_eq!(

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -70,6 +70,8 @@ mod tests {
 
     #[test]
     fn test_filter_banned_user_agents() {
+        let calypso_crawler = "Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36";
+
         let user_agents = [
             "Mediapartners-Google",
             "AdsBot-Google",
@@ -93,15 +95,14 @@ mod tests {
             "pingdom",
             "lyticsbot",
             "AWS Security Scanner",
-
-            "Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36",
-"Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
-"Slack-ImgProxy 0.19 (+https://api.slack.com/robots)",
-"Slackbot 1.0(+https://api.slack.com/robots)",
-"Twitterbot/1.0",
-"FeedFetcher-Google; (+http://www.google.com/feedfetcher.html)",
+            calypso_crawler,
+            "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
+            "Slack-ImgProxy 0.19 (+https://api.slack.com/robots)",
+            "Slackbot 1.0(+https://api.slack.com/robots)",
+            "Twitterbot/1.0",
+            "FeedFetcher-Google; (+http://www.google.com/feedfetcher.html)",
             "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-"AdsBot-Google (+http://www.google.com/adsbot.html)"
+            "AdsBot-Google (+http://www.google.com/adsbot.html)",
         ];
 
         for banned_user_agent in &user_agents {
@@ -118,10 +119,18 @@ mod tests {
 
     #[test]
     fn test_dont_filter_normal_user_agents() {
-        for user_agent in &["some user agent", "IE", "ie", "opera", "safari", 
-"APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)",
-"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
-        ] {
+        let google_api = "APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)";
+        let mozilla = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36";
+        let normal_user_agents = [
+            "some user agent",
+            "IE",
+            "ie",
+            "opera",
+            "safari",
+            google_api,
+            mozilla,
+        ];
+        for user_agent in &normal_user_agents {
             let event = testutils::get_event_with_user_agent(user_agent);
             let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
             assert_eq!(


### PR DESCRIPTION
Port some tests that are deleted as part of https://github.com/getsentry/sentry/pull/19135

They aren't really revelatory in terms of finding bugs, but they are good documentation.

For some reason running cargo fmt does not do any changes on this code even though it's clearly wrong. Will investigate what causes this and remove draft status then.