### PR TITLE
fix(server): Always apply cache debouncing for project states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+**Features**:
+
 - Rename upstream retries histogram metric and add upstream requests duration metric. ([#816](https://github.com/getsentry/relay/pull/816))
+
+**Internal**:
+
+- Always apply cache debouncing for project states. This reduces pressure on the Redis and file system cache. ([#819](https://github.com/getsentry/relay/pull/819))
 
 ## 20.10.1
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -439,7 +439,7 @@ impl Project {
             .map(|s| s.outdated(&self.config))
             .unwrap_or(Outdated::HardOutdated);
 
-        let alternative_rv = match (state, outdated) {
+        let cached_state = match (state, outdated) {
             // There is no project state that can be used, fetch a state and return it.
             (None, _) | (_, Outdated::HardOutdated) => None,
 
@@ -463,7 +463,7 @@ impl Project {
             }
         };
 
-        if let Some(rv) = alternative_rv {
+        if let Some(rv) = cached_state {
             return Response::ok(rv);
         }
 

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -176,22 +176,11 @@ pub struct FetchProjectState {
 #[derive(Debug)]
 pub struct ProjectStateResponse {
     pub state: Arc<ProjectState>,
-    pub is_local: bool,
 }
 
 impl ProjectStateResponse {
-    pub fn managed(state: Arc<ProjectState>) -> Self {
-        ProjectStateResponse {
-            state,
-            is_local: false,
-        }
-    }
-
-    pub fn local(state: Arc<ProjectState>) -> Self {
-        ProjectStateResponse {
-            state,
-            is_local: true,
-        }
+    pub fn new(state: Arc<ProjectState>) -> Self {
+        ProjectStateResponse { state }
     }
 }
 
@@ -239,23 +228,23 @@ impl Handler<FetchProjectState> for ProjectCache {
 
         let future = fetch_local.and_then(move |response| {
             if let Some(state) = response {
-                return Box::new(future::ok(ProjectStateResponse::local(state)))
+                return Box::new(future::ok(ProjectStateResponse::new(state)))
                     as ResponseFuture<_, _>;
             }
 
             match relay_mode {
                 RelayMode::Proxy => {
-                    return Box::new(future::ok(ProjectStateResponse::local(Arc::new(
+                    return Box::new(future::ok(ProjectStateResponse::new(Arc::new(
                         ProjectState::allowed(),
                     ))));
                 }
                 RelayMode::Static => {
-                    return Box::new(future::ok(ProjectStateResponse::local(Arc::new(
+                    return Box::new(future::ok(ProjectStateResponse::new(Arc::new(
                         ProjectState::missing(),
                     ))));
                 }
                 RelayMode::Capture => {
-                    return Box::new(future::ok(ProjectStateResponse::local(Arc::new(
+                    return Box::new(future::ok(ProjectStateResponse::new(Arc::new(
                         ProjectState::allowed(),
                     ))));
                 }
@@ -280,7 +269,7 @@ impl Handler<FetchProjectState> for ProjectCache {
 
             let fetch_redis = fetch_redis.and_then(move |response| {
                 if let Some(state) = response {
-                    return Box::new(future::ok(ProjectStateResponse::local(state)))
+                    return Box::new(future::ok(ProjectStateResponse::new(state)))
                         as ResponseFuture<_, _>;
                 }
 

--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -44,7 +44,9 @@ impl RedisProjectSource {
         let mut command = relay_redis::redis::cmd("GET");
 
         let prefix = self.config.projectconfig_cache_prefix();
-        command.arg(format!("{}:{}", prefix, key));
+        let key = format!("{}:{}", prefix, key);
+        log::info!("loading redis {}", key);
+        command.arg(key);
 
         let raw_response_opt: Option<String> = command
             .query(&mut self.redis.client()?.connection())

--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -44,9 +44,7 @@ impl RedisProjectSource {
         let mut command = relay_redis::redis::cmd("GET");
 
         let prefix = self.config.projectconfig_cache_prefix();
-        let key = format!("{}:{}", prefix, key);
-        log::info!("loading redis {}", key);
-        command.arg(key);
+        command.arg(format!("{}:{}", prefix, key));
 
         let raw_response_opt: Option<String> = command
             .query(&mut self.redis.client()?.connection())

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -335,7 +335,7 @@ impl Handler<FetchProjectState> for UpstreamProjectSource {
             channel
                 .receiver()
                 .map_err(|_| ())
-                .map(|x| ProjectStateResponse::managed((*x).clone())),
+                .map(|x| ProjectStateResponse::new((*x).clone())),
         )
     }
 }

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -14,7 +14,8 @@ from requests.exceptions import HTTPError
 
 def test_local_project_config(mini_sentry, relay):
     config = mini_sentry.basic_project_config()
-    relay = relay(mini_sentry, {"cache": {"file_interval": 1}}, wait_healthcheck=False)
+    relay_config = {"cache": {"file_interval": 1, "project_expiry": 0, "project_grace_period": 0}}
+    relay = relay(mini_sentry, relay_config, wait_healthcheck=False)
     relay.config_dir.mkdir("projects").join("42.json").write(
         json.dumps(
             {

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -14,7 +14,9 @@ from requests.exceptions import HTTPError
 
 def test_local_project_config(mini_sentry, relay):
     config = mini_sentry.basic_project_config()
-    relay_config = {"cache": {"file_interval": 1, "project_expiry": 0, "project_grace_period": 0}}
+    relay_config = {
+        "cache": {"file_interval": 1, "project_expiry": 0, "project_grace_period": 0}
+    }
     relay = relay(mini_sentry, relay_config, wait_healthcheck=False)
     relay.config_dir.mkdir("projects").join("42.json").write(
         json.dumps(


### PR DESCRIPTION
Removes the `is_local` override for all project state sources for multiple reasons:

- Reduces pressure on the Redis source.
- Reduces pressure on the contended project cache actor and the project sources.
- Applies equivalent caching across all sources.

This has one negative effect: When updating a local file system configuration, Relay will wait for the configured project cache (soft) timeout until it applies this configuration.