### PR TITLE
meta: Decouple prepare and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     # We want the release to be at 9-10am Pacific Time
     # We also want it to be 1 hour before the on-prem release
-    - cron: "0 17 15 * *"
+    - cron: "0 17 12 * *"
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Here's a PR to further the discussion started in [Slack](https://sentry.slack.com/archives/CJ3CW08F9/p1610707926013000) [internal] about introducing a few days' gap between preparing the monthly self-hosted release and publishing the release, in order to give time to react to significant bugs that may slip in at the last minute before the release is cut. I believe this is all that's required, yes? If we want to move forward with this:

- [ ] Match this in the other leaf repos:
    - [ ] `snuba`
    - [ ] `sentry`
- [ ] Update the [docs](https://www.notion.so/sentry/How-To-Cut-an-OSS-Release-7be1252f9d1247abad73181b64dc8ed1) [internal].
- [ ] Communicate revised expectations across the eng org.