### PR TITLE
chore(config): Remove config for emitting attachment flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Remove a temporary flag from attachment kafka messages indicating rate limited crash reports to Sentry. This is now enabled by default. ([#718](https://github.com/getsentry/relay/pull/718))
+
 ## 20.8.0
 
 **Features**:

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1402,7 +1402,6 @@ impl Config {
     pub fn max_rate_limit(&self) -> Option<u64> {
         self.values.processing.max_rate_limit.map(u32::into)
     }
-
 }
 
 impl Default for Config {

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -712,9 +712,6 @@ pub struct Processing {
     /// Maximum rate limit to report to clients.
     #[serde(default = "default_max_rate_limit")]
     pub max_rate_limit: Option<u32>,
-    /// Emits flags for rate limited attachments. Disabled by default.
-    #[serde(default)]
-    pub _attachment_flag: bool,
 }
 
 impl Default for Processing {
@@ -732,7 +729,6 @@ impl Default for Processing {
             attachment_chunk_size: default_chunk_size(),
             projectconfig_cache_prefix: default_projectconfig_cache_prefix(),
             max_rate_limit: default_max_rate_limit(),
-            _attachment_flag: false,
         }
     }
 }
@@ -1407,10 +1403,6 @@ impl Config {
         self.values.processing.max_rate_limit.map(u32::into)
     }
 
-    /// Emits flags for rate limited attachments. Disabled by default.
-    pub fn emit_attachment_rate_limit_flag(&self) -> bool {
-        self.values.processing._attachment_flag
-    }
 }
 
 impl Default for Config {

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -123,16 +123,8 @@ impl StoreForwarder {
                 .map(|content_type| content_type.as_str().to_owned()),
             attachment_type: item.attachment_type().unwrap_or_default(),
             chunks: chunk_index,
-            size: if self.config.emit_attachment_rate_limit_flag() {
-                Some(size)
-            } else {
-                None
-            },
-            rate_limited: if self.config.emit_attachment_rate_limit_flag() {
-                Some(item.rate_limited())
-            } else {
-                None
-            },
+            size: Some(size),
+            rate_limited: Some(item.rate_limited()),
         })
     }
 

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -74,7 +74,6 @@ def relay(tmpdir, mini_sentry, request, random_port, background_process, config_
                     "outcomes": "",
                 },
                 "redis": "",
-                "_attachment_flag": True,
             },
         }
 


### PR DESCRIPTION
Finishes work started in #640 by removing the configuration and turning it on by default. Onpremise and ST have been running compatible Sentry versions for long enough to remove this now.