### PR TITLE
ci(release): Configure Git globally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
       - id: set-git-user
         name: Set git user to getsentry-bot
         run: |
-          git config user.name getsentry-bot
-          git config user.email bot@getsentry.com
+          git config --global user.name getsentry-bot
+          git config --global user.email bot@getsentry.com
       - uses: getsentry/craft@master
         name: Craft Prepare
         if: ${{ !github.event.inputs.skip_prepare }}


### PR DESCRIPTION
Attempt to work around https://github.com/getsentry/relay/runs/1414356448.

#skip-changelog