### PR TITLE
fix(schema): Mechanism type is not really required

### DIFF
--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -95,7 +95,6 @@ pub struct Mechanism {
     /// exception, while for native it is e.g. `"minidump"` or `"applecrashreport"`.
     #[metastructure(
         field = "type",
-        required = "true",
         nonempty = "true",
         max_chars = "enumlike"
     )]


### PR DESCRIPTION
Would like to make this nullable as the Python SDK wants to send exceptions where the errno is known but the mechanism not.