### PR TITLE
fix(server): Support measurement data

### DIFF
--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -7,6 +7,9 @@ pub struct Measurement {
     /// Value of observed measurement value.
     #[metastructure(required = "true", skip_serialization = "never")]
     pub value: Annotated<f64>,
+
+    /// Arbitrary additional data on the measurement, like `extra` on the top-level event.
+    pub data: Annotated<Object<Value>>,
 }
 
 /// A map of observed measurement values.


### PR DESCRIPTION
For web vitals, we'd like to capture DOM sources that contribute to the CLS score and the LCP score.

Reference:

- https://developer.mozilla.org/en-US/docs/Web/API/LayoutShiftAttribution
- https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint