### PR TITLE
test: .NET Framework 4.8 without build id

### DIFF
--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -113,6 +113,18 @@ pub fn normalize_context(context: &mut Context) {
 use crate::protocol::LenientString;
 
 #[test]
+fn test_dotnet_framework_48_without_build_id() {
+    let mut runtime = RuntimeContext {
+        raw_description: ".NET Framework 4.8.4250.0".to_string().into(),
+        ..RuntimeContext::default()
+    };
+
+    normalize_runtime_context(&mut runtime);
+    assert_eq_dbg!(Some(".NET Framework"), runtime.name.as_str());
+    assert_eq_dbg!(Some("4.8.4250.0"), runtime.version.as_str());
+}
+
+#[test]
 fn test_dotnet_framework_472() {
     let mut runtime = RuntimeContext {
         raw_description: ".NET Framework 4.7.3056.0".to_string().into(),


### PR DESCRIPTION
Relay seems to parse correctly but in Sentry I see:

![image](https://user-images.githubusercontent.com/1633368/103600468-77cf3180-4ed5-11eb-8696-5752e5bcacd7.png)

The OS value is:

![image](https://user-images.githubusercontent.com/1633368/103600491-874e7a80-4ed5-11eb-9b7a-1d9a5b8c04c5.png)

Any idea what might be wrong?

#skip-changelog