### PR TITLE
feat(server): Add the client SDK to session kafka payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Experimental data scrubbing on minidumps([#682](https://github.com/getsentry/relay/pull/682))
 - Move `generate-schema` from the Relay CLI into a standalone tool. ([#739](//github.com/getsentry/relay/pull/739))
 - Move `process-event` from the Relay CLI into a standalone tool. ([#740](//github.com/getsentry/relay/pull/740))
+- Add the client SDK to session kafka payloads. ([#751](https://github.com/getsentry/relay/pull/751))
 
 ## 20.8.0
 

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -45,6 +45,7 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
         "release": "sentry-test@1.0.0",
         "environment": "production",
         "retention_days": 90,
+        "sdk": "raven-node/2.6.3",
     }
 
 
@@ -87,6 +88,7 @@ def test_session_with_processing_two_events(
         "release": "sentry-test@1.0.0",
         "environment": "production",
         "retention_days": 90,
+        "sdk": "raven-node/2.6.3",
     }
 
     relay.send_session(
@@ -117,6 +119,7 @@ def test_session_with_processing_two_events(
         "release": "sentry-test@1.0.0",
         "environment": "production",
         "retention_days": 90,
+        "sdk": "raven-node/2.6.3",
     }
 
 
@@ -209,6 +212,7 @@ def test_session_force_errors_on_crash(
         "release": "sentry-test@1.0.0",
         "environment": "production",
         "retention_days": 90,
+        "sdk": "raven-node/2.6.3",
     }
 
 


### PR DESCRIPTION
Allow for analytics by adding the client SDK (format `sentry-sdk/1.0.0`) to the
session kafka payload. This attribute will not be indexed in Snuba, but can be
processed by consumers.

cc @trillville 
