### PR TITLE
ci(gha): Trigger data-schemas only on default PR events

### DIFF
--- a/.github/workflows/data-schemas.yml
+++ b/.github/workflows/data-schemas.yml
@@ -6,7 +6,6 @@ on:
       - master
 
   pull_request:
-    types: [opened, synchronize, reopened, edited]
 
 jobs:
   event_schema:


### PR DESCRIPTION
The data-schemas workflow ran on every edit to the pull request. Instead, it is
sufficient to only trigger on default events: `opened`, `synchronize` and
`reopened`.

#skip-changelog
