### PR TITLE
fix(general): Make Trace Context Status optional

### DIFF
--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -460,7 +460,6 @@ pub struct TraceContext {
 
     /// Whether the trace failed or succeeded. Currently only used to indicate status of individual
     /// transactions.
-    #[metastructure(required = "true")]
     pub status: Annotated<SpanStatus>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2781,7 +2781,6 @@ expression: event_json_schema()
           "type": "object",
           "required": [
             "span_id",
-            "status",
             "trace_id"
           ],
           "properties": {
@@ -2818,6 +2817,7 @@ expression: event_json_schema()
             },
             "status": {
               "description": "Whether the trace failed or succeeded. Currently only used to indicate status of individual transactions.",
+              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/SpanStatus"


### PR DESCRIPTION
We are seeing processing errors on Sentry events along the lines of `contexts.trace.status: Missing value for required attribute` for a ton of events. I'm pretty sure this because we changed `status` on the `TraceContext` struct to be required in this PR: https://github.com/getsentry/relay/pull/558/files#diff-dc06c4b1e9477edd5139f689001c322fR388

![image](https://user-images.githubusercontent.com/18689448/88987519-2c6c8380-d2a4-11ea-9473-a0b7024314cc.png)

This PR changes status to be optional again.