### PR TITLE
build: Update minidump to fix location slice panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug Fixes**:
 
 - Log on INFO level when recovering from network outages. ([#918](https://github.com/getsentry/relay/pull/918))
+- Fix a panic in processing minidumps with invalid location descriptors. ([#919](https://github.com/getsentry/relay/pull/919))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.2.0"
-source = "git+https://github.com/luser/rust-minidump?rev=7a03c548837ea3006e74c8e8c809afe243bec655#7a03c548837ea3006e74c8e8c809afe243bec655"
+source = "git+https://github.com/luser/rust-minidump?rev=20070798b5e9216474013341ed80c5272558d9ee#20070798b5e9216474013341ed80c5272558d9ee"
 dependencies = [
  "chrono",
  "encoding",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.2.0"
-source = "git+https://github.com/luser/rust-minidump?rev=7a03c548837ea3006e74c8e8c809afe243bec655#7a03c548837ea3006e74c8e8c809afe243bec655"
+source = "git+https://github.com/luser/rust-minidump?rev=20070798b5e9216474013341ed80c5272558d9ee#20070798b5e9216474013341ed80c5272558d9ee"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.8.2"
 lazy_static = "1.4.0"
 maxminddb = "0.13.0"
 memmap = { version = "0.7.0", optional = true }
-minidump = { git = "https://github.com/luser/rust-minidump", rev = "7a03c548837ea3006e74c8e8c809afe243bec655" }
+minidump = { git = "https://github.com/luser/rust-minidump", rev = "20070798b5e9216474013341ed80c5272558d9ee" }
 num-traits = "0.2.12"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -41,7 +41,7 @@ itertools = "0.8.2"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
 lazy_static = "1.4.0"
 listenfd = "0.3.3"
-minidump = { git = "https://github.com/luser/rust-minidump", rev = "7a03c548837ea3006e74c8e8c809afe243bec655", optional = true }
+minidump = { git = "https://github.com/luser/rust-minidump", rev = "20070798b5e9216474013341ed80c5272558d9ee", optional = true }
 native-tls = { version = "0.2.4", optional = true }
 parking_lot = "0.10.0"
 rand_pcg="0.1.2"


### PR DESCRIPTION
Includes luser/rust-minidump#130, which fixes a panic when overflowing in
minidump location descriptors.
