### PR TITLE
feat(log): Enable stack traces for Sentry log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Emit metrics for outcomes in external relays. ([#851](https://github.com/getsentry/relay/pull/851))
 - Make `$error.value` `pii=true`. ([#837](https://github.com/getsentry/relay/pull/837))
 - Send `key_id` in partial project config. ([#854](https://github.com/getsentry/relay/pull/854))
+- Add stack traces to Sentry error reports. ([#872](https://github.com/getsentry/relay/pull/872))
+
 
 ## 20.11.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -241,12 +241,12 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.50"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "findshlibs"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00acd5e75443244c1f42fb330b8493d30b44da5b61565d8b8fbf4ecc9dda2a1"
+checksum = "37affc18a9c7cf90b6cf6a7700dab60439a8f138ac5ebc5f12b98281d8f687c9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1305,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "globset"
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -3373,8 +3373,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "sentry"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933beb0343c84eefd69a368318e9291b179e09e51982d49c65d7b362b0e9466f"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -3389,8 +3388,7 @@ dependencies = [
 [[package]]
 name = "sentry-backtrace"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e528fb457baf53fcd6c90beb420705f35c12c3d8caed8817dcf7be00eff7c7"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3401,8 +3399,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3a560a34cffac347f0b588fc29b31db969e27bf57208f946d6a2d588668b0b"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "hostname",
  "lazy_static",
@@ -3416,8 +3413,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b8c235063c1007fd8e2fc7e35ce7eac09dd678d198ecc996daee33d46b3dcc"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "im",
  "lazy_static",
@@ -3430,8 +3426,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632e47b19ff9712bd22424ccf57a21a0e5f3bf4a2e12baae447e01d81e8e2f22"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "findshlibs",
  "lazy_static",
@@ -3441,8 +3436,7 @@ dependencies = [
 [[package]]
 name = "sentry-log"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91b9d4f34cc53ebd109cae92b0e1373df2524e915af95f212b9d0601bff241"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "log",
  "sentry-core",
@@ -3451,8 +3445,7 @@ dependencies = [
 [[package]]
 name = "sentry-panic"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ee338d8292fcdcfb032929c9f53bc0dfac8e0b9d3096be79ceee96818851ed"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3487,8 +3480,7 @@ dependencies = [
 [[package]]
 name = "sentry-types"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbbea6debac0a24880a38239d4c2fc3dbb0b1b398f621bea03ed761796b7dfb"
+source = "git+https://github.com/getsentry/sentry-rust?rev=8e7442b839605998518742b1bda373957d8771d6#8e7442b839605998518742b1bda373957d8771d6"
 dependencies = [
  "chrono",
  "debugid",

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.7.1"
 failure = "0.1.8"
 log = { version = "0.4.11", features = ["serde"] }
 pretty_env_logger = "0.4.0"
-sentry = { version = "0.21.0", features = ["debug-images", "log"] }
+# https://github.com/getsentry/sentry-rust/pull/301
+sentry = { git = "https://github.com/getsentry/sentry-rust", rev = "8e7442b839605998518742b1bda373957d8771d6", features = ["debug-images", "log"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -233,6 +233,7 @@ pub fn init(config: &LogConfig, sentry: &SentryConfig) {
         ],
         integrations: vec![Arc::new(FailureIntegration::new())],
         release: sentry::release_name!(),
+        attach_stacktrace: config.enable_backtraces,
         ..Default::default()
     });
 

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -171,7 +171,7 @@ def mini_sentry(request):
 
     def get_error_message(data):
         exceptions = data.get("exception", {}).get("values", [])
-        exc_msg = (exceptions[0] or {}).get("value")
+        exc_msg = (exceptions and exceptions[0] or {}).get("value")
         message = data.get("message", {})
         message = message if type(message) == str else message.get("formatted")
         return exc_msg or message or "unknown error"


### PR DESCRIPTION
If `logging.enable_backtraces` is set, messages logged to Sentry will additionally receive a stack trace with the location of the log call. This also upgrades the `backtrace` library.