### PR TITLE
fix(server): Consume payloads from error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bug Fixes**:
 
-- Reuse connections for upstream event submission requests when the server supports connection keepalive. Relay did not consume the response body of all requests, which caused it to reopen a new connection for every event. ([#680](https://github.com/getsentry/relay/pull/680))
+- Reuse connections for upstream event submission requests when the server supports connection keepalive. Relay did not consume the response body of all requests, which caused it to reopen a new connection for every event. ([#680](https://github.com/getsentry/relay/pull/680), [#695](https://github.com/getsentry/relay/pull/695))
 
 **Internal**:
 

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -10,7 +10,7 @@ use actix_web::error::{JsonPayloadError, PayloadError};
 use actix_web::http::{header, Method, StatusCode};
 use actix_web::{Error as ActixError, HttpMessage};
 use failure::Fail;
-use futures::prelude::*;
+use futures::{future, prelude::*};
 use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -22,7 +22,7 @@ use relay_quotas::{
     DataCategories, QuotaScope, RateLimit, RateLimitScope, RateLimits, RetryAfter, Scoping,
 };
 
-use crate::utils;
+use crate::utils::{self, ApiErrorResponse};
 
 #[derive(Fail, Debug)]
 pub enum UpstreamRequestError {
@@ -42,13 +42,13 @@ pub enum UpstreamRequestError {
     BuildFailed(ActixError),
 
     #[fail(display = "failed to receive response from upstream")]
-    ResponseFailed(#[cause] PayloadError),
+    PayloadFailed(#[cause] PayloadError),
 
     #[fail(display = "upstream requests rate limited")]
     RateLimited(UpstreamRateLimits),
 
     #[fail(display = "upstream request returned error {}", _0)]
-    ResponseError(StatusCode),
+    ResponseError(StatusCode, #[cause] ApiErrorResponse),
 }
 
 /// Represents the current auth state.
@@ -133,6 +133,54 @@ impl UpstreamRateLimits {
     }
 }
 
+/// Handles a response returned from the upstream.
+///
+/// If the response indicates success via 2XX status codes, `Ok(response)` is returned. Otherwise,
+/// the response is consumed and an error is returned. Depending on the status code and details
+/// provided in the payload, one of the following errors can be returned:
+///
+///  1. `RateLimited` for a `429` status code.
+///  2. `ResponseError` in all other cases.
+fn handle_response(
+    response: ClientResponse,
+) -> ResponseFuture<ClientResponse, UpstreamRequestError> {
+    let status = response.status();
+
+    if status.is_success() {
+        return Box::new(future::ok(response));
+    }
+
+    // At this point, we consume the ClientResponse. This means we need to consume the response
+    // payload stream, regardless of the status code. Parsing the JSON body may fail, which is a
+    // non-fatal failure as the upstream is not expected to always include a valid JSON response.
+    let future = response.json().then(move |json_result| {
+        if response.status() == StatusCode::TOO_MANY_REQUESTS {
+            let headers = response.headers();
+            let retry_after = headers
+                .get(header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok());
+
+            let rate_limits = headers
+                .get_all(utils::RATE_LIMITS_HEADER)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .join(", ");
+
+            let upstream_limits = UpstreamRateLimits::new()
+                .retry_after(retry_after)
+                .rate_limits(rate_limits);
+
+            Err(UpstreamRequestError::RateLimited(upstream_limits))
+        } else {
+            // Coerce the result into an empty `ApiErrorResponse` if parsing JSON did not succeed.
+            let api_response = json_result.unwrap_or_default();
+            Err(UpstreamRequestError::ResponseError(status, api_response))
+        }
+    });
+
+    Box::new(future)
+}
+
 pub struct UpstreamRelay {
     backoff: RetryBackoff,
     config: Arc<Config>,
@@ -202,28 +250,7 @@ impl UpstreamRelay {
             // This is the timeout after wait + connect.
             .timeout(self.config.http_timeout())
             .map_err(UpstreamRequestError::SendFailed)
-            .and_then(|response| match response.status() {
-                StatusCode::TOO_MANY_REQUESTS => {
-                    let headers = response.headers();
-                    let retry_after = headers
-                        .get(header::RETRY_AFTER)
-                        .and_then(|v| v.to_str().ok());
-
-                    let rate_limits = headers
-                        .get_all(utils::RATE_LIMITS_HEADER)
-                        .iter()
-                        .filter_map(|v| v.to_str().ok())
-                        .join(", ");
-
-                    let upstream_limits = UpstreamRateLimits::new()
-                        .retry_after(retry_after)
-                        .rate_limits(rate_limits);
-
-                    Err(UpstreamRequestError::RateLimited(upstream_limits))
-                }
-                code if !code.is_success() => Err(UpstreamRequestError::ResponseError(code)),
-                _ => Ok(response),
-            });
+            .and_then(handle_response);
 
         Box::new(future)
     }
@@ -386,7 +413,7 @@ impl ResponseTransformer for () {
         let future = response
             .payload()
             .for_each(|_| Ok(()))
-            .map_err(UpstreamRequestError::ResponseFailed);
+            .map_err(UpstreamRequestError::PayloadFailed);
 
         Box::new(future)
     }

--- a/relay-server/src/utils/api.rs
+++ b/relay-server/src/utils/api.rs
@@ -4,11 +4,12 @@ use failure::Fail;
 use serde::{Deserialize, Serialize};
 
 /// An error response from an api.
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug, Fail)]
 pub struct ApiErrorResponse {
+    #[serde(default)]
     detail: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    causes: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    causes: Vec<String>,
 }
 
 impl ApiErrorResponse {
@@ -16,7 +17,7 @@ impl ApiErrorResponse {
     pub fn with_detail<S: AsRef<str>>(s: S) -> ApiErrorResponse {
         ApiErrorResponse {
             detail: Some(s.as_ref().to_string()),
-            causes: None,
+            causes: Vec::new(),
         }
     }
 
@@ -33,11 +34,7 @@ impl ApiErrorResponse {
 
         ApiErrorResponse {
             detail: Some(messages.remove(0)),
-            causes: if messages.is_empty() {
-                None
-            } else {
-                Some(messages)
-            },
+            causes: messages,
         }
     }
 }


### PR DESCRIPTION
Consumes the response payload from upstream requests with a non-200 status code. Additionally, this also retains the error details submitted by the upstream and renders them as cause of failure.

Before:

```
authentication encountered error: upstream request returned error 403 Forbidden
```

After:

```
authentication encountered error: upstream request returned error 403 Forbidden
  caused by: Relay is not allowed to register
```