### PR TITLE
fix: Emit metrics for outcomes in external relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 **Internal**:
 
 - Add reason codes to the `X-Sentry-Rate-Limits` header in store responses. This allows external Relays to emit outcomes with the proper reason codes. ([#850](https://github.com/getsentry/relay/pull/850))
-
+- Emit metrics for outcomes in external relays. ([#851](https://github.com/getsentry/relay/pull/851))
 
 ## 20.11.1
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -427,6 +427,7 @@ mod processing {
                 counter(RelayCounters::Outcomes) += 1,
                 reason = message.reason.as_deref().unwrap_or(""),
                 outcome = message.tag_name(),
+                to = "kafka",
             );
 
             // At the moment, we support outcomes with optional EventId.
@@ -455,6 +456,13 @@ mod processing {
                     return Ok(());
                 }
             };
+
+            metric!(
+                counter(RelayCounters::Outcomes) += 1,
+                reason = message.reason.as_deref().unwrap_or(""),
+                outcome = message.tag_name(),
+                to = "http",
+            );
 
             producer.do_send(message);
 

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -290,6 +290,8 @@ pub enum RelayCounters {
     ///  - `outcome`: The basic cause for rejecting the event.
     ///  - `reason`: A more detailed identifier describing the rule or mechanism leading to the
     ///    outcome.
+    ///  - `to`: Describes the destination of the outcome. Can be either 'kafka' (when in
+    ///    processing mode) or 'http' (when outcomes are enabled in an external relay).
     ///
     /// Possible outcomes are:
     ///  - `filtered`: Dropped by inbound data filters. The reason specifies the filter that


### PR DESCRIPTION
Until now we only emitted that metric when sending outcomes to Kafka, interesting to track it for external relays too.