### PR TITLE
fix(server): Allow keep-alive for forwarded requests

### DIFF
--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -95,8 +95,7 @@ fn forward_upstream(request: &HttpRequest<ServiceState>) -> ResponseFuture<HttpR
         .method(request.method().clone())
         .uri(upstream.get_url(path_and_query))
         .set_header("Host", host_header)
-        .set_header("X-Forwarded-For", ForwardedFor::from(request))
-        .set_header("Connection", "close");
+        .set_header("X-Forwarded-For", ForwardedFor::from(request));
 
     ForwardBody::new(request, limit)
         .map_err(Error::from)


### PR DESCRIPTION
The connection close header was introduced in https://github.com/getsentry/relay/commit/36b926097866bd0065f1b38ae179942c09905c57, but there is no indication that this actually fixes forwarding behavior. In the meanwhile, we have fixed various cases in which the request and response bodies were not consumed properly, which could have lead to dropped connections.