### PR TITLE
fix(user-report): Make all fields but event-id optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 20.12.1
 
-- No documented changes.
+**Bug Fixes**:
+
+- Make all fields but event-id optional to fix regressions in user feedback ingestion. ([#886](https://github.com/getsentry/relay/pull/886))
 
 ## 20.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 20.12.1
+## Unreleased
 
 **Bug Fixes**:
 
 - Make all fields but event-id optional to fix regressions in user feedback ingestion. ([#886](https://github.com/getsentry/relay/pull/886))
+
+## 20.12.1
+
+- No documented changes.
 
 ## 20.12.0
 

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 /// accepts goes.
 ///
 /// For example, `{"email": null}` is only invalid because `UserReport(email=None).save()` is. SDKs
-/// may neither send this (we can relax this), but more importantly the ingest consumer may never
-/// receive this... because it would end up crashing the ingest consumer (while in older versions
-/// of Sentry it would simply crash the endpoint).
+/// may neither send this (historically, in Relay we relaxed this already), but more importantly
+/// the ingest consumer may never receive this... because it would end up crashing the ingest
+/// consumer (while in older versions of Sentry it would simply crash the endpoint).
 ///
 /// The database/model schema is a bunch of not-null strings that have (pgsql) defaults, so that's
 /// how we end up with this struct definition.
@@ -20,12 +20,20 @@ pub struct UserReport {
     /// The event ID for which this user feedback is created.
     pub event_id: EventId,
     /// The user's name.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_to_default")]
     pub name: String,
     /// The user's email address.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_to_default")]
     pub email: String,
     /// Comments supplied by the user.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_to_default")]
     pub comments: String,
+}
+
+fn null_to_default<'de, D>(deserializer: D) -> Result<Priority, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_else(Priority::lowest))
 }

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -1,6 +1,6 @@
 use crate::protocol::EventId;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 
 /// User feedback for an event as sent by the client to the userfeedback/userreport endpoint.
 ///
@@ -30,10 +30,11 @@ pub struct UserReport {
     pub comments: String,
 }
 
-fn null_to_default<'de, D>(deserializer: D) -> Result<Priority, D::Error>
+fn null_to_default<'de, D, V>(deserializer: D) -> Result<V, D::Error>
 where
     D: Deserializer<'de>,
+    V: Default + DeserializeOwned,
 {
     let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_else(Priority::lowest))
+    Ok(opt.unwrap_or_default())
 }

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -8,9 +8,15 @@ pub struct UserReport {
     /// The event ID for which this user feedback is created.
     pub event_id: EventId,
     /// The user's name.
+    // Empty strings are in fact stored in the database already
+    #[serde(default)]
     pub name: String,
     /// The user's email address.
+    // Empty strings are in fact stored in the database already
+    #[serde(default)]
     pub email: String,
     /// Comments supplied by the user.
+    // Empty strings are in fact stored in the database already
+    #[serde(default)]
     pub comments: String,
 }

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -3,20 +3,26 @@ use crate::protocol::EventId;
 use serde::{Deserialize, Serialize};
 
 /// User feedback for an event as sent by the client to the userfeedback/userreport endpoint.
+///
+/// Historically the "schema" for user report has been "defined" as the set of possible
+/// keyword-arguments `sentry.models.UserReport` accepts. Anything the model constructor
+/// accepts goes.
+///
+/// For example, `{"email": null}` is only invalid because `UserReport(email=None).save()` is.
+///
+/// The database/model schema is a bunch of not-null strings that have (pgsql) defaults, so that's
+/// how we end up with this struct definition.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct UserReport {
     /// The event ID for which this user feedback is created.
     pub event_id: EventId,
     /// The user's name.
-    // Empty strings are in fact stored in the database already
     #[serde(default)]
     pub name: String,
     /// The user's email address.
-    // Empty strings are in fact stored in the database already
     #[serde(default)]
     pub email: String,
     /// Comments supplied by the user.
-    // Empty strings are in fact stored in the database already
     #[serde(default)]
     pub comments: String,
 }

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// For example, `{"email": null}` is only invalid because `UserReport(email=None).save()` is. SDKs
 /// may neither send this (we can relax this), but more importantly the ingest consumer may never
-/// receive this.
+/// receive this... because it would end up crashing the ingest consumer (while in older versions
+/// of Sentry it would simply crash the endpoint).
 ///
 /// The database/model schema is a bunch of not-null strings that have (pgsql) defaults, so that's
 /// how we end up with this struct definition.

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 /// keyword-arguments `sentry.models.UserReport` accepts. Anything the model constructor
 /// accepts goes.
 ///
-/// For example, `{"email": null}` is only invalid because `UserReport(email=None).save()` is.
+/// For example, `{"email": null}` is only invalid because `UserReport(email=None).save()` is. SDKs
+/// may neither send this (we can relax this), but more importantly the ingest consumer may never
+/// receive this.
 ///
 /// The database/model schema is a bunch of not-null strings that have (pgsql) defaults, so that's
 /// how we end up with this struct definition.


### PR DESCRIPTION
the exact schema has been really ill-defined, and it appears most SDK devs expect those fields to be optional now. We already store empty strings for all of those fields, so let's just make them all optional.

The "schema" for user report is "defined" is as the set of possible keyword-arguments to the Python model itself. Anything goes that the model constructor accepts. Explicit null was never really supported. Also changing to Option means that we would have to coerce to empty string on serialization precisely to avoid running UserReport(email=None).save() which would violate NotNullConstraint of the database.