### PR TITLE
fix(server): Send envelopes to the envelope endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add periodic re-authentication with the upstream server, previously there was only one initial authentication. ([#731](https://github.com/getsentry/relay/pull/731))
 - The module attribute on stack frames (`$frame.module`) and the (usually serverside-generated) attribute `culprit` can now be scrubbed with advanced data scrubbing. ([#744](https://github.com/getsentry/relay/pull/744))
 
-**Bug Fiexes**:
+**Bug Fixes**:
 
 - Send requests to the `/envelope/` endpoint instead of the older `/store/` endpoint. This particularly fixes spurious `413 Payload Too Large` errors returned when using Relay with Sentry SaaS. ([#746](https://github.com/getsentry/relay/pull/746))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add periodic re-authentication with the upstream server, previously there was only one initial authentication. ([#731](https://github.com/getsentry/relay/pull/731))
 - The module attribute on stack frames (`$frame.module`) and the (usually serverside-generated) attribute `culprit` can now be scrubbed with advanced data scrubbing. ([#744](https://github.com/getsentry/relay/pull/744))
 
+**Bug Fiexes**:
+
+- Send requests to the `/envelope/` endpoint instead of the older `/store/` endpoint. This particularly fixes spurious `413 Payload Too Large` errors returned when using Relay with Sentry SaaS. ([#746](https://github.com/getsentry/relay/pull/746))
+
 **Internal**:
 
 - Remove a temporary flag from attachment kafka messages indicating rate limited crash reports to Sentry. This is now enabled by default. ([#718](https://github.com/getsentry/relay/pull/718))
@@ -29,7 +33,6 @@
 - Reuse connections for upstream event submission requests when the server supports connection keepalive. Relay did not consume the response body of all requests, which caused it to reopen a new connection for every event. ([#680](https://github.com/getsentry/relay/pull/680), [#695](https://github.com/getsentry/relay/pull/695))
 - Fix hashing of user IP addresses in data scrubbing. Previously, this could create invalid IP addresses which were later rejected by Sentry. Now, the hashed IP address is moved to the `id` field. ([#692](https://github.com/getsentry/relay/pull/692))
 - Do not retry authentication with the upstream when a client error is reported (status code 4XX). ([#696](https://github.com/getsentry/relay/pull/696))
-
 
 **Internal**:
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1432,7 +1432,7 @@ impl Handler<HandleEnvelope> for EventManager {
                 }
 
                 log::trace!("sending event to sentry endpoint");
-                let request = SendRequest::post(format!("/api/{}/store/", project_id)).build(
+                let request = SendRequest::post(format!("/api/{}/envelope/", project_id)).build(
                     move |builder| {
                         // Override the `sent_at` timestamp. Since the event went through basic
                         // normalization, all timestamps have been corrected. We propagate the new

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -127,7 +127,7 @@ def mini_sentry(request):
         )
         return jsonify({"event_id": uuid.uuid4().hex})
 
-    @app.route("/api/42/store/", methods=["POST"])
+    @app.route("/api/42/envelope/", methods=["POST"])
     def store_event():
         if flask_request.headers.get("Content-Encoding", "") == "gzip":
             data = gzip.decompress(flask_request.data)
@@ -144,6 +144,7 @@ def mini_sentry(request):
         return jsonify({"event_id": uuid.uuid4().hex})
 
     @app.route("/api/<project>/store/", methods=["POST"])
+    @app.route("/api/<project>/envelope/", methods=["POST"])
     def store_event_catchall(project):
         raise AssertionError(f"Unknown project: {project}")
 


### PR DESCRIPTION
Envelopes were initially introduced on the `/store/` endpoints, but have since
moved to `/envelope/`. This is now the primary endpoint for ingesting Envelopes,
and sending Envelopes to the old endpoint is soft-deprecated.

Since the store endpoint has different size limits on Sentry SaaS, Relay has to
send envelopes to the correct endpoint to avoid spurious 413 responses.

