### PR TITLE
feat(pii): Merge padding and masking characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724), [#785](https://github.com/getsentry/relay/pull/785))
 - Add support for scrubbing UTF-16 data in attachments ([#742](https://github.com/getsentry/relay/pull/742), [#784](https://github.com/getsentry/relay/pull/784), [#787](https://github.com/getsentry/relay/pull/787))
 - Add upstream request metric. ([#793](https://github.com/getsentry/relay/pull/793))
-- The padding character in attachment scrubbing has been changed to match the masking character, there is no usability benefit from them being different.
+- The padding character in attachment scrubbing has been changed to match the masking character, there is no usability benefit from them being different. ([#810](https://github.com/getsentry/relay/pull/810))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for measurement ingestion. ([#724](https://github.com/getsentry/relay/pull/724), [#785](https://github.com/getsentry/relay/pull/785))
 - Add support for scrubbing UTF-16 data in attachments ([#742](https://github.com/getsentry/relay/pull/742), [#784](https://github.com/getsentry/relay/pull/784), [#787](https://github.com/getsentry/relay/pull/787))
 - Add upstream request metric. ([#793](https://github.com/getsentry/relay/pull/793))
+- The padding character in attachment scrubbing has been changed to match the masking character, there is no usability benefit from them being different.
 
 **Bug Fixes**:
 

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -151,7 +151,7 @@ trait StringMods: AsRef<[u8]> {
 
     /// Apply a PII scrubbing redaction to this string slice.
     fn apply_redaction(&mut self, redaction: &Redaction) {
-        const PADDING: char = 'x';
+        const PADDING: char = '*';
         const MASK: char = '*';
 
         match redaction {
@@ -600,7 +600,7 @@ mod tests {
             filename: "foo.txt",
             value_type: ValueType::Binary,
             input: b"before 127.0.0.1 after",
-            output: b"before [ip]xxxxx after",
+            output: b"before [ip]***** after",
             changed: true,
         }
         .run();
@@ -614,7 +614,7 @@ mod tests {
             filename: "foo.txt",
             value_type: ValueType::Binary,
             input: utf16le("before 127.0.0.1 after").as_slice(),
-            output: utf16le("before [ip]xxxxx after").as_slice(),
+            output: utf16le("before [ip]***** after").as_slice(),
             changed: true,
         }
         .run();
@@ -684,7 +684,7 @@ mod tests {
             filename: "foo.txt",
             value_type: ValueType::Binary,
             input: b"before 127.0.0.1 after",
-            output: b"before xxxxxxxxx after",
+            output: b"before ********* after",
             changed: true,
         }
         .run();
@@ -698,7 +698,7 @@ mod tests {
             filename: "foo.txt",
             value_type: ValueType::Binary,
             input: utf16le("before 127.0.0.1 after").as_slice(),
-            output: utf16le("before xxxxxxxxx after").as_slice(),
+            output: utf16le("before ********* after").as_slice(),
             changed: true,
         }
         .run();
@@ -734,7 +734,7 @@ mod tests {
             filename: "foo.txt",
             value_type: ValueType::Binary,
             input: (0..255 as u8).collect::<Vec<_>>().as_slice(),
-            output: &[b'x'; 255],
+            output: &[b'*'; 255],
             changed: true,
         }
         .run();
@@ -766,7 +766,7 @@ mod tests {
                 filename: "foo.txt",
                 value_type: ValueType::Binary,
                 input: bytes,
-                output: &vec![b'x'; bytes.len()],
+                output: &vec![b'*'; bytes.len()],
                 changed: true,
             }
             .run()


### PR DESCRIPTION
The implementation for scrubbing attachments distinguishes a padding
character to keep the binary size identical from the regular masking
character.  There is however little to gain from this and the
difference is probably only confusing.