### PR TITLE
ci(docs): Build docs on stable Rust

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,11 +21,9 @@ jobs:
         with:
           submodules: recursive
 
-      # compile with nightly for intra-doc-links
-      # see https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           components: rust-docs
           override: true

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ doc: doc-api
 .PHONY: doc-api
 
 doc-api: setup-git
-	cargo +nightly doc --workspace --all-features --no-deps
+	cargo doc --workspace --all-features --no-deps
 .PHONY: doc-api
 
 # Style checking


### PR DESCRIPTION
#skip-changelog
