### PR TITLE
test(quotas): Fix a flaky tests

### DIFF
--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -346,14 +346,18 @@ mod tests {
 
     #[test]
     fn test_parse_retry_after() {
+        // Note RetryAfter::remaining_seconds() adds 1s to so it always waits longer than
+        // the actual sub-second timeout.  Because of races between creating the struct and
+        // calling the method we can't do exact comparisons.
+
         // positive float
         let retry_after = "17.7".parse::<RetryAfter>().expect("parse RetryAfter");
-        assert_eq!(retry_after.remaining_seconds(), 18);
+        assert!(retry_after.remaining_seconds() - 17 <= 1);
         assert!(!retry_after.expired());
 
         // positive int
         let retry_after = "17".parse::<RetryAfter>().expect("parse RetryAfter");
-        assert_eq!(retry_after.remaining_seconds(), 17);
+        assert!(retry_after.remaining_seconds() - 17 <= 1);
         assert!(!retry_after.expired());
 
         // negative number

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -43,6 +43,7 @@ impl RetryAfter {
     pub fn remaining_seconds(self) -> u64 {
         match self.remaining() {
             // Compensate for the missing subsec part by adding 1s
+            Some(duration) if duration.subsec_nanos() == 0 => duration.as_secs(),
             Some(duration) => duration.as_secs() + 1,
             None => 0,
         }
@@ -346,18 +347,14 @@ mod tests {
 
     #[test]
     fn test_parse_retry_after() {
-        // Note RetryAfter::remaining_seconds() adds 1s to so it always waits longer than
-        // the actual sub-second timeout.  Because of races between creating the struct and
-        // calling the method we can't do exact comparisons.
-
         // positive float
         let retry_after = "17.7".parse::<RetryAfter>().expect("parse RetryAfter");
-        assert!(retry_after.remaining_seconds() - 17 <= 1);
+        assert_eq!(retry_after.remaining_seconds(), 18);
         assert!(!retry_after.expired());
 
         // positive int
         let retry_after = "17".parse::<RetryAfter>().expect("parse RetryAfter");
-        assert!(retry_after.remaining_seconds() - 17 <= 1);
+        assert_eq!(retry_after.remaining_seconds(), 17);
         assert!(!retry_after.expired());
 
         // negative number


### PR DESCRIPTION
When working with times we need to allow for the test to actually run.

#skip-changelog