### PR TITLE
fix: Ignore false-positive lints from Clippy 1.50

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -687,6 +687,7 @@ fn default_projectconfig_cache_prefix() -> String {
     "relayconfig".to_owned()
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn default_max_rate_limit() -> Option<u32> {
     Some(300) // 5 minutes
 }

--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -57,6 +57,7 @@ impl PartialEq for Pattern {
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn replace_groups_default() -> Option<BTreeSet<u8>> {
     let mut set = BTreeSet::new();
     set.insert(0);

--- a/relay-general/src/types/traits.rs
+++ b/relay-general/src/types/traits.rs
@@ -86,8 +86,10 @@ pub trait FromValue: Debug {
 }
 
 /// Implemented for all meta structures.
+// TODO: This trait should be named `IntoValue`.
 pub trait ToValue: Debug + Empty {
     /// Boxes the meta structure back into a value.
+    #[allow(clippy::wrong_self_convention)]
     fn to_value(self) -> Value
     where
         Self: Sized;


### PR DESCRIPTION
The `clippy::unnecessary_wraps` lint also warns when the call site cannot be
modified. Since this is the case for `serde(default)` callbacks, we need to
ignore the lint.

The `clippy::wrong_self_convention` lint is actually correct. However, since
this is a major refactoring, we will take this in a follow-up.

#skip-changelog
