### PR TITLE
ref: Remove actix-web client, make reqwest the new http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Relay now picks up HTTP proxies from environment variables. This is made possible by switching to a different HTTP client library. The undocumented `http._client` option has been removed. ([#938](https://github.com/getsentry/relay/pull/938))
+- Relay now picks up HTTP proxies from environment variables. This is made possible by switching to a different HTTP client library.
 
 **Bug Fixes**:
 
@@ -14,6 +14,7 @@
 **Internal**:
 
 - Emit the `category` field for outcomes of events. This field disambiguates error events, security events and transactions. As a side-effect, Relay no longer emits outcomes for broken JSON payloads or network errors. ([#931](https://github.com/getsentry/relay/pull/931))
+- The undocumented `http._client` option has been removed. ([#938](https://github.com/getsentry/relay/pull/938))
 
 ## 21.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Relay now picks up HTTP proxies from environment variables. This is made possible by switching to a different HTTP client library. The undocumented `http._client` option has been removed. ([#938](https://github.com/getsentry/relay/pull/938))
+
 **Bug Fixes**:
 
 - Fix a problem with Data Scrubbing source names (PII selectors) that caused `$frame.abs_path` to match, but not `$frame.abs_path || **` or `$frame.abs_path && **`. ([#932](https://github.com/getsentry/relay/pull/932))

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -488,17 +488,6 @@ pub enum HttpEncoding {
     Br,
 }
 
-/// (unstable) Http client to use for upstream store requests.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum HttpClient {
-    /// Use actix http client, the default.
-    Actix,
-    /// Use reqwest. Necessary for HTTP proxy support (standard envvars are picked up
-    /// automatically)
-    Reqwest,
-}
-
 /// Controls authentication with upstream.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
@@ -547,11 +536,6 @@ struct Http {
     ///  - `gzip` (default): Compression using gzip.
     ///  - `br`: Compression using the brotli algorithm.
     encoding: HttpEncoding,
-    /// (unstable) Which HTTP client to use. Can be "actix" or "reqwest", with "actix" being the
-    /// default. Switching to "reqwest" is required to get experimental HTTP proxy support.
-    ///
-    /// Note that this option will be removed in the future once "reqwest" is the default.
-    _client: HttpClient,
 }
 
 impl Default for Http {
@@ -564,7 +548,6 @@ impl Default for Http {
             auth_interval: Some(600), // 10 minutes
             outage_grace_period: DEFAULT_NETWORK_OUTAGE_GRACE_PERIOD,
             encoding: HttpEncoding::Gzip,
-            _client: HttpClient::Actix,
         }
     }
 }
@@ -1137,11 +1120,6 @@ impl Config {
     /// Content encoding of upstream requests.
     pub fn http_encoding(&self) -> HttpEncoding {
         self.values.http.encoding
-    }
-
-    /// (unstable) HTTP client to use for upstream requests.
-    pub fn http_client(&self) -> HttpClient {
-        self.values.http._client
     }
 
     /// Returns whether this Relay should emit outcomes.

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -195,6 +195,13 @@ pub fn forward_upstream(
                 forwarded_response.header(&key, &*value);
             }
 
+            // For reqwest the option to disable automatic response decompression can only be
+            // set per-client. For non-forwarded upstream requests that is desirable, so we
+            // keep it enabled.
+            //
+            // Essentially this means that content negotiation is done twice, and the response
+            // body is first decompressed by reqwest, then re-compressed by actix-web.
+
             Ok(if has_content_type {
                 forwarded_response.body(body)
             } else {

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -5,7 +5,7 @@
 
 use ::actix::prelude::*;
 use actix_web::error::ResponseError;
-use actix_web::http::{header, header::HeaderName, uri::PathAndQuery, ContentEncoding, StatusCode};
+use actix_web::http::{header, header::HeaderName, uri::PathAndQuery, StatusCode};
 use actix_web::{AsyncResponder, Error, HttpMessage, HttpRequest, HttpResponse};
 use failure::Fail;
 use futures::prelude::*;
@@ -155,17 +155,6 @@ pub fn forward_upstream(
                         builder.header(key, value);
                     }
 
-                    // actix-web specific workarounds. We don't remember why no_default_headers was
-                    // necessary, but we suspect that actix sends out headers twice instead of
-                    // having them be overridden (user-agent?)
-                    //
-                    // Need for disabling decompression is demonstrated by the
-                    // `test_forwarding_content_encoding` integration test.
-                    if let RequestBuilder::Actix(ref mut builder) = builder {
-                        builder.no_default_headers();
-                        builder.disable_decompress();
-                    }
-
                     builder.header("X-Forwarded-For", forwarded_for.as_ref());
 
                     builder
@@ -175,10 +164,9 @@ pub fn forward_upstream(
                 .transform(move |response: Response| {
                     let status = response.status();
                     let headers = response.clone_headers();
-                    let is_actix = matches!(response, Response::Actix(_));
                     response
                         .bytes(max_response_size)
-                        .and_then(move |body| Ok((is_actix, status, headers, body)))
+                        .and_then(move |body| Ok((status, headers, body)))
                         .map_err(UpstreamRequestError::Http)
                 });
 
@@ -189,28 +177,8 @@ pub fn forward_upstream(
             })
         })
         .and_then(move |result: Result<_, UpstreamRequestError>| {
-            let (is_actix, status, headers, body) =
-                result.map_err(ForwardedUpstreamRequestError::from)?;
+            let (status, headers, body) = result.map_err(ForwardedUpstreamRequestError::from)?;
             let mut forwarded_response = HttpResponse::build(status);
-
-            if is_actix {
-                // For actix-web we called ClientRequestBuilder::disable_decompress(), therefore
-                // the response body is already compressed and the headers contain the correct
-                // content-encoding
-                //
-                // The content negotiation has effectively happened between *our* upstream and
-                // *our* client, with us just forwarding raw bytes.
-                //
-                // Set content-encoding to identity such that actix-web will not to compress again
-                forwarded_response.content_encoding(ContentEncoding::Identity);
-            } else {
-                // For reqwest the option to disable automatic response decompression can only be
-                // set per-client. For non-forwarded upstream requests that is desirable, so we
-                // keep it enabled.
-                //
-                // Essentially this means that content negotiation is done twice, and the response
-                // body is first decompressed by reqwest, then re-compressed by actix-web.
-            }
 
             let mut has_content_type = false;
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -178,7 +178,7 @@ impl Response {
             serde_json::from_slice(&bytes)
                 .map_err(|e| HttpError::ActixJson(JsonPayloadError::Deserialize(e)))
         });
-        Box::new(future) as Box<dyn Future<Item = _, Error = _>>
+        Box::new(future)
     }
 
     pub fn consume(mut self) -> ResponseFuture<Self, HttpError> {
@@ -241,6 +241,6 @@ impl Response {
                 )
                 .boxed_local()
                 .compat(),
-        ) as Box<dyn Future<Item = _, Error = _>>
+        )
     }
 }

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -41,8 +41,8 @@ class Relay(SentryLike):
             raise
 
 
-@pytest.fixture(params=["reqwest", "actix"])
-def relay(mini_sentry, random_port, background_process, config_dir, request):
+@pytest.fixture
+def relay(mini_sentry, random_port, background_process, config_dir):
     def inner(
         upstream, options=None, prepare=None, external=None, wait_healthcheck=True
     ):
@@ -62,7 +62,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, request):
             "limits": {"max_api_file_upload_size": "1MiB"},
             "cache": {"batch_interval": 0},
             "logging": {"level": "trace"},
-            "http": {"timeout": 2, "_client": request.param},
+            "http": {"timeout": 2},
             "processing": {
                 "enabled": False,
                 "kafka_config": [],


### PR DESCRIPTION
Remove any use of actix-web's HTTP client. We still need to clean up error types and remove unnecessary abstractions, but this should alleviate most of the pain that comes from having to support two http client implementations. We should do the real refactor in a follow-up so as to not introduce accidental behavior changes new error grouping.