### PR TITLE
ref(server) Add request type to UpstreamMessageQueueSize histogram

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -236,8 +236,6 @@ impl UpstreamRequest {
             "project_configs"
         } else if self.path.contains("/publickeys/") {
             "project_ids"
-        } else if self.path.contains("/projectids/") {
-            "project_ids"
         } else if self.path.contains("/challenge/") {
             "challenge"
         } else if self.path.contains("/response/") {


### PR DESCRIPTION
#skip-changelog

**NOTE:** There is no plan to ever merge this into master.
If we want to add the functionality of this PR in master it should be reimplemented in a more careful way. 