### PR TITLE
fix(protocol): Add missing security directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Do not drop sessions due to an invalid age constraint set to `0`. ([#855](https://github.com/getsentry/relay/pull/855))
 - Do not emit outcomes after forwarding envelopes to the upstream, even if that envelope is rate limited, rejected, or dropped. Since the upstream logs an outcome, it would be a duplicate. ([#857](https://github.com/getsentry/relay/pull/857))
 - Fix status code for security report. ([#864](https://github.com/getsentry/relay/pull/864))
-- Add missing fields for ExpectCT security reports. ([#865](https://github.com/getsentry/relay/pull/865))
+- Support missing fields and directives in CSP reports. ([#865](https://github.com/getsentry/relay/pull/865), [#876](https://github.com/getsentry/relay/pull/876))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - Do not drop sessions due to an invalid age constraint set to `0`. ([#855](https://github.com/getsentry/relay/pull/855))
 - Do not emit outcomes after forwarding envelopes to the upstream, even if that envelope is rate limited, rejected, or dropped. Since the upstream logs an outcome, it would be a duplicate. ([#857](https://github.com/getsentry/relay/pull/857))
 - Fix status code for security report. ([#864](https://github.com/getsentry/relay/pull/864))
-- Support missing fields and directives in CSP reports. ([#865](https://github.com/getsentry/relay/pull/865), [#876](https://github.com/getsentry/relay/pull/876))
+- Add missing fields for Expect-CT reports. ([#865](https://github.com/getsentry/relay/pull/865))
+- Support more directives in CSP reports, such as `block-all-mixed-content` and `require-trusted-types-for`. ([#876](https://github.com/getsentry/relay/pull/876))
 
 **Internal**:
 

--- a/relay-general/src/protocol/security_report.rs
+++ b/relay-general/src/protocol/security_report.rs
@@ -50,7 +50,14 @@ pub enum CspDirective {
     StyleSrcAttr,
     UpgradeInsecureRequests,
     WorkerSrc,
-    // Sandbox , // unsupported
+    Sandbox,
+    NavigateTo,
+    ReportUri,
+    ReportTo,
+    BlockAllMixedContent,
+    RequireSriFor,
+    RequireTrustedTypesFor,
+    TrustedTypes,
 }
 
 derive_fromstr_and_display!(CspDirective, InvalidSecurityError, {
@@ -77,6 +84,14 @@ derive_fromstr_and_display!(CspDirective, InvalidSecurityError, {
     CspDirective::StyleSrcAttr => "style-src-attr",
     CspDirective::UpgradeInsecureRequests => "upgrade-insecure-requests",
     CspDirective::WorkerSrc => "worker-src",
+    CspDirective::Sandbox => "sandbox",
+    CspDirective::NavigateTo => "navigate-to",
+    CspDirective::ReportUri => "report-uri",
+    CspDirective::ReportTo => "report-to",
+    CspDirective::BlockAllMixedContent => "block-all-mixed-content",
+    CspDirective::RequireSriFor => "require-sri-for",
+    CspDirective::RequireTrustedTypesFor => "require-trusted-types-for",
+    CspDirective::TrustedTypes => "trusted-types",
 });
 
 impl_str_serde!(CspDirective);


### PR DESCRIPTION
Several variants of `CspDirective` were missing, which caused us to drop CSP
reports that specified them in their `effective-directive` field. The list of
directives was obtained from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

