### PR TITLE
fix(doc): Avoid unnecessary line-wrapping in schema docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
+
+[[package]]
 name = "dynfmt"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,7 +2706,6 @@ dependencies = [
  "relay-config",
  "relay-general",
  "relay-server",
- "schemars",
  "sentry",
  "serde",
  "serde_json",
@@ -3029,11 +3034,11 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77ed66abed6954aabf6a3e31a84706bedbf93750d267e92ef4a6d90bbd6a61"
+version = "0.8.0-alpha-4"
+source = "git+https://github.com/untitaker/schemars?branch=preserve-formatting#54810054ab7d85763090c07c4e498d9603814892"
 dependencies = [
  "chrono",
+ "dyn-clone",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -3042,9 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11af7a475c9ee266cfaa9e303a47c830ebe072bf3101ab907a7b7b9d816fa01d"
+version = "0.8.0-alpha-4"
+source = "git+https://github.com/untitaker/schemars?branch=preserve-formatting#54810054ab7d85763090c07c4e498d9603814892"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ jsonschema = ["relay-general/jsonschema"]
 [profile.release]
 debug = true
 
+# Direct dependencies of the main application in `src/`
 [dependencies]
 chrono = "0.4.11"
 clap = { version = "2.33.0", default-features = false, features = ["wrap_help"] }
@@ -47,7 +48,6 @@ relay-config = { path = "relay-config" }
 relay-server = { path = "relay-server" }
 relay-general = { path = "relay-general" }
 sentry = { version = "0.18.0", features = ["with_debug_meta"] }
-schemars = { version = "0.7.1", features = ["uuid", "chrono"] }
 serde = "1.0.114"
 serde_json = "1.0.55"
 hostname = "0.3.1"

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -22,7 +22,7 @@ lru = "0.4.0"
 parking_lot = "0.10.0"
 regex = "1.3.9"
 sentry-types = "0.14.1"
-schemars = { version = "0.7.1", features = ["uuid", "chrono"], optional = true }
+schemars = { version = "0.8.0-alpha-4", git = "https://github.com/untitaker/schemars", branch = "preserve-formatting", features = ["uuid", "chrono"], optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 
 [features]

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -35,7 +35,7 @@ uaparser = { version = "0.3.3", optional = true }
 url = "2.1.1"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 relay-common = { path = "../relay-common" }
-schemars = { version = "0.7.1", features = ["uuid", "chrono"], optional = true }
+schemars = { version = "0.8.0-alpha-4", git = "https://github.com/untitaker/schemars", branch = "preserve-formatting", features = ["uuid", "chrono"], optional = true }
 
 [dev-dependencies]
 difference = "2.0.0"

--- a/relay-general/derive/src/jsonschema.rs
+++ b/relay-general/derive/src/jsonschema.rs
@@ -25,7 +25,11 @@ pub fn derive_jsonschema(mut s: synstructure::Structure<'_>) -> TokenStream {
             let field_attrs = parse_field_attributes(index, &bi.ast(), &mut is_tuple_struct);
             let name = field_attrs.field_name;
 
-            fields = quote!(#fields #[schemars(rename = #name)]);
+            fields = quote! {
+                #fields
+                #[schemars_preserve_doc_formatting]
+                #[schemars(rename = #name)]
+            };
 
             if !field_attrs.required.unwrap_or(false) {
                 fields = quote!(#fields #[schemars(default = "__schemars_null")]);
@@ -80,6 +84,7 @@ pub fn derive_jsonschema(mut s: synstructure::Structure<'_>) -> TokenStream {
                 #[derive(schemars::JsonSchema)]
                 #[cfg_attr(feature = "jsonschema", schemars(untagged))]
                 #[cfg_attr(feature = "jsonschema", schemars(deny_unknown_fields))]
+                #[schemars_preserve_doc_formatting]
                 #attrs
                 enum Helper {
                     #arms

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -5,7 +5,7 @@ expression: event_json_schema()
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Event",
-  "description": "The sentry v7 event structure.",
+  "description": " The sentry v7 event structure.",
   "anyOf": [
     {
       "type": "object",
@@ -103,7 +103,7 @@ expression: event_json_schema()
           }
         },
         "event_id": {
-          "description": "Unique identifier of this event.\n\nHexadecimal string representing a uuid4 value. The length is exactly 32 characters. Dashes are not allowed. Has to be lowercase.\n\nEven though this field is backfilled on the server with a new uuid4, it is strongly recommended to generate that uuid4 clientside. There are some features like user feedback which are easier to implement that way, and debugging in case events get lost in your Sentry installation is also easier.\n\nExample:\n\n```json { \"event_id\": \"fc6d8c0c43fc4630ad850ee518f1b9d0\" } ```",
+          "description": " Unique identifier of this event.\n\n Hexadecimal string representing a uuid4 value. The length is exactly 32 characters. Dashes\n are not allowed. Has to be lowercase.\n\n Even though this field is backfilled on the server with a new uuid4, it is strongly\n recommended to generate that uuid4 clientside. There are some features like user feedback\n which are easier to implement that way, and debugging in case events get lost in your\n Sentry installation is also easier.\n\n Example:\n\n ```json\n {\n   \"event_id\": \"fc6d8c0c43fc4630ad850ee518f1b9d0\"\n }\n ```",
           "default": null,
           "anyOf": [
             {
@@ -443,7 +443,7 @@ expression: event_json_schema()
       "type": "string"
     },
     "AppContext": {
-      "description": "Application information.\n\nApp context describes the application. As opposed to the runtime, this is the actual application that was running and carries metadata about the current session.",
+      "description": " Application information.\n\n App context describes the application. As opposed to the runtime, this is the actual\n application that was running and carries metadata about the current session.",
       "anyOf": [
         {
           "type": "object",
@@ -473,7 +473,7 @@ expression: event_json_schema()
               ]
             },
             "app_start_time": {
-              "description": "Start time of the app.\n\nFormatted UTC timestamp when the user started the application.",
+              "description": " Start time of the app.\n\n Formatted UTC timestamp when the user started the application.",
               "default": null,
               "type": [
                 "string",
@@ -509,7 +509,7 @@ expression: event_json_schema()
       ]
     },
     "AppleDebugImage": {
-      "description": "Legacy apple debug images (MachO).\n\nThis was also used for non-apple platforms with similar debug setups.",
+      "description": " Legacy apple debug images (MachO).\n\n This was also used for non-apple platforms with similar debug setups.",
       "anyOf": [
         {
           "type": "object",
@@ -581,7 +581,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Path and name of the debug image (required).",
+              "description": " Path and name of the debug image (required).",
               "type": [
                 "string",
                 "null"
@@ -600,7 +600,7 @@ expression: event_json_schema()
       ]
     },
     "Breadcrumb": {
-      "description": "The Breadcrumbs Interface specifies a series of application events, or \"breadcrumbs\", that occurred before an event.\n\nAn event may contain one or more breadcrumbs in an attribute named `breadcrumbs`. The entries are ordered from oldest to newest. Consequently, the last entry in the list should be the last entry before the event occurred.\n\nWhile breadcrumb attributes are not strictly validated in Sentry, a breadcrumb is most useful when it includes at least a `timestamp` and `type`, `category` or `message`. The rendering of breadcrumbs in Sentry depends on what is provided.\n\nThe following example illustrates the breadcrumbs part of the event payload and omits other attributes for simplicity.\n\n```json { \"breadcrumbs\": { \"values\": [ { \"timestamp\": \"2016-04-20T20:55:53.845Z\", \"message\": \"Something happened\", \"category\": \"log\", \"data\": { \"foo\": \"bar\", \"blub\": \"blah\" } }, { \"timestamp\": \"2016-04-20T20:55:53.847Z\", \"type\": \"navigation\", \"data\": { \"from\": \"/login\", \"to\": \"/dashboard\" } } ] } } ```",
+      "description": " The Breadcrumbs Interface specifies a series of application events, or \"breadcrumbs\", that\n occurred before an event.\n\n An event may contain one or more breadcrumbs in an attribute named `breadcrumbs`. The entries\n are ordered from oldest to newest. Consequently, the last entry in the list should be the last\n entry before the event occurred.\n\n While breadcrumb attributes are not strictly validated in Sentry, a breadcrumb is most useful\n when it includes at least a `timestamp` and `type`, `category` or `message`. The rendering of\n breadcrumbs in Sentry depends on what is provided.\n\n The following example illustrates the breadcrumbs part of the event payload and omits other\n attributes for simplicity.\n\n ```json\n {\n   \"breadcrumbs\": {\n     \"values\": [\n       {\n         \"timestamp\": \"2016-04-20T20:55:53.845Z\",\n         \"message\": \"Something happened\",\n         \"category\": \"log\",\n         \"data\": {\n           \"foo\": \"bar\",\n           \"blub\": \"blah\"\n         }\n       },\n       {\n         \"timestamp\": \"2016-04-20T20:55:53.847Z\",\n         \"type\": \"navigation\",\n         \"data\": {\n           \"from\": \"/login\",\n           \"to\": \"/dashboard\"\n         }\n       }\n     ]\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -643,7 +643,7 @@ expression: event_json_schema()
               ]
             },
             "timestamp": {
-              "description": "The timestamp of the breadcrumb. Recommended.\n\nA timestamp representing when the breadcrumb occurred. The format is either a string as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float) value representing the number of seconds that have elapsed since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).\n\nBreadcrumbs are most useful when they include a timestamp, as it creates a timeline leading up to an event.",
+              "description": " The timestamp of the breadcrumb. Recommended.\n\n A timestamp representing when the breadcrumb occurred. The format is either a string as\n defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float)\n value representing the number of seconds that have elapsed since the [Unix\n epoch](https://en.wikipedia.org/wiki/Unix_time).\n\n Breadcrumbs are most useful when they include a timestamp, as it creates a timeline leading\n up to an event.",
               "default": null,
               "anyOf": [
                 {
@@ -667,13 +667,13 @@ expression: event_json_schema()
       ]
     },
     "BrowserContext": {
-      "description": "Web browser information.",
+      "description": " Web browser information.",
       "anyOf": [
         {
           "type": "object",
           "properties": {
             "name": {
-              "description": "Display name of the browser application.",
+              "description": " Display name of the browser application.",
               "default": null,
               "type": [
                 "string",
@@ -693,7 +693,7 @@ expression: event_json_schema()
       ]
     },
     "CError": {
-      "description": "POSIX signal with optional extended data.\n\nError codes set by Linux system calls and some library functions as specified in ISO C99, POSIX.1-2001, and POSIX.1-2008. See [`errno(3)`](https://man7.org/linux/man-pages/man3/errno.3.html) for more information.",
+      "description": " POSIX signal with optional extended data.\n\n Error codes set by Linux system calls and some library functions as specified in ISO C99,\n POSIX.1-2001, and POSIX.1-2008. See\n [`errno(3)`](https://man7.org/linux/man-pages/man3/errno.3.html) for more information.",
       "anyOf": [
         {
           "type": "object",
@@ -707,7 +707,7 @@ expression: event_json_schema()
               ]
             },
             "number": {
-              "description": "The error code as specified by ISO C99, POSIX.1-2001 or POSIX.1-2008.",
+              "description": " The error code as specified by ISO C99, POSIX.1-2001 or POSIX.1-2008.",
               "default": null,
               "type": [
                 "integer",
@@ -720,7 +720,7 @@ expression: event_json_schema()
       ]
     },
     "ClientSdkInfo": {
-      "description": "The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.",
+      "description": " The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.",
       "anyOf": [
         {
           "type": "object",
@@ -744,7 +744,7 @@ expression: event_json_schema()
               }
             },
             "name": {
-              "description": "Unique SDK name. _Required._\n\nThe name of the SDK. The format is `entity.ecosystem[.flavor]` where entity identifies the developer of the SDK, ecosystem refers to the programming language or platform where the SDK is to be used and the optional flavor is used to identify standalone SDKs that are part of a major ecosystem.\n\nOfficial Sentry SDKs use the entity `sentry`, as in `sentry.python` or `sentry.javascript.react-native`. Please use a different entity for your own SDKs.",
+              "description": " Unique SDK name. _Required._\n\n The name of the SDK. The format is `entity.ecosystem[.flavor]` where entity identifies the\n developer of the SDK, ecosystem refers to the programming language or platform where the\n SDK is to be used and the optional flavor is used to identify standalone SDKs that are part\n of a major ecosystem.\n\n Official Sentry SDKs use the entity `sentry`, as in `sentry.python` or\n `sentry.javascript.react-native`. Please use a different entity for your own SDKs.",
               "type": [
                 "string",
                 "null"
@@ -780,13 +780,13 @@ expression: event_json_schema()
       ]
     },
     "ClientSdkPackage": {
-      "description": "An installed and loaded package as part of the Sentry SDK.",
+      "description": " An installed and loaded package as part of the Sentry SDK.",
       "anyOf": [
         {
           "type": "object",
           "properties": {
             "name": {
-              "description": "Name of the package.",
+              "description": " Name of the package.",
               "default": null,
               "type": [
                 "string",
@@ -809,7 +809,7 @@ expression: event_json_schema()
       "type": "string"
     },
     "Context": {
-      "description": "A context describes environment info (e.g. device, os or browser).",
+      "description": " A context describes environment info (e.g. device, os or browser).",
       "anyOf": [
         {
           "$ref": "#/definitions/DeviceContext"
@@ -849,7 +849,7 @@ expression: event_json_schema()
       ]
     },
     "Contexts": {
-      "description": "The Contexts Interface provides additional context data. Typically, this is data related to the current user and the environment. For example, the device or application version. Its canonical name is `contexts`.\n\nThe `contexts` type can be used to define arbitrary contextual data on the event. It accepts an object of key/value pairs. The key is the “alias” of the context and can be freely chosen. However, as per policy, it should match the type of the context unless there are two values for a type. You can omit `type` if the key name is the type.\n\nUnknown data for the contexts is rendered as a key/value list.\n\nFor more details about sending additional data with your event, see the [full documentation on Additional Data](https://docs.sentry.io/enriching-error-data/additional-data/).",
+      "description": " The Contexts Interface provides additional context data. Typically, this is data related to the\n current user and the environment. For example, the device or application version. Its canonical\n name is `contexts`.\n\n The `contexts` type can be used to define arbitrary contextual data on the event. It accepts an\n object of key/value pairs. The key is the “alias” of the context and can be freely chosen.\n However, as per policy, it should match the type of the context unless there are two values for\n a type. You can omit `type` if the key name is the type.\n\n Unknown data for the contexts is rendered as a key/value list.\n\n For more details about sending additional data with your event, see the [full documentation on\n Additional Data](https://docs.sentry.io/enriching-error-data/additional-data/).",
       "anyOf": [
         {
           "type": "object",
@@ -867,7 +867,7 @@ expression: event_json_schema()
       ]
     },
     "Cookies": {
-      "description": "A map holding cookies.",
+      "description": " A map holding cookies.",
       "anyOf": [
         {
           "anyOf": [
@@ -913,7 +913,7 @@ expression: event_json_schema()
       "type": "string"
     },
     "DebugImage": {
-      "description": "A debug information file (debug image).",
+      "description": " A debug information file (debug image).",
       "anyOf": [
         {
           "$ref": "#/definitions/AppleDebugImage"
@@ -940,7 +940,7 @@ expression: event_json_schema()
       ]
     },
     "DebugMeta": {
-      "description": "Debugging and processing meta information.\n\nThe debug meta interface carries debug information for processing errors and crash reports. Sentry amends the information in this interface.\n\nExample (look at field types to see more detail):\n\n```json { \"debug_meta\": { \"images\": [], \"sdk_info\": { \"sdk_name\": \"iOS\", \"version_major\": 10, \"version_minor\": 3, \"version_patchlevel\": 0 } } } ```",
+      "description": " Debugging and processing meta information.\n\n The debug meta interface carries debug information for processing errors and crash reports.\n Sentry amends the information in this interface.\n\n Example (look at field types to see more detail):\n\n ```json\n {\n   \"debug_meta\": {\n     \"images\": [],\n     \"sdk_info\": {\n       \"sdk_name\": \"iOS\",\n       \"version_major\": 10,\n       \"version_minor\": 3,\n       \"version_patchlevel\": 0\n     }\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -964,7 +964,7 @@ expression: event_json_schema()
               }
             },
             "sdk_info": {
-              "description": "Information about the system SDK (e.g. iOS SDK).",
+              "description": " Information about the system SDK (e.g. iOS SDK).",
               "default": null,
               "anyOf": [
                 {
@@ -980,7 +980,7 @@ expression: event_json_schema()
       ]
     },
     "DeviceContext": {
-      "description": "Device information.\n\nDevice context describes the device that caused the event. This is most appropriate for mobile applications.",
+      "description": " Device information.\n\n Device context describes the device that caused the event. This is most appropriate for mobile\n applications.",
       "anyOf": [
         {
           "type": "object",
@@ -1117,7 +1117,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Name of the device.",
+              "description": " Name of the device.",
               "default": null,
               "type": [
                 "string",
@@ -1208,7 +1208,7 @@ expression: event_json_schema()
       ]
     },
     "EventId": {
-      "description": "Wrapper around a UUID with slightly different formatting.",
+      "description": " Wrapper around a UUID with slightly different formatting.",
       "anyOf": [
         {
           "type": "string",
@@ -1217,7 +1217,7 @@ expression: event_json_schema()
       ]
     },
     "EventProcessingError": {
-      "description": "An event processing error.",
+      "description": " An event processing error.",
       "anyOf": [
         {
           "type": "object",
@@ -1234,7 +1234,7 @@ expression: event_json_schema()
               ]
             },
             "type": {
-              "description": "The error kind.",
+              "description": " The error kind.",
               "type": [
                 "string",
                 "null"
@@ -1262,7 +1262,7 @@ expression: event_json_schema()
       ]
     },
     "Exception": {
-      "description": "A single exception.\n\nMultiple values inside of an [event](#Event) represent chained exceptions and should be sorted oldest to newest. For example, consider this Python code snippet:\n\n```python try: raise Exception(\"random boring invariant was not met!\") except Exception as e: raise ValueError(\"something went wrong, help!\") from e ```\n\n`Exception` would be described first in the values list, followed by a description of `ValueError`:\n\n```json { \"exception\": { \"values\": [ {\"type\": \"Exception\": \"value\": \"random boring invariant was not met!\"}, {\"type\": \"ValueError\", \"value\": \"something went wrong, help!\"}, ] } } ```",
+      "description": " A single exception.\n\n Multiple values inside of an [event](#Event) represent chained exceptions and should be sorted oldest to newest. For example, consider this Python code snippet:\n\n ```python\n try:\n     raise Exception(\"random boring invariant was not met!\")\n except Exception as e:\n     raise ValueError(\"something went wrong, help!\") from e\n ```\n\n `Exception` would be described first in the values list, followed by a description of `ValueError`:\n\n ```json\n {\n   \"exception\": {\n     \"values\": [\n       {\"type\": \"Exception\": \"value\": \"random boring invariant was not met!\"},\n       {\"type\": \"ValueError\", \"value\": \"something went wrong, help!\"},\n     ]\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -1312,7 +1312,7 @@ expression: event_json_schema()
               ]
             },
             "type": {
-              "description": "Exception type, e.g. `ValueError`.\n\nAt least one of `type` or `value` is required, otherwise the exception is discarded.",
+              "description": " Exception type, e.g. `ValueError`.\n\n At least one of `type` or `value` is required, otherwise the exception is discarded.",
               "default": null,
               "type": [
                 "string",
@@ -1336,7 +1336,7 @@ expression: event_json_schema()
       ]
     },
     "Fingerprint": {
-      "description": "A fingerprint value.",
+      "description": " A fingerprint value.",
       "anyOf": [
         {
           "type": "array",
@@ -1347,7 +1347,7 @@ expression: event_json_schema()
       ]
     },
     "Frame": {
-      "description": "Holds information about a single stacktrace frame.\n\nEach object should contain **at least** a `filename`, `function` or `instruction_addr` attribute. All values are optional, but recommended.",
+      "description": " Holds information about a single stacktrace frame.\n\n Each object should contain **at least** a `filename`, `function` or `instruction_addr` attribute. All values are optional, but recommended.",
       "anyOf": [
         {
           "type": "object",
@@ -1395,7 +1395,7 @@ expression: event_json_schema()
               ]
             },
             "function": {
-              "description": "Name of the frame's function. This might include the name of a class.\n\nThis function name may be shortened or demangled. If not, Sentry will demangle and shorten it for some platforms. The original function name will be stored in `raw_function`.",
+              "description": " Name of the frame's function. This might include the name of a class.\n\n This function name may be shortened or demangled. If not, Sentry will demangle and shorten\n it for some platforms. The original function name will be stored in `raw_function`.",
               "default": null,
               "type": [
                 "string",
@@ -1541,7 +1541,7 @@ expression: event_json_schema()
       ]
     },
     "FrameVars": {
-      "description": "Frame local variables.",
+      "description": " Frame local variables.",
       "anyOf": [
         {
           "type": "object",
@@ -1550,7 +1550,7 @@ expression: event_json_schema()
       ]
     },
     "Geo": {
-      "description": "Geographical location of the end user or device.",
+      "description": " Geographical location of the end user or device.",
       "anyOf": [
         {
           "type": "object",
@@ -1564,7 +1564,7 @@ expression: event_json_schema()
               ]
             },
             "country_code": {
-              "description": "Two-letter country code (ISO 3166-1 alpha-2).",
+              "description": " Two-letter country code (ISO 3166-1 alpha-2).",
               "default": null,
               "type": [
                 "string",
@@ -1584,7 +1584,7 @@ expression: event_json_schema()
       ]
     },
     "GpuContext": {
-      "description": "GPU information.\n\nExample:\n\n```json \"gpu\": { \"name\": \"AMD Radeon Pro 560\", \"vendor_name\": \"Apple\", \"memory_size\": 4096, \"api_type\": \"Metal\", \"multi_threaded_rendering\": true, \"version\": \"Metal\", \"npot_support\": \"Full\" } ```",
+      "description": " GPU information.\n\n Example:\n\n ```json\n \"gpu\": {\n   \"name\": \"AMD Radeon Pro 560\",\n   \"vendor_name\": \"Apple\",\n   \"memory_size\": 4096,\n   \"api_type\": \"Metal\",\n   \"multi_threaded_rendering\": true,\n   \"version\": \"Metal\",\n   \"npot_support\": \"Full\"\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -1620,7 +1620,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "The name of the graphics device.",
+              "description": " The name of the graphics device.",
               "default": null,
               "type": [
                 "string",
@@ -1664,7 +1664,7 @@ expression: event_json_schema()
       ]
     },
     "HeaderName": {
-      "description": "A \"into-string\" type that normalizes header names.",
+      "description": " A \"into-string\" type that normalizes header names.",
       "anyOf": [
         {
           "type": "string"
@@ -1672,7 +1672,7 @@ expression: event_json_schema()
       ]
     },
     "HeaderValue": {
-      "description": "A \"into-string\" type that normalizes header values.",
+      "description": " A \"into-string\" type that normalizes header values.",
       "anyOf": [
         {
           "type": "string"
@@ -1680,7 +1680,7 @@ expression: event_json_schema()
       ]
     },
     "Headers": {
-      "description": "A map holding headers.",
+      "description": " A map holding headers.",
       "anyOf": [
         {
           "anyOf": [
@@ -1735,7 +1735,7 @@ expression: event_json_schema()
       ]
     },
     "JsonLenientString": {
-      "description": "A \"into-string\" type of value. All non-string values are serialized as JSON.",
+      "description": " A \"into-string\" type of value. All non-string values are serialized as JSON.",
       "anyOf": [
         {
           "type": "string"
@@ -1754,7 +1754,7 @@ expression: event_json_schema()
       ]
     },
     "LogEntry": {
-      "description": "A log entry message.\n\nA log message is similar to the `message` attribute on the event itself but can additionally hold optional parameters.\n\n```json { \"message\": { \"message\": \"My raw message with interpreted strings like %s\", \"params\": [\"this\"] } } ```\n\n```json { \"message\": { \"message\": \"My raw message with interpreted strings like {foo}\", \"params\": {\"foo\": \"this\"} } } ```",
+      "description": " A log entry message.\n\n A log message is similar to the `message` attribute on the event itself but\n can additionally hold optional parameters.\n\n ```json\n {\n   \"message\": {\n     \"message\": \"My raw message with interpreted strings like %s\",\n     \"params\": [\"this\"]\n   }\n }\n ```\n\n ```json\n {\n   \"message\": {\n     \"message\": \"My raw message with interpreted strings like {foo}\",\n     \"params\": {\"foo\": \"this\"}\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -1772,7 +1772,7 @@ expression: event_json_schema()
               ]
             },
             "message": {
-              "description": "The log message with parameter placeholders.\n\nThis attribute is primarily used for grouping related events together into issues. Therefore this really should just be a string template, i.e. `Sending %d requests` instead of `Sending 9999 requests`. The latter is much better at home in `formatted`.\n\nIt must not exceed 8192 characters. Longer messages will be truncated.",
+              "description": " The log message with parameter placeholders.\n\n This attribute is primarily used for grouping related events together into issues.\n Therefore this really should just be a string template, i.e. `Sending %d requests` instead\n of `Sending 9999 requests`. The latter is much better at home in `formatted`.\n\n It must not exceed 8192 characters. Longer messages will be truncated.",
               "default": null,
               "anyOf": [
                 {
@@ -1792,7 +1792,7 @@ expression: event_json_schema()
       ]
     },
     "MachException": {
-      "description": "Mach exception information.",
+      "description": " Mach exception information.",
       "anyOf": [
         {
           "type": "object",
@@ -1808,7 +1808,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "exception": {
-              "description": "The mach exception type.",
+              "description": " The mach exception type.",
               "default": null,
               "type": [
                 "integer",
@@ -1839,7 +1839,7 @@ expression: event_json_schema()
       ]
     },
     "Mechanism": {
-      "description": "The mechanism by which an exception was generated and handled.\n\nThe exception mechanism is an optional field residing in the [exception](#Exception). It carries additional information about the way the exception was created on the target system. This includes general exception values obtained from the operating system or runtime APIs, as well as mechanism-specific values.",
+      "description": " The mechanism by which an exception was generated and handled.\n\n The exception mechanism is an optional field residing in the [exception](#Exception). It carries\n additional information about the way the exception was created on the target system. This\n includes general exception values obtained from the operating system or runtime APIs, as well\n as mechanism-specific values.",
       "anyOf": [
         {
           "type": "object",
@@ -1901,7 +1901,7 @@ expression: event_json_schema()
               ]
             },
             "type": {
-              "description": "Mechanism type (required).\n\nRequired unique identifier of this mechanism determining rendering and processing of the mechanism data.\n\nIn the Python SDK this is merely the name of the framework integration that produced the exception, while for native it is e.g. `\"minidump\"` or `\"applecrashreport\"`.",
+              "description": " Mechanism type (required).\n\n Required unique identifier of this mechanism determining rendering and processing of the\n mechanism data.\n\n In the Python SDK this is merely the name of the framework integration that produced the\n exception, while for native it is e.g. `\"minidump\"` or `\"applecrashreport\"`.",
               "type": [
                 "string",
                 "null"
@@ -1912,13 +1912,13 @@ expression: event_json_schema()
       ]
     },
     "MechanismMeta": {
-      "description": "Operating system or runtime meta information to an exception mechanism.\n\nThe mechanism metadata usually carries error codes reported by the runtime or operating system, along with a platform-dependent interpretation of these codes. SDKs can safely omit code names and descriptions for well-known error codes, as it will be filled out by Sentry. For proprietary or vendor-specific error codes, adding these values will give additional information to the user.",
+      "description": " Operating system or runtime meta information to an exception mechanism.\n\n The mechanism metadata usually carries error codes reported by the runtime or operating system,\n along with a platform-dependent interpretation of these codes. SDKs can safely omit code names\n and descriptions for well-known error codes, as it will be filled out by Sentry. For\n proprietary or vendor-specific error codes, adding these values will give additional\n information to the user.",
       "anyOf": [
         {
           "type": "object",
           "properties": {
             "errno": {
-              "description": "Optional ISO C standard error code.",
+              "description": " Optional ISO C standard error code.",
               "default": null,
               "anyOf": [
                 {
@@ -1965,7 +1965,7 @@ expression: event_json_schema()
       ]
     },
     "MonitorContext": {
-      "description": "Monitor information.",
+      "description": " Monitor information.",
       "anyOf": [
         {
           "type": "object",
@@ -1974,7 +1974,7 @@ expression: event_json_schema()
       ]
     },
     "NativeDebugImage": {
-      "description": "A generic (new-style) native platform debug information file.\n\nThe `type` key must be one of:\n\n- `macho` - `elf`: ELF images are used on Linux platforms. Their structure is identical to other native images. - `pe`\n\nExamples:\n\n```json { \"type\": \"elf\", \"code_id\": \"68220ae2c65d65c1b6aaa12fa6765a6ec2f5f434\", \"code_file\": \"/lib/x86_64-linux-gnu/libgcc_s.so.1\", \"debug_id\": \"e20a2268-5dc6-c165-b6aa-a12fa6765a6e\", \"image_addr\": \"0x7f5140527000\", \"image_size\": 90112, \"image_vmaddr\": \"0x40000\", \"arch\": \"x86_64\" } ```\n\n```json { \"type\": \"pe\", \"code_id\": \"57898e12145000\", \"code_file\": \"C:\\\\Windows\\\\System32\\\\dbghelp.dll\", \"debug_id\": \"9c2a902b-6fdf-40ad-8308-588a41d572a0-1\", \"debug_file\": \"dbghelp.pdb\", \"image_addr\": \"0x70850000\", \"image_size\": \"1331200\", \"image_vmaddr\": \"0x40000\", \"arch\": \"x86\" } ```\n\n```json { \"type\": \"macho\", \"debug_id\": \"84a04d24-0e60-3810-a8c0-90a65e2df61a\", \"debug_file\": \"libDiagnosticMessagesClient.dylib\", \"code_file\": \"/usr/lib/libDiagnosticMessagesClient.dylib\", \"image_addr\": \"0x7fffe668e000\", \"image_size\": 8192, \"image_vmaddr\": \"0x40000\", \"arch\": \"x86_64\", } ```",
+      "description": " A generic (new-style) native platform debug information file.\n\n The `type` key must be one of:\n\n - `macho`\n - `elf`: ELF images are used on Linux platforms. Their structure is identical to other native images.\n - `pe`\n\n Examples:\n\n ```json\n {\n   \"type\": \"elf\",\n   \"code_id\": \"68220ae2c65d65c1b6aaa12fa6765a6ec2f5f434\",\n   \"code_file\": \"/lib/x86_64-linux-gnu/libgcc_s.so.1\",\n   \"debug_id\": \"e20a2268-5dc6-c165-b6aa-a12fa6765a6e\",\n   \"image_addr\": \"0x7f5140527000\",\n   \"image_size\": 90112,\n   \"image_vmaddr\": \"0x40000\",\n   \"arch\": \"x86_64\"\n }\n ```\n\n ```json\n {\n   \"type\": \"pe\",\n   \"code_id\": \"57898e12145000\",\n   \"code_file\": \"C:\\\\Windows\\\\System32\\\\dbghelp.dll\",\n   \"debug_id\": \"9c2a902b-6fdf-40ad-8308-588a41d572a0-1\",\n   \"debug_file\": \"dbghelp.pdb\",\n   \"image_addr\": \"0x70850000\",\n   \"image_size\": \"1331200\",\n   \"image_vmaddr\": \"0x40000\",\n   \"arch\": \"x86\"\n }\n ```\n\n ```json\n {\n   \"type\": \"macho\",\n   \"debug_id\": \"84a04d24-0e60-3810-a8c0-90a65e2df61a\",\n   \"debug_file\": \"libDiagnosticMessagesClient.dylib\",\n   \"code_file\": \"/usr/lib/libDiagnosticMessagesClient.dylib\",\n   \"image_addr\": \"0x7fffe668e000\",\n   \"image_size\": 8192,\n   \"image_vmaddr\": \"0x40000\",\n   \"arch\": \"x86_64\",\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -2005,7 +2005,7 @@ expression: event_json_schema()
               ]
             },
             "code_id": {
-              "description": "Optional identifier of the code file.\n\n- `elf`: If the program was compiled with a relatively recent compiler, this should be the hex representation of the `NT_GNU_BUILD_ID` program header (type `PT_NOTE`), or the value of the `.note.gnu.build-id` note section (type `SHT_NOTE`). Otherwise, leave this value empty.\n\nCertain symbol servers use the code identifier to locate debug information for ELF images, in which case this field should be included if possible.\n\n- `pe`: Identifier of the executable or DLL. It contains the values of the `time_date_stamp` from the COFF header and `size_of_image` from the optional header formatted together into a hex string using `%08x%X` (note that the second value is not padded):\n\n```text time_date_stamp: 0x5ab38077 size_of_image:           0x9000 code_id:           5ab380779000 ```\n\nThe code identifier should be provided to allow server-side stack walking of binary crash reports, such as Minidumps.\n\n- `macho`: Identifier of the dynamic library or executable. It is the value of the `LC_UUID` load command in the Mach header, formatted as UUID. Can be empty for Mach images, as it is equivalent to the debug identifier.",
+              "description": " Optional identifier of the code file.\n\n - `elf`: If the program was compiled with a relatively recent compiler, this should be the hex representation of the `NT_GNU_BUILD_ID` program header (type `PT_NOTE`), or the value of the `.note.gnu.build-id` note section (type `SHT_NOTE`). Otherwise, leave this value empty.\n\n   Certain symbol servers use the code identifier to locate debug information for ELF images, in which case this field should be included if possible.\n\n - `pe`: Identifier of the executable or DLL. It contains the values of the `time_date_stamp` from the COFF header and `size_of_image` from the optional header formatted together into a hex string using `%08x%X` (note that the second value is not padded):\n\n   ```text\n   time_date_stamp: 0x5ab38077\n   size_of_image:           0x9000\n   code_id:           5ab380779000\n   ```\n\n   The code identifier should be provided to allow server-side stack walking of binary crash reports, such as Minidumps.\n\n\n - `macho`: Identifier of the dynamic library or executable. It is the value of the `LC_UUID` load command in the Mach header, formatted as UUID. Can be empty for Mach images, as it is equivalent to the debug identifier.",
               "default": null,
               "anyOf": [
                 {
@@ -2076,7 +2076,7 @@ expression: event_json_schema()
       ]
     },
     "NativeImagePath": {
-      "description": "A type for strings that are generally paths, might contain system user names, but still cannot be stripped liberally because it would break processing for certain platforms.\n\nThose strings get special treatment in our PII processor to avoid stripping the basename.",
+      "description": " A type for strings that are generally paths, might contain system user names, but still cannot\n be stripped liberally because it would break processing for certain platforms.\n\n Those strings get special treatment in our PII processor to avoid stripping the basename.",
       "anyOf": [
         {
           "type": "string"
@@ -2084,7 +2084,7 @@ expression: event_json_schema()
       ]
     },
     "OsContext": {
-      "description": "Operating system information.\n\nOS context describes the operating system on which the event was created. In web contexts, this is the operating system of the browser (generally pulled from the User-Agent string).",
+      "description": " Operating system information.\n\n OS context describes the operating system on which the event was created. In web contexts, this\n is the operating system of the browser (generally pulled from the User-Agent string).",
       "anyOf": [
         {
           "type": "object",
@@ -2106,7 +2106,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Name of the operating system.",
+              "description": " Name of the operating system.",
               "default": null,
               "type": [
                 "string",
@@ -2142,7 +2142,7 @@ expression: event_json_schema()
       ]
     },
     "PosixSignal": {
-      "description": "POSIX signal with optional extended data.\n\nOn Apple systems, signals also carry a code in addition to the signal number describing the signal in more detail. On Linux, this code does not exist.",
+      "description": " POSIX signal with optional extended data.\n\n On Apple systems, signals also carry a code in addition to the signal number describing the\n signal in more detail. On Linux, this code does not exist.",
       "anyOf": [
         {
           "type": "object",
@@ -2173,7 +2173,7 @@ expression: event_json_schema()
               ]
             },
             "number": {
-              "description": "The POSIX signal number.",
+              "description": " The POSIX signal number.",
               "default": null,
               "type": [
                 "integer",
@@ -2186,7 +2186,7 @@ expression: event_json_schema()
       ]
     },
     "ProguardDebugImage": {
-      "description": "Proguard mapping file.\n\nProguard images refer to `mapping.txt` files generated when Proguard obfuscates function names. The Java SDK integrations assign this file a unique identifier, which has to be included in the list of images.",
+      "description": " Proguard mapping file.\n\n Proguard images refer to `mapping.txt` files generated when Proguard obfuscates function names. The Java SDK integrations assign this file a unique identifier, which has to be included in the list of images.",
       "anyOf": [
         {
           "type": "object",
@@ -2195,7 +2195,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "uuid": {
-              "description": "UUID computed from the file contents, assigned by the Java SDK.",
+              "description": " UUID computed from the file contents, assigned by the Java SDK.",
               "type": [
                 "string",
                 "null"
@@ -2207,7 +2207,7 @@ expression: event_json_schema()
       ]
     },
     "Query": {
-      "description": "A map holding query string pairs.",
+      "description": " A map holding query string pairs.",
       "anyOf": [
         {
           "anyOf": [
@@ -2258,7 +2258,7 @@ expression: event_json_schema()
       ]
     },
     "RawStacktrace": {
-      "description": "A stack trace of a single thread.\n\nA stack trace contains a list of frames, each with various bits (most optional) describing the context of that frame. Frames should be sorted from oldest to newest.\n\nFor the given example program written in Python:\n\n```python def foo(): my_var = 'foo' raise ValueError()\n\ndef main(): foo() ```\n\nA minimalistic stack trace for the above program in the correct order:\n\n```json { \"frames\": [ {\"function\": \"main\"}, {\"function\": \"foo\"} ] } ```\n\nThe top frame fully symbolicated with five lines of source context:\n\n```json { \"frames\": [{ \"in_app\": true, \"function\": \"myfunction\", \"abs_path\": \"/real/file/name.py\", \"filename\": \"file/name.py\", \"lineno\": 3, \"vars\": { \"my_var\": \"'value'\" }, \"pre_context\": [ \"def foo():\", \"  my_var = 'foo'\", ], \"context_line\": \"  raise ValueError()\", \"post_context\": [ \"\", \"def main():\" ], }] } ```\n\nA minimal native stack trace with register values. Note that the `package` event attribute must be \"native\" for these frames to be symbolicated.\n\n```json { \"frames\": [ {\"instruction_addr\": \"0x7fff5bf3456c\"}, {\"instruction_addr\": \"0x7fff5bf346c0\"}, ], \"registers\": { \"rip\": \"0x00007ff6eef54be2\", \"rsp\": \"0x0000003b710cd9e0\" } } ```",
+      "description": " A stack trace of a single thread.\n\n A stack trace contains a list of frames, each with various bits (most optional) describing the context of that frame. Frames should be sorted from oldest to newest.\n\n For the given example program written in Python:\n\n ```python\n def foo():\n     my_var = 'foo'\n     raise ValueError()\n\n def main():\n     foo()\n ```\n\n A minimalistic stack trace for the above program in the correct order:\n\n ```json\n {\n   \"frames\": [\n     {\"function\": \"main\"},\n     {\"function\": \"foo\"}\n   ]\n }\n ```\n\n The top frame fully symbolicated with five lines of source context:\n\n ```json\n {\n   \"frames\": [{\n     \"in_app\": true,\n     \"function\": \"myfunction\",\n     \"abs_path\": \"/real/file/name.py\",\n     \"filename\": \"file/name.py\",\n     \"lineno\": 3,\n     \"vars\": {\n       \"my_var\": \"'value'\"\n     },\n     \"pre_context\": [\n       \"def foo():\",\n       \"  my_var = 'foo'\",\n     ],\n     \"context_line\": \"  raise ValueError()\",\n     \"post_context\": [\n       \"\",\n       \"def main():\"\n     ],\n   }]\n }\n ```\n\n A minimal native stack trace with register values. Note that the `package` event attribute must be \"native\" for these frames to be symbolicated.\n\n ```json\n {\n   \"frames\": [\n     {\"instruction_addr\": \"0x7fff5bf3456c\"},\n     {\"instruction_addr\": \"0x7fff5bf346c0\"},\n   ],\n   \"registers\": {\n     \"rip\": \"0x00007ff6eef54be2\",\n     \"rsp\": \"0x0000003b710cd9e0\"\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -2267,7 +2267,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "frames": {
-              "description": "Required. A non-empty list of stack frames. The list is ordered from caller to callee, or oldest to youngest. The last frame is the one creating the exception.",
+              "description": " Required. A non-empty list of stack frames. The list is ordered from caller to callee, or oldest to youngest. The last frame is the one creating the exception.",
               "type": [
                 "array",
                 "null"
@@ -2317,7 +2317,7 @@ expression: event_json_schema()
       "type": "string"
     },
     "Request": {
-      "description": "Http request information.\n\nThe Request interface contains information on a HTTP request related to the event. In client SDKs, this can be an outgoing request, or the request that rendered the current web page. On server SDKs, this could be the incoming web request that is being handled.\n\nThe data variable should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.\n\n### Ordered Maps\n\nIn the Request interface, several attributes can either be declared as string, object, or list of tuples. Sentry attempts to parse structured information from the string representation in such cases.\n\nSometimes, keys can be declared multiple times, or the order of elements matters. In such cases, use the tuple representation over a plain object.\n\nExample of request headers as object:\n\n```json { \"content-type\": \"application/json\", \"accept\": \"application/json, application/xml\" } ```\n\nExample of the same headers as list of tuples:\n\n```json [ [\"content-type\", \"application/json\"], [\"accept\", \"application/json\"], [\"accept\", \"application/xml\"] ] ```\n\nExample of a fully populated request object:\n\n```json { \"request\": { \"method\": \"POST\", \"url\": \"http://absolute.uri/foo\", \"query_string\": \"query=foobar&page=2\", \"data\": { \"foo\": \"bar\" }, \"cookies\": \"PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;\", \"headers\": { \"content-type\": \"text/html\" }, \"env\": { \"REMOTE_ADDR\": \"192.168.0.1\" } } } ```",
+      "description": " Http request information.\n\n The Request interface contains information on a HTTP request related to the event. In client\n SDKs, this can be an outgoing request, or the request that rendered the current web page. On\n server SDKs, this could be the incoming web request that is being handled.\n\n The data variable should only contain the request body (not the query string). It can either be\n a dictionary (for standard HTTP requests) or a raw request body.\n\n ### Ordered Maps\n\n In the Request interface, several attributes can either be declared as string, object, or list\n of tuples. Sentry attempts to parse structured information from the string representation in\n such cases.\n\n Sometimes, keys can be declared multiple times, or the order of elements matters. In such\n cases, use the tuple representation over a plain object.\n\n Example of request headers as object:\n\n ```json\n {\n   \"content-type\": \"application/json\",\n   \"accept\": \"application/json, application/xml\"\n }\n ```\n\n Example of the same headers as list of tuples:\n\n ```json\n [\n   [\"content-type\", \"application/json\"],\n   [\"accept\", \"application/json\"],\n   [\"accept\", \"application/xml\"]\n ]\n ```\n\n Example of a fully populated request object:\n\n ```json\n {\n   \"request\": {\n     \"method\": \"POST\",\n     \"url\": \"http://absolute.uri/foo\",\n     \"query_string\": \"query=foobar&page=2\",\n     \"data\": {\n       \"foo\": \"bar\"\n     },\n     \"cookies\": \"PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;\",\n     \"headers\": {\n       \"content-type\": \"text/html\"\n     },\n     \"env\": {\n       \"REMOTE_ADDR\": \"192.168.0.1\"\n     }\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -2396,7 +2396,7 @@ expression: event_json_schema()
               ]
             },
             "url": {
-              "description": "The URL of the request if available.\n\nThe query string can be declared either as part of the `url`, or separately in `query_string`.",
+              "description": " The URL of the request if available.\n\nThe query string can be declared either as part of the `url`, or separately in `query_string`.",
               "default": null,
               "type": [
                 "string",
@@ -2408,7 +2408,7 @@ expression: event_json_schema()
       ]
     },
     "RuntimeContext": {
-      "description": "Runtime information.\n\nRuntime context describes a runtime in more detail. Typically, this context is present in `contexts` multiple times if multiple runtimes are involved (for instance, if you have a JavaScript application running on top of JVM).",
+      "description": " Runtime information.\n\n Runtime context describes a runtime in more detail. Typically, this context is present in\n `contexts` multiple times if multiple runtimes are involved (for instance, if you have a\n JavaScript application running on top of JVM).",
       "anyOf": [
         {
           "type": "object",
@@ -2422,7 +2422,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Runtime name.",
+              "description": " Runtime name.",
               "default": null,
               "type": [
                 "string",
@@ -2523,7 +2523,7 @@ expression: event_json_schema()
               ]
             },
             "timestamp": {
-              "description": "Timestamp when the span was ended.",
+              "description": " Timestamp when the span was ended.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Timestamp"
@@ -2549,7 +2549,7 @@ expression: event_json_schema()
       ]
     },
     "SpanId": {
-      "description": "A 16-character hex string as described in the W3C trace context spec.",
+      "description": " A 16-character hex string as described in the W3C trace context spec.",
       "anyOf": [
         {
           "type": "string"
@@ -2590,13 +2590,13 @@ expression: event_json_schema()
       "type": "string"
     },
     "SystemSdkInfo": {
-      "description": "Holds information about the system SDK.\n\nThis is relevant for iOS and other platforms that have a system SDK.  Not to be confused with the client SDK.",
+      "description": " Holds information about the system SDK.\n\n This is relevant for iOS and other platforms that have a system\n SDK.  Not to be confused with the client SDK.",
       "anyOf": [
         {
           "type": "object",
           "properties": {
             "sdk_name": {
-              "description": "The internal name of the SDK.",
+              "description": " The internal name of the SDK.",
               "default": null,
               "type": [
                 "string",
@@ -2661,7 +2661,7 @@ expression: event_json_schema()
       ]
     },
     "Tags": {
-      "description": "Manual key/value tag pairs.",
+      "description": " Manual key/value tag pairs.",
       "anyOf": [
         {
           "anyOf": [
@@ -2692,7 +2692,7 @@ expression: event_json_schema()
       ]
     },
     "Thread": {
-      "description": "A process thread of an event.\n\nThe Threads Interface specifies threads that were running at the time an event happened. These threads can also contain stack traces.\n\nAn event may contain one or more threads in an attribute named `threads`.\n\nThe following example illustrates the threads part of the event payload and omits other attributes for simplicity.\n\n```json { \"threads\": { \"values\": [ { \"id\": \"0\", \"name\": \"main\", \"crashed\": true, \"stacktrace\": {} } ] } } ```",
+      "description": " A process thread of an event.\n\n The Threads Interface specifies threads that were running at the time an event happened. These threads can also contain stack traces.\n\n An event may contain one or more threads in an attribute named `threads`.\n\n The following example illustrates the threads part of the event payload and omits other attributes for simplicity.\n\n ```json\n {\n   \"threads\": {\n     \"values\": [\n       {\n         \"id\": \"0\",\n         \"name\": \"main\",\n         \"crashed\": true,\n         \"stacktrace\": {}\n       }\n     ]\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -2714,7 +2714,7 @@ expression: event_json_schema()
               ]
             },
             "id": {
-              "description": "The ID of the thread. Typically a number or numeric string.\n\nNeeds to be unique among the threads. An exception can set the `thread_id` attribute to cross-reference this thread.",
+              "description": " The ID of the thread. Typically a number or numeric string.\n\n Needs to be unique among the threads. An exception can set the `thread_id` attribute to cross-reference this thread.",
               "default": null,
               "anyOf": [
                 {
@@ -2750,7 +2750,7 @@ expression: event_json_schema()
       ]
     },
     "ThreadId": {
-      "description": "Represents a thread id.",
+      "description": " Represents a thread id.",
       "anyOf": [
         {
           "type": "integer",
@@ -2775,7 +2775,7 @@ expression: event_json_schema()
       ]
     },
     "TraceContext": {
-      "description": "Trace context",
+      "description": " Trace context",
       "anyOf": [
         {
           "type": "object",
@@ -2828,7 +2828,7 @@ expression: event_json_schema()
               ]
             },
             "trace_id": {
-              "description": "The trace ID.",
+              "description": " The trace ID.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/TraceId"
@@ -2843,7 +2843,7 @@ expression: event_json_schema()
       ]
     },
     "TraceId": {
-      "description": "A 32-character hex string as described in the W3C trace context spec.",
+      "description": " A 32-character hex string as described in the W3C trace context spec.",
       "anyOf": [
         {
           "type": "string"
@@ -2851,7 +2851,7 @@ expression: event_json_schema()
       ]
     },
     "User": {
-      "description": "Information about the user who triggered an event.\n\n```json { \"user\": { \"id\": \"unique_id\", \"username\": \"my_user\", \"email\": \"foo@example.com\", \"ip_address\": \"127.0.0.1\", \"subscription\": \"basic\" } } ```",
+      "description": " Information about the user who triggered an event.\n\n ```json\n {\n   \"user\": {\n     \"id\": \"unique_id\",\n     \"username\": \"my_user\",\n     \"email\": \"foo@example.com\",\n     \"ip_address\": \"127.0.0.1\",\n     \"subscription\": \"basic\"\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",
@@ -2886,7 +2886,7 @@ expression: event_json_schema()
               ]
             },
             "id": {
-              "description": "Unique identifier of the user.",
+              "description": " Unique identifier of the user.",
               "default": null,
               "type": [
                 "string",

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -11,7 +11,7 @@ expression: event_json_schema()
       "type": "object",
       "properties": {
         "breadcrumbs": {
-          "description": "List of breadcrumbs recorded before this event.",
+          "description": " List of breadcrumbs recorded before this event.",
           "default": null,
           "type": [
             "object",
@@ -37,7 +37,7 @@ expression: event_json_schema()
           }
         },
         "contexts": {
-          "description": "Contexts describing the environment (e.g. device, os or browser).",
+          "description": " Contexts describing the environment (e.g. device, os or browser).",
           "default": null,
           "anyOf": [
             {
@@ -49,7 +49,7 @@ expression: event_json_schema()
           ]
         },
         "culprit": {
-          "description": "Custom culprit of the event.",
+          "description": " Custom culprit of the event.",
           "default": null,
           "type": [
             "string",
@@ -57,7 +57,7 @@ expression: event_json_schema()
           ]
         },
         "debug_meta": {
-          "description": "Meta data for event processing and debugging.",
+          "description": " Meta data for event processing and debugging.",
           "default": null,
           "anyOf": [
             {
@@ -69,7 +69,7 @@ expression: event_json_schema()
           ]
         },
         "dist": {
-          "description": "Program's distribution identifier.\n\nThe distribution of the application.\n\nDistributions are used to disambiguate build or deployment variants of the same release of an application. For example, the dist can be the build number of an XCode build or the version code of an Android build.",
+          "description": " Program's distribution identifier.\n\n The distribution of the application.\n\n Distributions are used to disambiguate build or deployment variants of the same release of\n an application. For example, the dist can be the build number of an XCode build or the\n version code of an Android build.",
           "default": null,
           "type": [
             "string",
@@ -77,7 +77,7 @@ expression: event_json_schema()
           ]
         },
         "environment": {
-          "description": "The environment name, such as `production` or `staging`.",
+          "description": " The environment name, such as `production` or `staging`.",
           "default": null,
           "type": [
             "string",
@@ -85,7 +85,7 @@ expression: event_json_schema()
           ]
         },
         "errors": {
-          "description": "Errors encountered during processing. Intended to be phased out in favor of annotation/metadata system.",
+          "description": " Errors encountered during processing. Intended to be phased out in favor of\n annotation/metadata system.",
           "default": null,
           "type": [
             "array",
@@ -115,7 +115,7 @@ expression: event_json_schema()
           ]
         },
         "exception": {
-          "description": "One or multiple chained (nested) exceptions.",
+          "description": " One or multiple chained (nested) exceptions.",
           "default": null,
           "type": [
             "object",
@@ -141,7 +141,7 @@ expression: event_json_schema()
           }
         },
         "extra": {
-          "description": "Arbitrary extra information set by the user.",
+          "description": " Arbitrary extra information set by the user.",
           "default": null,
           "type": [
             "object",
@@ -150,7 +150,7 @@ expression: event_json_schema()
           "additionalProperties": true
         },
         "fingerprint": {
-          "description": "Manual fingerprint override.\n\nA list of strings used to dictate how this event is supposed to be grouped with other events into issues. For more information about overriding grouping see [Customize Grouping with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).",
+          "description": " Manual fingerprint override.\n\n A list of strings used to dictate how this event is supposed to be grouped with other\n events into issues. For more information about overriding grouping see [Customize Grouping\n with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).",
           "default": null,
           "anyOf": [
             {
@@ -162,7 +162,7 @@ expression: event_json_schema()
           ]
         },
         "key_id": {
-          "description": "Project key which sent this event.",
+          "description": " Project key which sent this event.",
           "default": null,
           "type": [
             "string",
@@ -170,7 +170,7 @@ expression: event_json_schema()
           ]
         },
         "level": {
-          "description": "Severity level of the event. Defaults to `error`.",
+          "description": " Severity level of the event. Defaults to `error`.",
           "default": null,
           "anyOf": [
             {
@@ -182,7 +182,7 @@ expression: event_json_schema()
           ]
         },
         "logentry": {
-          "description": "Custom parameterized message for this event.",
+          "description": " Custom parameterized message for this event.",
           "default": null,
           "anyOf": [
             {
@@ -194,7 +194,7 @@ expression: event_json_schema()
           ]
         },
         "logger": {
-          "description": "Logger that created the event.",
+          "description": " Logger that created the event.",
           "default": null,
           "type": [
             "string",
@@ -202,7 +202,7 @@ expression: event_json_schema()
           ]
         },
         "modules": {
-          "description": "Name and versions of all installed modules/packages/dependencies in the current environment/application.\n\n```json { \"django\": \"3.0.0\", \"celery\": \"4.2.1\" } ```\n\nIn Python this is a list of installed packages as reported by `pkg_resources` together with their reported version string.\n\nThis is primarily used for suggesting to enable certain SDK integrations from within the UI and for making informed decisions on which frameworks to support in future development efforts.",
+          "description": " Name and versions of all installed modules/packages/dependencies in the current\n environment/application.\n\n ```json\n { \"django\": \"3.0.0\", \"celery\": \"4.2.1\" }\n ```\n\n In Python this is a list of installed packages as reported by `pkg_resources` together with\n their reported version string.\n\n This is primarily used for suggesting to enable certain SDK integrations from within the UI\n and for making informed decisions on which frameworks to support in future development\n efforts.",
           "default": null,
           "type": [
             "object",
@@ -216,7 +216,7 @@ expression: event_json_schema()
           }
         },
         "platform": {
-          "description": "Platform identifier of this event (defaults to \"other\").\n\nA string representing the platform the SDK is submitting from. This will be used by the Sentry interface to customize various components in the interface, but also to enter or skip stacktrace processing.\n\nAcceptable values are: `as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `haskell`, `go`, `groovy`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`, `ruby`",
+          "description": " Platform identifier of this event (defaults to \"other\").\n\n A string representing the platform the SDK is submitting from. This will be used by the\n Sentry interface to customize various components in the interface, but also to enter or\n skip stacktrace processing.\n\n Acceptable values are: `as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `haskell`, `go`,\n `groovy`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`,\n `ruby`",
           "default": null,
           "type": [
             "string",
@@ -224,7 +224,7 @@ expression: event_json_schema()
           ]
         },
         "project": {
-          "description": "Project which sent this event.",
+          "description": " Project which sent this event.",
           "default": null,
           "type": [
             "integer",
@@ -234,7 +234,7 @@ expression: event_json_schema()
           "minimum": 0.0
         },
         "received": {
-          "description": "Timestamp when the event has been received by Sentry.",
+          "description": " Timestamp when the event has been received by Sentry.",
           "default": null,
           "anyOf": [
             {
@@ -246,7 +246,7 @@ expression: event_json_schema()
           ]
         },
         "release": {
-          "description": "The release version of the application.\n\n**Release versions must be unique across all projects in your organization.** This value can be the git SHA for the given project, or a product identifier with a semantic version.",
+          "description": " The release version of the application.\n\n **Release versions must be unique across all projects in your organization.** This value\n can be the git SHA for the given project, or a product identifier with a semantic version.",
           "default": null,
           "type": [
             "string",
@@ -254,7 +254,7 @@ expression: event_json_schema()
           ]
         },
         "request": {
-          "description": "Information about a web request that occurred during the event.",
+          "description": " Information about a web request that occurred during the event.",
           "default": null,
           "anyOf": [
             {
@@ -266,7 +266,7 @@ expression: event_json_schema()
           ]
         },
         "sdk": {
-          "description": "Information about the Sentry SDK that generated this event.",
+          "description": " Information about the Sentry SDK that generated this event.",
           "default": null,
           "anyOf": [
             {
@@ -278,7 +278,7 @@ expression: event_json_schema()
           ]
         },
         "server_name": {
-          "description": "Server or device name the event was generated on.\n\nThis is supposed to be a hostname.",
+          "description": " Server or device name the event was generated on.\n\n This is supposed to be a hostname.",
           "default": null,
           "type": [
             "string",
@@ -286,7 +286,7 @@ expression: event_json_schema()
           ]
         },
         "site": {
-          "description": "Deprecated in favor of tags.",
+          "description": " Deprecated in favor of tags.",
           "default": null,
           "type": [
             "string",
@@ -294,7 +294,7 @@ expression: event_json_schema()
           ]
         },
         "spans": {
-          "description": "Spans for tracing.",
+          "description": " Spans for tracing.",
           "default": null,
           "type": [
             "array",
@@ -312,7 +312,7 @@ expression: event_json_schema()
           }
         },
         "stacktrace": {
-          "description": "Event stacktrace.\n\nDEPRECATED: Prefer `threads` or `exception` depending on which is more appropriate.",
+          "description": " Event stacktrace.\n\n DEPRECATED: Prefer `threads` or `exception` depending on which is more appropriate.",
           "default": null,
           "anyOf": [
             {
@@ -324,7 +324,7 @@ expression: event_json_schema()
           ]
         },
         "start_timestamp": {
-          "description": "Timestamp when the event has started (relevant for event type = \"transaction\")",
+          "description": " Timestamp when the event has started (relevant for event type = \"transaction\")",
           "default": null,
           "anyOf": [
             {
@@ -336,7 +336,7 @@ expression: event_json_schema()
           ]
         },
         "tags": {
-          "description": "Custom tags for this event.\n\nA map or list of tags for this event. Each tag must be less than 200 characters.",
+          "description": " Custom tags for this event.\n\n A map or list of tags for this event. Each tag must be less than 200 characters.",
           "default": null,
           "anyOf": [
             {
@@ -348,7 +348,7 @@ expression: event_json_schema()
           ]
         },
         "threads": {
-          "description": "Threads that were active when the event occurred.",
+          "description": " Threads that were active when the event occurred.",
           "default": null,
           "type": [
             "object",
@@ -374,7 +374,7 @@ expression: event_json_schema()
           }
         },
         "time_spent": {
-          "description": "Time since the start of the transaction until the error occurred.",
+          "description": " Time since the start of the transaction until the error occurred.",
           "default": null,
           "type": [
             "integer",
@@ -384,7 +384,7 @@ expression: event_json_schema()
           "minimum": 0.0
         },
         "timestamp": {
-          "description": "Timestamp when the event was created.\n\nIndicates when the event was created in the Sentry SDK. The format is either a string as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float) value representing the number of seconds that have elapsed since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).\n\nSub-microsecond precision is not preserved with numeric values due to precision limitations with floats (at least in our systems). With that caveat in mind, just send whatever is easiest to produce.\n\nAll timestamps in the event protocol are formatted this way.\n\n```json { \"timestamp\": \"2011-05-02T17:41:36Z\" } { \"timestamp\": 1304358096.0 } ```",
+          "description": " Timestamp when the event was created.\n\n Indicates when the event was created in the Sentry SDK. The format is either a string as\n defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float)\n value representing the number of seconds that have elapsed since the [Unix\n epoch](https://en.wikipedia.org/wiki/Unix_time).\n\n Sub-microsecond precision is not preserved with numeric values due to precision\n limitations with floats (at least in our systems). With that caveat in mind, just send\n whatever is easiest to produce.\n\n All timestamps in the event protocol are formatted this way.\n\n ```json\n { \"timestamp\": \"2011-05-02T17:41:36Z\" }\n { \"timestamp\": 1304358096.0 }\n ```",
           "default": null,
           "anyOf": [
             {
@@ -396,7 +396,7 @@ expression: event_json_schema()
           ]
         },
         "transaction": {
-          "description": "Transaction name of the event.\n\nFor example, in a web app, this might be the route name (`\"/users/<username>/\"` or `UserView`), in a task queue it might be the function + module name.",
+          "description": " Transaction name of the event.\n\n For example, in a web app, this might be the route name (`\"/users/<username>/\"` or\n `UserView`), in a task queue it might be the function + module name.",
           "default": null,
           "type": [
             "string",
@@ -404,7 +404,7 @@ expression: event_json_schema()
           ]
         },
         "type": {
-          "description": "Type of event: error, csp, default",
+          "description": " Type of event: error, csp, default",
           "default": null,
           "anyOf": [
             {
@@ -416,7 +416,7 @@ expression: event_json_schema()
           ]
         },
         "user": {
-          "description": "Information about the user who triggered this event.",
+          "description": " Information about the user who triggered this event.",
           "default": null,
           "anyOf": [
             {
@@ -428,7 +428,7 @@ expression: event_json_schema()
           ]
         },
         "version": {
-          "description": "Version",
+          "description": " Version",
           "default": null,
           "type": [
             "string",
@@ -449,7 +449,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "app_build": {
-              "description": "Internal build ID as it appears on the platform.",
+              "description": " Internal build ID as it appears on the platform.",
               "default": null,
               "type": [
                 "string",
@@ -457,7 +457,7 @@ expression: event_json_schema()
               ]
             },
             "app_identifier": {
-              "description": "Version-independent application identifier, often a dotted bundle ID.",
+              "description": " Version-independent application identifier, often a dotted bundle ID.",
               "default": null,
               "type": [
                 "string",
@@ -465,7 +465,7 @@ expression: event_json_schema()
               ]
             },
             "app_name": {
-              "description": "Application name as it appears on the platform.",
+              "description": " Application name as it appears on the platform.",
               "default": null,
               "type": [
                 "string",
@@ -481,7 +481,7 @@ expression: event_json_schema()
               ]
             },
             "app_version": {
-              "description": "Application version as it appears on the platform.",
+              "description": " Application version as it appears on the platform.",
               "default": null,
               "type": [
                 "string",
@@ -489,7 +489,7 @@ expression: event_json_schema()
               ]
             },
             "build_type": {
-              "description": "String identifying the kind of build. For example, `testflight`.",
+              "description": " String identifying the kind of build. For example, `testflight`.",
               "default": null,
               "type": [
                 "string",
@@ -497,7 +497,7 @@ expression: event_json_schema()
               ]
             },
             "device_app_hash": {
-              "description": "Application-specific device identifier.",
+              "description": " Application-specific device identifier.",
               "default": null,
               "type": [
                 "string",
@@ -521,7 +521,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "arch": {
-              "description": "CPU architecture target.",
+              "description": " CPU architecture target.",
               "default": null,
               "type": [
                 "string",
@@ -529,7 +529,7 @@ expression: event_json_schema()
               ]
             },
             "cpu_subtype": {
-              "description": "MachO CPU subtype identifier.",
+              "description": " MachO CPU subtype identifier.",
               "default": null,
               "type": [
                 "integer",
@@ -539,7 +539,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "cpu_type": {
-              "description": "MachO CPU type identifier.",
+              "description": " MachO CPU type identifier.",
               "default": null,
               "type": [
                 "integer",
@@ -549,7 +549,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "image_addr": {
-              "description": "Starting memory address of the image (required).",
+              "description": " Starting memory address of the image (required).",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Addr"
@@ -560,7 +560,7 @@ expression: event_json_schema()
               ]
             },
             "image_size": {
-              "description": "Size of the image in bytes (required).",
+              "description": " Size of the image in bytes (required).",
               "type": [
                 "integer",
                 "null"
@@ -569,7 +569,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "image_vmaddr": {
-              "description": "Loading address in virtual memory.",
+              "description": " Loading address in virtual memory.",
               "default": null,
               "anyOf": [
                 {
@@ -588,7 +588,7 @@ expression: event_json_schema()
               ]
             },
             "uuid": {
-              "description": "The unique UUID of the image.",
+              "description": " The unique UUID of the image.",
               "type": [
                 "string",
                 "null"
@@ -606,7 +606,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "category": {
-              "description": "A dotted string indicating what the crumb is or from where it comes. _Optional._\n\nTypically it is a module name or a descriptive string. For instance, _ui.click_ could be used to indicate that a click happened in the UI or _flask_ could be used to indicate that the event originated in the Flask framework.",
+              "description": " A dotted string indicating what the crumb is or from where it comes. _Optional._\n\n Typically it is a module name or a descriptive string. For instance, _ui.click_ could be\n used to indicate that a click happened in the UI or _flask_ could be used to indicate that\n the event originated in the Flask framework.",
               "default": null,
               "type": [
                 "string",
@@ -614,7 +614,7 @@ expression: event_json_schema()
               ]
             },
             "data": {
-              "description": "Arbitrary data associated with this breadcrumb.\n\nContains a dictionary whose contents depend on the breadcrumb `type`. Additional parameters that are unsupported by the type are rendered as a key/value table.",
+              "description": " Arbitrary data associated with this breadcrumb.\n\n Contains a dictionary whose contents depend on the breadcrumb `type`. Additional parameters\n that are unsupported by the type are rendered as a key/value table.",
               "default": null,
               "type": [
                 "object",
@@ -623,7 +623,7 @@ expression: event_json_schema()
               "additionalProperties": true
             },
             "level": {
-              "description": "Severity level of the breadcrumb. _Optional._\n\nAllowed values are, from highest to lowest: `fatal`, `error`, `warning`, `info`, and `debug`. Levels are used in the UI to emphasize and deemphasize the crumb. Defaults to `info`.",
+              "description": " Severity level of the breadcrumb. _Optional._\n\n Allowed values are, from highest to lowest: `fatal`, `error`, `warning`, `info`, and\n `debug`. Levels are used in the UI to emphasize and deemphasize the crumb. Defaults to\n `info`.",
               "default": null,
               "anyOf": [
                 {
@@ -635,7 +635,7 @@ expression: event_json_schema()
               ]
             },
             "message": {
-              "description": "Human readable message for the breadcrumb.\n\nIf a message is provided, it is rendered as text with all whitespace preserved. Very long text might be truncated in the UI.",
+              "description": " Human readable message for the breadcrumb.\n\n If a message is provided, it is rendered as text with all whitespace preserved. Very long\n text might be truncated in the UI.",
               "default": null,
               "type": [
                 "string",
@@ -655,7 +655,7 @@ expression: event_json_schema()
               ]
             },
             "type": {
-              "description": "The type of the breadcrumb. _Optional_, defaults to `default`.\n\n- `default`: Describes a generic breadcrumb. This is typically a log message or user-generated breadcrumb. The `data` field is entirely undefined and as such, completely rendered as a key/value table.\n\n- `navigation`: Describes a navigation breadcrumb. A navigation event can be a URL change in a web application, or a UI transition in a mobile or desktop application, etc.\n\nSuch a breadcrumb's `data` object has the required fields `from` and `to`, which represent an application route/url each.\n\n- `http`: Describes an HTTP request breadcrumb. This represents an HTTP request transmitted from your application. This could be an AJAX request from a web application, or a server-to-server HTTP request to an API service provider, etc.\n\nSuch a breadcrumb's `data` property has the fields `url`, `method`, `status_code` (integer) and `reason` (string).",
+              "description": " The type of the breadcrumb. _Optional_, defaults to `default`.\n\n - `default`: Describes a generic breadcrumb. This is typically a log message or\n   user-generated breadcrumb. The `data` field is entirely undefined and as such, completely\n   rendered as a key/value table.\n\n - `navigation`: Describes a navigation breadcrumb. A navigation event can be a URL change\n   in a web application, or a UI transition in a mobile or desktop application, etc.\n\n   Such a breadcrumb's `data` object has the required fields `from` and `to`, which\n   represent an application route/url each.\n\n - `http`: Describes an HTTP request breadcrumb. This represents an HTTP request transmitted\n   from your application. This could be an AJAX request from a web application, or a\n   server-to-server HTTP request to an API service provider, etc.\n\n   Such a breadcrumb's `data` property has the fields `url`, `method`, `status_code`\n   (integer) and `reason` (string).",
               "default": null,
               "type": [
                 "string",
@@ -681,7 +681,7 @@ expression: event_json_schema()
               ]
             },
             "version": {
-              "description": "Version string of the browser.",
+              "description": " Version string of the browser.",
               "default": null,
               "type": [
                 "string",
@@ -699,7 +699,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "name": {
-              "description": "Optional name of the errno constant.",
+              "description": " Optional name of the errno constant.",
               "default": null,
               "type": [
                 "string",
@@ -730,7 +730,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "integrations": {
-              "description": "List of integrations that are enabled in the SDK. _Optional._\n\nThe list should have all enabled integrations, including default integrations. Default integrations are included because different SDK releases may contain different default integrations.",
+              "description": " List of integrations that are enabled in the SDK. _Optional._\n\n The list should have all enabled integrations, including default integrations. Default\n integrations are included because different SDK releases may contain different default\n integrations.",
               "default": null,
               "type": [
                 "array",
@@ -751,7 +751,7 @@ expression: event_json_schema()
               ]
             },
             "packages": {
-              "description": "List of installed and loaded SDK packages. _Optional._\n\nA list of packages that were installed as part of this SDK or the activated integrations. Each package consists of a name in the format `source:identifier` and `version`. If the source is a Git repository, the `source` should be `git`, the identifier should be a checkout link and the version should be a Git reference (branch, tag or SHA).",
+              "description": " List of installed and loaded SDK packages. _Optional._\n\n A list of packages that were installed as part of this SDK or the activated integrations.\n Each package consists of a name in the format `source:identifier` and `version`. If the\n source is a Git repository, the `source` should be `git`, the identifier should be a\n checkout link and the version should be a Git reference (branch, tag or SHA).",
               "default": null,
               "type": [
                 "array",
@@ -769,7 +769,7 @@ expression: event_json_schema()
               }
             },
             "version": {
-              "description": "The version of the SDK. _Required._\n\nIt should have the [Semantic Versioning](https://semver.org/) format `MAJOR.MINOR.PATCH`, without any prefix (no `v` or anything else in front of the major version number).\n\nExamples: `0.1.0`, `1.0.0`, `4.3.12`",
+              "description": " The version of the SDK. _Required._\n\n It should have the [Semantic Versioning](https://semver.org/) format `MAJOR.MINOR.PATCH`,\n without any prefix (no `v` or anything else in front of the major version number).\n\n Examples: `0.1.0`, `1.0.0`, `4.3.12`",
               "type": [
                 "string",
                 "null"
@@ -794,7 +794,7 @@ expression: event_json_schema()
               ]
             },
             "version": {
-              "description": "Version of the package.",
+              "description": " Version of the package.",
               "default": null,
               "type": [
                 "string",
@@ -946,7 +946,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "images": {
-              "description": "List of debug information files (debug images).",
+              "description": " List of debug information files (debug images).",
               "default": null,
               "type": [
                 "array",
@@ -986,7 +986,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "arch": {
-              "description": "Native cpu architecture of the device.",
+              "description": " Native cpu architecture of the device.",
               "default": null,
               "type": [
                 "string",
@@ -994,7 +994,7 @@ expression: event_json_schema()
               ]
             },
             "battery_level": {
-              "description": "Current battery level in %.\n\nIf the device has a battery, this can be a floating point value defining the battery level (in the range 0-100).",
+              "description": " Current battery level in %.\n\n If the device has a battery, this can be a floating point value defining the battery level\n (in the range 0-100).",
               "default": null,
               "type": [
                 "number",
@@ -1003,7 +1003,7 @@ expression: event_json_schema()
               "format": "double"
             },
             "boot_time": {
-              "description": "Indicator when the device was booted.",
+              "description": " Indicator when the device was booted.",
               "default": null,
               "type": [
                 "string",
@@ -1011,7 +1011,7 @@ expression: event_json_schema()
               ]
             },
             "brand": {
-              "description": "Brand of the device.",
+              "description": " Brand of the device.",
               "default": null,
               "type": [
                 "string",
@@ -1019,7 +1019,7 @@ expression: event_json_schema()
               ]
             },
             "charging": {
-              "description": "Whether the device was charging or not.",
+              "description": " Whether the device was charging or not.",
               "default": null,
               "type": [
                 "boolean",
@@ -1027,7 +1027,7 @@ expression: event_json_schema()
               ]
             },
             "external_free_storage": {
-              "description": "Free size of the attached external storage in bytes (eg: android SDK card).",
+              "description": " Free size of the attached external storage in bytes (eg: android SDK card).",
               "default": null,
               "type": [
                 "integer",
@@ -1037,7 +1037,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "external_storage_size": {
-              "description": "Total size of the attached external storage in bytes (eg: android SDK card).",
+              "description": " Total size of the attached external storage in bytes (eg: android SDK card).",
               "default": null,
               "type": [
                 "integer",
@@ -1047,7 +1047,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "family": {
-              "description": "Family of the device model.\n\nThis is usually the common part of model names across generations. For instance, `iPhone` would be a reasonable family, so would be `Samsung Galaxy`.",
+              "description": " Family of the device model.\n\n This is usually the common part of model names across generations. For instance, `iPhone`\n would be a reasonable family, so would be `Samsung Galaxy`.",
               "default": null,
               "type": [
                 "string",
@@ -1055,7 +1055,7 @@ expression: event_json_schema()
               ]
             },
             "free_memory": {
-              "description": "How much memory is still available in bytes.",
+              "description": " How much memory is still available in bytes.",
               "default": null,
               "type": [
                 "integer",
@@ -1065,7 +1065,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "free_storage": {
-              "description": "How much storage is free in bytes.",
+              "description": " How much storage is free in bytes.",
               "default": null,
               "type": [
                 "integer",
@@ -1075,7 +1075,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "low_memory": {
-              "description": "Whether the device was low on memory.",
+              "description": " Whether the device was low on memory.",
               "default": null,
               "type": [
                 "boolean",
@@ -1083,7 +1083,7 @@ expression: event_json_schema()
               ]
             },
             "manufacturer": {
-              "description": "Manufacturer of the device.",
+              "description": " Manufacturer of the device.",
               "default": null,
               "type": [
                 "string",
@@ -1091,7 +1091,7 @@ expression: event_json_schema()
               ]
             },
             "memory_size": {
-              "description": "Total memory available in bytes.",
+              "description": " Total memory available in bytes.",
               "default": null,
               "type": [
                 "integer",
@@ -1101,7 +1101,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "model": {
-              "description": "Device model.\n\nThis, for example, can be `Samsung Galaxy S3`.",
+              "description": " Device model.\n\n This, for example, can be `Samsung Galaxy S3`.",
               "default": null,
               "type": [
                 "string",
@@ -1109,7 +1109,7 @@ expression: event_json_schema()
               ]
             },
             "model_id": {
-              "description": "Device model (internal identifier).\n\nAn internal hardware revision to identify the device exactly.",
+              "description": " Device model (internal identifier).\n\n An internal hardware revision to identify the device exactly.",
               "default": null,
               "type": [
                 "string",
@@ -1125,7 +1125,7 @@ expression: event_json_schema()
               ]
             },
             "online": {
-              "description": "Whether the device was online or not.",
+              "description": " Whether the device was online or not.",
               "default": null,
               "type": [
                 "boolean",
@@ -1133,7 +1133,7 @@ expression: event_json_schema()
               ]
             },
             "orientation": {
-              "description": "Current screen orientation.\n\nThis can be a string `portrait` or `landscape` to define the orientation of a device.",
+              "description": " Current screen orientation.\n\n This can be a string `portrait` or `landscape` to define the orientation of a device.",
               "default": null,
               "type": [
                 "string",
@@ -1141,7 +1141,7 @@ expression: event_json_schema()
               ]
             },
             "screen_density": {
-              "description": "Device screen density.",
+              "description": " Device screen density.",
               "default": null,
               "type": [
                 "number",
@@ -1150,7 +1150,7 @@ expression: event_json_schema()
               "format": "double"
             },
             "screen_dpi": {
-              "description": "Screen density as dots-per-inch.",
+              "description": " Screen density as dots-per-inch.",
               "default": null,
               "type": [
                 "integer",
@@ -1160,7 +1160,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "screen_resolution": {
-              "description": "Device screen resolution.\n\n(e.g.: 800x600, 3040x1444)",
+              "description": " Device screen resolution.\n\n (e.g.: 800x600, 3040x1444)",
               "default": null,
               "type": [
                 "string",
@@ -1168,7 +1168,7 @@ expression: event_json_schema()
               ]
             },
             "simulator": {
-              "description": "Simulator/prod indicator.",
+              "description": " Simulator/prod indicator.",
               "default": null,
               "type": [
                 "boolean",
@@ -1176,7 +1176,7 @@ expression: event_json_schema()
               ]
             },
             "storage_size": {
-              "description": "Total storage size of the device in bytes.",
+              "description": " Total storage size of the device in bytes.",
               "default": null,
               "type": [
                 "integer",
@@ -1186,7 +1186,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "timezone": {
-              "description": "Timezone of the device.",
+              "description": " Timezone of the device.",
               "default": null,
               "type": [
                 "string",
@@ -1194,7 +1194,7 @@ expression: event_json_schema()
               ]
             },
             "usable_memory": {
-              "description": "How much memory is usable for the app in bytes.",
+              "description": " How much memory is usable for the app in bytes.",
               "default": null,
               "type": [
                 "integer",
@@ -1226,7 +1226,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "name": {
-              "description": "Affected key or deep path.",
+              "description": " Affected key or deep path.",
               "default": null,
               "type": [
                 "string",
@@ -1241,7 +1241,7 @@ expression: event_json_schema()
               ]
             },
             "value": {
-              "description": "The original value causing this error.",
+              "description": " The original value causing this error.",
               "default": null
             }
           }
@@ -1268,7 +1268,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "mechanism": {
-              "description": "Mechanism by which this exception was generated and handled.",
+              "description": " Mechanism by which this exception was generated and handled.",
               "default": null,
               "anyOf": [
                 {
@@ -1280,7 +1280,7 @@ expression: event_json_schema()
               ]
             },
             "module": {
-              "description": "The optional module, or package which the exception type lives in.",
+              "description": " The optional module, or package which the exception type lives in.",
               "default": null,
               "type": [
                 "string",
@@ -1288,7 +1288,7 @@ expression: event_json_schema()
               ]
             },
             "stacktrace": {
-              "description": "Stack trace containing frames of this exception.",
+              "description": " Stack trace containing frames of this exception.",
               "default": null,
               "anyOf": [
                 {
@@ -1300,7 +1300,7 @@ expression: event_json_schema()
               ]
             },
             "thread_id": {
-              "description": "An optional value which refers to a [thread](#Thread).",
+              "description": " An optional value which refers to a [thread](#Thread).",
               "default": null,
               "anyOf": [
                 {
@@ -1320,7 +1320,7 @@ expression: event_json_schema()
               ]
             },
             "value": {
-              "description": "Human readable display value.\n\nAt least one of `type` or `value` is required, otherwise the exception is discarded.",
+              "description": " Human readable display value.\n\n At least one of `type` or `value` is required, otherwise the exception is discarded.",
               "default": null,
               "anyOf": [
                 {
@@ -1353,7 +1353,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "abs_path": {
-              "description": "Absolute path to the source file.",
+              "description": " Absolute path to the source file.",
               "default": null,
               "anyOf": [
                 {
@@ -1365,7 +1365,7 @@ expression: event_json_schema()
               ]
             },
             "colno": {
-              "description": "Column number within the source file, starting at 1.",
+              "description": " Column number within the source file, starting at 1.",
               "default": null,
               "type": [
                 "integer",
@@ -1375,7 +1375,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "context_line": {
-              "description": "Source code of the current line (`lineno`).",
+              "description": " Source code of the current line (`lineno`).",
               "default": null,
               "type": [
                 "string",
@@ -1383,7 +1383,7 @@ expression: event_json_schema()
               ]
             },
             "filename": {
-              "description": "The source file name (basename only).",
+              "description": " The source file name (basename only).",
               "default": null,
               "anyOf": [
                 {
@@ -1403,7 +1403,7 @@ expression: event_json_schema()
               ]
             },
             "image_addr": {
-              "description": "(C/C++/Native) Start address of the containing code module (image).",
+              "description": " (C/C++/Native) Start address of the containing code module (image).",
               "default": null,
               "anyOf": [
                 {
@@ -1415,7 +1415,7 @@ expression: event_json_schema()
               ]
             },
             "in_app": {
-              "description": "Override whether this frame should be considered part of application code, or part of libraries/frameworks/dependencies.\n\nSetting this attribute to `false` causes the frame to be hidden/collapsed by default and mostly ignored during issue grouping.",
+              "description": " Override whether this frame should be considered part of application code, or part of\n libraries/frameworks/dependencies.\n\n Setting this attribute to `false` causes the frame to be hidden/collapsed by default and\n mostly ignored during issue grouping.",
               "default": null,
               "type": [
                 "boolean",
@@ -1423,7 +1423,7 @@ expression: event_json_schema()
               ]
             },
             "instruction_addr": {
-              "description": "(C/C++/Native) Absolute address of the frame's CPU instruction.",
+              "description": " (C/C++/Native) Absolute address of the frame's CPU instruction.",
               "default": null,
               "anyOf": [
                 {
@@ -1435,7 +1435,7 @@ expression: event_json_schema()
               ]
             },
             "lineno": {
-              "description": "Line number within the source file, starting at 1.",
+              "description": " Line number within the source file, starting at 1.",
               "default": null,
               "type": [
                 "integer",
@@ -1445,7 +1445,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "module": {
-              "description": "Name of the module the frame is contained in.\n\nNote that this might also include a class name if that is something the language natively considers to be part of the stack (for instance in Java).",
+              "description": " Name of the module the frame is contained in.\n\n Note that this might also include a class name if that is something the\n language natively considers to be part of the stack (for instance in Java).",
               "default": null,
               "type": [
                 "string",
@@ -1453,7 +1453,7 @@ expression: event_json_schema()
               ]
             },
             "package": {
-              "description": "Name of the package that contains the frame.\n\nFor instance this can be a dylib for native languages, the name of the jar or .NET assembly.",
+              "description": " Name of the package that contains the frame.\n\n For instance this can be a dylib for native languages, the name of the jar\n or .NET assembly.",
               "default": null,
               "type": [
                 "string",
@@ -1461,7 +1461,7 @@ expression: event_json_schema()
               ]
             },
             "platform": {
-              "description": "Which platform this frame is from.\n\nThis can override the platform for a single frame. Otherwise, the platform of the event is assumed. This can be used for multi-platform stack traces, such as in React Native.",
+              "description": " Which platform this frame is from.\n\n This can override the platform for a single frame. Otherwise, the platform of the event is\n assumed. This can be used for multi-platform stack traces, such as in React Native.",
               "default": null,
               "type": [
                 "string",
@@ -1469,7 +1469,7 @@ expression: event_json_schema()
               ]
             },
             "post_context": {
-              "description": "Source code of the lines after `lineno`.",
+              "description": " Source code of the lines after `lineno`.",
               "default": null,
               "type": [
                 "array",
@@ -1483,7 +1483,7 @@ expression: event_json_schema()
               }
             },
             "pre_context": {
-              "description": "Source code leading up to `lineno`.",
+              "description": " Source code leading up to `lineno`.",
               "default": null,
               "type": [
                 "array",
@@ -1497,7 +1497,7 @@ expression: event_json_schema()
               }
             },
             "raw_function": {
-              "description": "A raw (but potentially truncated) function value.\n\nThe original function name, if the function name is shortened or demangled. Sentry shows the raw function when clicking on the shortened one in the UI.\n\nIf this has the same value as `function` it's best to be omitted.  This exists because on many platforms the function itself contains additional information like overload specifies or a lot of generics which can make it exceed the maximum limit we provide for the field.  In those cases then we cannot reliably trim down the function any more at a later point because the more valuable information has been removed.\n\nThe logic to be applied is that an intelligently trimmed function name should be stored in `function` and the value before trimming is stored in this field instead.  However also this field will be capped at 256 characters at the moment which often means that not the entire original value can be stored.",
+              "description": " A raw (but potentially truncated) function value.\n\n The original function name, if the function name is shortened or demangled. Sentry shows\n the raw function when clicking on the shortened one in the UI.\n\n If this has the same value as `function` it's best to be omitted.  This\n exists because on many platforms the function itself contains additional\n information like overload specifies or a lot of generics which can make\n it exceed the maximum limit we provide for the field.  In those cases\n then we cannot reliably trim down the function any more at a later point\n because the more valuable information has been removed.\n\n The logic to be applied is that an intelligently trimmed function name\n should be stored in `function` and the value before trimming is stored\n in this field instead.  However also this field will be capped at 256\n characters at the moment which often means that not the entire original\n value can be stored.",
               "default": null,
               "type": [
                 "string",
@@ -1505,7 +1505,7 @@ expression: event_json_schema()
               ]
             },
             "symbol": {
-              "description": "Potentially mangled name of the symbol as it appears in an executable.\n\nThis is different from a function name by generally being the mangled name that appears natively in the binary.  This is relevant for languages like Swift, C++ or Rust.",
+              "description": " Potentially mangled name of the symbol as it appears in an executable.\n\n This is different from a function name by generally being the mangled\n name that appears natively in the binary.  This is relevant for languages\n like Swift, C++ or Rust.",
               "default": null,
               "type": [
                 "string",
@@ -1513,7 +1513,7 @@ expression: event_json_schema()
               ]
             },
             "symbol_addr": {
-              "description": "(C/C++/Native) Start address of the frame's function.",
+              "description": " (C/C++/Native) Start address of the frame's function.",
               "default": null,
               "anyOf": [
                 {
@@ -1525,7 +1525,7 @@ expression: event_json_schema()
               ]
             },
             "vars": {
-              "description": "Mapping of local variables and expression names that were available in this frame.",
+              "description": " Mapping of local variables and expression names that were available in this frame.",
               "default": null,
               "anyOf": [
                 {
@@ -1556,7 +1556,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "city": {
-              "description": "Human readable city name.",
+              "description": " Human readable city name.",
               "default": null,
               "type": [
                 "string",
@@ -1572,7 +1572,7 @@ expression: event_json_schema()
               ]
             },
             "region": {
-              "description": "Human readable region name or code.",
+              "description": " Human readable region name or code.",
               "default": null,
               "type": [
                 "string",
@@ -1590,7 +1590,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "api_type": {
-              "description": "The device low-level API type.\n\nExamples: `\"Apple Metal\"` or `\"Direct3D11\"`",
+              "description": " The device low-level API type.\n\n Examples: `\"Apple Metal\"` or `\"Direct3D11\"`",
               "default": null,
               "type": [
                 "string",
@@ -1598,11 +1598,11 @@ expression: event_json_schema()
               ]
             },
             "id": {
-              "description": "The PCI identifier of the graphics device.",
+              "description": " The PCI identifier of the graphics device.",
               "default": null
             },
             "memory_size": {
-              "description": "The total GPU memory available in Megabytes.",
+              "description": " The total GPU memory available in Megabytes.",
               "default": null,
               "type": [
                 "integer",
@@ -1612,7 +1612,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "multi_threaded_rendering": {
-              "description": "Whether the GPU has multi-threaded rendering or not.",
+              "description": " Whether the GPU has multi-threaded rendering or not.",
               "default": null,
               "type": [
                 "boolean",
@@ -1628,7 +1628,7 @@ expression: event_json_schema()
               ]
             },
             "npot_support": {
-              "description": "The Non-Power-Of-Two support.",
+              "description": " The Non-Power-Of-Two support.",
               "default": null,
               "type": [
                 "string",
@@ -1636,7 +1636,7 @@ expression: event_json_schema()
               ]
             },
             "vendor_id": {
-              "description": "The PCI vendor identifier of the graphics device.",
+              "description": " The PCI vendor identifier of the graphics device.",
               "default": null,
               "type": [
                 "string",
@@ -1644,7 +1644,7 @@ expression: event_json_schema()
               ]
             },
             "vendor_name": {
-              "description": "The vendor name as reported by the graphics device.",
+              "description": " The vendor name as reported by the graphics device.",
               "default": null,
               "type": [
                 "string",
@@ -1652,7 +1652,7 @@ expression: event_json_schema()
               ]
             },
             "version": {
-              "description": "The Version of the graphics device.",
+              "description": " The Version of the graphics device.",
               "default": null,
               "type": [
                 "string",
@@ -1760,7 +1760,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "formatted": {
-              "description": "The formatted message. If `message` and `params` are given, Sentry will attempt to backfill `formatted` if empty.\n\nIt must not exceed 8192 characters. Longer messages will be truncated.",
+              "description": " The formatted message. If `message` and `params` are given, Sentry\n will attempt to backfill `formatted` if empty.\n\n It must not exceed 8192 characters. Longer messages will be truncated.",
               "default": null,
               "anyOf": [
                 {
@@ -1784,7 +1784,7 @@ expression: event_json_schema()
               ]
             },
             "params": {
-              "description": "Parameters to be interpolated into the log message. This can be an array of positional parameters as well as a mapping of named arguments to their values.",
+              "description": " Parameters to be interpolated into the log message. This can be an array of positional\n parameters as well as a mapping of named arguments to their values.",
               "default": null
             }
           }
@@ -1798,7 +1798,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "code": {
-              "description": "The mach exception code.",
+              "description": " The mach exception code.",
               "default": null,
               "type": [
                 "integer",
@@ -1817,7 +1817,7 @@ expression: event_json_schema()
               "format": "int64"
             },
             "name": {
-              "description": "Optional name of the mach exception.",
+              "description": " Optional name of the mach exception.",
               "default": null,
               "type": [
                 "string",
@@ -1825,7 +1825,7 @@ expression: event_json_schema()
               ]
             },
             "subcode": {
-              "description": "The mach exception subcode.",
+              "description": " The mach exception subcode.",
               "default": null,
               "type": [
                 "integer",
@@ -1848,7 +1848,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "data": {
-              "description": "Additional attributes depending on the mechanism type.",
+              "description": " Additional attributes depending on the mechanism type.",
               "default": null,
               "type": [
                 "object",
@@ -1857,7 +1857,7 @@ expression: event_json_schema()
               "additionalProperties": true
             },
             "description": {
-              "description": "Optional human-readable description of the error mechanism.\n\nMay include a possible hint on how to solve this error.",
+              "description": " Optional human-readable description of the error mechanism.\n\n May include a possible hint on how to solve this error.",
               "default": null,
               "type": [
                 "string",
@@ -1865,7 +1865,7 @@ expression: event_json_schema()
               ]
             },
             "handled": {
-              "description": "Flag indicating whether this exception was handled.\n\nThis is a best-effort guess at whether the exception was handled by user code or not. For example:\n\n- Exceptions leading to a 500 Internal Server Error or to a hard process crash are `handled=false`, as the SDK typically has an integration that automatically captures the error.\n\n- Exceptions captured using `capture_exception` (called from user code) are `handled=true` as the user explicitly captured the exception (and therefore kind of handled it)",
+              "description": " Flag indicating whether this exception was handled.\n\n This is a best-effort guess at whether the exception was handled by user code or not. For\n example:\n\n - Exceptions leading to a 500 Internal Server Error or to a hard process crash are\n   `handled=false`, as the SDK typically has an integration that automatically captures the\n   error.\n\n - Exceptions captured using `capture_exception` (called from user code) are `handled=true`\n   as the user explicitly captured the exception (and therefore kind of handled it)",
               "default": null,
               "type": [
                 "boolean",
@@ -1873,7 +1873,7 @@ expression: event_json_schema()
               ]
             },
             "help_link": {
-              "description": "Link to online resources describing this error.",
+              "description": " Link to online resources describing this error.",
               "default": null,
               "type": [
                 "string",
@@ -1881,7 +1881,7 @@ expression: event_json_schema()
               ]
             },
             "meta": {
-              "description": "Operating system or runtime meta information.",
+              "description": " Operating system or runtime meta information.",
               "default": null,
               "anyOf": [
                 {
@@ -1893,7 +1893,7 @@ expression: event_json_schema()
               ]
             },
             "synthetic": {
-              "description": "If this is set then the exception is not a real exception but some form of synthetic error for instance from a signal handler, a hard segfault or similar where type and value are not useful for grouping or display purposes.",
+              "description": " If this is set then the exception is not a real exception but some\n form of synthetic error for instance from a signal handler, a hard\n segfault or similar where type and value are not useful for grouping\n or display purposes.",
               "default": null,
               "type": [
                 "boolean",
@@ -1930,7 +1930,7 @@ expression: event_json_schema()
               ]
             },
             "mach_exception": {
-              "description": "A Mach Exception on Apple systems comprising a code triple and optional descriptions.",
+              "description": " A Mach Exception on Apple systems comprising a code triple and optional descriptions.",
               "default": null,
               "anyOf": [
                 {
@@ -1942,7 +1942,7 @@ expression: event_json_schema()
               ]
             },
             "signal": {
-              "description": "Information on the POSIX signal.",
+              "description": " Information on the POSIX signal.",
               "default": null,
               "anyOf": [
                 {
@@ -1986,7 +1986,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "arch": {
-              "description": "CPU architecture target.\n\nArchitecture of the module. If missing, this will be backfilled by Sentry.",
+              "description": " CPU architecture target.\n\n Architecture of the module. If missing, this will be backfilled by Sentry.",
               "default": null,
               "type": [
                 "string",
@@ -1994,7 +1994,7 @@ expression: event_json_schema()
               ]
             },
             "code_file": {
-              "description": "Path and name of the image file (required).\n\nThe absolute path to the dynamic library or executable. This helps to locate the file if it is missing on Sentry.\n\n- `pe`: The code file should be provided to allow server-side stack walking of binary crash reports, such as Minidumps.",
+              "description": " Path and name of the image file (required).\n\n The absolute path to the dynamic library or executable. This helps to locate the file if it is missing on Sentry.\n\n - `pe`: The code file should be provided to allow server-side stack walking of binary crash reports, such as Minidumps.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/NativeImagePath"
@@ -2017,7 +2017,7 @@ expression: event_json_schema()
               ]
             },
             "debug_file": {
-              "description": "Path and name of the debug companion file.\n\n- `elf`: Name or absolute path to the file containing stripped debug information for this image. This value might be _required_ to retrieve debug files from certain symbol servers.\n\n- `pe`: Name of the PDB file containing debug information for this image. This value is often required to retrieve debug files from specific symbol servers.\n\n- `macho`: Name or absolute path to the dSYM file containing debug information for this image. This value might be required to retrieve debug files from certain symbol servers.",
+              "description": " Path and name of the debug companion file.\n\n - `elf`: Name or absolute path to the file containing stripped debug information for this image. This value might be _required_ to retrieve debug files from certain symbol servers.\n\n - `pe`: Name of the PDB file containing debug information for this image. This value is often required to retrieve debug files from specific symbol servers.\n\n - `macho`: Name or absolute path to the dSYM file containing debug information for this image. This value might be required to retrieve debug files from certain symbol servers.",
               "default": null,
               "anyOf": [
                 {
@@ -2029,7 +2029,7 @@ expression: event_json_schema()
               ]
             },
             "debug_id": {
-              "description": "Unique debug identifier of the image.\n\n- `elf`: Debug identifier of the dynamic library or executable. If a code identifier is available, the debug identifier is the little-endian UUID representation of the first 16-bytes of that identifier. Spaces are inserted for readability, note the byte order of the first fields:\n\n```text code id:  f1c3bcc0 2798 65fe 3058 404b2831d9e6 4135386c debug id: c0bcc3f1-9827-fe65-3058-404b2831d9e6 ```\n\nIf no code id is available, the debug id should be computed by XORing the first 4096 bytes of the `.text` section in 16-byte chunks, and representing it as a little-endian UUID (again swapping the byte order).\n\n- `pe`: `signature` and `age` of the PDB file. Both values can be read from the CodeView PDB70 debug information header in the PE. The value should be represented as little-endian UUID, with the age appended at the end. Note that the byte order of the UUID fields must be swapped (spaces inserted for readability):\n\n```text signature: f1c3bcc0 2798 65fe 3058 404b2831d9e6 age:                                            1 debug_id:  c0bcc3f1-9827-fe65-3058-404b2831d9e6-1 ```\n\n- `macho`: Identifier of the dynamic library or executable. It is the value of the `LC_UUID` load command in the Mach header, formatted as UUID.",
+              "description": " Unique debug identifier of the image.\n\n - `elf`: Debug identifier of the dynamic library or executable. If a code identifier is available, the debug identifier is the little-endian UUID representation of the first 16-bytes of that\n identifier. Spaces are inserted for readability, note the byte order of the first fields:\n\n   ```text\n   code id:  f1c3bcc0 2798 65fe 3058 404b2831d9e6 4135386c\n   debug id: c0bcc3f1-9827-fe65-3058-404b2831d9e6\n   ```\n\n   If no code id is available, the debug id should be computed by XORing the first 4096 bytes of the `.text` section in 16-byte chunks, and representing it as a little-endian UUID (again swapping the byte order).\n\n - `pe`: `signature` and `age` of the PDB file. Both values can be read from the CodeView PDB70 debug information header in the PE. The value should be represented as little-endian UUID, with the age appended at the end. Note that the byte order of the UUID fields must be swapped (spaces inserted for readability):\n\n   ```text\n   signature: f1c3bcc0 2798 65fe 3058 404b2831d9e6\n   age:                                            1\n   debug_id:  c0bcc3f1-9827-fe65-3058-404b2831d9e6-1\n   ```\n\n - `macho`: Identifier of the dynamic library or executable. It is the value of the `LC_UUID` load command in the Mach header, formatted as UUID.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/DebugId"
@@ -2040,7 +2040,7 @@ expression: event_json_schema()
               ]
             },
             "image_addr": {
-              "description": "Starting memory address of the image (required).\n\nMemory address, at which the image is mounted in the virtual address space of the process. Should be a string in hex representation prefixed with `\"0x\"`.",
+              "description": " Starting memory address of the image (required).\n\n Memory address, at which the image is mounted in the virtual address space of the process. Should be a string in hex representation prefixed with `\"0x\"`.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Addr"
@@ -2051,7 +2051,7 @@ expression: event_json_schema()
               ]
             },
             "image_size": {
-              "description": "Size of the image in bytes (required).\n\nThe size of the image in virtual memory. If missing, Sentry will assume that the image spans up to the next image, which might lead to invalid stack traces.",
+              "description": " Size of the image in bytes (required).\n\n The size of the image in virtual memory. If missing, Sentry will assume that the image spans up to the next image, which might lead to invalid stack traces.",
               "type": [
                 "integer",
                 "null"
@@ -2060,7 +2060,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "image_vmaddr": {
-              "description": "Loading address in virtual memory.\n\nPreferred load address of the image in virtual memory, as declared in the headers of the image. When loading an image, the operating system may still choose to place it at a different address.\n\nSymbols and addresses in the native image are always relative to the start of the image and do not consider the preferred load address. It is merely a hint to the loader.\n\n- `elf`/`macho`: If this value is non-zero, all symbols and addresses declared in the native image start at this address, rather than 0. By contrast, Sentry deals with addresses relative to the start of the image. For example, with `image_vmaddr: 0x40000`, a symbol located at `0x401000` has a relative address of `0x1000`.\n\nRelative addresses used in Apple Crash Reports and `addr2line` are usually in the preferred address space, and not relative address space.",
+              "description": " Loading address in virtual memory.\n\n Preferred load address of the image in virtual memory, as declared in the headers of the\n image. When loading an image, the operating system may still choose to place it at a\n different address.\n\n Symbols and addresses in the native image are always relative to the start of the image and do not consider the preferred load address. It is merely a hint to the loader.\n\n - `elf`/`macho`: If this value is non-zero, all symbols and addresses declared in the native image start at this address, rather than 0. By contrast, Sentry deals with addresses relative to the start of the image. For example, with `image_vmaddr: 0x40000`, a symbol located at `0x401000` has a relative address of `0x1000`.\n\n   Relative addresses used in Apple Crash Reports and `addr2line` are usually in the preferred address space, and not relative address space.",
               "default": null,
               "anyOf": [
                 {
@@ -2090,7 +2090,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "build": {
-              "description": "Internal build number of the operating system.",
+              "description": " Internal build number of the operating system.",
               "default": null,
               "type": [
                 "string",
@@ -2098,7 +2098,7 @@ expression: event_json_schema()
               ]
             },
             "kernel_version": {
-              "description": "Current kernel version.\n\nThis is typically the entire output of the `uname` syscall.",
+              "description": " Current kernel version.\n\n This is typically the entire output of the `uname` syscall.",
               "default": null,
               "type": [
                 "string",
@@ -2114,7 +2114,7 @@ expression: event_json_schema()
               ]
             },
             "raw_description": {
-              "description": "Unprocessed operating system info.\n\nAn unprocessed description string obtained by the operating system. For some well-known runtimes, Sentry will attempt to parse `name` and `version` from this string, if they are not explicitly given.",
+              "description": " Unprocessed operating system info.\n\n An unprocessed description string obtained by the operating system. For some well-known\n runtimes, Sentry will attempt to parse `name` and `version` from this string, if they are\n not explicitly given.",
               "default": null,
               "type": [
                 "string",
@@ -2122,7 +2122,7 @@ expression: event_json_schema()
               ]
             },
             "rooted": {
-              "description": "Indicator if the OS is rooted (mobile mostly).",
+              "description": " Indicator if the OS is rooted (mobile mostly).",
               "default": null,
               "type": [
                 "boolean",
@@ -2130,7 +2130,7 @@ expression: event_json_schema()
               ]
             },
             "version": {
-              "description": "Version of the operating system.",
+              "description": " Version of the operating system.",
               "default": null,
               "type": [
                 "string",
@@ -2148,7 +2148,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "code": {
-              "description": "An optional signal code present on Apple systems.",
+              "description": " An optional signal code present on Apple systems.",
               "default": null,
               "type": [
                 "integer",
@@ -2157,7 +2157,7 @@ expression: event_json_schema()
               "format": "int64"
             },
             "code_name": {
-              "description": "Optional name of the errno constant.",
+              "description": " Optional name of the errno constant.",
               "default": null,
               "type": [
                 "string",
@@ -2165,7 +2165,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Optional name of the errno constant.",
+              "description": " Optional name of the errno constant.",
               "default": null,
               "type": [
                 "string",
@@ -2284,7 +2284,7 @@ expression: event_json_schema()
               }
             },
             "lang": {
-              "description": "The language of the stacktrace.",
+              "description": " The language of the stacktrace.",
               "default": null,
               "type": [
                 "string",
@@ -2292,7 +2292,7 @@ expression: event_json_schema()
               ]
             },
             "registers": {
-              "description": "Register values of the thread (top frame).\n\nA map of register names and their values. The values should contain the actual register values of the thread, thus mapping to the last frame in the list.",
+              "description": " Register values of the thread (top frame).\n\n A map of register names and their values. The values should contain the actual register values of the thread, thus mapping to the last frame in the list.",
               "default": null,
               "type": [
                 "object",
@@ -2323,7 +2323,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "cookies": {
-              "description": "The cookie values.\n\nCan be given unparsed as string, as dictionary, or as a list of tuples.",
+              "description": " The cookie values.\n\n Can be given unparsed as string, as dictionary, or as a list of tuples.",
               "default": null,
               "anyOf": [
                 {
@@ -2335,11 +2335,11 @@ expression: event_json_schema()
               ]
             },
             "data": {
-              "description": "Request data in any format that makes sense.\n\nSDKs should discard large and binary bodies by default. Can be given as string or structural data of any format.",
+              "description": " Request data in any format that makes sense.\n\n SDKs should discard large and binary bodies by default. Can be given as string or\n structural data of any format.",
               "default": null
             },
             "env": {
-              "description": "Server environment data, such as CGI/WSGI.\n\nA dictionary containing environment information passed from the server. This is where information such as CGI/WSGI/Rack keys go that are not HTTP headers.\n\nSentry will explicitly look for `REMOTE_ADDR` to extract an IP address.",
+              "description": " Server environment data, such as CGI/WSGI.\n\n A dictionary containing environment information passed from the server. This is where\n information such as CGI/WSGI/Rack keys go that are not HTTP headers.\n\n Sentry will explicitly look for `REMOTE_ADDR` to extract an IP address.",
               "default": null,
               "type": [
                 "object",
@@ -2348,7 +2348,7 @@ expression: event_json_schema()
               "additionalProperties": true
             },
             "fragment": {
-              "description": "The fragment of the request URL.",
+              "description": " The fragment of the request URL.",
               "default": null,
               "type": [
                 "string",
@@ -2356,7 +2356,7 @@ expression: event_json_schema()
               ]
             },
             "headers": {
-              "description": "A dictionary of submitted headers.\n\nIf a header appears multiple times it, needs to be merged according to the HTTP standard for header merging. Header names are treated case-insensitively by Sentry.",
+              "description": " A dictionary of submitted headers.\n\n If a header appears multiple times it, needs to be merged according to the HTTP standard\n for header merging. Header names are treated case-insensitively by Sentry.",
               "default": null,
               "anyOf": [
                 {
@@ -2368,7 +2368,7 @@ expression: event_json_schema()
               ]
             },
             "inferred_content_type": {
-              "description": "The inferred content type of the request payload.",
+              "description": " The inferred content type of the request payload.",
               "default": null,
               "type": [
                 "string",
@@ -2376,7 +2376,7 @@ expression: event_json_schema()
               ]
             },
             "method": {
-              "description": "HTTP request method.",
+              "description": " HTTP request method.",
               "default": null,
               "type": [
                 "string",
@@ -2384,7 +2384,7 @@ expression: event_json_schema()
               ]
             },
             "query_string": {
-              "description": "The query string component of the URL.\n\nCan be given as unparsed string, dictionary, or list of tuples.\n\nIf the query string is not declared and part of the `url`, Sentry moves it to the query string.",
+              "description": " The query string component of the URL.\n\n Can be given as unparsed string, dictionary, or list of tuples.\n\n If the query string is not declared and part of the `url`, Sentry moves it to the\n query string.",
               "default": null,
               "anyOf": [
                 {
@@ -2414,7 +2414,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "build": {
-              "description": "Application build string, if it is separate from the version.",
+              "description": " Application build string, if it is separate from the version.",
               "default": null,
               "type": [
                 "string",
@@ -2430,7 +2430,7 @@ expression: event_json_schema()
               ]
             },
             "raw_description": {
-              "description": "Unprocessed runtime info.\n\nAn unprocessed description string obtained by the runtime. For some well-known runtimes, Sentry will attempt to parse `name` and `version` from this string, if they are not explicitly given.",
+              "description": " Unprocessed runtime info.\n\n An unprocessed description string obtained by the runtime. For some well-known runtimes,\n Sentry will attempt to parse `name` and `version` from this string, if they are not\n explicitly given.",
               "default": null,
               "type": [
                 "string",
@@ -2438,7 +2438,7 @@ expression: event_json_schema()
               ]
             },
             "version": {
-              "description": "Runtime version string.",
+              "description": " Runtime version string.",
               "default": null,
               "type": [
                 "string",
@@ -2461,7 +2461,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "description": {
-              "description": "Human readable description of a span (e.g. method URL).",
+              "description": " Human readable description of a span (e.g. method URL).",
               "default": null,
               "type": [
                 "string",
@@ -2469,7 +2469,7 @@ expression: event_json_schema()
               ]
             },
             "op": {
-              "description": "Span type (see `OperationType` docs).",
+              "description": " Span type (see `OperationType` docs).",
               "default": null,
               "type": [
                 "string",
@@ -2477,7 +2477,7 @@ expression: event_json_schema()
               ]
             },
             "parent_span_id": {
-              "description": "The ID of the span enclosing this span.",
+              "description": " The ID of the span enclosing this span.",
               "default": null,
               "anyOf": [
                 {
@@ -2489,7 +2489,7 @@ expression: event_json_schema()
               ]
             },
             "span_id": {
-              "description": "The Span id.",
+              "description": " The Span id.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/SpanId"
@@ -2500,7 +2500,7 @@ expression: event_json_schema()
               ]
             },
             "start_timestamp": {
-              "description": "Timestamp when the span started.",
+              "description": " Timestamp when the span started.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Timestamp"
@@ -2511,7 +2511,7 @@ expression: event_json_schema()
               ]
             },
             "status": {
-              "description": "The status of a span",
+              "description": " The status of a span",
               "default": null,
               "anyOf": [
                 {
@@ -2534,7 +2534,7 @@ expression: event_json_schema()
               ]
             },
             "trace_id": {
-              "description": "The ID of the trace the span belongs to.",
+              "description": " The ID of the trace the span belongs to.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/TraceId"
@@ -2604,7 +2604,7 @@ expression: event_json_schema()
               ]
             },
             "version_major": {
-              "description": "The major version of the SDK as integer or 0.",
+              "description": " The major version of the SDK as integer or 0.",
               "default": null,
               "type": [
                 "integer",
@@ -2614,7 +2614,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "version_minor": {
-              "description": "The minor version of the SDK as integer or 0.",
+              "description": " The minor version of the SDK as integer or 0.",
               "default": null,
               "type": [
                 "integer",
@@ -2624,7 +2624,7 @@ expression: event_json_schema()
               "minimum": 0.0
             },
             "version_patchlevel": {
-              "description": "The patch version of the SDK as integer or 0.",
+              "description": " The patch version of the SDK as integer or 0.",
               "default": null,
               "type": [
                 "integer",
@@ -2698,7 +2698,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "crashed": {
-              "description": "A flag indicating whether the thread crashed. Defaults to `false`.",
+              "description": " A flag indicating whether the thread crashed. Defaults to `false`.",
               "default": null,
               "type": [
                 "boolean",
@@ -2706,7 +2706,7 @@ expression: event_json_schema()
               ]
             },
             "current": {
-              "description": "A flag indicating whether the thread was in the foreground.  Defaults to `false`.",
+              "description": " A flag indicating whether the thread was in the foreground.  Defaults to `false`.",
               "default": null,
               "type": [
                 "boolean",
@@ -2726,7 +2726,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Display name of this thread.",
+              "description": " Display name of this thread.",
               "default": null,
               "type": [
                 "string",
@@ -2734,7 +2734,7 @@ expression: event_json_schema()
               ]
             },
             "stacktrace": {
-              "description": "Stack trace containing frames of this exception.\n\nThe thread that crashed with an exception should not have a stack trace, but instead, the `thread_id` attribute should be set on the exception and Sentry will connect the two.",
+              "description": " Stack trace containing frames of this exception.\n\n The thread that crashed with an exception should not have a stack trace, but instead, the `thread_id` attribute should be set on the exception and Sentry will connect the two.",
               "default": null,
               "anyOf": [
                 {
@@ -2785,7 +2785,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "op": {
-              "description": "Span type (see `OperationType` docs).",
+              "description": " Span type (see `OperationType` docs).",
               "default": null,
               "type": [
                 "string",
@@ -2793,7 +2793,7 @@ expression: event_json_schema()
               ]
             },
             "parent_span_id": {
-              "description": "The ID of the span enclosing this span.",
+              "description": " The ID of the span enclosing this span.",
               "default": null,
               "anyOf": [
                 {
@@ -2805,7 +2805,7 @@ expression: event_json_schema()
               ]
             },
             "span_id": {
-              "description": "The ID of the span.",
+              "description": " The ID of the span.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/SpanId"
@@ -2816,7 +2816,7 @@ expression: event_json_schema()
               ]
             },
             "status": {
-              "description": "Whether the trace failed or succeeded. Currently only used to indicate status of individual transactions.",
+              "description": " Whether the trace failed or succeeded. Currently only used to indicate status of individual\n transactions.",
               "default": null,
               "anyOf": [
                 {
@@ -2857,7 +2857,7 @@ expression: event_json_schema()
           "type": "object",
           "properties": {
             "data": {
-              "description": "Additional arbitrary fields, as stored in the database (and sometimes as sent by clients). All data from `self.other` should end up here after store normalization.",
+              "description": " Additional arbitrary fields, as stored in the database (and sometimes as sent by clients).\n All data from `self.other` should end up here after store normalization.",
               "default": null,
               "type": [
                 "object",
@@ -2866,7 +2866,7 @@ expression: event_json_schema()
               "additionalProperties": true
             },
             "email": {
-              "description": "Email address of the user.",
+              "description": " Email address of the user.",
               "default": null,
               "type": [
                 "string",
@@ -2874,7 +2874,7 @@ expression: event_json_schema()
               ]
             },
             "geo": {
-              "description": "Approximate geographical location of the end user or device.",
+              "description": " Approximate geographical location of the end user or device.",
               "default": null,
               "anyOf": [
                 {
@@ -2894,7 +2894,7 @@ expression: event_json_schema()
               ]
             },
             "ip_address": {
-              "description": "Remote IP address of the user. Defaults to \"{{auto}}\".",
+              "description": " Remote IP address of the user. Defaults to \"{{auto}}\".",
               "default": null,
               "anyOf": [
                 {
@@ -2906,7 +2906,7 @@ expression: event_json_schema()
               ]
             },
             "name": {
-              "description": "Human readable name of the user.",
+              "description": " Human readable name of the user.",
               "default": null,
               "type": [
                 "string",
@@ -2914,7 +2914,7 @@ expression: event_json_schema()
               ]
             },
             "username": {
-              "description": "Username of the user.",
+              "description": " Username of the user.",
               "default": null,
               "type": [
                 "string",


### PR DESCRIPTION
schemars does some funny text processing that destroys our beautiful hand-crafted markdown. Fork that dependency, add option to disable the behavior and use it here.

https://github.com/GREsau/schemars/pull/45