### PR TITLE
fix(server): Disable generic network error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Periodically re-authenticate with the upstream server. Previously, there was only one initial authentication. ([#731](https://github.com/getsentry/relay/pull/731))
 - The module attribute on stack frames (`$frame.module`) and the (usually server side generated) attribute `culprit` can now be scrubbed with advanced data scrubbing. ([#744](https://github.com/getsentry/relay/pull/744))
 - Compress outgoing store requests for events and envelopes including attachements using `gzip` content encoding. ([#745](https://github.com/getsentry/relay/pull/745))
-- Retry sending events on network errors instead of dropping them. Also, Relay now buffers all requests until it has authenticated with the upstream. ([#747](//github.com/getsentry/relay/pull/747))
+- Relay now buffers all requests until it has authenticated with the upstream. ([#747](//github.com/getsentry/relay/pull/747))
 - Add a configuration option to change content encoding of upstream store requests. The default is `gzip`, and other options are `identity`, `deflate`, or `br`. ([#771](https://github.com/getsentry/relay/pull/771))
 
 **Bug Fixes**:

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -611,6 +611,7 @@ def test_events_are_retried(relay, mini_sentry):
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
 
+@pytest.mark.skip(reason="Enable after fixing network error handling")
 def test_failed_network_requests_trigger_re_authentication(relay, mini_sentry):
     def network_error_endpoint(*args, **kwargs):
         # simulate a network error


### PR DESCRIPTION
Network error handling introduced in https://github.com/getsentry/relay/pull/747
relies on authentication, which is not available in proxy and static mode.
Additionally, it fails health checks, which can cause downstream clients to stop
sending data to Relay.

As a temporary measure, this PR disables network error handling outside of
authentication until a dedicated mechanism is implemented.

#skip-changelog
