### PR TITLE
fix: .NET Framework 4.8 versioning format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Make all fields but event-id optional to fix regressions in user feedback ingestion. ([#886](https://github.com/getsentry/relay/pull/886))
 - Remove `kafka-ssl` feature because it breaks development workflow on macOS. ([#889](https://github.com/getsentry/relay/pull/889))
 - Accept envelopes where their last item is empty and trailing newlines are omitted. This also fixes a panic in some cases. ([#894](https://github.com/getsentry/relay/pull/894))
+- Changes the .NET Framework version format to be 3 digits. ([#898](https://github.com/getsentry/relay/pull/898))
 
 **Internal**:
 

--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -113,6 +113,18 @@ pub fn normalize_context(context: &mut Context) {
 use crate::protocol::LenientString;
 
 #[test]
+fn test_dotnet_framework_48_without_build_id() {
+    let mut runtime = RuntimeContext {
+        raw_description: ".NET Framework 4.8.4250.0".to_string().into(),
+        ..RuntimeContext::default()
+    };
+
+    normalize_runtime_context(&mut runtime);
+    assert_eq_dbg!(Some(".NET Framework"), runtime.name.as_str());
+    assert_eq_dbg!(Some("4.8.4250.0"), runtime.version.as_str());
+}
+
+#[test]
 fn test_dotnet_framework_472() {
     let mut runtime = RuntimeContext {
         raw_description: ".NET Framework 4.7.3056.0".to_string().into(),

--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -15,7 +15,7 @@ lazy_static::lazy_static! {
     static ref OS_UNAME_REGEX: Regex = Regex::new(r#"^(?P<name>[a-zA-Z]+) (?P<version>\d+\.\d+\.\d+(\.[1-9]+)?).*$"#).unwrap();
 
     /// Mono 5.4, .NET Core 2.0
-    static ref RUNTIME_DOTNET_REGEX: Regex = Regex::new(r#"^(?P<name>.*) (?P<version>\d+\.\d+(\.\d+){0,2}).*$"#).unwrap();
+    static ref RUNTIME_DOTNET_REGEX: Regex = Regex::new(r#"^(?P<name>.*) (?P<version>\d+\.\d+(\.\d+)?)(\.\d+)?.*$"#).unwrap();
 }
 
 fn normalize_runtime_context(runtime: &mut RuntimeContext) {
@@ -121,7 +121,7 @@ fn test_dotnet_framework_48_without_build_id() {
 
     normalize_runtime_context(&mut runtime);
     assert_eq_dbg!(Some(".NET Framework"), runtime.name.as_str());
-    assert_eq_dbg!(Some("4.8.4250.0"), runtime.version.as_str());
+    assert_eq_dbg!(Some("4.8.4250"), runtime.version.as_str());
 }
 
 #[test]


### PR DESCRIPTION
Potentially supersedes #897 

If the problem here are the 4 digits (x.x.x.x) we can simply pick the first 3.
Another alternative is to drop the third too and keep (4.8) which is the branding version and last version of .NET Framework, but I'm believe hotfixes shipped (which seem to now be added as the patch version) could be useful and hence indexing would be benefitial.