### PR TITLE
ref(server): Do not retry auth on client errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug Fixes**:
 
 - Reuse connections for upstream event submission requests when the server supports connection keepalive. Relay did not consume the response body of all requests, which caused it to reopen a new connection for every event. ([#680](https://github.com/getsentry/relay/pull/680), [#695](https://github.com/getsentry/relay/pull/695))
+- Do not retry authentication with the upstream when a client error is reported (status code 4XX). ([#696](https://github.com/getsentry/relay/pull/696))
 
 **Internal**:
 


### PR DESCRIPTION
Do not retry client errors including authentication failures since client errors are usually permanent. This allows the upstream to reject unsupported Relays without infinite retries.

This prepares for rejecting unsupported Relays during authentication.