### PR TITLE
Revert "fix: Also build rdkafka with ssl if ssl feature is enabled"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Remove `kafka-ssl` feature again because it breaks development workflow on OS X. ([#889](https://github.com/getsentry/relay/pull/889))
+
 **Bug Fixes**:
 
 - Make all fields but event-id optional to fix regressions in user feedback ingestion. ([#886](https://github.com/getsentry/relay/pull/886))
@@ -14,6 +18,7 @@
 
 **Features**:
 
+- Add `kafka-ssl` compilation feature that builds Kafka linked against OpenSSL. This feature is enabled in Docker containers only. This is only relevant for Relays running as part of on-premise Sentry. ([#881](https://github.com/getsentry/relay/pull/881))
 - Relay is now able to ingest pre-aggregated sessions, which will make it possible to efficiently handle applications that produce thousands of sessions per second. ([#815](https://github.com/getsentry/relay/pull/815))
 - Add protocol support for WASM. ([#852](https://github.com/getsentry/relay/pull/852))
 - Add dynamic sampling for transactions. ([#835](https://github.com/getsentry/relay/pull/835))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 **Features**:
 
 - Support dynamic sampling for error events. ([#883](https://github.com/getsentry/relay/pull/883))
-- Remove `kafka-ssl` feature again because it breaks development workflow on OS X. ([#889](https://github.com/getsentry/relay/pull/889))
 
 **Bug Fixes**:
 
 - Make all fields but event-id optional to fix regressions in user feedback ingestion. ([#886](https://github.com/getsentry/relay/pull/886))
+- Remove `kafka-ssl` feature because it breaks development workflow on macOS. ([#889](https://github.com/getsentry/relay/pull/889))
 
 ## 20.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 **Features**:
 
-- Add `kafka-ssl` compilation feature that builds Kafka linked against OpenSSL. This feature is enabled in Docker containers only. This is only relevant for Relays running as part of on-premise Sentry. ([#881](https://github.com/getsentry/relay/pull/881))
 - Relay is now able to ingest pre-aggregated sessions, which will make it possible to efficiently handle applications that produce thousands of sessions per second. ([#815](https://github.com/getsentry/relay/pull/815))
 - Add protocol support for WASM. ([#852](https://github.com/getsentry/relay/pull/852))
 - Add dynamic sampling for transactions. ([#835](https://github.com/getsentry/relay/pull/835))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
- "openssl-sys",
  "pkg-config",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,7 @@ ENV BUILD_ARCH=${BUILD_ARCH}
 ENV OPENSSL_ARCH=${OPENSSL_ARCH}
 
 ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
-# For native-tls
 ENV OPENSSL_DIR=/usr/local/build/$BUILD_TARGET
-# For rdkafka
-ENV OPENSSL_ROOT_DIR=/usr/local/build/$BUILD_TARGET
 ENV OPENSSL_STATIC=1
 
 RUN apt-get update \
@@ -66,9 +63,7 @@ RUN echo "Building OpenSSL" \
 FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM relay-deps AS relay-builder
 
-# ssl and processing are required for basic functionality in onprem
-# kafka-ssl is for free since we already have OpenSSL because we are on Linux
-ARG RELAY_FEATURES=ssl,kafka-ssl,processing
+ARG RELAY_FEATURES=ssl,processing
 ENV RELAY_FEATURES=${RELAY_FEATURES}
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@ SHELL=/bin/bash
 export RELAY_PYTHON_VERSION := python3
 export RELAY_FEATURES := ssl
 
-# This is the subset of --all-features that actually works on OS X. Notably it
-# is missing kafka-ssl which would require openssl to be installed on OS X.
-export RELAY_DEV_FEATURES := ssl,processing
-
 all: check test
 .PHONY: all
 
@@ -20,7 +16,7 @@ clean:
 # Builds
 
 build: setup-git
-	cd relay && cargo +stable build --features ${RELAY_DEV_FEATURES}
+	cargo +stable build --all-features
 .PHONY: build
 
 release: setup-git
@@ -56,7 +52,7 @@ test-rust: setup-git
 .PHONY: test-rust
 
 test-rust-all: setup-git
-	cargo test --workspace --features ${RELAY_DEV_FEATURES}
+	cargo test --workspace --all-features
 .PHONY: test-rust-all
 
 test-python: setup-git setup-venv

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 [features]
 default = []
 ssl = ["native-tls", "actix-web/tls"]
-kafka-ssl = ["rdkafka/ssl"]
 processing = [
     "minidump",
     "rdkafka",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -11,10 +11,8 @@ license-file = "../LICENSE"
 publish = false
 
 [features]
-# See https://getsentry.github.io/relay/relay/#feature-flags for explanation of feature flags
 default = ["ssl"]
 ssl = ["relay-server/ssl"]
-kafka-ssl = ["relay-server/kafka-ssl"]
 processing = ["relay-server/processing"]
 
 # Direct dependencies of the main application in `src/`

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -21,19 +21,9 @@
 //!
 //! # Feature Flags
 //!
-//! - `ssl` _(default)_: Enables SSL support for incoming and outgoing HTTP using the [`native-tls`
-//!   crate](https://crates.io/crates/native-tls). On Windows/Mac this will use the native SSL
-//!   capabilities while for other platforms OpenSSL is required.
-//!
-//!   Disable this feature to remove the dependency on OpenSSL under Linux.
-//!
+//! - `ssl` _(default)_: Enables SSL support using `native-tls`.
 //! - `processing`: Includes event ingestion and processing functionality. This should only be
-//!   specified when compiling Relay as Sentry service.  Standalone Relays do not need this feature.
-//!
-//! - `kafka-ssl`: This feature is only relevant in combination with `processing`.
-//!   The Kafka client `librdkafka` requires OpenSSL on *all* platforms to speak SSL.
-//!   As this is an extra requirement on Windows and Mac, this is disabled by default.
-
+//!   specified when compiling Relay as Sentry service. Standalone Relays do not need this feature.
 //!
 //! # Workspace Crates
 //!


### PR DESCRIPTION
Reverts getsentry/relay#888
Reverts getsentry/relay#881

We should find a different solution that does not prevent us from using `--all-features`.

#skip-changelog