### PR TITLE
feat(protocol): Add snapshot to the stack trace interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - By adding `.no-cache` to the DSN key, Relay refreshes project configuration caches immediately. This allows to apply changed settings instantly, such as updates to data scrubbing or inbound filter rules. ([#911](https://github.com/getsentry/relay/pull/911))
 - Add NSError to mechanism. ([#925](https://github.com/getsentry/relay/pull/925))
+- Add snapshot to the stack trace interface. ([#927](https://github.com/getsentry/relay/pull/927))
 
 **Bug Fixes**:
 
@@ -16,6 +17,7 @@
 
 - Improve dynamic sampling rule configuration. ([#907](https://github.com/getsentry/relay/pull/907))
 - Compatibility mode for pre-aggregated sessions was removed. The feature is now enabled by default in full fidelity. ([#913](https://github.com/getsentry/relay/pull/913))
+
 
 ## 21.1.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add NSError to mechanism. ([#925](https://github.com/getsentry/relay/pull/925))
+- Add snapshot to the stack trace interface. ([#927](https://github.com/getsentry/relay/pull/927))
+
 ## 0.8.2
 
 - Fix compile errors in the sdist with Rust 1.47 and later. ([#801](https://github.com/getsentry/relay/pull/801))

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -297,6 +297,17 @@ pub struct RawStacktrace {
     #[metastructure(max_chars = "enumlike")]
     pub lang: Annotated<String>,
 
+    /// Indicates that this stack trace is a snapshot triggered by an external signal.
+    ///
+    /// If this field is `false`, then the stack trace points to the code that caused this stack
+    /// trace to be created. This can be the location of a raised exception, as well as an exception
+    /// or signal handler.
+    ///
+    /// If this field is `true`, then the stack trace was captured as part of creating an unrelated
+    /// event. For example, a thread other than the crashing thread, or a stack trace computed as a
+    /// result of an external kill signal.
+    pub snapshot: Annotated<bool>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,
@@ -441,6 +452,7 @@ fn test_stacktrace_roundtrip() {
     "sp": "0x16fd75060"
   },
   "lang": "rust",
+  "snapshot": false,
   "other": "value"
 }"#;
     let stack = Annotated::new(RawStacktrace {
@@ -457,6 +469,7 @@ fn test_stacktrace_roundtrip() {
             Annotated::new(registers)
         },
         lang: Annotated::new("rust".into()),
+        snapshot: Annotated::new(false),
         other: {
             let mut other = Object::new();
             other.insert(

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2251,6 +2251,14 @@ expression: event_json_schema()
                   }
                 ]
               }
+            },
+            "snapshot": {
+              "description": " Indicates that this stack trace is a snapshot triggered by an external signal.\n\n If this field is `false`, then the stack trace points to the code that caused this stack\n trace to be created. This can be the location of a raised exception, as well as an exception\n or signal handler.\n\n If this field is `true`, then the stack trace was captured as part of creating an unrelated\n event. For example, a thread other than the crashing thread, or a stack trace computed as a\n result of an external kill signal.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
             }
           }
         }


### PR DESCRIPTION
Indicates that this stack trace is a snapshot triggered by an external signal.

If this field is `false`, then the stack trace points to the code that caused this stack
trace to be created. This can be the location of a raised exception, as well as an exception
or signal handler.

If this field is `true`, then the stack trace was captured as part of creating an unrelated
event. For example, a thread other than the crashing thread, or a stack trace computed as a
result of an external kill signal.

