### PR TITLE
fix(ci): Use loopback ipv4 (127.0.0.1) for Kafka advertised listeners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
         image: confluentinc/cp-kafka
         env:
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
         ports:


### PR DESCRIPTION
The new Docker version does not proxy the ipv6 loopback by default anymore. The GitHub actions virtual environment is adding an alias for localhost pointing to the ipv6 address which causes `librdkafka` to resolve `localhost` into two addresses and round-robin connections. With the recent update of docker in Ubuntu repositories, this mechanism is now broken (for the ipv6 address).

Using 127.0.0.1 in advertised listeners will circumvent the IP resolution.


- https://github.com/actions/virtual-environments/blob/0ae118c6aebdddf2269b0670edc41e3a2254fe99/images/linux/scripts/installers/configure-environment.sh#L16-L17
- https://github.com/moby/moby/issues/41858
- https://github.com/actions/virtual-environments/issues/2630

#skip-changelog