### PR TITLE
ci(release): Add killswitch via issues w/ release-blocker label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
+        - id: killswitch
+          if: ${{ !github.event.inputs.force }}
+          run: |
+            if curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?state=open&labels=release-blocker" | grep -Pzvo '\[[\s\n\r]*\]'; then
+              echo "Open release-blocking issues found, cancelling release...";
+              curl -sf -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/cancel;
+            fi
         - id: calver
           if: ${{ !github.event.inputs.version }}
           run: echo "::set-output name=version::$(date +'%y.%-m.0')"


### PR DESCRIPTION
Implements https://app.asana.com/0/1169344595888357/1146357826982899/f which would cancel the workflow (stop the release) when the repo has open issues with the label 'release-blocker'.
