### PR TITLE
fix(pii): Make request url scrubbable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Make request url scrubbable. ([#955](https://github.com/getsentry/relay/pull/955))
+
 **Internal**:
 
 - Emit the `quantity` field for outcomes of events. This field describes the total size in bytes for attachments or the event count for all other categories. A separate outcome is emitted for attachments in a rejected envelope, if any, in addition to the event outcome. ([#942](https://github.com/getsentry/relay/pull/942))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Make request url scrubbable. ([#955](https://github.com/getsentry/relay/pull/955))
+
 ## 0.8.4
 
 - Deny backslashes in release names. ([#904](https://github.com/getsentry/relay/pull/904))

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -438,7 +438,7 @@ pub struct Request {
     /// The URL of the request if available.
     ///
     ///The query string can be declared either as part of the `url`, or separately in `query_string`.
-    #[metastructure(max_chars = "path")]
+    #[metastructure(max_chars = "path", pii = "maybe")]
     pub url: Annotated<String>,
 
     /// HTTP request method.


### PR DESCRIPTION
Per customer ticket. No reason why this shouldn't be scrubbable.