### PR TITLE
ref: Avoid the encoding crate by using WStr and Utf16Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,7 +2936,6 @@ dependencies = [
  "debugid",
  "difference",
  "dynfmt",
- "encoding",
  "failure",
  "hmac",
  "insta 0.15.0",

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -14,7 +14,6 @@ chrono = { version = "0.4.11", features = ["serde"] }
 cookie = { version = "0.12.0", features = ["percent-encode"] }
 debugid = { version = "0.7.2", features = ["serde"] }
 dynfmt = { version = "0.1.4", features = ["python", "curly"] }
-encoding = "0.2"
 failure = "0.1.8"
 hmac = "0.7.1"
 itertools = "0.8.2"

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -285,11 +285,12 @@ impl<'a> Iterator for WStrSegmentIter<'a> {
                 }
                 Err(err) => {
                     let start = self.offset;
+                    let end = start + err.valid_up_to();
                     match err.error_len() {
                         Some(len) => self.offset += err.valid_up_to() + len,
                         None => self.offset = self.data.len(),
                     }
-                    &mut self.data[start..start + err.valid_up_to()]
+                    &mut self.data[start..end]
                 }
             };
 

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -285,7 +285,7 @@ impl<'a> Iterator for WStrSegmentIter<'a> {
                 return None;
             }
 
