### PR TITLE
Ref(test): Cleanup mini_sentry

### DIFF
--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -55,7 +55,11 @@ class SentryLike(object):
             return self.default_dsn_public_key
 
         if len(public_keys) <= idx:
-            raise Exception("Invalid public key index:{} requested for project_id:{}".format(idx, project_id))
+            raise Exception(
+                "Invalid public key index:{} requested for project_id:{}".format(
+                    idx, project_id
+                )
+            )
 
         key_config = public_keys[idx]
 
@@ -65,7 +69,7 @@ class SentryLike(object):
     def url(self):
         return "http://{}:{}".format(*self.server_address)
 
-    def get_auth_header(self, project_id, dsn_key_idx=0, dsn_key= None):
+    def get_auth_header(self, project_id, dsn_key_idx=0, dsn_key=None):
         if dsn_key is None:
             dsn_key = self.get_dsn_public_key(project_id, dsn_key_idx)
         return (
@@ -107,7 +111,15 @@ class SentryLike(object):
             else:
                 yield from self.upstream.iter_public_keys()
 
-    def send_event(self, project_id, payload=None, headers=None, legacy=False, dsn_key_idx=0, dsn_key=None):
+    def send_event(
+        self,
+        project_id,
+        payload=None,
+        headers=None,
+        legacy=False,
+        dsn_key_idx=0,
+        dsn_key=None,
+    ):
         if payload is None:
             payload = {"message": "Hello, World!"}
 
@@ -159,12 +171,19 @@ class SentryLike(object):
         self.send_envelope(project_id, envelope)
 
     def send_security_report(
-        self, project_id, content_type, payload, release, environment, origin=None, dsn_key_idx=0
+        self,
+        project_id,
+        content_type,
+        payload,
+        release,
+        environment,
+        origin=None,
+        dsn_key_idx=0,
     ):
         headers = {
             "Content-Type": content_type,
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                          "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+            "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
         }
 
         if origin is not None:
@@ -172,7 +191,10 @@ class SentryLike(object):
 
         response = self.post(
             "/api/{}/security/?sentry_key={}&sentry_release={}&sentry_environment={}".format(
-                project_id, self.get_dsn_public_key(project_id, dsn_key_idx), release, environment
+                project_id,
+                self.get_dsn_public_key(project_id, dsn_key_idx),
+                release,
+                environment,
             ),
             headers=headers,
             json=payload,
@@ -199,10 +221,12 @@ class SentryLike(object):
                 all_files[param[0]] = (None, param[1])
 
         response = self.post(
-            "/api/{}/minidump/?sentry_key={}".format(project_id, self.get_dsn_public_key(project_id, dsn_key_idx)),
+            "/api/{}/minidump/?sentry_key={}".format(
+                project_id, self.get_dsn_public_key(project_id, dsn_key_idx)
+            ),
             headers={
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                              "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+                "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
             },
             files=all_files,
         )
@@ -217,10 +241,12 @@ class SentryLike(object):
         :param file_content: the unreal file content
         """
         response = self.post(
-            "/api/{}/unreal/{}/".format(project_id, self.get_dsn_public_key(project_id,dsn_key_idx)),
+            "/api/{}/unreal/{}/".format(
+                project_id, self.get_dsn_public_key(project_id, dsn_key_idx)
+            ),
             headers={
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                              "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+                "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
             },
             data=file_content,
         )
@@ -236,11 +262,13 @@ class SentryLike(object):
             "/api/{}/events/{}/attachments/".format(project_id, event_id),
             headers={
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                              "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+                "(KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
                 "X-Sentry-Auth": (
                     "Sentry sentry_version=5, sentry_timestamp=1535376240291, "
                     "sentry_client=raven-node/2.6.3, "
-                    "sentry_key={}".format(self.get_dsn_public_key(project_id,dsn_key_idx))
+                    "sentry_key={}".format(
+                        self.get_dsn_public_key(project_id, dsn_key_idx)
+                    )
                 ),
             },
             files=files,

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -16,6 +16,7 @@ class SentryLike(object):
         self.server_address = server_address
         self.upstream = upstream
         self.public_key = public_key
+        self.public_keys = {}
 
     @property
     def url(self):
@@ -68,6 +69,7 @@ class SentryLike(object):
             else:
                 yield from self.upstream.iter_public_keys()
 
+    # TODO RaduW remove after figuring out how to replace it in: test_store.py::test_store_external_relay
     def basic_project_config(self):
         return {
             "projectId": 42,
@@ -90,32 +92,6 @@ class SentryLike(object):
                     },
                 },
             },
-        }
-
-    def full_project_config(self):
-        basic = self.basic_project_config()
-        full = {
-            "organizationId": 1,
-            "config": {
-                "excludeFields": [],
-                "filterSettings": {},
-                "scrubIpAddresses": False,
-                "sensitiveFields": [],
-                "scrubDefaults": True,
-                "scrubData": True,
-                "groupingConfig": {
-                    "id": "legacy:2019-03-12",
-                    "enhancements": "eJybzDhxY05qemJypZWRgaGlroGxrqHRBABbEwcC",
-                },
-                "blacklistedIps": ["127.43.33.22"],
-                "trustedRelays": [],
-            },
-        }
-
-        return {
-            **basic,
-            **full,
-            "config": {**basic["config"], **full["config"]},
         }
 
     def send_event(self, project_id, payload=None, headers=None, legacy=False):

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -69,31 +69,6 @@ class SentryLike(object):
             else:
                 yield from self.upstream.iter_public_keys()
 
-    # TODO RaduW remove after figuring out how to replace it in: test_store.py::test_store_external_relay
-    def basic_project_config(self):
-        return {
-            "projectId": 42,
-            "slug": "python",
-            "publicKeys": [
-                {"publicKey": self.dsn_public_key, "isEnabled": True, "numericId": 123}
-            ],
-            "rev": "5ceaea8c919811e8ae7daae9fe877901",
-            "disabled": False,
-            "lastFetch": datetime.datetime.utcnow().isoformat() + "Z",
-            "lastChange": datetime.datetime.utcnow().isoformat() + "Z",
-            "config": {
-                "allowedDomains": ["*"],
-                "trustedRelays": list(self.iter_public_keys()),
-                "piiConfig": {
-                    "rules": {},
-                    "applications": {
-                        "$string": ["@email", "@mac", "@creditcard", "@userpath"],
-                        "$object": ["@password"],
-                    },
-                },
-            },
-        }
-
     def send_event(self, project_id, payload=None, headers=None, legacy=False):
         if payload is None:
             payload = {"message": "Hello, World!"}

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -36,7 +36,7 @@ class Sentry(SentryLike):
     @property
     def internal_error_dsn(self):
         """DSN whose events make the test fail."""
-        return "http://{}@{}:{}/666".format(self.dsn_public_key, *self.server_address)
+        return "http://{}@{}:{}/666".format(self.default_dsn_public_key, *self.server_address)
 
     def get_hits(self, path):
         return self.hits.get(path) or 0
@@ -51,13 +51,19 @@ class Sentry(SentryLike):
             s += "> %s: %s\n" % (route, error)
         return s
 
-    def add_basic_project_config(self, project_id, public_key=None):
-        #TODO fix public_key
+    def add_basic_project_config(self, project_id, dsn_public_key=None):
+
+        if dsn_public_key is None:
+            dsn_public_key = uuid.uuid4().hex
+
+        print("Adding dsn:{} to project:{}".format(dsn_public_key, project_id))
+        self.dsn_public_keys[project_id] = dsn_public_key
+
         ret_val = {
             "projectId": project_id,
             "slug": "python",
             "publicKeys": [
-                {"publicKey": self.dsn_public_key, "isEnabled": True, "numericId": 123}
+                {"publicKey": dsn_public_key, "isEnabled": True, "numericId": 123}
             ],
             "rev": "5ceaea8c919811e8ae7daae9fe877901",
             "disabled": False,
@@ -78,8 +84,8 @@ class Sentry(SentryLike):
         self.project_configs[project_id] = ret_val
         return ret_val
 
-    def add_full_project_config(self, project_id, public_key=None):
-        basic = self.add_basic_project_config(project_id, public_key)
+    def add_full_project_config(self, project_id, dsn_public_key=None):
+        basic = self.add_basic_project_config(project_id, dsn_public_key)
         full = {
             "organizationId": 1,
             "config": {

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -36,7 +36,9 @@ class Sentry(SentryLike):
     @property
     def internal_error_dsn(self):
         """DSN whose events make the test fail."""
-        return "http://{}@{}:{}/666".format(self.default_dsn_public_key, *self.server_address)
+        return "http://{}@{}:{}/666".format(
+            self.default_dsn_public_key, *self.server_address
+        )
 
     def get_hits(self, path):
         return self.hits.get(path) or 0
@@ -51,33 +53,43 @@ class Sentry(SentryLike):
             s += "> %s: %s\n" % (route, error)
         return s
 
-    def add_dsn_key_to_project(self, project_id, dsn_public_key=None, numeric_id=None, is_enabled=True):
+    def add_dsn_key_to_project(
+        self, project_id, dsn_public_key=None, numeric_id=None, is_enabled=True
+    ):
         if project_id not in self.project_configs:
             raise Exception("trying to add dsn public key to nonexisting project")
 
         if dsn_public_key is None:
             dsn_public_key = uuid.uuid4().hex
 
-        public_keys = self.project_configs[project_id]['publicKeys']
+        public_keys = self.project_configs[project_id]["publicKeys"]
 
         # generate some unique numeric id ( 1 + max of any other numeric id)
         if numeric_id is None:
             numeric_id = 0
             for public_key_config in public_keys:
-                if public_key_config['publicKey'] == dsn_public_key:
+                if public_key_config["publicKey"] == dsn_public_key:
                     # we already have this key, just return
                     return dsn_public_key
                 numeric_id = max(numeric_id, public_key_config["numericId"])
             numeric_id += 1
 
-        key_entry = {"publicKey": dsn_public_key, 'isEnabled': is_enabled, "numericId": numeric_id}
+        key_entry = {
+            "publicKey": dsn_public_key,
+            "isEnabled": is_enabled,
+            "numericId": numeric_id,
+        }
         public_keys.append(key_entry)
 
         return key_entry
 
     def basic_project_config(self, project_id, dsn_public_key=None):
         if dsn_public_key is None:
-            dsn_public_key = {"publicKey": uuid.uuid4().hex, "isEnabled": True, "numericId": 123}
+            dsn_public_key = {
+                "publicKey": uuid.uuid4().hex,
+                "isEnabled": True,
+                "numericId": 123,
+            }
 
         return {
             "projectId": project_id,

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -191,7 +191,9 @@ def test_attachments_quotas(
     attachments = [("att_1", "foo.txt", attachment_body)]
 
     for i in range(5):
-        relay.send_attachments(project_id, event_id, [("att_1", "%s.txt" % i, attachment_body)])
+        relay.send_attachments(
+            project_id, event_id, [("att_1", "%s.txt" % i, attachment_body)]
+        )
         chunk, _ = attachments_consumer.get_attachment_chunk()
         assert chunk == attachment_body
         attachment = attachments_consumer.get_individual_attachment()

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -8,7 +8,7 @@ from requests.exceptions import HTTPError
 def test_attachments_400(mini_sentry, relay_with_processing, attachments_consumer):
     proj_id = 42
     relay = relay_with_processing()
-    mini_sentry.project_configs[proj_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(proj_id)
     attachments_consumer = attachments_consumer()
 
     event_id = "123abc"
@@ -26,7 +26,7 @@ def test_attachments_with_processing(
     event_id = "515539018c9b4260a6f999572f1661ee"
 
     relay = relay_with_processing()
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
 
@@ -111,7 +111,7 @@ def test_empty_attachments_with_processing(
     event_id = "515539018c9b4260a6f999572f1661ee"
 
     relay = relay_with_processing()
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
     attachments_consumer = attachments_consumer()
 
     attachments = [("att_1", "foo.txt", b"")]
@@ -144,7 +144,8 @@ def test_attachments_ratelimit(
     event_id = "515539018c9b4260a6f999572f1661ee"
 
     relay = relay_with_processing()
-    project_config = mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["quotas"] = [
         {"categories": rate_limits, "limit": 0, "reasonCode": "static_disabled_quota"}
     ]
@@ -153,7 +154,7 @@ def test_attachments_ratelimit(
     attachments = [("att_1", "foo.txt", b"")]
 
     # First attachment returns 200 but is rate limited in processing
-    relay.send_attachments(42, event_id, attachments)
+    relay.send_attachments(project_id, event_id, attachments)
     # TODO: There are no outcomes emitted for attachments yet. Instead, sleep to allow Relay to
     # process the event and cache the rate limit
     # outcomes_consumer.assert_rate_limited("static_disabled_quota")
@@ -161,7 +162,7 @@ def test_attachments_ratelimit(
 
     # Second attachment returns 429 in endpoint
     with pytest.raises(HTTPError) as excinfo:
-        relay.send_attachments(42, event_id, attachments)
+        relay.send_attachments(project_id, event_id, attachments)
     assert excinfo.value.response.status_code == 429
     # outcomes_consumer.assert_rate_limited("static_disabled_quota")
 
@@ -173,7 +174,8 @@ def test_attachments_quotas(
     attachment_body = b"blabla"
 
     relay = relay_with_processing()
-    project_config = mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["quotas"] = [
         {
             "id": "test_rate_limiting_{}".format(uuid.uuid4().hex),
@@ -189,14 +191,14 @@ def test_attachments_quotas(
     attachments = [("att_1", "foo.txt", attachment_body)]
 
     for i in range(5):
-        relay.send_attachments(42, event_id, [("att_1", "%s.txt" % i, attachment_body)])
+        relay.send_attachments(project_id, event_id, [("att_1", "%s.txt" % i, attachment_body)])
         chunk, _ = attachments_consumer.get_attachment_chunk()
         assert chunk == attachment_body
         attachment = attachments_consumer.get_individual_attachment()
         assert attachment["attachment"]["name"] == "%s.txt" % i
 
     # First attachment returns 200 but is rate limited in processing
-    relay.send_attachments(42, event_id, attachments)
+    relay.send_attachments(project_id, event_id, attachments)
     # TODO: There are no outcomes emitted for attachments yet. Instead, sleep to allow Relay to
     # process the event and cache the rate limit
     # outcomes_consumer.assert_rate_limited("static_disabled_quota")

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -14,8 +14,9 @@ def test_graceful_shutdown(mini_sentry, relay):
         return get_project_config_original()
 
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[42] = relay.basic_project_config()
-    relay.send_event(42)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+    relay.send_event(project_id)
 
     relay.shutdown(sig=signal.SIGTERM)
     event = mini_sentry.captured_events.get(timeout=0).get_event()
@@ -33,8 +34,9 @@ def test_forced_shutdown(mini_sentry, relay):
         return get_project_config_original()
 
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[42] = relay.basic_project_config()
-    relay.send_event(42)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+    relay.send_event(project_id)
 
     relay.shutdown(sig=signal.SIGINT)
     pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
@@ -64,7 +66,7 @@ def test_forced_shutdown(mini_sentry, relay):
     ],
 )
 def test_store_pixel_gif(mini_sentry, relay, input, trailing_slash):
-    mini_sentry.project_configs[42] = mini_sentry.basic_project_config()
+    mini_sentry.add_basic_project_config(42)
     relay = relay(mini_sentry)
 
     response = relay.get(
@@ -80,7 +82,7 @@ def test_store_pixel_gif(mini_sentry, relay, input, trailing_slash):
 
 @pytest.mark.parametrize("route", ["/api/42/store/", "/api/42/store//"])
 def test_store_post_trailing_slash(mini_sentry, relay, route):
-    mini_sentry.project_configs[42] = mini_sentry.basic_project_config()
+    mini_sentry.add_basic_project_config(42)
     relay = relay(mini_sentry)
 
     response = relay.post(
@@ -112,7 +114,7 @@ def id_fun1(param):
 )
 def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     allowed_domains, should_be_allowed = allowed_origins
-    config = mini_sentry.project_configs[42] = mini_sentry.basic_project_config()
+    config = mini_sentry.add_basic_project_config(42)
     config["config"]["allowedDomains"] = allowed_domains
 
     relay = relay(mini_sentry)

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -71,7 +71,8 @@ def test_store_pixel_gif(mini_sentry, relay, input, trailing_slash):
     relay = relay(mini_sentry)
 
     response = relay.get(
-        "/api/%d/store/?sentry_data=%s&sentry_key=%s" % (project_id, input, mini_sentry.get_dsn_public_key(project_id),)
+        "/api/%d/store/?sentry_data=%s&sentry_key=%s"
+        % (project_id, input, mini_sentry.get_dsn_public_key(project_id),)
     )
     response.raise_for_status()
     assert response.headers["content-type"] == "image/gif"
@@ -87,7 +88,8 @@ def test_store_post_trailing_slash(mini_sentry, relay, route):
     relay = relay(mini_sentry)
 
     response = relay.post(
-        "%s?sentry_key=%s" % (route, mini_sentry.get_dsn_public_key(project_id),), json={"message": "hi"},
+        "%s?sentry_key=%s" % (route, mini_sentry.get_dsn_public_key(project_id),),
+        json={"message": "hi"},
     )
     response.raise_for_status()
 
@@ -122,7 +124,8 @@ def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     relay = relay(mini_sentry)
 
     relay.post(
-        "/api/%d/store/?sentry_key=%s" % (project_id, mini_sentry.get_dsn_public_key(project_id),),
+        "/api/%d/store/?sentry_key=%s"
+        % (project_id, mini_sentry.get_dsn_public_key(project_id),),
         headers={"Origin": "http://valid.com"},
         json={"message": "hi"},
     )

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -66,12 +66,12 @@ def test_forced_shutdown(mini_sentry, relay):
     ],
 )
 def test_store_pixel_gif(mini_sentry, relay, input, trailing_slash):
-    mini_sentry.add_basic_project_config(42)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
     relay = relay(mini_sentry)
 
     response = relay.get(
-        "/api/42/store/?sentry_data=%s"
-        "&sentry_key=%s" % (input, relay.dsn_public_key,)
+        "/api/%d/store/?sentry_data=%s&sentry_key=%s" % (project_id, input, mini_sentry.get_dsn_public_key(project_id),)
     )
     response.raise_for_status()
     assert response.headers["content-type"] == "image/gif"
@@ -82,11 +82,12 @@ def test_store_pixel_gif(mini_sentry, relay, input, trailing_slash):
 
 @pytest.mark.parametrize("route", ["/api/42/store/", "/api/42/store//"])
 def test_store_post_trailing_slash(mini_sentry, relay, route):
-    mini_sentry.add_basic_project_config(42)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
     relay = relay(mini_sentry)
 
     response = relay.post(
-        "%s?sentry_key=%s" % (route, relay.dsn_public_key,), json={"message": "hi"},
+        "%s?sentry_key=%s" % (route, mini_sentry.get_dsn_public_key(project_id),), json={"message": "hi"},
     )
     response.raise_for_status()
 
@@ -114,13 +115,14 @@ def id_fun1(param):
 )
 def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     allowed_domains, should_be_allowed = allowed_origins
-    config = mini_sentry.add_basic_project_config(42)
+    project_id = 42
+    config = mini_sentry.add_basic_project_config(project_id)
     config["config"]["allowedDomains"] = allowed_domains
 
     relay = relay(mini_sentry)
 
     relay.post(
-        "/api/42/store/?sentry_key=%s" % (relay.dsn_public_key,),
+        "/api/%d/store/?sentry_key=%s" % (project_id, mini_sentry.get_dsn_public_key(project_id),),
         headers={"Origin": "http://valid.com"},
         json={"message": "hi"},
     )

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -8,11 +8,12 @@ from sentry_sdk.utils import format_timestamp
 
 def test_envelope(mini_sentry, relay_chain):
     relay = relay_chain()
-    mini_sentry.project_configs[42] = relay.basic_project_config()
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
 
     envelope = Envelope()
     envelope.add_event({"message": "Hello, World!"})
-    relay.send_envelope(42, envelope)
+    relay.send_envelope(project_id, envelope)
 
     event = mini_sentry.captured_events.get(timeout=1).get_event()
 
@@ -54,7 +55,7 @@ def test_normalize_measurement_interface(
     # set up relay
 
     relay = relay_with_processing()
-    mini_sentry.project_configs[42] = relay.basic_project_config()
+    mini_sentry.add_basic_project_config(42)
 
     events_consumer = transactions_consumer()
 
@@ -105,7 +106,7 @@ def test_empty_measurement_interface(mini_sentry, relay_chain):
     # set up relay
 
     relay = relay_chain()
-    mini_sentry.project_configs[42] = relay.basic_project_config()
+    mini_sentry.add_basic_project_config(42)
 
     # construct envelope
 
@@ -137,7 +138,7 @@ def test_strip_measurement_interface(
     # set up relay
 
     relay = relay_with_processing()
-    mini_sentry.project_configs[42] = relay.basic_project_config()
+    mini_sentry.add_basic_project_config(42)
 
     events_consumer = events_consumer()
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -278,7 +278,7 @@ def test_minidump_raw(mini_sentry, relay, content_type):
 
     relay.request(
         "post",
-        "/api/42/minidump?sentry_key={}".format(relay.dsn_public_key),
+        "/api/{}/minidump?sentry_key={}".format(project_id, mini_sentry.get_dsn_public_key(project_id)),
         headers={"Content-Type": content_type},
         data="MDMP content",
     )

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -278,7 +278,9 @@ def test_minidump_raw(mini_sentry, relay, content_type):
 
     relay.request(
         "post",
-        "/api/{}/minidump?sentry_key={}".format(project_id, mini_sentry.get_dsn_public_key(project_id)),
+        "/api/{}/minidump?sentry_key={}".format(
+            project_id, mini_sentry.get_dsn_public_key(project_id)
+        ),
         headers={"Content-Type": content_type},
         data="MDMP content",
     )

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -40,7 +40,7 @@ def assert_only_minidump(envelope, assert_payload=True):
 def test_minidump(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
@@ -64,7 +64,7 @@ def test_minidump(mini_sentry, relay):
 def test_minidump_attachments(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     event = {"event_id": "2dd132e467174db48dbaddabd3cbed57", "user": {"id": "123"}}
     breadcrumbs1 = {
@@ -132,7 +132,7 @@ def test_minidump_attachments(mini_sentry, relay):
 def test_minidump_multipart(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
@@ -161,7 +161,7 @@ def test_minidump_multipart(mini_sentry, relay):
 def test_minidump_sentry_json(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
@@ -190,7 +190,7 @@ def test_minidump_sentry_json(mini_sentry, relay):
 def test_minidump_sentry_json_chunked(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
@@ -225,7 +225,7 @@ def test_minidump_sentry_json_chunked(mini_sentry, relay):
 def test_minidump_invalid_json(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
@@ -245,7 +245,7 @@ def test_minidump_invalid_json(mini_sentry, relay):
 def test_minidump_invalid_magic(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "content without MDMP magic"),
@@ -258,7 +258,7 @@ def test_minidump_invalid_magic(mini_sentry, relay):
 def test_minidump_invalid_field(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     attachments = [
         ("unknown_field_name", "minidump.dmp", "MDMP content"),
@@ -274,7 +274,7 @@ def test_minidump_invalid_field(mini_sentry, relay):
 def test_minidump_raw(mini_sentry, relay, content_type):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     relay.request(
         "post",
@@ -293,7 +293,7 @@ def test_minidump_raw(mini_sentry, relay, content_type):
 def test_minidump_nested_formdata(mini_sentry, relay, test_file_name):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     dmp_path = os.path.join(
         os.path.dirname(__file__), "fixtures", "native", test_file_name
@@ -314,7 +314,7 @@ def test_minidump_nested_formdata(mini_sentry, relay, test_file_name):
 def test_minidump_invalid_nested_formdata(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
 
     dmp_path = os.path.join(
         os.path.dirname(__file__), "fixtures", "native", "bad_electron_simple.dmp"
@@ -344,7 +344,8 @@ def test_minidump_with_processing(
         }
     )
 
-    project_config = mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
 
     # Disable scurbbing, the basic and full project configs from the mini_sentry fixture
     # will modify the minidump since it contains user paths in the module list.  This breaks
@@ -366,7 +367,7 @@ def test_minidump_with_processing(
     attachments_consumer = attachments_consumer()
 
     attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", content)]
-    relay.send_minidump(project_id=42, files=attachments)
+    relay.send_minidump(project_id=project_id, files=attachments)
 
     attachment = b""
     num_chunks = 0
@@ -407,7 +408,8 @@ def test_minidump_with_processing_invalid(
 
     relay = relay_with_processing()
 
-    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
 
     attachments_consumer = attachments_consumer()
 
@@ -449,7 +451,8 @@ def test_minidump_ratelimit(
 ):
     relay = relay_with_processing()
 
-    project_config = mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["quotas"] = [
         {"categories": rate_limits, "limit": 0, "reasonCode": "static_disabled_quota"}
     ]
@@ -458,9 +461,9 @@ def test_minidump_ratelimit(
     attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content")]
 
     # First minidump returns 200 but is rate limited in processing
-    relay.send_minidump(project_id=42, files=attachments)
+    relay.send_minidump(project_id=project_id, files=attachments)
     outcomes_consumer.assert_rate_limited("static_disabled_quota")
 
     # Minidumps never return rate limits
-    relay.send_minidump(project_id=42, files=attachments)
+    relay.send_minidump(project_id=project_id, files=attachments)
     outcomes_consumer.assert_rate_limited("static_disabled_quota")

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -365,7 +365,8 @@ def test_no_outcomes_rate_limit(
         "outcomes": {"emit_outcomes": True, "batch_size": 1, "batch_interval": 1,}
     }
     relay = relay_with_processing(config)
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["quotas"] = [
         {
             "id": "transaction category",
@@ -375,11 +376,10 @@ def test_no_outcomes_rate_limit(
             "reasonCode": "transactions are banned",
         }
     ]
-    mini_sentry.project_configs[42] = project_config
     outcomes_consumer = outcomes_consumer()
 
     message = _get_message(category_type)
-    result = relay.send_event(42, message)
+    result = relay.send_event(project_id, message)
     event_id = result["id"]
 
     # give relay some to handle the message (and send any outcomes it needs to send)
@@ -391,7 +391,7 @@ def test_no_outcomes_rate_limit(
     # end on the same partition (to prove there was noting before)
     dummy_outcome = {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "reason": "fake",
         "event_id": event_id,
     }

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -35,7 +35,7 @@ def test_local_project_config(mini_sentry, relay):
     # get the dsn key from the config
     # we need to provide it manually to Relay since it is not in the config (of MiniSentry) and
     # we don't look on the file system
-    dsn_key = config["publicKeys"][0]['publicKey']
+    dsn_key = config["publicKeys"][0]["publicKey"]
 
     relay.wait_relay_healthcheck()
     relay.send_event(project_id, dsn_key=dsn_key)

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -197,7 +197,7 @@ def test_processing_redis_query(
     cfg = mini_sentry.add_full_project_config(project_id)
     cfg["disabled"] = disabled
 
-    key = mini_sentry.dsn_public_key
+    key = mini_sentry.get_dsn_public_key(project_id)
     redis_client = redis.Redis(host="127.0.0.1", port=6379, db=0)
     projectconfig_cache_prefix = relay.options["processing"][
         "projectconfig_cache_prefix"

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -33,7 +33,7 @@ def test_uses_origins(mini_sentry, relay, json_fixture_provider, allowed_origins
     proj_id = 42
     relay = relay(mini_sentry)
     report = fixture_provider.load("csp", ".input")
-    mini_sentry.project_configs[proj_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(proj_id)
 
     relay.send_security_report(
         project_id=proj_id,
@@ -62,7 +62,7 @@ def test_security_report_with_processing(
     proj_id = 42
     relay = relay_with_processing()
     report = fixture_provider.load(test_name, ".input")
-    mini_sentry.project_configs[proj_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(proj_id)
     events_consumer = events_consumer()
 
     relay.send_security_report(
@@ -111,7 +111,7 @@ def test_security_report(mini_sentry, relay, test_case, json_fixture_provider):
     proj_id = 42
     relay = relay(mini_sentry)
     report = fixture_provider.load(test_name, ".input")
-    mini_sentry.project_configs[proj_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(proj_id)
 
     relay.send_security_report(
         project_id=proj_id,

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -12,9 +12,10 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
 
-    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "did": "foobarbaz",
@@ -32,7 +33,7 @@ def test_session_with_processing(mini_sentry, relay_with_processing, sessions_co
     session = sessions_consumer.get_session()
     assert session == {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         # seq is forced to 0 when init is true
@@ -58,9 +59,10 @@ def test_session_with_processing_two_events(
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
 
-    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "did": "foobarbaz",
@@ -75,7 +77,7 @@ def test_session_with_processing_two_events(
     session = sessions_consumer.get_session()
     assert session == {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         # seq is forced to 0 when init is true
@@ -92,7 +94,7 @@ def test_session_with_processing_two_events(
     }
 
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "did": "foobarbaz",
@@ -107,7 +109,7 @@ def test_session_with_processing_two_events(
     session = sessions_consumer.get_session()
     assert session == {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         "seq": 43,
@@ -129,13 +131,13 @@ def test_session_with_custom_retention(
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 17
-    mini_sentry.project_configs[42] = project_config
 
     timestamp = datetime.now(tz=timezone.utc)
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),
@@ -152,15 +154,15 @@ def test_session_age_discard(mini_sentry, relay_with_processing, sessions_consum
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 17
-    mini_sentry.project_configs[42] = project_config
 
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(days=5, hours=1)
 
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),
@@ -181,9 +183,10 @@ def test_session_force_errors_on_crash(
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
 
-    mini_sentry.project_configs[42] = mini_sentry.full_project_config()
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "did": "foobarbaz",
@@ -199,7 +202,7 @@ def test_session_force_errors_on_crash(
     session = sessions_consumer.get_session()
     assert session == {
         "org_id": 1,
-        "project_id": 42,
+        "project_id": project_id,
         "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
         "distinct_id": "367e2499-2b45-586d-814f-778b60144e87",
         # seq is forced to 0 when init is true
@@ -222,15 +225,15 @@ def test_session_release_required(
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 17
-    mini_sentry.project_configs[42] = project_config
 
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(days=5, hours=1)
 
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),
@@ -247,7 +250,8 @@ def test_session_quotas(mini_sentry, relay_with_processing, sessions_consumer):
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 17
     project_config["config"]["quotas"] = [
         {
@@ -260,7 +264,6 @@ def test_session_quotas(mini_sentry, relay_with_processing, sessions_consumer):
             "reasonCode": "sessions_exceeded",
         }
     ]
-    mini_sentry.project_configs[42] = project_config
 
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
@@ -273,15 +276,15 @@ def test_session_quotas(mini_sentry, relay_with_processing, sessions_consumer):
     }
 
     for i in range(5):
-        relay.send_session(42, session)
+        relay.send_session(project_id, session)
         sessions_consumer.get_session()
 
     # Rate limited, but responds with 200 because of deferred processing
-    relay.send_session(42, session)
+    relay.send_session(project_id, session)
     assert sessions_consumer.poll() is None
 
     with pytest.raises(HTTPError):
-        relay.send_session(42, session)
+        relay.send_session(project_id, session)
     assert sessions_consumer.poll() is None
 
 
@@ -289,7 +292,8 @@ def test_session_disabled(mini_sentry, relay_with_processing, sessions_consumer)
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 17
     project_config["config"]["quotas"] = [
         {
@@ -300,13 +304,12 @@ def test_session_disabled(mini_sentry, relay_with_processing, sessions_consumer)
             "reasonCode": "sessions_exceeded",
         }
     ]
-    mini_sentry.project_configs[42] = project_config
 
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(hours=1)
 
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),
@@ -322,13 +325,13 @@ def test_session_auto_ip(mini_sentry, relay_with_processing, sessions_consumer):
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 
-    project_config = mini_sentry.full_project_config()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 17
-    mini_sentry.project_configs[42] = project_config
 
     timestamp = datetime.now(tz=timezone.utc)
     relay.send_session(
-        42,
+        project_id,
         {
             "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
             "timestamp": timestamp.isoformat(),

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -22,6 +22,7 @@ def test_store(mini_sentry, relay_chain):
 
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
+
 @pytest.mark.parametrize("allowed", [True, False])
 def test_store_external_relay(mini_sentry, relay, allowed):
     # Use 3 Relays to force the middle one to fetch public keys
@@ -31,7 +32,7 @@ def test_store_external_relay(mini_sentry, relay, allowed):
 
     if allowed:
         # manually  add all public keys form the relays to the configuration
-        project_config["config"]["trustedRelays"]=list(relay.iter_public_keys())
+        project_config["config"]["trustedRelays"] = list(relay.iter_public_keys())
 
     # Send the event, which always succeeds. The project state is fetched asynchronously and Relay
     # drops the event internally if it does not have permissions.
@@ -280,7 +281,9 @@ def test_store_static_config(mini_sentry, relay):
     def configure_static_project(dir):
         os.remove(dir.join("credentials.json"))
         os.makedirs(dir.join("projects"))
-        dir.join("projects").join("{}.json".format(project_id)).write(json.dumps(project_config))
+        dir.join("projects").join("{}.json".format(project_id)).write(
+            json.dumps(project_config)
+        )
 
     relay_options = {"relay": {"mode": "static"}}
     relay = relay(mini_sentry, options=relay_options, prepare=configure_static_project)
@@ -526,7 +529,9 @@ def test_processing_quotas(
 
     for i in range(5):
         # send using the first dsn
-        relay.send_event(project_id, transform({"message": f"regular{i}"}), dsn_key_idx=0)
+        relay.send_event(
+            project_id, transform({"message": f"regular{i}"}), dsn_key_idx=0
+        )
 
         event, _ = events_consumer.get_event()
         assert event["logentry"]["formatted"] == f"regular{i}"
@@ -557,7 +562,9 @@ def test_processing_quotas(
 
     for i in range(10):
         # now send using the second key
-        relay.send_event(project_id, transform({"message": f"otherkey{i}"}), dsn_key_idx=1)
+        relay.send_event(
+            project_id, transform({"message": f"otherkey{i}"}), dsn_key_idx=1
+        )
         event, _ = events_consumer.get_event()
 
         assert event["logentry"]["formatted"] == f"otherkey{i}"
@@ -687,7 +694,9 @@ def test_no_auth(relay, mini_sentry, mode):
     def configure_static_project(dir):
         os.remove(dir.join("credentials.json"))
         os.makedirs(dir.join("projects"))
-        dir.join("projects").join("{}.json".format(project_id)).write(json.dumps(project_config))
+        dir.join("projects").join("{}.json".format(project_id)).write(
+            json.dumps(project_config)
+        )
 
     relay_options = {"relay": {"mode": mode}}
     relay = relay(mini_sentry, options=relay_options, prepare=configure_static_project)

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -511,6 +511,9 @@ def test_processing_quotas(
     }
 
     second_project_id = 43
+    # TODO replace with new
+    # second_public_key = second_key["publicKey"]
+    # second_config = mini_sentry.add_full_project_config(second_project_id, second_public_key)
     second_config = mini_sentry.add_full_project_config(second_project_id)
     second_config["publicKeys"] = [second_key]
     # Hack we want the Id to be still 42  but with a new public key
@@ -564,6 +567,7 @@ def test_processing_quotas(
         if generates_outcomes:
             outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
 
+    #TODO remove after fix
     relay.dsn_public_key = second_key["publicKey"]
 
     for i in range(10):

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -18,7 +18,7 @@ def _load_dump_file(base_file_name: str):
 def test_unreal_crash(mini_sentry, relay, dump_file_name):
     project_id = 42
     relay = relay(mini_sentry)
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
     unreal_content = _load_dump_file(dump_file_name)
 
     response = relay.send_unreal_request(project_id, unreal_content)
@@ -45,7 +45,7 @@ def test_unreal_minidump_with_processing(
     relay = relay_with_processing(options)
     attachments_consumer = attachments_consumer()
 
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
     unreal_content = _load_dump_file("unreal_crash")
 
     relay.send_unreal_request(project_id, unreal_content)
@@ -131,7 +131,7 @@ def test_unreal_apple_crash_with_processing(
     relay = relay_with_processing(options)
     attachments_consumer = attachments_consumer()
 
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
     unreal_content = _load_dump_file("unreal_crash_apple")
 
     relay.send_unreal_request(project_id, unreal_content)
@@ -236,7 +236,7 @@ def test_unreal_minidump_with_config_and_processing(
     relay = relay_with_processing(options)
     attachments_consumer = attachments_consumer()
 
-    mini_sentry.project_configs[project_id] = mini_sentry.full_project_config()
+    mini_sentry.add_full_project_config(project_id)
     unreal_content = _load_dump_file("unreal_crash_with_config")
 
     relay.send_unreal_request(project_id, unreal_content)


### PR DESCRIPTION
Ref(test): Cleanup mini_sentry

Make more explicit the use of DSN keys and project configurations in mini_sentry.

Now you add a project configuration to mini_sentry.
Relay does not have (inherit from SentryLike) a `def project_config()`
Dsn keys are not reused, each project gets its own dsn key
We now support multiple dsn keys per project (in tests) and the ability to specify
which dsn key to use when sending a message.

This PR only deals with integration tests: #skip-changelog