### PR TITLE
fix(server): Rate limit outcomes emited only for events on "fast-path"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Project states are now cached separately per DSN public key instead of per project ID. This means that there will be multiple separate cache entries for projects with more than one DSN. ([#778](https://github.com/getsentry/relay/pull/778))
 - Relay no longer uses the Sentry endpoint to resolve project IDs by public key. Ingestion for the legacy store endpoint has been refactored to rely on key-based caches only. As a result, the legacy endpoint is supported only on managed Relays. ([#800](https://github.com/getsentry/relay/pull/800))
-- Fix rate limit outcomes, now emitted only for events. ([#806](https://github.com/getsentry/relay/pull/806)) ([#809](https://github.com/getsentry/relay/pull/809))
+- Fix rate limit outcomes, now emitted only for error events but not transactions. ([#806](https://github.com/getsentry/relay/pull/806), [#809](https://github.com/getsentry/relay/pull/809))
 
 ## 20.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,12 @@
 - Fix issue where `$span` would not be recognized in Advanced Data Scrubbing. ([#781](https://github.com/getsentry/relay/pull/781))
 - Accept big-endian minidumps. ([#789](https://github.com/getsentry/relay/pull/789))
 - Detect network outages and retry sending events instead of dropping them. ([#788](https://github.com/getsentry/relay/pull/788))
-- Rate limit outcomes emitted only for events. ([#806](https://github.com/getsentry/relay/pull/806))
-- Rate limit outcomes emited only for events on "fast-path". ([#809](https://github.com/getsentry/relay/pull/809))
 
 **Internal**:
 
 - Project states are now cached separately per DSN public key instead of per project ID. This means that there will be multiple separate cache entries for projects with more than one DSN. ([#778](https://github.com/getsentry/relay/pull/778))
 - Relay no longer uses the Sentry endpoint to resolve project IDs by public key. Ingestion for the legacy store endpoint has been refactored to rely on key-based caches only. As a result, the legacy endpoint is supported only on managed Relays. ([#800](https://github.com/getsentry/relay/pull/800))
+- Fix rate limit outcomes, now emitted only for events. ([#806](https://github.com/getsentry/relay/pull/806)) ([#809](https://github.com/getsentry/relay/pull/809))
 
 ## 20.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Accept big-endian minidumps. ([#789](https://github.com/getsentry/relay/pull/789))
 - Detect network outages and retry sending events instead of dropping them. ([#788](https://github.com/getsentry/relay/pull/788))
 - Rate limit outcomes emitted only for events. ([#806](https://github.com/getsentry/relay/pull/806))
+- Rate limit outcomes emited only for events on "fast-path". ([#809](https://github.com/getsentry/relay/pull/809))
 
 **Internal**:
 

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -286,6 +286,21 @@ impl RateLimits {
     pub fn longest(&self) -> Option<&RateLimit> {
         self.iter().max_by_key(|limit| limit.retry_after)
     }
+
+    /// Returns the most relevant rate limit.
+    ///
+    /// The most relevant rate limit is the longest rate limit for events and if there is no
+    /// rate limit for events then the longest rate limit for anything else
+    pub fn longest_error(&self) -> Option<&RateLimit> {
+        let is_event_related = |rate_limit: &&RateLimit| {
+            rate_limit.categories.is_empty()
+                || rate_limit.categories.iter().any(|cat| cat.is_error())
+        };
+
+        self.iter()
+            .filter(is_event_related)
+            .max_by_key(|limit| limit.retry_after)
+    }
 }
 
 /// Immutable rate limits iterator.

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -465,6 +465,7 @@ where
                     });
                 }
             }
+
             if !emit_rate_limit && matches!(error, BadStoreRequest::RateLimited(_)) {
                 return Ok(create_response(*event_id.borrow()));
             }

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -550,7 +550,8 @@ def test_processing_quotas(
         retry_after2, rest = headers["x-sentry-rate-limits"].split(":", 1)
         assert int(retry_after2) == int(retry_after)
         assert rest == "%s:key" % category
-        outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
+        if generates_outcomes:
+            outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
 
     relay.dsn_public_key = second_key["publicKey"]
 


### PR DESCRIPTION
Fixes outcome generation on the "fast-path" i.e. when we know from the cache that we are rate limited and 
we don't try to process the envelope.