### PR TITLE
feat(tool): Add a binary to generate the schema file

### DIFF
--- a/.github/workflows/data-schemas.yml
+++ b/.github/workflows/data-schemas.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - run: make init-submodules
       - run: cargo run -p generate-schema > event.schema.json
       - name: commit and push
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/data-schemas.yml
+++ b/.github/workflows/data-schemas.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: make doc-schema
+      - run: cargo run -p generate-schema > event.schema.json
       - name: commit and push
         if: github.ref == 'refs/heads/master'
         env:
@@ -28,7 +28,7 @@ jobs:
           git clone https://getsentry-bot:$GITHUB_TOKEN@github.com/getsentry/sentry-data-schemas
           cd sentry-data-schemas/
           mkdir -p ./relay/
-          cp ../docs/event-schema/event.schema.json ./relay/event.schema.json
+          mv ../event.schema.json ./relay/event.schema.json
           if git diff-files --quiet; then
             echo "No changes"
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Remove a temporary flag from attachment kafka messages indicating rate limited crash reports to Sentry. This is now enabled by default. ([#718](https://github.com/getsentry/relay/pull/718))
 - Performance improvement of http requests to upstream, high priority messages are sent first. ([#678](https://github.com/getsentry/relay/pull/678))
 - Experimental data scrubbing on minidumps([#682](https://github.com/getsentry/relay/pull/682))
+- Move `generate-schema` from the Relay CLI into a standalone tool. ([#739](//github.com/getsentry/relay/pull/739))
 
 ## 20.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate-schema"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "paw",
+ "relay-general",
+ "serde_json",
+ "structopt",
+]
+
+[[package]]
 name = "generator"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -89,16 +89,6 @@ doc-metrics: .venv/bin/python
 	.venv/bin/pip install -U -r requirements-doc.txt
 	cd scripts && ../.venv/bin/python extract_metric_docs.py
 
-doc-schema: init-submodules
-	# Makes no sense to nest this in docs, but unfortunately that's the path
-	# Snuba uses in their setup right now. Eventually this should be gone in
-	# favor of the data schemas repo
-	mkdir -p docs/event-schema/
-	rm -rf docs/event-schema/event.schema.*
-	set -e && cd relay && cargo run --features jsonschema -- event-json-schema \
-		> ../docs/event-schema/event.schema.json
-.PHONY: doc-schema
-
 doc-server: doc-prose
 	.venv/bin/mkdocs serve
 .PHONY: doc-server

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 default = ["ssl"]
 ssl = ["relay-server/ssl"]
 processing = ["relay-server/processing"]
-jsonschema = ["relay-general/jsonschema"]
 
 # Direct dependencies of the main application in `src/`
 [dependencies]

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -46,12 +46,6 @@ pub fn execute() -> Result<(), Error> {
         return generate_completions(&matches);
     } else if let Some(matches) = matches.subcommand_matches("process-event") {
         return process_event(&matches);
-    } else if let Some(_matches) = matches.subcommand_matches("event-json-schema") {
-        #[cfg(feature = "jsonschema")]
-        return event_json_schema(&_matches);
-
-        #[cfg(not(feature = "jsonschema"))]
-        failure::bail!("Relay needs to be compiled with the 'jsonschema' feature for this command to be available.");
     }
 
     // Commands that need a loaded config:
@@ -393,15 +387,6 @@ pub fn process_event<'a>(matches: &ArgMatches<'a>) -> Result<(), Error> {
         println!("{}", event.to_json()?);
     }
 
-    Ok(())
-}
-
-#[cfg(feature = "jsonschema")]
-pub fn event_json_schema<'a>(_matches: &ArgMatches<'a>) -> Result<(), Error> {
-    serde_json::to_writer_pretty(
-        &mut io::stdout().lock(),
-        &relay_general::protocol::event_json_schema(),
-    )?;
     Ok(())
 }
 

--- a/tools/generate-schema/Cargo.toml
+++ b/tools/generate-schema/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "generate-schema"
+version = "0.1.0"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Generates an event payload schema file"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0.32"
+paw = "1.0.0"
+relay-general = { path = "../../relay-general", features = ["jsonschema"] }
+serde_json = "1.0.55"
+structopt = { version = "0.3.16", features = ["paw"] }

--- a/tools/generate-schema/src/main.rs
+++ b/tools/generate-schema/src/main.rs
@@ -1,0 +1,90 @@
+use std::fmt;
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+
+#[derive(Clone, Copy, Debug)]
+enum SchemaFormat {
+    JsonSchema,
+}
+
+impl fmt::Display for SchemaFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::JsonSchema => write!(f, "jsonschema"),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ParseSchemaFormatError;
+
+impl fmt::Display for ParseSchemaFormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid schema format")
+    }
+}
+
+impl std::error::Error for ParseSchemaFormatError {}
+
+impl std::str::FromStr for SchemaFormat {
+    type Err = ParseSchemaFormatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "jsonschema" => Ok(Self::JsonSchema),
+            _ => Err(ParseSchemaFormatError),
+        }
+    }
+}
+
+/// Prints the event protocol schema.
+#[derive(Debug, StructOpt)]
+#[structopt(verbatim_doc_comment, setting = AppSettings::ColoredHelp)]
+struct Cli {
+    /// The format to output the schema in.
+    #[structopt(short, long, default_value = "jsonschema")]
+    format: SchemaFormat,
+
+    /// Optional output path. By default, the schema is printed on stdout.
+    #[structopt(short, long, value_name = "PATH")]
+    output: Option<PathBuf>,
+}
+
+impl Cli {
+    pub fn run(self) -> Result<()> {
+        let schema = relay_general::protocol::event_json_schema();
+
+        match self.output {
+            Some(path) => serde_json::to_writer_pretty(File::create(path)?, &schema)?,
+            None => serde_json::to_writer_pretty(io::stdout(), &schema)?,
+        }
+
+        Ok(())
+    }
+}
+
+fn print_error(error: &anyhow::Error) {
+    eprintln!("Error: {}", error);
+
+    let mut cause = error.source();
+    while let Some(ref e) = cause {
+        eprintln!("  caused by: {}", e);
+        cause = e.source();
+    }
+}
+
+#[paw::main]
+fn main(cli: Cli) {
+    match cli.run() {
+        Ok(()) => (),
+        Err(error) => {
+            print_error(&error);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Moves the generate-schema command into a separate tool, removing both the
command and the feature flag from the Relay CLI.

