### PR TITLE
meta: Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
+# Default code owners 
+*   @getsentry/owners-ingest
+
 # Legal
 /LICENSE  @getsentry/owners-legal
 
 # Build & Releases
 /.github/workflows/release.yml  @getsentry/releases
 
-# Everything else
-*   @getsentry/owners-ingest


### PR DESCRIPTION
Based on https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file, the order matters and **the last line that matches** takes precedence. That makes all definitions above the `*` catch-all definition useless. This PR fixes that.

#skip-changelog