### PR TITLE
fix(pii): Make and/or work correctly with pii=maybe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#726](https://github.com/getsentry/relay/pull/726))
+
 ## 21.2.0
 
 **Features**:
@@ -139,10 +145,6 @@
 **Bug Fixes**:
 
 - Send requests to the `/envelope/` endpoint instead of the older `/store/` endpoint. This particularly fixes spurious `413 Payload Too Large` errors returned when using Relay with Sentry SaaS. ([#746](https://github.com/getsentry/relay/pull/746))
-
-**Bug Fixes**:
-
-- Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#726](https://github.com/getsentry/relay/pull/726))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**:
 
-- Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#726](https://github.com/getsentry/relay/pull/726))
+- Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#932](https://github.com/getsentry/relay/pull/932))
 
 ## 21.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@
 
 - Send requests to the `/envelope/` endpoint instead of the older `/store/` endpoint. This particularly fixes spurious `413 Payload Too Large` errors returned when using Relay with Sentry SaaS. ([#746](https://github.com/getsentry/relay/pull/746))
 
+**Bug Fixes**:
+
+- Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#726](https://github.com/getsentry/relay/pull/726))
+
 **Internal**:
 
 - Remove a temporary flag from attachment kafka messages indicating rate limited crash reports to Sentry. This is now enabled by default. ([#718](https://github.com/getsentry/relay/pull/718))

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -391,10 +391,6 @@ impl<'a> PiiAttachmentsProcessor<'a> {
         let mut changed = false;
 
         for (selector, rules) in &self.compiled_config.applications {
-            if pii == Pii::Maybe && !selector.is_specific() {
-                continue;
-            }
-
             if state.path().matches_selector(&selector) {
                 for rule in rules {
                     // Note:

--- a/relay-general/src/pii/generate_selectors.rs
+++ b/relay-general/src/pii/generate_selectors.rs
@@ -41,7 +41,7 @@ impl Processor for GenerateSelectorsProcessor {
         }
 
         let mut insert_path = |path: SelectorSpec| {
-            if state.attrs().pii != Pii::Maybe || path.is_specific() {
+            if state.path().matches_selector(&path) {
                 let mut string_value = None;
                 if let Some(value) = value {
                     if let Value::String(s) = value.clone().to_value() {

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -49,10 +49,6 @@ impl<'a> PiiProcessor<'a> {
         }
 
         for (selector, rules) in self.compiled_config.applications.iter() {
-            if pii == Pii::Maybe && !selector.is_specific() {
-                continue;
-            }
-
             if state.path().matches_selector(selector) {
                 for rule in rules {
                     let reborrowed_value = value.as_deref_mut();

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -373,38 +373,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_specific() {
-        assert!(SelectorSpec::from_str("$frame.vars.foo")
-            .unwrap()
-            .is_specific());
-        assert!(!SelectorSpec::from_str("foo.$frame.vars.foo")
-            .unwrap()
-            .is_specific());
-        assert!(!SelectorSpec::from_str("$object.foo").unwrap().is_specific());
-        assert!(SelectorSpec::from_str("extra.foo").unwrap().is_specific());
-
-        assert!(SelectorSpec::from_str("extra.foo && extra.foo")
-            .unwrap()
-            .is_specific());
-        assert!(SelectorSpec::from_str("extra.foo && $string")
-            .unwrap()
-            .is_specific());
-        assert!(!SelectorSpec::from_str("$string && $string")
-            .unwrap()
-            .is_specific());
-
-        assert!(SelectorSpec::from_str("extra.foo || extra.foo")
-            .unwrap()
-            .is_specific());
-        assert!(!SelectorSpec::from_str("extra.foo || $string")
-            .unwrap()
-            .is_specific());
-        assert!(!SelectorSpec::from_str("$string || $string")
-            .unwrap()
-            .is_specific());
-    }
-
-    #[test]
     fn test_invalid() {
         assert!(matches!(
             SelectorSpec::from_str("* && foo"),
@@ -414,70 +382,5 @@ mod tests {
             SelectorSpec::from_str("$frame.**.foo.**"),
             Err(InvalidSelectorError::InvalidDeepWildcard)
         ));
-    }
-
-    /// These tests are relevant for Pii::Maybe tagged items since they only match when a
-    /// selector is considered specific.
-    mod attachments {
-        use super::*;
-
-        #[test]
-        fn test_specific_attachments() {
-            let selector = SelectorSpec::from_str("$attachments").unwrap();
-            assert!(selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_attachments_filename() {
-            let selector = SelectorSpec::from_str("$attachments.'file.txt'").unwrap();
-            assert!(selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_binary() {
-            let selector = SelectorSpec::from_str("$binary").unwrap();
-            assert!(!selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_attachments_binary() {
-            // WAT.  All entire attachments are binary, so why not be able to select them
-            // like this?  Especially since we can select them with wildcard.
-            let selector = SelectorSpec::from_str("$attachments.$binary").unwrap();
-            assert!(!selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_attachments_wildcard() {
-            // WAT.  This is not problematic but rather... weird?
-            let selector = SelectorSpec::from_str("$attachments.*").unwrap();
-            assert!(selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_attachments_deep_wildcard() {
-            let selector = SelectorSpec::from_str("$attachments.**").unwrap();
-            assert!(!selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_minidump() {
-            let selector = SelectorSpec::from_str("$minidump").unwrap();
-            assert!(selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_attachments_minidump() {
-            // WAT.  This should not behave differently from plain $minidump
-            let selector = SelectorSpec::from_str("$attachments.$minidump").unwrap();
-            assert!(!selector.is_specific());
-        }
-
-        #[test]
-        fn test_specific_attachments_minidump_binary() {
-            // WAT.  We have the full path to a field here.
-            let selector = SelectorSpec::from_str("$attachments.$minidump.$binary").unwrap();
-            assert!(!selector.is_specific());
-        }
     }
 }


### PR DESCRIPTION
This fixes a bug where OR-ing a specific selector with `**` would make it non-specific. This should not be the case universally, the selector should continue to be specific if the specific sub-selector matches. Example:

    ** || culprit || $string || $frame.module || $frame.abs_path

this should match against culprit, but doesn't because of the disjunction with `**`.

Right now the only workaround is to create multiple rules for `**`, `culprit`, ... each

successor to #726 