### PR TITLE
meta: Update CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
 
 # Official Sentry Relay
 
-[![Travis](https://travis-ci.com/getsentry/relay.svg?branch=master)](https://travis-ci.com/getsentry/relay)
-[![AppVeyor](https://img.shields.io/appveyor/ci/sentry/relay.svg)](https://ci.appveyor.com/project/sentry/relay)
-[![GitHub release](https://img.shields.io/github/release/getsentry/relay.svg)](https://github.com/getsentry/relay/releases/latest)
+[![CI](https://github.com/getsentry/relay/workflows/CI/badge.svg?branch=master)](https://github.com/getsentry/relay/actions?query=workflow%3ACI+branch%3Amaster)
+[![GitHub Release](https://img.shields.io/github/release/getsentry/relay.svg)](https://github.com/getsentry/relay/releases/latest)
 [![PyPI](https://img.shields.io/pypi/v/sentry-relay.svg)](https://pypi.python.org/pypi/sentry-relay)
 
 <p align="center">

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -26,7 +26,7 @@ def processing_config(get_topic_name):
     """
 
     def inner(options=None):
-        # The Travis script sets the kafka bootstrap server into system environment variable.
+        # The CI script sets the kafka bootstrap server into system environment variable.
         bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVER", "127.0.0.1:9092")
 
         options = deepcopy(options)  # avoid lateral effects


### PR DESCRIPTION
After moving to GitHub Actions in #780, the Travis and AppVeyor badges are no 
longer relevant. Replace them with a badge for the GitHub CI workflow.

#skip-changelog

