### PR TITLE
fix(server): Allow numbers in measurement names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724))
+- Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724), [#785](https://github.com/getsentry/relay/pull/785))
 - Add support for scrubbing UTF-16 data in attachments ([#742](https://github.com/getsentry/relay/pull/742), [#784](https://github.com/getsentry/relay/pull/784))
 
 **Bug Fixes**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724))
+- Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724), [#785](https://github.com/getsentry/relay/pull/785))
 
 ## 0.8.0
 

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -53,7 +53,7 @@ impl FromValue for Measurements {
 
 fn is_valid_measurement_name(name: &str) -> bool {
     name.chars()
-        .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '-' | '_' | '.'))
+        .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
 }
 
 #[test]
@@ -63,7 +63,7 @@ fn test_measurements_serialization() {
     let input = r#"{
     "measurements": {
         "LCP": {"value": 420.69},
-        "   lcp_final.element-Size  ": {"value": 1},
+        "   lcp_final.element-Size123  ": {"value": 1},
         "fid": {"value": 2020},
         "cls": {"value": null},
         "fp": {"value": "im a first paint"},
@@ -86,7 +86,7 @@ fn test_measurements_serialization() {
     "lcp": {
       "value": 420.69
     },
-    "lcp_final.element-size": {
+    "lcp_final.element-size123": {
       "value": 1.0
     },
     "missing_value": null
@@ -150,7 +150,7 @@ fn test_measurements_serialization() {
             }),
         );
         measurements.insert(
-            "lcp_final.element-size".to_owned(),
+            "lcp_final.element-size123".to_owned(),
             Annotated::new(Measurement {
                 value: Annotated::new(1f64),
             }),

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -66,7 +66,7 @@ def test_normalize_measurement_interface(
         {
             "measurements": {
                 "LCP": {"value": 420.69},
-                "   lcp_final.element-Size  ": {"value": 1},
+                "   lcp_final.element-Size123  ": {"value": 1},
                 "fid": {"value": 2020},
                 "cls": {"value": None},
                 "fp": {"value": "im a first paint"},
@@ -92,7 +92,7 @@ def test_normalize_measurement_interface(
     assert "measurements" in event, event
     assert event["measurements"] == {
         "lcp": {"value": 420.69},
-        "lcp_final.element-size": {"value": 1},
+        "lcp_final.element-size123": {"value": 1},
         "fid": {"value": 2020},
         "cls": {"value": None},
         "fp": {"value": None},


### PR DESCRIPTION
I missed this in https://github.com/getsentry/relay/pull/724 and was discovered in https://github.com/getsentry/sentry/pull/20719

This doesn't break the web vital metrics since their names do not contain numbers. 