### PR TITLE
feat: Basic metrics for minidump scrubbing

### DIFF
--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1019,8 +1019,17 @@ impl EventProcessor {
                 // must be conservative and treat it as a plain attachment. Under extreme
                 // conditions, this could destroy stack memory.
                 if let Err(scrub_error) = processor.scrub_minidump(filename, &mut payload) {
-                    log::debug!("failed to scrub minidump: {}", LogError(&scrub_error));
+                    metric!(
+                        counter(RelayCounters::MinidumpsScrubbed) += 1,
+                        status = "error"
+                    );
+                    log::warn!("failed to scrub minidump: {}", LogError(&scrub_error));
                     processor.scrub_attachment(filename, &mut payload);
+                } else {
+                    metric!(
+                        counter(RelayCounters::MinidumpsScrubbed) += 1,
+                        status = "ok"
+                    );
                 }
 
                 let content_type = item

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1018,16 +1018,17 @@ impl EventProcessor {
                 // Minidump scrubbing can fail if the minidump cannot be parsed. In this case, we
                 // must be conservative and treat it as a plain attachment. Under extreme
                 // conditions, this could destroy stack memory.
+                let start = Instant::now();
                 match processor.scrub_minidump(filename, &mut payload) {
                     Ok(modified) => {
                         metric!(
-                            counter(RelayCounters::MinidumpsScrubbed) += 1,
+                            timer(RelayTimers::MinidumpScrubbing) = start.elapsed(),
                             status = if modified { "ok" } else { "n/a" },
                         );
                     }
                     Err(scrub_error) => {
                         metric!(
-                            counter(RelayCounters::MinidumpsScrubbed) += 1,
+                            timer(RelayTimers::MinidumpScrubbing) = start.elapsed(),
                             status = "error"
                         );
                         log::warn!("failed to scrub minidump: {}", LogError(&scrub_error));

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1032,7 +1032,9 @@ impl EventProcessor {
                             status = "error"
                         );
                         log::warn!("failed to scrub minidump: {}", LogError(&scrub_error));
-                        processor.scrub_attachment(filename, &mut payload);
+                        metric!(timer(RelayTimers::AttachmentScrubbing), {
+                            processor.scrub_attachment(filename, &mut payload);
+                        })
                     }
                 }
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1020,12 +1020,10 @@ impl EventProcessor {
                 // conditions, this could destroy stack memory.
                 match processor.scrub_minidump(filename, &mut payload) {
                     Ok(modified) => {
-                        if modified {
-                            metric!(
-                                counter(RelayCounters::MinidumpsScrubbed) += 1,
-                                status = "ok"
-                            );
-                        }
+                        metric!(
+                            counter(RelayCounters::MinidumpsScrubbed) += 1,
+                            status = if modified { "ok" } else { "n/a" },
+                        );
                     }
                     Err(scrub_error) => {
                         metric!(

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -374,7 +374,9 @@ pub enum RelayCounters {
     ///
     /// Tags:
     ///
-    /// - `status`: Scrubbing status: "ok" or "error".
+    /// - `status`: Scrubbing status: "ok" means successful scrubbed, "error" means there
+    ///       was an error during scrubbing and finally "n/a" means scrubbing was successful
+    ///       but no scurbbing rules apply.
     MinidumpsScrubbed,
 }
 

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -370,6 +370,12 @@ pub enum RelayCounters {
     ConnectorErrors,
     /// Number of upstream connections that experienced a timeout.
     ConnectorTimeouts,
+    /// Number of minidump attachments scrubbed.
+    ///
+    /// Tags:
+    ///
+    /// - `status`: Scrubbing status: "ok" or "error".
+    MinidumpsScrubbed,
 }
 
 impl CounterMetric for RelayCounters {
@@ -398,6 +404,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ConnectorClosed => "connector.closed",
             RelayCounters::ConnectorErrors => "connector.errors",
             RelayCounters::ConnectorTimeouts => "connector.timeouts",
+            RelayCounters::MinidumpsScrubbed => "scrubbing.minidumps",
         }
     }
 }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -201,6 +201,18 @@ pub enum RelayTimers {
     ///  - `method`: The HTTP method of the request.
     ///  - `route`: Unique dashed identifier of the endpoint.
     RequestsDuration,
+    /// Time spent on minidump scrubbing.
+    ///
+    /// This is the total time spent on parsing and scrubbing the minidump.  Even if no PII
+    /// scrubbing rules applied the minidump will still be parsed and the rules evaluated on
+    /// the parsed minidump, this duration is reported here with status of "n/a".
+    ///
+    /// This metric is tagged with:
+    ///
+    /// - `status`: Scrubbing status: "ok" means successful scrubbed, "error" means there
+    ///       was an error during scrubbing and finally "n/a" means scrubbing was successful
+    ///       but no scurbbing rules applied.
+    MinidumpScrubbing,
 }
 
 impl TimerMetric for RelayTimers {
@@ -222,6 +234,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::ProjectStateRequestDuration => "project_state.request.duration",
             RelayTimers::ProjectIdRequestDuration => "project_id.request.duration",
             RelayTimers::RequestsDuration => "requests.duration",
+            RelayTimers::MinidumpScrubbing => "scrubbing.minidumps.duration",
         }
     }
 }
@@ -370,14 +383,6 @@ pub enum RelayCounters {
     ConnectorErrors,
     /// Number of upstream connections that experienced a timeout.
     ConnectorTimeouts,
-    /// Number of minidump attachments scrubbed.
-    ///
-    /// Tags:
-    ///
-    /// - `status`: Scrubbing status: "ok" means successful scrubbed, "error" means there
-    ///       was an error during scrubbing and finally "n/a" means scrubbing was successful
-    ///       but no scurbbing rules apply.
-    MinidumpsScrubbed,
 }
 
 impl CounterMetric for RelayCounters {
@@ -406,7 +411,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ConnectorClosed => "connector.closed",
             RelayCounters::ConnectorErrors => "connector.errors",
             RelayCounters::ConnectorTimeouts => "connector.timeouts",
-            RelayCounters::MinidumpsScrubbed => "scrubbing.minidumps",
         }
     }
 }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -213,6 +213,14 @@ pub enum RelayTimers {
     ///       was an error during scrubbing and finally "n/a" means scrubbing was successful
     ///       but no scurbbing rules applied.
     MinidumpScrubbing,
+    /// Time spend on attachment scrubbing.
+    ///
+    /// This represents the total time spent on evaluating the scrubbing rules for an
+    /// attachment and the attachment scrubbing itself, regardless of whether any rules were
+    /// applied.  Note that minidumps which failed to be parsed (status="error" in
+    /// scrubbing.minidumps.duration) will be scrubbed as plain attachments and count
+    /// towards this.
+    AttachmentScrubbing,
 }
 
 impl TimerMetric for RelayTimers {
@@ -235,6 +243,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::ProjectIdRequestDuration => "project_id.request.duration",
             RelayTimers::RequestsDuration => "requests.duration",
             RelayTimers::MinidumpScrubbing => "scrubbing.minidumps.duration",
+            RelayTimers::AttachmentScrubbing => "scrubbing.attachments.duration",
         }
     }
 }


### PR DESCRIPTION
A dump counter keeping track of minidump scrubbing.

I'm considering this as part of the larger minidump scrubbing work, so:

#skip-changelog