-            let slice: &mut [u8] = match WStr::from_utf16le_mut(&mut self.data[self.offset..]) {
+            let slice = match WStr::from_utf16le_mut(&mut self.data[self.offset..]) {
                 Ok(wstr) => {
                     self.offset += wstr.len();
                     unsafe { wstr.as_bytes_mut() }

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -299,10 +299,6 @@ impl<'a> Iterator for WStrSegmentIter<'a> {
                     &mut self.data[start..start + err.valid_up_to()]
                 }
             };
-            if slice.len() < MIN_STRING_LEN * std::mem::size_of::<u16>() {
-                // Quick shortcut, actual char count check done below
-                continue;
-            }
 
             // We are handing out multiple mutable slices from the same mutable slice.  This
             // is safe because we know they are not overlapping.  However the compiler
@@ -314,7 +310,7 @@ impl<'a> Iterator for WStrSegmentIter<'a> {
                 WStr::from_utf16le_unchecked_mut(std::slice::from_raw_parts_mut(ptr, len))
             };
 
-            if encoded.chars().count() < MIN_STRING_LEN {
+            if encoded.chars().take(MIN_STRING_LEN).count() < MIN_STRING_LEN {
                 continue;
             }
             let decoded = encoded.to_utf8();

--- a/relay-wstring/src/lib.rs
+++ b/relay-wstring/src/lib.rs
@@ -53,7 +53,7 @@ impl Utf16Error {
     /// Return the length of the error if it might be recoverable.
     ///
     /// If `Some` you should be able to attempt to parse again from the offset given by
-    /// adding the error legnth to [Self::valid_up_to].
+    /// adding the error length to [Self::valid_up_to].
     pub fn error_len(&self) -> Option<usize> {
         self.error_len.map(|len| len.into())
     }

--- a/relay-wstring/src/lib.rs
+++ b/relay-wstring/src/lib.rs
@@ -495,7 +495,7 @@ fn validate_raw_utf16le(raw: &[u8]) -> Result<(), Utf16Error> {
     }
 
     let remainder = chunks.remainder();
-    if remainder.len() > 0 {
+    if !remainder.is_empty() {
         return Err(Utf16Error {
             valid_up_to: remainder.as_ptr() as usize - base_ptr,
             error_len: None,

--- a/relay-wstring/src/lib.rs
+++ b/relay-wstring/src/lib.rs
@@ -31,7 +31,10 @@ pub use crate::slicing::SliceIndex;
 
 /// Error for invalid UTF-16 encoded bytes.
 #[derive(Debug, Copy, Clone)]
-pub struct Utf16Error {}
+pub struct Utf16Error {
+    valid_up_to: usize,
+    error_len: Option<u8>,
+}
 
 impl fmt::Display for Utf16Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -42,15 +45,17 @@ impl fmt::Display for Utf16Error {
 impl Error for Utf16Error {}
 
 impl Utf16Error {
-    /// Create a new [Utf16Error].
-    pub fn new() -> Self {
-        Self {}
+    /// Returns the index in given bytes up to which valid UTF-16 was verified.
+    pub fn valid_up_to(&self) -> usize {
+        self.valid_up_to
     }
-}
 
-impl Default for Utf16Error {
-    fn default() -> Self {
-        Self::new()
+    /// Return the length of the error if it might be recoverable.
+    ///
+    /// If `Some` you should be able to attempt to parse again from the offset given by
+    /// adding the error legnth to [Self::valid_up_to].
+    pub fn error_len(&self) -> Option<usize> {
+        self.error_len.map(|len| len.into())
     }
 }
 
@@ -434,21 +439,58 @@ unsafe fn decode_surrogates(u: u16, u2: u16) -> char {
 }
 
 /// Checks that the raw bytes are valid UTF-16LE.
+///
+/// When an error occurs this code needs to set `error_len` to skip forward 2 bytes *if*
+/// there still are more bytes to consume.  This is the repetitive
+/// `chunks.next().map(|_chunk| std:mem::size_of::<u16>() as u8)`, but we compute this
+/// lazily for performance.
+///
+/// Likewise we compute `valid_up_to` lazily for performance.
 fn validate_raw_utf16le(raw: &[u8]) -> Result<(), Utf16Error> {
-    // This could be optimised as it does not need to be actually decoded, just needs to
-    // be a valid byte sequence.
-    if raw.len() % 2 != 0 {
-        return Err(Utf16Error::new());
+    let base_ptr = raw.as_ptr() as usize;
+    let mut chunks = raw.chunks_exact(std::mem::size_of::<u16>());
+
+    while let Some(chunk) = chunks.next() {
+        let code_point_ptr = chunk.as_ptr() as usize;
+        // Chunks always returns 2 bytes, avoid generating panicking code
+        let u = u16::copy_from_le_bytes(chunk).unwrap_or_default();
+
+        if is_trailing_surrogate(u) {
+            return Err(Utf16Error {
+                valid_up_to: code_point_ptr - base_ptr,
+                error_len: chunks.next().map(|_chunk| std::mem::size_of::<u16>() as u8),
+            });
+        }
+
+        if is_leading_surrogate(u) {
+            match chunks.next().and_then(u16::copy_from_le_bytes) {
+                Some(u2) => {
+                    if !is_trailing_surrogate(u2) {
+                        return Err(Utf16Error {
+                            valid_up_to: code_point_ptr - base_ptr,
+                            error_len: chunks.next().map(|_chunk| std::mem::size_of::<u16>() as u8),
+                        });
+                    }
+                }
+                None => {
+                    return Err(Utf16Error {
+                        valid_up_to: code_point_ptr - base_ptr,
+                        error_len: None,
+                    });
+                }
+            }
+        }
     }
-    let u16iter = raw
-        .chunks_exact(2)
-        // Using filter_map to avoid generating panicking code
-        .filter_map(|chunk| u16::copy_from_le_bytes(chunk));
-    if std::char::decode_utf16(u16iter).all(|result| result.is_ok()) {
-        Ok(())
-    } else {
-        Err(Utf16Error::new())
+
+    let remainder = chunks.remainder();
+    if remainder.len() > 0 {
+        return Err(Utf16Error {
+            valid_up_to: remainder.as_ptr() as usize - raw.as_ptr() as usize,
+            error_len: None,
+        });
     }
+
+    Ok(())
 }
 
 /// Private u16 extension trait.
@@ -494,6 +536,35 @@ mod tests {
         let b = b"\x00\xdcx\x00";
         let s = WStr::from_utf16le(b);
         assert!(s.is_err());
+    }
+
+    #[test]
+    fn test_wstr_utf16error() {
+        // Lone trailing surrogate in 2nd char
+        let b = b"h\x00\x00\xdce\x00l\x00l\x00o\x00";
+        let e = WStr::from_utf16le(b).err().unwrap();
+        assert_eq!(e.valid_up_to(), 2);
+        assert_eq!(e.error_len(), Some(2));
+
+        let head = WStr::from_utf16le(&b[..e.valid_up_to()]).unwrap();
+        assert_eq!(head.to_utf8(), "h");
+
+        let start = e.valid_up_to() + e.error_len().unwrap();
+        let tail = WStr::from_utf16le(&b[start..]).unwrap();
+        assert_eq!(tail.to_utf8(), "ello");
+
+        // Leading surrogate, missing trailing surrogate in 2nd char
+        let b = b"h\x00\x00\xd8e\x00l\x00l\x00o\x00";
+        let e = WStr::from_utf16le(b).err().unwrap();
+        assert_eq!(e.valid_up_to(), 2);
+        assert_eq!(e.error_len(), Some(2));
+
+        let head = WStr::from_utf16le(&b[..e.valid_up_to()]).unwrap();
+        assert_eq!(head.to_utf8(), "h");
+
+        let start = e.valid_up_to() + e.error_len().unwrap();
+        let tail = WStr::from_utf16le(&b[start..]).unwrap();
+        assert_eq!(tail.to_utf8(), "ello");
     }
 
     #[test]

--- a/relay-wstring/src/lib.rs
+++ b/relay-wstring/src/lib.rs
@@ -54,7 +54,7 @@ impl Utf16Error {
     ///
     /// If `None`: the end of the input was reached unexpectedly.  `self.valid_up_to()` is 1
     /// to 3 bytes from the end of the input.  If a byte stream such as a file or a network
-    /// socket is being decoded incrementall, this could still be a valid char whose byte
+    /// socket is being decoded incrementally, this could still be a valid char whose byte
     /// sequence is spanning multiple chunks.
     ///
     /// If `Some(len)`: an unexpected byte was encountered.  The length provided is that of

--- a/relay-wstring/src/lib.rs
+++ b/relay-wstring/src/lib.rs
@@ -52,8 +52,15 @@ impl Utf16Error {
 
     /// Return the length of the error if it might be recoverable.
     ///
-    /// If `Some` you should be able to attempt to parse again from the offset given by
-    /// adding the error length to [Self::valid_up_to].
+    /// If `None`: the end of the input was reached unexpectedly.  `self.valid_up_to()` is 1
+    /// to 3 bytes from the end of the input.  If a byte stream such as a file or a network
+    /// socket is being decoded incrementall, this could still be a valid char whose byte
+    /// sequence is spanning multiple chunks.
+    ///
+    /// If `Some(len)`: an unexpected byte was encountered.  The length provided is that of
+    /// the invalid byte sequence that starts at the index given by `valid_up_to()`.
+    /// Decoding should resume after that sequence (after inserting a `U+FFFD REPLACEMENT
+    /// CHARACTER`) in case of lossy decoding.
     pub fn error_len(&self) -> Option<usize> {
         self.error_len.map(|len| len.into())
     }


### PR DESCRIPTION
This re-models the Utf16Error after std::str::Utf8Error which allows
it to provide enough information to write a decoder.  This means we no
longer need a decoder and can write our segmentation iterator a little
simpler.

The complexity of this is a lot less than using the RawDecoder API
plus there is fewer duplication in the branches, so this is more
maintainable.  Downside is that this has had less production scrutiny.


----

This also fixes a minor bug where we counted the bytes length instead
of character count for deciding if the string is long enough.

#skip-changelog