### PR TITLE
fix: Send key_id in partial project config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Add reason codes to the `X-Sentry-Rate-Limits` header in store responses. This allows external Relays to emit outcomes with the proper reason codes. ([#850](https://github.com/getsentry/relay/pull/850))
 - Emit metrics for outcomes in external relays. ([#851](https://github.com/getsentry/relay/pull/851))
+- Send `key_id` in partial project config. ([#854](https://github.com/getsentry/relay/pull/854))
 
 ## 20.11.1
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -134,7 +134,7 @@ pub struct LimitedProjectState {
     pub project_id: Option<ProjectId>,
     pub last_change: Option<DateTime<Utc>>,
     pub disabled: bool,
-    #[serde(with = "limited_public_key_comfigs")]
+    #[serde(with = "limited_public_key_configs")]
     pub public_keys: SmallVec<[PublicKeyConfig; 1]>,
     pub slug: Option<String>,
     #[serde(with = "LimitedProjectConfig")]
@@ -365,13 +365,11 @@ pub struct PublicKeyConfig {
     pub public_key: ProjectKey,
 
     /// The primary key of the DSN in Sentry's main database.
-    ///
-    /// Only available for internal relays.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub numeric_id: Option<u64>,
 }
 
-mod limited_public_key_comfigs {
+mod limited_public_key_configs {
     use super::*;
     use serde::ser::SerializeSeq;
 
@@ -380,6 +378,8 @@ mod limited_public_key_comfigs {
     #[serde(rename_all = "camelCase", remote = "PublicKeyConfig")]
     pub struct LimitedPublicKeyConfig {
         pub public_key: ProjectKey,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub numeric_id: Option<u64>,
     }
 
     /// Serializes a list of `PublicKeyConfig` objects using `LimitedPublicKeyConfig`.

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -79,11 +79,7 @@ def test_outcomes_non_processing(relay, mini_sentry):
     with all necessary information set.
     """
     config = {
-        "outcomes": {
-            "emit_outcomes": True,
-            "batch_size": 1,
-            "batch_interval": 1,
-        }
+        "outcomes": {"emit_outcomes": True, "batch_size": 1, "batch_interval": 1,}
     }
 
     relay = relay(mini_sentry, config)
@@ -122,11 +118,7 @@ def test_outcomes_not_sent_when_disabled(relay, mini_sentry):
     when we disable outcomes.
     """
     config = {
-        "outcomes": {
-            "emit_outcomes": False,
-            "batch_size": 1,
-            "batch_interval": 1,
-        }
+        "outcomes": {"emit_outcomes": False, "batch_size": 1, "batch_interval": 1,}
     }
 
     relay = relay(mini_sentry, config)
@@ -430,10 +422,7 @@ def _get_message(message_type):
             "duration": 1947.49,
             "status": "exited",
             "errors": 0,
-            "attrs": {
-                "release": "sentry-test@1.0.0",
-                "environment": "production",
-            },
+            "attrs": {"release": "sentry-test@1.0.0", "environment": "production",},
         }
     else:
         raise Exception("Invalid message_type")
@@ -454,11 +443,7 @@ def test_no_outcomes_rate_limit(
     """
 
     config = {
-        "outcomes": {
-            "emit_outcomes": True,
-            "batch_size": 1,
-            "batch_interval": 1,
-        }
+        "outcomes": {"emit_outcomes": True, "batch_size": 1, "batch_interval": 1,}
     }
     relay = relay_with_processing(config)
     project_id = 42

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import uuid
 from queue import Empty
 
+import requests
 import pytest
 import time
 
@@ -49,7 +50,12 @@ def test_outcomes_processing(relay_with_processing, mini_sentry, outcomes_consum
     assert start <= event_emission <= end
 
 
-def _send_event(relay):
+def _send_event(relay, project_id=42):
+    """
+    Send an event to the given project.
+
+    If the project doesn't exist, relay should generate INVALID outcome with reason "project_id".
+    """
     event_id = uuid.uuid1().hex
     message_text = "some message {}".format(datetime.now())
     event_body = {
@@ -59,7 +65,7 @@ def _send_event(relay):
     }
 
     try:
-        relay.send_event(42, event_body)
+        relay.send_event(project_id=project_id, payload=event_body)
     except:
         pass
     return event_id
@@ -73,7 +79,11 @@ def test_outcomes_non_processing(relay, mini_sentry):
     with all necessary information set.
     """
     config = {
-        "outcomes": {"emit_outcomes": True, "batch_size": 1, "batch_interval": 1,}
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+        }
     }
 
     relay = relay(mini_sentry, config)
@@ -112,7 +122,11 @@ def test_outcomes_not_sent_when_disabled(relay, mini_sentry):
     when we disable outcomes.
     """
     config = {
-        "outcomes": {"emit_outcomes": False, "batch_size": 1, "batch_interval": 1,}
+        "outcomes": {
+            "emit_outcomes": False,
+            "batch_size": 1,
+            "batch_interval": 1,
+        }
     }
 
     relay = relay(mini_sentry, config)
@@ -211,22 +225,6 @@ def test_outcomes_non_processing_batching(relay, mini_sentry):
     assert mini_sentry.captured_events.empty()
 
 
-def _send_event(relay):
-    event_id = uuid.uuid1().hex
-    message_text = "some message {}".format(datetime.now())
-    event_body = {
-        "event_id": event_id,
-        "message": message_text,
-        "extra": {"msg_text": message_text},
-    }
-
-    try:
-        relay.send_event(42, event_body)
-    except:
-        pass
-    return event_id
-
-
 def test_outcome_source(relay, mini_sentry):
     """
     Test that the source is picked from configuration and passed in outcomes
@@ -306,15 +304,104 @@ def test_outcome_forwarding(
 
     outcomes_consumer = outcomes_consumer()
     outcome = outcomes_consumer.get_outcome()
-    assert outcome.get("source") == "downstream-layer"
-    assert outcome.get("event_id") == event_id
+
+    expected_outcome = {
+        "project_id": 42,
+        "outcome": 3,
+        "source": "downstream-layer",
+        "reason": "project_id",
+        "event_id": event_id,
+        "remote_addr": "127.0.0.1",
+    }
+    outcome.pop("timestamp")
+
+    assert outcome == expected_outcome
+
+
+# FIXME(anton)
+@pytest.mark.xfail(
+    reason="Might be inconsistent now because we sometimes emit outcomes twice when rate limiting"
+)
+def test_outcomes_forwarding_rate_limited(
+    mini_sentry, relay, relay_with_processing, outcomes_consumer
+):
+    """
+    TODO
+    """
+    processing_config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+            "source": "processing-layer",
+        }
+    }
+    # The innermost Relay needs to be in processing mode
+    upstream = relay_with_processing(processing_config)
+
+    config_downstream = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+            "source": "downstream-layer",
+        }
+    }
+    downstream_relay = relay(upstream, config_downstream)
+
+    # Create project config
+    project_id = 42
+    category = "error"
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["quotas"] = [
+        {
+            "id": "drop-everything",
+            "categories": [category],
+            "limit": 0,
+            "window": 1600,
+            "reasonCode": "rate_limited",
+        }
+    ]
+
+    outcomes_consumer = outcomes_consumer()
+
+    # Send an event
+    result = downstream_relay.send_event(project_id, _get_message(category))
+    event_id = result["id"]
+
+    outcome = outcomes_consumer.get_outcome()
+    outcome.pop("timestamp")
+    expected_outcome = {
+        "reason": "rate_limited",
+        "org_id": 1,
+        "key_id": 123,
+        "outcome": 2,
+        "project_id": 42,
+        "remote_addr": "127.0.0.1",
+        "event_id": event_id,
+        "source": "processing-layer",
+    }
+    assert outcome == expected_outcome
+
+    # Send another event
+    with pytest.raises(requests.exceptions.HTTPError, match="429 Client Error"):
+        result = downstream_relay.send_event(project_id, _get_message(category))
+
+    expected_outcome_from_downstream = deepcopy(expected_outcome)
+    expected_outcome_from_downstream["source"] = "downstream-layer"
+
+    outcome = outcomes_consumer.get_outcome()
+    outcome.pop("timestamp")
+
+    assert outcome == expected_outcome_from_downstream
+
+    assert False, "check that we don't send redundant outcomes"
 
 
 def _get_message(message_type):
-
-    if message_type == "event":
+    if message_type == "error":
         return {"message": "hello"}
-    if message_type == "transaction":
+    elif message_type == "transaction":
         now = datetime.utcnow()
         return {
             "type": "transaction",
@@ -330,7 +417,7 @@ def _get_message(message_type):
             },
             "transaction": "hi",
         }
-    if message_type == "session":
+    elif message_type == "session":
         timestamp = datetime.now(tz=timezone.utc)
         started = timestamp - timedelta(hours=1)
         return {
@@ -343,8 +430,13 @@ def _get_message(message_type):
             "duration": 1947.49,
             "status": "exited",
             "errors": 0,
-            "attrs": {"release": "sentry-test@1.0.0", "environment": "production",},
+            "attrs": {
+                "release": "sentry-test@1.0.0",
+                "environment": "production",
+            },
         }
+    else:
+        raise Exception("Invalid message_type")
 
 
 @pytest.mark.parametrize("category_type", ["session", "transaction"])
@@ -362,7 +454,11 @@ def test_no_outcomes_rate_limit(
     """
 
     config = {
-        "outcomes": {"emit_outcomes": True, "batch_size": 1, "batch_interval": 1,}
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+        }
     }
     relay = relay_with_processing(config)
     project_id = 42


### PR DESCRIPTION
With this change external relays will receive DSN ids as part of (partial) project config. This will allow trusted external relays to emit proper outcomes.