### PR TITLE
feat(kafka): Report producer errors

### DIFF
--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -338,7 +338,7 @@ mod processing {
 
     use failure::{Fail, ResultExt};
     use rdkafka::error::KafkaError;
-    use rdkafka::producer::{BaseRecord, DefaultProducerContext};
+    use rdkafka::producer::BaseRecord;
     use rdkafka::ClientConfig;
     use serde_json::Error as SerdeSerializationError;
 
@@ -347,8 +347,7 @@ mod processing {
 
     use crate::metrics::RelayCounters;
     use crate::service::ServerErrorKind;
-
-    type ThreadedProducer = rdkafka::producer::ThreadedProducer<DefaultProducerContext>;
+    use crate::utils::{CaptureErrorContext, ThreadedProducer};
 
     #[derive(Fail, Debug)]
     pub enum OutcomeError {
@@ -388,7 +387,7 @@ mod processing {
                     client_config.set(config_p.name.as_str(), config_p.value.as_str());
                 }
                 let future_producer = client_config
-                    .create()
+                    .create_with_context(CaptureErrorContext)
                     .context(ServerErrorKind::KafkaError)?;
                 (Some(future_producer), None)
             } else {

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -8,8 +8,8 @@ use actix::prelude::*;
 use bytes::Bytes;
 use failure::{Fail, ResultExt};
 use rdkafka::error::KafkaError;
-use rdkafka::producer::{BaseRecord, DefaultProducerContext};
-use rdkafka::ClientConfig;
+use rdkafka::producer::{BaseRecord, DeliveryResult, ProducerContext};
+use rdkafka::{ClientConfig, ClientContext};
 use rmp_serde::encode::Error as RmpError;
 use serde::{ser::Error, Serialize};
 
@@ -23,7 +23,22 @@ use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::metrics::RelayCounters;
 use crate::service::{ServerError, ServerErrorKind};
 
-type ThreadedProducer = rdkafka::producer::ThreadedProducer<DefaultProducerContext>;
+struct CaptureErrorContext;
+
+impl ClientContext for CaptureErrorContext {}
+impl ProducerContext for CaptureErrorContext {
+    type DeliveryOpaque = ();
+    fn delivery(&self, result: &DeliveryResult, _delivery_opaque: Self::DeliveryOpaque) {
+        if let Err((e, _message)) = result {
+            println!("BLABLA Error: {}", e);
+
+            // TODO send a metric
+            // metric!(counter(RelayCounters::EventProtocol) += 1);
+        }
+    }
+}
+
+type ThreadedProducer = rdkafka::producer::ThreadedProducer<CaptureErrorContext>;
 
 lazy_static::lazy_static! {
     static ref NAMESPACE_DID: Uuid =
@@ -61,7 +76,7 @@ impl StoreForwarder {
         }
 
         let producer = client_config
-            .create()
+            .create_with_context(CaptureErrorContext)
             .context(ServerErrorKind::KafkaError)?;
 
         Ok(Self {

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -215,6 +215,12 @@ pub enum RelayCounters {
     /// either `event` or `attachment` representing the type of message produced on the Kafka queue.
     #[cfg(feature = "processing")]
     ProcessingMessageProduced,
+    /// Counts the number of producer errors occurred after an event was already enqueued for
+    /// sending to Kafka. These errors might include e.g. MessageTooLarge errors when the broker
+    /// does not accept the requests over a certain size, which is usually due to invalic or
+    /// inconsistent broker/producer configurations.
+    #[cfg(feature = "processing")]
+    ProcessingProduceError,
     /// Counts the number of events that hit any of the Store like endpoints (Store, Security,
     /// MiniDump, Unreal). The events are counted before they are rate limited , filtered or
     /// processed in any way. The counter has a `version` tag that tracks the message event
@@ -265,6 +271,8 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ServerStarting => "server.starting",
             #[cfg(feature = "processing")]
             RelayCounters::ProcessingMessageProduced => "processing.event.produced",
+            #[cfg(feature = "processing")]
+            RelayCounters::ProcessingProduceError => "processing.produce.error",
             RelayCounters::EventProtocol => "event.protocol",
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",

--- a/relay-server/src/utils/kafka.rs
+++ b/relay-server/src/utils/kafka.rs
@@ -1,0 +1,20 @@
+use rdkafka::producer::{DeliveryResult, ProducerContext};
+use rdkafka::ClientContext;
+
+pub struct CaptureErrorContext;
+
+impl ClientContext for CaptureErrorContext {}
+
+impl ProducerContext for CaptureErrorContext {
+    type DeliveryOpaque = ();
+    fn delivery(&self, result: &DeliveryResult, _delivery_opaque: Self::DeliveryOpaque) {
+        if let Err((e, _message)) = result {
+            log::error!("producer error: {}", e);
+
+            // TODO send a metric
+            // metric!(counter(RelayCounters::EventProtocol) += 1);
+        }
+    }
+}
+
+pub type ThreadedProducer = rdkafka::producer::ThreadedProducer<CaptureErrorContext>;

--- a/relay-server/src/utils/kafka.rs
+++ b/relay-server/src/utils/kafka.rs
@@ -5,15 +5,22 @@ use relay_common::{metric, LogError};
 
 use crate::metrics::RelayCounters;
 
+/// Kafka producer context that logs producer errors
 pub struct CaptureErrorContext;
 
 impl ClientContext for CaptureErrorContext {}
 
 impl ProducerContext for CaptureErrorContext {
     type DeliveryOpaque = ();
+
+    /// This method is called after attempting to send a message to Kafka.
+    /// It's called asynchronously for every message, so we want to handle errors explicitly here.
     fn delivery(&self, result: &DeliveryResult, _delivery_opaque: Self::DeliveryOpaque) {
         if let Err((error, _message)) = result {
-            log::error!("callback producer error: {}", LogError(error));
+            log::error!(
+                "failed to produce message to Kafka (delivery callback): {}",
+                LogError(error)
+            );
 
             metric!(counter(RelayCounters::ProcessingProduceError) += 1);
         }

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -9,6 +9,9 @@ mod shutdown;
 mod timer;
 
 #[cfg(feature = "processing")]
+mod kafka;
+
+#[cfg(feature = "processing")]
 mod unreal;
 
 pub use self::actix::*;
@@ -20,6 +23,9 @@ pub use self::rate_limits::*;
 pub use self::request::*;
 pub use self::shutdown::*;
 pub use self::timer::*;
+
+#[cfg(feature = "processing")]
+pub use self::kafka::*;
 
 #[cfg(feature = "processing")]
 pub use self::unreal::*;


### PR DESCRIPTION
Currently, asynchronous errors (those happening after the event was queued) in the kafka producer are silently dropped. With this change, the goal is to report those errors to Sentry (or at least write them in the logs).

