### PR TITLE
fix: Prettify event schema

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -398,7 +398,7 @@ pub fn process_event<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
 
 #[cfg(feature = "jsonschema")]
 pub fn event_json_schema<'a>(_matches: &ArgMatches<'a>) -> Result<(), Error> {
-    serde_json::to_writer(
+    serde_json::to_writer_pretty(
         &mut io::stdout().lock(),
         &relay_general::protocol::event_json_schema(),
     )?;


### PR DESCRIPTION
The diffs in https://github.com/getsentry/sentry-data-schemas are atrocious right now: https://github.com/getsentry/sentry-data-schemas/commit/e887ab5c8e7b1fbddf5e5cf45db896ee49b6e701#diff-104d624749062233b6fb6bfa7ec10af4L1