### PR TITLE
ref(transactions): Normalize transaction spans into an array

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Always create a spans array for transactions in normalization. ([#667](https://github.com/getsentry/relay/pull/667))
+
 ## 0.5.11
 
 - Add SpanStatus to span struct. ([#603](https://github.com/getsentry/relay/pull/603))

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -86,13 +86,13 @@ impl Processor for TransactionsProcessor {
             }
         }
 
-        if let Some(spans) = event.spans.value() {
-            for span in spans {
-                if span.value().is_none() {
-                    return Err(ProcessingAction::InvalidTransaction(
-                        "spans must be valid in transaction event",
-                    ));
-                }
+        let spans = event.spans.value_mut().get_or_insert_with(|| Vec::new());
+
+        for span in spans {
+            if span.value().is_none() {
+                return Err(ProcessingAction::InvalidTransaction(
+                    "spans must be valid in transaction event",
+                ));
             }
         }
 

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -501,6 +501,43 @@ mod tests {
     }
 
     #[test]
+    fn test_allows_transaction_event_with_null_span_list() {
+        let mut event = new_test_event();
+
+        event
+            .apply(|event, _| {
+                event.spans.set_value(None);
+                Ok(())
+            })
+            .unwrap();
+
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(event, @r###"
+        {
+          "type": "transaction",
+          "transaction": "/",
+          "timestamp": 946684810.0,
+          "start_timestamp": 946684800.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "http.server",
+              "type": "trace"
+            }
+          },
+          "spans": []
+        }
+        "###);
+    }
+
+    #[test]
     fn test_discards_transaction_event_with_nulled_out_span() {
         let mut event = Annotated::new(Event {
             ty: Annotated::new(EventType::Transaction),

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -427,7 +427,8 @@ mod tests {
               "op": "default",
               "type": "trace"
             }
-          }
+          },
+          "spans": []
         }
         "###);
     }


### PR DESCRIPTION
On the Sentry product, the frontend relies on the existence of the span entry for the span view to be displayed.

This could occur if `event.spans` is anything but an array (e.g. `null`, `undefined`, etc)

Example of a transaction event with a trace context, but no presence of a span entry:  https://sentry.io/organizations/sentry-test/discover/otel-collector-exporter:aae3cb260d2c4094af92de01c2ce6ea4/


## TODO

- [x] update any broken tests 
- [x] add some test cases
