### PR TITLE
fix(server): Add a client SDK interface for unreal crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Discard invalid user feedback sent as part of envelope. ([#823](https://github.com/getsentry/relay/pull/823))
 - Emit event errors and normalization errors for unknown breadcrumb keys. ([#824](https://github.com/getsentry/relay/pull/824))
 - Normalize `breadcrumb.ty` into `breadcrumb.type` for broken Python SDK versions. ([#824](https://github.com/getsentry/relay/pull/824))
+- Add the client SDK interface for unreal crashes and set the name to `unreal.crashreporter`. ([#828](https://github.com/getsentry/relay/pull/828))
 
 ## 20.10.1
 

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
@@ -1,0 +1,36 @@
+---
+source: relay-server/src/utils/unreal.rs
+expression: "Annotated::new(event).to_json_pretty().unwrap()"
+---
+{
+  "logentry": {
+    "formatted": "Access violation - code c0000005 (first/second chance not available)"
+  },
+  "user": {
+    "username": "bruno"
+  },
+  "contexts": {
+    "device": {
+      "memory_size": 6896832512,
+      "type": "device"
+    },
+    "gpu": {
+      "name": "Parallels Display Adapter (WDDM)",
+      "type": "gpu"
+    },
+    "os": {
+      "name": "Windows 10",
+      "type": "os"
+    },
+    "unreal": {
+      "crash_reporter_client_version": "1.0",
+      "custom": {
+        "CrashVersion": "3",
+        "PlatformFullName": "Win64 [Windows 10  64b]"
+      },
+      "memory_stats_total_virtual": 140737488224256,
+      "misc_cpu_brand": "Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz",
+      "misc_cpu_vendor": "GenuineIntel"
+    }
+  }
+}

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
@@ -23,7 +23,6 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "type": "os"
     },
     "unreal": {
-      "crash_reporter_client_version": "1.0",
       "custom": {
         "CrashVersion": "3",
         "PlatformFullName": "Win64 [Windows 10  64b]"
@@ -32,5 +31,9 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "misc_cpu_brand": "Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz",
       "misc_cpu_vendor": "GenuineIntel"
     }
+  },
+  "sdk": {
+    "name": "unreal.crashreporter",
+    "version": "1.0"
   }
 }

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
@@ -29,7 +29,6 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "build_configuration": "Development",
       "build_version": "++UE4+Release-4.20-CL-4369336",
       "crash_guid": "UE4CC-Windows-63456D684167A2659DE73EA3517BEDC4_0000",
-      "crash_reporter_client_version": "1.0",
       "crash_type": "Crash",
       "custom": {
         "CommandLine": "",
@@ -90,5 +89,9 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "machine_id",
       "C52DC39D-DAF3-5E36-A8D3-BF5F53A5D38F"
     ]
-  ]
+  ],
+  "sdk": {
+    "name": "unreal.crashreporter",
+    "version": "1.0"
+  }
 }

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
@@ -1,6 +1,6 @@
 ---
 source: relay-server/src/utils/unreal.rs
-expression: event.to_json_pretty().unwrap()
+expression: "Annotated::new(event).to_json_pretty().unwrap()"
 ---
 {
   "logentry": {

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_logs.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_logs.snap
@@ -1,0 +1,30 @@
+---
+source: relay-server/src/utils/unreal.rs
+expression: "Annotated::new(event).to_json_pretty().unwrap()"
+---
+{
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1540832198.0,
+        "category": "LogGameplayTags",
+        "message": "Display: UGameplayTagsManager::DoneAddingNativeTags. DelegateIsBound: 0"
+      },
+      {
+        "timestamp": 1540832199.0,
+        "category": "LogStats",
+        "message": "UGameplayTagsManager::ConstructGameplayTagTree: ImportINI prefixes -  0.000 s"
+      },
+      {
+        "timestamp": 1540832200.0,
+        "category": "LogStats",
+        "message": "UGameplayTagsManager::ConstructGameplayTagTree: Construct from data asset -  0.000 s"
+      },
+      {
+        "timestamp": 1540832201.0,
+        "category": "LogStats",
+        "message": "UGameplayTagsManager::ConstructGameplayTagTree: ImportINI -  0.000 s"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Cleans up unreal testing code and adds a client SDK interface named `unreal.crashreporter` to the event payload when an unreal context was detected. 

This was omitted in #376 originally, since the unreal crash reporter is not an SDK. However, the SDK interface is used for analytics. Note that the original value of this was `sentry.unreal.crashreporter`.

See [Python store code](https://github.com/getsentry/sentry/blob/b20681562efa3d9b3543a6db95b2863590ce4107/src/sentry/lang/native/unreal.py#L125-L126)