### PR TITLE
chore: Switch to manylinux2010

### DIFF
--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -25,6 +25,6 @@ targets:
 
 requireNames:
   - /^sentry_relay-.*-py2.py3-none-macosx_10_15_x86_64.whl$/
-  - /^sentry_relay-.*-py2.py3-none-manylinux1_i686.whl$/
-  - /^sentry_relay-.*-py2.py3-none-manylinux1_x86_64.whl$/
+  - /^sentry_relay-.*-py2.py3-none-manylinux2010_i686.whl$/
+  - /^sentry_relay-.*-py2.py3-none-manylinux2010_x86_64.whl$/
   - /^sentry-relay-.*.zip$/

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add missing fields for Expect-CT reports. ([#865](https://github.com/getsentry/relay/pull/865))
 - Support more directives in CSP reports, such as `block-all-mixed-content` and `require-trusted-types-for`. ([#876](https://github.com/getsentry/relay/pull/876))
 - Fix a long-standing bug where log messages were not addressible as `$string`. ([#882](https://github.com/getsentry/relay/pull/882))
+- Use manylinux2010 to build releases instead of manylinux1 to fix issues with newer Rust.
 
 ## 0.8.1
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add missing fields for Expect-CT reports. ([#865](https://github.com/getsentry/relay/pull/865))
 - Support more directives in CSP reports, such as `block-all-mixed-content` and `require-trusted-types-for`. ([#876](https://github.com/getsentry/relay/pull/876))
 - Fix a long-standing bug where log messages were not addressible as `$string`. ([#882](https://github.com/getsentry/relay/pull/882))
-- Use manylinux2010 to build releases instead of manylinux1 to fix issues with newer Rust.
+- Use manylinux2010 to build releases instead of manylinux1 to fix issues with newer Rust. ([#917](https://github.com/getsentry/relay/pull/917))
 
 ## 0.8.1
 

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -3,11 +3,13 @@ set -e
 
 # Install dependencies needed by our wheel
 echo "Installing packages..."
-yum -y -q -e 0 install gcc libffi-devel openssl101e-devel
+yum -y -q install gcc libffi-devel openssl-devel
 
-export OPENSSL_INCLUDE_DIR=/usr/include/openssl101e
-export I686_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/openssl101e
-export X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib64/openssl101e
+export OPENSSL_INCLUDE_DIR=/usr/include/openssl
+export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
+
+echo /usr/lib*/openssl*
+echo /usr/include/openssl*
 
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -5,11 +5,7 @@ set -e
 echo "Installing packages..."
 yum -y -q install gcc libffi-devel openssl-devel
 
-export OPENSSL_INCLUDE_DIR=/usr/include/openssl
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
-
-echo /usr/lib*/openssl*
-echo /usr/include/openssl*
 
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -6,7 +6,7 @@ BUILD_DIR="/work"
 docker run \
         -w /work/py \
         -v `pwd`:/work \
-        quay.io/pypa/manylinux1_${BUILD_ARCH} \
+        quay.io/pypa/manylinux2010_${BUILD_ARCH} \
         sh manylinux.sh
 
 # Fix permissions for shared directories


### PR DESCRIPTION
This is necessary to fix broken release setup:

```
/tmp/tmp.avOSIWRQ29/rustup-init: /lib/libc.so.6: version `GLIBC_2.7' not found (required by /tmp/tmp.avOSIWRQ29/rustup-init)
/tmp/tmp.avOSIWRQ29/rustup-init: /lib/libc.so.6: version `GLIBC_2.9' not found (required by /tmp/tmp.avOSIWRQ29/rustup-init)
```

symbolic already uses manylinux2010