### PR TITLE
fix(server): Panic when last envelope item is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Make all fields but event-id optional to fix regressions in user feedback ingestion. ([#886](https://github.com/getsentry/relay/pull/886))
 - Remove `kafka-ssl` feature because it breaks development workflow on macOS. ([#889](https://github.com/getsentry/relay/pull/889))
+- Accept envelopes where their last item is empty and trailing newlines are omitted. This also fixes a panic in some cases. ([#894](https://github.com/getsentry/relay/pull/894))
 
 **Internal**:
 


### PR DESCRIPTION
Trailing newlines can be omitted in envelopes. When the last envelope item was
empty, the parsing code could yield two invalid results:

- If an explicit length of `0` was specified, then the envelope was rejected
	with `UnexpectedEof`.
- If implicit length was used, the parser would panic.

This can both be solved by aligning the parse offset with the end of the buffer.

