### PR TITLE
feat(config): Make the connection timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Add the `http.connection_timeout` configuration option to adjust the connection and SSL handshake timeout. ([#688](https://github.com/getsentry/relay/pull/688))
+
 **Bug Fixes**:
 
 - Reuse connections for upstream event submission requests when the server supports connection keepalive. Relay did not consume the response body of all requests, which caused it to reopen a new connection for every event. ([#680](https://github.com/getsentry/relay/pull/680))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Add the `http.connection_timeout` configuration option to adjust the connection and SSL handshake timeout. ([#688](https://github.com/getsentry/relay/pull/688))
+- Add the `http.connection_timeout` configuration option to adjust the connection and SSL handshake timeout. The default connect timeout is now increased from 1s to 3s. ([#688](https://github.com/getsentry/relay/pull/688))
 
 **Bug Fixes**:
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -72,6 +72,20 @@ Set various network-related settings.
 
 Timeout for upstream requests in seconds.
 
+This timeout covers the time from sending the request until receiving response
+headers. Neither the connection process and handshakes, nor reading the response
+body is covered in this timeout.
+
+### `http.connection_timeout`
+
+*Integer, default: `1`*
+
+Timeout for establishing connections with the upstream in seconds.
+
+This includes SSL handshakes. Relay reuses connections when the upstream
+supports connection keep-alive. Connections are retained for a maximum 75
+seconds, or 15 seconds of inactivity.
+
 ### `http.max_retry_interval`
 
 *Integer, default: `60`*

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -78,7 +78,7 @@ body is covered in this timeout.
 
 ### `http.connection_timeout`
 
-*Integer, default: `1`*
+*Integer, default: `3`*
 
 Timeout for establishing connections with the upstream in seconds.
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -509,8 +509,10 @@ impl Default for Limits {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 struct Http {
-    /// Timeout for upstream requests in seconds.
+    /// Timeout for upstream requests in seconds (excluding connecting).
     timeout: u32,
+    /// Timeout for establishing connections with the upstream in seconds.
+    connection_timeout: u32,
     /// Maximum interval between failed request retries in seconds.
     max_retry_interval: u32,
     /// The custom HTTP Host header to send to the upstream.
@@ -521,6 +523,7 @@ impl Default for Http {
     fn default() -> Self {
         Http {
             timeout: 5,
+            connection_timeout: 1,
             max_retry_interval: 60,
             host_header: None,
         }
@@ -1171,6 +1174,11 @@ impl Config {
     /// Returns the default timeout for all upstream HTTP requests.
     pub fn http_timeout(&self) -> Duration {
         Duration::from_secs(self.values.http.timeout.into())
+    }
+
+    /// Returns the connection timeout for all upstream HTTP requests.
+    pub fn http_connection_timeout(&self) -> Duration {
+        Duration::from_secs(self.values.http.connection_timeout.into())
     }
 
     /// Returns the failed upstream request retry interval.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -509,9 +509,16 @@ impl Default for Limits {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 struct Http {
-    /// Timeout for upstream requests in seconds (excluding connecting).
+    /// Timeout for upstream requests in seconds.
+    ///
+    /// This timeout covers the time from sending the request until receiving response headers.
+    /// Neither the connection process and handshakes, nor reading the response body is covered in
+    /// this timeout.
     timeout: u32,
     /// Timeout for establishing connections with the upstream in seconds.
+    ///
+    /// This includes SSL handshakes. Relay reuses connections when the upstream supports connection
+    /// keep-alive. Connections are retained for a maximum 75 seconds, or 15 seconds of inactivity.
     connection_timeout: u32,
     /// Maximum interval between failed request retries in seconds.
     max_retry_interval: u32,

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -530,7 +530,7 @@ impl Default for Http {
     fn default() -> Self {
         Http {
             timeout: 5,
-            connection_timeout: 1,
+            connection_timeout: 3,
             max_retry_interval: 60,
             host_header: None,
         }

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -198,6 +198,7 @@ impl UpstreamRelay {
             //   1. Have own connection pool for `store` requests
             //   2. Buffer up/queue/synchronize events before creating the request
             .wait_timeout(self.config.event_buffer_expiry())
+            .conn_timeout(self.config.http_connection_timeout())
             // This is the timeout after wait + connect.
             .timeout(self.config.http_timeout())
             .map_err(UpstreamRequestError::SendFailed)


### PR DESCRIPTION
Adds a configuration option for the connection timeout, covering establishing the connection and SSL handshakes. This defaults to 3s, which corresponds to the default TCP packet retransmission window.

For more information, see [`requests` docs](https://requests.readthedocs.io/en/master/user/advanced/#timeouts) and [RFC 2988](https://www.hjp.at/doc/rfc/rfc2988.txt).