### PR TITLE
fix(perf): Improve performance of event processing by avoiding regex clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add the client SDK to session kafka payloads. ([#751](https://github.com/getsentry/relay/pull/751))
 - Add a standalone tool to document metrics in JSON or YAML. ([#752](https://github.com/getsentry/relay/pull/752))
 - Emit `processing.event.produced` for user report and session Kafka messages. ([#757](https://github.com/getsentry/relay/pull/757))
+- Improve performance of event processing by avoiding regex clone. ([#767](https://github.com/getsentry/relay/pull/767))
 
 ## 20.8.0
 

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -728,12 +728,9 @@ impl FieldAttrs {
         };
 
         let match_regex = if let Some(ref match_regex) = self.match_regex {
-            quote!(Some(
-                #[allow(clippy::trivial_regex)]
-                ::regex::Regex::new(#match_regex).unwrap()
-            ))
+            quote!(Some(#match_regex))
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
-            quote!(#parent_attrs.match_regex.clone())
+            quote!(#parent_attrs.match_regex)
         } else {
             quote!(None)
         };

--- a/relay-general/derive/src/process.rs
+++ b/relay-general/derive/src/process.rs
@@ -81,10 +81,7 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
             let field_attrs_tokens = field_attrs.as_tokens(None);
 
             (quote! {
-                ::lazy_static::lazy_static! {
-                    static ref #field_attrs_name: crate::processor::FieldAttrs =
-                        #field_attrs_tokens;
-                }
+                static #field_attrs_name: crate::processor::FieldAttrs = #field_attrs_tokens;
             })
             .to_tokens(&mut body);
 
@@ -94,13 +91,13 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
                 }
 
                 quote! {
-                    __state.enter_nothing(Some(::std::borrow::Cow::Borrowed(&*#field_attrs_name)))
+                    __state.enter_nothing(Some(::std::borrow::Cow::Borrowed(&#field_attrs_name)))
                 }
             } else if is_tuple_struct {
                 quote! {
                     __state.enter_index(
                         #index,
-                        Some(::std::borrow::Cow::Borrowed(&*#field_attrs_name)),
+                        Some(::std::borrow::Cow::Borrowed(&#field_attrs_name)),
                         crate::processor::ValueType::for_field(#ident),
                     )
                 }
@@ -108,7 +105,7 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
                 quote! {
                     __state.enter_static(
                         #field_name,
-                        Some(::std::borrow::Cow::Borrowed(&*#field_attrs_name)),
+                        Some(::std::borrow::Cow::Borrowed(&#field_attrs_name)),
                         crate::processor::ValueType::for_field(#ident),
                     )
                 }

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::str::FromStr;
 
 use failure::Fail;
-use regex::Regex;
 use smallvec::SmallVec;
 
 use crate::processor::{ProcessValue, SelectorPathItem, SelectorSpec};
@@ -232,7 +231,7 @@ pub enum Pii {
 }
 
 /// Meta information about a field.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct FieldAttrs {
     /// Optionally the name of the field.
     pub name: Option<&'static str>,
@@ -243,7 +242,7 @@ pub struct FieldAttrs {
     /// Whether to trim whitespace from this string.
     pub trim_whitespace: bool,
     /// A regex to validate the (string) value against.
-    pub match_regex: Option<Regex>,
+    pub match_regex: Option<&'static str>,
     /// The maximum char length of this field.
     pub max_chars: Option<MaxChars>,
     /// The maximum bag size of this field.


### PR DESCRIPTION
We clone the regex field for newtypes as we inherit the parent
processing state. That is very expensive.

We could just use Arc here, but we could also just make FieldAttrs Copy
again like Armin had it from the start, and build up a map of regexes
someplace else.

I think I didn't know how to write Rust when I introduced the newtypes
behavior.