### PR TITLE
fix(pii): Allow scrubbing of frame.module and culprit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for attaching Sentry event payloads in Unreal crash reports by adding `__sentry` game data entries. ([#715](https://github.com/getsentry/relay/pull/715))
 - Support chunked formdata keys for event payloads on the Minidump endpoint. Since crashpad has a limit for the length of custom attributes, the sentry event payload can be split up into `sentry__1`, `sentry__2`, etc. ([#721](https://github.com/getsentry/relay/pull/721))
 - Add periodic re-authentication with the upstream server, previously there was only one initial authentication. ([#731](https://github.com/getsentry/relay/pull/731))
+- The module attribute on stack frames (`$frame.module`) and the (usually serverside-generated) attribute `culprit` can now be scrubbed with advanced data scrubbing. ([#744](https://github.com/getsentry/relay/pull/744))
 
 **Internal**:
 

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -220,7 +220,7 @@ pub struct Event {
     pub fingerprint: Annotated<Fingerprint>,
 
     /// Custom culprit of the event.
-    #[metastructure(max_chars = "culprit")]
+    #[metastructure(max_chars = "culprit", pii = "maybe")]
     pub culprit: Annotated<String>,
 
     /// Transaction name of the event.

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -53,7 +53,7 @@ pub struct Frame {
     ///
     /// Note that this might also include a class name if that is something the
     /// language natively considers to be part of the stack (for instance in Java).
-    #[metastructure(skip_serialization = "empty")]
+    #[metastructure(skip_serialization = "empty", pii = "maybe")]
     // TODO: Cap? This can be a FS path or a dotted path
     pub module: Annotated<String>,
 


### PR DESCRIPTION
A customer reported that their Electron crashes (with client-side symbolication as it seems) were sending sensitive filepaths in frame.module, which ended up in culprit.

We were completely unable to reproduce this issue (Electron should not send frame.module, and the processing pipeline should not have added the full abs path to the frame.module either), so we're just adding all the remaining fields where this sensitive data ends up.

This also means that Java users can scrub frame.module, which we originally wanted to prevent as it is a footgun that breaks their stacktraces (and, well, we assumed there was no sensitive data in frame.module anyway)

For this specific situation it's likely that culprit does not need to be made scrubbable, as it is filled out based on sensitive data that should be scrubbed otherwise, but in the interest of unblocking the customer for sure, and fixing future similar issues, let's just do it. We already wasted enough time investigating.

The new attributes can be scrubbed with `$frame.module` and `culprit`, for example `$frame.abs_path || $frame.filename || $frame.module || culprit`