### PR TITLE
feat(server): Ingest and normalize sample rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Extract crashpad annotations into contexts. ([#892](https://github.com/getsentry/relay/pull/892))
 - Normalize user reports during ingestion and create empty fields. ([#903](https://github.com/getsentry/relay/pull/903))
+- Ingest and normalize sample rates from envelope item headers. ([#910](https://github.com/getsentry/relay/pull/910))
 
 ## 20.12.1
 

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -49,7 +49,7 @@ pub use self::fingerprint::Fingerprint;
 pub use self::logentry::{LogEntry, Message};
 pub use self::measurements::Measurements;
 pub use self::mechanism::{CError, MachException, Mechanism, MechanismMeta, PosixSignal};
-pub use self::metrics::Metrics;
+pub use self::metrics::{Metrics, SampleRate};
 pub use self::request::{Cookies, HeaderName, HeaderValue, Headers, Query, Request};
 #[cfg(feature = "jsonschema")]
 pub use self::schema::event_json_schema;

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -353,6 +353,7 @@ pub struct ItemHeaders {
     ///
     /// Multiple entries in `sample_rates` mean that the event was sampled multiple times. The
     /// effective sample rate is multiplied.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     sample_rates: Option<Value>,
 
     /// Other attributes for forward compatibility.

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -349,6 +349,12 @@ pub struct ItemHeaders {
     #[serde(default, skip)]
     rate_limited: bool,
 
+    /// A list of cumulative sample rates applied to this event.
+    ///
+    /// Multiple entries in `sample_rates` mean that the event was sampled multiple times. The
+    /// effective sample rate is multiplied.
+    sample_rates: Option<Value>,
+
     /// Other attributes for forward compatibility.
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -371,6 +377,7 @@ impl Item {
                 content_type: None,
                 filename: None,
                 rate_limited: false,
+                sample_rates: None,
                 other: BTreeMap::new(),
             },
             payload: Bytes::new(),
@@ -454,6 +461,18 @@ impl Item {
     /// Sets whether this item should be rate limited.
     pub fn set_rate_limited(&mut self, rate_limited: bool) {
         self.headers.rate_limited = rate_limited;
+    }
+
+    /// Removes sample rates from the headers, if any.
+    pub fn take_sample_rates(&mut self) -> Option<Value> {
+        self.headers.sample_rates.take()
+    }
+
+    /// Sets sample rates for this item.
+    pub fn set_sample_rates(&mut self, sample_rates: Value) {
+        if matches!(sample_rates, Value::Array(ref a) if !a.is_empty()) {
+            self.headers.sample_rates = Some(sample_rates);
+        }
     }
 
     /// Returns the specified header value, if present.

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -51,18 +51,12 @@ def generate_transaction_item():
 def test_normalize_measurement_interface(
     mini_sentry, relay_with_processing, transactions_consumer
 ):
-
-    # set up relay
-
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(42)
 
     events_consumer = transactions_consumer()
 
-    # construct envelope
-
     transaction_item = generate_transaction_item()
-
     transaction_item.update(
         {
             "measurements": {
@@ -79,15 +73,9 @@ def test_normalize_measurement_interface(
 
     envelope = Envelope()
     envelope.add_transaction(transaction_item)
-
-    # ingest envelope
-
     relay.send_envelope(42, envelope)
 
     event, _ = events_consumer.try_get_event()
-
-    # test actual output
-
     assert event["transaction"] == "/organizations/:orgId/performance/:eventSlug/"
     assert "trace" in event["contexts"]
     assert "measurements" in event, event
@@ -102,30 +90,18 @@ def test_normalize_measurement_interface(
 
 
 def test_empty_measurement_interface(mini_sentry, relay_chain):
-
-    # set up relay
-
     relay = relay_chain()
     mini_sentry.add_basic_project_config(42)
 
-    # construct envelope
-
     transaction_item = generate_transaction_item()
-
     transaction_item.update({"measurements": {}})
 
     envelope = Envelope()
     envelope.add_transaction(transaction_item)
-
-    # ingest envelope
-
     relay.send_envelope(42, envelope)
 
     envelope = mini_sentry.captured_events.get(timeout=1)
-
     event = envelope.get_transaction_event()
-
-    # test actual output
 
     assert event["transaction"] == "/organizations/:orgId/performance/:eventSlug/"
     assert "measurements" not in event, event
@@ -134,15 +110,8 @@ def test_empty_measurement_interface(mini_sentry, relay_chain):
 def test_strip_measurement_interface(
     mini_sentry, relay_with_processing, events_consumer
 ):
-
-    # set up relay
-
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(42)
-
-    events_consumer = events_consumer()
-
-    # construct envelope
 
     envelope = Envelope()
     envelope.add_event(
@@ -155,16 +124,49 @@ def test_strip_measurement_interface(
             },
         }
     )
-
-    # ingest envelope
-
     relay.send_envelope(42, envelope)
 
+    events_consumer = events_consumer()
     event, _ = events_consumer.try_get_event()
 
-    # test actual output
-
     assert event["logentry"] == {"formatted": "Hello, World!"}
-
     # expect measurements interface object to be stripped out since it's attached to a non-transaction event
     assert "measurements" not in event, event
+
+
+def test_sample_rates(mini_sentry, relay_chain):
+    relay = relay_chain()
+    mini_sentry.add_basic_project_config(42)
+
+    sample_rates = [
+        {"id": "client_sampler", "rate": 0.01},
+        {"id": "dyanmic_user", "rate": 0.5},
+    ]
+
+    envelope = Envelope()
+    envelope.add_event({"message": "hello, world!"})
+    envelope.items[0].headers["sample_rates"] = sample_rates
+    relay.send_envelope(42, envelope)
+
+    envelope = mini_sentry.captured_events.get(timeout=1)
+    assert envelope.items[0].headers["sample_rates"] == sample_rates
+
+
+def test_sample_rates_metrics(mini_sentry, relay_with_processing, events_consumer):
+    relay = relay_with_processing()
+    mini_sentry.add_basic_project_config(42)
+
+    sample_rates = [
+        {"id": "client_sampler", "rate": 0.01},
+        {"id": "dyanmic_user", "rate": 0.5},
+    ]
+
+    envelope = Envelope()
+    envelope.add_event({"message": "hello, world!"})
+    envelope.items[0].headers["sample_rates"] = sample_rates
+    relay.send_envelope(42, envelope)
+
+    events_consumer = events_consumer()
+    event, _ = events_consumer.try_get_event()
+
+    assert event["_metrics"]["sample_rates"] == sample_rates


### PR DESCRIPTION
We want to be able to look at the sample rate users set for specific events and
transactions. In regular mode, Relay takes the sample rates from the effective
event item and forwards them to the upstream. In processing mode, the sample
rates are instead written into `_metrics`.

The JavaScript SDK implements this with getsentry/sentry-javascript#3068.

