### PR TITLE
feat(metrics): Add metrics buffering and sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Rename upstream retries histogram metric and add upstream requests duration metric. ([#816](https://github.com/getsentry/relay/pull/816))
+- Add metrics buffering and sampling. ([#821](https://github.com/getsentry/relay/pull/821))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Rename upstream retries histogram metric and add upstream requests duration metric. ([#816](https://github.com/getsentry/relay/pull/816))
-- Add metrics buffering and sampling. ([#821](https://github.com/getsentry/relay/pull/821))
+- Add options for metrics buffering (`metrics.buffering`) and sampling (`metrics.sample_rate`). ([#821](https://github.com/getsentry/relay/pull/821))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,6 +2901,7 @@ dependencies = [
  "log",
  "lru",
  "parking_lot 0.10.2",
+ "rand 0.7.3",
  "regex",
  "schemars",
  "sentry-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "actix_derive",
  "bitflags",
  "bytes 0.4.12",
- "crossbeam-channel",
+ "crossbeam-channel 0.3.9",
  "failure",
  "fnv",
  "futures 0.1.29",
@@ -390,11 +390,11 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "0.17.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773c648ebe292d8fcdac6a0d332edd2a54bb3110890751c7a05e6b76659c7df0"
+checksum = "6281d1200ac3293fd08be899c9a0c17b83cda0672221fcbe1fefc886a555e35e"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.4.4",
 ]
 
 [[package]]
@@ -628,6 +628,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 dependencies = [
  "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 # Builds
 
 build: setup-git
-	@cargo +stable build --all-features
+	cargo +stable build --all-features
 .PHONY: build
 
 release: setup-git

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 backoff = "0.1.6"
-cadence = "0.17.1"
+cadence = "0.22.0"
 chrono = "0.4.11"
 failure = "0.1.8"
 globset = "0.4.5"

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -20,6 +20,7 @@ lazycell = "1.2.1"
 log = { version = "0.4.8", features = ["serde"] }
 lru = "0.4.0"
 parking_lot = "0.10.0"
+rand = "0.7.3"
 regex = "1.3.9"
 sentry-types = "0.20.0"
 schemars = { version = "0.8.0-alpha-4", features = ["uuid", "chrono"], optional = true }

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -106,22 +106,7 @@ impl MetricsClient {
     where
         T: Metric + From<String>,
     {
-        // Decide if we want to sample this metric
-        let sample_rate: f32 = 0.5;
-
-        let to_send = if sample_rate <= 0.0 {
-            println!("zero");
-            false
-        } else if sample_rate >= 1.0 {
-            println!("one!!!");
-            true
-        } else {
-            let mut rng = rand::thread_rng();
-            let between = Uniform::new(0.0, 1.0);
-            between.sample(&mut rng) <= sample_rate
-        };
-
-        if !to_send {
+        if !self._should_send() {
             return;
         }
 
@@ -137,6 +122,23 @@ impl MetricsClient {
                 METRICS_MAX_QUEUE_SIZE
             ),
         };
+    }
+
+    fn _should_send(&self) -> bool {
+        // Decide if we want to sample this metric
+        let sample_rate: f32 = 0.5;
+
+        if sample_rate <= 0.0 {
+            println!("zero");
+            false
+        } else if sample_rate >= 1.0 {
+            println!("one!!!");
+            true
+        } else {
+            let mut rng = rand::thread_rng();
+            let between = Uniform::new(0.0, 1.0);
+            between.sample(&mut rng) <= sample_rate
+        }
     }
 }
 

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -116,13 +116,12 @@ impl MetricsClient {
             metric = metric.with_tag(k, v);
         }
 
-        match metric.try_send() {
-            Ok(_) => (),
-            Err(error) => log::error!(
+        if let Err(error) = metric.try_send() {
+            log::error!(
                 "Error sending a metric: {}, maximum capacity: {}",
                 LogError(&error),
                 METRICS_MAX_QUEUE_SIZE
-            ),
+            );
         };
     }
 

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -222,7 +222,7 @@ pub fn configure_statsd<A: ToSocketAddrs>(
     set_client(MetricsClient {
         statsd_client,
         default_tags,
-        normalized_sample_rate,
+        sample_rate: normalized_sample_rate,
     });
 }
 

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -185,17 +185,12 @@ pub fn configure_statsd<A: ToSocketAddrs>(
         log::info!("reporting metrics to statsd at {}", addrs[0]);
     }
 
-    let normalized_sample_rate = if sample_rate >= 1.0 {
-        1.0
-    } else if sample_rate <= 0.0 {
-        0.0
-    } else {
-        sample_rate
-    };
+    // Normalize sample_rate
+    let sample_rate = sample_rate.max(0.).min(1.);
     log::debug!(
         "metrics sample rate is set to {}{}",
-        normalized_sample_rate,
-        if normalized_sample_rate == 0.0 {
+        sample_rate,
+        if sample_rate == 0.0 {
             ", no metrics will be reported"
         } else {
             ""
@@ -221,7 +216,7 @@ pub fn configure_statsd<A: ToSocketAddrs>(
     set_client(MetricsClient {
         statsd_client,
         default_tags,
-        sample_rate: normalized_sample_rate,
+        sample_rate,
     });
 }
 

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -69,6 +69,7 @@ use cadence::{
 };
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
+use rand::distributions::{Distribution, Uniform};
 
 use crate::LogError;
 
@@ -105,6 +106,25 @@ impl MetricsClient {
     where
         T: Metric + From<String>,
     {
+        // Decide if we want to sample this metric
+        let sample_rate: f32 = 0.5;
+
+        let to_send = if sample_rate <= 0.0 {
+            println!("zero");
+            false
+        } else if sample_rate >= 1.0 {
+            println!("one!!!");
+            true
+        } else {
+            let mut rng = rand::thread_rng();
+            let between = Uniform::new(0.0, 1.0);
+            between.sample(&mut rng) <= sample_rate
+        };
+
+        if !to_send {
+            return;
+        }
+
         for (k, v) in &self.default_tags {
             metric = metric.with_tag(k, v);
         }

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -172,6 +172,10 @@ pub fn configure_statsd<A: ToSocketAddrs>(
         let simple_sink = UdpMetricSink::from(host, socket).unwrap();
         StatsdClient::from_sink(prefix, simple_sink)
     };
+    log::debug!(
+        "metrics buffering is {}",
+        if buffering { "enabled" } else { "disabled" }
+    );
 
     set_client(MetricsClient {
         statsd_client,

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -133,8 +133,8 @@ impl MetricsClient {
             true
         } else {
             let mut rng = rand::thread_rng();
-            let between = Uniform::new(0.0, 1.0);
-            between.sample(&mut rng) <= self.sample_rate
+            RNG_UNIFORM_DISTRIBUTION
+                .with(|uniform_dist| uniform_dist.sample(&mut rng) <= self.sample_rate)
         }
     }
 }
@@ -145,6 +145,7 @@ lazy_static! {
 
 thread_local! {
     static CURRENT_CLIENT: Option<Arc<MetricsClient>> = METRICS_CLIENT.read().clone();
+    static RNG_UNIFORM_DISTRIBUTION: Uniform<f32> = Uniform::new(0.0, 1.0);
 }
 
 /// Internal prelude for the macro
@@ -217,7 +218,7 @@ pub fn configure_statsd<A: ToSocketAddrs>(
     set_client(MetricsClient {
         statsd_client,
         default_tags,
-        sample_rate,
+        normalized_sample_rate,
     });
 }
 

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -24,7 +24,7 @@
 //! # use std::collections::BTreeMap;
 //! use relay_common::metrics;
 //!
-//! metrics::configure_statsd("myprefix", "localhost:8125", BTreeMap::new());
+//! metrics::configure_statsd("myprefix", "localhost:8125", BTreeMap::new(), true, 1.0);
 //! ```
 //!
 //! ## Macro Usage
@@ -203,7 +203,7 @@ pub fn configure_statsd<A: ToSocketAddrs>(
         }
     );
 
-    let socket = UdpSocket::bind(&addrs[..]).unwrap();
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     socket.set_nonblocking(true).unwrap();
 
     let statsd_client = if buffering {

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -132,6 +132,10 @@ impl MetricsClient {
         } else if self.sample_rate >= 1.0 {
             true
         } else {
+            // Using thread local RNG and uniform distribution here because Rng::gen_range is
+            // "optimized for the case that only a single sample is made from the given range".
+            // See https://docs.rs/rand/0.7.3/rand/distributions/uniform/struct.Uniform.html for more
+            // details.
             let mut rng = rand::thread_rng();
             RNG_UNIFORM_DISTRIBUTION
                 .with(|uniform_dist| uniform_dist.sample(&mut rng) <= self.sample_rate)

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -427,6 +427,8 @@ struct Metrics {
     /// If set to true, emitted metrics will be buffered to optimize performance.
     /// Defaults to true.
     buffering: bool,
+    /// Global sample rate for all emitted metrics.
+    sample_rate: f32,
 }
 
 impl Default for Metrics {
@@ -437,6 +439,7 @@ impl Default for Metrics {
             default_tags: BTreeMap::new(),
             hostname_tag: None,
             buffering: true,
+            sample_rate: 1.0,
         }
     }
 }
@@ -1251,9 +1254,14 @@ impl Config {
         self.values.metrics.hostname_tag.as_deref()
     }
 
-    /// Returns true if metrics buffering is enabled, false otherwise
+    /// Returns true if metrics buffering is enabled, false otherwise.
     pub fn metrics_buffering(&self) -> bool {
         self.values.metrics.buffering
+    }
+
+    /// Returns the global sample rate for all metrics.
+    pub fn metrics_sample_rate(&self) -> f32 {
+        self.values.metrics.sample_rate
     }
 
     /// Returns the default timeout for all upstream HTTP requests.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -427,7 +427,8 @@ struct Metrics {
     /// If set to true, emitted metrics will be buffered to optimize performance.
     /// Defaults to true.
     buffering: bool,
-    /// Global sample rate for all emitted metrics.
+    /// Global sample rate for all emitted metrics. Should be between 0.0 and 1.0.
+    /// For example, the value of 0.3 means that only 30% of the emitted metrics will be sent.
     sample_rate: f32,
 }
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -424,6 +424,9 @@ struct Metrics {
     default_tags: BTreeMap<String, String>,
     /// A tag name to report the hostname to, for each metric. Defaults to not sending such a tag.
     hostname_tag: Option<String>,
+    /// If set to true, emitted metrics will be buffered to optimize performance.
+    /// Defaults to true.
+    buffering: bool,
 }
 
 impl Default for Metrics {
@@ -433,6 +436,7 @@ impl Default for Metrics {
             prefix: "sentry.relay".into(),
             default_tags: BTreeMap::new(),
             hostname_tag: None,
+            buffering: true,
         }
     }
 }
@@ -1245,6 +1249,11 @@ impl Config {
     /// Returns the name of the hostname tag that should be attached to each outgoing metric.
     pub fn metrics_hostname_tag(&self) -> Option<&str> {
         self.values.metrics.hostname_tag.as_deref()
+    }
+
+    /// Returns true if metrics buffering is enabled, false otherwise
+    pub fn metrics_buffering(&self) -> bool {
+        self.values.metrics.buffering
     }
 
     /// Returns the default timeout for all upstream HTTP requests.

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -219,6 +219,7 @@ pub fn init_metrics(config: &Config) -> Result<(), Error> {
         &addrs[..],
         default_tags,
         config.metrics_buffering(),
+        config.metrics_sample_rate(),
     );
 
     Ok(())

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -214,7 +214,12 @@ pub fn init_metrics(config: &Config) -> Result<(), Error> {
             default_tags.insert(hostname_tag.to_owned(), hostname);
         }
     }
-    metrics::configure_statsd(config.metrics_prefix(), &addrs[..], default_tags);
+    metrics::configure_statsd(
+        config.metrics_prefix(),
+        &addrs[..],
+        default_tags,
+        config.metrics_buffering(),
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds the following features: 
1. Buffering + queuing option (`metrics.buffering`). If enabled, metrics will be queued and buffered in a separate thread. Set to `true` by default.
Caveat: `BufferedUdpMetricSink` doesn't flush until the buffer is full, so _theoretically_, if relay doesn't emit any metrics for a while (or if the sampling rate is set to something low), there could be delays in sending the metrics. But some metrics relay sends (e.g. about open/reused connections) are emitted regularly, so it shouldn't be an issue.
2. Global sampling rate (`metrics.sample_rate`). Set to 1.0 by default.

Note: the sampling implementation is pretty naive now, so for example we might simply ignore some calls to counters without scaling it back.