### PR TITLE
fix(auth): Disable reauthentication in processing mode

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -509,7 +509,9 @@ impl Handler<Authenticate> for UpstreamRelay {
                 slf.backoff.reset();
                 slf.first_error = None;
 
-                ctx.notify_later(Authenticate, slf.config.http_auth_interval());
+                if let Some(interval) = slf.config.http_auth_interval() {
+                    ctx.notify_later(Authenticate, interval);
+                }
             })
             .map_err(|err, slf, ctx| {
                 log::error!("authentication encountered error: {}", LogError(&err));


### PR DESCRIPTION
Disables re-authentication in processing mode since Relay can produce events
into the ingestion queue even without valid authentication. Instead, in such a
case, project config requests fail.

Note that in a follow-up, Relay will detect failed queries and automatically
re-establish authentication in such cases.

#skip-changelog

