### PR TITLE
ci(craft): Remove gh-pages target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,7 +9,6 @@ statusProvider:
 
 targets:
   - name: github
-  - name: gh-pages
   - name: registry
     type: app
     urlTemplate: "https://downloads.sentry-cdn.com/relay/{{version}}/{{file}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Bug Fixes**:
 
 - Send requests to the `/envelope/` endpoint instead of the older `/store/` endpoint. This particularly fixes spurious `413 Payload Too Large` errors returned when using Relay with Sentry SaaS. ([#746](https://github.com/getsentry/relay/pull/746))
+- Remove gh-pages target from Craft ([#776](https://github.com/getsentry/relay/pull/776))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 **Bug Fixes**:
 
 - Send requests to the `/envelope/` endpoint instead of the older `/store/` endpoint. This particularly fixes spurious `413 Payload Too Large` errors returned when using Relay with Sentry SaaS. ([#746](https://github.com/getsentry/relay/pull/746))
-- Remove gh-pages target from Craft ([#776](https://github.com/getsentry/relay/pull/776))
 
 **Internal**:
 


### PR DESCRIPTION
We no longer build artifacts for gh-pages and publish there. Fixes the latest release.

Follow up to #756.

#skip-changelog
