### PR TITLE
ci(gcb): Remove redundant steps in test

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,15 +65,10 @@ steps:
     - '-c'
     - |
       mkdir onpremise && cd onpremise
-      # TODO(byk): We may also build this part as a builder image everytime
-      #            there's a push to onpremise and use that image for
       curl -L "https://github.com/getsentry/onpremise/archive/master.tar.gz" | tar xzf - --strip-components=1
       # The following trick is from https://stackoverflow.com/a/52400857/90297 with great gratuity
       echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
       ./install.sh
-      docker-compose run --rm web createuser --superuser --email test@example.com --password test123TEST
-      docker-compose up -d
-      timeout 20 bash -c 'until $(curl -Isf -o /dev/null http://nginx); do printf "."; sleep 0.5; done' || docker-compose logs web
       ./test.sh || docker-compose logs nginx web relay
     timeout: 450s
 


### PR DESCRIPTION
These are now built in after getsentry/onpremise#649

#skip-changelog