### PR TITLE
ref(envelopes): Validate user reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Internal**:
 
 - Always apply cache debouncing for project states. This reduces pressure on the Redis and file system cache. ([#819](https://github.com/getsentry/relay/pull/819))
+- Discard invalid user feedback sent as part of envelope. ([#823](https://github.com/getsentry/relay/pull/823))
 
 ## 20.10.1
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -18,7 +18,7 @@ use relay_general::pii::{PiiAttachmentsProcessor, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
     Breadcrumb, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp, LenientString,
-    Metrics, SecurityReportType, SessionUpdate, Timestamp, Values,
+    Metrics, SecurityReportType, SessionUpdate, Timestamp, UserReport, Values,
 };
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, Object, ProcessingAction, Value};
@@ -269,36 +269,41 @@ pub struct EventProcessor {
 }
 
 impl EventProcessor {
-    #[cfg(feature = "processing")]
-    pub fn new(
-        config: Arc<Config>,
-        rate_limiter: Option<RedisRateLimiter>,
-        geoip_lookup: Option<Arc<GeoIpLookup>>,
-    ) -> Self {
+    #[inline]
+    pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
-            rate_limiter,
-            geoip_lookup,
+            #[cfg(feature = "processing")]
+            rate_limiter: None,
+            #[cfg(feature = "processing")]
+            geoip_lookup: None,
         }
     }
 
-    #[cfg(not(feature = "processing"))]
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    #[cfg(feature = "processing")]
+    #[inline]
+    pub fn with_rate_limiter(mut self, rate_limiter: Option<RedisRateLimiter>) -> Self {
+        self.rate_limiter = rate_limiter;
+        self
+    }
+
+    #[cfg(feature = "processing")]
+    #[inline]
+    pub fn with_geoip_lookup(mut self, geoip_lookup: Option<Arc<GeoIpLookup>>) -> Self {
+        self.geoip_lookup = geoip_lookup;
+        self
     }
 
     /// Validates all sessions in the envelope, if any.
     ///
     /// Sessions are removed from the envelope if they contain invalid JSON or if their timestamps
     /// are out of range after clock drift correction.
-    fn process_sessions(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+    fn process_sessions(&self, state: &mut ProcessEnvelopeState) {
         let envelope = &mut state.envelope;
         let received = state.received_at;
-        let project_id = state.project_id;
 
         let clock_drift_processor =
             ClockDriftProcessor::new(envelope.sent_at(), received).at_least(MINIMUM_CLOCK_DRIFT);
-        let client = envelope.meta().client().map(str::to_owned);
 
         envelope.retain_items(|item| {
             if item.ty() != ItemType::Session {
@@ -311,20 +316,13 @@ impl EventProcessor {
             let mut session = match SessionUpdate::parse(&payload) {
                 Ok(session) => session,
                 Err(error) => {
-                    return sentry::with_scope(
-                        |scope| {
-                            scope.set_tag("project", project_id);
-                            if let Some(ref client) = client {
-                                scope.set_tag("sdk", client);
-                            }
-                            scope.set_extra("session", String::from_utf8_lossy(&payload).into());
-                        },
-                        || {
-                            // Skip gracefully here to allow sending other sessions.
-                            log::error!("failed to store session: {}", LogError(&error));
-                            false
-                        },
-                    );
+                    sentry::configure_scope(|scope| {
+                        scope.set_extra("session", String::from_utf8_lossy(&payload).into());
+                    });
+
+                    // Skip gracefully here to allow sending other sessions.
+                    log::error!("failed to store session: {}", LogError(&error));
+                    return false;
                 }
             };
 
@@ -371,8 +369,25 @@ impl EventProcessor {
 
             true
         });
+    }
 
-        Ok(())
+    /// Validates all user report/feedback items in the envelope, if any.
+    ///
+    /// User feedback items are removed from the envelope if they contain invalid JSON or if the
+    /// JSON violates the schema (basic type validation).
+    fn process_user_reports(&self, state: &mut ProcessEnvelopeState) {
+        state.envelope.retain_items(|item| {
+            if item.ty() != ItemType::UserReport {
+                return true;
+            };
+
+            if let Err(error) = serde_json::from_slice::<UserReport>(&item.payload()) {
+                log::error!("failed to store user report: {}", LogError(&error));
+                return false;
+            }
+
+            true
+        });
     }
 
     /// Creates and initializes the processing state.
@@ -1111,7 +1126,15 @@ impl EventProcessor {
         }
 
         let mut state = self.prepare_state(message)?;
-        self.process_sessions(&mut state)?;
+        sentry::configure_scope(|scope| {
+            scope.set_tag("project", state.project_id);
+            if let Some(ref client) = state.envelope.meta().client().map(str::to_owned) {
+                scope.set_tag("sdk", client);
+            }
+        });
+
+        self.process_sessions(&mut state);
+        self.process_user_reports(&mut state);
 
         if state.creates_event() {
             if_processing!({
@@ -1182,9 +1205,14 @@ impl Handler<ProcessEnvelope> for EventProcessor {
 
     fn handle(&mut self, message: ProcessEnvelope, _context: &mut Self::Context) -> Self::Result {
         metric!(timer(RelayTimers::EnvelopeWaitTime) = message.start_time.elapsed());
-        metric!(timer(RelayTimers::EnvelopeProcessingTime), {
-            self.process(message)
-        })
+        sentry::with_scope(
+            |_| (),
+            || {
+                metric!(timer(RelayTimers::EnvelopeProcessingTime), {
+                    self.process(message)
+                })
+            },
+        )
     }
 }
 
@@ -1229,11 +1257,9 @@ impl EventManager {
 
             SyncArbiter::start(
                 thread_count,
-                clone!(config, || EventProcessor::new(
-                    config.clone(),
-                    rate_limiter.clone(),
-                    geoip_lookup.clone(),
-                )),
+                clone!(config, || EventProcessor::new(config.clone())
+                    .with_rate_limiter(rate_limiter.clone())
+                    .with_geoip_lookup(geoip_lookup.clone())),
             )
         };
 
@@ -1612,6 +1638,8 @@ impl Handler<GetCapturedEvent> for EventManager {
 mod tests {
     use super::*;
 
+    use crate::extractors::RequestMeta;
+
     use chrono::{DateTime, TimeZone, Utc};
 
     fn create_breadcrumbs_item(breadcrumbs: &[(Option<DateTime<Utc>>, &str)]) -> Item {
@@ -1754,5 +1782,43 @@ mod tests {
 
         // regression test to ensure we don't fail parsing an empty file
         result.expect("event_from_attachments");
+    }
+
+    #[test]
+    fn test_user_report_invalid() {
+        let processor = EventProcessor::new(Arc::new(Default::default()));
+        let event_id = EventId::new();
+
+        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
+            .parse()
+            .unwrap();
+
+        let request_meta = RequestMeta::new(dsn);
+        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
+
+        envelope.add_item({
+            let mut item = Item::new(ItemType::UserReport);
+            item.set_payload(ContentType::Json, r###"{"foo": "bar"}"###);
+            item
+        });
+
+        envelope.add_item({
+            let mut item = Item::new(ItemType::Event);
+            item.set_payload(ContentType::Json, "{}");
+            item
+        });
+
+        let envelope_response = processor
+            .process(ProcessEnvelope {
+                envelope,
+                project_state: Arc::new(ProjectState::allowed()),
+                start_time: Instant::now(),
+            })
+            .unwrap();
+
+        let new_envelope = envelope_response.envelope.unwrap();
+
+        assert_eq!(new_envelope.len(), 1);
+        assert_eq!(new_envelope.items().next().unwrap().ty(), ItemType::Event);
     }
 }


### PR DESCRIPTION
This is modelled after session validation.

While doing that I noticed that some of the Sentry tags we set are
useful for both codepaths, so I moved the with_scope outside, which is
more expensive due to allocating new strings 100% of the time, but
cleaner.  Ideally we would be able to assign borrowed data to the scope
at some point to actually make this fast.

I also wanted to test this within Rust, so I changed some of the
constructors to be easier to use from tests.