### PR TITLE
feat: Enable use of multiple value types per field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Bug Fixes**:
 
+- Fix a long-standing bug where log messages were not addressible as `$string`. ([#882](https://github.com/getsentry/relay/pull/882/)
 - Allow params in content-type for security requests to support content types like `"application/expect-ct-report+json; charset=utf-8"`. ([#844](https://github.com/getsentry/relay/pull/844))
 - Fix a panic in CSP filters. ([#848](https://github.com/getsentry/relay/pull/848))
 - Do not drop sessions due to an invalid age constraint set to `0`. ([#855](https://github.com/getsentry/relay/pull/855))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 **Bug Fixes**:
 
-- Fix a long-standing bug where log messages were not addressible as `$string`. ([#882](https://github.com/getsentry/relay/pull/882/)
+- Fix a long-standing bug where log messages were not addressible as `$string`. ([#882](https://github.com/getsentry/relay/pull/882))
 - Allow params in content-type for security requests to support content types like `"application/expect-ct-report+json; charset=utf-8"`. ([#844](https://github.com/getsentry/relay/pull/844))
 - Fix a panic in CSP filters. ([#848](https://github.com/getsentry/relay/pull/848))
 - Do not drop sessions due to an invalid age constraint set to `0`. ([#855](https://github.com/getsentry/relay/pull/855))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "term_size",
  "textwrap",
  "unicode-width",
@@ -759,6 +759,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "strsim 0.9.3",
+ "syn 1.0.39",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote 1.0.7",
+ "syn 1.0.39",
+]
+
+[[package]]
 name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1020,28 @@ dependencies = [
  "num-traits 0.1.43",
  "quote 0.3.15",
  "syn 0.11.11",
+]
+
+[[package]]
+name = "enumset"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "959a80a2062fedd66ed41d99736212de987b3a8c83a4c2cef243968075256bd1"
+dependencies = [
+ "enumset_derive",
+ "num-traits 0.2.12",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1503,6 +1560,12 @@ dependencies = [
  "tokio 0.2.21",
  "tokio-tls 0.3.1",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2969,6 +3032,7 @@ dependencies = [
  "debugid",
  "difference",
  "dynfmt",
+ "enumset",
  "failure",
  "hmac",
  "insta 0.15.0",
@@ -3716,6 +3780,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -147,7 +147,8 @@ def test_pii_strip_event():
 def test_pii_selector_suggestions_from_event():
     event = {"logentry": {"formatted": "hi"}}
     assert sentry_relay.pii_selector_suggestions_from_event(event) == [
-        {"path": "$message", "value": "hi"}
+        {"path": "$string", "value": "hi"},
+        {"path": "$message", "value": "hi"},
     ]
 
 

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -38,6 +38,7 @@ uaparser = { version = "0.3.3", optional = true }
 url = "2.1.1"
 utf16string = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
+enumset = "1.0.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -543,7 +543,7 @@ fn parse_bag_size(name: &str) -> TokenStream {
 #[derive(Default)]
 struct TypeAttrs {
     process_func: Option<String>,
-    value_type: Option<String>,
+    value_type: Vec<String>,
     tag_key: Option<String>,
 }
 
@@ -600,7 +600,7 @@ fn parse_type_attributes(s: &synstructure::Structure<'_>) -> TypeAttrs {
                             } else if ident == "value_type" {
                                 match name_value.lit {
                                     Lit::Str(litstr) => {
-                                        rv.value_type = Some(litstr.value());
+                                        rv.value_type.push(litstr.value());
                                     }
                                     _ => {
                                         panic!("Got non string literal for value type");

--- a/relay-general/derive/src/process.rs
+++ b/relay-general/derive/src/process.rs
@@ -130,22 +130,25 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
     let _ = s.bind_with(|_bi| synstructure::BindStyle::Ref);
 
     let value_type_arms = s.each_variant(|variant| {
-        if let Some(ref value_name) = type_attrs.value_type {
-            let value_name = Ident::new(value_name, Span::call_site());
-            quote!(Some(crate::processor::ValueType::#value_name))
+        if !type_attrs.value_type.is_empty() {
+            let value_names = type_attrs
+                .value_type
+                .iter()
+                .map(|value_name| Ident::new(value_name, Span::call_site()));
+            quote!(enumset::enum_set!( #(crate::processor::ValueType::#value_names)|* ))
         } else if is_newtype(variant) {
             let bi = &variant.bindings()[0];
             let ident = &bi.binding;
             quote!(crate::processor::ProcessValue::value_type(#ident))
         } else {
-            quote!(None)
+            quote!(enumset::EnumSet::empty())
         }
     });
 
     s.gen_impl(quote! {
         #[automatically_derived]
         gen impl crate::processor::ProcessValue for @Self {
-            fn value_type(&self) -> Option<crate::processor::ValueType> {
+            fn value_type(&self) -> enumset::EnumSet<crate::processor::ValueType> {
                 match *self {
                     #value_type_arms
                 }

--- a/relay-general/src/pii/generate_selectors.rs
+++ b/relay-general/src/pii/generate_selectors.rs
@@ -33,7 +33,7 @@ impl Processor for GenerateSelectorsProcessor {
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
         // The following skip-conditions are in sync with what the PiiProcessor does.
-        if state.value_type() == Some(ValueType::Boolean)
+        if state.value_type().contains(ValueType::Boolean)
             || value.is_none()
             || state.attrs().pii == Pii::False
         {
@@ -66,32 +66,30 @@ impl Processor for GenerateSelectorsProcessor {
                 continue;
             }
 
-            match substate.value_type() {
-                // $array.0.foo and $object.bar are not particularly good suggestions.
-                Some(ValueType::Object) | Some(ValueType::Array) => {}
+            for value_type in substate.value_type() {
+                match value_type {
+                    // $array.0.foo and $object.bar are not particularly good suggestions.
+                    ValueType::Object | ValueType::Array => {}
 
-                // a.b.c.$string is not a good suggestion, so special case those.
-                ty @ Some(ValueType::String)
-                | ty @ Some(ValueType::Number)
-                | ty @ Some(ValueType::Boolean)
-                | ty @ Some(ValueType::DateTime) => {
-                    insert_path(SelectorSpec::Path(vec![SelectorPathItem::Type(
-                        ty.unwrap(),
-                    )]));
-                }
+                    // a.b.c.$string is not a good suggestion, so special case those.
+                    ty @ ValueType::String
+                    | ty @ ValueType::Number
+                    | ty @ ValueType::Boolean
+                    | ty @ ValueType::DateTime => {
+                        insert_path(SelectorSpec::Path(vec![SelectorPathItem::Type(ty)]));
+                    }
 
-                Some(ty) => {
-                    let mut path = path.clone();
-                    path.push(SelectorPathItem::Type(ty));
-                    path.reverse();
-                    if insert_path(SelectorSpec::Path(path)) {
-                        // If we managed to generate $http.header.Authorization, we do not want to
-                        // generate request.headers.Authorization as well.
-                        return Ok(());
+                    ty => {
+                        let mut path = path.clone();
+                        path.push(SelectorPathItem::Type(ty));
+                        path.reverse();
+                        if insert_path(SelectorSpec::Path(path)) {
+                            // If we managed to generate $http.header.Authorization, we do not want to
+                            // generate request.headers.Authorization as well.
+                            return Ok(());
+                        }
                     }
                 }
-
-                None => {}
             }
 
             if let Some(key) = substate.path().key() {
@@ -228,6 +226,8 @@ mod tests {
           value: Something failed
         - path: $string
           value: bar
+        - path: $string
+          value: hi
         - path: $string
           value: not really
         - path: $error.value

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -264,37 +264,21 @@ impl PiiAttachmentsProcessor<'_> {
                         .get_mut(range)
                         .ok_or(ScrubMinidumpError::InvalidAddress)?;
 
-                    // Backwards-compatible visit
-                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
-                    let state =
-                        file_state.enter_static("", Some(attrs), Some(ValueType::StackMemory));
-                    changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
-
-                    // Documented visit
                     let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
                     let state = file_state.enter_static(
                         "stack_memory",
                         Some(attrs),
-                        Some(ValueType::Binary),
+                        ValueType::Binary | ValueType::StackMemory,
                     );
                     changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
                 }
                 MinidumpItem::NonStackMemory(range) => {
-                    // Backwards-compatible visit.
-                    let slice = data
-                        .get_mut(range)
-                        .ok_or(ScrubMinidumpError::InvalidAddress)?;
-                    let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::Maybe));
-                    let state =
-                        file_state.enter_static("", Some(attrs), Some(ValueType::HeapMemory));
-                    changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
-
                     // Documented visit.
                     let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::True));
                     let state = file_state.enter_static(
                         "heap_memory",
                         Some(attrs),
-                        Some(ValueType::Binary),
+                        ValueType::Binary | ValueType::HeapMemory,
                     );
                     changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
                 }

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -273,7 +273,9 @@ impl PiiAttachmentsProcessor<'_> {
                     changed |= self.scrub_bytes(slice, &state, ScrubEncodings::All);
                 }
                 MinidumpItem::NonStackMemory(range) => {
-                    // Documented visit.
+                    let slice = data
+                        .get_mut(range)
+                        .ok_or(ScrubMinidumpError::InvalidAddress)?;
                     let attrs = Cow::Owned(FieldAttrs::new().pii(Pii::True));
                     let state = file_state.enter_static(
                         "heap_memory",

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -73,7 +73,9 @@ impl<'a> Processor for PiiProcessor<'a> {
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
         // booleans cannot be PII, and strings are handled in process_string
-        if let Some(ValueType::Boolean) | Some(ValueType::String) = state.value_type() {
+        if state.value_type().contains(ValueType::Boolean)
+            || state.value_type().contains(ValueType::String)
+        {
             return Ok(());
         }
 
@@ -836,6 +838,7 @@ fn test_logentry_value_types() {
         "$logentry.formatted",
         "$message",
         "$logentry.formatted && $message",
+        "$string",
     ] {
         let config = PiiConfig::from_json(&format!(
             r##"

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -468,9 +468,8 @@ impl<'a> ProcessingState<'a> {
         Path(&self)
     }
 
-    pub fn value_type(&self) -> Option<ValueType> {
-        // TODO
-        self.value_type.iter().next()
+    pub fn value_type(&self) -> EnumSet<ValueType> {
+        self.value_type
     }
 
     /// Returns the field attributes.

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::fmt;
-use std::mem;
 use std::ops::RangeInclusive;
 
 use enumset::{EnumSet, EnumSetType};
@@ -51,8 +50,11 @@ pub enum ValueType {
 }
 
 impl ValueType {
-    pub fn for_field<T: ProcessValue>(field: &Annotated<T>) -> Option<Self> {
-        field.value().and_then(ProcessValue::value_type)
+    pub fn for_field<T: ProcessValue>(field: &Annotated<T>) -> EnumSet<Self> {
+        field
+            .value()
+            .map(ProcessValue::value_type)
+            .unwrap_or_else(EnumSet::empty)
     }
 }
 
@@ -381,7 +383,7 @@ static ROOT_STATE: ProcessingState = ProcessingState {
     parent: None,
     path_item: None,
     attrs: None,
-    value_type: unsafe { mem::transmute::<u32, EnumSet<ValueType>>(0) },
+    value_type: enumset::enum_set!(),
     depth: 0,
 };
 

--- a/relay-general/src/processor/impls.rs
+++ b/relay-general/src/processor/impls.rs
@@ -1,3 +1,4 @@
+use enumset::EnumSet;
 use uuid::Uuid;
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
@@ -5,8 +6,8 @@ use crate::types::{Annotated, Array, Meta, Object, ProcessingResult};
 
 impl ProcessValue for String {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::String)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::String)
     }
 
     #[inline]
@@ -25,8 +26,8 @@ impl ProcessValue for String {
 
 impl ProcessValue for bool {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Boolean)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Boolean)
     }
 
     #[inline]
@@ -45,8 +46,8 @@ impl ProcessValue for bool {
 
 impl ProcessValue for u64 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Number)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Number)
     }
 
     #[inline]
@@ -65,8 +66,8 @@ impl ProcessValue for u64 {
 
 impl ProcessValue for i64 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Number)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Number)
     }
 
     #[inline]
@@ -85,8 +86,8 @@ impl ProcessValue for i64 {
 
 impl ProcessValue for f64 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Number)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Number)
     }
 
     #[inline]
@@ -110,8 +111,8 @@ where
     T: ProcessValue,
 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Array)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Array)
     }
 
     #[inline]
@@ -153,8 +154,8 @@ where
     T: ProcessValue,
 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Object)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Object)
     }
 
     #[inline]
@@ -196,7 +197,7 @@ where
     T: ProcessValue,
 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
+    fn value_type(&self) -> EnumSet<ValueType> {
         (**self).value_type()
     }
 
@@ -218,9 +219,7 @@ macro_rules! process_tuple {
     ($($name: ident),+) => {
         impl< $( $name: ProcessValue ),* > ProcessValue for ( $( Annotated<$name>, )* ) {
             #[inline]
-            fn value_type(&self) -> Option<ValueType> {
-                Some(ValueType::Array)
-            }
+            fn value_type(&self) -> EnumSet<ValueType> { EnumSet::only(ValueType::Array) }
 
             #[inline]
             #[allow(non_snake_case, unused_assignments)]

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -72,7 +72,7 @@ impl SelectorPathItem {
         match *self {
             SelectorPathItem::Wildcard => true,
             SelectorPathItem::DeepWildcard => true,
-            SelectorPathItem::Type(ty) => state.value_type() == Some(ty),
+            SelectorPathItem::Type(ty) => state.value_type().contains(ty),
             SelectorPathItem::Index(idx) => state.path().index() == Some(idx),
             SelectorPathItem::Key(ref key) => state
                 .path()

--- a/relay-general/src/processor/traits.rs
+++ b/relay-general/src/processor/traits.rs
@@ -3,6 +3,8 @@
 
 use std::fmt::Debug;
 
+use enumset::EnumSet;
+
 use crate::processor::{process_value, ProcessingState, ValueType};
 use crate::types::{FromValue, Meta, ProcessingResult, ToValue};
 
@@ -115,8 +117,8 @@ pub trait Processor: Sized {
 pub trait ProcessValue: FromValue + ToValue + Debug + Clone {
     /// Returns the type of the value.
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        None
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::empty()
     }
 
     /// Executes a processor on this value.

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -7,6 +7,7 @@ use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
 
+use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -39,14 +40,14 @@ impl<T: Into<String>> From<T> for NativeImagePath {
 
 impl ProcessValue for NativeImagePath {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
+    fn value_type(&self) -> EnumSet<ValueType> {
         // Explicit decision not to expose NativeImagePath as valuetype, as people should not be
         // able to address processing internals.
         //
         // Also decided against exposing a $filepath ("things that may contain filenames") because
         // ruletypes/regexes are better suited for this, and in the case of $frame.package (where
         // it depends on platform) it's really not that useful.
-        Some(ValueType::String)
+        EnumSet::only(ValueType::String)
     }
 
     #[inline]

--- a/relay-general/src/protocol/logentry.rs
+++ b/relay-general/src/protocol/logentry.rs
@@ -65,7 +65,7 @@ impl From<String> for LogEntry {
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, ToValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-#[metastructure(value_type = "Message")]
+#[metastructure(value_type = "Message", value_type = "String")]
 pub struct Message(String);
 
 impl From<String> for Message {

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -14,6 +14,7 @@ use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
 
+use enumset::EnumSet;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
@@ -329,8 +330,8 @@ where
     T: ProcessValue + AsPair,
 {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::Object)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::Object)
     }
 
     #[inline]
@@ -867,8 +868,8 @@ impl Timestamp {
 
 impl ProcessValue for Timestamp {
     #[inline]
-    fn value_type(&self) -> Option<ValueType> {
-        Some(ValueType::DateTime)
+    fn value_type(&self) -> EnumSet<ValueType> {
+        EnumSet::only(ValueType::DateTime)
     }
 
     #[inline]


### PR DESCRIPTION
Add ability to assign multiple value types to a protocol type. For example (part of the patch):

    #[metastructure(value_type = "Message", value_type = "String")]

This allows us to fix a long-standing issue with logentry.formatted,
which is supposed to be addressible by $string as well as
$logentry.formatted as well as $message.

It also makes a bit of code in minidump attachment processing simpler,
and removes an obstacle in introducing valuetypes in a
backwards-compatible manner.

For future consideration we may change the behavior of the derive on
newtypes to *append* to the list of valuetypes rather than replace them,
such that the actual syntactic change in logentry.rs is not necessary
(as the Message wraps a String already). Similarly one could make all
structs-with-fields addressible under $object.