### PR TITLE
fix(craft): Add specific github contexts for library releases

### DIFF
--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -4,6 +4,12 @@ github:
   owner: getsentry
   repo: relay
 changelogPolicy: auto
+statusProvider:
+  name: github
+  config:
+    contexts:
+      - Travis CI - Branch
+      - continuous-integration/appveyor/branch
 preReleaseCommand: ../scripts/bump-library.sh
 releaseBranchPrefix: release-library
 


### PR DESCRIPTION
..to make sure we don't wait for Cloud Build when doing library releases.