### PR TITLE
feat(server): Report metrics for upstream connections

### DIFF
--- a/relay-server/src/actors/connector.rs
+++ b/relay-server/src/actors/connector.rs
@@ -1,0 +1,87 @@
+//! Provides a metered client connector for upstream connections.
+//!
+//! See the [`MeteredConnector`] struct for more information.
+//!
+//! [`MeteredConnector`]: struct.MeteredConnector.html
+
+use std::sync::Arc;
+
+use actix::prelude::*;
+use actix_web::client::{ClientConnector, ClientConnectorStats};
+
+use relay_common::metric;
+use relay_config::Config;
+
+use crate::metrics::{RelayCounters, RelayHistograms};
+
+/// Actor that reports connection metrics.
+///
+/// This actor implements a receiver for `ClientConnectorStats`, which provide periodic updates on
+/// the client connector used to establish upstream connections. The numbers are reported into the
+/// `connector.*` counter and historgram metrics.
+///
+/// # Example
+///
+/// To start the connector, use [`MeteredConnector::start`]. This also starts the actual client
+/// connector and registers it as default system service. After that, each client request uses this
+/// connector by default.
+///
+/// ```
+/// use std::sync::Arc;
+/// use relay_config::Config;
+///
+/// let config = Arc::new(Config::default());
+/// MeteredConnector::start(config);
+///
+/// let request = actix_web::client::get("http://example.org")
+///    .finish();
+/// ```
+#[derive(Debug)]
+pub struct MeteredConnector;
+
+impl MeteredConnector {
+    pub fn start(config: Arc<Config>) -> Addr<Self> {
+        let metered_connector = Self.start();
+
+        let connector = ClientConnector::default()
+            .limit(config.max_concurrent_requests())
+            .stats(metered_connector.clone().recipient())
+            .start();
+
+        // Register as default system service.
+        System::current().registry().set(connector);
+
+        metered_connector
+    }
+}
+
+impl Default for MeteredConnector {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl Actor for MeteredConnector {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _context: &mut Self::Context) {
+        log::info!("metered connector started");
+    }
+
+    fn stopped(&mut self, _context: &mut Self::Context) {
+        log::info!("metered connector stopped");
+    }
+}
+
+impl Handler<ClientConnectorStats> for MeteredConnector {
+    type Result = ();
+
+    fn handle(&mut self, message: ClientConnectorStats, _context: &mut Self::Context) {
+        metric!(histogram(RelayHistograms::ConnectorWaitQueue) = message.wait_queue as u64);
+        metric!(counter(RelayCounters::ConnectorReused) += message.reused as i64);
+        metric!(counter(RelayCounters::ConnectorOpened) += message.opened as i64);
+        metric!(counter(RelayCounters::ConnectorClosed) += message.closed as i64);
+        metric!(counter(RelayCounters::ConnectorErrors) += message.errors as i64);
+        metric!(counter(RelayCounters::ConnectorTimeouts) += message.timeouts as i64);
+    }
+}

--- a/relay-server/src/actors/connector.rs
+++ b/relay-server/src/actors/connector.rs
@@ -26,7 +26,7 @@ use crate::metrics::{RelayCounters, RelayHistograms};
 /// connector and registers it as default system service. After that, each client request uses this
 /// connector by default.
 ///
-/// ```
+/// ```ignore
 /// use std::sync::Arc;
 /// use relay_config::Config;
 ///

--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -39,6 +39,7 @@
 //! [`EventProcessor`]: controller/struct.EventProcessor.html
 //! [`UpstreamRelay`]: controller/struct.UpstreamRelay.html
 
+pub mod connector;
 pub mod controller;
 pub mod events;
 pub mod healthcheck;

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -54,6 +54,8 @@ pub enum RelayHistograms {
     ProjectStateReceived,
     /// Number of project states currently held in the in-memory project cache.
     ProjectStateCacheSize,
+    /// The number of upstream requests queued up for a connection in the connection pool.
+    ConnectorWaitQueue,
 }
 
 impl HistogramMetric for RelayHistograms {
@@ -67,6 +69,7 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",
             RelayHistograms::ProjectStateReceived => "project_state.received",
             RelayHistograms::ProjectStateCacheSize => "project_cache.size",
+            RelayHistograms::ConnectorWaitQueue => "connector.wait_queue",
         }
     }
 }
@@ -229,6 +232,22 @@ pub enum RelayCounters {
     /// We are scanning our in-memory project cache for stale entries. This counter is incremented
     /// before doing the expensive operation.
     EvictingStaleProjectCaches,
+    /// The number of requests that reused an already open upstream connection.
+    ///
+    /// Relay employs connection keep-alive whenever possible. Connections are kept open for 15
+    /// seconds of inactivity, or 75 seconds of activity.
+    ConnectorReused,
+    /// The number of upstream connections opened.
+    ConnectorOpened,
+    /// The number of upstream connections closed due to connection timeouts.
+    ///
+    /// Relay employs connection keep-alive whenever possible. Connections are kept open for 15
+    /// seconds of inactivity, or 75 seconds of activity.
+    ConnectorClosed,
+    /// The number of upstream connections that experienced errors.
+    ConnectorErrors,
+    /// The number of upstream connections that experienced a timeout.
+    ConnectorTimeouts,
 }
 
 impl CounterMetric for RelayCounters {
@@ -250,6 +269,11 @@ impl CounterMetric for RelayCounters {
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
+            RelayCounters::ConnectorReused => "connector.reused",
+            RelayCounters::ConnectorOpened => "connector.opened",
+            RelayCounters::ConnectorClosed => "connector.closed",
+            RelayCounters::ConnectorErrors => "connector.errors",
+            RelayCounters::ConnectorTimeouts => "connector.timeouts",
         }
     }
 }


### PR DESCRIPTION
This replaces our bare use of the actix `ClientConnector` with a metered connector actor. It starts the actual connector internally and then registers a subscriber for periodic stats updates. These stats are reported to statsd under the `connector.*` key.