### PR TITLE
fix(reqwest): Repair totally broken request body handling

### DIFF
--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -175,9 +175,10 @@ pub fn forward_upstream(
                 .transform(move |response: Response| {
                     let status = response.status();
                     let headers = response.clone_headers();
+                    let is_actix = matches!(response, Response::Actix(_));
                     response
                         .bytes(max_response_size)
-                        .and_then(move |body| Ok((status, headers, body)))
+                        .and_then(move |body| Ok((is_actix, status, headers, body)))
                         .map_err(UpstreamRequestError::Http)
                 });
 
@@ -188,15 +189,28 @@ pub fn forward_upstream(
             })
         })
         .and_then(move |result: Result<_, UpstreamRequestError>| {
-            let (status, headers, body) = result.map_err(ForwardedUpstreamRequestError::from)?;
+            let (is_actix, status, headers, body) =
+                result.map_err(ForwardedUpstreamRequestError::from)?;
             let mut forwarded_response = HttpResponse::build(status);
 
-            // For the response body we're able to disable all automatic decompression and
-            // compression done by actix-web or actix' http client.
-            //
-            // 0. Use ClientRequestBuilder::disable_decompress() (see above)
-            // 1. Set content-encoding to identity such that actix-web will not to compress again
-            forwarded_response.content_encoding(ContentEncoding::Identity);
+            if is_actix {
+                // For actix-web we called ClientRequestBuilder::disable_decompress(), therefore
+                // the response body is already compressed and the headers contain the correct
+                // content-encoding
+                //
+                // The content negotiation has effectively happened between *our* upstream and
+                // *our* client, with us just forwarding raw bytes.
+                //
+                // Set content-encoding to identity such that actix-web will not to compress again
+                forwarded_response.content_encoding(ContentEncoding::Identity);
+            } else {
+                // For reqwest the option to disable automatic response decompression can only be
+                // set per-client. For non-forwarded upstream requests that is desirable, so we
+                // keep it enabled.
+                //
+                // Essentially this means that content negotiation is done twice, and the response
+                // body is first decompressed by reqwest, then re-compressed by actix-web.
+            }
 
             let mut has_content_type = false;
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -215,7 +215,7 @@ where
 {
     // Local imports because importing them top-level is too confusing with two futures crates
     use futures03::{stream::poll_fn, task::Poll};
-    let mut buf = vec![0; 8192];
+    let mut buf = [0; 8192];
 
     let stream = poll_fn(move |_| {
         let bytes_read = match reader.read(&mut buf) {

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -43,6 +43,20 @@ pub enum HttpError {
     ActixPayload(#[cause] PayloadError),
 }
 
+impl HttpError {
+    /// Returns `true` if the error indicates a network downtime.
+    pub fn is_network_error(&self) -> bool {
+        match self {
+            HttpError::ActixPayload(_) | HttpError::Io(_) => true,
+
+            // note: status codes are not handled here because we never call error_for_status. This
+            // logic is part of upstream actor.
+            HttpError::Reqwest(error) => error.is_timeout(),
+            _ => false,
+        }
+    }
+}
+
 impl From<reqwest::Error> for HttpError {
     fn from(e: reqwest::Error) -> Self {
         HttpError::Reqwest(e)

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -62,7 +62,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, request):
             "limits": {"max_api_file_upload_size": "1MiB"},
             "cache": {"batch_interval": 0},
             "logging": {"level": "trace"},
-            "http": {"timeout": 2, "client": request.param},
+            "http": {"timeout": 2, "_client": request.param},
             "processing": {
                 "enabled": False,
                 "kafka_config": [],

--- a/tests/integration/test_forwarding.py
+++ b/tests/integration/test_forwarding.py
@@ -7,8 +7,14 @@ import requests
 from flask import Response, request
 
 
-@pytest.mark.parametrize("compress_request", (True, False))
-@pytest.mark.parametrize("compress_response", (True, False))
+@pytest.mark.parametrize(
+    "compress_request", (True, False), ids=("compress_request", "no_compress_request")
+)
+@pytest.mark.parametrize(
+    "compress_response",
+    (True, False),
+    ids=("compress_response", "no_compress_response"),
+)
 def test_forwarding_content_encoding(
     compress_request, compress_response, mini_sentry, relay_chain
 ):
@@ -17,6 +23,7 @@ def test_forwarding_content_encoding(
     @mini_sentry.app.route("/api/test/reflect", methods=["POST"])
     def test():
         _data = request.data
+
         if request.headers.get("Content-Encoding", "") == "gzip":
             _data = gzip.decompress(_data)
 
@@ -24,7 +31,7 @@ def test_forwarding_content_encoding(
 
         headers = {}
 
-        if compress_response:
+        if request.headers.get("Accept-Encoding", "") == "gzip":
             _data = gzip.compress(_data)
             headers["Content-Encoding"] = "gzip"
 
@@ -40,16 +47,14 @@ def test_forwarding_content_encoding(
     else:
         payload = data
 
+    if compress_response:
+        headers["Accept-Encoding"] = "gzip"
+
     response = relay.post(
         "/api/test/reflect", data=payload, headers=headers, stream=True
     )
     response.raise_for_status()
-    if compress_response:
-        assert response.headers["content-encoding"] == "gzip"
-        assert gzip.decompress(response.raw.read()) == data
-    else:
-        assert response.headers.get("content-encoding", "identity") == "identity"
-        assert response.raw.read() == data
+    assert response.content == data
 
 
 def test_forwarding_routes(mini_sentry, relay):


### PR DESCRIPTION
* Realized that you don't need to convert actix_web::Binary -> bytes::Bytes -> bytes::Buf -> Read, you can just wrap the Binary in a Cursor which ends up happening anyway.

* Realized that after the rename of `http.client` to `http._client` was requested, the tests have not been updated accordingly. Since we discard unknown options when parsing the config file, this caused all tests to just test awc twice instead of testing awc and reqwest.

* Actual bug: `Vec::with_capacity(8192)` is an empty vec, so it dereferences to an empty slice. `read` on an empty slice will read zero bytes which is also code for EOF. This bug was introduced *after* manual testing in attempt to address review comments.

#skip-changelog since this is within the same release