### PR TITLE
feat(server): Add rule id to outcomes coming from event sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add inbound filters functionality to dynamic sampling rules. ([#920](https://github.com/getsentry/relay/pull/920))
 - The undocumented `http._client` option has been removed. ([#938](https://github.com/getsentry/relay/pull/938))
 - Log old events and sessions in the `requests.timestamp_delay` metric. ([#933](https://github.com/getsentry/relay/pull/933))
+- Add rule id to outcomes coming from event sampling. ([#943](https://github.com/getsentry/relay/pull/943))
 
 ## 21.2.0
 

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -208,7 +208,8 @@ def test_validate_sampling_configuration():
                     "op": "custom",
                     "name": "event.legacy_browser",
                     "value":["ie10"]
-                }
+                },
+                "id":1
             },
             {
                 "type": "trace",
@@ -218,7 +219,8 @@ def test_validate_sampling_configuration():
                     "name": "event.release",
                     "value":["1.1.*"],
                     "options": {"ignoreCase": true}
-                }
+                },
+                "id":2
             }
         ]
     }"""

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::fmt::{self, Display, Formatter};
 use std::net::IpAddr;
 
 use rand::{distributions::Uniform, Rng};
@@ -272,6 +273,16 @@ impl RuleCondition {
     }
 }
 
+/// Sampling rule Id
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuleId(pub u32);
+
+impl Display for RuleId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A sampling rule as it is deserialized from the project configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -280,7 +291,7 @@ pub struct SamplingRule {
     pub sample_rate: f64,
     #[serde(rename = "type")]
     pub ty: RuleType,
-    pub id: u32,
+    pub id: RuleId,
 }
 
 impl SamplingRule {
@@ -1267,7 +1278,7 @@ mod tests {
                     ]),
                     sample_rate: 0.1,
                     ty: RuleType::Trace,
-                    id: 1,
+                    id: RuleId(1),
                 },
                 // no user segments
                 SamplingRule {
@@ -1277,7 +1288,7 @@ mod tests {
                     ]),
                     sample_rate: 0.2,
                     ty: RuleType::Trace,
-                    id: 2,
+                    id: RuleId(2),
                 },
                 // no releases
                 SamplingRule {
@@ -1287,7 +1298,7 @@ mod tests {
                     ]),
                     sample_rate: 0.3,
                     ty: RuleType::Trace,
-                    id: 3,
+                    id: RuleId(3),
                 },
                 // no environments
                 SamplingRule {
@@ -1297,14 +1308,14 @@ mod tests {
                     ]),
                     sample_rate: 0.4,
                     ty: RuleType::Trace,
-                    id: 4,
+                    id: RuleId(4),
                 },
                 // no user segments releases or environments
                 SamplingRule {
                     condition: RuleCondition::And(AndCondition { inner: vec![] }),
                     sample_rate: 0.5,
                     ty: RuleType::Trace,
-                    id: 5,
+                    id: RuleId(5),
                 },
             ],
             next_id: None,
@@ -1322,7 +1333,7 @@ mod tests {
         // complete match with first rule
         assert_eq!(
             result.unwrap().id,
-            1,
+            RuleId(1),
             "did not match the expected first rule"
         );
 
@@ -1338,7 +1349,7 @@ mod tests {
         // should mach the second rule because of the release
         assert_eq!(
             result.unwrap().id,
-            2,
+            RuleId(2),
             "did not match the expected second rule"
         );
 
@@ -1354,7 +1365,7 @@ mod tests {
         // should match the third rule because of the unknown release
         assert_eq!(
             result.unwrap().id,
-            3,
+            RuleId(3),
             "did not match the expected third rule"
         );
 
@@ -1370,7 +1381,7 @@ mod tests {
         // should match the fourth rule because of the unknown environment
         assert_eq!(
             result.unwrap().id,
-            4,
+            RuleId(4),
             "did not match the expected fourth rule"
         );
 
@@ -1386,7 +1397,7 @@ mod tests {
         // should match the fourth rule because of the unknown user segment
         assert_eq!(
             result.unwrap().id,
-            5,
+            RuleId(5),
             "did not match the expected fourth rule"
         );
     }

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -35,7 +35,7 @@ use crate::envelope::{self, AttachmentType, ContentType, Envelope, Item, ItemTyp
 use crate::http::{HttpError, RequestBuilder};
 use crate::metrics::{RelayCounters, RelayHistograms, RelaySets, RelayTimers};
 use crate::service::ServerError;
-use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter, FutureExt};
+use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter, FutureExt, SamplingResult};
 
 #[cfg(feature = "processing")]
 use {
@@ -129,8 +129,8 @@ enum ProcessingError {
     #[fail(display = "envelope empty, transaction removed by sampling")]
     TransactionSampled,
 
-    #[fail(display = "envelope empty, event removed by sampling")]
-    EventSampled,
+    #[fail(display = "envelope empty, event removed by sampling rule:{}", _0)]
+    EventSampled(u32),
 }
 
 impl ProcessingError {
@@ -170,7 +170,7 @@ impl ProcessingError {
 
             // Dynamic sampling (not an error, just discarding messages that were removed by sampling)
             Self::TransactionSampled => Some(Outcome::Invalid(DiscardReason::TransactionSampled)),
-            Self::EventSampled => Some(Outcome::Invalid(DiscardReason::EventSampled)),
+            Self::EventSampled(rule_id) => Some(Outcome::FilteredSampling(rule_id)),
 
             // If we send to an upstream, we don't emit outcomes.
             Self::SendFailed(_) => None,
@@ -1148,9 +1148,10 @@ impl EventProcessor {
             &state.project_state,
             self.config.processing_enabled(),
         ) {
-            Some(false) => Err(ProcessingError::EventSampled),
-            Some(true) => Ok(()),
-            None => Ok(()), // Not enough info to make a definite evaluation, keep the event
+            SamplingResult::Drop(rule_id) => Err(ProcessingError::EventSampled(rule_id)),
+            SamplingResult::Keep => Ok(()),
+            // Not enough info to make a definite evaluation, keep the event
+            SamplingResult::NoDecision => Ok(()),
         }
     }
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -24,6 +24,7 @@ use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction
 use relay_log::LogError;
 use relay_quotas::{DataCategory, RateLimits};
 use relay_redis::RedisPool;
+use relay_sampling::RuleId;
 
 use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
 use crate::actors::project::{
@@ -130,7 +131,7 @@ enum ProcessingError {
     TransactionSampled,
 
     #[fail(display = "envelope empty, event removed by sampling rule:{}", _0)]
-    EventSampled(u32),
+    EventSampled(RuleId),
 }
 
 impl ProcessingError {

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -22,6 +22,7 @@ use relay_filter::FilterStatKey;
 use relay_general::protocol::EventId;
 use relay_log::LogError;
 use relay_quotas::{ReasonCode, Scoping};
+use relay_sampling::RuleId;
 
 use crate::actors::upstream::SendQuery;
 use crate::actors::upstream::{UpstreamQuery, UpstreamRelay};
@@ -104,7 +105,7 @@ pub enum Outcome {
     Filtered(FilterStatKey),
 
     /// The event has been filtered by a Sampling Rule
-    FilteredSampling(u32),
+    FilteredSampling(RuleId),
 
     /// The event has been rate limited.
     RateLimited(Option<ReasonCode>),

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -103,6 +103,9 @@ pub enum Outcome {
     #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     Filtered(FilterStatKey),
 
+    /// The event has been filtered by a Sampling Rule
+    FilteredSampling(u32),
+
     /// The event has been rate limited.
     RateLimited(Option<ReasonCode>),
 
@@ -118,19 +121,23 @@ impl Outcome {
     fn to_outcome_id(&self) -> u8 {
         match self {
             Outcome::Accepted => 0,
-            Outcome::Filtered(_) => 1,
+            Outcome::Filtered(_) | Outcome::FilteredSampling(_) => 1,
             Outcome::RateLimited(_) => 2,
             Outcome::Invalid(_) => 3,
             Outcome::Abuse => 4,
         }
     }
 
-    fn to_reason(&self) -> Option<&str> {
+    fn to_reason(&self) -> Option<Cow<str>> {
         match self {
             Outcome::Accepted => None,
-            Outcome::Invalid(discard_reason) => Some(discard_reason.name()),
-            Outcome::Filtered(filter_key) => Some(filter_key.name()),
-            Outcome::RateLimited(code_opt) => code_opt.as_ref().map(|code| code.as_str()),
+            Outcome::Invalid(discard_reason) => Some(Cow::Borrowed(discard_reason.name())),
+            Outcome::Filtered(filter_key) => Some(Cow::Borrowed(filter_key.name())),
+            Outcome::FilteredSampling(rule_id) => Some(Cow::Owned(format!("Sampled:{}", rule_id))),
+            //TODO can we do better ? (not re copying the string )
+            Outcome::RateLimited(code_opt) => code_opt
+                .as_ref()
+                .map(|code| Cow::Owned(code.as_str().into())),
             Outcome::Abuse => None,
         }
     }
@@ -239,10 +246,6 @@ pub enum DiscardReason {
     /// [Relay] The envelope, which contained only a transaction, was discarded by the
     /// dynamic sampling rules.
     TransactionSampled,
-
-    /// [Relay] The envelope, which contained an event, was discarded by the
-    /// dynamic sampling rules.
-    EventSampled,
 }
 
 impl DiscardReason {
@@ -276,7 +279,6 @@ impl DiscardReason {
             DiscardReason::NoEventPayload => "no_event_payload",
             DiscardReason::Internal => "internal",
             DiscardReason::TransactionSampled => "transaction_sampled",
-            DiscardReason::EventSampled => "event_sampled",
             DiscardReason::EmptyEnvelope => "empty_envelope",
         }
     }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -13,18 +13,18 @@ use relay_sampling::{
 use crate::actors::project::{GetCachedProjectState, GetProjectState, Project, ProjectState};
 use crate::envelope::{Envelope, ItemType};
 
-/// The result of a Sampling operation
+/// The result of a Sampling operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SamplingResult {
-    /// Keep event
+    /// Keep the event.
     Keep,
-    /// Drop event, due to rule with provided Id
+    /// Drop the event, due to the rule with provided Id.
     Drop(RuleId),
-    /// No decision made  
+    /// No decision can be made.  
     NoDecision,
 }
 
-// Checks whether an event should be kept or removed by dynamic sampling
+/// Checks whether an event should be kept or removed by dynamic sampling.
 pub fn should_keep_event(
     event: &Event,
     ip_addr: Option<IpAddr>,
@@ -32,7 +32,8 @@ pub fn should_keep_event(
     processing_enabled: bool,
 ) -> SamplingResult {
     let sampling_config = match &project_state.config.dynamic_sampling {
-        None => return SamplingResult::NoDecision, // without config there is not enough info to make up my mind
+        // without config there is not enough info to make up my mind
+        None => return SamplingResult::NoDecision,
         Some(config) => config,
     };
 
@@ -42,7 +43,8 @@ pub fn should_keep_event(
     }
 
     let event_id = match event.id.0 {
-        None => return SamplingResult::NoDecision, // if no eventID we can't really sample so keep everything
+        // if no eventID we can't really do sampling so do not take a decision
+        None => return SamplingResult::NoDecision,
         Some(EventId(id)) => id,
     };
 
@@ -55,7 +57,8 @@ pub fn should_keep_event(
             return SamplingResult::Drop(rule.id);
         }
     }
-    SamplingResult::NoDecision // if no matching rule there is not enough info to make a decision
+    // if there are no matching rules there is not enough info to make a sampling decision
+    SamplingResult::NoDecision
 }
 
 /// Takes an envelope and potentially removes the transaction item from it if that
@@ -110,7 +113,7 @@ fn sample_transaction_internal(
 }
 
 /// Check if we should remove transactions from this envelope (because of trace sampling) and
-/// return what is left of the envelope
+/// return what is left of the envelope.
 pub fn sample_transaction(
     envelope: Envelope,
     project: Option<Addr<Project>>,
@@ -209,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    /// should_keep_event returns the expected results
+    /// Should_keep_event returns the expected results.
     fn test_should_keep_event() {
         let event = Event {
             id: Annotated::new(EventId::new()),

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -6,7 +6,9 @@ use actix::prelude::*;
 use futures::{future, prelude::*};
 
 use relay_general::protocol::{Event, EventId};
-use relay_sampling::{get_matching_event_rule, pseudo_random_from_uuid, rule_type_for_event};
+use relay_sampling::{
+    get_matching_event_rule, pseudo_random_from_uuid, rule_type_for_event, RuleId,
+};
 
 use crate::actors::project::{GetCachedProjectState, GetProjectState, Project, ProjectState};
 use crate::envelope::{Envelope, ItemType};
@@ -17,7 +19,7 @@ pub enum SamplingResult {
     /// Keep event
     Keep,
     /// Drop event, due to rule with provided Id
-    Drop(u32),
+    Drop(RuleId),
     /// No decision made  
     NoDecision,
 }
@@ -218,7 +220,7 @@ mod tests {
         let proj_state = get_project_state(Some(0.0));
 
         assert_eq!(
-            SamplingResult::Drop(1),
+            SamplingResult::Drop(RuleId(1)),
             should_keep_event(&event, None, &proj_state, true)
         );
         let proj_state = get_project_state(Some(1.0));


### PR DESCRIPTION
This PR adds rule ids to outcomes for events that were dropped due to event sampling.
The outcomes from these events has also changed from 3 (Invalid) to 1 (Filtered).