### PR TITLE
doc: Update some fields doc from the public docs

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -191,6 +191,11 @@ pub struct Event {
     pub id: Annotated<EventId>,
 
     /// Severity level of the event. Defaults to `error`.
+    /// Example:
+    ///
+    /// ```json
+    /// {"level": "warning"}
+    /// ```
     pub level: Annotated<Level>,
 
     /// Version
@@ -205,6 +210,11 @@ pub struct Event {
     /// A list of strings used to dictate how this event is supposed to be grouped with other
     /// events into issues. For more information about overriding grouping see [Customize Grouping
     /// with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).
+    ///
+    /// ```json
+    /// {
+    ///     "fingerprint": ["myrpc", "POST", "/foo.bar"]
+    /// }
     #[metastructure(skip_serialization = "empty")]
     pub fingerprint: Annotated<Fingerprint>,
 
@@ -323,6 +333,10 @@ pub struct Event {
     pub dist: Annotated<String>,
 
     /// The environment name, such as `production` or `staging`.
+    ///
+    /// ```json
+    /// { "environment": "production" }
+    /// ```
     #[metastructure(
         max_chars = "environment",
         match_regex = r"^[^\r\n\x0C/]+$",
@@ -384,6 +398,14 @@ pub struct Event {
     pub tags: Annotated<Tags>,
 
     /// Arbitrary extra information set by the user.
+    ///
+    /// ```json
+    /// {
+    ///     "extra": {
+    ///         "my_key": 1,
+    ///         "some_other_value": "foo bar"
+    ///     }
+    /// }```
     #[metastructure(bag_size = "massive")]
     #[metastructure(pii = "true", skip_serialization = "empty")]
     pub extra: Annotated<Object<ExtraValue>>,

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -130,7 +130,7 @@ pub struct Mechanism {
     ///   as the user explicitly captured the exception (and therefore kind of handled it)
     pub handled: Annotated<bool>,
 
-    /// Additional attributes depending on the mechanism type.
+    /// Arbitrary extra data that might help the user understand the error thrown by this mechanism.
     #[metastructure(pii = "true", bag_size = "medium")]
     #[metastructure(skip_serialization = "empty")]
     pub data: Annotated<Object<Value>>,

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -118,10 +118,16 @@ pub struct Frame {
     /// (C/C++/Native) Start address of the containing code module (image).
     pub image_addr: Annotated<Addr>,
 
-    /// (C/C++/Native) Absolute address of the frame's CPU instruction.
+    /// (C/C++/Native) An optional instruction address for symbolication.
+    /// This should be a string with a hexadecimal number that includes a 0x prefix.
+    /// If this is set and a known image is defined in the
+    /// [Debug Meta Interface]({%- link _documentation/development/sdk-dev/event-payloads/debugmeta.md -%}),
+    /// then symbolication can take place.
     pub instruction_addr: Annotated<Addr>,
 
     /// (C/C++/Native) Start address of the frame's function.
+    /// We use the instruction address for symbolication, but this can be used to calculate
+    /// an instruction offset automatically.
     pub symbol_addr: Annotated<Addr>,
 
     /// (C/C++/Native) Used for native crashes to indicate how much we can "trust" the instruction_addr

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -77,7 +77,7 @@ expression: event_json_schema()
           ]
         },
         "environment": {
-          "description": " The environment name, such as `production` or `staging`.",
+          "description": " The environment name, such as `production` or `staging`.\n\n ```json\n { \"environment\": \"production\" }\n ```",
           "default": null,
           "type": [
             "string",
@@ -141,7 +141,7 @@ expression: event_json_schema()
           }
         },
         "extra": {
-          "description": " Arbitrary extra information set by the user.",
+          "description": " Arbitrary extra information set by the user.\n\n ```json\n {\n     \"extra\": {\n         \"my_key\": 1,\n         \"some_other_value\": \"foo bar\"\n     }\n }```",
           "default": null,
           "type": [
             "object",
@@ -150,7 +150,7 @@ expression: event_json_schema()
           "additionalProperties": true
         },
         "fingerprint": {
-          "description": " Manual fingerprint override.\n\n A list of strings used to dictate how this event is supposed to be grouped with other\n events into issues. For more information about overriding grouping see [Customize Grouping\n with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).",
+          "description": " Manual fingerprint override.\n\n A list of strings used to dictate how this event is supposed to be grouped with other\n events into issues. For more information about overriding grouping see [Customize Grouping\n with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).\n\n ```json\n {\n     \"fingerprint\": [\"myrpc\", \"POST\", \"/foo.bar\"]\n }",
           "default": null,
           "anyOf": [
             {
@@ -170,7 +170,7 @@ expression: event_json_schema()
           ]
         },
         "level": {
-          "description": " Severity level of the event. Defaults to `error`.",
+          "description": " Severity level of the event. Defaults to `error`.\n Example:\n\n ```json\n {\"level\": \"warning\"}\n ```",
           "default": null,
           "anyOf": [
             {
@@ -1423,7 +1423,7 @@ expression: event_json_schema()
               ]
             },
             "instruction_addr": {
-              "description": " (C/C++/Native) Absolute address of the frame's CPU instruction.",
+              "description": " (C/C++/Native) An optional instruction address for symbolication.\n This should be a string with a hexadecimal number that includes a 0x prefix.\n If this is set and a known image is defined in the\n [Debug Meta Interface]({%- link _documentation/development/sdk-dev/event-payloads/debugmeta.md -%}),\n then symbolication can take place.",
               "default": null,
               "anyOf": [
                 {
@@ -1513,7 +1513,7 @@ expression: event_json_schema()
               ]
             },
             "symbol_addr": {
-              "description": " (C/C++/Native) Start address of the frame's function.",
+              "description": " (C/C++/Native) Start address of the frame's function.\n We use the instruction address for symbolication, but this can be used to calculate\n an instruction offset automatically.",
               "default": null,
               "anyOf": [
                 {
@@ -1848,7 +1848,7 @@ expression: event_json_schema()
           ],
           "properties": {
             "data": {
-              "description": " Additional attributes depending on the mechanism type.",
+              "description": " Arbitrary extra data that might help the user understand the error thrown by this mechanism.",
               "default": null,
               "type": [
                 "object",


### PR DESCRIPTION
Updates some of the docstrings in relay from the public event structure documentation.
https://develop.sentry.dev/sdk/event-payloads/