### PR TITLE
fix: Streamline bump-version and warn on macOS

### DIFF
--- a/scripts/bump-library.sh
+++ b/scripts/bump-library.sh
@@ -10,7 +10,6 @@ NEW_VERSION="${2}"
 echo "Current version: ${OLD_VERSION}"
 echo "Bumping version: ${NEW_VERSION}"
 
-VERSION_RE=${OLD_VERSION//\./\\.}
-sed -i '' -e "1,/^version/ s/^version.*/version = \"${NEW_VERSION}\"/" relay-cabi/Cargo.toml
+perl -pi -e "s/^version = .*\$/version = \"$NEW_VERSION\"/" relay-cabi/Cargo.toml
 
 cargo update -p relay-common --manifest-path ./relay-cabi/Cargo.toml

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Relay can only be released on Linux!"
+    echo "Please use the GitHub Action instead."
+    exit 1
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
 
@@ -16,6 +22,6 @@ perl -pi -e "s/^version = .*\$/version = \"$NEW_VERSION\"/" $TOML_FILES
 cargo update -p relay
 cargo update -p relay-common --manifest-path ./relay-cabi/Cargo.toml
 
-CHANGE_DATE="$(perl -MPOSIX -e '@a=gmtime(); @a[5]+=3; print(strftime("%Y-%m-%d", @a))')"
+CHANGE_DATE="$(date +'%Y-%m-%d' -d '3 years')"
 echo "Bumping Change Date to $CHANGE_DATE"
-perl -pi -e "s/^(Change Date: +)[-0-9]+\$/\${1}$CHANGE_DATE/" LICENSE
+sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$CHANGE_DATE/" LICENSE

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,12 +10,12 @@ NEW_VERSION="${2}"
 echo "Current version: ${OLD_VERSION}"
 echo "Bumping version: ${NEW_VERSION}"
 
-VERSION_RE=${OLD_VERSION//\./\\.}
-find . -name Cargo.toml -not -path './relay-cabi/*' -exec sed -i.bak -e "1,/^version/ s/^version.*/version = \"${NEW_VERSION}\"/" {} \;
-find . -name Cargo.toml.bak -exec rm {} \;
+TOML_FILES="$(git ls-files '*Cargo.toml' | grep -v cabi)"
+perl -pi -e "s/^version = .*\$/version = \"$NEW_VERSION\"/" $TOML_FILES
 
 cargo update -p relay
 cargo update -p relay-common --manifest-path ./relay-cabi/Cargo.toml
 
-sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
-
+CHANGE_DATE="$(perl -MPOSIX -e '@a=gmtime(); @a[5]+=3; print(strftime("%Y-%m-%d", @a))')"
+echo "Bumping Change Date to $CHANGE_DATE"
+perl -pi -e "s/^(Change Date: +)[-0-9]+\$/\${1}$CHANGE_DATE/" LICENSE


### PR DESCRIPTION
The latest change to the `bump-version.sh` script made it incompatible with macOS, both due to `sed` and `date`. This issues a warning to use the GitHub Action instead of releasing the binary locally.