### PR TITLE
test: Improve integration tests to reduce flakyness

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -270,18 +270,19 @@ where
 }
 
 #[cfg(not(feature = "ssl"))]
-fn listen_ssl<H>(
-    server: server::HttpServer<H>,
+fn listen_ssl<H, F>(
+    server: server::HttpServer<H, F>,
     config: &Config,
-) -> Result<server::HttpServer<H>, ServerError>
+) -> Result<server::HttpServer<H, F>, ServerError>
 where
     H: server::IntoHttpHandler + 'static,
+    F: Fn() -> H + Send + Clone + 'static,
 {
     if config.tls_listen_addr().is_some()
         || config.tls_identity_path().is_some()
         || config.tls_identity_password().is_some()
     {
-        Err(ServerErrorKind::TlsNotSupported)
+        Err(ServerErrorKind::TlsNotSupported.into())
     } else {
         Ok(server)
     }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-confluent-kafka==1.3.0
+confluent-kafka==1.6.0
 flask==1.1.1
 msgpack==1.0.0
 pytest-localserver==0.5.0

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -16,7 +16,7 @@ from sentry_sdk.envelope import Envelope
 
 from . import SentryLike
 
-_version_re = re.compile(r'^version\s*=\s*"(.*?)"\s*$(?m)')
+_version_re = re.compile(r'(?m)^version\s*=\s*"(.*?)"\s*$')
 with open(os.path.join(os.path.dirname(__file__), "../../../relay/Cargo.toml")) as f:
     CURRENT_VERSION = _version_re.search(f.read()).group(1)
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -184,7 +184,9 @@ class ConsumerBase(object):
 
 @pytest.fixture
 def outcomes_consumer(kafka_consumer):
-    return lambda: OutcomesConsumer(*kafka_consumer("outcomes"))
+    return lambda timeout=None: OutcomesConsumer(
+        timeout=timeout, *kafka_consumer("outcomes")
+    )
 
 
 class OutcomesConsumer(ConsumerBase):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -13,7 +13,7 @@ def test_graceful_shutdown(mini_sentry, relay):
         sleep(1)  # Causes the process to wait for one second before shutting down
         return get_project_config_original()
 
-    relay = relay(mini_sentry)
+    relay = relay(mini_sentry, {"limits": {"shutdown_timeout": 2}})
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
     relay.send_event(project_id)

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -334,11 +334,10 @@ def test_bad_dynamic_rules_in_processing_relays(
     envelope, trace_id, event_id = event_factory(public_key)
     relay.send_envelope(project_id, envelope)
 
-    event, _ = consumer.try_get_event()
     if should_remove:
-        assert event is None
+        consumer.assert_empty()
     else:
-        assert event is not None
+        consumer.get_event()
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -75,7 +75,7 @@ def test_normalize_measurement_interface(
     envelope.add_transaction(transaction_item)
     relay.send_envelope(42, envelope)
 
-    event, _ = events_consumer.try_get_event()
+    event, _ = events_consumer.get_event()
     assert event["transaction"] == "/organizations/:orgId/performance/:eventSlug/"
     assert "trace" in event["contexts"]
     assert "measurements" in event, event
@@ -110,6 +110,8 @@ def test_empty_measurement_interface(mini_sentry, relay_chain):
 def test_strip_measurement_interface(
     mini_sentry, relay_with_processing, events_consumer
 ):
+    events_consumer = events_consumer()
+
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(42)
 
@@ -126,9 +128,7 @@ def test_strip_measurement_interface(
     )
     relay.send_envelope(42, envelope)
 
-    events_consumer = events_consumer()
-    event, _ = events_consumer.try_get_event()
-
+    event, _ = events_consumer.get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
     # expect measurements interface object to be stripped out since it's attached to a non-transaction event
     assert "measurements" not in event, event
@@ -153,6 +153,8 @@ def test_sample_rates(mini_sentry, relay_chain):
 
 
 def test_sample_rates_metrics(mini_sentry, relay_with_processing, events_consumer):
+    events_consumer = events_consumer()
+
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(42)
 
@@ -166,7 +168,5 @@ def test_sample_rates_metrics(mini_sentry, relay_with_processing, events_consume
     envelope.items[0].headers["sample_rates"] = sample_rates
     relay.send_envelope(42, envelope)
 
-    events_consumer = events_consumer()
-    event, _ = events_consumer.try_get_event()
-
+    event, _ = events_consumer.get_event()
     assert event["_metrics"]["sample_rates"] == sample_rates

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -245,11 +245,7 @@ def test_outcome_source(relay, mini_sentry):
 
 @pytest.mark.parametrize("num_intermediate_relays", [1, 3])
 def test_outcome_forwarding(
-    mini_sentry,
-    relay,
-    relay_with_processing,
-    outcomes_consumer,
-    num_intermediate_relays,
+    relay, relay_with_processing, outcomes_consumer, num_intermediate_relays,
 ):
     """
     Tests that Relay forwards outcomes from a chain of relays
@@ -258,7 +254,7 @@ def test_outcome_forwarding(
     and verify that the outcomes sent by  the first (downstream relay)
     are properly forwarded up to sentry.
     """
-    outcomes_consumer = outcomes_consumer()
+    outcomes_consumer = outcomes_consumer(timeout=2)
 
     processing_config = {
         "outcomes": {

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -258,6 +258,7 @@ def test_outcome_forwarding(
     and verify that the outcomes sent by  the first (downstream relay)
     are properly forwarded up to sentry.
     """
+    outcomes_consumer = outcomes_consumer()
 
     processing_config = {
         "outcomes": {
@@ -292,7 +293,6 @@ def test_outcome_forwarding(
 
     event_id = _send_event(downstream_relay)
 
-    outcomes_consumer = outcomes_consumer()
     outcome = outcomes_consumer.get_outcome()
 
     expected_outcome = {
@@ -323,6 +323,8 @@ def test_outcomes_forwarding_rate_limited(
     - The second one is emittedy by the downstream, and then sent to the upstream that writes it
       to Kafka.
     """
+    outcomes_consumer = outcomes_consumer()
+
     processing_config = {
         "outcomes": {
             "emit_outcomes": True,
@@ -358,13 +360,11 @@ def test_outcomes_forwarding_rate_limited(
         }
     ]
 
-    outcomes_consumer_instance = outcomes_consumer()
-
     # Send an event, it should be dropped in the upstream (processing) relay
     result = downstream_relay.send_event(project_id, _get_message(category))
     event_id = result["id"]
 
-    outcome = outcomes_consumer_instance.get_outcome()
+    outcome = outcomes_consumer.get_outcome()
     outcome.pop("timestamp")
     expected_outcome = {
         "reason": "rate_limited",
@@ -387,31 +387,13 @@ def test_outcomes_forwarding_rate_limited(
     expected_outcome_from_downstream["source"] = "downstream-layer"
     expected_outcome_from_downstream.pop("event_id")
 
-    outcome = outcomes_consumer_instance.get_outcome()
+    outcome = outcomes_consumer.get_outcome()
     outcome.pop("timestamp")
     outcome.pop("event_id")
 
     assert outcome == expected_outcome_from_downstream
 
-    _assert_outcomes_topic_empty(outcomes_consumer_instance)
-
-
-def _assert_outcomes_topic_empty(outcomes_consumer_instance):
-    """
-    To prove there's nothing in the topic, we send a randomized message and then
-    immediately consume it.
-    """
-    event_id = "".join(random.choice("0123456789abcdef") for _ in range(32))
-    print(event_id)
-    dummy_outcome = {
-        "org_id": 0,
-        "project_id": 0,
-        "reason": "fake",
-        "event_id": event_id,
-    }
-    outcomes_consumer_instance.produce_test_message(dummy_outcome)
-    outcome = outcomes_consumer_instance.get_outcome()
-    assert outcome == dummy_outcome
+    outcomes_consumer.assert_empty()
 
 
 def _get_message(message_type):
@@ -487,5 +469,5 @@ def test_no_outcomes_rate_limit(
     # give relay some to handle the message (and send any outcomes it needs to send)
     time.sleep(1)
 
-    # we should not have anything on the outcome topic,
-    _assert_outcomes_topic_empty(outcomes_consumer)
+    # we should not have anything on the outcome topic
+    outcomes_consumer.assert_empty()

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -57,13 +57,14 @@ def test_security_report_with_processing(
     test_case,
     json_fixture_provider,
 ):
+    events_consumer = events_consumer(timeout=5)
+
     fixture_provider = json_fixture_provider(__file__)
     test_name, ignored_properties = test_case
     proj_id = 42
     relay = relay_with_processing()
     report = fixture_provider.load(test_name, ".input")
     mini_sentry.add_full_project_config(proj_id)
-    events_consumer = events_consumer()
 
     relay.send_security_report(
         project_id=proj_id,


### PR DESCRIPTION
- Fixes python deprecation warnings, including an upgrade of `confluent-kafka`
- Removes consumer config attributes from Kafka producer
- Send a test message on Kafka consumer creation to wait for the connection
- Use the same test message to assert a topic is empty instead of polling with timeout
- Reduce default poll timeouts to speed up tests
- Increase poll timeout where UA parsing occurs. Relay needs to lazy initialize the UA parser, which takes a few seconds in debug mode.
- Remove user agents from tests that don't need them. This speeds up tests.
- For tests that expect errors in `mini_sentry`, clear them in a `finally` block so that the original assertion is not hidden.
- Increase the rate limiting window in `test_processing_quotas` to 1d, reducing the chance of wrap-around during the test.
- Only check for one error in `test_forced_shutdown`, the other is only raised if the event is sending at time of shutdown, which is not deterministic.

#skip-changelog