### PR TITLE
fix(server): Log when recovering from network outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Log on INFO level when recovering from network outages. ([#918](https://github.com/getsentry/relay/pull/918))
+
 **Internal**:
 
 - Compatibility mode for pre-aggregated sessions was removed. The feature is now enabled by default in full fidelity. ([#913](https://github.com/getsentry/relay/pull/913))

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -487,9 +487,12 @@ impl UpstreamRelay {
 
     /// Called when a message to the upstream goes through without a network error.
     fn reset_network_error(&mut self) {
+        if self.outage_backoff.started() {
+            relay_log::info!("Recovering from network outage.")
+        }
+
         self.first_error = None;
         self.outage_backoff.reset();
-        relay_log::debug!("Recovering from network outage.")
     }
 
     fn upstream_connection_check(&mut self, ctx: &mut Context<Self>) {


### PR DESCRIPTION
Promotes the log when resetting network outage status to INFO level. Now, Relay
only logs this message if actually recovering from network outage status.

