### PR TITLE
fix(server): Allow params in content-type for security requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Relay is now able to ingest pre-aggregated sessions, which will make it possible to efficiently handle applications that produce thousands of sessions per second. ([#815](https://github.com/getsentry/relay/pull/815))
 
+**Bug Fixes**:
+
+- Allow params in content-type for security requests to support content types like `"application/expect-ct-report+json; charset=utf-8"`. ([#844](https://github.com/getsentry/relay/pull/844))
+
+
 ## 20.11.1
 
 - No documented changes.

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -37,7 +37,7 @@ def test_uses_origins(mini_sentry, relay, json_fixture_provider, allowed_origins
 
     relay.send_security_report(
         project_id=proj_id,
-        content_type="application/json",
+        content_type="application/json; charset=utf-8",
         payload=report,
         release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
         environment="production",
@@ -67,7 +67,7 @@ def test_security_report_with_processing(
 
     relay.send_security_report(
         project_id=proj_id,
-        content_type="application/json",
+        content_type="application/json; charset=utf-8",
         payload=report,
         release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
         environment="production",


### PR DESCRIPTION
Currently security report endpoint filters out requests depending on the provided `Content-Type`. In case of Except-CT [two content type values are accepted](https://github.com/getsentry/relay/blob/20.11.1/relay-server/src/endpoints/security_report.rs#L93-L94): `"application/expect-ct-report"` and `"application/expect-ct-report+json"`. While this complies with the [current Expect-CT Extension for HTTP revision](https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct-08#section-8.2) or is even less strict, modern browsers tend to send charset along with the media type as the value of [`Content-Type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) header e.g. `application/expect-ct-report+json; charset=utf-8`, causing the request to be rejected with HTTP 400 Bad Request - `Invalid Content-Type`. Security report endpoint should match the media type of `Content-Type` request header value instead of matching the whole header.

Ref https://github.com/getsentry/relay/issues/843