### PR TITLE
ci(release): Align release workflow with getsentry/sentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,10 @@ jobs:
       # but it is broken now.
       - run: sleep 10
       - uses: getsentry/craft@master
+        name: Craft Publish
         with:
           action: publish
-          version: ${{ github.event.inputs.version || steps.calver.outputs.version }}
+          version: ${{ env.RELEASE_VERSION }}
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,51 +16,61 @@ on:
   schedule:
     # We want the release to be at 9-10am Pacific Time
     # We also want it to be 1 hour before the on-prem release
-    - cron:  '0 17 15 * *'
+    - cron: '0 17 15 * *'
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: "Release a new version"
+    name: 'Release a new version'
     steps:
-        - id: killswitch
-          if: ${{ !github.event.inputs.force }}
-          run: |
-            if curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?state=open&labels=release-blocker" | grep -Pzvo '\[[\s\n\r]*\]'; then
-              echo "Open release-blocking issues found, cancelling release...";
-              curl -sf -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/cancel;
-            fi
-        - id: calver
-          if: ${{ !github.event.inputs.version }}
-          run: echo "::set-output name=version::$(date +'%y.%-m.0')"
-        - uses: actions/checkout@v2
-          with:
-            token: ${{ secrets.GH_SENTRY_BOT_PAT }}
-        - uses: getsentry/craft@master
-          if: ${{ !github.event.inputs.skip_prepare }}
-          with:
-            action: prepare
-            version: ${{ github.event.inputs.version || steps.calver.outputs.version }}
-          env:
-            DRY_RUN: ${{ github.event.inputs.dry_run }}
-            GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
-            GIT_COMMITTER_NAME: getsentry-bot
-            GIT_AUTHOR_NAME: getsentry-bot
-            EMAIL: bot@getsentry.com
-        # Wait until the builds start. Craft should do this automatically
-        # but it is broken now.
-        # TODO: Remove this once getsentry/craft#111 is fixed
-        - run: sleep 10
-        - uses: getsentry/craft@master
-          with:
-            action: publish
-            version: ${{ github.event.inputs.version || steps.calver.outputs.version }}
-          env:
-            DRY_RUN: ${{ github.event.inputs.dry_run }}
-            GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
-            GIT_COMMITTER_NAME: getsentry-bot
-            GIT_AUTHOR_NAME: getsentry-bot
-            EMAIL: bot@getsentry.com
-            ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
-            CRAFT_GCS_TARGET_CREDS_JSON: ${{ secrets.CRAFT_GCS_TARGET_CREDS_JSON }}
-            DOCKER_USERNAME: 'sentrybuilder'
-            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - id: killswitch
+        name: Check release blockers
+        if: ${{ !github.event.inputs.force }}
+        run: |
+          if curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?state=open&labels=release-blocker" | grep -Pzvo '\[[\s\n\r]*\]'; then
+            echo "Open release-blocking issues found, cancelling release...";
+            curl -sf -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/cancel;
+          fi
+      - id: set-version
+        name: Determine version
+        run: |
+          if [[ -n '${{ github.event.inputs.version }}' ]]; then
+            echo 'RELEASE_VERSION=${{ github.event.inputs.version }}' >> $GITHUB_ENV;
+          else
+            DATE_PART=$(date +'%y.%-m')
+            declare -i PATCH_VERSION=0
+            while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
+              PATCH_VERSION+=1
+            done
+            echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
+          fi
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_SENTRY_BOT_PAT }}
+      - id: set-git-user
+        name: Set git user to getsentry-bot
+        run: |
+          git config user.name getsentry-bot
+          git config user.email bot@getsentry.com
+      - uses: getsentry/craft@master
+        name: Craft Prepare
+        if: ${{ !github.event.inputs.skip_prepare }}
+        with:
+          action: prepare
+          version: ${{ env.RELEASE_VERSION }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
+      # Wait until the builds start. Craft should do this automatically
+      # but it is broken now.
+      - run: sleep 10
+      - uses: getsentry/craft@master
+        with:
+          action: publish
+          version: ${{ github.event.inputs.version || steps.calver.outputs.version }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
+          ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
+          CRAFT_GCS_TARGET_CREDS_JSON: ${{ secrets.CRAFT_GCS_TARGET_CREDS_JSON }}
+          DOCKER_USERNAME: 'sentrybuilder'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Adds names to steps and auto patch version determination for the version step.

#skip-changelog 