### PR TITLE
ref(common): Make the DSN public key Copy

### DIFF
--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -11,6 +11,7 @@ mod cell;
 mod constants;
 mod glob;
 mod log;
+mod project;
 mod retry;
 mod time;
 mod utils;
@@ -19,11 +20,12 @@ pub use crate::cell::*;
 pub use crate::constants::*;
 pub use crate::glob::*;
 pub use crate::log::*;
+pub use crate::project::*;
 pub use crate::retry::*;
 pub use crate::time::*;
 pub use crate::utils::*;
 
 pub use sentry_types::protocol::LATEST as PROTOCOL_VERSION;
 pub use sentry_types::{
-    Auth, Dsn, ParseAuthError, ParseDsnError, ParseProjectIdError, ProjectId, Scheme, Uuid,
+    Auth, Dsn, ParseAuthError, ParseDsnError, ParseProjectIdError, Scheme, Uuid,
 };

--- a/relay-common/src/project.rs
+++ b/relay-common/src/project.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[doc(inline)]
+pub use sentry_types::ProjectId;
+
+/// An error parsing [`ProjectKey`](struct.ProjectKey.html).
+#[derive(Clone, Copy, Debug)]
+pub struct ParseProjectKeyError;
+
+impl fmt::Display for ParseProjectKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid project key")
+    }
+}
+
+impl std::error::Error for ParseProjectKeyError {}
+
+/// The public key used in a DSN to identify and authenticate for a project at Sentry.
+///
+/// Project keys are always 32-character hexadecimal strings.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialOrd, PartialEq)]
+pub struct ProjectKey([u8; 32]);
+
+impl Serialize for ProjectKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ProjectKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let cow = Cow::<str>::deserialize(deserializer)?;
+        Self::parse(&cow).map_err(serde::de::Error::custom)
+    }
+}
+
+impl ProjectKey {
+    /// Parses a `ProjectKey` from a string.
+    pub fn parse(key: &str) -> Result<Self, ParseProjectKeyError> {
+        if key.len() != 32 || !key.is_ascii() {
+            return Err(ParseProjectKeyError);
+        }
+
+        let mut project_key = Self(Default::default());
+        project_key.0.copy_from_slice(key.as_bytes());
+        Ok(project_key)
+    }
+
+    /// Returns the string representation of the project key.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        // Safety: The string is already validated to be of length 32 and valid ASCII when
+        // constructing `ProjectKey`.
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+impl fmt::Debug for ProjectKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ProjectKey(\"{}\")", self.as_str())
+    }
+}
+
+impl fmt::Display for ProjectKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -4,12 +4,12 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use relay_common::ProjectId;
+use relay_common::{ProjectId, ProjectKey};
 
 /// Data scoping information.
 ///
 /// This structure holds information of all scopes required for attributing an item to quotas.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Scoping {
     /// The organization id.
     pub organization_id: u64,
@@ -18,7 +18,7 @@ pub struct Scoping {
     pub project_id: ProjectId,
 
     /// The DSN public key.
-    pub public_key: String,
+    pub public_key: ProjectKey,
 
     /// The public key's internal id.
     pub key_id: Option<u64>,
@@ -567,7 +567,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -590,7 +590,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -613,7 +613,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -623,7 +623,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -646,7 +646,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -669,7 +669,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -679,7 +679,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 0,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -702,7 +702,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -712,7 +712,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(0),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -735,7 +735,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(17),
             }
         }));
@@ -745,7 +745,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(0),
             }
         }));
@@ -755,7 +755,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
-use relay_common::ProjectId;
+use relay_common::{ProjectId, ProjectKey};
 
 use crate::quota::{DataCategories, ItemScoping, Quota, QuotaScope, ReasonCode, Scoping};
 use crate::REJECT_ALL_SECS;
