### PR TITLE
doc(protocol): Improve documentation on event types

### DIFF
--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -12,6 +12,17 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// The type of an event.
+///
+/// The event type determines how Sentry handles the event and has an impact on processing, rate
+/// limiting, and quotas. There are three fundamental classes of event types:
+///
+///  - **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues
+///    based on their exception stack traces and error messages.
+///  - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser
+///    security violation reports and grouped into unique issues based on the endpoint and
+///    violation. SDKs do not send such events.
+///  - **Transaction events** (`transaction`): Contain operation spans and collected into traces for
+///    performance monitoring.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -202,7 +202,30 @@ pub struct Event {
     /// Version
     pub version: Annotated<String>,
 
-    /// Type of event: error, csp, default
+    /// Type of the event. Defaults to `default`.
+    ///
+    /// The event type determines how Sentry handles the event and has an impact on processing, rate
+    /// limiting, and quotas. There are three fundamental classes of event types:
+    ///
+    ///  - **Error monitoring events**: Processed and grouped into unique issues based on their
+    ///    exception stack traces and error messages.
+    ///  - **Security events**: Derived from Browser security violation reports and grouped into
+    ///    unique issues based on the endpoint and violation. SDKs do not send such events.
+    ///  - **Transaction events** (`transaction`): Contain operation spans and collected into traces
+    ///    for performance monitoring.
+    ///
+    /// Transactions must explicitly specify the `"transaction"` event type. In all other cases,
+    /// Sentry infers the appropriate event type from the payload and overrides the stated type.
+    /// SDKs should not send an event type other than for transactions.
+    ///
+    /// Example:
+    ///
+    /// ```json
+    /// {
+    ///   "type": "transaction",
+    ///   "spans": []
+    /// }
+    /// ```
     #[metastructure(field = "type")]
     pub ty: Annotated<EventType>,
 

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -348,7 +348,7 @@ expression: event_json_schema()
           ]
         },
         "type": {
-          "description": " Type of event: error, csp, default",
+          "description": " Type of the event. Defaults to `default`.\n\n The event type determines how Sentry handles the event and has an impact on processing, rate\n limiting, and quotas. There are three fundamental classes of event types:\n\n  - **Error monitoring events**: Processed and grouped into unique issues based on their\n    exception stack traces and error messages.\n  - **Security events**: Derived from Browser security violation reports and grouped into\n    unique issues based on the endpoint and violation. SDKs do not send such events.\n  - **Transaction events** (`transaction`): Contain operation spans and collected into traces\n    for performance monitoring.\n\n Transactions must explicitly specify the `\"transaction\"` event type. In all other cases,\n Sentry infers the appropriate event type from the payload and overrides the stated type.\n SDKs should not send an event type other than for transactions.\n\n Example:\n\n ```json\n {\n   \"type\": \"transaction\",\n   \"spans\": []\n }\n ```",
           "default": null,
           "anyOf": [
             {
@@ -1196,7 +1196,7 @@ expression: event_json_schema()
       ]
     },
     "EventType": {
-      "description": "The type of an event.",
+      "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring.",
       "type": "string",
       "enum": [
         "error",


### PR DESCRIPTION
Improves incomplete documentation on event types. The description largely
repeats itself so that information can be found in both places. The is one
slight difference: On the event field, we do not mention specific event types
since SDKs are not supposed to send them. For more details, one can still look
up the enumeration docs.

#skip-changelog
