### PR TITLE
ref(store): Emit event errors for unknown breadcrumb keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 **Internal**:
 
 - Always apply cache debouncing for project states. This reduces pressure on the Redis and file system cache. ([#819](https://github.com/getsentry/relay/pull/819))
+- Emit event errors and normalization errors for unknown breadcrumb keys. ([#824](https://github.com/getsentry/relay/pull/824))
+- Normalize `breadcrumb.ty` into `breadcrumb.type` for broken Python SDK versions. ([#824](https://github.com/getsentry/relay/pull/824))
 
 ## 20.10.1
 

--- a/relay-general/src/protocol/breadcrumb.rs
+++ b/relay-general/src/protocol/breadcrumb.rs
@@ -76,7 +76,7 @@ pub struct Breadcrumb {
     ///
     ///   Such a breadcrumb's `data` property has the fields `url`, `method`, `status_code`
     ///   (integer) and `reason` (string).
-    #[metastructure(field = "type", max_chars = "enumlike")]
+    #[metastructure(field = "type", legacy_alias = "ty", max_chars = "enumlike")]
     pub ty: Annotated<String>,
 
     /// A dotted string indicating what the crumb is or from where it comes. _Optional._
@@ -177,6 +177,22 @@ fn test_breadcrumb_default_values() {
 
     let breadcrumb = Annotated::new(Breadcrumb {
         timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0).into()),
+        ..Default::default()
+    });
+
+    assert_eq_dbg!(breadcrumb, Annotated::from_json(input).unwrap());
+    assert_eq_str!(output, breadcrumb.to_json().unwrap());
+}
+
+#[test]
+fn test_python_ty_regression() {
+    // The Python SDK used to send "ty" instead of "type". We're lenient to accept both.
+    let input = r#"{"timestamp":946684800,"ty":"http"}"#;
+    let output = r#"{"timestamp":946684800.0,"type":"http"}"#;
+
+    let breadcrumb = Annotated::new(Breadcrumb {
+        timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0).into()),
+        ty: Annotated::new("http".into()),
         ..Default::default()
     });
 


### PR DESCRIPTION
Emits normalization errors and event errors for unknown attributes in breadcrumbs.

See discussion on https://github.com/getsentry/sentry-python/pull/884#issuecomment-713682192.