### PR TITLE
test: Ensure invalid minidumps leave events creation intact

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = --tb=native --durations 5 -ra
+testpaths = tests/integration
 markers =
     extra_failure_checks: Marker which can add additional failure checks to
        a test.  It accepts the keyword argument `checks` which should be a


### PR DESCRIPTION
When a user sends in an invalid minidump we want to ensure processing
manages to progress normally.

This also changes the pytest config slightly to speed up test
collection when invoked from the relay project directory.