### PR TITLE
fix(danger): Comment only on missing changelogs

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -19,9 +19,9 @@ If none of the above apply, you can opt out by adding _#skip-changelog_ to the P
 const skipChangelog =
   danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
 
-if (!hasChangelog && !hasPyChangelog && !skipChangelog) {
+if (skipChangelog) {
+  message("Opted out of changelogs due to #skip-changelog.");
+} else if (!hasChangelog && !hasPyChangelog) {
   fail(ERROR_MESSAGE);
   markdown(DETAILS);
-} else {
-  message("Opted out of changelogs due to #skip-changelog.");
 }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -19,9 +19,7 @@ If none of the above apply, you can opt out by adding _#skip-changelog_ to the P
 const skipChangelog =
   danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
 
-if (skipChangelog) {
-  message("Opted out of changelogs due to #skip-changelog.");
-} else if (!hasChangelog && !hasPyChangelog) {
+if (!skipChangelog && !hasChangelog && !hasPyChangelog) {
   fail(ERROR_MESSAGE);
   markdown(DETAILS);
 }


### PR DESCRIPTION
Our danger bot comments with a skip message even if there is a valid changelog, for instance in https://github.com/getsentry/relay/pull/721#issuecomment-675588561.

#skip-changelog