### PR TITLE
fix(server): Ensure outcome data categories are numeric

### DIFF
--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -3,6 +3,7 @@
 // FIXME: Workaround for https://github.com/GREsau/schemars/pull/65
 #![allow(clippy::field_reassign_with_default)]
 
+use std::convert::TryInto;
 use std::fmt;
 use std::str::FromStr;
 
@@ -133,6 +134,11 @@ impl DataCategory {
     /// Returns true if the DataCategory refers to an error (i.e an error event).
     pub fn is_error(self) -> bool {
         matches!(self, Self::Error | Self::Default | Self::Security)
+    }
+
+    /// Returns the numeric value for this outcome.
+    pub fn value(self) -> Option<u8> {
+        (self as i8).try_into().ok()
     }
 }
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -308,7 +308,7 @@ pub struct TrackRawOutcome {
     source: Option<String>,
     /// The event's data category.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub category: Option<DataCategory>,
+    pub category: Option<u8>,
 }
 
 impl TrackRawOutcome {
@@ -343,7 +343,7 @@ impl TrackRawOutcome {
             event_id: msg.event_id,
             remote_addr: msg.remote_addr.map(|addr| addr.to_string()),
             source,
-            category: Some(msg.category),
+            category: msg.category.value(),
         }
     }
 }

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -189,6 +189,22 @@ def outcomes_consumer(kafka_consumer):
     )
 
 
+def category_value(category):
+    if category == "default":
+        return 0
+    if category == "error":
+        return 1
+    if category == "transaction":
+        return 2
+    if category == "security":
+        return 3
+    if category == "attachment":
+        return 4
+    if category == "session":
+        return 5
+    assert False, "invalid category"
+
+
 class OutcomesConsumer(ConsumerBase):
     def get_outcome(self):
         outcome = self.poll()
@@ -203,9 +219,10 @@ class OutcomesConsumer(ConsumerBase):
         if key_id is not None:
             assert outcome["key_id"] == key_id
         if category is not None:
-            assert outcome["category"] == category, outcome["category"]
+            value = category_value(category)
+            assert outcome["category"] == value, outcome["category"]
         else:
-            assert outcome["category"] is not None
+            assert isinstance(outcome["category"], int)
 
     def assert_dropped_internal(self):
         outcome = self.get_outcome()

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -103,7 +103,7 @@ def test_outcomes_non_processing(relay, mini_sentry, event_type):
         "reason": "project_id",  # missing project id
         "event_id": event_id,
         "remote_addr": "127.0.0.1",
-        "category": event_type,
+        "category": 2 if event_type == "transaction" else 1,
     }
     assert outcome == expected_outcome
 
@@ -302,7 +302,7 @@ def test_outcome_forwarding(
         "reason": "project_id",
         "event_id": event_id,
         "remote_addr": "127.0.0.1",
-        "category": event_type,
+        "category": 2 if event_type == "transaction" else 1,
     }
     outcome.pop("timestamp")
 
@@ -376,7 +376,7 @@ def test_outcomes_forwarding_rate_limited(
         "remote_addr": "127.0.0.1",
         "event_id": event_id,
         "source": "processing-layer",
-        "category": "error",
+        "category": 1,
     }
     assert outcome == expected_outcome
 


### PR DESCRIPTION
In #931, we missed that Kafka consumer of the `outcomes` topic expect the data
category as numeric value, rather than as a string. To keep the schema
consistent, `TrackRawOutcome` now uses a `u8` to represent the category. The
conversion happens explicitly.

#skip-changelog

