### PR TITLE
fix: Stop using --all-features in makefile due to kafka-ssl feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ SHELL=/bin/bash
 export RELAY_PYTHON_VERSION := python3
 export RELAY_FEATURES := ssl
 
+# This is the subset of --all-features that actually works on OS X. Notably it
+# is missing kafka-ssl which would require openssl to be installed on OS X.
+export RELAY_DEV_FEATURES := ssl,processing
+
 all: check test
 .PHONY: all
 
@@ -16,7 +20,7 @@ clean:
 # Builds
 
 build: setup-git
-	cargo +stable build --all-features
+	cd relay && cargo +stable build --features ${RELAY_DEV_FEATURES}
 .PHONY: build
 
 release: setup-git
@@ -52,7 +56,7 @@ test-rust: setup-git
 .PHONY: test-rust
 
 test-rust-all: setup-git
-	cargo test --workspace --all-features
+	cargo test --workspace --features ${RELAY_DEV_FEATURES}
 .PHONY: test-rust-all
 
 test-python: setup-git setup-venv


### PR DESCRIPTION
1. `kafka-ssl` cannot build on OS X, so running `make test-integration` is broken atm
2. Therefore we cannot use `--all-features` for local development (CI does not use makefile)
2. `--features` does not work at workspace-level, it seems https://github.com/rust-lang/cargo/issues/4463 is related (they just completely disabled it because it was so broken)
3. Solution: `cd relay` like we do for release


#skip-changelog