### PR TITLE
feat(auth): Supply a version during auth for compatibility checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add the `http.connection_timeout` configuration option to adjust the connection and SSL handshake timeout. The default connect timeout is now increased from 1s to 3s. ([#688](https://github.com/getsentry/relay/pull/688))
+- Supply Relay's version during authentication and check if this Relay is still supported. An error message prompting to upgrade Relay will be supplied if Relay is unsupported. ([#697](https://github.com/getsentry/relay/pull/697))
 
 **Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Always create a spans array for transactions in normalization. ([#667](https://github.com/getsentry/relay/pull/667))
 - Retain the full span description in transaction events instead of trimming it. ([#674](https://github.com/getsentry/relay/pull/674))
 - Add "HubSpot Crawler" to the list of web crawlers for inbound filters. ([#693](https://github.com/getsentry/relay/pull/693))
+- Add `is_version_supported` to check for Relay compatibility during authentication. ([#697](https://github.com/getsentry/relay/pull/697))
 
 ## 0.5.11
 

--- a/py/sentry_relay/auth.py
+++ b/py/sentry_relay/auth.py
@@ -20,6 +20,7 @@ __all__ = [
     "create_register_challenge",
     "get_register_response_relay_id",
     "validate_register_response",
+    "is_version_supported",
 ]
 
 
@@ -121,3 +122,11 @@ def validate_register_response(public_key, data, signature, max_age=60 * 15):
 
     response = json.loads(decode_str(response_json, free=True))
     return {"relay_id": uuid.UUID(response["relay_id"]), "token": response["token"]}
+
+
+def is_version_supported(version):
+    """
+    Checks if the provided Relay version is still compatible with this library. The version can be
+    ``None``, in which case a legacy Relay is assumed.
+    """
+    return rustcall(lib.relay_version_supported, encode_str(version or ""))

--- a/py/tests/test_auth.py
+++ b/py/tests/test_auth.py
@@ -49,3 +49,11 @@ def test_register_response():
         == "iiWGyrgBZDOOclHjnQILU6zHL1Mjl-yXUpjHOIaArowhrZ2djSUkzPuH_l7UF6sKYpbKD4C2nZWCBhuULLJE-w"
     )
     assert resp["relay_id"] == uuid.UUID("2ffe6ba6-3a27-4936-b30f-d6944a4f1216")
+
+
+def test_is_version_supported():
+    assert sentry_relay.is_version_supported("99.99.99")
+
+    # These can be updated when deprecating legacy versions:
+    assert sentry_relay.is_version_supported("")
+    assert sentry_relay.is_version_supported(None)

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -8,6 +8,7 @@ version = "20.7.2"
 edition = "2018"
 license-file = "../LICENSE"
 publish = false
+build = "build.rs"
 
 [dependencies]
 base64 = "0.10.1"

--- a/relay-auth/build.rs
+++ b/relay-auth/build.rs
@@ -1,0 +1,24 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("constants.gen.rs");
+    let mut f = File::create(&dest_path).unwrap();
+
+    macro_rules! write_version {
+        ($component:literal) => {{
+            let value = env::var(concat!("CARGO_PKG_VERSION_", $component)).unwrap();
+            writeln!(f, "pub const VERSION_{}: u8 = {};", $component, value).unwrap();
+        }};
+    }
+
+    write_version!("MAJOR");
+    write_version!("MINOR");
+    write_version!("PATCH");
+
+    println!("cargo:rerun-if-changed=build.rs\n");
+    println!("cargo:rerun-if-changed=Cargo.toml\n");
+}

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
 
@@ -9,9 +10,103 @@ use sha2::Sha512;
 
 use relay_common::Uuid;
 
-/// Alias for relay IDs (UUIDs)
+include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
+
+/// The latest Relay version known to this Relay. This is the current version.
+const LATEST_VERSION: RelayVersion = RelayVersion::new(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+
+/// The oldest downstream Relay version still supported by this Relay.
+const OLDEST_VERSION: RelayVersion = RelayVersion::new(0, 0, 0); // support all
+
+/// Alias for relay IDs (UUIDs).
 pub type RelayId = Uuid;
 
+/// The version of a Relay.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RelayVersion {
+    major: u8,
+    minor: u8,
+    patch: u8,
+}
+
+impl RelayVersion {
+    /// Returns the current Relay version.
+    pub fn current() -> Self {
+        LATEST_VERSION
+    }
+
+    /// Returns the oldest compatible Relay version.
+    ///
+    /// Relays older than this cannot authenticate with this Relay. It is possible for newer Relays
+    /// to authenticate.
+    pub fn oldest() -> Self {
+        OLDEST_VERSION
+    }
+
+    /// Creates a new version with the given components.
+    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Returns `true` if this version is still supported.
+    pub fn supported(self) -> bool {
+        self >= Self::oldest()
+    }
+
+    /// Returns `true` if this version is older than the current version.
+    pub fn outdated(self) -> bool {
+        self < Self::current()
+    }
+}
+
+impl fmt::Display for RelayVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Fail)]
+#[fail(display = "hello")]
+pub struct ParseRelayVersionError;
+
+impl FromStr for RelayVersion {
+    type Err = ParseRelayVersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s
+            .split('.')
+            .map(|s| s.parse().map_err(|_| ParseRelayVersionError));
+
+        let major = iter.next().ok_or(ParseRelayVersionError)??;
+        let minor = iter.next().ok_or(ParseRelayVersionError)??;
+        let patch = iter.next().ok_or(ParseRelayVersionError)??;
+
+        Ok(Self::new(major, minor, patch))
+    }
+}
+
+impl<'de> Deserialize<'de> for RelayVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let string = Cow::<str>::deserialize(deserializer)?;
+        Ok(string.parse().map_err(serde::de::Error::custom)?)
+    }
+}
+
+impl Serialize for RelayVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
 /// Raised if a key could not be parsed.
 #[derive(Debug, Fail, PartialEq, Eq, Hash)]
 pub enum KeyParseError {
@@ -338,6 +433,8 @@ pub fn generate_key_pair() -> (SecretKey, PublicKey) {
 pub struct RegisterRequest {
     relay_id: RelayId,
     public_key: PublicKey,
+    #[serde(default)]
+    version: RelayVersion,
 }
 
 impl RegisterRequest {
@@ -346,6 +443,7 @@ impl RegisterRequest {
         RegisterRequest {
             relay_id: *relay_id,
             public_key: public_key.clone(),
+            version: RelayVersion::current(),
         }
     }
 
@@ -542,4 +640,41 @@ fn test_registration() {
         .unwrap();
     assert_eq!(reg_resp.relay_id(), &relay_id);
     assert_eq!(reg_resp.token(), challenge.token());
+}
+
+#[test]
+fn test_relay_version_current() {
+    assert_eq!(
+        env!("CARGO_PKG_VERSION"),
+        RelayVersion::current().to_string()
+    );
+}
+
+#[test]
+fn test_relay_version_oldest() {
+    // Regression test against unintentional changes.
+    assert_eq!("0.0.0", RelayVersion::oldest().to_string());
+}
+
+#[test]
+fn test_relay_version_oldest_supported() {
+    assert!(RelayVersion::oldest().supported());
+}
+
+#[test]
+fn test_relay_version_any_supported() {
+    // Every version must be supported at the moment.
+    // This test can be changed when dropping support for older versions.
+    assert!(RelayVersion::default().supported());
+}
+
+#[test]
+fn test_relay_version_from_str() {
+    let expected = RelayVersion {
+        major: 20,
+        minor: 7,
+        patch: 0,
+    };
+
+    assert_eq!(expected, "20.7.0".parse().unwrap())
 }

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -78,7 +78,7 @@ impl FromStr for RelayVersion {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut iter = s
-            .split('.')
+            .split(&['.', '-'][..])
             .map(|s| s.parse().map_err(|_| ParseRelayVersionError));
 
         let major = iter.next().ok_or(ParseRelayVersionError)??;
@@ -657,6 +657,14 @@ fn test_relay_version_oldest() {
 }
 
 #[test]
+fn test_relay_version_parse() {
+    assert_eq!(
+        RelayVersion::new(20, 7, 0),
+        "20.7.0-beta.0".parse().unwrap()
+    );
+}
+
+#[test]
 fn test_relay_version_oldest_supported() {
     assert!(RelayVersion::oldest().supported());
 }
@@ -670,11 +678,5 @@ fn test_relay_version_any_supported() {
 
 #[test]
 fn test_relay_version_from_str() {
-    let expected = RelayVersion {
-        major: 20,
-        minor: 7,
-        patch: 0,
-    };
-
-    assert_eq!(expected, "20.7.0".parse().unwrap())
+    assert_eq!(RelayVersion::new(20, 7, 0), "20.7.0".parse().unwrap());
 }

--- a/relay-cabi/Cargo.lock
+++ b/relay-cabi/Cargo.lock
@@ -1014,7 +1014,6 @@ dependencies = [
  "chrono",
  "cookie",
  "debugid",
- "derive_more",
  "dynfmt",
  "failure",
  "hmac",
@@ -1028,7 +1027,6 @@ dependencies = [
  "regex",
  "relay-common",
  "relay-general-derive",
- "schemars",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1070,31 +1068,6 @@ name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
-
-[[package]]
-name = "schemars"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
-dependencies = [
- "chrono",
- "schemars_derive",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
-dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
- "serde_derive_internals",
- "syn 1.0.17",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1161,17 +1134,6 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.3",
  "syn 1.0.33",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
-dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
- "syn 1.0.17",
 ]
 
 [[package]]

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -481,4 +481,9 @@ RelayStr relay_validate_register_response(const RelayPublicKey *pk,
                                           const RelayStr *signature,
                                           uint32_t max_age);
 
+/**
+ * Returns true if the given version is supported by this library.
+ */
+bool relay_version_supported(const RelayStr *version);
+
 #endif /* RELAY_H_INCLUDED */

--- a/relay-cabi/src/auth.rs
+++ b/relay-cabi/src/auth.rs
@@ -195,6 +195,11 @@ ffi_fn! {
 ffi_fn! {
     /// Returns true if the given version is supported by this library.
     unsafe fn relay_version_supported(version: &RelayStr) -> Result<bool> {
-        Ok(version.as_str().parse::<RelayVersion>()?.supported())
+        let relay_version = match version.as_str() {
+            "" => RelayVersion::default(),
+            s => s.parse::<RelayVersion>()?,
+        };
+
+        Ok(relay_version.supported())
     }
 }

--- a/relay-cabi/src/auth.rs
+++ b/relay-cabi/src/auth.rs
@@ -2,7 +2,8 @@ use chrono::Duration;
 use serde::Serialize;
 
 use relay_auth::{
-    generate_key_pair, generate_relay_id, PublicKey, RegisterRequest, RegisterResponse, SecretKey,
+    generate_key_pair, generate_relay_id, PublicKey, RegisterRequest, RegisterResponse,
+    RelayVersion, SecretKey,
 };
 use relay_common::Uuid;
 
@@ -188,5 +189,12 @@ ffi_fn! {
             relay_id: *reg_resp.relay_id(),
             token: reg_resp.token().to_string(),
         })?))
+    }
+}
+
+ffi_fn! {
+    /// Returns true if the given version is supported by this library.
+    unsafe fn relay_version_supported(version: &RelayStr) -> Result<bool> {
+        Ok(version.as_str().parse::<RelayVersion>()?.supported())
     }
 }


### PR DESCRIPTION
Adds a version payload to the register challenge request so that the upstream can choose to reject outdated versions. The current version is inferred from the crate version. 

Currently, all versions are supported. Legacy Relays that do not send a version are coerced to `0.0.0`.