### PR TITLE
feat(server): Add reason codes to the rate limit response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Allow params in content-type for security requests to support content types like `"application/expect-ct-report+json; charset=utf-8"`. ([#844](https://github.com/getsentry/relay/pull/844))
 - Fix a panic in CSP filters. ([#848](https://github.com/getsentry/relay/pull/848))
 
+**Internal**:
+
+- Add reason codes to the `X-Sentry-Rate-Limits` header in store responses. This allows external Relays to emit outcomes with the proper reason codes. ([#850](https://github.com/getsentry/relay/pull/850))
+
 
 ## 20.11.1
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -192,7 +192,6 @@ impl ReasonCode {
     ///
     /// This method is only to be used by tests. Reason codes should only be deserialized from
     /// quotas, but never constructed manually.
-    #[cfg(test)]
     pub fn new<S: Into<String>>(code: S) -> Self {
         Self(code.into())
     }
@@ -200,6 +199,12 @@ impl ReasonCode {
     /// Returns the string representation of this reason code.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl fmt::Display for ReasonCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Write};
 
 use relay_quotas::{
     DataCategories, DataCategory, ItemScoping, QuotaScope, RateLimit, RateLimitScope, RateLimits,
-    Scoping,
+    ReasonCode, Scoping,
 };
 
 use crate::envelope::{Envelope, Item, ItemType};
@@ -29,6 +29,10 @@ pub fn format_rate_limits(rate_limits: &RateLimits) -> String {
         }
 
         write!(header, ":{}", rate_limit.scope.name()).ok();
+
+        if let Some(ref reason_code) = rate_limit.reason_code {
+            write!(header, ":{}", reason_code).ok();
+        }
     }
 
     header
@@ -61,10 +65,12 @@ pub fn parse_rate_limits(scoping: &Scoping, string: &str) -> RateLimits {
         let quota_scope = QuotaScope::from_name(components.next().unwrap_or(""));
         let scope = RateLimitScope::for_quota(scoping, quota_scope);
 
+        let reason_code = components.next().map(ReasonCode::new);
+
         rate_limits.add(RateLimit {
             categories,
             scope,
-            reason_code: None,
+            reason_code,
             retry_after,
         });
     }
@@ -302,7 +308,7 @@ mod tests {
         rate_limits.add(RateLimit {
             categories: DataCategories::new(),
             scope: RateLimitScope::Organization(42),
-            reason_code: None,
+            reason_code: Some(ReasonCode::new("my_limit")),
             retry_after: RetryAfter::from_secs(42),
         });
 
@@ -315,7 +321,7 @@ mod tests {
         });
 
         let formatted = format_rate_limits(&rate_limits);
-        let expected = "42::organization, 4711:transaction;security:project";
+        let expected = "42::organization:my_limit, 4711:transaction;security:project";
         assert_eq!(formatted, expected);
     }
 
@@ -343,7 +349,8 @@ mod tests {
         };
 
         // contains "foobar", an unknown scope that should be mapped to Unknown
-        let formatted = "42::organization, invalid, 4711:foobar;transaction;security:project";
+        let formatted =
+            "42::organization:my_limit, invalid, 4711:foobar;transaction;security:project";
         let rate_limits: Vec<RateLimit> =
             parse_rate_limits(&scoping, formatted).into_iter().collect();
 
@@ -353,7 +360,7 @@ mod tests {
                 RateLimit {
                     categories: DataCategories::new(),
                     scope: RateLimitScope::Organization(42),
-                    reason_code: None,
+                    reason_code: Some(ReasonCode::new("my_limit")),
                     retry_after: rate_limits[0].retry_after,
                 },
                 RateLimit {

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -556,7 +556,7 @@ def test_processing_quotas(
         assert int(retry_after) <= max_rate_limit
         retry_after2, rest = headers["x-sentry-rate-limits"].split(":", 1)
         assert int(retry_after2) == int(retry_after)
-        assert rest == "%s:key" % category
+        assert rest == "%s:key:get_lost" % category
         if generates_outcomes:
             outcomes_consumer.assert_rate_limited("get_lost", key_id=key_id)
 


### PR DESCRIPTION
Adds reason codes to the `X-Sentry-Rate-Limit` response headers. This allows external Relays to emit outcomes with the proper reason code. SDKs are not required to handle this field.

- Old format: `<retry_after>:<categories>:<scope>`
- New format: `<retry_after>:<categories>:<scope>:<reason_code>`
