### PR TITLE
fix: Avoid rust-analyzer recursion bug

### DIFF
--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -16,8 +16,10 @@ use crate::protocol::{AsPair, IpAddr, NativeImagePath, PairList, User};
 use crate::types::{Meta, ProcessingAction, ProcessingResult, Remark, RemarkType};
 
 lazy_static! {
-    static ref NULL_SPLIT_RE: Regex = #[allow(clippy::trivial_regex)]
-    Regex::new("\x00").unwrap();
+    static ref NULL_SPLIT_RE: Regex = {
+        #[allow(clippy::trivial_regex)]
+        Regex::new("\x00").unwrap()
+    };
 }
 
 /// A processor that performs PII stripping.

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -15,6 +15,9 @@ use crate::processor::{
 use crate::protocol::{AsPair, IpAddr, NativeImagePath, PairList, User};
 use crate::types::{Meta, ProcessingAction, ProcessingResult, Remark, RemarkType};
 
+// The Regex initializer needs a scope to avoid an endless loop/recursion in RustAnalyzer:
+// https://github.com/rust-analyzer/rust-analyzer/issues/5896. Note that outside of lazy_static,
+// this would require the unstable `stmt_expr_attributes` feature.
 lazy_static! {
     static ref NULL_SPLIT_RE: Regex = {
         #[allow(clippy::trivial_regex)]


### PR DESCRIPTION
The attribute alone triggers a parsing error which leads to an endless loop or recursion in Rust Analyzer.

#skip-changelog