### PR TITLE
feat(server): Support chunked formdata for Crashpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Support chunked formdata keys for event payloads on the Minidump endpoint. Since crashpad has a limit for the length of custom attributes, the sentry event payload can be split up into `sentry__1`, `sentry__2`, etc. ([#721](https://github.com/getsentry/relay/pull/721))
+
 **Internal**:
 
 - Remove a temporary flag from attachment kafka messages indicating rate limited crash reports to Sentry. This is now enabled by default. ([#718](https://github.com/getsentry/relay/pull/718))

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -33,7 +33,7 @@ use crate::actors::upstream::{SendRequest, UpstreamRelay, UpstreamRequestError};
 use crate::envelope::{self, AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::metrics::{RelayCounters, RelayHistograms, RelaySets, RelayTimers};
 use crate::service::ServerError;
-use crate::utils::{self, FormDataIter, FutureExt};
+use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter, FutureExt};
 
 #[cfg(feature = "processing")]
 use {
@@ -468,14 +468,20 @@ impl EventProcessor {
 
     fn merge_formdata(&self, target: &mut SerdeValue, item: Item) {
         let payload = item.payload();
+        let mut aggregator = ChunkedFormDataAggregator::new();
+
         for entry in FormDataIter::new(&payload) {
             if entry.key() == "sentry" {
                 // Custom clients can submit longer payloads and should JSON encode event data into
                 // the optional `sentry` field.
                 match serde_json::from_str(entry.value()) {
                     Ok(event) => utils::merge_values(target, event),
-                    Err(_) => log::debug!("invalid json event payload in form data"),
+                    Err(_) => log::debug!("invalid json event payload in sentry form field"),
                 }
+            } else if let Some(index) = utils::get_sentry_chunk_index(entry.key(), "sentry__") {
+                // Electron SDK splits up long payloads into chunks starting at sentry__1 with an
+                // incrementing counter. Assemble these chunks here and then decode them below.
+                aggregator.insert(index, entry.value());
             } else if let Some(keys) = utils::get_sentry_entry_indexes(entry.key()) {
                 // Try to parse the nested form syntax `sentry[key][key]` This is required for the
                 // Breakpad client library, which only supports string values of up to 64
@@ -486,6 +492,13 @@ impl EventProcessor {
                 // payload and set defaults for processing. This is sent by clients like Breakpad or
                 // Crashpad.
                 utils::update_nested_value(target, &["extra", entry.key()], entry.value());
+            }
+        }
+
+        if !aggregator.is_empty() {
+            match serde_json::from_str(&aggregator.join()) {
+                Ok(event) => utils::merge_values(target, event),
+                Err(_) => log::debug!("invalid json event payload in sentry__* form fields"),
             }
         }
     }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -253,6 +253,11 @@ pub fn event_id_from_formdata(data: &[u8]) -> Result<Option<EventId>, BadStoreRe
 ///  2. The `__sentry-event` event attachment.
 ///  3. The `sentry` JSON payload.
 ///  4. The `sentry[event_id]` formdata key.
+///
+/// # Limitations
+///
+/// Extracting the event id from chunked formdata fields on the Minidump endpoint (`sentry__1`,
+/// `sentry__2`, ...) is not supported. In this case, `None` is returned.
 pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreRequest> {
     if let Some(item) = items.iter().find(|item| item.ty() == ItemType::Event) {
         if let Some(event_id) = event_id_from_json(&item.payload())? {

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -188,7 +188,6 @@ def test_minidump_sentry_json(mini_sentry, relay):
     assert event_item["user"]["id"] == "123"
 
 
-
 def test_minidump_sentry_json_chunked(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)


### PR DESCRIPTION
Google Crashpad has a limitation on the length of values for custom attributes. This makes it impossible to send scope information and event payloads using the default Crashpad uploader. In the past, our SDKs had to disable automatic uploading, and implement their own logic, which comes with a set of disadvantages. In the future, Crashpad will support custom attachments on all platforms, but until that is available, we need a workaround on our end.

An upcoming version of Electron will send long crashpad annotations in chunks to work around this limitation. When a long value is detected, the annotation is duplicated with a postfix of `__n`, where *n* is the 1-based index of the chunk.

This PR joins these chunks, assuming they come in random order, and then parses JSON to extract the payload. An event id is not allowed in these payloads, as it cannot be parsed efficiently in the endpoint. Instead, Relay generates a random event id and always overrides the one in the payload.