### PR TITLE
fix(quotas): Use whole seconds for rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - The undocumented `http._client` option has been removed. ([#938](https://github.com/getsentry/relay/pull/938))
 - Log old events and sessions in the `requests.timestamp_delay` metric. ([#933](https://github.com/getsentry/relay/pull/933))
 - Add rule id to outcomes coming from event sampling. ([#943](https://github.com/getsentry/relay/pull/943))
+- Fix a bug in rate limiting that leads to accepting all events in the last second of a rate limiting window, regardless of whether the rate limit applies. ([#946](https://github.com/getsentry/relay/pull/946))
 
 ## 21.2.0
 

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -15,21 +15,22 @@ pub fn instant_to_date_time(instant: Instant) -> chrono::DateTime<chrono::Utc> {
     instant_to_system_time(instant).into()
 }
 
-/// A unix timestap (time elapsed since 1970).
+/// A unix timestap (full seconds elapsed since 1970).
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-pub struct UnixTimestamp(Duration);
+pub struct UnixTimestamp(u64);
 
 impl UnixTimestamp {
     /// Creates a unix timestamp from the given number of seconds.
     pub fn from_secs(secs: u64) -> Self {
-        Self(Duration::from_secs(secs))
+        Self(secs)
     }
 
     /// Creates a unix timestamp from the given system time.
     pub fn from_system(time: SystemTime) -> Self {
         let duration = time
             .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .as_secs();
 
         Self(duration)
     }
@@ -51,12 +52,7 @@ impl UnixTimestamp {
 
     /// Returns the number of seconds since the UNIX epoch start.
     pub fn as_secs(self) -> u64 {
-        self.0.as_secs()
-    }
-
-    /// Returns the number of milliseconds since the UNIX epoch start.
-    pub fn as_millis(self) -> u128 {
-        self.0.as_millis()
+        self.0
     }
 }
 
@@ -66,19 +62,11 @@ impl fmt::Debug for UnixTimestamp {
     }
 }
 
-impl std::ops::Add<Duration> for UnixTimestamp {
-    type Output = Self;
-
-    fn add(self, rhs: Duration) -> Self::Output {
-        Self(self.0 + rhs)
-    }
-}
-
 impl std::ops::Sub for UnixTimestamp {
     type Output = Duration;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        self.0 - rhs.0
+        Duration::from_secs(self.0 - rhs.0)
     }
 }
 
@@ -87,7 +75,7 @@ impl Serialize for UnixTimestamp {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_u64(self.0.as_secs())
+        serializer.serialize_u64(self.as_secs())
     }
 }
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1003,19 +1003,19 @@ impl EventProcessor {
         }
 
         let mut remove_event = false;
-        let category = state.event_category();
+        let event_category = state.event_category();
 
         // When invoking the rate limiter, capture if the event item has been rate limited to also
         // remove it from the processing state eventually.
         let mut envelope_limiter = EnvelopeLimiter::new(|item_scope, quantity| {
             let limits = rate_limiter.is_rate_limited(quotas, item_scope, quantity)?;
-            remove_event |= Some(item_scope.category) == category && limits.is_limited();
+            remove_event |= Some(item_scope.category) == event_category && limits.is_limited();
             Ok(limits)
         });
 
         // Tell the envelope limiter about the event, since it has been removed from the Envelope at
         // this stage in processing.
-        if let Some(category) = category {
+        if let Some(category) = event_category {
             envelope_limiter.assume_event(category);
         }
 


### PR DESCRIPTION
Relay over-accepts events in the last second of each rate limiting window. This shows by a `RetryAfter(0)` returned from the Redis rate limiting function, which immediately counts as expired.

For each rate limited item, the rate limiter takes the current timestamp and places it in a window. The `RetryAfter` value is the duration to the end of the window, rounded up to whole seconds. The code assumed that `UnixTimestamp` cannot contain a sub-second part, and thus computed: `(expiry - timestamp).as_secs()`. Within the last second of the window, the difference is less than one second, which is rounded to `0`.

To avoid similar issues, this PR removes the sub-second from `UnixTimestamp` and makes it whole seconds.