### PR TITLE
 ref: Remove unused redaction options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Report all Kafka producer errors to Sentry. Previously, only immediate errors were reported but not those during asynchronous flushing of messages. ([#677](https://github.com/getsentry/relay/pull/677))
 - Add "HubSpot Crawler" to the list of web crawlers for inbound filters. ([#693](https://github.com/getsentry/relay/pull/693))
 - Improved typing for span data of transaction events, no breaking changes. ([#713](https://github.com/getsentry/relay/pull/713))
+- **Breaking change:** In PII configs, all options on hash and mask redactions (replacement characters, ignored characters, hash algorithm/key) are removed. If they still exist in the configuration, they are ignored. ([#760](https://github.com/getsentry/relay/pull/760))
 
 ## 20.7.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.5.5",
  "sha-1",
- "sha2",
  "smallvec 1.4.0",
  "uaparser",
  "url 2.1.1",

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- In PII configs, all options on hash and mask redactions (replacement characters, ignored characters, hash algorithm/key) are removed. If they still exist in the configuration, they are ignored. ([#760](https://github.com/getsentry/relay/pull/760))
+
 ## 0.6.1
 
 - Removed deprecated `pii_selectors_from_event`.

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -32,7 +32,6 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.5.5"
 sha-1 = "0.8.1"
-sha2 = "0.8.1"
 smallvec = { version = "1.4.0", features = ["serde"] }
 uaparser = { version = "0.3.3", optional = true }
 url = "2.1.1"

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -73,6 +73,7 @@ fn apply_regex_to_bytes(
     }
 
     const DEFAULT_PADDING: u8 = b'x';
+    const MASK_PADDING: u8 = b'*';
 
     match rule.redaction {
         Redaction::Default | Redaction::Remove => {
@@ -82,31 +83,18 @@ fn apply_regex_to_bytes(
                 }
             }
         }
-        Redaction::Mask(ref mask) => {
-            let chars_to_ignore: BTreeSet<u8> = mask
-                .chars_to_ignore
-                .chars()
-                .filter_map(|x| if x.is_ascii() { Some(x as u8) } else { None })
-                .collect();
-            let mask_char = if mask.mask_char.is_ascii() {
-                mask.mask_char as u8
-            } else {
-                DEFAULT_PADDING
-            };
-
+        Redaction::Mask => {
             for (start, end) in matches {
                 let match_slice = &mut data[start..end];
                 let match_slice_len = match_slice.len();
                 for (idx, c) in match_slice.iter_mut().enumerate() {
-                    if in_range(mask.range, idx, match_slice_len) && !chars_to_ignore.contains(c) {
-                        *c = mask_char;
-                    }
+                    *c = MASK_PADDING;
                 }
             }
         }
-        Redaction::Hash(ref hash) => {
+        Redaction::Hash => {
             for (start, end) in matches {
-                let hashed = hash_value(hash.algorithm, &data[start..end], hash.key.as_deref());
+                let hashed = hash_value(&data[start..end]);
                 replace_bytes_padded(hashed.as_bytes(), &mut data[start..end], DEFAULT_PADDING);
             }
         }

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use regex::bytes::RegexBuilder as BytesRegexBuilder;
 use regex::Regex;
@@ -7,7 +6,7 @@ use smallvec::SmallVec;
 
 use crate::pii::compiledconfig::RuleRef;
 use crate::pii::regexes::{get_regex_for_rule_type, ReplaceBehavior};
-use crate::pii::utils::{hash_value, in_range};
+use crate::pii::utils::hash_value;
 use crate::pii::{CompiledPiiConfig, Redaction};
 use crate::processor::{FieldAttrs, Pii, ProcessingState, ValueType};
 
@@ -86,8 +85,7 @@ fn apply_regex_to_bytes(
         Redaction::Mask => {
             for (start, end) in matches {
                 let match_slice = &mut data[start..end];
-                let match_slice_len = match_slice.len();
-                for (idx, c) in match_slice.iter_mut().enumerate() {
+                for c in match_slice.iter_mut() {
                     *c = MASK_PADDING;
                 }
             }

--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -4,8 +4,7 @@ use std::collections::BTreeMap;
 use lazy_static::lazy_static;
 
 use crate::pii::{
-    AliasRule, HashRedaction, MaskRedaction, MultipleRule, PatternRule, Redaction,
-    ReplaceRedaction, RuleSpec, RuleType,
+    AliasRule, MultipleRule, PatternRule, Redaction, ReplaceRedaction, RuleSpec, RuleType,
 };
 
 macro_rules! declare_builtin_rules {
@@ -85,11 +84,11 @@ declare_builtin_rules! {
     };
     "@anything:hash" => RuleSpec {
         ty: RuleType::Anything,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@anything:mask" => RuleSpec {
         ty: RuleType::Anything,
-        redaction: Redaction::Mask(MaskRedaction::default()),
+        redaction: Redaction::Mask,
     };
 
     // ip rules
@@ -102,11 +101,11 @@ declare_builtin_rules! {
     };
     "@ip:hash" => RuleSpec {
         ty: RuleType::Ip,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@ip:mask" => RuleSpec {
         ty: RuleType::Ip,
-        redaction: Redaction::Mask(MaskRedaction::default()),
+        redaction: Redaction::Mask,
     };
     "@ip:remove" => RuleSpec {
         ty: RuleType::Ip,
@@ -123,11 +122,11 @@ declare_builtin_rules! {
     };
     "@imei:hash" => RuleSpec {
         ty: RuleType::Imei,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@imei:mask" => RuleSpec {
         ty: RuleType::Imei,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@imei:remove" => RuleSpec {
         ty: RuleType::Imei,
@@ -144,15 +143,11 @@ declare_builtin_rules! {
     };
     "@mac:hash" => RuleSpec {
         ty: RuleType::Mac,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@mac:mask" => RuleSpec {
         ty: RuleType::Mac,
-        redaction: Redaction::Mask(MaskRedaction {
-            mask_char: '*',
-            chars_to_ignore: "-:".into(),
-            range: (Some(9), None),
-        }),
+        redaction: Redaction::Mask,
     };
     "@mac:remove" => RuleSpec {
         ty: RuleType::Mac,
@@ -169,15 +164,11 @@ declare_builtin_rules! {
     };
     "@uuid:hash" => RuleSpec {
         ty: RuleType::Uuid,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@uuid:mask" => RuleSpec {
         ty: RuleType::Uuid,
-        redaction: Redaction::Mask(MaskRedaction {
-            mask_char: '*',
-            chars_to_ignore: "-".into(),
-            range: (None, None),
-        }),
+        redaction: Redaction::Mask,
     };
     "@uuid:remove" => RuleSpec {
         ty: RuleType::Uuid,
@@ -194,15 +185,11 @@ declare_builtin_rules! {
     };
     "@email:hash" => RuleSpec {
         ty: RuleType::Email,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@email:mask" => RuleSpec {
         ty: RuleType::Email,
-        redaction: Redaction::Mask(MaskRedaction {
-            mask_char: '*',
-            chars_to_ignore: ".@".into(),
-            range: (None, None),
-        }),
+        redaction: Redaction::Mask,
     };
     "@email:remove" => RuleSpec {
         ty: RuleType::Email,
@@ -213,7 +200,7 @@ declare_builtin_rules! {
     "@creditcard" => rule_alias!("@creditcard:replace");
     "@creditcard:hash" => RuleSpec {
         ty: RuleType::Creditcard,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@creditcard:replace" => RuleSpec {
         ty: RuleType::Creditcard,
@@ -223,11 +210,7 @@ declare_builtin_rules! {
     };
     "@creditcard:mask" => RuleSpec {
         ty: RuleType::Creditcard,
-        redaction: Redaction::Mask(MaskRedaction {
-            mask_char: '*',
-            chars_to_ignore: " -".into(),
-            range: (None, Some(-4)),
-        }),
+        redaction: Redaction::Mask,
     };
     "@creditcard:filter" => RuleSpec {
         ty: RuleType::Creditcard,
@@ -256,11 +239,11 @@ declare_builtin_rules! {
     };
     "@pemkey:hash" => RuleSpec {
         ty: RuleType::Pemkey,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@pemkey:mask" => RuleSpec {
         ty: RuleType::Pemkey,
-        redaction: Redaction::Mask(MaskRedaction::default()),
+        redaction: Redaction::Mask,
     };
     "@pemkey:remove" => RuleSpec {
         ty: RuleType::Pemkey,
@@ -277,11 +260,11 @@ declare_builtin_rules! {
     };
     "@urlauth:hash" => RuleSpec {
         ty: RuleType::UrlAuth,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@urlauth:mask" => RuleSpec {
         ty: RuleType::UrlAuth,
-        redaction: Redaction::Mask(MaskRedaction::default()),
+        redaction: Redaction::Mask,
     };
     "@urlauth:remove" => RuleSpec {
         ty: RuleType::UrlAuth,
@@ -314,15 +297,11 @@ declare_builtin_rules! {
     };
     "@usssn:mask" => RuleSpec {
         ty: RuleType::UsSsn,
-        redaction: Redaction::Mask(MaskRedaction {
-            mask_char: '*',
-            chars_to_ignore: "-".into(),
-            range: (None, None),
-        }),
+        redaction: Redaction::Mask,
     };
     "@usssn:hash" => RuleSpec {
         ty: RuleType::UsSsn,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@usssn:remove" => RuleSpec {
         ty: RuleType::UsSsn,
@@ -339,11 +318,11 @@ declare_builtin_rules! {
     };
     "@userpath:mask" => RuleSpec {
         ty: RuleType::Userpath,
-        redaction: Redaction::Mask(MaskRedaction::default()),
+        redaction: Redaction::Mask,
     };
     "@userpath:hash" => RuleSpec {
         ty: RuleType::Userpath,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@userpath:remove" => RuleSpec {
         ty: RuleType::Userpath,
@@ -360,7 +339,7 @@ declare_builtin_rules! {
     };
     "@password:hash" => RuleSpec {
         ty: RuleType::Password,
-        redaction: Redaction::Hash(HashRedaction::default()),
+        redaction: Redaction::Hash,
     };
     "@password:replace" => RuleSpec {
         ty: RuleType::Password,
@@ -370,7 +349,7 @@ declare_builtin_rules! {
     };
     "@password:mask" => RuleSpec {
         ty: RuleType::Password,
-        redaction: Redaction::Mask(MaskRedaction::default()),
+        redaction: Redaction::Mask,
     };
     "@password:remove" => RuleSpec {
         ty: RuleType::Password,
@@ -385,7 +364,7 @@ mod tests {
 
     use crate::pii::config::{PiiConfig, RuleSpec, RuleType};
     use crate::pii::processor::PiiProcessor;
-    use crate::pii::{HashRedaction, MaskRedaction, Redaction, ReplaceRedaction};
+    use crate::pii::{Redaction, ReplaceRedaction};
     use crate::processor::{process_value, ProcessingState, ValueType};
     use crate::types::{Annotated, Remark, RemarkType};
 
@@ -452,8 +431,8 @@ mod tests {
                             redaction: match b {
                                 "remove" => Redaction::Remove,
                                 "replace" => Redaction::Replace(ReplaceRedaction::default()),
-                                "mask" => Redaction::Mask(MaskRedaction::default()),
-                                "hash" => Redaction::Hash(HashRedaction::default()),
+                                "mask" => Redaction::Mask,
+                                "hash" => Redaction::Hash,
                                 _ => panic!("Unknown redaction method"),
                             },
                         },

--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -607,7 +607,7 @@ mod tests {
         assert_text_rule!(
             rule = "@mac";
             input = "ether 4a:00:04:10:9b:50";
-            output = "ether 4a:00:04:**:**:**";
+            output = "ether *****************";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@mac", (6, 23)),
             ];
@@ -615,7 +615,7 @@ mod tests {
         assert_text_rule!(
             rule = "@mac:mask";
             input = "ether 4a:00:04:10:9b:50";
-            output = "ether 4a:00:04:**:**:**";
+            output = "ether *****************";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@mac:mask", (6, 23)),
             ];
@@ -667,7 +667,7 @@ mod tests {
         assert_text_rule!(
             rule = "@uuid";
             input = "user id ceee0822-ed8f-4622-b2a3-789e73e75cd1";
-            output = "user id ********-****-****-****-************";
+            output = "user id ************************************";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@uuid", (8, 44)),
             ];
@@ -675,7 +675,7 @@ mod tests {
         assert_text_rule!(
             rule = "@uuid:mask";
             input = "user id ceee0822-ed8f-4622-b2a3-789e73e75cd1";
-            output = "user id ********-****-****-****-************";
+            output = "user id ************************************";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@uuid:mask", (8, 44)),
             ];
@@ -751,7 +751,7 @@ mod tests {
         assert_text_rule!(
             rule = "@email:mask";
             input = "John Appleseed <john@appleseed.com>";
-            output = "John Appleseed <****@*********.***>";
+            output = "John Appleseed <******************>";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@email:mask", (16, 34)),
             ];
@@ -803,7 +803,7 @@ mod tests {
         assert_text_rule!(
             rule = "@creditcard:mask";
             input = "John Appleseed 4571234567890111!";
-            output = "John Appleseed ************0111!";
+            output = "John Appleseed ****************!";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@creditcard:mask", (15, 31)),
             ];
@@ -927,7 +927,7 @@ HdmUCGvfKiF2CodxyLon1XkK8pX+Ap86MbJhluqK
         assert_text_rule!(
             rule = "@usssn";
             input = "Hi I'm Hilda and my SSN is 078-05-1120";
-            output = "Hi I'm Hilda and my SSN is ***-**-****";
+            output = "Hi I'm Hilda and my SSN is ***********";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@usssn", (27, 38)),
             ];
@@ -935,7 +935,7 @@ HdmUCGvfKiF2CodxyLon1XkK8pX+Ap86MbJhluqK
         assert_text_rule!(
             rule = "@usssn:mask";
             input = "Hi I'm Hilda and my SSN is 078-05-1120";
-            output = "Hi I'm Hilda and my SSN is ***-**-****";
+            output = "Hi I'm Hilda and my SSN is ***********";
             remarks = vec![
                 Remark::with_range(RemarkType::Masked, "@usssn:mask", (27, 38)),
             ];

--- a/relay-general/src/pii/mod.rs
+++ b/relay-general/src/pii/mod.rs
@@ -24,6 +24,4 @@ pub use self::generate_selectors::selector_suggestions_from_value;
 pub use self::legacy::DataScrubbingConfig;
 pub use self::minidumps::ScrubMinidumpError;
 pub use self::processor::PiiProcessor;
-pub use self::redactions::{
-    HashAlgorithm, HashRedaction, MaskRedaction, Redaction, ReplaceRedaction,
-};
+pub use self::redactions::{Redaction, ReplaceRedaction};

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -333,16 +333,11 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
                 ty: RemarkType::Removed,
             });
         }
-        Redaction::Mask(mask) => {
-            let chars_to_ignore: BTreeSet<char> = mask.chars_to_ignore.chars().collect();
+        Redaction::Mask => {
             let mut buf = Vec::with_capacity(text.len());
 
             for (idx, c) in text.chars().enumerate() {
-                if in_range(mask.range, idx, text.len()) && !chars_to_ignore.contains(&c) {
-                    buf.push(mask.mask_char);
-                } else {
-                    buf.push(c);
-                }
+                buf.push('*');
             }
             output.push(Chunk::Redaction {
                 ty: RemarkType::Masked,
@@ -350,14 +345,12 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
                 text: buf.into_iter().collect(),
             })
         }
-        Redaction::Hash(hash) => {
+        Redaction::Hash => {
             output.push(Chunk::Redaction {
                 ty: RemarkType::Pseudonymized,
                 rule_id: Cow::Owned(rule.origin.to_string()),
                 text: Cow::Owned(hash_value(
-                    hash.algorithm,
                     text.as_bytes(),
-                    hash.key.as_deref(),
                 )),
             });
         }

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 use std::mem;
 
 use lazy_static::lazy_static;
@@ -7,7 +6,7 @@ use regex::Regex;
 
 use crate::pii::compiledconfig::RuleRef;
 use crate::pii::regexes::{get_regex_for_rule_type, PatternType, ReplaceBehavior, ANYTHING_REGEX};
-use crate::pii::utils::{hash_value, in_range, process_pairlist};
+use crate::pii::utils::{hash_value, process_pairlist};
 use crate::pii::{CompiledPiiConfig, Redaction, RuleType};
 use crate::processor::{
     process_chunked_value, Chunk, Pii, ProcessValue, ProcessingState, Processor, ValueType,
@@ -334,11 +333,8 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
             });
         }
         Redaction::Mask => {
-            let mut buf = Vec::with_capacity(text.len());
+            let buf = vec!['*'; text.chars().count()];
 
-            for (idx, c) in text.chars().enumerate() {
-                buf.push('*');
-            }
             output.push(Chunk::Redaction {
                 ty: RemarkType::Masked,
                 rule_id: Cow::Owned(rule.origin.to_string()),
@@ -349,9 +345,7 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
             output.push(Chunk::Redaction {
                 ty: RemarkType::Pseudonymized,
                 rule_id: Cow::Owned(rule.origin.to_string()),
-                text: Cow::Owned(hash_value(
-                    text.as_bytes(),
-                )),
+                text: Cow::Owned(hash_value(text.as_bytes())),
             });
         }
         Redaction::Replace(replace) => {

--- a/relay-general/src/pii/redactions.rs
+++ b/relay-general/src/pii/redactions.rs
@@ -1,31 +1,6 @@
 //! Redactions for rules.
 use serde::{Deserialize, Serialize};
 
-/// Defines the hash algorithm to use for hashing
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[allow(clippy::enum_variant_names)]
-pub enum HashAlgorithm {
-    /// HMAC-SHA1
-    #[serde(rename = "HMAC-SHA1")]
-    HmacSha1,
-    /// HMAC-SHA256
-    #[serde(rename = "HMAC-SHA256")]
-    HmacSha256,
-    /// HMAC-SHA512
-    #[serde(rename = "HMAC-SHA512")]
-    HmacSha512,
-}
-
-impl Default for HashAlgorithm {
-    fn default() -> HashAlgorithm {
-        HashAlgorithm::HmacSha1
-    }
-}
-
-fn default_mask_char() -> char {
-    '*'
-}
-
 fn default_replace_text() -> String {
     "[Filtered]".into()
 }
@@ -53,52 +28,6 @@ impl Default for ReplaceRedaction {
     }
 }
 
-/// Masks the value
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct MaskRedaction {
-    /// The character to mask with.
-    #[serde(default = "default_mask_char")]
-    pub mask_char: char,
-    /// Characters to skip during masking to preserve structure.
-    #[serde(default)]
-    pub chars_to_ignore: String,
-    /// Index range to mask in. Negative indices count from the string's end.
-    #[serde(default)]
-    pub range: (Option<i32>, Option<i32>),
-}
-
-impl Default for MaskRedaction {
-    fn default() -> Self {
-        MaskRedaction {
-            mask_char: default_mask_char(),
-            chars_to_ignore: String::new(),
-            range: (None, None),
-        }
-    }
-}
-
-/// Replaces the value with a hash
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct HashRedaction {
-    /// The hash algorithm
-    #[serde(default)]
-    pub algorithm: HashAlgorithm,
-    /// The secret key (if not to use the default)
-    #[serde(default)]
-    pub key: Option<String>,
-}
-
-impl Default for HashRedaction {
-    fn default() -> Self {
-        HashRedaction {
-            algorithm: HashAlgorithm::default(),
-            key: None,
-        }
-    }
-}
-
 /// Defines how replacements happen.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(tag = "method", rename_all = "snake_case")]
@@ -114,9 +43,9 @@ pub enum Redaction {
     /// Replaces the matched group with a new value.
     Replace(ReplaceRedaction),
     /// Overwrites the matched value by masking.
-    Mask(MaskRedaction),
+    Mask,
     /// Replaces the value with a hash
-    Hash(HashRedaction),
+    Hash,
 }
 
 impl Default for Redaction {

--- a/relay-general/src/pii/utils.rs
+++ b/relay-general/src/pii/utils.rs
@@ -1,8 +1,5 @@
-use std::cmp;
-
 use hmac::{Hmac, Mac};
 use sha1::Sha1;
-use sha2::{Sha256, Sha512};
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
 use crate::protocol::{AsPair, PairList};
@@ -46,20 +43,6 @@ pub fn process_pairlist<P: Processor, T: ProcessValue + AsPair>(
     }
 
     Ok(())
-}
-
-pub fn in_range(range: (Option<i32>, Option<i32>), pos: usize, len: usize) -> bool {
-    fn get_range_index(idx: Option<i32>, len: usize, default: usize) -> usize {
-        match idx {
-            None => default,
-            Some(idx) if idx < 0 => len.saturating_sub(-idx as usize),
-            Some(idx) => cmp::min(idx as usize, len),
-        }
-    }
-
-    let start = get_range_index(range.0, len, 0);
-    let end = get_range_index(range.1, len, len);
-    pos >= start && pos < end
 }
 
 pub fn hash_value(data: &[u8]) -> String {

--- a/relay-general/src/pii/utils.rs
+++ b/relay-general/src/pii/utils.rs
@@ -4,7 +4,6 @@ use hmac::{Hmac, Mac};
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 
-use crate::pii::HashAlgorithm;
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
 use crate::protocol::{AsPair, PairList};
 use crate::types::ProcessingResult;
@@ -63,18 +62,8 @@ pub fn in_range(range: (Option<i32>, Option<i32>), pos: usize, len: usize) -> bo
     pos >= start && pos < end
 }
 
-pub fn hash_value(algorithm: HashAlgorithm, data: &[u8], key: Option<&str>) -> String {
-    let key = key.unwrap_or("");
-    macro_rules! hmac {
-        ($ty:ident) => {{
-            let mut mac = Hmac::<$ty>::new_varkey(key.as_bytes()).unwrap();
-            mac.input(data);
-            format!("{:X}", mac.result().code())
-        }};
-    }
-    match algorithm {
-        HashAlgorithm::HmacSha1 => hmac!(Sha1),
-        HashAlgorithm::HmacSha256 => hmac!(Sha256),
-        HashAlgorithm::HmacSha512 => hmac!(Sha512),
-    }
+pub fn hash_value(data: &[u8]) -> String {
+    let mut mac = Hmac::<Sha1>::new_varkey(&[]).unwrap();
+    mac.input(data);
+    format!("{:X}", mac.result().code())
 }


### PR DESCRIPTION
Those options cannot be configured in the UI. The builtins change in masking behavior, but that's okay because the UI doesn't use the builtins either (it generates custom rule defs in all cases).

The primary reason for doing this now is to simplify the implementation of attachment scrubbing (and particularly its utf16 support in #742)

I kinda want to remove PII builtins entirely, but that will break some customers that are using relay in static mode. So maybe just refactor?