### PR TITLE
fix(quotas): Apply GRACE only to redis TTL, not the actual retry-after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug Fixes**:
 
 - Accept sessions with IP address set to `{{auto}}`. This was previously rejected and silently dropped. ([#827](https://github.com/getsentry/relay/pull/827))
+- Fix an issue where every retry-after response would be too large by one minute. ([#829](https://github.com/getsentry/relay/pull/829))
 
 **Internal**:
 

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -93,7 +93,7 @@ impl<'a> RedisQuota<'a> {
     fn expiry(&self) -> UnixTimestamp {
         let next_slot = self.slot() + 1;
         let next_start = next_slot * self.window + self.shift();
-        UnixTimestamp::from_secs(next_start + GRACE)
+        UnixTimestamp::from_secs(next_start)
     }
 
     fn key(&self) -> String {
@@ -197,7 +197,7 @@ impl RedisRateLimiter {
                 invocation.key(refund_key);
 
                 invocation.arg(quota.limit());
-                invocation.arg(quota.expiry().as_secs());
+                invocation.arg(quota.expiry().as_secs() + GRACE);
                 invocation.arg(quantity);
 
                 tracked_quotas.push(quota);

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -8,6 +8,7 @@ import six
 import socket
 import threading
 import pytest
+import time
 
 from requests.exceptions import HTTPError
 from flask import abort, Response
@@ -462,6 +463,10 @@ def test_processing(
     assert event.get("version") is not None
 
 
+@pytest.mark.parametrize("window,max_rate_limit", [
+    (100, 300),
+    (300, 100),
+])
 @pytest.mark.parametrize("event_type", ["default", "error", "transaction"])
 def test_processing_quotas(
     mini_sentry,
@@ -470,10 +475,12 @@ def test_processing_quotas(
     events_consumer,
     transactions_consumer,
     event_type,
+    window,
+    max_rate_limit
 ):
     from time import sleep
 
-    relay = relay_with_processing({"processing": {"max_rate_limit": 120}})
+    relay = relay_with_processing({"processing": {"max_rate_limit": max_rate_limit}})
 
     mini_sentry.project_configs[42] = projectconfig = mini_sentry.full_project_config()
     public_keys = projectconfig["publicKeys"]
@@ -489,7 +496,7 @@ def test_processing_quotas(
             "scopeId": six.text_type(key_id),
             "categories": [category],
             "limit": 5,
-            "window": 3600,
+            "window": window,
             "reasonCode": "get_lost",
         }
     ]
@@ -543,10 +550,9 @@ def test_processing_quotas(
             relay.send_event(42, transform({"message": "rate_limited"}))
         headers = excinfo.value.response.headers
 
-        # The rate limit is actually for 1 hour, but we cap at 120s with the
-        # max_rate_limit parameter
         retry_after = headers["retry-after"]
-        assert int(retry_after) <= 120
+        assert int(retry_after) <= window
+        assert int(retry_after) <= max_rate_limit
         retry_after2, rest = headers["x-sentry-rate-limits"].split(":", 1)
         assert int(retry_after2) == int(retry_after)
         assert rest == "%s:key" % category

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -463,10 +463,7 @@ def test_processing(
     assert event.get("version") is not None
 
 
-@pytest.mark.parametrize("window,max_rate_limit", [
-    (100, 300),
-    (300, 100),
-])
+@pytest.mark.parametrize("window,max_rate_limit", [(100, 300), (300, 100),])
 @pytest.mark.parametrize("event_type", ["default", "error", "transaction"])
 def test_processing_quotas(
     mini_sentry,
@@ -476,7 +473,7 @@ def test_processing_quotas(
     transactions_consumer,
     event_type,
     window,
-    max_rate_limit
+    max_rate_limit,
 ):
     from time import sleep
 


### PR DESCRIPTION
See original Python code, where grace has only been added for some invocations of get_next_period_start.

This bug was introduced during the first port, not jan's refactor.

https://github.com/getsentry/sentry/blob/28d497fb8af6cc3efbe160e28c1c08f08bd688fc/src/sentry/quotas/redis.py#L199