### PR TITLE
fix(metrics): Disallow empty metric names, require alphabetic start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Emit the `quantity` field for outcomes of events. This field describes the total size in bytes for attachments or the event count for all other categories. A separate outcome is emitted for attachments in a rejected envelope, if any, in addition to the event outcome. ([#942](https://github.com/getsentry/relay/pull/942))
 - Add experimental metrics ingestion without bucketing or pre-aggregation. ([#948](https://github.com/getsentry/relay/pull/948))
+- Disallow empty metric names, require alphabetic start. ([#952](https://github.com/getsentry/relay/pull/952))
 
 ## 21.3.0
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -199,7 +199,8 @@ impl fmt::Display for ParseMetricError {
 
 /// Validates a metric name.
 ///
-/// Metric names can consist of ASCII alphanumerics, underscores and periods.
+/// Metric names cannot be empty, must begin with a letter and can consist of ASCII alphanumerics,
+/// underscores and periods.
 fn is_valid_name(name: &str) -> bool {
     let mut iter = name.as_bytes().iter();
     if let Some(first_byte) = iter.next() {
@@ -317,7 +318,8 @@ fn parse_timestamp(string: &str) -> Option<UnixTimestamp> {
 pub struct Metric {
     /// The name of the metric without its unit.
     ///
-    /// Metric names can consist of ASCII alphanumerics, underscores and periods.
+    /// Metric names cannot be empty, must start with a letter and can consist of ASCII
+    /// alphanumerics, underscores and periods.
     pub name: String,
     /// The unit of the metric value.
     ///

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -201,9 +201,13 @@ impl fmt::Display for ParseMetricError {
 ///
 /// Metric names can consist of ASCII alphanumerics, underscores and periods.
 fn is_valid_name(name: &str) -> bool {
-    name.as_bytes()
-        .iter()
-        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_'))
+    let mut iter = name.as_bytes().iter();
+    if let Some(first_byte) = iter.next() {
+        if first_byte.is_ascii_alphabetic() {
+            return iter.all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_'));
+        }
+    }
+    false
 }
 
 /// Parses the `name[@unit]` part of a metric string.
@@ -647,6 +651,22 @@ mod tests {
     #[test]
     fn test_parse_invalid_name() {
         let s = "foo#bar:42|c";
+        let timestamp = UnixTimestamp::from_secs(4711);
+        let metric = Metric::parse(s.as_bytes(), timestamp);
+        assert!(metric.is_err());
+    }
+
+    #[test]
+    fn test_parse_empty_name() {
+        let s = ":42|c";
+        let timestamp = UnixTimestamp::from_secs(4711);
+        let metric = Metric::parse(s.as_bytes(), timestamp);
+        assert!(metric.is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_name_with_leading_digit() {
+        let s = "64bit:42|c";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp);
         assert!(metric.is_err());


### PR DESCRIPTION
Metric names in the protocol must consist of at least one character.

In addition, require a letter as first character to prevent purely numeric / special character names.