### PR TITLE
fix(server): Normalize user reports during ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Internal**:
 
 - Extract crashpad annotations into contexts. ([#892](https://github.com/getsentry/relay/pull/892))
+- Normalize user reports during ingestion and create empty fields. ([#903](https://github.com/getsentry/relay/pull/903))
 
 ## 20.12.1
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -388,21 +388,31 @@ impl EventProcessor {
         });
     }
 
-    /// Validates all user report/feedback items in the envelope, if any.
+    /// Validates and normalizes all user report items in the envelope.
     ///
     /// User feedback items are removed from the envelope if they contain invalid JSON or if the
-    /// JSON violates the schema (basic type validation).
+    /// JSON violates the schema (basic type validation). Otherwise, their normalized representation
+    /// is written back into the item.
     fn process_user_reports(&self, state: &mut ProcessEnvelopeState) {
         state.envelope.retain_items(|item| {
             if item.ty() != ItemType::UserReport {
                 return true;
             };
 
-            if let Err(error) = serde_json::from_slice::<UserReport>(&item.payload()) {
-                relay_log::error!("failed to store user report: {}", LogError(&error));
-                return false;
-            }
+            let report = match serde_json::from_slice::<UserReport>(&item.payload()) {
+                Ok(session) => session,
+                Err(error) => {
+                    relay_log::error!("failed to store user report: {}", LogError(&error));
+                    return false;
+                }
+            };
 
+            let json_string = match serde_json::to_string(&report) {
+                Ok(json) => json,
+                Err(_) => return false,
+            };
+
+            item.set_payload(ContentType::Json, json_string);
             true
         });
     }

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -378,7 +378,10 @@ impl EventProcessor {
             if changed {
                 let json_string = match serde_json::to_string(&session) {
                     Ok(json) => json,
-                    Err(_) => return false,
+                    Err(err) => {
+                        relay_log::error!("failed to serialize session: {}", LogError(&err));
+                        return false;
+                    }
                 };
 
                 item.set_payload(ContentType::Json, json_string);
@@ -409,7 +412,10 @@ impl EventProcessor {
 
             let json_string = match serde_json::to_string(&report) {
                 Ok(json) => json,
-                Err(_) => return false,
+                Err(err) => {
+                    relay_log::error!("failed to serialize user report: {}", LogError(&err));
+                    return false;
+                }
             };
 
             item.set_payload(ContentType::Json, json_string);


### PR DESCRIPTION
Sentry requires that user reports always have a non-null email, name, and
comments. This ensures that we create these fields with empty strings if they
are missing or `null`.

