### PR TITLE
feat(tool): Document metrics in YAML or JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Experimental data scrubbing on minidumps([#682](https://github.com/getsentry/relay/pull/682))
 - Move `generate-schema` from the Relay CLI into a standalone tool. ([#739](//github.com/getsentry/relay/pull/739))
 - Move `process-event` from the Relay CLI into a standalone tool. ([#740](//github.com/getsentry/relay/pull/740))
+- Add a standalone tool to document metrics in JSON or YAML. ([#752](https://github.com/getsentry/relay/pull/752))
 
 ## 20.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ checksum = "bc655351f820d774679da6cdc23355a93de496867d8203496675162e17b1d671"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -793,6 +793,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "document-metrics"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "insta 0.15.0",
+ "paw",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "structopt",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -997,7 +1011,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
  "synstructure 0.12.4",
 ]
 
@@ -1162,7 +1176,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2007,7 +2021,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2167,7 +2181,7 @@ checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2217,7 +2231,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2286,7 +2300,7 @@ checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2359,7 +2373,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
  "version_check 0.9.2",
 ]
 
@@ -2910,7 +2924,7 @@ version = "20.8.0"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
  "synstructure 0.12.4",
 ]
 
@@ -3144,7 +3158,7 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "serde_derive_internals",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3203,7 +3217,7 @@ checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3324,7 +3338,7 @@ checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3335,7 +3349,7 @@ checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3543,7 +3557,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3624,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -3662,7 +3676,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
  "unicode-xid 0.2.1",
 ]
 
@@ -4299,7 +4313,7 @@ dependencies = [
  "nom",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -4411,7 +4425,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -4445,7 +4459,7 @@ checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "document-metrics"
+version = "0.1.0"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Generates documentation for metrics"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0.32"
+paw = "1.0.0"
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.55"
+serde_yaml = "0.8.13"
+structopt = { version = "0.3.16", features = ["paw"] }
+syn = "1.0.39"
+
+[dev-dependencies]
+insta = "0.15.0"

--- a/tools/document-metrics/src/main.rs
+++ b/tools/document-metrics/src/main.rs
@@ -1,0 +1,345 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+
+static FILE_CONTENTS: &str = include_str!("../../../relay-server/src/metrics.rs");
+
+#[derive(Clone, Copy, Debug)]
+enum SchemaFormat {
+    Json,
+    Yaml,
+}
+
+impl fmt::Display for SchemaFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Json => write!(f, "json"),
+            Self::Yaml => write!(f, "yaml"),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ParseSchemaFormatError;
+
+impl fmt::Display for ParseSchemaFormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid schema format")
+    }
+}
+
+impl std::error::Error for ParseSchemaFormatError {}
+
+impl std::str::FromStr for SchemaFormat {
+    type Err = ParseSchemaFormatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "json" => Ok(Self::Json),
+            "yaml" => Ok(Self::Yaml),
+            _ => Err(ParseSchemaFormatError),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+enum MetricType {
+    Timer,
+    Counter,
+    Histogram,
+    Set,
+    Gauge,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct MetricPath(syn::Ident, syn::Ident);
+
+#[derive(Debug, Serialize)]
+struct Metric {
+    ty: MetricType,
+    name: String,
+    description: String,
+    features: Vec<String>,
+}
+
+/// Returns the value of a matching attribute in form `#[name = "value"]`.
+fn get_attr(name: &str, nv: syn::MetaNameValue) -> Option<String> {
+    match nv.lit {
+        syn::Lit::Str(lit_string) if nv.path.is_ident(name) => Some(lit_string.value()),
+        _ => None,
+    }
+}
+
+/// Adds a line to the string if the attribute is a doc attribute.
+fn add_doc_line(docs: &mut String, nv: syn::MetaNameValue) {
+    if let Some(line) = get_attr("doc", nv) {
+        if !docs.is_empty() {
+            docs.push('\n');
+        }
+        docs.push_str(line.trim());
+    }
+}
+
+/// Adds the name of the feature if the given attribute is a `cfg(feature)` attribute.
+fn add_feature(features: &mut Vec<String>, l: syn::MetaList) {
+    if l.path.is_ident("cfg") {
+        for nested in l.nested {
+            if let syn::NestedMeta::Meta(syn::Meta::NameValue(nv)) = nested {
+                if let Some(feature) = get_attr("feature", nv) {
+                    features.push(feature);
+                }
+            }
+        }
+    }
+}
+
+/// Returns metric information from metric enum variant attributes.
+fn parse_variant_parts(attrs: &[syn::Attribute]) -> Result<(String, Vec<String>)> {
+    let mut features = Vec::new();
+    let mut docs = String::new();
+
+    for attribute in attrs {
+        match attribute.parse_meta()? {
+            syn::Meta::NameValue(nv) => add_doc_line(&mut docs, nv),
+            syn::Meta::List(l) => add_feature(&mut features, l),
+            _ => (),
+        }
+    }
+
+    Ok((docs, features))
+}
+
+/// Returns the final type name from a path in format `path::to::Type`.
+fn get_path_type(mut path: syn::Path) -> Option<syn::Ident> {
+    let last_segment = path.segments.pop()?;
+    Some(last_segment.into_value().ident)
+}
+
+/// Returns the variant name and string value of a match arm in format `Type::Variant => "value"`.
+fn get_match_pair(arm: syn::Arm) -> Option<(syn::Ident, String)> {
+    let variant = match arm.pat {
+        syn::Pat::Path(path) => get_path_type(path.path)?,
+        _ => return None,
+    };
+
+    if let syn::Expr::Lit(lit) = *arm.body {
+        if let syn::Lit::Str(s) = lit.lit {
+            return Some((variant, s.value()));
+        }
+    }
+
+    None
+}
+
+/// Returns the metric type of a trait implementation.
+fn get_metric_type(imp: &mut syn::ItemImpl) -> Option<MetricType> {
+    let (_, path, _) = imp.trait_.take()?;
+    let trait_name = get_path_type(path)?;
+
+    if trait_name == "TimerMetric" {
+        Some(MetricType::Timer)
+    } else if trait_name == "CounterMetric" {
+        Some(MetricType::Counter)
+    } else if trait_name == "HistogramMetric" {
+        Some(MetricType::Histogram)
+    } else if trait_name == "SetMetric" {
+        Some(MetricType::Set)
+    } else if trait_name == "GaugeMetric" {
+        Some(MetricType::Gauge)
+    } else {
+        None
+    }
+}
+
+/// Returns the type name of a type in format `path::to::Type`.
+fn get_type_name(ty: syn::Type) -> Option<syn::Ident> {
+    match ty {
+        syn::Type::Path(path) => get_path_type(path.path),
+        _ => None,
+    }
+}
+
+/// Resolves match arms in the implementation of the `name` method.
+fn find_name_arms(items: Vec<syn::ImplItem>) -> Option<Vec<syn::Arm>> {
+    for item in items {
+        let method = match item {
+            syn::ImplItem::Method(method) if method.sig.ident == "name" => method,
+            _ => continue,
+        };
+
+        for stmt in method.block.stmts {
+            if let syn::Stmt::Expr(syn::Expr::Match(mat)) = stmt {
+                return Some(mat.arms);
+            }
+        }
+    }
+
+    None
+}
+
+/// Parses metrics information from an impl block.
+fn parse_impl_parts(mut imp: syn::ItemImpl) -> Option<(MetricType, syn::Ident, Vec<syn::Arm>)> {
+    let ty = get_metric_type(&mut imp)?;
+    let type_name = get_type_name(*imp.self_ty)?;
+    let arms = find_name_arms(imp.items)?;
+    Some((ty, type_name, arms))
+}
+
+/// Parses metrics from the given source code.
+fn parse_metrics(source: &str) -> Result<Vec<Metric>> {
+    let ast = syn::parse_file(source).with_context(|| "failed to parse metrics file")?;
+
+    let mut variant_parts = HashMap::new();
+    let mut impl_parts = HashMap::new();
+
+    for item in ast.items {
+        match item {
+            syn::Item::Enum(enum_item) => {
+                for variant in enum_item.variants {
+                    let path = MetricPath(enum_item.ident.clone(), variant.ident);
+                    let (description, features) = parse_variant_parts(&variant.attrs)?;
+                    variant_parts.insert(path, (description, features));
+                }
+            }
+            syn::Item::Impl(imp) => {
+                if let Some((ty, type_name, arms)) = parse_impl_parts(imp) {
+                    for (variant, name) in arms.into_iter().filter_map(get_match_pair) {
+                        let path = MetricPath(type_name.clone(), variant);
+                        impl_parts.insert(path, (name, ty));
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+
+    let mut metrics = Vec::new();
+
+    for (path, (name, ty)) in impl_parts {
+        let (description, features) = variant_parts.remove(&path).unwrap();
+        metrics.push(Metric {
+            name,
+            ty,
+            description,
+            features,
+        });
+    }
+
+    metrics.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(metrics)
+}
+
+/// Prints the event protocol schema.
+#[derive(Debug, StructOpt)]
+#[structopt(verbatim_doc_comment, setting = AppSettings::ColoredHelp)]
+struct Cli {
+    /// The format to output the schema in.
+    #[structopt(short, long, default_value = "yaml")]
+    format: SchemaFormat,
+
+    /// Optional output path. By default, the schema is printed on stdout.
+    #[structopt(short, long, value_name = "PATH")]
+    output: Option<PathBuf>,
+}
+
+impl Cli {
+    fn write_metrics<W: Write>(&self, writer: W, metrics: &[Metric]) -> Result<()> {
+        match self.format {
+            SchemaFormat::Json => serde_json::to_writer_pretty(writer, metrics)?,
+            SchemaFormat::Yaml => serde_yaml::to_writer(writer, metrics)?,
+        };
+
+        Ok(())
+    }
+
+    pub fn run(self) -> Result<()> {
+        let metrics = parse_metrics(FILE_CONTENTS)?;
+
+        match self.output {
+            Some(ref path) => self.write_metrics(File::create(path)?, &metrics)?,
+            None => self.write_metrics(io::stdout(), &metrics)?,
+        }
+
+        Ok(())
+    }
+}
+
+fn print_error(error: &anyhow::Error) {
+    eprintln!("Error: {}", error);
+
+    let mut cause = error.source();
+    while let Some(ref e) = cause {
+        eprintln!("  caused by: {}", e);
+        cause = e.source();
+    }
+}
+
+#[paw::main]
+fn main(cli: Cli) {
+    match cli.run() {
+        Ok(()) => (),
+        Err(error) => {
+            print_error(&error);
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_metrics() -> Result<()> {
+        let source = r#"
+            /// A metric collection used for testing.
+            pub enum TestSets {
+                /// The metric we test.
+                UniqueSet,
+                /// The metric we test.
+                #[cfg(feature = "conditional")]
+                ConditionalSet,
+            }
+
+            impl SetMetric for TestSets {
+                fn name(&self) -> &'static str {
+                    match self {
+                        Self::UniqueSet => "test.unique",
+                        #[cfg(feature = "conditional")]
+                        Self::ConditionalSet => "test.conditional",
+                    }
+                }
+            }
+        "#;
+
+        let metrics = parse_metrics(&source)?;
+        insta::assert_debug_snapshot!(metrics, @r###"
+        [
+            Metric {
+                ty: Set,
+                name: "test.conditional",
+                description: "The metric we test.",
+                features: [
+                    "conditional",
+                ],
+            },
+            Metric {
+                ty: Set,
+                name: "test.unique",
+                description: "The metric we test.",
+                features: [],
+            },
+        ]
+        "###);
+
+        Ok(())
+    }
+}

--- a/tools/document-metrics/src/main.rs
+++ b/tools/document-metrics/src/main.rs
@@ -63,6 +63,7 @@ struct MetricPath(syn::Ident, syn::Ident);
 
 #[derive(Debug, Serialize)]
 struct Metric {
+    #[serde(rename = "type")]
     ty: MetricType,
     name: String,
     description: String,

--- a/tools/document-metrics/src/main.rs
+++ b/tools/document-metrics/src/main.rs
@@ -243,7 +243,7 @@ fn parse_metrics(source: &str) -> Result<Vec<Metric>> {
 #[structopt(verbatim_doc_comment, setting = AppSettings::ColoredHelp)]
 struct Cli {
     /// The format to output the schema in.
-    #[structopt(short, long, default_value = "yaml")]
+    #[structopt(short, long, default_value = "json")]
     format: SchemaFormat,
 
     /// Optional output path. By default, the schema is printed on stdout.


### PR DESCRIPTION
After moving Relay documentation to sentry-docs in
https://github.com/getsentry/sentry-docs/pull/2197, this generates metrics docs
in YAML format for dynamic rendering. 
