### PR TITLE
ref: Upgrade to upcoming sentry SDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,7 +2904,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "schemars",
- "sentry-types 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.20.1",
  "serde",
 ]
 
@@ -3351,8 +3351,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933beb0343c84eefd69a368318e9291b179e09e51982d49c65d7b362b0e9466f"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -3367,8 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e528fb457baf53fcd6c90beb420705f35c12c3d8caed8817dcf7be00eff7c7"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3378,8 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3a560a34cffac347f0b588fc29b31db969e27bf57208f946d6a2d588668b0b"
 dependencies = [
  "hostname",
  "lazy_static",
@@ -3392,21 +3395,23 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b8c235063c1007fd8e2fc7e35ce7eac09dd678d198ecc996daee33d46b3dcc"
 dependencies = [
  "im",
  "lazy_static",
  "rand 0.7.3",
- "sentry-types 0.20.1 (git+https://github.com/getsentry/sentry-rust)",
+ "sentry-types 0.21.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632e47b19ff9712bd22424ccf57a21a0e5f3bf4a2e12baae447e01d81e8e2f22"
 dependencies = [
  "findshlibs",
  "lazy_static",
@@ -3415,8 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-failure"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50990857da645b6f3f6d97d94dc3a34295d40286961164572052bcf78c113021"
 dependencies = [
  "failure",
  "sentry-backtrace",
@@ -3425,8 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af91b9d4f34cc53ebd109cae92b0e1373df2524e915af95f212b9d0601bff241"
 dependencies = [
  "log",
  "sentry-core",
@@ -3434,8 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ee338d8292fcdcfb032929c9f53bc0dfac8e0b9d3096be79ceee96818851ed"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3469,8 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.20.1"
-source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fbbea6debac0a24880a38239d4c2fc3dbb0b1b398f621bea03ed761796b7dfb"
 dependencies = [
  "chrono",
  "debugid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2904,7 +2904,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "schemars",
- "sentry-types",
+ "sentry-types 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -3046,6 +3046,7 @@ dependencies = [
  "env_logger",
  "failure",
  "flate2",
+ "fragile",
  "futures 0.1.29",
  "insta 0.16.0",
  "itertools 0.8.2",
@@ -3069,7 +3070,6 @@ dependencies = [
  "relay-redis",
  "rmp-serde",
  "sentry",
- "sentry-actix",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
@@ -3352,8 +3352,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "sentry"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144e85b28d129f056ef91664fe2b985eade906d2838752c2f61c9f233cd98e4a"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -3367,23 +3366,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-actix"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f534ff69609cdb84413cea364545d9318a02dccd629a5786cceff2604480f85f"
-dependencies = [
- "actix-web",
- "failure",
- "fragile",
- "sentry",
- "sentry-failure",
-]
-
-[[package]]
 name = "sentry-backtrace"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92dabd890482f152fb6d261fe2034a193facc2c99c0c571bbf7687c356fcb2e8"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3394,8 +3379,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039ac50d2d740d51c5d376c2e9e93725eea662fa3acdcbcfe1b8b93a3b30c478"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "hostname",
  "lazy_static",
@@ -3409,13 +3393,12 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe4fe890b12416701f838c702898a9c5e574c333cfbbee9fb7855a14e6490a3"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "im",
  "lazy_static",
  "rand 0.7.3",
- "sentry-types",
+ "sentry-types 0.20.1 (git+https://github.com/getsentry/sentry-rust)",
  "serde",
  "serde_json",
 ]
@@ -3423,8 +3406,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3d5f2b7822a6e54a7711cc49a92e2bab023198fb1a7342b8d1768d4987ec6a"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "findshlibs",
  "lazy_static",
@@ -3434,8 +3416,7 @@ dependencies = [
 [[package]]
 name = "sentry-failure"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead35e7019f77a79ed0345b3f3c28427139100f87f318c1c3e2788db2cdea8b7"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "failure",
  "sentry-backtrace",
@@ -3445,19 +3426,16 @@ dependencies = [
 [[package]]
 name = "sentry-log"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecacbaff50702c1028124ac834a25040bf13b6fbd720156fb817eafaea2c0e9"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "log",
- "sentry-backtrace",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-panic"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8a3ac989339a76efd6155f9d02675ce4b04419cd8083ca58d083c222554147"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3479,6 +3457,20 @@ name = "sentry-types"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8124f0e9bc1113ecbcc8c3746e0e590943cf23e7d09c70a088c116869bb12e3"
+dependencies = [
+ "chrono",
+ "debugid",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url 2.1.1",
+ "uuid 0.8.1",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.20.1"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "chrono",
  "debugid",

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -23,7 +23,7 @@ failure = { version = "0.1.8", optional = true }
 log = { version = "0.4.8", optional = true }
 relay-common = { path = "../relay-common" }
 relay-redis = { path = "../relay-redis", optional = true }
-sentry = { git = "https://github.com/getsentry/sentry-rust", optional = true }
+sentry = { version = "0.21.0", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 smallvec = { version = "1.4.0", features = ["serde"] }
 

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -23,7 +23,7 @@ failure = { version = "0.1.8", optional = true }
 log = { version = "0.4.8", optional = true }
 relay-common = { path = "../relay-common" }
 relay-redis = { path = "../relay-redis", optional = true }
-sentry = { version = "0.20.1", optional = true }
+sentry = { git = "https://github.com/getsentry/sentry-rust", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 smallvec = { version = "1.4.0", features = ["serde"] }
 

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -53,8 +53,8 @@ relay-general = { path = "../relay-general" }
 relay-quotas = { path = "../relay-quotas" }
 relay-redis = { path = "../relay-redis" }
 rmp-serde = "0.14.3"
-sentry = "0.20.1"
-sentry-actix = "0.20.1"
+sentry = { git = "https://github.com/getsentry/sentry-rust", features = ["failure"] }
+fragile = "1.0.0" # used for vendoring sentry-actix
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -53,7 +53,7 @@ relay-general = { path = "../relay-general" }
 relay-quotas = { path = "../relay-quotas" }
 relay-redis = { path = "../relay-redis" }
 rmp-serde = "0.14.3"
-sentry = { git = "https://github.com/getsentry/sentry-rust", features = ["failure"] }
+sentry = { version = "0.21.0", features = ["failure"] }
 fragile = "1.0.0" # used for vendoring sentry-actix
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -3,13 +3,13 @@ use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, HttpResponse, Resp
 use failure::Fail;
 use futures::prelude::*;
 use sentry::Hub;
-use sentry_actix::ActixWebHubExt;
 use serde::de::DeserializeOwned;
 
 use relay_auth::RelayId;
 use relay_common::tryf;
 
 use crate::actors::relays::{GetRelay, RelayInfo};
+use crate::middlewares::ActixWebHubExt;
 use crate::service::ServiceState;
 use crate::utils::ApiErrorResponse;
 

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -1,9 +1,19 @@
+#![allow(deprecated)]
+
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use actix_web::error::Error;
 use actix_web::middleware::{Finished, Middleware, Response, Started};
 use actix_web::{http::header, Body, HttpMessage, HttpRequest, HttpResponse};
+use failure::Fail;
 use futures::prelude::*;
+use sentry::integrations::failure::exception_from_single_fail;
+use sentry::protocol::{ClientSdkPackage, Event};
+use sentry::types::Uuid;
+use sentry::{Hub, Level, ScopeGuard};
 
 use relay_common::metric;
 
@@ -108,5 +118,212 @@ impl<S> Middleware<S> for ReadRequestMiddleware {
             .map_err(Error::from);
 
         Ok(Response::Future(Box::new(future)))
+    }
+}
+
+/// Reports certain failures to sentry.
+pub struct SentryMiddleware {
+    emit_header: bool,
+    capture_server_errors: bool,
+}
+
+struct HubWrapper {
+    hub: Arc<Hub>,
+    root_scope: RefCell<Option<ScopeGuard>>,
+}
+
+impl SentryMiddleware {
+    /// Creates a new sentry middleware.
+    pub fn new() -> SentryMiddleware {
+        SentryMiddleware {
+            emit_header: false,
+            capture_server_errors: true,
+        }
+    }
+
+    fn new_hub(&self) -> Arc<Hub> {
+        Arc::new(Hub::new_from_top(Hub::main()))
+    }
+}
+
+impl Default for SentryMiddleware {
+    fn default() -> Self {
+        SentryMiddleware::new()
+    }
+}
+
+fn extract_request<S: 'static>(
+    req: &HttpRequest<S>,
+    with_pii: bool,
+) -> (Option<String>, sentry::protocol::Request) {
+    let resource = req.resource();
+    let transaction = if let Some(rdef) = resource.rdef() {
+        Some(rdef.pattern().to_string())
+    } else if resource.name() != "" {
+        Some(resource.name().to_string())
+    } else {
+        None
+    };
+    let mut sentry_req = sentry::protocol::Request {
+        url: format!(
+            "{}://{}{}",
+            req.connection_info().scheme(),
+            req.connection_info().host(),
+            req.uri()
+        )
+        .parse()
+        .ok(),
+        method: Some(req.method().to_string()),
+        headers: req
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str().into(), v.to_str().unwrap_or("").into()))
+            .collect(),
+        ..Default::default()
+    };
+
+    if with_pii {
+        if let Some(remote) = req.connection_info().remote() {
+            sentry_req.env.insert("REMOTE_ADDR".into(), remote.into());
+        }
+    };
+
+    (transaction, sentry_req)
+}
+
+impl<S: 'static> Middleware<S> for SentryMiddleware {
+    fn start(&self, req: &HttpRequest<S>) -> Result<Started, Error> {
+        let hub = self.new_hub();
+        let outer_req = req;
+        let req = outer_req.clone();
+        let client = hub.client();
+
+        let req = fragile::SemiSticky::new(req);
+        let cached_data = Arc::new(Mutex::new(None));
+
+        let root_scope = hub.push_scope();
+        hub.configure_scope(move |scope| {
+            scope.add_event_processor(Box::new(move |mut event| {
+                let mut cached_data = cached_data.lock().unwrap();
+                if cached_data.is_none() && req.is_valid() {
+                    let with_pii = client
+                        .as_ref()
+                        .map_or(false, |x| x.options().send_default_pii);
+                    *cached_data = Some(extract_request(&req.get(), with_pii));
+                }
+
+                if let Some((ref transaction, ref req)) = *cached_data {
+                    if event.transaction.is_none() {
+                        event.transaction = transaction.clone();
+                    }
+                    if event.request.is_none() {
+                        event.request = Some(req.clone());
+                    }
+                }
+
+                if let Some(sdk) = event.sdk.take() {
+                    let mut sdk = sdk.into_owned();
+                    sdk.packages.push(ClientSdkPackage {
+                        name: "sentry-actix".into(),
+                        version: env!("CARGO_PKG_VERSION").into(),
+                    });
+                    event.sdk = Some(Cow::Owned(sdk));
+                }
+
+                Some(event)
+            }));
+        });
+
+        outer_req.extensions_mut().insert(HubWrapper {
+            hub,
+            root_scope: RefCell::new(Some(root_scope)),
+        });
+        Ok(Started::Done)
+    }
+
+    fn response(&self, req: &HttpRequest<S>, mut resp: HttpResponse) -> Result<Response, Error> {
+        if self.capture_server_errors && resp.status().is_server_error() {
+            let event_id = if let Some(error) = resp.error() {
+                Some(Hub::from_request(req).capture_actix_error(error))
+            } else {
+                None
+            };
+            match event_id {
+                Some(event_id) if self.emit_header => {
+                    resp.headers_mut().insert(
+                        "x-sentry-event",
+                        event_id.to_simple_ref().to_string().parse().unwrap(),
+                    );
+                }
+                _ => {}
+            }
+        }
+        Ok(Response::Done(resp))
+    }
+
+    fn finish(&self, req: &HttpRequest<S>, _resp: &HttpResponse) -> Finished {
+        // if we make it to the end of the request we want to first drop the root
+        // scope before we drop the entire hub.  This will first drop the closures
+        // on the scope which in turn will release the circular dependency we have
+        // with the hub via the request.
+        if let Some(hub_wrapper) = req.extensions().get::<HubWrapper>() {
+            if let Ok(mut guard) = hub_wrapper.root_scope.try_borrow_mut() {
+                guard.take();
+            }
+        }
+        Finished::Done
+    }
+}
+
+/// Hub extensions for actix.
+pub trait ActixWebHubExt {
+    /// Returns the hub from a given http request.
+    ///
+    /// This requires that the `SentryMiddleware` middleware has been enabled or the
+    /// call will panic.
+    fn from_request<S>(req: &HttpRequest<S>) -> Arc<Hub>;
+    /// Captures an actix error on the given hub.
+    fn capture_actix_error(&self, err: &Error) -> Uuid;
+}
+
+impl ActixWebHubExt for Hub {
+    fn from_request<S>(req: &HttpRequest<S>) -> Arc<Hub> {
+        req.extensions()
+            .get::<HubWrapper>()
+            .expect("SentryMiddleware middleware was not registered")
+            .hub
+            .clone()
+    }
+
+    fn capture_actix_error(&self, err: &Error) -> Uuid {
+        let mut exceptions = vec![];
+        let mut ptr: Option<&dyn Fail> = Some(err.as_fail());
+        let mut idx = 0;
+        while let Some(fail) = ptr {
+            // Check whether the failure::Fail held by err is a failure::Error wrapped in Compat
+            // If that's the case, we should be logging that error and its fail instead of the wrapper's construction in actix_web
+            // This wouldn't be necessary if failure::Compat<failure::Error>'s Fail::backtrace() impl was not "|| None",
+            // that is however impossible to do as of now because it conflicts with the generic implementation of Fail also provided in failure.
+            // Waiting for update that allows overlap, (https://github.com/rust-lang/rfcs/issues/1053), but chances are by then failure/std::error will be refactored anyway
+            let compat: Option<&failure::Compat<failure::Error>> = fail.downcast_ref();
+            let failure_err = compat.map(failure::Compat::get_ref);
+            let fail = failure_err.map_or(fail, |x| x.as_fail());
+            exceptions.push(exception_from_single_fail(
+                fail,
+                if idx == 0 {
+                    Some(failure_err.map_or_else(|| err.backtrace(), |err| err.backtrace()))
+                } else {
+                    fail.backtrace()
+                },
+            ));
+            ptr = fail.cause();
+            idx += 1;
+        }
+        exceptions.reverse();
+        self.capture_event(Event {
+            exception: exceptions.into(),
+            level: Level::Error,
+            ..Default::default()
+        })
     }
 }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -6,7 +6,6 @@ use actix_web::{server, App};
 use failure::ResultExt;
 use failure::{Backtrace, Context, Fail};
 use listenfd::ListenFd;
-use sentry_actix::SentryMiddleware;
 
 use relay_common::clone;
 use relay_config::Config;
@@ -21,7 +20,9 @@ use crate::actors::project_cache::ProjectCache;
 use crate::actors::relays::RelayCache;
 use crate::actors::upstream::UpstreamRelay;
 use crate::endpoints;
-use crate::middlewares::{AddCommonHeaders, ErrorHandlers, Metrics, ReadRequestMiddleware};
+use crate::middlewares::{
+    AddCommonHeaders, ErrorHandlers, Metrics, ReadRequestMiddleware, SentryMiddleware,
+};
 
 /// Common error type for the relay server.
 #[derive(Debug)]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -30,7 +30,7 @@ pretty_env_logger = "0.4.0"
 relay-common = { path = "../relay-common" }
 relay-config = { path = "../relay-config" }
 relay-server = { path = "../relay-server" }
-sentry = { git = "https://github.com/getsentry/sentry-rust", features = ["debug-images", "log"] }
+sentry = { version = "0.21.0", features = ["debug-images", "log"] }
 serde = "1.0.114"
 serde_json = "1.0.55"
 hostname = "0.3.1"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -30,7 +30,7 @@ pretty_env_logger = "0.4.0"
 relay-common = { path = "../relay-common" }
 relay-config = { path = "../relay-config" }
 relay-server = { path = "../relay-server" }
-sentry = { version = "0.20.1", features = ["debug-images", "log"] }
+sentry = { git = "https://github.com/getsentry/sentry-rust", features = ["debug-images", "log"] }
 serde = "1.0.114"
 serde_json = "1.0.55"
 hostname = "0.3.1"

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -77,7 +77,8 @@ def mini_sentry(request):
     def get_error_message(data):
         exceptions = data.get("exception", {}).get("values", [])
         exc_msg = (exceptions[0] or {}).get("value")
-        message = data.get("message", {}).get("formatted")
+        message = data.get("message", {})
+        message = message if type(message) == str else message.get("formatted")
         return exc_msg or message or "unknown error"
 
     @app.before_request


### PR DESCRIPTION
This is vendoring in the old sentry-actix integration, as the new SDK only supports actix-web 3

#skip-changelog