### PR TITLE
fix(server): Do not stream with chunked transfer encoding

### DIFF
--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -185,6 +185,11 @@ def mini_sentry(request):
         if flask_request.url_rule:
             sentry.hit(flask_request.url_rule.rule)
 
+        # Store endpoints theoretically support chunked transfer encoding,
+        # but for now, we're conservative and don't allow that anywhere.
+        if flask_request.headers.get("transfer-encoding"):
+            abort(400, "transfer encoding not supported")
+
     @app.route("/api/0/relays/register/challenge/", methods=["POST"])
     def get_challenge():
         relay_id = flask_request.json["relay_id"]


### PR DESCRIPTION
The reqwest client implemenation creates a stream to compress request payloads
on the fly when sending them to the upstream. Unsurprisingly, this switches the
client into "chunked" transfer encoding mode, since it no longer knows the
content length ahead of time.

While this is not an issue for store requests, the Sentry web server does not
understand chunked transfer encoding and rejects such requests. This was not
caught in integration tests, since those build on `flask` which supports chunked
transfer encoding by default.

This PR reverts request compression to an earlier draft, which compresses the
entire body eagerly.

#skip-changelog since this is an unstable feature under development.