### PR TITLE
feat(tool): Add a binary to proccess events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Performance improvement of http requests to upstream, high priority messages are sent first. ([#678](https://github.com/getsentry/relay/pull/678))
 - Experimental data scrubbing on minidumps([#682](https://github.com/getsentry/relay/pull/682))
 - Move `generate-schema` from the Relay CLI into a standalone tool. ([#739](//github.com/getsentry/relay/pull/739))
+- Move `process-event` from the Relay CLI into a standalone tool. ([#740](//github.com/getsentry/relay/pull/740))
 
 ## 20.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-event"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "paw",
+ "relay-general",
+ "structopt",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,7 +2791,6 @@ dependencies = [
  "pretty_env_logger",
  "relay-common",
  "relay-config",
- "relay-general",
  "relay-server",
  "sentry",
  "serde",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -30,7 +30,6 @@ pretty_env_logger = "0.4.0"
 relay-common = { path = "../relay-common" }
 relay-config = { path = "../relay-config" }
 relay-server = { path = "../relay-server" }
-relay-general = { path = "../relay-general" }
 sentry = { version = "0.18.0", features = ["with_debug_meta"] }
 serde = "1.0.114"
 serde_json = "1.0.55"

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -247,43 +247,6 @@ pub fn make_app() -> App<'static, 'static> {
                 ),
         )
         .subcommand(
-            App::new("process-event")
-                .setting(AppSettings::Hidden)
-                .about("Processes a single event piped in")
-                .after_help(
-                    "This takes an event on stdin and puts the processed event to stdout. \
-                     Optionally an additional PII processing config can be supplied.  This is \
-                     primarily useful for PII config testing as well as SDK integration tests.",
-                )
-                .arg(
-                    Arg::with_name("pretty")
-                        .long("pretty")
-                        .help("Pretty print the output JSON"),
-                )
-                .arg(
-                    Arg::with_name("debug")
-                        .long("debug")
-                        .conflicts_with("pretty")
-                        .help("Debug print the internal structure."),
-                )
-                .arg(
-                    Arg::with_name("pii_config")
-                        .long("pii-config")
-                        .value_name("PATH")
-                        .help("The path to a PII processing config"),
-                )
-                .arg(
-                    Arg::with_name("store")
-                        .long("store")
-                        .help("Run through store normalization"),
-                ),
-        )
-        .subcommand(
-            App::new("event-json-schema")
-                .about("Dump JSON schema representation of event schema to stdout.")
-                .setting(AppSettings::Hidden),
-        )
-        .subcommand(
             App::new("generate-completions")
                 .about("Generate shell completion file")
                 .after_help(

--- a/tools/process-event/Cargo.toml
+++ b/tools/process-event/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "process-event"
+version = "0.1.0"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Process a Sentry event payload"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.32"
+paw = "1.0.0"
+relay-general = { path = "../../relay-general" }
+structopt = { version = "0.3.16", features = ["paw"] }

--- a/tools/process-event/src/main.rs
+++ b/tools/process-event/src/main.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use relay_general::pii::{PiiConfig, PiiProcessor};
+use relay_general::processor::{process_value, ProcessingState};
+use relay_general::protocol::Event;
+use relay_general::store::{StoreConfig, StoreProcessor};
+use relay_general::types::Annotated;
+
+use anyhow::{format_err, Context, Result};
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+
+/// Processes a Sentry event payload.
+///
+/// This command takes a JSON event payload on stdin and write the processed event payload to
+/// stdout. Optionally, an additional PII config can be supplied.
+#[derive(Debug, StructOpt)]
+#[structopt(verbatim_doc_comment, setting = AppSettings::ColoredHelp)]
+struct Cli {
+    /// Path to a PII processing config JSON file.
+    #[structopt(short = "c", long)]
+    pii_config: Option<PathBuf>,
+
+    /// Path to an event payload JSON file (defaults to stdin).
+    #[structopt(short, long)]
+    event: Option<PathBuf>,
+
+    /// Apply full store normalization.
+    #[structopt(long)]
+    store: bool,
+
+    /// Pretty print the output JSON.
+    #[structopt(long, conflicts_with = "debug")]
+    pretty: bool,
+
+    /// Debug print the internal structure.
+    #[structopt(long)]
+    debug: bool,
+}
+
+impl Cli {
+    fn load_pii_config(&self) -> Result<Option<PiiConfig>> {
+        let path = match self.pii_config {
+            Some(ref path) => path,
+            None => return Ok(None),
+        };
+
+        let json = fs::read_to_string(path).with_context(|| "failed to read PII config")?;
+        let config = PiiConfig::from_json(&json).with_context(|| "failed to parse PII config")?;
+        Ok(Some(config))
+    }
+
+    fn load_event(&self) -> Result<Annotated<Event>> {
+        let json = match self.event {
+            Some(ref path) => fs::read_to_string(path).with_context(|| "failed to read event")?,
+            None => {
+                let mut json = String::new();
+                io::stdin()
+                    .read_to_string(&mut json)
+                    .with_context(|| "failed to read event")?;
+                json
+            }
+        };
+
+        let event = Annotated::from_json(&json).with_context(|| "failed to parse event")?;
+        Ok(event)
+    }
+
+    pub fn run(self) -> Result<()> {
+        let mut event = self.load_event()?;
+
+        if let Some(pii_config) = self.load_pii_config()? {
+            let compiled = pii_config.compiled();
+            let mut processor = PiiProcessor::new(&compiled);
+            process_value(&mut event, &mut processor, ProcessingState::root())
+                .map_err(|e| format_err!("{}", e))?;
+        }
+
+        if self.store {
+            let mut processor = StoreProcessor::new(StoreConfig::default(), None);
+            process_value(&mut event, &mut processor, ProcessingState::root())
+                .map_err(|e| format_err!("{}", e))
+                .with_context(|| "failed to store process event")?;
+        }
+
+        if self.debug {
+            println!("{:#?}", event);
+        } else if self.pretty {
+            println!("{}", event.to_json_pretty()?);
+        } else {
+            println!("{}", event.to_json()?);
+        }
+
+        Ok(())
+    }
+}
+
+fn print_error(error: &anyhow::Error) {
+    eprintln!("Error: {}", error);
+
+    let mut cause = error.source();
+    while let Some(ref e) = cause {
+        eprintln!("  caused by: {}", e);
+        cause = e.source();
+    }
+}
+
+#[paw::main]
+fn main(cli: Cli) {
+    match cli.run() {
+        Ok(()) => (),
+        Err(error) => {
+            print_error(&error);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Moves the process-event command into a separate tool, removing both the
command and the dependency to `relay_general` from the Relay CLI.
