### PR TITLE
fix: Get rid of schemars fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,7 +3035,8 @@ dependencies = [
 [[package]]
 name = "schemars"
 version = "0.8.0-alpha-4"
-source = "git+https://github.com/untitaker/schemars?branch=preserve-formatting#54810054ab7d85763090c07c4e498d9603814892"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb19de085c2896c0f4ac42cb2af046ec769be3fdcaf8e93a599f5cbbdf543ffa"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -3048,7 +3049,8 @@ dependencies = [
 [[package]]
 name = "schemars_derive"
 version = "0.8.0-alpha-4"
-source = "git+https://github.com/untitaker/schemars?branch=preserve-formatting#54810054ab7d85763090c07c4e498d9603814892"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0c2d87acadcb53176cee5cb10eb3d4024de3d3619dd38d0041ce53c601748"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -22,7 +22,7 @@ lru = "0.4.0"
 parking_lot = "0.10.0"
 regex = "1.3.9"
 sentry-types = "0.14.1"
-schemars = { version = "0.8.0-alpha-4", git = "https://github.com/untitaker/schemars", branch = "preserve-formatting", features = ["uuid", "chrono"], optional = true }
+schemars = { version = "0.8.0-alpha-4", features = ["uuid", "chrono"], optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 
 [features]

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -35,7 +35,7 @@ uaparser = { version = "0.3.3", optional = true }
 url = "2.1.1"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 relay-common = { path = "../relay-common" }
-schemars = { version = "0.8.0-alpha-4", git = "https://github.com/untitaker/schemars", branch = "preserve-formatting", features = ["uuid", "chrono"], optional = true }
+schemars = { version = "0.8.0-alpha-4", features = ["uuid", "chrono"], optional = true }
 
 [dev-dependencies]
 difference = "2.0.0"


### PR DESCRIPTION
Turns out the fork was entirely unnecessary as one can explicitly set the description, which bypasses all the odd line rewrapping.