### PR TITLE
ci: Add an action to release the library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
-# Default code owners 
+# Default code owners
 *   @getsentry/owners-ingest
 
 # Legal
 /LICENSE  @getsentry/owners-legal
 
 # Build & Releases
-/.github/workflows/release.yml  @getsentry/releases
+/.github/workflows/release*.yml  @getsentry/releases
 

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -1,4 +1,5 @@
 name: Release
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,19 +9,23 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
+
   schedule:
     # We want the release to be at 9-10am Pacific Time
     # We also want it to be 1 hour before the on-prem release
     - cron: "0 17 15 * *"
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: "Release a new version"
+    name: "Release a new Relay version"
+
     steps:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
+
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1
         env:

--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -1,0 +1,31 @@
+name: Release Library
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new librelay version"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          path: py

--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -1,5 +1,5 @@
 ---
-minVersion: "0.13.2"
+minVersion: "0.16.1"
 github:
   owner: getsentry
   repo: relay


### PR DESCRIPTION
Adds another action similar to the main Release action that publishes the Python
library. It runs craft in the `py` subfolder.

#skip-changelog

