### PR TITLE
docker: Allow delayed relay startup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,9 +9,16 @@ if [[ "${RELAY_ENABLE_COREDUMPS:-}" == "1" ]]; then
   ulimit -c unlimited
 fi
 
+# Sleep for the specified number of seconds before starting.
+# For example, can be helpful to synchronize container startup in Kubernetes environment.
+if [[ -n "${RELAY_DELAY_STARTUP_SECONDS:-}" ]]; then
+  echo "Sleeping for ${RELAY_DELAY_STARTUP_SECONDS}s..."
+  sleep "${RELAY_DELAY_STARTUP_SECONDS}"
+fi
+
 # For compatibility with older images
 if [ "$1" == "bash" ]; then
-  set -- bash
+  set -- bash "${@:2}"
 elif [ "$(id -u)" == "0" ]; then
   set -- gosu relay /bin/relay "$@"
 else


### PR DESCRIPTION
This is a small hack to allow delayed container startup. This can be helpful in e.g. Kubernetes environment when multiple containers start in the same pod, and we want relay to start with some delay. It _can_ be done by changing entrypoint in Kuberenetes config, but that would mean we lose all other steps from `docker-entrypoint.sh`.

The environment variable is optional, nothing new happens by default.

#skip-changelog