### PR TITLE
fix(server): Fix status code for security report 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix a panic in CSP filters. ([#848](https://github.com/getsentry/relay/pull/848))
 - Do not drop sessions due to an invalid age constraint set to `0`. ([#855](https://github.com/getsentry/relay/pull/855))
 - Do not emit outcomes after forwarding envelopes to the upstream, even if that envelope is rate limited, rejected, or dropped. Since the upstream logs an outcome, it would be a duplicate. ([#857](https://github.com/getsentry/relay/pull/857))
+- Fix status code for security report. ([#864](https://github.com/getsentry/relay/pull/864))
 
 **Internal**:
 

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -52,9 +52,7 @@ fn extract_envelope(
 }
 
 fn create_response() -> HttpResponse {
-    HttpResponse::Created()
-        .content_type("application/javascript")
-        .finish()
+    HttpResponse::Ok().finish()
 }
 
 /// This handles all messages coming on the Security endpoint.

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -205,6 +205,7 @@ class SentryLike(object):
             json=payload,
         )
         response.raise_for_status()
+        return response
 
     def send_minidump(self, project_id, params=None, files=None, dsn_key_idx=0):
         """


### PR DESCRIPTION
This bug fix addresses (and fixes part of) https://github.com/getsentry/relay/issues/843 bug report. 

Changed the status code for the security reporting endpoint, that serves
CSP, ExpectCt, ExpectStaple and Hpkp security reports, from returning
HTTP 201 Created, to HTTP 200 OK.

The change was done to satisfy the chrome security report tester for
ExpectCt. Although the standard allows replies with any HTTP 2XX, the
Chrome browser tester (chrome://net-internals/#hsts) expects a HTTP 200
reply.

Also added an integration test to check that we accept and return the
proper HTTP headers in the preflight request for the security endpoint.