### PR TITLE
feat(server): Add rule id to outcomes coming from transaction sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Emit the `quantity` field for outcomes of events. This field describes the total size in bytes for attachments or the event count for all other categories. A separate outcome is emitted for attachments in a rejected envelope, if any, in addition to the event outcome. ([#942](https://github.com/getsentry/relay/pull/942))
 - Add experimental metrics ingestion without bucketing or pre-aggregation. ([#948](https://github.com/getsentry/relay/pull/948))
 - Disallow empty metric names, require alphabetic start. ([#952](https://github.com/getsentry/relay/pull/952))
+- Add rule id to outcomes coming from transaction sampling. ([#953](https://github.com/getsentry/relay/pull/953))
 
 ## 21.3.0
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -30,14 +30,14 @@ pub enum RuleType {
     Error,
 }
 
-/// The result of a Sampling operation.
+/// The result of a sampling operation returned by [`TraceContext::should_keep`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SamplingResult {
     /// Keep the event.
     Keep,
-    /// Drop the event, due to the rule with provided Id.
+    /// Drop the event, due to the rule with provided identifier.
     Drop(RuleId),
-    /// No decision can be made.  
+    /// No decision can be made.
     NoDecision,
 }
 
@@ -503,10 +503,11 @@ pub struct TraceContext {
 }
 
 impl TraceContext {
-    /// Returns the sampling decision of whether to drop or not a transaction based on the configuration rules.
+    /// Returns whether a trace should be retained based on sampling rules.
     ///
-    /// If None then a decision can't be made either because of an invalid of missing trace context or
-    /// because no applicable sampling rule could be found.
+    /// If [`SamplingResult::NoDecision`] is returned, then no rule matched this trace. In this
+    /// case, the caller may decide whether to keep the trace or not. The same is returned if the
+    /// configuration is invalid.
     pub fn should_keep(&self, ip_addr: Option<IpAddr>, config: &SamplingConfig) -> SamplingResult {
         if let Some(rule) = get_matching_trace_rule(config, self, ip_addr, RuleType::Trace) {
             let rate = match pseudo_random_from_uuid(self.trace_id) {

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -9,7 +9,6 @@ use actix::prelude::*;
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use failure::Fail;
 use futures::prelude::*;
-use relay_metrics::Metric;
 use serde_json::Value as SerdeValue;
 
 use relay_common::{clone, metric, ProjectId, UnixTimestamp};
@@ -23,9 +22,10 @@ use relay_general::protocol::{
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
 use relay_log::LogError;
+use relay_metrics::Metric;
 use relay_quotas::{DataCategory, RateLimits};
 use relay_redis::RedisPool;
-use relay_sampling::RuleId;
+use relay_sampling::{RuleId, SamplingResult};
 
 use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
 use crate::actors::project::{
@@ -37,9 +37,7 @@ use crate::envelope::{self, AttachmentType, ContentType, Envelope, Item, ItemTyp
 use crate::http::{HttpError, RequestBuilder};
 use crate::metrics::{RelayCounters, RelayHistograms, RelaySets, RelayTimers};
 use crate::service::ServerError;
-use crate::utils::{
-    self, ChunkedFormDataAggregator, EnvelopeSummary, FormDataIter, FutureExt, SamplingResult,
-};
+use crate::utils::{self, ChunkedFormDataAggregator, EnvelopeSummary, FormDataIter, FutureExt};
 
 #[cfg(feature = "processing")]
 use {
@@ -130,8 +128,11 @@ enum ProcessingError {
     #[fail(display = "event exceeded its configured lifetime")]
     Timeout,
 
-    #[fail(display = "envelope empty, transaction removed by sampling")]
-    TransactionSampled,
+    #[fail(
+        display = "envelope empty, transaction removed by sampling rule:{}",
+        _0
+    )]
+    TransactionSampled(RuleId),
 
     #[fail(display = "envelope empty, event removed by sampling rule:{}", _0)]
     EventSampled(RuleId),
@@ -173,7 +174,7 @@ impl ProcessingError {
             }
 
             // Dynamic sampling (not an error, just discarding messages that were removed by sampling)
-            Self::TransactionSampled => Some(Outcome::Invalid(DiscardReason::TransactionSampled)),
+            Self::TransactionSampled(rule_id) => Some(Outcome::FilteredSampling(rule_id)),
             Self::EventSampled(rule_id) => Some(Outcome::FilteredSampling(rule_id)),
 
             // If we send to an upstream, we don't emit outcomes.
@@ -1554,14 +1555,7 @@ impl Handler<HandleEnvelope> for EventManager {
             }))
             .and_then(move |envelope| {
                 utils::sample_transaction(envelope, sampling_project, false, processing_enabled)
-                    .map_err(|()| (ProcessingError::TransactionSampled))
-            })
-            .and_then(|envelope| {
-                if envelope.is_empty() {
-                    Err(ProcessingError::TransactionSampled)
-                } else {
-                    Ok(envelope)
-                }
+                    .map_err(|rule_id| (ProcessingError::TransactionSampled(rule_id)))
             })
             .and_then(clone!(project, |envelope| {
                 // get the state for the current project. we can always fetch the cached version
@@ -1798,11 +1792,11 @@ impl Handler<GetCapturedEnvelope> for EventManager {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
 
     use crate::extractors::RequestMeta;
 
-    use chrono::{DateTime, TimeZone, Utc};
+    use super::*;
 
     fn create_breadcrumbs_item(breadcrumbs: &[(Option<DateTime<Utc>>, &str)]) -> Item {
         let mut data = Vec::new();

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1555,7 +1555,7 @@ impl Handler<HandleEnvelope> for EventManager {
             }))
             .and_then(move |envelope| {
                 utils::sample_transaction(envelope, sampling_project, false, processing_enabled)
-                    .map_err(|rule_id| (ProcessingError::TransactionSampled(rule_id)))
+                    .map_err(ProcessingError::TransactionSampled)
             })
             .and_then(clone!(project, |envelope| {
                 // get the state for the current project. we can always fetch the cached version

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -142,7 +142,7 @@ def test_it_removes_transactions(mini_sentry, relay):
     config = mini_sentry.add_basic_project_config(project_id)
     # add a sampling rule to project config that removes all transactions (sample_rate=0)
     public_key = config["publicKeys"][0]["publicKey"]
-    rules=_add_sampling_config(config, sample_rate=0, rule_type="trace")
+    rules = _add_sampling_config(config, sample_rate=0, rule_type="trace")
 
     # create an envelope with a trace context that is initiated by this project (for simplicity)
     envelope = Envelope()
@@ -161,6 +161,7 @@ def test_it_removes_transactions(mini_sentry, relay):
     outcome = outcomes["outcomes"][0]
     assert outcome.get("outcome") == 1
     assert outcome.get("reason") == f"Sampled:{rules[0]['id']}"
+
 
 def test_it_keeps_transactions(mini_sentry, relay):
     """

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -142,7 +142,7 @@ def test_it_removes_transactions(mini_sentry, relay):
     config = mini_sentry.add_basic_project_config(project_id)
     # add a sampling rule to project config that removes all transactions (sample_rate=0)
     public_key = config["publicKeys"][0]["publicKey"]
-    _add_sampling_config(config, sample_rate=0, rule_type="trace")
+    rules=_add_sampling_config(config, sample_rate=0, rule_type="trace")
 
     # create an envelope with a trace context that is initiated by this project (for simplicity)
     envelope = Envelope()
@@ -159,9 +159,8 @@ def test_it_removes_transactions(mini_sentry, relay):
     outcomes = mini_sentry.captured_outcomes.get(timeout=2)
     assert outcomes is not None
     outcome = outcomes["outcomes"][0]
-    assert outcome.get("outcome") == 3
-    assert outcome.get("reason") == "transaction_sampled"
-
+    assert outcome.get("outcome") == 1
+    assert outcome.get("reason") == f"Sampled:{rules[0]['id']}"
 
 def test_it_keeps_transactions(mini_sentry, relay):
     """


### PR DESCRIPTION
This PR adds rule ids to outcomes for transactions that were dropped due to transaction sampling.
The outcomes from these events has also changed from 3 (Invalid) to 1 (Filtered).