### PR TITLE
ref(server): Log for status changes for network outages

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -524,7 +524,7 @@ impl UpstreamRelay {
 
     fn upstream_connection_check(&mut self, ctx: &mut Context<Self>) {
         let next_backoff = self.outage_backoff.next_backoff();
-        log::debug!(
+        log::warn!(
             "Network outage, scheduling another check in {:?}",
             next_backoff
         );


### PR DESCRIPTION
This should not change any funtionality. 
It simply adds logs for detecting when the upstream changes state between outage and upstream ok

 #skip-changelog
