### PR TITLE
fix(wstring): Correct out-of-range indexing and is_char_boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724), [#785](https://github.com/getsentry/relay/pull/785))
-- Add support for scrubbing UTF-16 data in attachments ([#742](https://github.com/getsentry/relay/pull/742), [#784](https://github.com/getsentry/relay/pull/784))
+- Add support for scrubbing UTF-16 data in attachments ([#742](https://github.com/getsentry/relay/pull/742), [#784](https://github.com/getsentry/relay/pull/784), [#787](https://github.com/getsentry/relay/pull/787))
 
 **Bug Fixes**:
 

--- a/relay-wstring/src/lib.rs
+++ b/relay-wstring/src/lib.rs
@@ -121,7 +121,7 @@ impl WStr {
         if index == 0 || index == self.len() {
             return true;
         }
-        if index % 2 != 0 {
+        if index % 2 != 0 || index > self.len() {
             return false;
         }
 
@@ -521,6 +521,7 @@ mod tests {
         assert!(!s.is_char_boundary(5));
         assert!(s.is_char_boundary(6));
         assert!(!s.is_char_boundary(7)); // out of range
+        assert!(!s.is_char_boundary(8)); // out of range
     }
 
     #[test]

--- a/relay-wstring/src/slicing.rs
+++ b/relay-wstring/src/slicing.rs
@@ -361,3 +361,91 @@ where
         index.index_mut(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_range() {
+        let b = b"h\x00e\x00l\x00l\x00o\x00\x00\xd8\x00\xdc"; // "hello\u{10000}"
+        let s = WStr::from_utf16le(b).unwrap();
+
+        assert_eq!(s.get(0..14).unwrap(), s);
+
+        // not char boundaries
+        assert!(s.get(1..14).is_none());
+        assert!(s.get(0..12).is_none());
+
+        // out of range
+        assert!(s.get(0..16).is_none());
+    }
+
+    #[test]
+    fn test_range_to() {
+        let b = b"h\x00e\x00l\x00l\x00o\x00\x00\xd8\x00\xdc"; // "hello\u{10000}"
+        let s = WStr::from_utf16le(b).unwrap();
+
+        assert_eq!(s.get(..14).unwrap(), s);
+
+        // not char boundaries
+        assert!(s.get(..9).is_none());
+        assert!(s.get(..12).is_none());
+
+        // out of range
+        assert!(s.get(..16).is_none());
+    }
+
+    #[test]
+    fn test_range_from() {
+        let b = b"h\x00e\x00l\x00l\x00o\x00\x00\xd8\x00\xdc"; // "hello\u{10000}"
+        let s = WStr::from_utf16le(b).unwrap();
+
+        assert_eq!(s.get(0..).unwrap(), s);
+
+        // not char boundaries
+        assert!(s.get(1..).is_none());
+        assert!(s.get(12..).is_none());
+
+        // out of range
+        assert!(s.get(16..).is_none());
+    }
+
+    #[test]
+    fn test_range_inclusive() {
+        let b = b"h\x00e\x00l\x00l\x00o\x00\x00\xd8\x00\xdc"; // "hello\u{10000}"
+        let s = WStr::from_utf16le(b).unwrap();
+
+        assert_eq!(s.get(0..=13).unwrap(), s);
+
+        // not char boundaries
+        assert!(s.get(0..=8).is_none());
+        assert!(s.get(0..=11).is_none());
+
+        // out of range
+        assert!(s.get(0..=15).is_none());
+    }
+
+    #[test]
+    fn test_range_to_inclusive() {
+        let b = b"h\x00e\x00l\x00l\x00o\x00\x00\xd8\x00\xdc"; // "hello\u{10000}"
+        let s = WStr::from_utf16le(b).unwrap();
+
+        assert_eq!(s.get(..=13).unwrap(), s);
+
+        // not char boundaries
+        assert!(s.get(..=8).is_none());
+        assert!(s.get(..=11).is_none());
+
+        // out of range
+        assert!(s.get(..=15).is_none());
+    }
+
+    #[test]
+    fn test_range_full() {
+        let b = b"h\x00e\x00l\x00l\x00o\x00\x00\xd8\x00\xdc"; // "hello\u{10000}"
+        let s = WStr::from_utf16le(b).unwrap();
+
+        assert_eq!(s.get(..).unwrap(), s);
+    }
+}


### PR DESCRIPTION
Fixes a bug when detecting UTF-16 surrogate pairs. Instead of checking
the full 6 bits, only four bits were checked. This leads to panics when
slicing valid wstrings at character boundaries.

Additionally, when indexing beyond the size of the slice, we should
error clearly. This is done by the `is_char_boundary()` check, which is
supposed to handle character boundaries outside of the slice len
gracefully by returning false instead of panicking. Fixing this fixes
all the indexing.