### PR TITLE
fix(server): Fix wrong http status tags for `upstream.requests.duration` and `upstream.retries`

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -1054,7 +1054,7 @@ impl Handler<CheckUpstreamConnection> for UpstreamRelay {
             UpstreamRequestConfig {
                 priority: RequestPriority::Immediate,
                 retry: false,
-                update_rate_limits: false,
+                update_rate_limits: true,
                 set_relay_id: true,
             },
             Method::GET,

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -367,8 +367,9 @@ pub struct UpstreamRelay {
 /// Handles a response returned from the upstream.
 ///
 /// If the response indicates success via 2XX status codes, `Ok(response)` is returned. Otherwise,
-/// the response is consumed and an error is returned. Depending on the status code and details
-/// provided in the payload, one of the following errors can be returned:
+/// the response is consumed and an error is returned. If intercept_status_errors is set to true,
+/// depending on the status code and details provided in the payload, one
+/// of the following errors is returned:
 ///
 ///  1. `RateLimited` for a `429` status code.
 ///  2. `ResponseError` in all other cases.

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -138,7 +138,7 @@ pub fn forward_upstream(
         .and_then(move |data| {
             let forward_request = SendRequest::new(method, path_and_query)
                 .retry(false)
-                .update_rate_limits(false)
+                .intercept_status_errors(false)
                 .set_relay_id(false)
                 .build(move |mut builder: RequestBuilder| {
                     for (key, value) in &headers {


### PR DESCRIPTION
This fixes a regression that resulted in incorrectly tagging the status of two metrics `upstream.retries` & `upstream.requests.duration` for some requests.
 #skip-changelog 