### PR TITLE
ref(cabi): Remove unused scrub_event function

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,7 +5,7 @@
 - In PII configs, all options on hash and mask redactions (replacement characters, ignored characters, hash algorithm/key) are removed. If they still exist in the configuration, they are ignored. ([#760](https://github.com/getsentry/relay/pull/760))
 - Rename to the library target to `relay_cabi` and add documentation. ([#763](https://github.com/getsentry/relay/pull/763))
 - Update FFI bindings with a new implementation for error handling. ([#766](https://github.com/getsentry/relay/pull/766))
-- Remove unused `scrub_event` function. ([#773](https://github.com/getsentry/relay/pull/773))
+- **Breaking:** Delete `scrub_event` function from public API. ([#773](https://github.com/getsentry/relay/pull/773))
 
 ## 0.6.1
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,7 @@
 - In PII configs, all options on hash and mask redactions (replacement characters, ignored characters, hash algorithm/key) are removed. If they still exist in the configuration, they are ignored. ([#760](https://github.com/getsentry/relay/pull/760))
 - Rename to the library target to `relay_cabi` and add documentation. ([#763](https://github.com/getsentry/relay/pull/763))
 - Update FFI bindings with a new implementation for error handling. ([#766](https://github.com/getsentry/relay/pull/766))
+- Remove unused `scrub_event` function. ([#773](https://github.com/getsentry/relay/pull/773))
 
 ## 0.6.1
 

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -17,7 +17,6 @@ __all__ = [
     "meta_with_chunks",
     "StoreNormalizer",
     "GeoIpLookup",
-    "scrub_event",
     "is_glob_match",
     "parse_release",
     "validate_pii_config",
@@ -127,19 +126,6 @@ def _encode_raw_event(raw_event):
     event = encode_str(raw_event, mutable=True)
     rustcall(lib.relay_translate_legacy_python_json, event)
     return event
-
-
-def scrub_event(config, data):
-    if not config:
-        return data
-
-    config = json.dumps(config)
-
-    raw_event = _serialize_event(data)
-    event = _encode_raw_event(raw_event)
-
-    rv = rustcall(lib.relay_scrub_event, encode_str(config), event)
-    return json.loads(decode_str(rv, free=True))
 
 
 def is_glob_match(

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -101,60 +101,6 @@ def test_broken_json():
         assert event["logentry"]["formatted"] != bad_str
 
 
-def test_data_scrubbing_missing_config():
-    event = {"extra": PII_VARS}
-    config = None
-
-    scrubbed = sentry_relay.scrub_event(config, event)
-    assert event == scrubbed
-
-
-def test_data_scrubbing_empty_config():
-    event = {"extra": PII_VARS}
-    config = {}
-
-    scrubbed = sentry_relay.scrub_event(config, event)
-    assert event == scrubbed
-
-
-def test_data_scrubbing_disabled_config():
-    event = {"extra": PII_VARS}
-    config = {
-        "scrubData": False,
-        "excludeFields": [],
-        "scrubIpAddresses": False,
-        "sensitiveFields": [],
-        "scrubDefaults": True,
-    }
-
-    scrubbed = sentry_relay.scrub_event(config, event)
-    assert event == scrubbed
-
-
-def test_data_scrubbing_default_config():
-    event = {"extra": PII_VARS}
-    config = {
-        "scrubData": True,
-        "excludeFields": [],
-        "scrubIpAddresses": True,
-        "sensitiveFields": [],
-        "scrubDefaults": True,
-    }
-
-    scrubbed = sentry_relay.scrub_event(config, event)
-    assert scrubbed.pop("_meta", None)
-    assert scrubbed == {
-        "extra": {
-            "foo": "bar",
-            "password": "[Filtered]",
-            "the_secret": "[Filtered]",
-            "a_password_here": "[Filtered]",
-            "api_key": "[Filtered]",
-            "apiKey": "[Filtered]",
-        }
-    }
-
-
 def test_validate_pii_config():
     sentry_relay.validate_pii_config("{}")
     sentry_relay.validate_pii_config('{"applications": {}}')

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -116,28 +116,6 @@ pub unsafe extern "C" fn relay_translate_legacy_python_json(event: *mut RelayStr
     true
 }
 
-/// Scrub an event using old data scrubbing settings.
-#[no_mangle]
-#[relay_ffi::catch_unwind]
-pub unsafe extern "C" fn relay_scrub_event(
-    config: *const RelayStr,
-    event: *const RelayStr,
-) -> RelayStr {
-    let config: DataScrubbingConfig = serde_json::from_str((*config).as_str())?;
-    let pii_config = config.pii_config();
-    let pii_config = match *pii_config {
-        Some(ref pii_config) => pii_config,
-        None => return Ok(RelayStr::new((*event).as_str())),
-    };
-
-    let compiled = pii_config.compiled();
-    let mut processor = PiiProcessor::new(&compiled);
-    let mut event = Annotated::<Event>::from_json((*event).as_str())?;
-    process_value(&mut event, &mut processor, ProcessingState::root())?;
-
-    RelayStr::from_string(event.to_json()?)
-}
-
 /// Validate a PII config against the schema. Used in project options UI.
 #[no_mangle]
 #[relay_ffi::catch_unwind]


### PR DESCRIPTION
Sentry has stopped using this function for a while, so let's remove it.