### PR TITLE
fix(pii): Make username pii-strippable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#932](https://github.com/getsentry/relay/pull/932))
+- Make username pii-strippable. ([#935](https://github.com/getsentry/relay/pull/935))
 
 ## 21.2.0
 

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
@@ -5,7 +5,7 @@ expression: data
 {
   "user": {
     "ip_address": null,
-    "username": "secret",
+    "username": "[Filtered]",
     "data": {
       "a_password_here": "[Filtered]",
       "apiKey": "[Filtered]",
@@ -92,6 +92,19 @@ expression: data
               "x"
             ]
           ]
+        }
+      },
+      "username": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 6
         }
       }
     }

--- a/relay-general/src/protocol/user.rs
+++ b/relay-general/src/protocol/user.rs
@@ -53,7 +53,7 @@ pub struct User {
     pub ip_address: Annotated<IpAddr>,
 
     /// Username of the user.
-    #[metastructure(pii = "false", max_chars = "enumlike", skip_serialization = "empty")]
+    #[metastructure(pii = "true", max_chars = "enumlike", skip_serialization = "empty")]
     pub username: Annotated<String>,
 
     /// Human readable name of the user.


### PR DESCRIPTION
No particular reason why this can't be scrubbed, I think. Was this perhaps even a regression when porting to Rust?

Classifying this as bug since it really defies user expectations.