### PR TITLE
build(make): Streamline doc targets

### DIFF
--- a/.github/workflows/data-schemas.yml
+++ b/.github/workflows/data-schemas.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: make jsonschema
+      - run: make doc-schema
       - name: commit and push
         if: github.ref == 'refs/heads/master'
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ jobs:
     - name: "release: docs"
       if: branch ~= /^release\/[\d.]+$/
       before_script: npm install -g @zeus-ci/cli
-      script: make -e travis-upload-prose-docs
+      script: make -e doc-upload-travis
 
     # -------------------------------------
     # PYTHON RELEASE BUILDS


### PR DESCRIPTION
Ensures a consistent `doc-` prefix on all doc targets in the Makefile. All other
targets follow a common pattern of `{action}-{flavor}`.

#skip-changelog

