### PR TITLE
fix(server): Use correct response type for outcomes requests

### DIFF
--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -37,14 +37,14 @@ pub type OutcomeProducer = processing::ProcessingOutcomeProducer;
 pub type OutcomeProducer = HttpOutcomeProducer;
 
 /// Defines the structure of the HTTP outcomes requests
-#[derive(Deserialize, Serialize, Debug, Default)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SendOutcomes {
     #[serde(default)]
     pub outcomes: Vec<TrackRawOutcome>,
 }
 
 impl UpstreamQuery for SendOutcomes {
-    type Response = SendOutcomes;
+    type Response = SendOutcomesResponse;
 
     fn method(&self) -> Method {
         Method::POST
@@ -56,7 +56,7 @@ impl UpstreamQuery for SendOutcomes {
 }
 
 /// Defines the structure of the HTTP outcomes responses for successful requests
-#[derive(Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SendOutcomesResponse {
     // nothing yet, future features will go here
 }

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -8,9 +8,11 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
     if !body.relay.internal || !state.config().emit_outcomes() {
         return HttpResponse::Forbidden().finish();
     }
+
     for outcome in body.inner.outcomes {
         state.outcome_producer().do_send(outcome);
     }
+
     HttpResponse::Accepted().json(SendOutcomesResponse {})
 }
 


### PR DESCRIPTION
Fixes a typo in the response type of outcomes upstream requests. Since the response is currently expected to be empty, there is no change in behavior.

cc @RaduW 