### PR TITLE
feat(protocol): Add protocol support for WASM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Relay is now able to ingest pre-aggregated sessions, which will make it possible to efficiently handle applications that produce thousands of sessions per second. ([#815](https://github.com/getsentry/relay/pull/815))
+- Add protocol support for WASM. ([#852](https://github.com/getsentry/relay/pull/852))
 
 **Bug Fixes**:
 

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -377,13 +377,11 @@ pub struct NativeDebugImage {
     /// Starting memory address of the image (required).
     ///
     /// Memory address, at which the image is mounted in the virtual address space of the process. Should be a string in hex representation prefixed with `"0x"`.
-    #[metastructure(required = "true")]
     pub image_addr: Annotated<Addr>,
 
     /// Size of the image in bytes (required).
     ///
     /// The size of the image in virtual memory. If missing, Sentry will assume that the image spans up to the next image, which might lead to invalid stack traces.
-    #[metastructure(required = "true")]
     pub image_size: Annotated<u64>,
 
     /// Loading address in virtual memory.
@@ -436,6 +434,8 @@ pub enum DebugImage {
     Pe(Box<NativeDebugImage>),
     /// A reference to a proguard debug file.
     Proguard(Box<ProguardDebugImage>),
+    /// WASM debug image.
+    Wasm(Box<NativeDebugImage>),
     /// A debug image that is unknown to this protocol specification.
     #[metastructure(fallback_variant)]
     Other(Object<Value>),

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::protocol::{Addr, NativeImagePath, RegVal};
+use crate::protocol::{Addr, DebugId, NativeImagePath, RegVal};
 use crate::types::{Annotated, Array, FromValue, Object, Value};
 
 /// Holds information about a single stacktrace frame.
@@ -125,6 +125,10 @@ pub struct Frame {
     /// [Debug Meta Interface]({%- link _documentation/development/sdk-dev/event-payloads/debugmeta.md -%}),
     /// then symbolication can take place.
     pub instruction_addr: Annotated<Addr>,
+
+    /// When provided switches `instruction_addr` to be relative within
+    /// a specific image.
+    pub in_image: Annotated<DebugId>,
 
     /// (C/C++/Native) Start address of the frame's function.
     ///
@@ -361,6 +365,7 @@ fn test_frame_roundtrip() {
   },
   "image_addr": "0x400",
   "instruction_addr": "0x404",
+  "in_image": "f3283016-637c-463b-8b3e-46eda376c9dd",
   "symbol_addr": "0x404",
   "trust": "69",
   "lang": "rust",
@@ -395,6 +400,9 @@ fn test_frame_roundtrip() {
         }),
         image_addr: Annotated::new(Addr(0x400)),
         instruction_addr: Annotated::new(Addr(0x404)),
+        in_image: Annotated::new(DebugId(
+            "f3283016-637c-463b-8b3e-46eda376c9dd".parse().unwrap(),
+        )),
         symbol_addr: Annotated::new(Addr(0x404)),
         trust: Annotated::new("69".into()),
         lang: Annotated::new("rust".into()),

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::protocol::{Addr, DebugId, NativeImagePath, RegVal};
+use crate::protocol::{Addr, NativeImagePath, RegVal};
 use crate::types::{Annotated, Array, FromValue, Object, Value};
 
 /// Holds information about a single stacktrace frame.

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -126,9 +126,8 @@ pub struct Frame {
     /// then symbolication can take place.
     pub instruction_addr: Annotated<Addr>,
 
-    /// When provided switches `instruction_addr` to be relative within
-    /// a specific image.
-    pub in_image: Annotated<DebugId>,
+    /// Defines the addressing mode for addresses.
+    pub addr_mode: Annotated<String>,
 
     /// (C/C++/Native) Start address of the frame's function.
     ///
@@ -365,7 +364,7 @@ fn test_frame_roundtrip() {
   },
   "image_addr": "0x400",
   "instruction_addr": "0x404",
-  "in_image": "f3283016-637c-463b-8b3e-46eda376c9dd",
+  "addr_mode": "abs",
   "symbol_addr": "0x404",
   "trust": "69",
   "lang": "rust",
@@ -400,9 +399,7 @@ fn test_frame_roundtrip() {
         }),
         image_addr: Annotated::new(Addr(0x400)),
         instruction_addr: Annotated::new(Addr(0x404)),
-        in_image: Annotated::new(DebugId(
-            "f3283016-637c-463b-8b3e-46eda376c9dd".parse().unwrap(),
-        )),
+        addr_mode: Annotated::new("abs".into()),
         symbol_addr: Annotated::new(Addr(0x404)),
         trust: Annotated::new("69".into()),
         lang: Annotated::new("rust".into()),

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1311,6 +1311,14 @@ expression: event_json_schema()
                 }
               ]
             },
+            "addr_mode": {
+              "description": " Defines the addressing mode for addresses.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "colno": {
               "description": " Column number within the source file, starting at 1.",
               "default": null,
@@ -1367,18 +1375,6 @@ expression: event_json_schema()
               "type": [
                 "boolean",
                 "null"
-              ]
-            },
-            "in_image": {
-              "description": " When provided switches `instruction_addr` to be relative within\n a specific image.",
-              "default": null,
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/DebugId"
-                },
-                {
-                  "type": "null"
-                }
               ]
             },
             "instruction_addr": {

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -878,6 +878,9 @@ expression: event_json_schema()
           "$ref": "#/definitions/ProguardDebugImage"
         },
         {
+          "$ref": "#/definitions/NativeDebugImage"
+        },
+        {
           "type": "object",
           "additionalProperties": true
         }
@@ -1364,6 +1367,18 @@ expression: event_json_schema()
               "type": [
                 "boolean",
                 "null"
+              ]
+            },
+            "in_image": {
+              "description": " When provided switches `instruction_addr` to be relative within\n a specific image.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DebugId"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "instruction_addr": {
@@ -1924,9 +1939,7 @@ expression: event_json_schema()
           "type": "object",
           "required": [
             "code_file",
-            "debug_id",
-            "image_addr",
-            "image_size"
+            "debug_id"
           ],
           "properties": {
             "arch": {
@@ -1985,6 +1998,7 @@ expression: event_json_schema()
             },
             "image_addr": {
               "description": " Starting memory address of the image (required).\n\n Memory address, at which the image is mounted in the virtual address space of the process. Should be a string in hex representation prefixed with `\"0x\"`.",
+              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/Addr"
@@ -1996,6 +2010,7 @@ expression: event_json_schema()
             },
             "image_size": {
               "description": " Size of the image in bytes (required).\n\n The size of the image in virtual memory. If missing, Sentry will assume that the image spans up to the next image, which might lead to invalid stack traces.",
+              "default": null,
               "type": [
                 "integer",
                 "null"


### PR DESCRIPTION
This extends the protocol for WASM. In the frame you can now provide `addr_mode` to override the behavior of an address. For instance one can set this to `rel:index` to set it relative to the index of a debug image. This is all handled in the background in sentry.

Refs https://github.com/getsentry/symbolicator/pull/301