### PR TITLE
feat: Add Session Aggregates as new Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Relay is now able to ingest pre-aggregated sessions, which will make it possible to efficiently handle applications that produce thousands of sessions per second. ([#815](https://github.com/getsentry/relay/pull/815))
+
 ## 20.11.1
 
 - No documented changes.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -734,11 +734,18 @@ fn default_max_rate_limit() -> Option<u32> {
     Some(300) // 5 minutes
 }
 
+fn default_explode_session_aggregates() -> bool {
+    true
+}
+
 /// Controls Sentry-internal event processing.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Processing {
     /// True if the Relay should do processing. Defaults to `false`.
     pub enabled: bool,
+    /// Indicates if session aggregates should be exploded into individual session updates.
+    #[serde(default = "default_explode_session_aggregates")]
+    pub explode_session_aggregates: bool,
     /// GeoIp DB file source.
     #[serde(default)]
     pub geoip_path: Option<PathBuf>,
@@ -775,6 +782,7 @@ impl Default for Processing {
     fn default() -> Self {
         Self {
             enabled: false,
+            explode_session_aggregates: default_explode_session_aggregates(),
             geoip_path: None,
             max_secs_in_future: 0,
             max_secs_in_past: 0,
@@ -1432,6 +1440,11 @@ impl Config {
     /// True if the Relay should do processing.
     pub fn processing_enabled(&self) -> bool {
         self.values.processing.enabled
+    }
+
+    /// Indicates if session aggregates should be exploded into individual session updates.
+    pub fn explode_session_aggregates(&self) -> bool {
+        self.values.processing.explode_session_aggregates
     }
 
     /// The path to the GeoIp database required for event processing.

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -50,7 +50,9 @@ pub use self::request::{Cookies, HeaderName, HeaderValue, Headers, Query, Reques
 #[cfg(feature = "jsonschema")]
 pub use self::schema::event_json_schema;
 pub use self::security_report::{Csp, ExpectCt, ExpectStaple, Hpkp, SecurityReportType};
-pub use self::session::{ParseSessionStatusError, SessionAttributes, SessionStatus, SessionUpdate};
+pub use self::session::{
+    ParseSessionStatusError, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
+};
 pub use self::span::Span;
 pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrace};
 pub use self::tags::{TagEntry, Tags};

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -51,7 +51,8 @@ pub use self::request::{Cookies, HeaderName, HeaderValue, Headers, Query, Reques
 pub use self::schema::event_json_schema;
 pub use self::security_report::{Csp, ExpectCt, ExpectStaple, Hpkp, SecurityReportType};
 pub use self::session::{
-    ParseSessionStatusError, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
+    ParseSessionStatusError, SessionAggregateItem, SessionAggregates, SessionAttributes,
+    SessionStatus, SessionUpdate,
 };
 pub use self::span::Span;
 pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrace};

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -21,6 +21,8 @@ pub enum SessionStatus {
     Crashed,
     /// The session had an unexpected abrupt termination (not crashing).
     Abnormal,
+    /// The session exited cleanly but experienced some errors during its run.
+    Errored,
 }
 
 impl Default for SessionStatus {
@@ -39,6 +41,7 @@ derive_fromstr_and_display!(SessionStatus, ParseSessionStatusError, {
     SessionStatus::Crashed => "crashed",
     SessionStatus::Abnormal => "abnormal",
     SessionStatus::Exited => "exited",
+    SessionStatus::Errored => "errored",
 });
 
 /// Additional attributes for Sessions.
@@ -114,6 +117,103 @@ impl SessionUpdate {
     /// Serializes a session update back into JSON.
     pub fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
         serde_json::to_vec(self)
+    }
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_zero(val: &u32) -> bool {
+    *val == 0
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionAggregateItem {
+    /// The timestamp of when the session itself started.
+    pub started: DateTime<Utc>,
+    /// The distinct identifier.
+    #[serde(rename = "did", default, skip_serializing_if = "Option::is_none")]
+    pub distinct_id: Option<String>,
+    /// The number of exited sessions that ocurred.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub exited: u32,
+    /// The number of errored sessions that ocurred, not including the abnormal and crashed ones.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub errored: u32,
+    /// The number of abnormal sessions that ocurred.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub abnormal: u32,
+    /// The number of crashed sessions that ocurred.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub crashed: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionAggregates {
+    /// A batch of sessions that were started.
+    #[serde(default)]
+    pub aggregates: Vec<SessionAggregateItem>,
+    /// The shared session event attributes.
+    #[serde(rename = "attrs")]
+    pub attributes: SessionAttributes,
+}
+
+impl SessionAggregates {
+    /// Parses a session batch from JSON.
+    pub fn parse(payload: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(payload)
+    }
+
+    /// Serializes a session batch back into JSON.
+    pub fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// The total number of sessions in this aggregate.
+    pub fn num_sessions(&self) -> u32 {
+        self.aggregates
+            .iter()
+            .map(|i| i.exited + i.errored + i.abnormal + i.crashed)
+            .sum()
+    }
+
+    /// Creates individual session updates from the aggregates.
+    pub fn into_updates_iter(self) -> impl Iterator<Item = SessionUpdate> {
+        let attributes = self.attributes;
+        let mut items = self.aggregates;
+        let mut item_opt = items.pop();
+        std::iter::from_fn(move || loop {
+            let item = item_opt.as_mut()?;
+
+            let (status, errors) = if item.exited > 0 {
+                item.exited -= 1;
+                (SessionStatus::Exited, 0)
+            } else if item.errored > 0 {
+                item.errored -= 1;
+                // when exploding, we create "legacy" session updates that have no `errored` state
+                (SessionStatus::Exited, 1)
+            } else if item.abnormal > 0 {
+                item.abnormal -= 1;
+                (SessionStatus::Abnormal, 1)
+            } else if item.crashed > 0 {
+                item.crashed -= 1;
+                (SessionStatus::Crashed, 1)
+            } else {
+                item_opt = items.pop();
+                continue;
+            };
+            let attributes = attributes.clone();
+            return Some(SessionUpdate {
+                session_id: Uuid::new_v4(),
+                distinct_id: item.distinct_id.clone(),
+                sequence: 0,
+                init: true,
+                timestamp: Utc::now(),
+                started: item.started,
+                duration: None,
+                status,
+                errors,
+                attributes,
+            });
+        })
     }
 }
 
@@ -240,5 +340,100 @@ mod tests {
 
         let update = SessionUpdate::parse(json.as_bytes()).unwrap();
         assert_eq_dbg!(update.attributes.ip_address, Some(IpAddr::auto()));
+    }
+
+    #[test]
+    fn test_session_aggregates() {
+        let json = r#"{
+  "aggregates": [{
+    "started": "2020-02-07T14:16:00Z",
+    "exited": 2,
+    "abnormal": 1
+  },{
+    "started": "2020-02-07T14:17:00Z",
+    "did": "some-user",
+    "errored": 1
+  }],
+  "attrs": {
+    "release": "sentry-test@1.0.0",
+    "environment": "production",
+    "ip_address": "::1",
+    "user_agent": "Firefox/72.0"
+  }
+}"#;
+        let aggregates = SessionAggregates::parse(json.as_bytes()).unwrap();
+        let mut iter = aggregates.into_updates_iter();
+
+        let mut settings = insta::Settings::new();
+        settings.add_redaction(".timestamp", "[TS]");
+        settings.add_redaction(".sid", "[SID]");
+        settings.bind(|| {
+            insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
+            ---
+            sid: "[SID]"
+            did: some-user
+            seq: 0
+            init: true
+            timestamp: "[TS]"
+            started: "2020-02-07T14:17:00Z"
+            status: exited
+            errors: 1
+            attrs:
+              release: sentry-test@1.0.0
+              environment: production
+              ip_address: "::1"
+              user_agent: Firefox/72.0
+            "###);
+            insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
+            ---
+            sid: "[SID]"
+            did: ~
+            seq: 0
+            init: true
+            timestamp: "[TS]"
+            started: "2020-02-07T14:16:00Z"
+            status: exited
+            errors: 0
+            attrs:
+              release: sentry-test@1.0.0
+              environment: production
+              ip_address: "::1"
+              user_agent: Firefox/72.0
+            "###);
+            insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
+            ---
+            sid: "[SID]"
+            did: ~
+            seq: 0
+            init: true
+            timestamp: "[TS]"
+            started: "2020-02-07T14:16:00Z"
+            status: exited
+            errors: 0
+            attrs:
+              release: sentry-test@1.0.0
+              environment: production
+              ip_address: "::1"
+              user_agent: Firefox/72.0
+            "###);
+            insta::assert_yaml_snapshot!(iter.next().unwrap(), @r###"
+            ---
+            sid: "[SID]"
+            did: ~
+            seq: 0
+            init: true
+            timestamp: "[TS]"
+            started: "2020-02-07T14:16:00Z"
+            status: abnormal
+            errors: 1
+            attrs:
+              release: sentry-test@1.0.0
+              environment: production
+              ip_address: "::1"
+              user_agent: Firefox/72.0
+            "###);
+        });
+
+        assert_eq!(iter.next(), None);
     }
 }

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -681,6 +681,7 @@ impl EventProcessor {
 
             // session data is never considered as part of deduplication
             ItemType::Session => false,
+            ItemType::Sessions => false,
         }
     }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -15,7 +15,9 @@ use serde::{ser::Error, Serialize};
 
 use relay_common::{metric, ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
-use relay_general::protocol::{self, EventId, SessionStatus, SessionUpdate};
+use relay_general::protocol::{
+    self, EventId, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
+};
 use relay_quotas::Scoping;
 
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
@@ -27,6 +29,9 @@ lazy_static::lazy_static! {
     static ref NAMESPACE_DID: Uuid =
         Uuid::new_v5(&Uuid::NAMESPACE_URL, b"https://sentry.io/#did");
 }
+
+/// The maximum number of individual session updates generated for each aggregate item.
+const MAX_EXPLODED_SESSIONS: usize = 100;
 
 /// Fallback name used for attachment items without a `filename` header.
 const UNNAMED_ATTACHMENT: &str = "Unnamed Attachment";
@@ -151,7 +156,7 @@ impl StoreForwarder {
         self.produce(KafkaTopic::Attachments, message)
     }
 
-    fn produce_session(
+    fn produce_sessions(
         &self,
         org_id: u64,
         project_id: ProjectId,
@@ -159,12 +164,132 @@ impl StoreForwarder {
         client: Option<&str>,
         item: &Item,
     ) -> Result<(), StoreError> {
-        let session = match SessionUpdate::parse(&item.payload()) {
-            Ok(session) => session,
-            Err(_) => return Ok(()),
+        match item.ty() {
+            ItemType::Session => {
+                let mut session = match SessionUpdate::parse(&item.payload()) {
+                    Ok(session) => session,
+                    Err(_) => return Ok(()),
+                };
+                if session.status == SessionStatus::Errored {
+                    // Individual updates should never have the status `errored`
+                    session.status = SessionStatus::Exited;
+                }
+                self.produce_session_update(org_id, project_id, event_retention, client, session)?;
+            }
+            ItemType::Sessions => {
+                let aggregates = match SessionAggregates::parse(&item.payload()) {
+                    Ok(aggregates) => aggregates,
+                    Err(_) => return Ok(()),
+                };
+
+                if self.config.explode_session_aggregates() {
+                    if aggregates.num_sessions() as usize > MAX_EXPLODED_SESSIONS {
+                        log::warn!("exploded session items from aggregate exceed threshold");
+                    }
+
+                    for session in aggregates.into_updates_iter().take(MAX_EXPLODED_SESSIONS) {
+                        self.produce_session_update(
+                            org_id,
+                            project_id,
+                            event_retention,
+                            client,
+                            session,
+                        )?;
+                    }
+                } else {
+                    self.produce_sessions_from_aggregate(
+                        org_id,
+                        project_id,
+                        event_retention,
+                        client,
+                        aggregates,
+                    )?
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn produce_sessions_from_aggregate(
+        &self,
+        org_id: u64,
+        project_id: ProjectId,
+        event_retention: u16,
+        client: Option<&str>,
+        aggregates: SessionAggregates,
+    ) -> Result<(), StoreError> {
+        let SessionAggregates {
+            aggregates,
+            attributes,
+        } = aggregates;
+        let message = SessionKafkaMessage {
+            org_id,
+            project_id,
+            session_id: Uuid::nil(),
+            distinct_id: Uuid::nil(),
+            quantity: 1,
+            seq: 0,
+            received: protocol::datetime_to_timestamp(chrono::Utc::now()),
+            started: 0f64,
+            duration: None,
+            errors: 0,
+            release: attributes.release,
+            environment: attributes.environment,
+            sdk: client.map(str::to_owned),
+            retention_days: event_retention,
+            status: SessionStatus::Exited,
         };
 
-        let message = KafkaMessage::Session(SessionKafkaMessage {
+        if aggregates.len() > MAX_EXPLODED_SESSIONS {
+            log::warn!("aggregated session items exceed threshold");
+        }
+
+        for item in aggregates.into_iter().take(MAX_EXPLODED_SESSIONS) {
+            let mut message = message.clone();
+            message.started = protocol::datetime_to_timestamp(item.started);
+            message.distinct_id = item
+                .distinct_id
+                .as_deref()
+                .map(make_distinct_id)
+                .unwrap_or_default();
+
+            if item.exited > 0 {
+                message.errors = 0;
+                message.quantity = item.exited;
+                self.send_session_message(message.clone())?;
+            }
+            if item.errored > 0 {
+                message.errors = 1;
+                message.status = SessionStatus::Errored;
+                message.quantity = item.errored;
+                self.send_session_message(message.clone())?;
+            }
+            if item.abnormal > 0 {
+                message.errors = 1;
+                message.status = SessionStatus::Abnormal;
+                message.quantity = item.abnormal;
+                self.send_session_message(message.clone())?;
+            }
+            if item.crashed > 0 {
+                message.errors = 1;
+                message.status = SessionStatus::Crashed;
+                message.quantity = item.crashed;
+                self.send_session_message(message)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn produce_session_update(
+        &self,
+        org_id: u64,
+        project_id: ProjectId,
+        event_retention: u16,
+        client: Option<&str>,
+        session: SessionUpdate,
+    ) -> Result<(), StoreError> {
+        self.send_session_message(SessionKafkaMessage {
             org_id,
             project_id,
             session_id: session.session_id,
@@ -173,6 +298,7 @@ impl StoreForwarder {
                 .as_deref()
                 .map(make_distinct_id)
                 .unwrap_or_default(),
+            quantity: 1,
             seq: if session.init { 0 } else { session.sequence },
             received: protocol::datetime_to_timestamp(session.timestamp),
             started: protocol::datetime_to_timestamp(session.started),
@@ -186,10 +312,17 @@ impl StoreForwarder {
             environment: session.attributes.environment,
             sdk: client.map(str::to_owned),
             retention_days: event_retention,
-        });
+        })
+    }
 
+    fn send_session_message(&self, message: SessionKafkaMessage) -> Result<(), StoreError> {
         log::trace!("Sending session item to kafka");
-        self.produce(KafkaTopic::Sessions, message)
+        self.produce(KafkaTopic::Sessions, KafkaMessage::Session(message))?;
+        metric!(
+            counter(RelayCounters::ProcessingMessageProduced) += 1,
+            event_type = "session"
+        );
+        Ok(())
     }
 }
 
@@ -325,12 +458,13 @@ struct UserReportKafkaMessage {
     event_id: EventId,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct SessionKafkaMessage {
     org_id: u64,
     project_id: ProjectId,
     session_id: Uuid,
     distinct_id: Uuid,
+    quantity: u32,
     seq: u64,
     received: f64,
     started: f64,
@@ -452,18 +586,14 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                         event_type = "user_report"
                     );
                 }
-                ItemType::Session => {
-                    self.produce_session(
+                ItemType::Session | ItemType::Sessions => {
+                    self.produce_sessions(
                         scoping.organization_id,
                         scoping.project_id,
                         retention,
                         client,
                         item,
                     )?;
-                    metric!(
-                        counter(RelayCounters::ProcessingMessageProduced) += 1,
-                        event_type = "session"
-                    );
                 }
                 _ => {}
             }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -346,6 +346,7 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
                 attachments_size += item.len()
             }
             ItemType::Session => session_count += 1,
+            ItemType::Sessions => session_count += 1,
             ItemType::UserReport => (),
         }
     }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -91,6 +91,8 @@ pub enum ItemType {
     UserReport,
     /// Session update data.
     Session,
+    /// Aggregated session data.
+    Sessions,
 }
 
 impl ItemType {
@@ -118,6 +120,7 @@ impl fmt::Display for ItemType {
             Self::UnrealReport => write!(f, "unreal report"),
             Self::UserReport => write!(f, "user feedback"),
             Self::Session => write!(f, "session"),
+            Self::Sessions => write!(f, "aggregated sessions"),
         }
     }
 }
@@ -500,7 +503,7 @@ impl Item {
             ItemType::FormData => false,
 
             // The remaining item types cannot carry event payloads.
-            ItemType::UserReport | ItemType::Session => false,
+            ItemType::UserReport | ItemType::Session | ItemType::Sessions => false,
         }
     }
 
@@ -518,6 +521,7 @@ impl Item {
             ItemType::UnrealReport => true,
             ItemType::UserReport => true,
             ItemType::Session => false,
+            ItemType::Sessions => false,
         }
     }
 }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -88,6 +88,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Attachment if item.creates_event() => Some(DataCategory::Error),
         ItemType::Attachment => None,
         ItemType::Session => None,
+        ItemType::Sessions => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
     }

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -173,7 +173,7 @@ class SentryLike(object):
     def send_session_aggregates(self, project_id, payload):
         envelope = Envelope()
         envelope.add_item(
-            Item(payload=PayloadRef(json=payload), type="session_aggregates")
+            Item(payload=PayloadRef(json=payload), type="sessions")
         )
         self.send_envelope(project_id, envelope)
 

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -2,7 +2,7 @@ import datetime
 import time
 
 import requests
-from sentry_sdk.envelope import Envelope
+from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
 session = requests.session()
 
@@ -168,6 +168,13 @@ class SentryLike(object):
     def send_session(self, project_id, payload):
         envelope = Envelope()
         envelope.add_session(payload)
+        self.send_envelope(project_id, envelope)
+
+    def send_session_aggregates(self, project_id, payload):
+        envelope = Envelope()
+        envelope.add_item(
+            Item(payload=PayloadRef(json=payload), type="session_aggregates")
+        )
         self.send_envelope(project_id, envelope)
 
     def send_security_report(

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -172,9 +172,7 @@ class SentryLike(object):
 
     def send_session_aggregates(self, project_id, payload):
         envelope = Envelope()
-        envelope.add_item(
-            Item(payload=PayloadRef(json=payload), type="sessions")
-        )
+        envelope.add_item(Item(payload=PayloadRef(json=payload), type="sessions"))
         self.send_envelope(project_id, envelope)
 
     def send_security_report(

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -135,9 +135,10 @@ def test_session_aggregates(mini_sentry, relay_with_processing, sessions_consume
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
 
-    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
     relay.send_session_aggregates(
-        42,
+        project_id,
         {
             "aggregates": [
                 {
@@ -155,7 +156,7 @@ def test_session_aggregates(mini_sentry, relay_with_processing, sessions_consume
     del session["received"]
     assert session == {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "session_id": "00000000-0000-0000-0000-000000000000",
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         "quantity": 2,
@@ -174,7 +175,7 @@ def test_session_aggregates(mini_sentry, relay_with_processing, sessions_consume
     del session["received"]
     assert session == {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "session_id": "00000000-0000-0000-0000-000000000000",
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         "quantity": 3,
@@ -199,9 +200,10 @@ def test_session_aggregates_explode(
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
 
-    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
     relay.send_session_aggregates(
-        42,
+        project_id,
         {
             "aggregates": [
                 {"started": started.isoformat(), "did": "foobarbaz", "exited": 2,}
@@ -212,7 +214,7 @@ def test_session_aggregates_explode(
 
     expected = {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         "quantity": 1,
         "seq": 0,


### PR DESCRIPTION
This adds a more efficient envelope item for sending lots of sessions up that happened in the same minute.

Right now they are exploded in relay, but in the future they will be stored directly as-is.