### PR TITLE
fix(common): Use zero-copy deserialization when FromStr is implemented

### DIFF
--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
 
@@ -90,24 +89,8 @@ impl FromStr for RelayVersion {
     }
 }
 
-impl<'de> Deserialize<'de> for RelayVersion {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let string = Cow::<str>::deserialize(deserializer)?;
-        Ok(string.parse().map_err(serde::de::Error::custom)?)
-    }
-}
+relay_common::impl_str_serde!(RelayVersion, "a version string");
 
-impl Serialize for RelayVersion {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
 /// Raised if a key could not be parsed.
 #[derive(Debug, Fail, PartialEq, Eq, Hash)]
 pub enum KeyParseError {
@@ -297,7 +280,7 @@ impl fmt::Debug for SecretKey {
     }
 }
 
-relay_common::impl_str_serialization!(SecretKey, "a secret key");
+relay_common::impl_str_serde!(SecretKey, "a secret key");
 
 impl PublicKey {
     /// Verifies the signature and returns the embedded signature
@@ -413,7 +396,7 @@ impl fmt::Debug for PublicKey {
     }
 }
 
-relay_common::impl_str_serialization!(PublicKey, "a public key");
+relay_common::impl_str_serde!(PublicKey, "a public key");
 
 /// Generates an relay ID.
 pub fn generate_relay_id() -> RelayId {
@@ -819,7 +802,7 @@ fn test_registration() {
 /// This is a pseudo-test to easily generate the strings used by test_auth.py
 /// You can copy the output to the top of the test_auth.py when there are changes in the
 /// exchanged authentication structures.
-/// It follows test_registration but instead of asserting it prints the strings  
+/// It follows test_registration but instead of asserting it prints the strings
 #[test]
 fn test_generate_strings_for_test_auth_py() {
     let max_age = Duration::minutes(15);

--- a/relay-common/src/macros.rs
+++ b/relay-common/src/macros.rs
@@ -1,12 +1,11 @@
 /// Helper macro to implement string based serialization.
 ///
-/// If a type implements `FromStr` and `Display` then this automatically
-/// implements a serializer/deserializer for that type that dispatches
-/// appropriately.  First argument is the name of the type, the second
-/// is a message for the expectation error (human readable type effectively).
+/// If a type implements `Display` then this automatically
+/// implements a serializer for that type that dispatches
+/// appropriately.
 #[macro_export]
-macro_rules! impl_str_serialization {
-    ($type:ty, $expectation:expr) => {
+macro_rules! impl_str_ser {
+    ($type:ty) => {
         impl ::serde::ser::Serialize for $type {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -15,7 +14,17 @@ macro_rules! impl_str_serialization {
                 serializer.serialize_str(&self.to_string())
             }
         }
+    };
+}
 
+/// Helper macro to implement string based deserialization.
+///
+/// If a type implements `FromStr` then this automatically
+/// implements a deserializer for that type that dispatches
+/// appropriately.
+#[macro_export]
+macro_rules! impl_str_de {
+    ($type:ty, $expectation:expr) => {
         impl<'de> ::serde::de::Deserialize<'de> for $type {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
@@ -46,6 +55,19 @@ macro_rules! impl_str_serialization {
                 deserializer.deserialize_str(V)
             }
         }
+    };
+}
+
+/// Helper macro to implement string based serialization and deserialization.
+///
+/// If a type implements `FromStr` and `Display` then this automatically
+/// implements a serializer/deserializer for that type that dispatches
+/// appropriately.
+#[macro_export]
+macro_rules! impl_str_serde {
+    ($type:ty, $expectation:expr) => {
+        $crate::impl_str_ser!($type);
+        $crate::impl_str_de!($type, $expectation);
     };
 }
 

--- a/relay-common/src/project.rs
+++ b/relay-common/src/project.rs
@@ -1,8 +1,5 @@
-use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
-
-use serde::{Deserialize, Serialize};
 
 #[doc(inline)]
 pub use sentry_types::ProjectId;
@@ -25,24 +22,7 @@ impl std::error::Error for ParseProjectKeyError {}
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct ProjectKey([u8; 32]);
 
-impl Serialize for ProjectKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for ProjectKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let cow = Cow::<str>::deserialize(deserializer)?;
-        Self::parse(&cow).map_err(serde::de::Error::custom)
-    }
-}
+impl_str_serde!(ProjectKey, "a project key string");
 
 impl ProjectKey {
     /// Parses a `ProjectKey` from a string.

--- a/relay-common/src/utils.rs
+++ b/relay-common/src/utils.rs
@@ -97,7 +97,7 @@ impl From<String> for Glob {
     }
 }
 
-impl_str_serialization!(Glob, "a glob pattern");
+impl_str_serde!(Glob, "a glob pattern");
 
 /// Helper for glob matching
 #[derive(Debug)]

--- a/relay-config/src/upstream.rs
+++ b/relay-config/src/upstream.rs
@@ -158,7 +158,7 @@ impl FromStr for UpstreamDescriptor<'static> {
     }
 }
 
-relay_common::impl_str_serialization!(UpstreamDescriptor<'static>, "a sentry upstream URL");
+relay_common::impl_str_serde!(UpstreamDescriptor<'static>, "a sentry upstream URL");
 
 #[cfg(test)]
 mod test {

--- a/relay-general/src/macros.rs
+++ b/relay-general/src/macros.rs
@@ -47,58 +47,6 @@ macro_rules! derive_string_meta_structure {
     };
 }
 
-/// Helper macro to implement string based serialization.
-///
-/// If a type implements `Display` then this automatically
-/// implements a serializer for that type that dispatches
-/// appropriately.
-macro_rules! impl_str_ser {
-    ($type:ty) => {
-        impl ::serde::ser::Serialize for $type {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: ::serde::ser::Serializer,
-            {
-                serializer.serialize_str(&self.to_string())
-            }
-        }
-    };
-}
-
-/// Helper macro to implement string based deserialization.
-///
-/// If a type implements `FromStr` then this automatically
-/// implements a deserializer for that type that dispatches
-/// appropriately.
-#[allow(unused_macros)]
-macro_rules! impl_str_de {
-    ($type:ty) => {
-        impl<'de> ::serde::de::Deserialize<'de> for $type {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: ::serde::de::Deserializer<'de>,
-            {
-                <::std::borrow::Cow<str>>::deserialize(deserializer)?
-                    .parse()
-                    .map_err(::serde::de::Error::custom)
-            }
-        }
-    };
-}
-
-/// Helper macro to implement string based serialization and deserialization.
-///
-/// If a type implements `FromStr` and `Display` then this automatically
-/// implements a serializer/deserializer for that type that dispatches
-/// appropriately.
-#[allow(unused_macros)]
-macro_rules! impl_str_serde {
-    ($type:ty) => {
-        impl_str_ser!($type);
-        impl_str_de!($type);
-    };
-}
-
 /// Implements FromStr and Display on a flat/C-like enum such that strings roundtrip correctly and
 /// all variants can be FromStr'd.
 ///

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -232,7 +232,7 @@ impl FromStr for SelectorSpec {
     }
 }
 
-impl_str_serde!(SelectorSpec);
+relay_common::impl_str_serde!(SelectorSpec, "a selector");
 
 impl From<ValueType> for SelectorSpec {
     fn from(value_type: ValueType) -> Self {

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -62,7 +62,7 @@ impl FromStr for EventId {
     }
 }
 
-impl_str_serde!(EventId);
+relay_common::impl_str_serde!(EventId, "an event identifier");
 
 #[doc(inline)]
 pub use relay_common::{EventType, ParseEventTypeError};

--- a/relay-general/src/protocol/security_report.rs
+++ b/relay-general/src/protocol/security_report.rs
@@ -94,7 +94,7 @@ derive_fromstr_and_display!(CspDirective, InvalidSecurityError, {
     CspDirective::TrustedTypes => "trusted-types",
 });
 
-impl_str_serde!(CspDirective);
+relay_common::impl_str_serde!(CspDirective, "a csp directive");
 
 fn is_local(uri: &str) -> bool {
     matches!(uri, "" | "self" | "'self'")
@@ -508,7 +508,7 @@ derive_fromstr_and_display!(ExpectCtStatus, InvalidSecurityError, {
     ExpectCtStatus::Invalid => "invalid",
 });
 
-impl_str_serde!(ExpectCtStatus);
+relay_common::impl_str_serde!(ExpectCtStatus, "an expect-ct status");
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ExpectCtSource {
@@ -523,7 +523,7 @@ derive_fromstr_and_display!(ExpectCtSource, InvalidSecurityError, {
             ExpectCtSource::Embedded => "embedded",
 });
 
-impl_str_serde!(ExpectCtSource);
+relay_common::impl_str_serde!(ExpectCtSource, "an expect-ct source");
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 struct SingleCertificateTimestampRaw {
@@ -899,7 +899,7 @@ derive_fromstr_and_display!(ExpectStapleResponseStatus, InvalidSecurityError, {
     ExpectStapleResponseStatus::ParseResponseDataError => "PARSE_RESPONSE_DATA_ERROR",
 });
 
-impl_str_serde!(ExpectStapleResponseStatus);
+relay_common::impl_str_serde!(ExpectStapleResponseStatus, "an expect-ct response status");
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExpectStapleCertStatus {
@@ -914,7 +914,7 @@ derive_fromstr_and_display!(ExpectStapleCertStatus, InvalidSecurityError, {
     ExpectStapleCertStatus::Unknown => "UNKNOWN",
 });
 
-impl_str_serde!(ExpectStapleCertStatus);
+relay_common::impl_str_serde!(ExpectStapleCertStatus, "an expect-staple cert status");
 
 /// Inner (useful) part of a Expect Stable report as sent by a user agent ( browser)
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -30,7 +30,7 @@
 //!
 //! ```
 
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Write};
@@ -205,6 +205,14 @@ impl From<&'_ str> for ContentType {
     }
 }
 
+impl std::str::FromStr for ContentType {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(s.into())
+    }
+}
+
 impl PartialEq<str> for ContentType {
     fn eq(&self, other: &str) -> bool {
         // Take an indirection via ContentType::from_str to also check aliases. Do not allocate in
@@ -255,16 +263,7 @@ impl Serialize for ContentType {
     }
 }
 
-impl<'de> Deserialize<'de> for ContentType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let content_type = Cow::<'_, str>::deserialize(deserializer)?;
-        Ok(Self::from_str(&content_type)
-            .unwrap_or_else(|| ContentType::Other(content_type.into_owned())))
-    }
-}
+relay_common::impl_str_de!(ContentType, "a content type string");
 
 /// The type of an event attachment.
 ///


### PR DESCRIPTION
We sometimes implement both `FromStr` and `serde::Deserialize`. In cases where
we share the implementation, we provide an explicit definition of `FromStr` and
use macros to implement `serde::Deserialize`.

There were two implementations of this macro:

 1. `relay_common::impl_str_serialization`
 2. `relay_general::impl_str_serde`

The implementation in `relay_general` allows to implement just deserialization
or serialization, but had a bug: It is not zero-copy. Instead, it always
allocates a `String`, only to then parse it.

In this PR, we deduplicate the macro and ensure that there are no allocations
when deserializing.

#skip-changelog

