### PR TITLE
deploy(docker): Add prestart endpoint to docker-entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN sentry-cli --version \
 FROM debian:buster-slim
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates gosu --no-install-recommends \
+    && apt-get install -y ca-certificates gosu curl --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,22 +20,23 @@ fi
 # Only 200 response is accepted as success.
 if [[ -n "${RELAY_PRESTART_ENDPOINT:-}" ]]; then
   max_retry="${RELAY_PRESTART_MAX_RETRIES:-120}"
-  for attempt in $(seq 1 "$max_retry"); do
-    status=$(curl --max-time 1 --silent --output /dev/null \
-                  --write-out "%{http_code}" \
+  curl_timeout="${RELAY_PRESTART_REQUEST_TIMEOUT:-1}"
+  for attempt in $(seq 0 "${max_retry}"); do
+    if [[ "${attempt}" == "${max_retry}" ]]; then
+      echo "The prestart endpoint has not returned 200 after ${max_retry} attempts, exiting!"
+      exit 1
+    fi
+    status=$(curl --max-time "${curl_timeout}" --show-error --silent \
+                  --output /dev/null --write-out "%{http_code}" \
                   -H 'Connection: close' \
                   "${RELAY_PRESTART_ENDPOINT}" \
               || true)
-    if [[ "$status" == "200" ]]; then
+    if [[ "${status}" == "200" ]]; then
       break
     fi
-    echo "Waiting for a 200 response from ${RELAY_PRESTART_ENDPOINT}"
+    echo "Waiting for a 200 response from ${RELAY_PRESTART_ENDPOINT}, got ${status}"
     sleep 1
   done
-  if [[ "$attempt" == "$max_retry" ]]; then
-    echo "The prestart endpoint has not returned 200 for $max_retry seconds, exiting!"
-    exit 1
-  fi
 fi
 
 # For compatibility with older images

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,28 @@ if [[ -n "${RELAY_DELAY_STARTUP_SECONDS:-}" ]]; then
   sleep "${RELAY_DELAY_STARTUP_SECONDS}"
 fi
 
+# Make sure that a specified URL (e.g. the upstream or a proxy sidecar) is reachable before starting.
+# Only 200 response is accepted as success.
+if [[ -n "${RELAY_PRESTART_ENDPOINT:-}" ]]; then
+  max_retry="${RELAY_PRESTART_MAX_RETRIES:-120}"
+  for attempt in $(seq 1 "$max_retry"); do
+    status=$(curl --max-time 1 --silent --output /dev/null \
+                  --write-out "%{http_code}" \
+                  -H 'Connection: close' \
+                  "${RELAY_PRESTART_ENDPOINT}" \
+              || true)
+    if [[ "$status" == "200" ]]; then
+      break
+    fi
+    echo "Waiting for a 200 response from ${RELAY_PRESTART_ENDPOINT}"
+    sleep 1
+  done
+  if [[ "$attempt" == "$max_retry" ]]; then
+    echo "The prestart endpoint has not returned 200 for $max_retry seconds, exiting!"
+    exit 1
+  fi
+fi
+
 # For compatibility with older images
 if [ "$1" == "bash" ]; then
   set -- bash "${@:2}"


### PR DESCRIPTION
Did this to see how ugly it looks in the end.
This is a bit smarter hack to allow "service dependencies" when using image in environment like Kubernetes. 
E.g. for PoP relays we want to make sure that the Relay container is started after Envoy sidecar is up and running, otherwise first auth requests to the upstream will just fail. They are retried, yes, but it doesn't make sense to even try them before Envoy is up.

By default, this doesn't change the entrypoint behavior. If `RELAY_PRESTART_ENDPOINT` is defined (e.g. `RELAY_PRESTART_ENDPOINT=http://127.0.0.1:12345`), the entrypoint will try to reach it before proceeding further.

#skip-changelog