### PR TITLE
ref(pii): Split out regex mapping into separate module

### DIFF
--- a/relay-general/src/pii/mod.rs
+++ b/relay-general/src/pii/mod.rs
@@ -8,6 +8,7 @@ mod generate_selectors;
 mod legacy;
 mod processor;
 mod redactions;
+mod regexes;
 mod utils;
 
 pub use self::builtin::BUILTIN_RULES;

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -9,6 +9,7 @@ use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 
 use crate::pii::compiledconfig::RuleRef;
+use crate::pii::regexes::{get_regex_for_rule_type, PatternType, ReplaceBehavior, ANYTHING_REGEX};
 use crate::pii::utils::process_pairlist;
 use crate::pii::{CompiledPiiConfig, HashAlgorithm, Redaction, RuleType};
 use crate::processor::{
@@ -20,156 +21,6 @@ use crate::types::{Meta, ProcessingAction, ProcessingResult, Remark, RemarkType}
 lazy_static! {
     static ref NULL_SPLIT_RE: Regex = #[allow(clippy::trivial_regex)]
     Regex::new("\x00").unwrap();
-}
-
-#[rustfmt::skip]
-macro_rules! ip {
-    (v4s) => { "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" };
-    (v4a) => { concat!(ip!(v4s), "\\.", ip!(v4s), "\\.", ip!(v4s), "\\.", ip!(v4s)) };
-    (v6s) => { "[0-9a-fA-F]{1,4}" };
-}
-
-#[rustfmt::skip]
-lazy_static! {
-    static ref GROUP_0: BTreeSet<u8> = {
-        let mut set = BTreeSet::new();
-        set.insert(0);
-        set
-    };
-    static ref GROUP_1: BTreeSet<u8> = {
-        let mut set = BTreeSet::new();
-        set.insert(1);
-        set
-    };
-    static ref ANYTHING_REGEX: Regex = Regex::new(".*").unwrap();
-    static ref IMEI_REGEX: Regex = Regex::new(
-        r#"(?x)
-            \b
-                (\d{2}-?
-                 \d{6}-?
-                 \d{6}-?
-                 \d{1,2})
-            \b
-        "#
-    ).unwrap();
-    static ref MAC_REGEX: Regex = Regex::new(
-        r#"(?x)
-            \b([[:xdigit:]]{2}[:-]){5}[[:xdigit:]]{2}\b
-        "#
-    ).unwrap();
-    static ref UUID_REGEX: Regex = Regex::new(
-        r#"(?ix)
-            \b
-            [a-z0-9]{8}-?
-            [a-z0-9]{4}-?
-            [a-z0-9]{4}-?
-            [a-z0-9]{4}-?
-            [a-z0-9]{12}
-            \b
-        "#
-    ).unwrap();
-    static ref EMAIL_REGEX: Regex = Regex::new(
-        r#"(?x)
-            \b
-                [a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+
-                @
-                [a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*
-            \b
-        "#
-    ).unwrap();
-    static ref IPV4_REGEX: Regex = Regex::new(concat!("\\b", ip!(v4a), "\\b")).unwrap();
-    static ref IPV6_REGEX: Regex = Regex::new(
-        concat!(
-            "(?i)(?:[\\s]|[[:punct:]]|^)(",
-                "(", ip!(v6s), ":){7}", ip!(v6s), "|",
-                "(", ip!(v6s), ":){1,7}:|",
-                "(", ip!(v6s), ":){1,6}::", ip!(v6s), "|",
-                "(", ip!(v6s), ":){1,5}:(:", ip!(v6s), "){1,2}|",
-                "(", ip!(v6s), ":){1,4}:(:", ip!(v6s), "){1,3}|",
-                "(", ip!(v6s), ":){1,3}:(:", ip!(v6s), "){1,4}|",
-                "(", ip!(v6s), ":){1,2}:(:", ip!(v6s), "){1,5}|",
-                ip!(v6s), ":((:", ip!(v6s), "){1,6})|",
-                ":((:", ip!(v6s), "){1,7}|:)|",
-                "fe80:(:", ip!(v6s), "){0,4}%[0-9a-zA-Z]{1,}",
-                "::(ffff(:0{1,4}){0,1}:){0,1}", ip!(v4a), "|",
-                "(", ip!(v6s), ":){1,4}:", ip!(v4a),
-            ")([\\s]|[[:punct:]]|$)",
-        )
-    ).unwrap();
-
-    // http://www.richardsramblings.com/regex/credit-card-numbers/
-    // Re-formatted with comments and dashes support
-    //
-    // Why so complicated? Because creditcard numbers are variable length and we do not want to
-    // strip any number that just happens to have the same length.
-    static ref CREDITCARD_REGEX: Regex = Regex::new(
-        r#"(?x)
-        \b(
-            (?:  # vendor specific prefixes
-                  3[47]\d      # amex (no 13-digit version) (length: 15)
-                | 4\d{3}       # visa (16-digit version only)
-                | 5[1-5]\d\d   # mastercard
-                | 65\d\d       # discover network (subset)
-                | 6011         # discover network (subset)
-            )
-
-            # "wildcard" remainder (allowing dashes in every position because of variable length)
-            ([-\s]?\d){12}
-        )\b
-        "#
-    ).unwrap();
-    static ref PATH_REGEX: Regex = Regex::new(
-        r#"(?ix)
-            (?:
-                (?:
-                    \b(?:[a-zA-Z]:[\\/])?
-                    (?:users|home|documents and settings|[^/\\]+[/\\]profiles)[\\/]
-                ) | (?:
-                    /(?:home|users)/
-                )
-            )
-            (
-                [^/\\]+
-            )
-        "#
-    ).unwrap();
-    static ref PEM_KEY_REGEX: Regex = Regex::new(
-        r#"(?sx)
-            (?:
-                -----
-                BEGIN[A-Z\ ]+(?:PRIVATE|PUBLIC)\ KEY
-                -----
-                [\t\ ]*\r?\n?
-            )
-            (.+?)
-            (?:
-                \r?\n?
-                -----
-                END[A-Z\ ]+(?:PRIVATE|PUBLIC)\ KEY
-                -----
-            )
-        "#
-    ).unwrap();
-    static ref URL_AUTH_REGEX: Regex = Regex::new(
-        r#"(?x)
-            \b(?:
-                (?:[a-z0-9+-]+:)?//
-                ([a-zA-Z0-9%_.-]+(?::[a-zA-Z0-9%_.-]+)?)
-            )@
-        "#
-    ).unwrap();
-    static ref US_SSN_REGEX: Regex = Regex::new(
-        r#"(?x)
-            \b(
-                [0-9]{3}-
-                [0-9]{2}-
-                [0-9]{4}
-            )\b
-        "#
-    ).unwrap();
-    static ref PASSWORD_KEY_REGEX: Regex = Regex::new(
-        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)"
-    ).unwrap();
 }
 
 /// A processor that performs PII stripping.
@@ -303,69 +154,46 @@ fn apply_rule_to_value(
         _ => true,
     };
 
+    // In case the value is not a string (but a container, bool or number) and the rule matches on
+    // anything, we can only remove the value (not replace, hash, etc).
+    if rule.ty == RuleType::Anything && (value.is_none() || !should_redact_chunks) {
+        // The value is a container, @anything on a container can do nothing but delete.
+        meta.add_remark(Remark::new(RemarkType::Removed, rule.origin.clone()));
+        return Err(ProcessingAction::DeleteValueHard);
+    }
+
     macro_rules! apply_regex {
-        ($regex:expr, $replace_groups:expr) => {
+        ($regex:expr, $replace_behavior:expr) => {
             if let Some(ref mut value) = value {
                 process_chunked_value(value, meta, |chunks| {
-                    apply_regex_to_chunks(chunks, rule, $regex, $replace_groups)
+                    apply_regex_to_chunks(chunks, rule, $regex, $replace_behavior)
                 });
             }
         };
     }
 
-    match rule.ty {
-        RuleType::RedactPair(_) | RuleType::Password => {
-            let key_pattern = match rule.ty {
-                RuleType::RedactPair(ref redact_pair) => &redact_pair.key_pattern.0,
-                RuleType::Password => &PASSWORD_KEY_REGEX,
-                _ => unreachable!(),
-            };
-
-            if key_pattern.is_match(key.unwrap_or("")) {
-                if value.is_some() && should_redact_chunks {
-                    // If we're given a string value here, redact the value like we would with
-                    // @anything.
-                    apply_regex!(&ANYTHING_REGEX, Some(&*GROUP_0));
+    for (pattern_type, regex, replace_behavior) in get_regex_for_rule_type(&rule.ty) {
+        match pattern_type {
+            PatternType::KeyValue => {
+                if regex.is_match(key.unwrap_or("")) {
+                    if value.is_some() && should_redact_chunks {
+                        // If we're given a string value here, redact the value like we would with
+                        // @anything.
+                        apply_regex!(&ANYTHING_REGEX, replace_behavior);
+                    } else {
+                        meta.add_remark(Remark::new(RemarkType::Removed, rule.origin.clone()));
+                        return Err(ProcessingAction::DeleteValueHard);
+                    }
                 } else {
-                    meta.add_remark(Remark::new(RemarkType::Removed, rule.origin.clone()));
-                    return Err(ProcessingAction::DeleteValueHard);
+                    // If we did not redact using the key, we will redact the entire value if the key
+                    // appears in it.
+                    apply_regex!(regex, ReplaceBehavior::Value);
                 }
-            } else {
-                // If we did not redact using the key, we will redact the entire value if the key
-                // appears in it.
-                //
-                // $replace_groups = None: Replace entire value if match is inside
-                // $replace_groups = Some(GROUP_0): Replace entire match
-                apply_regex!(&key_pattern, None);
+            }
+            PatternType::Value => {
+                apply_regex!(regex, replace_behavior);
             }
         }
-        RuleType::Anything => {
-            if value.is_some() && should_redact_chunks {
-                apply_regex!(&ANYTHING_REGEX, Some(&*GROUP_0));
-            } else {
-                // The value is a container, @anything on a container can do nothing but delete.
-                meta.add_remark(Remark::new(RemarkType::Removed, rule.origin.clone()));
-                return Err(ProcessingAction::DeleteValueHard);
-            }
-        }
-
-        RuleType::Pattern(ref r) => apply_regex!(&r.pattern.0, r.replace_groups.as_ref()),
-        RuleType::Imei => apply_regex!(&IMEI_REGEX, Some(&*GROUP_0)),
-        RuleType::Mac => apply_regex!(&MAC_REGEX, Some(&*GROUP_0)),
-        RuleType::Uuid => apply_regex!(&UUID_REGEX, Some(&*GROUP_0)),
-        RuleType::Email => apply_regex!(&EMAIL_REGEX, Some(&*GROUP_0)),
-        RuleType::Ip => {
-            apply_regex!(&IPV4_REGEX, Some(&*GROUP_0));
-            apply_regex!(&IPV6_REGEX, Some(&*GROUP_1));
-        }
-        RuleType::Creditcard => apply_regex!(&CREDITCARD_REGEX, Some(&*GROUP_0)),
-        RuleType::Pemkey => apply_regex!(&PEM_KEY_REGEX, Some(&*GROUP_1)),
-        RuleType::UrlAuth => apply_regex!(&URL_AUTH_REGEX, Some(&*GROUP_1)),
-        RuleType::UsSsn => apply_regex!(&US_SSN_REGEX, Some(&*GROUP_0)),
-        RuleType::Userpath => apply_regex!(&PATH_REGEX, Some(&*GROUP_1)),
-
-        // These have been resolved by `collect_applications` and will never occur here.
-        RuleType::Alias(_) | RuleType::Multiple(_) => {}
     }
 
     Ok(())
@@ -375,7 +203,7 @@ fn apply_regex_to_chunks<'a>(
     chunks: Vec<Chunk<'a>>,
     rule: &RuleRef,
     regex: &Regex,
-    replace_groups: Option<&BTreeSet<u8>>,
+    replace_behavior: ReplaceBehavior,
 ) -> Vec<Chunk<'a>> {
     // NB: This function allocates the entire string and all chunks a second time. This means it
     // cannot reuse chunks and reallocates them. Ideally, we would be able to run the regex directly
@@ -430,8 +258,8 @@ fn apply_regex_to_chunks<'a>(
     let mut rv = Vec::with_capacity(replacement_chunks.len());
 
     for m in captures_iter {
-        match replace_groups {
-            Some(groups) => {
+        match replace_behavior {
+            ReplaceBehavior::Groups(ref groups) => {
                 for (idx, g) in m.iter().enumerate() {
                     if let Some(g) = g {
                         if groups.contains(&(idx as u8)) {
@@ -446,7 +274,7 @@ fn apply_regex_to_chunks<'a>(
                     }
                 }
             }
-            None => {
+            ReplaceBehavior::Value => {
                 process_text(&"", &mut rv, &mut replacement_chunks);
                 insert_replacement_chunks(&rule, &search_string, &mut rv);
                 pos = search_string.len();

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -1,0 +1,234 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use smallvec::{smallvec, SmallVec};
+
+use crate::pii::RuleType;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum PatternType {
+    /// Pattern-match on key and value
+    KeyValue,
+    /// Pattern-match on value only
+    Value,
+}
+
+/// What to do with regex matches once found.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReplaceBehavior {
+    /// Replace the entire string value (or just more than the match, depending on context).
+    Value,
+
+    /// Replace the following specific regex groups.
+    Groups(SmallVec<[u8; 1]>),
+}
+
+impl ReplaceBehavior {
+    /// Replace the entire string value (or just more than the match, depending on context).
+    pub fn replace_value() -> Self {
+        ReplaceBehavior::Value
+    }
+
+    /// Replace the entire match, equivalent to `ReplaceBehavior::Groups([0])`.
+    pub fn replace_match() -> Self {
+        ReplaceBehavior::replace_group(0)
+    }
+
+    /// Replace the following singular regex group.
+    pub fn replace_group(g: u8) -> Self {
+        ReplaceBehavior::Groups(smallvec![g])
+    }
+
+    /// Replace the following specific regex groups.
+    pub fn replace_groups(gs: SmallVec<[u8; 1]>) -> Self {
+        ReplaceBehavior::Groups(gs)
+    }
+}
+
+/// Return a list of regexes to apply for the given rule type.
+pub fn get_regex_for_rule_type(
+    ty: &RuleType,
+) -> SmallVec<[(PatternType, &Regex, ReplaceBehavior); 2]> {
+    let v = PatternType::Value;
+    let kv = PatternType::KeyValue;
+
+    match ty {
+        RuleType::RedactPair(ref redact_pair) => smallvec![(
+            kv,
+            &redact_pair.key_pattern.0,
+            ReplaceBehavior::replace_value()
+        )],
+        RuleType::Password => {
+            smallvec![(kv, &*PASSWORD_KEY_REGEX, ReplaceBehavior::replace_value())]
+        }
+        RuleType::Anything => smallvec![(v, &*ANYTHING_REGEX, ReplaceBehavior::replace_match())],
+        RuleType::Pattern(ref r) => {
+            let replace_behavior = match r.replace_groups {
+                Some(ref groups) => {
+                    ReplaceBehavior::replace_groups(groups.iter().copied().collect())
+                }
+                None => ReplaceBehavior::replace_match(),
+            };
+
+            smallvec![(v, &r.pattern.0, replace_behavior)]
+        }
+
+        RuleType::Imei => smallvec![(v, &*IMEI_REGEX, ReplaceBehavior::replace_match())],
+        RuleType::Mac => smallvec![(v, &*MAC_REGEX, ReplaceBehavior::replace_match())],
+        RuleType::Uuid => smallvec![(v, &*UUID_REGEX, ReplaceBehavior::replace_match())],
+        RuleType::Email => smallvec![(v, &*EMAIL_REGEX, ReplaceBehavior::replace_match())],
+        RuleType::Ip => smallvec![
+            (v, &*IPV4_REGEX, ReplaceBehavior::replace_match()),
+            (v, &*IPV6_REGEX, ReplaceBehavior::replace_group(1)),
+        ],
+        RuleType::Creditcard => {
+            smallvec![(v, &*CREDITCARD_REGEX, ReplaceBehavior::replace_match())]
+        }
+        RuleType::Pemkey => smallvec![(v, &*PEM_KEY_REGEX, ReplaceBehavior::replace_group(1))],
+        RuleType::UrlAuth => smallvec![(v, &*URL_AUTH_REGEX, ReplaceBehavior::replace_group(1))],
+        RuleType::UsSsn => smallvec![(v, &*US_SSN_REGEX, ReplaceBehavior::replace_match())],
+        RuleType::Userpath => smallvec![(v, &*PATH_REGEX, ReplaceBehavior::replace_group(1))],
+
+        // These ought to have been resolved in CompiledConfig
+        RuleType::Alias(_) | RuleType::Multiple(_) => smallvec![],
+    }
+}
+
+#[rustfmt::skip]
+macro_rules! ip {
+    (v4s) => { "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" };
+    (v4a) => { concat!(ip!(v4s), "\\.", ip!(v4s), "\\.", ip!(v4s), "\\.", ip!(v4s)) };
+    (v6s) => { "[0-9a-fA-F]{1,4}" };
+}
+
+#[rustfmt::skip]
+lazy_static! {
+    pub static ref ANYTHING_REGEX: Regex = Regex::new(".*").unwrap();
+    static ref IMEI_REGEX: Regex = Regex::new(
+        r#"(?x)
+            \b
+                (\d{2}-?
+                 \d{6}-?
+                 \d{6}-?
+                 \d{1,2})
+            \b
+        "#
+    ).unwrap();
+    static ref MAC_REGEX: Regex = Regex::new(
+        r#"(?x)
+            \b([[:xdigit:]]{2}[:-]){5}[[:xdigit:]]{2}\b
+        "#
+    ).unwrap();
+    static ref UUID_REGEX: Regex = Regex::new(
+        r#"(?ix)
+            \b
+            [a-z0-9]{8}-?
+            [a-z0-9]{4}-?
+            [a-z0-9]{4}-?
+            [a-z0-9]{4}-?
+            [a-z0-9]{12}
+            \b
+        "#
+    ).unwrap();
+    static ref EMAIL_REGEX: Regex = Regex::new(
+        r#"(?x)
+            \b
+                [a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+
+                @
+                [a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*
+            \b
+        "#
+    ).unwrap();
+    static ref IPV4_REGEX: Regex = Regex::new(concat!("\\b", ip!(v4a), "\\b")).unwrap();
+    static ref IPV6_REGEX: Regex = Regex::new(
+        concat!(
+            "(?i)(?:[\\s]|[[:punct:]]|^)(",
+                "(", ip!(v6s), ":){7}", ip!(v6s), "|",
+                "(", ip!(v6s), ":){1,7}:|",
+                "(", ip!(v6s), ":){1,6}::", ip!(v6s), "|",
+                "(", ip!(v6s), ":){1,5}:(:", ip!(v6s), "){1,2}|",
+                "(", ip!(v6s), ":){1,4}:(:", ip!(v6s), "){1,3}|",
+                "(", ip!(v6s), ":){1,3}:(:", ip!(v6s), "){1,4}|",
+                "(", ip!(v6s), ":){1,2}:(:", ip!(v6s), "){1,5}|",
+                ip!(v6s), ":((:", ip!(v6s), "){1,6})|",
+                ":((:", ip!(v6s), "){1,7}|:)|",
+                "fe80:(:", ip!(v6s), "){0,4}%[0-9a-zA-Z]{1,}",
+                "::(ffff(:0{1,4}){0,1}:){0,1}", ip!(v4a), "|",
+                "(", ip!(v6s), ":){1,4}:", ip!(v4a),
+            ")([\\s]|[[:punct:]]|$)",
+        )
+    ).unwrap();
+
+    // http://www.richardsramblings.com/regex/credit-card-numbers/
+    // Re-formatted with comments and dashes support
+    //
+    // Why so complicated? Because creditcard numbers are variable length and we do not want to
+    // strip any number that just happens to have the same length.
+    static ref CREDITCARD_REGEX: Regex = Regex::new(
+        r#"(?x)
+        \b(
+            (?:  # vendor specific prefixes
+                  3[47]\d      # amex (no 13-digit version) (length: 15)
+                | 4\d{3}       # visa (16-digit version only)
+                | 5[1-5]\d\d   # mastercard
+                | 65\d\d       # discover network (subset)
+                | 6011         # discover network (subset)
+            )
+
+            # "wildcard" remainder (allowing dashes in every position because of variable length)
+            ([-\s]?\d){12}
+        )\b
+        "#
+    ).unwrap();
+    static ref PATH_REGEX: Regex = Regex::new(
+        r#"(?ix)
+            (?:
+                (?:
+                    \b(?:[a-zA-Z]:[\\/])?
+                    (?:users|home|documents and settings|[^/\\]+[/\\]profiles)[\\/]
+                ) | (?:
+                    /(?:home|users)/
+                )
+            )
+            (
+                [^/\\]+
+            )
+        "#
+    ).unwrap();
+    static ref PEM_KEY_REGEX: Regex = Regex::new(
+        r#"(?sx)
+            (?:
+                -----
+                BEGIN[A-Z\ ]+(?:PRIVATE|PUBLIC)\ KEY
+                -----
+                [\t\ ]*\r?\n?
+            )
+            (.+?)
+            (?:
+                \r?\n?
+                -----
+                END[A-Z\ ]+(?:PRIVATE|PUBLIC)\ KEY
+                -----
+            )
+        "#
+    ).unwrap();
+    static ref URL_AUTH_REGEX: Regex = Regex::new(
+        r#"(?x)
+            \b(?:
+                (?:[a-z0-9+-]+:)?//
+                ([a-zA-Z0-9%_.-]+(?::[a-zA-Z0-9%_.-]+)?)
+            )@
+        "#
+    ).unwrap();
+    static ref US_SSN_REGEX: Regex = Regex::new(
+        r#"(?x)
+            \b(
+                [0-9]{3}-
+                [0-9]{2}-
+                [0-9]{4}
+            )\b
+        "#
+    ).unwrap();
+    static ref PASSWORD_KEY_REGEX: Regex = Regex::new(
+        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)"
+    ).unwrap();
+}

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -102,6 +102,7 @@ impl SelectorSpec {
                         SelectorPathItem::Type(ty) => match ty {
                             // "Generic" JSON value types cannot be part of a specific path
                             ValueType::String
+                            | ValueType::Binary
                             | ValueType::Number
                             | ValueType::Boolean
                             | ValueType::DateTime

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -102,7 +102,6 @@ impl SelectorSpec {
                         SelectorPathItem::Type(ty) => match ty {
                             // "Generic" JSON value types cannot be part of a specific path
                             ValueType::String
-                            | ValueType::Binary
                             | ValueType::Number
                             | ValueType::Boolean
                             | ValueType::DateTime


### PR DESCRIPTION
Move regex mapping into separate module. We need to share this logic with attachment scrubbing once it's there.

Also change usage of `Option<BTreeSet<u8>>` into dedicated enum.