### PR TITLE
fix(auth): Include state in authentication requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "failure",
+ "hmac",
  "rand 0.6.5",
  "relay-common",
  "serde",

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Updates the authentication mechanism by introducing a signed register state. Signatures of `create_register_challenge` and `validate_register_response` now take a mandatory `secret` parameter, and the public key is encoded into the state. ([#743](https://github.com/getsentry/relay/pull/743))
+
 ## 0.5.13
 
 *Note: This accidentally got released as 0.15.13 as well, which has since been yanked.*

--- a/py/sentry_relay/auth.py
+++ b/py/sentry_relay/auth.py
@@ -18,7 +18,6 @@ __all__ = [
     "SecretKey",
     "generate_key_pair",
     "create_register_challenge",
-    "get_register_response_relay_id",
     "validate_register_response",
     "is_version_supported",
 ]
@@ -91,34 +90,28 @@ def generate_relay_id():
     return decode_uuid(rustcall(lib.relay_generate_relay_id))
 
 
-def create_register_challenge(data, signature, max_age=60 * 15):
+def create_register_challenge(data, signature, secret, max_age=60):
     challenge_json = rustcall(
         lib.relay_create_register_challenge,
         make_buf(data),
         encode_str(signature),
+        encode_str(secret),
         max_age,
     )
 
     challenge = json.loads(decode_str(challenge_json, free=True))
     return {
         "relay_id": uuid.UUID(challenge["relay_id"]),
-        "public_key": PublicKey.parse(challenge["public_key"]),
         "token": challenge["token"],
     }
 
 
-def get_register_response_relay_id(data):
-    return decode_uuid(
-        rustcall(lib.relay_get_register_response_relay_id, make_buf(data))
-    )
-
-
-def validate_register_response(public_key, data, signature, max_age=60 * 15):
+def validate_register_response(data, signature, secret, max_age=60):
     response_json = rustcall(
         lib.relay_validate_register_response,
-        public_key._objptr,
         make_buf(data),
         encode_str(signature),
+        encode_str(secret),
         max_age,
     )
 

--- a/py/sentry_relay/auth.py
+++ b/py/sentry_relay/auth.py
@@ -116,7 +116,11 @@ def validate_register_response(data, signature, secret, max_age=60):
     )
 
     response = json.loads(decode_str(response_json, free=True))
-    return {"relay_id": uuid.UUID(response["relay_id"]), "token": response["token"]}
+    return {
+        "relay_id": uuid.UUID(response["relay_id"]),
+        "token": response["token"],
+        "public_key": response["public_key"],
+    }
 
 
 def is_version_supported(version):

--- a/py/tests/test_auth.py
+++ b/py/tests/test_auth.py
@@ -3,6 +3,17 @@ import sentry_relay
 import pytest
 
 
+UPSTREAM_SECRET = "secret"
+
+RELAY_ID = b"6b7d15b8-cee2-4354-9fee-dae7ef43e434"
+RELAY_KEY = b"kMpGbydHZSvohzeMlghcWwHd8MkreKGzl_ncdkZSOMg"
+REQUEST = b'{"relay_id":"6b7d15b8-cee2-4354-9fee-dae7ef43e434","public_key":"kMpGbydHZSvohzeMlghcWwHd8MkreKGzl_ncdkZSOMg","version":"20.8.0"}'
+REQUEST_SIG = "JIwzIb3kuOaVwgq_DRuPpquGVIIu0plfpOSvz_ixzfw_RmdyHr35cJrna7Jg_uXqNHQbSP1Yj0-4X5Omk9jcBA.eyJ0IjoiMjAyMC0wOS0wMVQxMzozNzoxNC40Nzk0NjVaIn0"
+TOKEN = "eyJ0aW1lc3RhbXAiOjE1OTg5Njc0MzQsInJlbGF5X2lkIjoiNmI3ZDE1YjgtY2VlMi00MzU0LTlmZWUtZGFlN2VmNDNlNDM0IiwicHVibGljX2tleSI6ImtNcEdieWRIWlN2b2h6ZU1sZ2hjV3dIZDhNa3JlS0d6bF9uY2RrWlNPTWciLCJyYW5kIjoiLUViNG9Hal80dUZYOUNRRzFBVmdqTjRmdGxaNU9DSFlNOFl2d1podmlyVXhUY0tFSWYtQzhHaldsZmgwQTNlMzYxWE01dVh0RHhvN00tbWhZeXpWUWcifQ:KJUDXlwvibKNQmex-_Cu1U0FArlmoDkyqP7bYIDGrLXudfjGfCjH-UjNsUHWVDnbM28YdQ-R2MBSyF51aRLQcw"
+RESPONSE = b'{"relay_id":"6b7d15b8-cee2-4354-9fee-dae7ef43e434","token":"eyJ0aW1lc3RhbXAiOjE1OTg5Njc0MzQsInJlbGF5X2lkIjoiNmI3ZDE1YjgtY2VlMi00MzU0LTlmZWUtZGFlN2VmNDNlNDM0IiwicHVibGljX2tleSI6ImtNcEdieWRIWlN2b2h6ZU1sZ2hjV3dIZDhNa3JlS0d6bF9uY2RrWlNPTWciLCJyYW5kIjoiLUViNG9Hal80dUZYOUNRRzFBVmdqTjRmdGxaNU9DSFlNOFl2d1podmlyVXhUY0tFSWYtQzhHaldsZmgwQTNlMzYxWE01dVh0RHhvN00tbWhZeXpWUWcifQ:KJUDXlwvibKNQmex-_Cu1U0FArlmoDkyqP7bYIDGrLXudfjGfCjH-UjNsUHWVDnbM28YdQ-R2MBSyF51aRLQcw"}'
+RESPONSE_SIG = "HUp3eybT_5AmRJ_QzutfvStKTeE-cgD_reLPjIf4OpoOJT_Hln8ThrFqGyT_C6P8qF1LHbFLcrYFvQy4iNaqAQ.eyJ0IjoiMjAyMC0wOS0wMVQxMzozNzoxNC40ODEwNTNaIn0"
+
+
 def test_basic_key_functions():
     sk, pk = sentry_relay.generate_key_pair()
     signature = sk.sign(b"some secret data")
@@ -17,43 +28,34 @@ def test_basic_key_functions():
 
 def test_challenge_response():
     resp = sentry_relay.create_register_challenge(
-        b'{"relay_id":"95dc7c80-6db7-4505-8969-3a0927bfb85d","public_key":"KXxwPvbhadLYTglsiGnQe2lxKLCT4VB2qEDd-OQVLbQ"}',
-        "EQXKqDYLei5XhDucMDIR3n1khdcOqGWmUWDYhcnvi-OBkW92qfcAMSjSn8xPYDmkB2kLnNNsaFeBx1VifD3TCw.eyJ0IjoiMjAxOC0wMy0wMVQwOTo0NjowNS41NDA0NzdaIn0",
-        max_age=0xFFFFFFFF,
+        REQUEST, REQUEST_SIG, UPSTREAM_SECRET, max_age=0,
     )
-    assert str(resp["public_key"]) == "KXxwPvbhadLYTglsiGnQe2lxKLCT4VB2qEDd-OQVLbQ"
-    assert resp["relay_id"] == uuid.UUID("95dc7c80-6db7-4505-8969-3a0927bfb85d")
+    assert resp["relay_id"] == uuid.UUID(RELAY_ID.decode("utf8"))
     assert len(resp["token"]) > 40
+    assert ":" in resp["token"]
 
 
 def test_challenge_response_validation_errors():
     with pytest.raises(sentry_relay.UnpackErrorSignatureExpired):
         sentry_relay.create_register_challenge(
-            b'{"relay_id":"95dc7c80-6db7-4505-8969-3a0927bfb85d","public_key":"KXxwPvbhadLYTglsiGnQe2lxKLCT4VB2qEDd-OQVLbQ"}',
-            "EQXKqDYLei5XhDucMDIR3n1khdcOqGWmUWDYhcnvi-OBkW92qfcAMSjSn8xPYDmkB2kLnNNsaFeBx1VifD3TCw.eyJ0IjoiMjAxOC0wMy0wMVQwOTo0NjowNS41NDA0NzdaIn0",
-            max_age=1,
+            REQUEST, REQUEST_SIG, UPSTREAM_SECRET, max_age=1,
         )
     with pytest.raises(sentry_relay.UnpackErrorBadPayload):
         sentry_relay.create_register_challenge(
-            b'{"relay_id":"95dc7c80-6db7-4505-8969-3a0927bfb85d","public_key":"KXxwPvbhadLYTglsiGnQe2lxKLCT4VB2qEDd-OQVLbQ"}glumpat',
-            "EQXKqDYLei5XhDucMDIR3n1khdcOqGWmUWDYhcnvi-OBkW92qfcAMSjSn8xPYDmkB2kLnNNsaFeBx1VifD3TCw.eyJ0IjoiMjAxOC0wMy0wMVQwOTo0NjowNS41NDA0NzdaIn0",
-            max_age=1,
+            REQUEST + b"__broken", REQUEST_SIG, UPSTREAM_SECRET, max_age=0,
+        )
+    with pytest.raises(sentry_relay.UnpackErrorBadSignature):
+        sentry_relay.create_register_challenge(
+            REQUEST, REQUEST_SIG + "__broken", UPSTREAM_SECRET, max_age=0,
         )
 
 
 def test_register_response():
-    pk = sentry_relay.PublicKey.parse("sFTtnMGut3xR_EqP1hSmyfBc6590wDQzHFGWj5nEG18")
     resp = sentry_relay.validate_register_response(
-        pk,
-        b'{"relay_id":"2ffe6ba6-3a27-4936-b30f-d6944a4f1216","token":"iiWGyrgBZDOOclHjnQILU6zHL1Mjl-yXUpjHOIaArowhrZ2djSUkzPuH_l7UF6sKYpbKD4C2nZWCBhuULLJE-w"}',
-        "uLvKHrTtFohGVMLDxlMZythEXmTJTx8DCT2VwZ_x5Aw0UzTzoastrn2tFy4I8jeTYzS-N8D-PZ_khfVzfFZHBg.eyJ0IjoiMjAxOC0wMy0wMVQwOTo0ODo1OC41ODMzNTRaIn0",
-        max_age=0xFFFFFFFF,
+        RESPONSE, RESPONSE_SIG, UPSTREAM_SECRET, max_age=0,
     )
-    assert (
-        resp["token"]
-        == "iiWGyrgBZDOOclHjnQILU6zHL1Mjl-yXUpjHOIaArowhrZ2djSUkzPuH_l7UF6sKYpbKD4C2nZWCBhuULLJE-w"
-    )
-    assert resp["relay_id"] == uuid.UUID("2ffe6ba6-3a27-4936-b30f-d6944a4f1216")
+    assert resp["token"] == TOKEN
+    assert resp["relay_id"] == uuid.UUID(RELAY_ID.decode("utf8"))
 
 
 def test_is_version_supported():

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.10.1"
 chrono = "0.4.11"
 ed25519-dalek = "0.9.1"
 failure = "0.1.8"
+hmac = "0.7.1"
 rand = "0.6.5"
 relay-common = { path = "../relay-common" }
 serde = { version = "1.0.114", features = ["derive"] }

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -527,7 +527,7 @@ pub struct RegisterState {
     timestamp: UnixTimestamp,
     relay_id: RelayId,
     public_key: PublicKey,
-    nonce: String,
+    rand: String,
 }
 
 impl RegisterState {
@@ -609,7 +609,7 @@ impl RegisterRequest {
             timestamp: UnixTimestamp::now(),
             relay_id: self.relay_id,
             public_key: self.public_key,
-            nonce: nonce(),
+            rand: nonce(),
         };
 
         RegisterChallenge {

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -527,7 +527,7 @@ pub struct RegisterState {
     timestamp: UnixTimestamp,
     relay_id: RelayId,
     public_key: PublicKey,
-    rand: String,
+    nonce: String,
 }
 
 impl RegisterState {
@@ -548,7 +548,7 @@ impl RegisterState {
 }
 
 /// Generates a new random token for the register state.
-fn random_token() -> String {
+fn nonce() -> String {
     let mut rng = thread_rng();
     let mut bytes = vec![0u8; 64];
     rng.fill_bytes(&mut bytes);
@@ -609,7 +609,7 @@ impl RegisterRequest {
             timestamp: UnixTimestamp::now(),
             relay_id: self.relay_id,
             public_key: self.public_key,
-            rand: random_token(),
+            nonce: nonce(),
         };
 
         RegisterChallenge {

--- a/relay-cabi/Cargo.lock
+++ b/relay-cabi/Cargo.lock
@@ -1094,6 +1094,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "failure",
+ "hmac",
  "rand 0.6.5",
  "relay-common",
  "serde",

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -71,6 +71,7 @@ enum RelayErrorCode {
   RELAY_ERROR_CODE_UNPACK_ERROR_BAD_SIGNATURE = 1003,
   RELAY_ERROR_CODE_UNPACK_ERROR_BAD_PAYLOAD = 1004,
   RELAY_ERROR_CODE_UNPACK_ERROR_SIGNATURE_EXPIRED = 1005,
+  RELAY_ERROR_CODE_UNPACK_ERROR_BAD_ENCODING = 1006,
   RELAY_ERROR_CODE_PROCESSING_ERROR_INVALID_TRANSACTION = 2001,
   RELAY_ERROR_CODE_PROCESSING_ERROR_INVALID_GEO_IP = 2002,
   RELAY_ERROR_CODE_INVALID_RELEASE_ERROR_TOO_LONG = 3001,
@@ -279,6 +280,7 @@ RelayStr relay_convert_datascrubbing_config(const RelayStr *config);
  */
 RelayStr relay_create_register_challenge(const RelayBuf *data,
                                          const RelayStr *signature,
+                                         const RelayStr *secret,
                                          uint32_t max_age);
 
 /**
@@ -334,12 +336,6 @@ RelayUuid relay_generate_relay_id(void);
 void relay_geoip_lookup_free(RelayGeoIpLookup *lookup);
 
 RelayGeoIpLookup *relay_geoip_lookup_new(const char *path);
-
-/**
- * Given just the data from a register response returns the
- * conained relay id without validating the signature.
- */
-RelayUuid relay_get_register_response_relay_id(const RelayBuf *data);
 
 /**
  * Initializes the library
@@ -476,9 +472,9 @@ RelayStr relay_validate_pii_config(const RelayStr *value);
 /**
  * Validates a register response.
  */
-RelayStr relay_validate_register_response(const RelayPublicKey *pk,
-                                          const RelayBuf *data,
+RelayStr relay_validate_register_response(const RelayBuf *data,
                                           const RelayStr *signature,
+                                          const RelayStr *secret,
                                           uint32_t max_age);
 
 /**

--- a/relay-cabi/src/core.rs
+++ b/relay-cabi/src/core.rs
@@ -32,6 +32,7 @@ pub enum RelayErrorCode {
     UnpackErrorBadSignature = 1003,
     UnpackErrorBadPayload = 1004,
     UnpackErrorSignatureExpired = 1005,
+    UnpackErrorBadEncoding = 1006,
 
     // relay_general::types::annotated::ProcessingAction
     ProcessingErrorInvalidTransaction = 2001,
@@ -67,6 +68,7 @@ impl RelayErrorCode {
                     UnpackError::BadSignature => RelayErrorCode::UnpackErrorBadSignature,
                     UnpackError::BadPayload(..) => RelayErrorCode::UnpackErrorBadPayload,
                     UnpackError::SignatureExpired => RelayErrorCode::UnpackErrorSignatureExpired,
+                    UnpackError::BadEncoding => RelayErrorCode::UnpackErrorBadEncoding,
                 };
             }
             if let Some(err) = cause.downcast_ref::<ProcessingAction>() {

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -3,6 +3,8 @@
 use std::fmt;
 use std::time::{Duration, Instant, SystemTime};
 
+use serde::{Deserialize, Serialize};
+
 /// Converts an `Instant` into a `SystemTime`.
 pub fn instant_to_system_time(instant: Instant) -> SystemTime {
     SystemTime::now() - instant.elapsed()
@@ -64,10 +66,37 @@ impl fmt::Debug for UnixTimestamp {
     }
 }
 
+impl std::ops::Add<Duration> for UnixTimestamp {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
 impl std::ops::Sub for UnixTimestamp {
     type Output = Duration;
 
     fn sub(self, rhs: Self) -> Self::Output {
         self.0 - rhs.0
+    }
+}
+
+impl Serialize for UnixTimestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.0.as_secs())
+    }
+}
+
+impl<'de> Deserialize<'de> for UnixTimestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(Self::from_secs(secs))
     }
 }

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -495,7 +495,7 @@ impl Handler<Authenticate> for UpstreamRelay {
             .into_actor(self)
             .and_then(|challenge, slf, ctx| {
                 log::debug!("got register challenge (token = {})", challenge.token());
-                let challenge_response = challenge.create_response();
+                let challenge_response = challenge.into_response();
 
                 log::debug!("sending register challenge response");
                 let fut = slf.send_query(challenge_response).into_actor(slf);


### PR DESCRIPTION
Changes the authentication payloads so that Sentry can authenticate without keeping state between the request and response API calls. This fixes a range of issues with the former authentication system.

## Issues

- Only one Relay could use the same identifier. While this was intended, it introduced a race condition and DoS vector to deny authentication if multiple Relays authenticate concurrently with the same identifier. In the worst case, an attacker could prevent authentication using replay attacks.
- The upstream was required to keep state between the register and response calls. Spamming the upstream with register requests would result in increased resource usage over time.
- The random token created by the upstream was enforced at no point. This means that the downstream Relay could have swapped the token and still succeed with registration.

## Changes

This change introduces `RegisterState`, a data container that is signed with a secret by the upstream. As it contains the public key and a timestamp, it ensures that the downstream cannot tamper with the state or use another Relay's token. Since the public key of the state is also used to verify the Relay request signature, the upstream can rely on the state without keeping caches. By encoding the state into the `token`, the HTTP API remains backwards compatible.

In addition to this, the default challenge TTL has been reduced from 15 minutes to 60 seconds.

## Release

This change contains **breaking changes to the Python API** and requires a minor bump of the `sentry_relay` library. It is **backwards compatible on the HTTP API**. After updating in Sentry, old Relays will also use the new authentication system.

## Deployment

This change can be deployed independently to Sentry and Relay in no particular order. Updating the library in Sentry will require code changes.

There is a minimal potential for breakage if Relays are authenticating while Sentry is being deployed. However, Relays will retry on authentication failure and as such, the condition resolves automatically as soon as the deployment finishes.