### PR TITLE
build: drop python 2.7 support

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.7
 
       - name: Build Wheel
         run: |
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.7
 
       - name: Build sdist
         run: python setup.py sdist --format=zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.7]
+        python-version: [3.7]
 
     # Skip redundant checks for binary releases
     if: "!startsWith(github.ref, 'refs/heads/release/')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - By adding `.no-cache` to the DSN key, Relay refreshes project configuration caches immediately. This allows to apply changed settings instantly, such as updates to data scrubbing or inbound filter rules. ([#911](https://github.com/getsentry/relay/pull/911))
 - Add NSError to mechanism. ([#925](https://github.com/getsentry/relay/pull/925))
 - Add snapshot to the stack trace interface. ([#927](https://github.com/getsentry/relay/pull/927))
+- drop python 2.7 support. ([#929](https://github.com/getsentry/relay/pull/929))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - By adding `.no-cache` to the DSN key, Relay refreshes project configuration caches immediately. This allows to apply changed settings instantly, such as updates to data scrubbing or inbound filter rules. ([#911](https://github.com/getsentry/relay/pull/911))
 - Add NSError to mechanism. ([#925](https://github.com/getsentry/relay/pull/925))
 - Add snapshot to the stack trace interface. ([#927](https://github.com/getsentry/relay/pull/927))
-- drop python 2.7 support. ([#929](https://github.com/getsentry/relay/pull/929))
 
 **Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add NSError to mechanism. ([#925](https://github.com/getsentry/relay/pull/925))
 - Add snapshot to the stack trace interface. ([#927](https://github.com/getsentry/relay/pull/927))
+- Drop python 2.7 support. ([#929](https://github.com/getsentry/relay/pull/929))
 
 ## 0.8.2
 

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -16,7 +16,7 @@ if [ "$AUDITWHEEL_ARCH" == "i686" ]; then
   LINUX32=linux32
 fi
 
-$LINUX32 /opt/python/cp27-cp27mu/bin/python setup.py bdist_wheel
+$LINUX32 /opt/python/cp37-cp37mu/bin/python setup.py bdist_wheel
 
 # Audit wheels
 for wheel in dist/*-linux_*.whl; do


### PR DESCRIPTION
manylinux2010 no longer supports 2.7.  We're also no longer using it in production
so we can likely drop support here.

Refs https://github.com/pypa/manylinux/issues/428