### PR TITLE
ref(server): Simplify capture mode implementation

### DIFF
--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -4,7 +4,7 @@ use ::actix::prelude::*;
 use actix_web::{http::Method, HttpResponse, Path};
 use futures::future::Future;
 
-use crate::actors::events::GetCapturedEvent;
+use crate::actors::events::GetCapturedEnvelope;
 use crate::envelope;
 use crate::extractors::CurrentServiceState;
 use crate::service::ServiceApp;
@@ -17,7 +17,7 @@ fn get_captured_event(
 ) -> ResponseFuture<HttpResponse, actix::MailboxError> {
     let future = state
         .event_manager()
-        .send(GetCapturedEvent {
+        .send(GetCapturedEnvelope {
             event_id: *event_id,
         })
         .map(|captured_event| match captured_event {


### PR DESCRIPTION
Removes the `RwLock` around the map of captured envelopes and instead uses an `ActorFuture` for synchronization. This removes the need to place the map into an `Arc` and clone it across the future.

Since capture mode no longer only records events but entire envelopes, the associated types are now called `CapturedEnvelope`.

#skip-changelog