### PR TITLE
ref(server): Add a header for rate limited items

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -131,7 +131,7 @@ impl StoreForwarder {
                 None
             },
             rate_limited: if self.config.emit_attachment_rate_limit_flag() {
-                Some(item.get_header("rate_limited") == Some(&true.into()))
+                Some(item.rate_limited())
             } else {
                 None
             },
@@ -243,7 +243,7 @@ struct ChunkedAttachment {
     ///
     /// By default, rate limited attachments are immediately removed from Envelopes. For processing,
     /// native crash reports still need to be retained. These attachments are marked with the
-    /// `"rate_limited"` header, which signals to the processing pipeline that the attachment should
+    /// `rate_limited` header, which signals to the processing pipeline that the attachment should
     /// not be persisted after processing.
     #[serde(skip_serializing_if = "Option::is_none")]
     rate_limited: Option<bool>,

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -334,6 +334,17 @@ pub struct ItemHeaders {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     filename: Option<String>,
 
+    /// Indicates that this item is being rate limited.
+    ///
+    /// By default, rate limited items are immediately removed from Envelopes. For processing,
+    /// native crash reports still need to be retained. These attachments are marked with the
+    /// `rate_limited` header, which signals to the processing pipeline that the attachment should
+    /// not be persisted after processing.
+    ///
+    /// NOTE: This is internal-only and not exposed into the Envelope.
+    #[serde(default, skip)]
+    rate_limited: bool,
+
     /// Other attributes for forward compatibility.
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -355,6 +366,7 @@ impl Item {
                 attachment_type: None,
                 content_type: None,
                 filename: None,
+                rate_limited: false,
                 other: BTreeMap::new(),
             },
             payload: Bytes::new(),
@@ -428,6 +440,16 @@ impl Item {
         S: Into<String>,
     {
         self.headers.filename = Some(filename.into());
+    }
+
+    /// Returns whether this item should be rate limited.
+    pub fn rate_limited(&self) -> bool {
+        self.headers.rate_limited
+    }
+
+    /// Sets whether this item should be rate limited.
+    pub fn set_rate_limited(&mut self, rate_limited: bool) {
+        self.headers.rate_limited = rate_limited;
     }
 
     /// Returns the specified header value, if present.


### PR DESCRIPTION
Separates the logic for summarizing Envelope contents into a separate helper. As part of this, the new helper skips items that have been rate limited before. Otherwise, this would invoke the rate limiter with redundant quantities.

Additionally, the rate limited header is now typed out in envelope headers. However, this header is never serialized or deserialized, so that clients cannot set it. For Relays, this means that each Relay can independently determine whether items need to be rate limited, rather than trusting the downstream.
