### PR TITLE
fix(server): Reject empty envelopes with an explicit error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#932](https://github.com/getsentry/relay/pull/932))
 - Make username pii-strippable. ([#935](https://github.com/getsentry/relay/pull/935))
+- Respond with `400 Bad Request` and an error message `"empty envelope"` instead of `429` when envelopes without items are sent to the envelope endpoint. ([#937](https://github.com/getsentry/relay/pull/937))
 
 **Internal**:
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -161,6 +161,9 @@ pub enum DiscardReason {
     /// [Relay] The store request was missing an event payload.
     NoData,
 
+    /// [Relay] The envelope contains no items.
+    EmptyEnvelope,
+
     /// [Relay] The event payload exceeds the maximum size limit for the respective endpoint.
     TooLarge,
 
@@ -274,6 +277,7 @@ impl DiscardReason {
             DiscardReason::Internal => "internal",
             DiscardReason::TransactionSampled => "transaction_sampled",
             DiscardReason::EventSampled => "event_sampled",
+            DiscardReason::EmptyEnvelope => "empty_envelope",
         }
     }
 }

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -1,13 +1,11 @@
-import json
+import pytest
 
-from datetime import datetime
-
-from sentry_sdk.envelope import Envelope, PayloadRef, Item
-from sentry_sdk.utils import format_timestamp
+from requests.exceptions import HTTPError
+from sentry_sdk.envelope import Envelope
 
 
-def test_envelope(mini_sentry, relay_chain):
-    relay = relay_chain()
+def test_envelope(mini_sentry, relay):
+    relay = relay()
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
 
@@ -18,6 +16,19 @@ def test_envelope(mini_sentry, relay_chain):
     event = mini_sentry.captured_events.get(timeout=1).get_event()
 
     assert event["logentry"] == {"formatted": "Hello, World!"}
+
+
+def test_envelope_empty(mini_sentry, relay_chain):
+    relay = relay_chain()
+    PROJECT_ID = 42
+    mini_sentry.add_basic_project_config(PROJECT_ID)
+
+    envelope = Envelope()
+
+    with pytest.raises(HTTPError) as excinfo:
+        relay.send_envelope(PROJECT_ID, envelope)
+
+    assert excinfo.value.response.status_code == 400
 
 
 def generate_transaction_item():

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -4,8 +4,8 @@ from requests.exceptions import HTTPError
 from sentry_sdk.envelope import Envelope
 
 
-def test_envelope(mini_sentry, relay):
-    relay = relay()
+def test_envelope(mini_sentry, relay_chain):
+    relay = relay_chain()
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
 
@@ -18,8 +18,8 @@ def test_envelope(mini_sentry, relay):
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
 
-def test_envelope_empty(mini_sentry, relay_chain):
-    relay = relay_chain()
+def test_envelope_empty(mini_sentry, relay):
+    relay = relay(mini_sentry)
     PROJECT_ID = 42
     mini_sentry.add_basic_project_config(PROJECT_ID)
 


### PR DESCRIPTION
Relay assumes that envelopes contain items at various places. Most importantly,
endpoints respond with `429` if the envelope is empty after rate limiting. To
disabiguate these two cases, we now respond with `400` and an explicit error
message if empty envelopes are being ingested.

This error can only happen on the new envelope endpoint. All other endpoints
always create at least one item.

