### PR TITLE
fix: Also build rdkafka with ssl if ssl feature is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Add `kafka-ssl` compilation feature that builds Kafka linked against OpenSSL. This feature is enabled in Docker containers only. This is only relevant for Relays running as part of on-premise Sentry. ([#881](https://github.com/getsentry/relay/pull/881))
 - Relay is now able to ingest pre-aggregated sessions, which will make it possible to efficiently handle applications that produce thousands of sessions per second. ([#815](https://github.com/getsentry/relay/pull/815))
 - Add protocol support for WASM. ([#852](https://github.com/getsentry/relay/pull/852))
 - Add dynamic sampling for transactions. ([#835](https://github.com/getsentry/relay/pull/835))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,6 +2769,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ ENV BUILD_ARCH=${BUILD_ARCH}
 ENV OPENSSL_ARCH=${OPENSSL_ARCH}
 
 ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
+# For native-tls
 ENV OPENSSL_DIR=/usr/local/build/$BUILD_TARGET
+# For rdkafka
+ENV OPENSSL_ROOT_DIR=/usr/local/build/$BUILD_TARGET
 ENV OPENSSL_STATIC=1
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,9 @@ RUN echo "Building OpenSSL" \
 FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM relay-deps AS relay-builder
 
-ARG RELAY_FEATURES=ssl,processing
+# ssl and processing are required for basic functionality in onprem
+# kafka-ssl is for free since we already have OpenSSL because we are on Linux
+ARG RELAY_FEATURES=ssl,kafka-ssl,processing
 ENV RELAY_FEATURES=${RELAY_FEATURES}
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [features]
 default = []
-ssl = ["native-tls", "actix-web/tls"]
+ssl = ["native-tls", "actix-web/tls", "rdkafka/ssl"]
 processing = [
     "minidump",
     "rdkafka",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -12,7 +12,8 @@ publish = false
 
 [features]
 default = []
-ssl = ["native-tls", "actix-web/tls", "rdkafka/ssl"]
+ssl = ["native-tls", "actix-web/tls"]
+kafka-ssl = ["rdkafka/ssl"]
 processing = [
     "minidump",
     "rdkafka",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -11,8 +11,10 @@ license-file = "../LICENSE"
 publish = false
 
 [features]
+# See https://getsentry.github.io/relay/relay/#feature-flags for explanation of feature flags
 default = ["ssl"]
 ssl = ["relay-server/ssl"]
+kafka-ssl = ["relay-server/kafka-ssl"]
 processing = ["relay-server/processing"]
 
 # Direct dependencies of the main application in `src/`

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -21,9 +21,21 @@
 //!
 //! # Feature Flags
 //!
-//! - `ssl` _(default)_: Enables SSL support using `native-tls`.
+//! - `ssl` _(default)_: Enables SSL support for incoming and outgoing HTTP using the [`native-tls`
+//!   crate](https://crates.io/crates/native-tls). On Windows/Mac this will use the native SSL
+//!   capabilities while for other platforms OpenSSL is required.
+//!
+//!   Disable this feature to remove the dependency on OpenSSL under Linux.
+//!
 //! - `processing`: Includes event ingestion and processing functionality. This should only be
-//!   specified when compiling Relay as Sentry service. Standalone Relays do not need this feature.
+//!   specified when compiling Relay as Sentry service.  Standalone Relays do not need this feature.
+//!
+//! - `kafka-ssl`: Our Kafka client `librdkafka` requires OpenSSL on *all* platforms to speak SSL.
+//!   As this is an extra requirement on Windows and Mac it is its own featureflag and disabled by
+//!   default.
+//!
+//!   This feature is only relevant when Relay is compiled with `processing` enabled, as without it
+//!   `librdkafka` is not installed.
 //!
 //! # Workspace Crates
 //!

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -30,12 +30,10 @@
 //! - `processing`: Includes event ingestion and processing functionality. This should only be
 //!   specified when compiling Relay as Sentry service.  Standalone Relays do not need this feature.
 //!
-//! - `kafka-ssl`: Our Kafka client `librdkafka` requires OpenSSL on *all* platforms to speak SSL.
-//!   As this is an extra requirement on Windows and Mac it is its own featureflag and disabled by
-//!   default.
-//!
-//!   This feature is only relevant when Relay is compiled with `processing` enabled, as without it
-//!   `librdkafka` is not installed.
+//! - `kafka-ssl`: This feature is only relevant in combination with `processing`. 
+//!   The Kafka client `librdkafka` requires OpenSSL on *all* platforms to speak SSL.
+//!   As this is an extra requirement on Windows and Mac, this is disabled by default.
+
 //!
 //! # Workspace Crates
 //!

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -30,7 +30,7 @@
 //! - `processing`: Includes event ingestion and processing functionality. This should only be
 //!   specified when compiling Relay as Sentry service.  Standalone Relays do not need this feature.
 //!
-//! - `kafka-ssl`: This feature is only relevant in combination with `processing`. 
+//! - `kafka-ssl`: This feature is only relevant in combination with `processing`.
 //!   The Kafka client `librdkafka` requires OpenSSL on *all* platforms to speak SSL.
 //!   As this is an extra requirement on Windows and Mac, this is disabled by default.
 


### PR DESCRIPTION
Fix https://github.com/getsentry/relay/issues/879

librdkafka can link exclusively against openssl, while relay's http stack actually uses native-tls abstraction which does not require openssl outside of linux (see relay's release page, we also offer standalone .exe outside of docker). This poses a problem for our local dev workflow, as all our workstations are OS X, have no OpenSSL, but we still want to compile Relay in processing mode. The solution is a separate featureflag `kafka-ssl`.