### PR TITLE
fix(clippy): Fix clippy warnings

### DIFF
--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -31,7 +31,7 @@ pub enum EventType {
     /// An HPKP violation payload.
     Hpkp,
     /// An ExpectCT violation payload.
-    ExpectCT,
+    ExpectCt,
     /// An ExpectStaple violation payload.
     ExpectStaple,
     /// Performance monitoring transactions carrying spans.
@@ -68,7 +68,7 @@ impl FromStr for EventType {
             "error" => EventType::Error,
             "csp" => EventType::Csp,
             "hpkp" => EventType::Hpkp,
-            "expectct" => EventType::ExpectCT,
+            "expectct" => EventType::ExpectCt,
             "expectstaple" => EventType::ExpectStaple,
             "transaction" => EventType::Transaction,
             _ => return Err(ParseEventTypeError),
@@ -83,7 +83,7 @@ impl fmt::Display for EventType {
             EventType::Error => write!(f, "error"),
             EventType::Csp => write!(f, "csp"),
             EventType::Hpkp => write!(f, "hpkp"),
-            EventType::ExpectCT => write!(f, "expectct"),
+            EventType::ExpectCt => write!(f, "expectct"),
             EventType::ExpectStaple => write!(f, "expectstaple"),
             EventType::Transaction => write!(f, "transaction"),
         }
@@ -169,7 +169,7 @@ impl From<EventType> for DataCategory {
         match ty {
             EventType::Default | EventType::Error => Self::Error,
             EventType::Transaction => Self::Transaction,
-            EventType::Csp | EventType::Hpkp | EventType::ExpectCT | EventType::ExpectStaple => {
+            EventType::Csp | EventType::Hpkp | EventType::ExpectCt | EventType::ExpectStaple => {
                 Self::Security
             }
         }

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -400,15 +400,16 @@ fn test_basic_stripping() {
                 Annotated::new(rv)
             },
             headers: {
-                let mut rv = Vec::new();
-                rv.push(Annotated::new((
-                    Annotated::new("Cookie".to_string().into()),
-                    Annotated::new("super secret".to_string().into()),
-                )));
-                rv.push(Annotated::new((
-                    Annotated::new("X-Forwarded-For".to_string().into()),
-                    Annotated::new("127.0.0.1".to_string().into()),
-                )));
+                let rv = vec![
+                    Annotated::new((
+                        Annotated::new("Cookie".to_string().into()),
+                        Annotated::new("super secret".to_string().into()),
+                    )),
+                    Annotated::new((
+                        Annotated::new("X-Forwarded-For".to_string().into()),
+                        Annotated::new("127.0.0.1".to_string().into()),
+                    )),
+                ];
                 Annotated::new(Headers(PairList(rv)))
             },
             ..Default::default()

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -677,13 +677,11 @@ mod tests {
             let actual = $state.path().matches_selector(&$selector.parse().unwrap());
             assert!(
                 actual == $expected,
-                format!(
-                    "Matched {} against {}, expected {:?}, actually {:?}",
-                    $selector,
-                    $state.path(),
-                    $expected,
-                    actual
-                )
+                "Matched {} against {}, expected {:?}, actually {:?}",
+                $selector,
+                $state.path(),
+                $expected,
+                actual
             );
         }};
     }

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -31,6 +31,7 @@ pub enum InvalidSelectorError {
 }
 
 mod parser {
+    #![allow(clippy::upper_case_acronyms)]
     use pest_derive::Parser;
 
     #[derive(Parser)]

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -593,11 +593,10 @@ fn test_event_roundtrip() {
         dist: Annotated::new("mydist".to_string()),
         environment: Annotated::new("myenv".to_string()),
         tags: {
-            let mut items = Array::new();
-            items.push(Annotated::new(TagEntry(
+            let items = vec![Annotated::new(TagEntry(
                 Annotated::new("tag".to_string()),
                 Annotated::new("value".to_string()),
-            )));
+            ))];
             Annotated::new(Tags(items.into()))
         },
         extra: {

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -509,23 +509,24 @@ fn test_header_normalization() {
   "x-sentry": "version=8"
 }"#;
 
-    let mut headers = Vec::new();
-    headers.push(Annotated::new((
-        Annotated::new("-Other-".to_string().into()),
-        Annotated::new("header".to_string().into()),
-    )));
-    headers.push(Annotated::new((
-        Annotated::new("Accept".to_string().into()),
-        Annotated::new("application/json".to_string().into()),
-    )));
-    headers.push(Annotated::new((
-        Annotated::new("WWW-Authenticate".to_string().into()),
-        Annotated::new("basic".to_string().into()),
-    )));
-    headers.push(Annotated::new((
-        Annotated::new("X-Sentry".to_string().into()),
-        Annotated::new("version=8".to_string().into()),
-    )));
+    let headers = vec![
+        Annotated::new((
+            Annotated::new("-Other-".to_string().into()),
+            Annotated::new("header".to_string().into()),
+        )),
+        Annotated::new((
+            Annotated::new("Accept".to_string().into()),
+            Annotated::new("application/json".to_string().into()),
+        )),
+        Annotated::new((
+            Annotated::new("WWW-Authenticate".to_string().into()),
+            Annotated::new("basic".to_string().into()),
+        )),
+        Annotated::new((
+            Annotated::new("X-Sentry".to_string().into()),
+            Annotated::new("version=8".to_string().into()),
+        )),
+    ];
 
     let headers = Annotated::new(Headers(PairList(headers)));
     assert_eq_dbg!(headers, Annotated::from_json(json).unwrap());
@@ -537,11 +538,10 @@ fn test_header_from_sequence() {
   ["accept", "application/json"]
 ]"#;
 
-    let mut headers = Vec::new();
-    headers.push(Annotated::new((
+    let headers = vec![Annotated::new((
         Annotated::new("Accept".to_string().into()),
         Annotated::new("application/json".to_string().into()),
-    )));
+    ))];
 
     let headers = Annotated::new(Headers(PairList(headers)));
     assert_eq_dbg!(headers, Annotated::from_json(json).unwrap());
@@ -678,19 +678,16 @@ fn test_request_roundtrip() {
         )),
         fragment: Annotated::new("home".to_string()),
         cookies: Annotated::new(Cookies({
-            let mut map = Vec::new();
-            map.push(Annotated::new((
+            PairList(vec![Annotated::new((
                 Annotated::new("GOOGLE".to_string()),
                 Annotated::new("1".to_string()),
-            )));
-            PairList(map)
+            ))])
         })),
         headers: Annotated::new(Headers({
-            let mut headers = Vec::new();
-            headers.push(Annotated::new((
+            let headers = vec![Annotated::new((
                 Annotated::new("Referer".to_string().into()),
                 Annotated::new("https://google.com/".to_string().into()),
-            )));
+            ))];
             PairList(headers)
         })),
         env: Annotated::new({
@@ -798,19 +795,20 @@ fn test_query_invalid() {
 fn test_cookies_parsing() {
     let json = "\" PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;\"";
 
-    let mut map = Vec::new();
-    map.push(Annotated::new((
-        Annotated::new("PHPSESSID".to_string()),
-        Annotated::new("298zf09hf012fh2".to_string()),
-    )));
-    map.push(Annotated::new((
-        Annotated::new("csrftoken".to_string()),
-        Annotated::new("u32t4o3tb3gg43".to_string()),
-    )));
-    map.push(Annotated::new((
-        Annotated::new("_gat".to_string()),
-        Annotated::new("1".to_string()),
-    )));
+    let map = vec![
+        Annotated::new((
+            Annotated::new("PHPSESSID".to_string()),
+            Annotated::new("298zf09hf012fh2".to_string()),
+        )),
+        Annotated::new((
+            Annotated::new("csrftoken".to_string()),
+            Annotated::new("u32t4o3tb3gg43".to_string()),
+        )),
+        Annotated::new((
+            Annotated::new("_gat".to_string()),
+            Annotated::new("1".to_string()),
+        )),
+    ];
 
     let cookies = Annotated::new(Cookies(PairList(map)));
     assert_eq_dbg!(cookies, Annotated::from_json(json).unwrap());
@@ -821,19 +819,17 @@ fn test_cookies_array() {
     let input = r#"{"cookies":[["foo","bar"],["invalid", 42],["none",null]]}"#;
     let output = r#"{"cookies":[["foo","bar"],["invalid",null],["none",null]],"_meta":{"cookies":{"1":{"1":{"":{"err":[["invalid_data",{"reason":"expected a string"}]],"val":42}}}}}}"#;
 
-    let mut map = Vec::new();
-    map.push(Annotated::new((
-        Annotated::new("foo".to_string()),
-        Annotated::new("bar".to_string()),
-    )));
-    map.push(Annotated::new((
-        Annotated::new("invalid".to_string()),
-        Annotated::from_error(Error::expected("a string"), Some(Value::I64(42))),
-    )));
-    map.push(Annotated::new((
-        Annotated::new("none".to_string()),
-        Annotated::empty(),
-    )));
+    let map = vec![
+        Annotated::new((
+            Annotated::new("foo".to_string()),
+            Annotated::new("bar".to_string()),
+        )),
+        Annotated::new((
+            Annotated::new("invalid".to_string()),
+            Annotated::from_error(Error::expected("a string"), Some(Value::I64(42))),
+        )),
+        Annotated::new((Annotated::new("none".to_string()), Annotated::empty())),
+    ];
 
     let cookies = Annotated::new(Cookies(PairList(map)));
     let request = Annotated::new(Request {
@@ -848,15 +844,16 @@ fn test_cookies_array() {
 fn test_cookies_object() {
     let json = r#"{"foo":"bar", "invalid": 42}"#;
 
-    let mut map = Vec::new();
-    map.push(Annotated::new((
-        Annotated::new("foo".to_string()),
-        Annotated::new("bar".to_string()),
-    )));
-    map.push(Annotated::new((
-        Annotated::new("invalid".to_string()),
-        Annotated::from_error(Error::expected("a string"), Some(Value::I64(42))),
-    )));
+    let map = vec![
+        Annotated::new((
+            Annotated::new("foo".to_string()),
+            Annotated::new("bar".to_string()),
+        )),
+        Annotated::new((
+            Annotated::new("invalid".to_string()),
+            Annotated::from_error(Error::expected("a string"), Some(Value::I64(42))),
+        )),
+    ];
 
     let cookies = Annotated::new(Cookies(PairList(map)));
     assert_eq_dbg!(cookies, Annotated::from_json(json).unwrap());

--- a/relay-general/src/protocol/tags.rs
+++ b/relay-general/src/protocol/tags.rs
@@ -70,28 +70,28 @@ fn test_tags_from_object() {
   "bam": null
 }"#;
 
-    let mut arr = Array::new();
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("bam".to_string()),
-        Annotated::empty(),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("blah".to_string()),
-        Annotated::new("blub".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("bool".to_string()),
-        Annotated::new("True".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("foo-bar".to_string()),
-        Annotated::new("baz".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("non-string".to_string()),
-        Annotated::new("42".to_string()),
-    )));
-
+    let arr = vec![
+        Annotated::new(TagEntry(
+            Annotated::new("bam".to_string()),
+            Annotated::empty(),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("blah".to_string()),
+            Annotated::new("blub".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("bool".to_string()),
+            Annotated::new("True".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("foo-bar".to_string()),
+            Annotated::new("baz".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("non-string".to_string()),
+            Annotated::new("42".to_string()),
+        )),
+    ];
     let tags = Annotated::new(Tags(arr.into()));
     assert_eq_dbg!(tags, Annotated::from_json(json).unwrap());
 }
@@ -150,27 +150,28 @@ fn test_tags_from_array() {
   ]
 }"#;
 
-    let mut arr = Array::new();
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("bool".to_string()),
-        Annotated::new("True".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("foo-bar".to_string()),
-        Annotated::new("baz".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("23".to_string()),
-        Annotated::new("42".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("blah".to_string()),
-        Annotated::new("blub".to_string()),
-    )));
-    arr.push(Annotated::new(TagEntry(
-        Annotated::new("bam".to_string()),
-        Annotated::empty(),
-    )));
+    let arr = vec![
+        Annotated::new(TagEntry(
+            Annotated::new("bool".to_string()),
+            Annotated::new("True".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("foo-bar".to_string()),
+            Annotated::new("baz".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("23".to_string()),
+            Annotated::new("42".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("blah".to_string()),
+            Annotated::new("blub".to_string()),
+        )),
+        Annotated::new(TagEntry(
+            Annotated::new("bam".to_string()),
+            Annotated::empty(),
+        )),
+    ];
 
     let tags = Annotated::new(Tags(arr.into()));
     let event = Annotated::new(Event {

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -271,7 +271,7 @@ impl<'a> NormalizeProcessor<'a> {
         } else if event.hpkp.value().is_some() {
             EventType::Hpkp
         } else if event.expectct.value().is_some() {
-            EventType::ExpectCT
+            EventType::ExpectCt
         } else if event.expectstaple.value().is_some() {
             EventType::ExpectStaple
         } else {

--- a/relay-general/src/testutils.rs
+++ b/relay-general/src/testutils.rs
@@ -137,21 +137,20 @@ macro_rules! get_value {
 #[cfg(feature = "uaparser")]
 /// Creates an Event with the specified user agent.
 pub(super) fn get_event_with_user_agent(user_agent: &str) -> Event {
-    let mut headers = Vec::new();
-
-    headers.push(Annotated::new((
-        Annotated::new("Accept".to_string().into()),
-        Annotated::new("application/json".to_string().into()),
-    )));
-
-    headers.push(Annotated::new((
-        Annotated::new("UsEr-AgeNT".to_string().into()),
-        Annotated::new(user_agent.to_string().into()),
-    )));
-    headers.push(Annotated::new((
-        Annotated::new("WWW-Authenticate".to_string().into()),
-        Annotated::new("basic".to_string().into()),
-    )));
+    let headers = vec![
+        Annotated::new((
+            Annotated::new("Accept".to_string().into()),
+            Annotated::new("application/json".to_string().into()),
+        )),
+        Annotated::new((
+            Annotated::new("UsEr-AgeNT".to_string().into()),
+            Annotated::new(user_agent.to_string().into()),
+        )),
+        Annotated::new((
+            Annotated::new("WWW-Authenticate".to_string().into()),
+            Annotated::new("basic".to_string().into()),
+        )),
+    ];
 
     Event {
         request: Annotated::new(Request {

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -724,7 +724,7 @@ mod tests {
 
         for (rule_test_name, condition) in conditions.iter() {
             let failure_name = format!("Failed on test: '{}'!!!", rule_test_name);
-            assert!(condition.matches_trace(&tc, None), failure_name);
+            assert!(condition.matches_trace(&tc, None), "{}", failure_name);
         }
     }
 
@@ -797,7 +797,7 @@ mod tests {
         for (rule_test_name, condition) in conditions.iter() {
             let failure_name = format!("Failed on test: '{}'!!!", rule_test_name);
             let ip_addr = Some(NetIpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
-            assert!(condition.matches_event(&evt, ip_addr), failure_name);
+            assert!(condition.matches_event(&evt, ip_addr), "{}", failure_name);
         }
     }
 
@@ -890,6 +890,7 @@ mod tests {
             let failure_name = format!("Failed on test: '{}'!!!", rule_test_name);
             assert!(
                 condition.matches_trace(&tc, None) == *expected,
+                "{}",
                 failure_name
             );
         }
@@ -945,6 +946,7 @@ mod tests {
             let failure_name = format!("Failed on test: '{}'!!!", rule_test_name);
             assert!(
                 condition.matches_trace(&tc, None) == *expected,
+                "{}",
                 failure_name
             );
         }
@@ -977,6 +979,7 @@ mod tests {
             let failure_name = format!("Failed on test: '{}'!!!", rule_test_name);
             assert!(
                 condition.matches_trace(&tc, None) == *expected,
+                "{}",
                 failure_name
             );
         }
@@ -1022,7 +1025,7 @@ mod tests {
 
         for (rule_test_name, condition) in conditions.iter() {
             let failure_name = format!("Failed on test: '{}'!!!", rule_test_name);
-            assert!(!condition.matches_trace(&tc, None), failure_name);
+            assert!(!condition.matches_trace(&tc, None), "{}", failure_name);
         }
     }
 

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -604,7 +604,7 @@ impl EventProcessor {
         // instead of a regular `Event` item.
         event.ty = Annotated::new(match report_type {
             SecurityReportType::Csp => EventType::Csp,
-            SecurityReportType::ExpectCt => EventType::ExpectCT,
+            SecurityReportType::ExpectCt => EventType::ExpectCt,
             SecurityReportType::ExpectStaple => EventType::ExpectStaple,
             SecurityReportType::Hpkp => EventType::Hpkp,
         });

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -657,7 +657,7 @@ mod tests {
             minimal,
             MinimalEvent {
                 id: None,
-                ty: EventType::ExpectCT,
+                ty: EventType::ExpectCt,
             }
         );
     }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -105,7 +105,7 @@ impl ItemType {
         match event_type {
             EventType::Default | EventType::Error => ItemType::Event,
             EventType::Transaction => ItemType::Transaction,
-            EventType::Csp | EventType::Hpkp | EventType::ExpectCT | EventType::ExpectStaple => {
+            EventType::Csp | EventType::Hpkp | EventType::ExpectCt | EventType::ExpectStaple => {
                 ItemType::Security
             }
         }

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -36,22 +36,15 @@ pub enum BadEventMeta {
 
     #[fail(display = "bad sentry DSN public key")]
     BadPublicKey(ParseProjectKeyError),
-
-    #[fail(display = "bad project key: project does not exist")]
-    BadProjectKey,
-
-    #[fail(display = "could not schedule event processing")]
-    ScheduleFailed,
 }
 
 impl ResponseError for BadEventMeta {
     fn error_response(&self) -> HttpResponse {
         let mut builder = match *self {
-            Self::MissingAuth | Self::MultipleAuth | Self::BadProjectKey | Self::BadAuth(_) => {
+            Self::MissingAuth | Self::MultipleAuth | Self::BadAuth(_) => {
                 HttpResponse::Unauthorized()
             }
             Self::BadProject(_) | Self::BadPublicKey(_) => HttpResponse::BadRequest(),
-            Self::ScheduleFailed => HttpResponse::ServiceUnavailable(),
         };
 
         builder.json(&ApiErrorResponse::from_fail(self))


### PR DESCRIPTION
Attempt to fix new failing github checks which appear to be have been introduced with Rust version 1.51.

#skip-changelog