### PR TITLE
fix(server): Consume all upstream responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Reuse connections for upstream event submission requests when the server supports connection keepalive. Relay did not consume the response body of all requests, which caused it to reopen a new connection for every event. ([#680](https://github.com/getsentry/relay/pull/680))
+
 **Internal**:
 
 - Extract the event `timestamp` from Minidump files during event normalization. ([#662](https://github.com/getsentry/relay/pull/662))

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -101,10 +101,12 @@ pub struct ReadRequestMiddleware;
 
 impl<S> Middleware<S> for ReadRequestMiddleware {
     fn response(&self, req: &HttpRequest<S>, resp: HttpResponse) -> Result<Response, Error> {
-        let consume_request = req.payload().for_each(|_| Ok(()));
+        let future = req
+            .payload()
+            .for_each(|_| Ok(()))
+            .map(|_| resp)
+            .map_err(Error::from);
 
-        Ok(Response::Future(Box::new(
-            consume_request.map(|_| resp).map_err(Error::from),
-        )))
+        Ok(Response::Future(Box::new(future)))
     }
 }


### PR DESCRIPTION
Relays do not reuse connections for store requests. The default response transformer for upstream requests does not consume the response payload, which is a potential cause for this.

cc @RaduW for https://github.com/getsentry/relay/pull/678