### PR TITLE
feat(pii): Adopt new selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Rename upstream retries histogram metric and add upstream requests duration metric. ([#816](https://github.com/getsentry/relay/pull/816))
+- Fine-tune the selectors for minidump PII scrubbing. ([#818](https://github.com/getsentry/relay/pull/818))
 
 ## 20.10.1
 

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -369,7 +369,7 @@ impl<'a> PiiAttachmentsProcessor<'a> {
     ) -> ProcessingState<'s> {
         self.root_state.enter_borrowed(
             filename,
-            Some(Cow::Owned(FieldAttrs::new().pii(Pii::Maybe))),
+            Some(Cow::Owned(FieldAttrs::new().pii(Pii::True))),
             Some(value_type),
         )
     }

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -383,9 +383,18 @@ impl<'a> PiiAttachmentsProcessor<'a> {
         state: &ProcessingState<'_>,
         encodings: ScrubEncodings,
     ) -> bool {
+        let pii = state.attrs().pii;
+        if pii == Pii::False {
+            return false;
+        }
+
         let mut changed = false;
 
         for (selector, rules) in &self.compiled_config.applications {
+            if pii == Pii::Maybe && !selector.is_specific() {
+                continue;
+            }
+
             if state.path().matches_selector(&selector) {
                 for rule in rules {
                     // Note:

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -595,13 +595,15 @@ mod tests {
 
     #[test]
     fn test_stack_scrubbing_backwards_compatible_selector() {
+        // Some users already use this bare selector, that's all we care about for backwards
+        // compatibility.
         let scrubber = TestScrubber::new(
             "linux.dmp",
             include_bytes!("../../../tests/fixtures/linux.dmp"),
             serde_json::json!(
                 {
                     "applications": {
-                        "$minidump.$stack_memory": ["@anything:mask"],
+                        "$stack_memory": ["@anything:mask"],
                     }
                 }
             ),
@@ -630,7 +632,10 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_stack_scrubbing_valuetype_selector() {
+        // This should work, but is known to fail currently because the selector logic never
+        // considers a selector containing $binary as specific.
         let scrubber = TestScrubber::new(
             "linux.dmp",
             include_bytes!("../../../tests/fixtures/linux.dmp"),
@@ -671,8 +676,10 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_stack_scrubbing_wildcard() {
-        // Wildcard should not touch the stack
+        // Wildcard should not touch the stack.  However currently wildcards are considered
+        // specific selectors so they do.  This is a known issue.
         let scrubber = TestScrubber::new(
             "linux.dmp",
             include_bytes!("../../../tests/fixtures/linux.dmp"),

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -607,7 +607,7 @@ mod tests {
             ),
         );
         for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(stack.iter().all(|b| *b == '*' as u8));
+            assert!(stack.iter().all(|b| *b == b'*'));
         }
     }
 
@@ -625,7 +625,7 @@ mod tests {
             ),
         );
         for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(stack.iter().all(|b| *b == '*' as u8));
+            assert!(stack.iter().all(|b| *b == b'*'));
         }
     }
 
@@ -643,7 +643,7 @@ mod tests {
             ),
         );
         for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(stack.iter().all(|b| *b == '*' as u8));
+            assert!(stack.iter().all(|b| *b == b'*'));
         }
     }
 

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -649,7 +649,7 @@ mod tests {
 
     #[test]
     fn test_stack_scrubbing_valuetype_not_fully_qualified() {
-        // Not fully qualified valuetype should not touch the stack: FAILS
+        // Not fully qualified valuetype should not touch the stack
         let scrubber = TestScrubber::new(
             "linux.dmp",
             include_bytes!("../../../tests/fixtures/linux.dmp"),
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn test_stack_scrubbing_wildcard() {
-        // Wildcard should not touch the stack: FAILS
+        // Wildcard should not touch the stack
         let scrubber = TestScrubber::new(
             "linux.dmp",
             include_bytes!("../../../tests/fixtures/linux.dmp"),
@@ -695,7 +695,7 @@ mod tests {
 
     #[test]
     fn test_stack_scrubbing_deep_wildcard() {
-        // Wildcard should not touch the stack: FAILS
+        // Wildcard should not touch the stack
         let scrubber = TestScrubber::new(
             "linux.dmp",
             include_bytes!("../../../tests/fixtures/linux.dmp"),

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -256,32 +256,53 @@ impl PiiAttachmentsProcessor<'_> {
         let mut changed = false;
 
         for item in items {
-            // IMPORTANT: Minidump sections are always classified as Pii:Maybe. This avoids to
-            // accidentally scrub stack memory with highly generic selectors. TODO: Update the PII
-            // system with a better approach.
-            let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
-
             match item {
                 MinidumpItem::StackMemory(range) => {
+                    // IMPORTANT: The stack is PII::Maybe to avoid accidentally scrubbing it
+                    // with highly generic selectors.
                     let slice = data
                         .get_mut(range)
                         .ok_or(ScrubMinidumpError::InvalidAddress)?;
+
+                    // Backwards-compatible visit
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
                     let state =
                         file_state.enter_static("", Some(attrs), Some(ValueType::StackMemory));
                     changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
+
+                    // Documented visit
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
+                    let state = file_state.enter_static(
+                        "stack_memory",
+                        Some(attrs),
+                        Some(ValueType::Binary),
+                    );
+                    changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
                 }
                 MinidumpItem::NonStackMemory(range) => {
+                    // Backwards-compatible visit.
                     let slice = data
                         .get_mut(range)
                         .ok_or(ScrubMinidumpError::InvalidAddress)?;
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
                     let state =
                         file_state.enter_static("", Some(attrs), Some(ValueType::HeapMemory));
+                    changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
+
+                    // Documented visit.
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
+                    let state = file_state.enter_static(
+                        "heap_memory",
+                        Some(attrs),
+                        Some(ValueType::Binary),
+                    );
                     changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
                 }
                 MinidumpItem::LinuxEnviron(range) | MinidumpItem::LinuxCmdLine(range) => {
                     let slice = data
                         .get_mut(range)
                         .ok_or(ScrubMinidumpError::InvalidAddress)?;
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
                     let state = file_state.enter_static("", Some(attrs), Some(ValueType::Binary));
                     changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
                 }
@@ -289,6 +310,7 @@ impl PiiAttachmentsProcessor<'_> {
                     let slice = data
                         .get_mut(range)
                         .ok_or(ScrubMinidumpError::InvalidAddress)?;
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
                     // Mirrors decisions made on NativeImagePath type
                     let state =
                         file_state.enter_static("code_file", Some(attrs), Some(ValueType::String));
@@ -299,6 +321,7 @@ impl PiiAttachmentsProcessor<'_> {
                     let slice = data
                         .get_mut(range)
                         .ok_or(ScrubMinidumpError::InvalidAddress)?;
+                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
                     // Mirrors decisions made on NativeImagePath type
                     let state =
                         file_state.enter_static("debug_file", Some(attrs), Some(ValueType::String));
@@ -376,6 +399,33 @@ mod tests {
             let mut iter = modules.iter();
             iter.next(); // remove main module
             iter.cloned().collect()
+        }
+
+        /// Returns the raw stack memory regions.
+        fn stacks<'slf>(&'slf self, which: Which) -> Vec<&'slf [u8]> {
+            let dump: &'slf Minidump<&'static [u8]> = match which {
+                Which::Original => &self.orig_dump,
+                Which::Scrubbed => &self.scrubbed_dump,
+            };
+
+            let thread_list: MinidumpThreadList = dump.get_stream().unwrap();
+            let stack_rvas: Vec<RVA> = thread_list
+                .threads
+                .iter()
+                .map(|t| t.raw.stack.memory.rva)
+                .collect();
+
+            // These bytes are kept alive by our struct itself, so returning them with the
+            // lifetime of our struct is fine.  The lifetimes on the Minidump::MemoryRegions
+            // iterator are currenty wrong and assumes we keep a reference to the
+            // MinidumpMemoryList, hence we need to transmute this.  See
+            // https://github.com/luser/rust-minidump/pull/111
+            let mem_list: MinidumpMemoryList<'slf> = dump.get_stream().unwrap();
+            mem_list
+                .iter()
+                .filter(|mem| stack_rvas.contains(&mem.desc.memory.rva))
+                .map(|mem| unsafe { std::mem::transmute(mem.bytes) })
+                .collect()
         }
     }
 
@@ -540,6 +590,135 @@ mod tests {
                 module.debug_file().unwrap().matches('/').count() == 0,
                 "scrubbed debug file contains a path"
             );
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_backwards_compatible_selector() {
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$minidump.$stack_memory": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(stack.iter().all(|b| *b == '*' as u8));
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_path_item_selector() {
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$minidump.stack_memory": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(stack.iter().all(|b| *b == '*' as u8));
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_valuetype_selector() {
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$minidump.$binary": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(stack.iter().all(|b| *b == '*' as u8));
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_valuetype_not_fully_qualified() {
+        // Not fully qualified valuetype should not touch the stack: FAILS
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$binary": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_wildcard() {
+        // Wildcard should not touch the stack: FAILS
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$minidump:*": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_deep_wildcard() {
+        // Wildcard should not touch the stack: FAILS
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$attachments:**": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        }
+    }
+
+    #[test]
+    fn test_stack_scrubbing_binary_not_stack() {
+        let scrubber = TestScrubber::new(
+            "linux.dmp",
+            include_bytes!("../../../tests/fixtures/linux.dmp"),
+            serde_json::json!(
+                {
+                    "applications": {
+                        "$binary && !stack_memory": ["@anything:mask"],
+                    }
+                }
+            ),
+        );
+        for stack in scrubber.stacks(Which::Scrubbed) {
+            assert!(!stack.iter().all(|b| *b == '*' as u8));
         }
     }
 }

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -661,8 +661,12 @@ mod tests {
                 }
             ),
         );
-        for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        for (scrubbed_stack, original_stack) in scrubber
+            .stacks(Which::Scrubbed)
+            .iter()
+            .zip(scrubber.stacks(Which::Original).iter())
+        {
+            assert_eq!(scrubbed_stack, original_stack);
         }
     }
 
@@ -675,13 +679,17 @@ mod tests {
             serde_json::json!(
                 {
                     "applications": {
-                        "$minidump:*": ["@anything:mask"],
+                        "$minidump.*": ["@anything:mask"],
                     }
                 }
             ),
         );
-        for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        for (scrubbed_stack, original_stack) in scrubber
+            .stacks(Which::Scrubbed)
+            .iter()
+            .zip(scrubber.stacks(Which::Original).iter())
+        {
+            assert_eq!(scrubbed_stack, original_stack);
         }
     }
 
@@ -694,13 +702,17 @@ mod tests {
             serde_json::json!(
                 {
                     "applications": {
-                        "$attachments:**": ["@anything:mask"],
+                        "$attachments.**": ["@anything:mask"],
                     }
                 }
             ),
         );
-        for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        for (scrubbed_stack, original_stack) in scrubber
+            .stacks(Which::Scrubbed)
+            .iter()
+            .zip(scrubber.stacks(Which::Original).iter())
+        {
+            assert_eq!(scrubbed_stack, original_stack);
         }
     }
 
@@ -717,8 +729,12 @@ mod tests {
                 }
             ),
         );
-        for stack in scrubber.stacks(Which::Scrubbed) {
-            assert!(!stack.iter().all(|b| *b == '*' as u8));
+        for (scrubbed_stack, original_stack) in scrubber
+            .stacks(Which::Scrubbed)
+            .iter()
+            .zip(scrubber.stacks(Which::Original).iter())
+        {
+            assert_eq!(scrubbed_stack, original_stack);
         }
     }
 }

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -355,59 +355,129 @@ fn key_needs_quoting(key: &str) -> bool {
     SelectorParser::parse(Rule::RootUnquotedKey, key).is_err()
 }
 
-#[test]
-fn test_roundtrip() {
-    fn check_roundtrip(s: &str) {
-        assert_eq!(SelectorSpec::from_str(s).unwrap().to_string(), s);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip() {
+        fn check_roundtrip(s: &str) {
+            assert_eq!(SelectorSpec::from_str(s).unwrap().to_string(), s);
+        }
+
+        check_roundtrip("!(!a)");
+        check_roundtrip("!a || !b");
+        check_roundtrip("!a && !b");
+        check_roundtrip("!(a && !b)");
+        check_roundtrip("!(a && b)");
     }
 
-    check_roundtrip("!(!a)");
-    check_roundtrip("!a || !b");
-    check_roundtrip("!a && !b");
-    check_roundtrip("!(a && !b)");
-    check_roundtrip("!(a && b)");
-}
+    #[test]
+    fn test_is_specific() {
+        assert!(SelectorSpec::from_str("$frame.vars.foo")
+            .unwrap()
+            .is_specific());
+        assert!(!SelectorSpec::from_str("foo.$frame.vars.foo")
+            .unwrap()
+            .is_specific());
+        assert!(!SelectorSpec::from_str("$object.foo").unwrap().is_specific());
+        assert!(SelectorSpec::from_str("extra.foo").unwrap().is_specific());
 
-#[test]
-fn test_is_specific() {
-    assert!(SelectorSpec::from_str("$frame.vars.foo")
-        .unwrap()
-        .is_specific());
-    assert!(!SelectorSpec::from_str("foo.$frame.vars.foo")
-        .unwrap()
-        .is_specific());
-    assert!(!SelectorSpec::from_str("$object.foo").unwrap().is_specific());
-    assert!(SelectorSpec::from_str("extra.foo").unwrap().is_specific());
+        assert!(SelectorSpec::from_str("extra.foo && extra.foo")
+            .unwrap()
+            .is_specific());
+        assert!(SelectorSpec::from_str("extra.foo && $string")
+            .unwrap()
+            .is_specific());
+        assert!(!SelectorSpec::from_str("$string && $string")
+            .unwrap()
+            .is_specific());
 
-    assert!(SelectorSpec::from_str("extra.foo && extra.foo")
-        .unwrap()
-        .is_specific());
-    assert!(SelectorSpec::from_str("extra.foo && $string")
-        .unwrap()
-        .is_specific());
-    assert!(!SelectorSpec::from_str("$string && $string")
-        .unwrap()
-        .is_specific());
+        assert!(SelectorSpec::from_str("extra.foo || extra.foo")
+            .unwrap()
+            .is_specific());
+        assert!(!SelectorSpec::from_str("extra.foo || $string")
+            .unwrap()
+            .is_specific());
+        assert!(!SelectorSpec::from_str("$string || $string")
+            .unwrap()
+            .is_specific());
+    }
 
-    assert!(SelectorSpec::from_str("extra.foo || extra.foo")
-        .unwrap()
-        .is_specific());
-    assert!(!SelectorSpec::from_str("extra.foo || $string")
-        .unwrap()
-        .is_specific());
-    assert!(!SelectorSpec::from_str("$string || $string")
-        .unwrap()
-        .is_specific());
-}
+    #[test]
+    fn test_invalid() {
+        assert!(matches!(
+            SelectorSpec::from_str("* && foo"),
+            Err(InvalidSelectorError::InvalidWildcard)
+        ));
+        assert!(matches!(
+            SelectorSpec::from_str("$frame.**.foo.**"),
+            Err(InvalidSelectorError::InvalidDeepWildcard)
+        ));
+    }
 
-#[test]
-fn test_invalid() {
-    assert!(matches!(
-        SelectorSpec::from_str("* && foo"),
-        Err(InvalidSelectorError::InvalidWildcard)
-    ));
-    assert!(matches!(
-        SelectorSpec::from_str("$frame.**.foo.**"),
-        Err(InvalidSelectorError::InvalidDeepWildcard)
-    ));
+    /// These tests are relevant for Pii::Maybe tagged items since they only match when a
+    /// selector is considered specific.
+    mod attachments {
+        use super::*;
+
+        #[test]
+        fn test_specific_attachments() {
+            let selector = SelectorSpec::from_str("$attachments").unwrap();
+            assert!(selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_attachments_filename() {
+            let selector = SelectorSpec::from_str("$attachments.'file.txt'").unwrap();
+            assert!(selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_binary() {
+            let selector = SelectorSpec::from_str("$binary").unwrap();
+            assert!(!selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_attachments_binary() {
+            // WAT.  All entire attachments are binary, so why not be able to select them
+            // like this?  Especially since we can select them with wildcard.
+            let selector = SelectorSpec::from_str("$attachments.$binary").unwrap();
+            assert!(!selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_attachments_wildcard() {
+            // WAT.  This is not problematic but rather... weird?
+            let selector = SelectorSpec::from_str("$attachments.*").unwrap();
+            assert!(selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_attachments_deep_wildcard() {
+            let selector = SelectorSpec::from_str("$attachments.**").unwrap();
+            assert!(!selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_minidump() {
+            let selector = SelectorSpec::from_str("$minidump").unwrap();
+            assert!(selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_attachments_minidump() {
+            // WAT.  This should not behave differently from plain $minidump
+            let selector = SelectorSpec::from_str("$attachments.$minidump").unwrap();
+            assert!(!selector.is_specific());
+        }
+
+        #[test]
+        fn test_specific_attachments_minidump_binary() {
+            // WAT.  We have the full path to a field here.
+            let selector = SelectorSpec::from_str("$attachments.$minidump.$binary").unwrap();
+            assert!(!selector.is_specific());
+        }
+    }
 }


### PR DESCRIPTION
This adds new selectors for the minidump for the heap and stack.

@untitaker as the new tests show this sadly means any generic rule for `$binary` will apply to the stack.  Which is what we were trying to avoid.  So I'm not sure this proposed change will work.  I guess the question is whether we still want to this for just the heap or not.