@@ -107,7 +107,7 @@ pub enum RateLimitScope {
     /// A project with identifier.
     Project(ProjectId),
     /// A DSN public key.
-    Key(String),
+    Key(ProjectKey),
 }
 
 impl RateLimitScope {
@@ -116,9 +116,9 @@ impl RateLimitScope {
         match scope {
             QuotaScope::Organization => RateLimitScope::Organization(scoping.organization_id),
             QuotaScope::Project => RateLimitScope::Project(scoping.project_id),
-            QuotaScope::Key => RateLimitScope::Key(scoping.public_key.clone()),
+            QuotaScope::Key => RateLimitScope::Key(scoping.public_key),
             // For unknown scopes, assume the most specific scope:
-            QuotaScope::Unknown => RateLimitScope::Key(scoping.public_key.clone()),
+            QuotaScope::Unknown => RateLimitScope::Key(scoping.public_key),
         }
     }
 
@@ -379,7 +379,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -389,7 +389,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -409,7 +409,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -419,7 +419,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 0,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -439,7 +439,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -449,7 +449,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(0),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -459,7 +459,9 @@ mod tests {
     fn test_rate_limit_matches_key() {
         let rate_limit = RateLimit {
             categories: DataCategories::new(),
-            scope: RateLimitScope::Key("a94ae32be2584e0bbd7a4cbb95971fee".to_owned()),
+            scope: RateLimitScope::Key(
+                ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            ),
             reason_code: None,
             retry_after: RetryAfter::from_secs(1),
         };
@@ -469,7 +471,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             }
         }));
@@ -479,7 +481,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 0,
                 project_id: ProjectId::new(21),
-                public_key: "deadbeefdeadbeefdeadbeefdeadbeef".to_owned(),
+                public_key: ProjectKey::parse("deadbeefdeadbeefdeadbeefdeadbeef").unwrap(),
                 key_id: None,
             }
         }));
@@ -715,7 +717,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             },
         });
@@ -762,7 +764,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(21),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: None,
             },
         };

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -2,10 +2,10 @@ use std::fmt;
 use std::sync::Arc;
 
 use failure::Fail;
+use sentry::protocol::value;
 
 use relay_common::UnixTimestamp;
 use relay_redis::{redis::Script, RedisError, RedisPool};
-use sentry::protocol::value;
 
 use crate::quota::{ItemScoping, Quota, QuotaScope};
 use crate::rate_limit::{RateLimit, RateLimits, RetryAfter};
@@ -248,7 +248,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use relay_common::ProjectId;
+    use relay_common::{ProjectId, ProjectKey};
     use relay_redis::redis::Commands;
 
     use crate::quota::{DataCategories, DataCategory, ReasonCode, Scoping};
@@ -295,7 +295,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(43),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(44),
             },
         };
@@ -334,7 +334,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(43),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(44),
             },
         };
@@ -371,7 +371,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(43),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(44),
             },
         };
@@ -413,7 +413,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(43),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(44),
             },
         };
@@ -460,7 +460,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 42,
                 project_id: ProjectId::new(43),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(44),
             },
         };
@@ -507,7 +507,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 69420,
                 project_id: ProjectId::new(42),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(4711),
             },
         };
@@ -534,7 +534,7 @@ mod tests {
             scoping: &Scoping {
                 organization_id: 69420,
                 project_id: ProjectId::new(42),
-                public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+                public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(4711),
             },
         };

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -874,7 +874,7 @@ impl EventProcessor {
         } = *state;
 
         let key_id = project_state
-            .get_public_key_config(&envelope.meta().public_key())
+            .get_public_key_config(envelope.meta().public_key())
             .and_then(|k| Some(k.numeric_id?.to_string()));
 
         if key_id.is_none() {
@@ -1408,7 +1408,7 @@ impl Handler<HandleEnvelope> for EventManager {
                             .send(StoreEnvelope {
                                 envelope,
                                 start_time,
-                                scoping: scoping.borrow().clone(),
+                                scoping: *scoping.borrow(),
                             })
                             .map_err(ProcessingError::ScheduleFailed)
                             .and_then(move |result| result.map_err(ProcessingError::StoreFailed));
@@ -1525,7 +1525,7 @@ impl Handler<HandleEnvelope> for EventManager {
                 if let Some(outcome) = outcome {
                     outcome_producer.do_send(TrackOutcome {
                         timestamp: Instant::now(),
-                        scoping: scoping.borrow().clone(),
+                        scoping: *scoping.borrow(),
                         outcome,
                         event_id,
                         remote_addr,

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -468,7 +468,7 @@ where
             if is_event {
                 outcome_producer.do_send(TrackOutcome {
                     timestamp: start_time,
-                    scoping: scoping.borrow().clone(),
+                    scoping: *scoping.borrow(),
                     outcome: error.to_outcome(),
                     event_id: *event_id.borrow(),
                     remote_addr,

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1033,7 +1033,10 @@ mod tests {
             .unwrap();
         assert_eq!(*meta.dsn(), dsn);
         assert_eq!(meta.project_id(), ProjectId::new(42));
-        assert_eq!(meta.public_key(), "e12d836b15bb49d7bbf99e64295d995b");
+        assert_eq!(
+            meta.public_key().as_str(),
+            "e12d836b15bb49d7bbf99e64295d995b"
+        );
         assert_eq!(meta.client(), Some("sentry/javascript"));
         assert_eq!(meta.version(), 6);
         assert_eq!(meta.origin(), Some(&"http://localhost/".parse().unwrap()));
@@ -1155,7 +1158,10 @@ mod tests {
             .unwrap();
         assert_eq!(*meta.dsn(), dsn);
         assert_eq!(meta.project_id(), ProjectId::new(42));
-        assert_eq!(meta.public_key(), "e12d836b15bb49d7bbf99e64295d995b");
+        assert_eq!(
+            meta.public_key().as_str(),
+            "e12d836b15bb49d7bbf99e64295d995b"
+        );
         assert_eq!(meta.client(), Some("sentry/client"));
         assert_eq!(meta.version(), 7);
         assert_eq!(meta.origin(), Some(&"http://origin/".parse().unwrap()));

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use relay_common::{
-    tryf, Auth, Dsn, ParseAuthError, ParseDsnError, ParseProjectIdError, ProjectId,
+    tryf, Auth, Dsn, ParseAuthError, ParseDsnError, ParseProjectIdError, ParseProjectKeyError,
+    ProjectId, ProjectKey,
 };
 use relay_quotas::Scoping;
 
@@ -38,6 +39,9 @@ pub enum BadEventMeta {
     #[fail(display = "bad sentry DSN")]
     BadDsn(#[fail(cause)] ParseDsnError),
 
+    #[fail(display = "bad sentry DSN public key")]
+    BadPublicKey(ParseProjectKeyError),
+
     #[fail(display = "bad project key: project does not exist")]
     BadProjectKey,
 
@@ -51,11 +55,47 @@ impl ResponseError for BadEventMeta {
             Self::MissingAuth | Self::MultipleAuth | Self::BadProjectKey | Self::BadAuth(_) => {
                 HttpResponse::Unauthorized()
             }
-            Self::BadProject(_) | Self::BadDsn(_) => HttpResponse::BadRequest(),
+            Self::BadProject(_) | Self::BadDsn(_) | Self::BadPublicKey(_) => {
+                HttpResponse::BadRequest()
+            }
             Self::ScheduleFailed => HttpResponse::ServiceUnavailable(),
         };
 
         builder.json(&ApiErrorResponse::from_fail(self))
+    }
+}
+
+/// Wrapper around a Sentry DSN with parsed public key.
+#[derive(Debug, Clone)]
+pub struct FullDsn {
+    dsn: Dsn,
+    public_key: ProjectKey,
+}
+
+impl FullDsn {
+    /// Ensures a valid public key in the DSN.
+    fn from_dsn(dsn: Dsn) -> Result<Self, ParseProjectKeyError> {
+        let public_key = ProjectKey::parse(dsn.public_key())?;
+        Ok(Self { dsn, public_key })
+    }
+}
+
+impl<'de> Deserialize<'de> for FullDsn {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let dsn = Dsn::deserialize(deserializer)?;
+        Self::from_dsn(dsn).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for FullDsn {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.dsn.serialize(serializer)
     }
 }
 
@@ -65,7 +105,7 @@ const fn default_version() -> u16 {
 
 /// Request information for sentry ingest data, such as events, envelopes or metrics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RequestMeta<D = Dsn> {
+pub struct RequestMeta<D = FullDsn> {
     /// The DSN describing the target of this envelope.
     dsn: D,
 
@@ -154,7 +194,7 @@ impl RequestMeta {
     #[cfg(test)]
     pub fn new(dsn: Dsn) -> Self {
         RequestMeta {
-            dsn,
+            dsn: FullDsn::from_dsn(dsn).expect("invalid DSN key"),
             client: Some("sentry/client".to_string()),
             version: 7,
             origin: Some("http://origin/".parse().unwrap()),
@@ -170,7 +210,7 @@ impl RequestMeta {
     /// The DSN declares the project and auth information and upstream address. When RequestMeta is
     /// constructed from a web request, the DSN is set to point to the upstream host.
     pub fn dsn(&self) -> &Dsn {
-        &self.dsn
+        &self.dsn.dsn
     }
 
     /// Returns the project identifier that the DSN points to.
@@ -179,8 +219,8 @@ impl RequestMeta {
     }
 
     /// Returns the public key part of the DSN for authentication.
-    pub fn public_key(&self) -> &str {
-        &self.dsn.public_key()
+    pub fn public_key(&self) -> ProjectKey {
+        self.dsn.public_key
     }
 
     /// Formats the Sentry authentication header.
@@ -209,7 +249,7 @@ impl RequestMeta {
         Scoping {
             organization_id: 0,
             project_id: self.project_id(),
-            public_key: self.public_key().to_owned(),
+            public_key: self.public_key(),
             key_id: None,
         }
     }
@@ -368,8 +408,11 @@ fn extract_event_meta(
             project_id,
         );
 
+        let dsn = dsn_string.parse().map_err(BadEventMeta::BadDsn)?;
+        let dsn = FullDsn::from_dsn(dsn).map_err(BadEventMeta::BadPublicKey)?;
+
         Ok(RequestMeta {
-            dsn: dsn_string.parse().map_err(BadEventMeta::BadDsn)?,
+            dsn,
             version,
             client,
             origin,

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -66,6 +66,13 @@ impl ResponseError for BadEventMeta {
 }
 
 /// Wrapper around a Sentry DSN with parsed public key.
+///
+/// The Sentry DSN type carries a plain public key string. However, Relay handles copy `ProjectKey`
+/// types internally. Converting from `String` to `ProjectKey` is fallible and should be caught when
+/// deserializing the request.
+///
+/// This type caches the parsed project key in addition to the DSN. Other than that, it
+/// transparently serializes to and deserializes from a DSN string.
 #[derive(Debug, Clone)]
 pub struct FullDsn {
     dsn: Dsn,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -288,7 +288,7 @@ mod tests {
 
     use smallvec::smallvec;
 
-    use relay_common::ProjectId;
+    use relay_common::{ProjectId, ProjectKey};
     use relay_quotas::RetryAfter;
 
     use crate::envelope::{AttachmentType, ContentType};
@@ -323,7 +323,7 @@ mod tests {
         let scoping = Scoping {
             organization_id: 42,
             project_id: ProjectId::new(21),
-            public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+            public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
             key_id: Some(17),
         };
 
@@ -337,7 +337,7 @@ mod tests {
         let scoping = Scoping {
             organization_id: 42,
             project_id: ProjectId::new(21),
-            public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+            public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
             key_id: Some(17),
         };
 
@@ -377,7 +377,7 @@ mod tests {
         let scoping = Scoping {
             organization_id: 42,
             project_id: ProjectId::new(21),
-            public_key: "a94ae32be2584e0bbd7a4cbb95971fee".to_owned(),
+            public_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
             key_id: Some(17),
         };
 
@@ -416,7 +416,7 @@ mod tests {
         Scoping {
             organization_id: 42,
             project_id: ProjectId::new(21),
-            public_key: "e12d836b15bb49d7bbf99e64295d995b".to_owned(),
+            public_key: ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
             key_id: Some(17),
         }
     }


### PR DESCRIPTION
Creates a type for DSN public keys that implements copy. Every public key is a 32-character hexadecimal string. Storage requirements could be halved by parsing the hexadecimal contents of the key, however this is currently not enforced anywhere in Sentry. For this reason, we're taking the conservative approach using 32 bytes.

The type is called `ProjectKey` to distinguish it from Relay's own public key.

#skip-changelog