### PR TITLE
feat(server): Send pre-aggregated metrics in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 **Internal**:
 
 - Emit the `quantity` field for outcomes of events. This field describes the total size in bytes for attachments or the event count for all other categories. A separate outcome is emitted for attachments in a rejected envelope, if any, in addition to the event outcome. ([#942](https://github.com/getsentry/relay/pull/942))
-- Add experimental metrics ingestion with bucketing or pre-aggregation. ([#948](https://github.com/getsentry/relay/pull/948), [#952](https://github.com/getsentry/relay/pull/952), [#958](https://github.com/getsentry/relay/pull/958))
+- Add experimental metrics ingestion with bucketing and pre-aggregation. ([#948](https://github.com/getsentry/relay/pull/948), [#952](https://github.com/getsentry/relay/pull/952), [#958](https://github.com/getsentry/relay/pull/958), [#966](https://github.com/getsentry/relay/pull/966))
 - Change HTTP response for upstream timeouts from 502 to 504. ([#859](https://github.com/getsentry/relay/pull/859))
 - Add rule id to outcomes coming from transaction sampling. ([#953](https://github.com/getsentry/relay/pull/953))
 - Add support for breakdowns ingestion. ([#934](https://github.com/getsentry/relay/pull/934))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,7 @@ dependencies = [
  "relay-auth",
  "relay-common",
  "relay-log",
+ "relay-metrics",
  "relay-redis",
  "serde",
  "serde_json",

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -20,6 +20,7 @@ num_cpus = "1.13.0"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log", features = ["init"] }
+relay-metrics = { path = "../relay-metrics" }
 relay-redis = { path = "../relay-redis" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -13,6 +13,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
 use relay_common::Uuid;
+use relay_metrics::AggregatorConfig;
 use relay_redis::RedisConfig;
 
 use crate::byte_size::ByteSize;
@@ -813,6 +814,8 @@ struct ConfigValues {
     processing: Processing,
     #[serde(default)]
     outcomes: Outcomes,
+    #[serde(default)]
+    aggregator: AggregatorConfig,
 }
 
 impl ConfigObject for ConfigValues {
@@ -1420,6 +1423,11 @@ impl Config {
     /// Maximum rate limit to report to clients in seconds.
     pub fn max_rate_limit(&self) -> Option<u64> {
         self.values.processing.max_rate_limit.map(u32::into)
+    }
+
+    /// Returns configuration for the metrics [aggregator](relay_metrics::Aggregator).
+    pub fn aggregator_config(&self) -> AggregatorConfig {
+        self.values.aggregator.clone()
     }
 }
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -195,7 +195,7 @@ pub struct Bucket {
     /// A list of tags adding dimensions to the metric for filtering and aggregation.
     ///
     /// See [`Metric::tags`]. Every combination of tags results in a different bucket.
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub tags: BTreeMap<String, String>,
 }
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -851,6 +851,39 @@ mod tests {
     }
 
     #[test]
+    fn test_bucket_value_insert_counter() {
+        let mut value = BucketValue::Counter(42.);
+        MetricValue::Counter(43.).merge_into(&mut value).unwrap();
+        assert_eq!(value, BucketValue::Counter(85.));
+    }
+
+    #[test]
+    fn test_bucket_value_insert_distribution() {
+        let mut value = BucketValue::Distribution(vec![1., 2., 3.]);
+        MetricValue::Distribution(2.0)
+            .merge_into(&mut value)
+            .unwrap();
+        // TODO: This should be ordered
+        assert_eq!(value, BucketValue::Distribution(vec![1., 2., 3., 2.]));
+    }
+
+    #[test]
+    fn test_bucket_value_insert_set() {
+        let mut value = BucketValue::Set(vec![1, 2].into_iter().collect());
+        MetricValue::Set(3).merge_into(&mut value).unwrap();
+        assert_eq!(value, BucketValue::Set(vec![1, 2, 3].into_iter().collect()));
+        MetricValue::Set(2).merge_into(&mut value).unwrap();
+        assert_eq!(value, BucketValue::Set(vec![1, 2, 3].into_iter().collect()));
+    }
+
+    #[test]
+    fn test_bucket_value_insert_gauge() {
+        let mut value = BucketValue::Gauge(42.);
+        MetricValue::Gauge(43.).merge_into(&mut value).unwrap();
+        assert_eq!(value, BucketValue::Gauge(43.));
+    }
+
+    #[test]
     fn test_aggregator_merge_counters() {
         relay_test::setup();
 

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -49,6 +49,36 @@
 //!   }
 //! ]
 //! ```
+//!
+//! # Ingestion
+//!
+//! Processing Relays write aggregate buckets into the ingestion Kafka stream. The schema is similar
+//! to the aggregation payload, with the addition of scoping information:
+//!
+//! ```json
+//! [
+//!   {
+//!
+//!     "name": "endpoint.response_time",
+//!     "unit": "ms",
+//!     "value": [36, 49, 57, 68],
+//!     "type": "d",
+//!     "timestamp": 1615889440,
+//!     "tags": {
+//!       "route": "user_index"
+//!     }
+//!   },
+//!   {
+//!     "name": "endpoint.hits",
+//!     "value": 4,
+//!     "type": "c",
+//!     "timestamp": 1615889440,
+//!     "tags": {
+//!       "route": "user_index"
+//!     }
+//!   }
+//! ]
+//! ```
 #![warn(missing_docs)]
 
 mod aggregation;

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -58,7 +58,8 @@
 //! ```json
 //! [
 //!   {
-//!
+//!     "org_id": 1,
+//!     "project_id": 42,
 //!     "name": "endpoint.response_time",
 //!     "unit": "ms",
 //!     "value": [36, 49, 57, 68],
@@ -69,6 +70,8 @@
 //!     }
 //!   },
 //!   {
+//!     "org_id": 1,
+//!     "project_id": 42,
 //!     "name": "endpoint.hits",
 //!     "value": 4,
 //!     "type": "c",

--- a/relay-server/build.rs
+++ b/relay-server/build.rs
@@ -14,6 +14,12 @@ fn main() {
         env::var("CARGO_PKG_VERSION").unwrap()
     )
     .unwrap();
+    writeln!(
+        f,
+        "pub const CLIENT: &str = \"sentry.relay/{}\";",
+        env::var("CARGO_PKG_VERSION").unwrap()
+    )
+    .unwrap();
     println!("cargo:rerun-if-changed=build.rs\n");
     println!("cargo:rerun-if-changed=Cargo.toml\n");
 }

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1789,6 +1789,7 @@ impl Handler<HandleEnvelope> for EventManager {
                     .then(move |result| {
                         let received = match result {
                             Ok(_) => true,
+                            Err(SendEnvelopeError::RateLimited(_)) => true,
                             Err(SendEnvelopeError::SendFailed(ref e)) => e.is_received(),
                             Err(_) => false,
                         };

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1336,6 +1336,7 @@ impl Handler<ProcessMetrics> for EventProcessor {
 #[derive(Debug)]
 enum SendEnvelopeError {
     ScheduleFailed(MailboxError),
+    #[cfg(feature = "processing")]
     StoreFailed(StoreError),
     SendFailed(UpstreamRequestError),
     RateLimited(RateLimits),
@@ -1423,7 +1424,7 @@ impl EventManager {
         project: Addr<Project>,
         mut envelope: Envelope,
         scoping: Scoping,
-        start_time: Instant,
+        #[allow(unused_variables)] start_time: Instant,
     ) -> ResponseFuture<(), SendEnvelopeError> {
         #[cfg(feature = "processing")]
         {
@@ -1746,6 +1747,7 @@ impl Handler<HandleEnvelope> for EventManager {
                             SendEnvelopeError::ScheduleFailed(e) => {
                                 ProcessingError::ScheduleFailed(e)
                             }
+                            #[cfg(feature = "processing")]
                             SendEnvelopeError::StoreFailed(e) => ProcessingError::StoreFailed(e),
                             SendEnvelopeError::SendFailed(e) => ProcessingError::SendFailed(e),
                             SendEnvelopeError::RateLimited(e) => ProcessingError::RateLimited(e),

--- a/relay-server/src/actors/events.rs
+++ b/relay-server/src/actors/events.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::fmt;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -8,7 +9,7 @@ use std::time::{Duration, Instant};
 use actix::prelude::*;
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use failure::Fail;
-use futures::prelude::*;
+use futures::{future, prelude::*};
 use serde_json::Value as SerdeValue;
 
 use relay_common::{clone, metric, ProjectId, UnixTimestamp};
@@ -22,8 +23,8 @@ use relay_general::protocol::{
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
 use relay_log::LogError;
-use relay_metrics::Metric;
-use relay_quotas::{DataCategory, RateLimits};
+use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric};
+use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_redis::RedisPool;
 use relay_sampling::{RuleId, SamplingResult};
 
@@ -34,6 +35,7 @@ use crate::actors::project::{
 use crate::actors::project_cache::ProjectError;
 use crate::actors::upstream::{SendRequest, UpstreamRelay, UpstreamRequestError};
 use crate::envelope::{self, AttachmentType, ContentType, Envelope, Item, ItemType};
+use crate::extractors::{PartialDsn, RequestMeta};
 use crate::http::{HttpError, RequestBuilder};
 use crate::metrics::{RelayCounters, RelayHistograms, RelaySets, RelayTimers};
 use crate::service::ServerError;
@@ -307,47 +309,6 @@ impl EventProcessor {
     pub fn with_geoip_lookup(mut self, geoip_lookup: Option<Arc<GeoIpLookup>>) -> Self {
         self.geoip_lookup = geoip_lookup;
         self
-    }
-
-    /// Validates all metrics in the envelope, if any.
-    ///
-    /// Metrics are removed from the envelope if they contain invalid syntax or if their timestamps
-    /// are out of range after clock drift correction.
-    fn process_metrics(&self, state: &mut ProcessEnvelopeState) {
-        let envelope = &mut state.envelope;
-        let received = state.received_at;
-        // TODO(ja): Avoid unsafe cast
-        let timestamp = UnixTimestamp::from_secs(received.timestamp() as u64);
-
-        let clock_drift_processor =
-            ClockDriftProcessor::new(envelope.sent_at(), received).at_least(MINIMUM_CLOCK_DRIFT);
-
-        envelope.retain_items(|item| {
-            if item.ty() != ItemType::Metrics {
-                return true;
-            }
-
-            let payload = item.payload();
-            let mut normalized = Vec::with_capacity(payload.len());
-
-            for metric_result in Metric::parse_all(&payload, timestamp) {
-                let mut metric = match metric_result {
-                    Ok(metric) => metric,
-                    Err(_) => continue,
-                };
-
-                clock_drift_processor.process_timestamp(&mut metric.timestamp);
-
-                if !normalized.is_empty() {
-                    normalized.push(b'\n');
-                }
-                normalized.extend(metric.serialize().as_bytes());
-            }
-
-            item.set_payload(ContentType::Text, normalized);
-
-            true
-        });
     }
 
     /// Validates all sessions in the envelope, if any.
@@ -775,6 +736,7 @@ impl EventProcessor {
             ItemType::Session => false,
             ItemType::Sessions => false,
             ItemType::Metrics => false,
+            ItemType::MetricBuckets => false,
         }
     }
 
@@ -1065,7 +1027,7 @@ impl EventProcessor {
 
         // Fetch scoping again from the project state. This is a rather cheap operation at this
         // point and it is easier than passing scoping through all layers of `process_envelope`.
-        let scoping = project_state.get_scoping(state.envelope.meta());
+        let scoping = project_state.scope_request(state.envelope.meta());
 
         state.rate_limits = metric!(timer(RelayTimers::EventProcessingRateLimiting), {
             envelope_limiter
@@ -1212,7 +1174,6 @@ impl EventProcessor {
             };
         }
 
-        self.process_metrics(&mut state);
         self.process_sessions(&mut state);
         self.process_user_reports(&mut state);
 
@@ -1319,6 +1280,67 @@ impl Handler<ProcessEnvelope> for EventProcessor {
     }
 }
 
+struct ProcessMetrics {
+    pub items: Vec<Item>,
+    pub project: Addr<Project>,
+    pub start_time: Instant,
+    pub sent_at: Option<DateTime<Utc>>,
+}
+
+impl Message for ProcessMetrics {
+    type Result = ();
+}
+
+impl Handler<ProcessMetrics> for EventProcessor {
+    type Result = ();
+
+    fn handle(&mut self, message: ProcessMetrics, _context: &mut Self::Context) -> Self::Result {
+        let ProcessMetrics {
+            items,
+            project,
+            start_time,
+            sent_at,
+        } = message;
+
+        let received = relay_common::instant_to_date_time(start_time);
+        let timestamp = UnixTimestamp::from_secs(received.timestamp() as u64);
+
+        let clock_drift_processor =
+            ClockDriftProcessor::new(sent_at, received).at_least(MINIMUM_CLOCK_DRIFT);
+
+        for item in items {
+            let payload = item.payload();
+            if item.ty() == ItemType::Metrics {
+                let metrics = Metric::parse_all(&payload, timestamp).filter_map(|result| {
+                    let mut metric = result.ok()?;
+                    clock_drift_processor.process_timestamp(&mut metric.timestamp);
+                    Some(metric)
+                });
+
+                relay_log::trace!("inserting metrics into project aggregator");
+                project.do_send(InsertMetrics::new(metrics));
+            } else if item.ty() == ItemType::MetricBuckets {
+                if let Ok(mut buckets) = Bucket::parse_all(&payload) {
+                    for bucket in &mut buckets {
+                        clock_drift_processor.process_timestamp(&mut bucket.timestamp);
+                    }
+
+                    relay_log::trace!("merging metric buckets into project aggregator");
+                    project.do_send(MergeBuckets::new(buckets));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SendEnvelopeError {
+    ScheduleFailed(MailboxError),
+    StoreFailed(StoreError),
+    SendFailed(UpstreamRequestError),
+    RateLimited(RateLimits),
+}
+
 /// Either a captured envelope or an error that occured during processing.
 pub type CapturedEnvelope = Result<Envelope, String>;
 
@@ -1394,6 +1416,107 @@ impl EventManager {
             outcome_producer,
         })
     }
+
+    /// Sends an envelope to the upstream or Kafka and handles returned rate limits.
+    fn send_envelope(
+        &mut self,
+        project: Addr<Project>,
+        mut envelope: Envelope,
+        scoping: Scoping,
+        start_time: Instant,
+    ) -> ResponseFuture<(), SendEnvelopeError> {
+        #[cfg(feature = "processing")]
+        {
+            if let Some(ref store_forwarder) = self.store_forwarder {
+                relay_log::trace!("sending envelope to kafka");
+                let future = store_forwarder
+                    .send(StoreEnvelope {
+                        envelope,
+                        start_time,
+                        scoping,
+                    })
+                    .map_err(SendEnvelopeError::ScheduleFailed)
+                    .and_then(|result| result.map_err(SendEnvelopeError::StoreFailed));
+
+                return Box::new(future);
+            }
+        }
+
+        // if we are in capture mode, we stash away the event instead of
+        // forwarding it.
+        if self.config.relay_mode() == RelayMode::Capture {
+            // XXX: this is wrong because captured_events does not take envelopes without
+            // event_id into account.
+            if let Some(event_id) = envelope.event_id() {
+                relay_log::debug!("capturing envelope");
+                self.captures.insert(event_id, Ok(envelope));
+            } else {
+                relay_log::debug!("dropping non event envelope");
+            }
+
+            return Box::new(future::ok(()));
+        }
+
+        relay_log::trace!("sending envelope to sentry endpoint");
+        let http_encoding = self.config.http_encoding();
+        let request = SendRequest::post(format!("/api/{}/envelope/", scoping.project_id)).build(
+            move |mut builder: RequestBuilder| {
+                // Override the `sent_at` timestamp. Since the event went through basic
+                // normalization, all timestamps have been corrected. We propagate the new
+                // `sent_at` to allow the next Relay to double-check this timestamp and
+                // potentially apply correction again. This is done as close to sending as
+                // possible so that we avoid internal delays.
+                envelope.set_sent_at(Utc::now());
+
+                let meta = envelope.meta();
+
+                if let Some(origin) = meta.origin() {
+                    builder.header("Origin", origin.as_str());
+                }
+
+                if let Some(user_agent) = meta.user_agent() {
+                    builder.header("User-Agent", user_agent);
+                }
+
+                builder
+                    .content_encoding(http_encoding)
+                    .header("X-Sentry-Auth", meta.auth_header())
+                    .header("X-Forwarded-For", meta.forwarded_for())
+                    .header("Content-Type", envelope::CONTENT_TYPE);
+
+                builder
+                    .body(
+                        envelope
+                            .to_vec()
+                            // XXX: upstream actor should allow for custom error type,
+                            // right now we are forced to shoehorn our envelope errors into
+                            // UpstreamRequestError
+                            .map_err(failure::Error::from)
+                            .map_err(actix_web::Error::from)
+                            .map_err(HttpError::Actix)
+                            .map_err(UpstreamRequestError::Http)?
+                            .into(),
+                    )
+                    .map_err(UpstreamRequestError::Http)
+            },
+        );
+
+        let future = self
+            .upstream
+            .send(request)
+            .map_err(SendEnvelopeError::ScheduleFailed)
+            .and_then(move |result| {
+                if let Err(UpstreamRequestError::RateLimited(upstream_limits)) = result {
+                    let limits = upstream_limits.scope(&scoping);
+                    project.do_send(UpdateRateLimits(limits.clone()));
+                    return Err(SendEnvelopeError::RateLimited(limits));
+                }
+
+                result.map_err(SendEnvelopeError::SendFailed)
+            });
+
+        Box::new(future)
+    }
 }
 
 impl Actor for EventManager {
@@ -1445,11 +1568,29 @@ impl Handler<QueueEnvelope> for EventManager {
 
         let event_id = message.envelope.event_id();
 
+        // Remove metrics from the envelope and queue them directly on the project's `Aggregator`.
+        let mut metric_items = Vec::new();
+        let is_metric = |i: &Item| matches!(i.ty(), ItemType::Metrics | ItemType::MetricBuckets);
+        while let Some(item) = message.envelope.take_item_by(is_metric) {
+            metric_items.push(item);
+        }
+
+        if !metric_items.is_empty() {
+            relay_log::trace!("sending metrics into processing queue");
+            self.processor.do_send(ProcessMetrics {
+                items: metric_items,
+                project: message.project.clone(),
+                start_time: message.start_time,
+                sent_at: message.envelope.sent_at(),
+            });
+        }
+
         // Split the envelope into event-related items and other items. This allows to fast-track:
         //  1. Envelopes with only session items. They only require rate limiting.
         //  2. Event envelope processing can bail out if the event is filtered or rate limited,
         //     since all items depend on this event.
         if let Some(event_envelope) = message.envelope.split_by(Item::requires_event) {
+            relay_log::trace!("queueing separate envelope for non-event items");
             self.current_active_events += 1;
             context.notify(HandleEnvelope {
                 envelope: event_envelope,
@@ -1459,19 +1600,21 @@ impl Handler<QueueEnvelope> for EventManager {
             });
         }
 
-        self.current_active_events += 1;
-        context.notify(HandleEnvelope {
-            envelope: message.envelope,
-            sampling_project: message.sampling_project,
-            project: message.project,
-            start_time: message.start_time,
-        });
+        if !message.envelope.is_empty() {
+            relay_log::trace!("queueing envelope");
+            self.current_active_events += 1;
+            context.notify(HandleEnvelope {
+                envelope: message.envelope,
+                sampling_project: message.sampling_project,
+                project: message.project,
+                start_time: message.start_time,
+            });
+        }
 
         // Actual event handling is performed asynchronously in a separate future. The lifetime of
         // that future will be tied to the EventManager's context. This allows to keep the Project
         // actor alive even if it is cleaned up in the ProjectManager.
 
-        relay_log::trace!("queued event");
         Ok(event_id)
     }
 }
@@ -1507,15 +1650,10 @@ impl Handler<HandleEnvelope> for EventManager {
         //    being sent to the upstream (including delays in the upstream). This can be regarded
         //    the total time an event spent in this relay, corrected by incoming network delays.
 
-        let upstream = self.upstream.clone();
         let processor = self.processor.clone();
         let outcome_producer = self.outcome_producer.clone();
         let capture = self.config.relay_mode() == RelayMode::Capture;
-        let http_encoding = self.config.http_encoding();
         let processing_enabled = self.config.processing_enabled();
-
-        #[cfg(feature = "processing")]
-        let store_forwarder = self.store_forwarder.clone();
 
         let HandleEnvelope {
             envelope,
@@ -1591,108 +1729,29 @@ impl Handler<HandleEnvelope> for EventManager {
                 }
             }))
             .into_actor(self)
-            .and_then(clone!(scoping, is_received, |mut envelope, slf, _| {
-                #[cfg(feature = "processing")]
-                {
-                    if let Some(store_forwarder) = store_forwarder {
-                        relay_log::trace!("sending envelope to kafka");
-                        let future = store_forwarder
-                            .send(StoreEnvelope {
-                                envelope,
-                                start_time,
-                                scoping: *scoping.borrow(),
-                            })
-                            .map_err(ProcessingError::ScheduleFailed)
-                            .and_then(move |result| result.map_err(ProcessingError::StoreFailed))
-                            .into_actor(slf);
-
-                        return Box::new(future) as ResponseActFuture<_, _, _>;
-                    }
-                }
-
-                // if we are in capture mode, we stash away the event instead of
-                // forwarding it.
-                if capture {
-                    // XXX: this is wrong because captured_events does not take envelopes without
-                    // event_id into account.
-                    if let Some(event_id) = event_id {
-                        relay_log::debug!("capturing envelope");
-                        slf.captures.insert(event_id, Ok(envelope));
-                    } else {
-                        relay_log::debug!("dropping non event envelope");
-                    }
-                    return Box::new(fut::ok(())) as ResponseActFuture<_, _, _>;
-                }
-
-                relay_log::trace!("sending event to sentry endpoint");
-                let project_id = scoping.borrow().project_id;
-                let request = SendRequest::post(format!("/api/{}/envelope/", project_id)).build(
-                    move |mut builder: RequestBuilder| {
-                        // Override the `sent_at` timestamp. Since the event went through basic
-                        // normalization, all timestamps have been corrected. We propagate the new
-                        // `sent_at` to allow the next Relay to double-check this timestamp and
-                        // potentially apply correction again. This is done as close to sending as
-                        // possible so that we avoid internal delays.
-                        envelope.set_sent_at(Utc::now());
-
-                        let meta = envelope.meta();
-
-                        if let Some(origin) = meta.origin() {
-                            builder.header("Origin", origin.as_str());
-                        }
-
-                        if let Some(user_agent) = meta.user_agent() {
-                            builder.header("User-Agent", user_agent);
-                        }
-
-                        builder
-                            .content_encoding(http_encoding)
-                            .header("X-Sentry-Auth", meta.auth_header())
-                            .header("X-Forwarded-For", meta.forwarded_for())
-                            .header("Content-Type", envelope::CONTENT_TYPE);
-
-                        builder
-                            .body(
-                                envelope
-                                    .to_vec()
-                                    // XXX: upstream actor should allow for custom error type,
-                                    // right now we are forced to shoehorn our envelope errors into
-                                    // UpstreamRequestError
-                                    .map_err(failure::Error::from)
-                                    .map_err(actix_web::Error::from)
-                                    .map_err(HttpError::Actix)
-                                    .map_err(UpstreamRequestError::Http)?
-                                    .into(),
-                            )
-                            .map_err(UpstreamRequestError::Http)
-                    },
-                );
-
-                let future = upstream
-                    .send(request)
-                    .map_err(ProcessingError::ScheduleFailed)
-                    .and_then(move |result| {
+            .and_then(clone!(scoping, is_received, |envelope, slf, _| {
+                slf.send_envelope(project, envelope, *scoping.borrow(), start_time)
+                    .then(move |result| {
                         let received = match result {
                             Ok(_) => true,
-                            Err(ref e) => e.is_received(),
+                            Err(SendEnvelopeError::SendFailed(ref e)) => e.is_received(),
+                            Err(_) => false,
                         };
 
                         // Flag that upstream has received the request, which will skip outcome
                         // generation below.
                         is_received.store(received, Ordering::SeqCst);
 
-                        result.map_err(move |error| match error {
-                            UpstreamRequestError::RateLimited(upstream_limits) => {
-                                let limits = upstream_limits.scope(&scoping.borrow());
-                                project.do_send(UpdateRateLimits(limits.clone()));
-                                ProcessingError::RateLimited(limits)
+                        result.map_err(|error| match error {
+                            SendEnvelopeError::ScheduleFailed(e) => {
+                                ProcessingError::ScheduleFailed(e)
                             }
-                            other => ProcessingError::SendFailed(other),
+                            SendEnvelopeError::StoreFailed(e) => ProcessingError::StoreFailed(e),
+                            SendEnvelopeError::SendFailed(e) => ProcessingError::SendFailed(e),
+                            SendEnvelopeError::RateLimited(e) => ProcessingError::RateLimited(e),
                         })
                     })
-                    .into_actor(slf);
-
-                Box::new(future) as ResponseActFuture<_, _, _>
+                    .into_actor(slf)
             }))
             .timeout(self.config.event_buffer_expiry(), ProcessingError::Timeout)
             .map(|_, _, _| metric!(counter(RelayCounters::EnvelopeAccepted) += 1))
@@ -1762,6 +1821,59 @@ impl Handler<HandleEnvelope> for EventManager {
                 fut::result(x)
             })
             .drop_guard("process_event");
+
+        Box::new(future)
+    }
+}
+
+pub struct SendMetrics {
+    pub buckets: Vec<Bucket>,
+    pub scoping: Scoping,
+    pub project: Addr<Project>,
+}
+
+impl fmt::Debug for SendMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(std::any::type_name::<Self>())
+            .field("buckets", &self.buckets)
+            .field("scoping", &self.scoping)
+            .field("project", &format_args!("Addr<Project>"))
+            .finish()
+    }
+}
+
+impl Message for SendMetrics {
+    type Result = Result<(), Vec<Bucket>>;
+}
+
+impl Handler<SendMetrics> for EventManager {
+    type Result = ResponseFuture<(), Vec<Bucket>>;
+
+    fn handle(&mut self, message: SendMetrics, _context: &mut Self::Context) -> Self::Result {
+        let SendMetrics {
+            buckets,
+            scoping,
+            project,
+        } = message;
+
+        let upstream = self.config.upstream_descriptor();
+        let dsn = PartialDsn {
+            scheme: upstream.scheme(),
+            public_key: scoping.public_key,
+            host: upstream.host().to_owned(),
+            port: upstream.port(),
+            path: "".to_owned(),
+            project_id: Some(scoping.project_id),
+        };
+
+        let mut item = Item::new(ItemType::MetricBuckets);
+        item.set_payload(ContentType::Json, Bucket::serialize_all(&buckets).unwrap());
+        let mut envelope = Envelope::from_request(None, RequestMeta::outbound(dsn));
+        envelope.add_item(item);
+
+        let future = self
+            .send_envelope(project, envelope, scoping, Instant::now())
+            .map_err(|_| buckets);
 
         Box::new(future)
     }

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -12,14 +12,13 @@ use relay_common::{metric, ProjectKey};
 use relay_config::{Config, RelayMode};
 use relay_redis::RedisPool;
 
+use crate::actors::events::EventManager;
 use crate::actors::project::{Project, ProjectState};
 use crate::actors::project_local::LocalProjectSource;
 use crate::actors::project_upstream::UpstreamProjectSource;
 use crate::actors::upstream::UpstreamRelay;
 use crate::metrics::{RelayCounters, RelayHistograms, RelayTimers};
 use crate::utils::Response;
-
-use super::events::EventManager;
 
 #[cfg(feature = "processing")]
 use {crate::actors::project_redis::RedisProjectSource, relay_common::clone};

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -11,7 +11,7 @@ use failure::{Fail, ResultExt};
 use rdkafka::error::KafkaError;
 use rdkafka::producer::BaseRecord;
 use rdkafka::ClientConfig;
-use relay_metrics::{Metric, MetricUnit, MetricValue};
+use relay_metrics::{Bucket, BucketValue, MetricUnit};
 use rmp_serde::encode::Error as RmpError;
 use serde::{ser::Error, Serialize};
 
@@ -317,19 +317,16 @@ impl StoreForwarder {
     ) -> Result<(), StoreError> {
         let payload = item.payload();
 
-        // NB: Metrics are guaranteed to contain a timestamp at this point.
-        for metric_result in Metric::parse_all(&payload, UnixTimestamp::from_secs(0)) {
-            if let Ok(metric) = metric_result {
-                self.send_metric_message(MetricKafkaMessage {
-                    org_id,
-                    project_id,
-                    name: metric.name,
-                    unit: metric.unit,
-                    value: metric.value,
-                    timestamp: metric.timestamp,
-                    tags: metric.tags,
-                })?;
-            }
+        for bucket in Bucket::parse_all(&payload).unwrap_or_default() {
+            self.send_metric_message(MetricKafkaMessage {
+                org_id,
+                project_id,
+                name: bucket.name,
+                unit: MetricUnit::default(),
+                value: bucket.value,
+                timestamp: bucket.timestamp,
+                tags: bucket.tags,
+            })?;
         }
 
         Ok(())
@@ -504,7 +501,7 @@ struct MetricKafkaMessage {
     pub name: String,
     pub unit: MetricUnit,
     #[serde(flatten)]
-    pub value: MetricValue,
+    pub value: BucketValue,
     pub timestamp: UnixTimestamp,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub tags: BTreeMap<String, String>,
@@ -634,7 +631,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                         item,
                     )?;
                 }
-                ItemType::Metrics => {
+                ItemType::MetricBuckets => {
                     self.produce_metrics(scoping.organization_id, scoping.project_id, item)?
                 }
                 _ => {}

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -498,13 +498,13 @@ struct SessionKafkaMessage {
 struct MetricKafkaMessage {
     org_id: u64,
     project_id: ProjectId,
-    pub name: String,
-    pub unit: MetricUnit,
+    name: String,
+    unit: MetricUnit,
     #[serde(flatten)]
-    pub value: BucketValue,
-    pub timestamp: UnixTimestamp,
+    value: BucketValue,
+    timestamp: UnixTimestamp,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub tags: BTreeMap<String, String>,
+    tags: BTreeMap<String, String>,
 }
 
 /// An enum over all possible ingest messages.

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -357,8 +357,9 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
             }
             ItemType::Session => session_count += 1,
             ItemType::Sessions => session_count += 1,
-            ItemType::Metrics => (),
             ItemType::UserReport => (),
+            ItemType::Metrics => (),
+            ItemType::MetricBuckets => (),
         }
     }
 

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -95,8 +95,10 @@ pub enum ItemType {
     Session,
     /// Aggregated session data.
     Sessions,
-    /// Metrics.
+    /// Individual metrics in text encoding.
     Metrics,
+    /// Buckets of preaggregated metrics encoded as JSON.
+    MetricBuckets,
 }
 
 impl ItemType {
@@ -126,6 +128,7 @@ impl fmt::Display for ItemType {
             Self::Session => write!(f, "session"),
             Self::Sessions => write!(f, "aggregated sessions"),
             Self::Metrics => write!(f, "metrics"),
+            Self::MetricBuckets => write!(f, "metric buckets"),
         }
     }
 }
@@ -527,9 +530,11 @@ impl Item {
             ItemType::FormData => false,
 
             // The remaining item types cannot carry event payloads.
-            ItemType::UserReport | ItemType::Session | ItemType::Sessions | ItemType::Metrics => {
-                false
-            }
+            ItemType::UserReport
+            | ItemType::Session
+            | ItemType::Sessions
+            | ItemType::Metrics
+            | ItemType::MetricBuckets => false,
         }
     }
 
@@ -549,6 +554,7 @@ impl Item {
             ItemType::Session => false,
             ItemType::Sessions => false,
             ItemType::Metrics => false,
+            ItemType::MetricBuckets => false,
         }
     }
 }

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -61,12 +61,12 @@ impl ResponseError for BadEventMeta {
 /// transparently serializes to and deserializes from a DSN string.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PartialDsn {
-    scheme: Scheme,
-    public_key: ProjectKey,
-    host: String,
-    port: u16,
-    path: String,
-    project_id: Option<ProjectId>,
+    pub scheme: Scheme,
+    pub public_key: ProjectKey,
+    pub host: String,
+    pub port: u16,
+    pub path: String,
+    pub project_id: Option<ProjectId>,
 }
 
 impl PartialDsn {
@@ -251,6 +251,21 @@ impl<D> RequestMeta<D> {
 }
 
 impl RequestMeta {
+    /// Creates meta for an outbound request of this Relay.
+    pub fn outbound(dsn: PartialDsn) -> Self {
+        Self {
+            dsn,
+            client: Some(crate::constants::CLIENT.to_owned()),
+            version: default_version(),
+            origin: None,
+            remote_addr: None,
+            forwarded_for: "".to_string(),
+            user_agent: Some(crate::constants::SERVER.to_owned()),
+            no_cache: false,
+            start_time: Instant::now(),
+        }
+    }
+
     #[cfg(test)]
     // TODO: Remove Dsn here?
     pub fn new(dsn: relay_common::Dsn) -> Self {

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -139,8 +139,13 @@ impl ServiceState {
         .context(ServerErrorKind::ConfigError)?
         .start();
 
-        let project_cache =
-            ProjectCache::new(config.clone(), upstream_relay.clone(), redis_pool).start();
+        let project_cache = ProjectCache::new(
+            config.clone(),
+            event_manager.clone(),
+            upstream_relay.clone(),
+            redis_pool,
+        )
+        .start();
 
         Ok(ServiceState {
             config: config.clone(),

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -96,6 +96,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Session => None,
         ItemType::Sessions => None,
         ItemType::Metrics => None,
+        ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
     }

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -279,7 +279,9 @@ def sessions_consumer(kafka_consumer):
 
 @pytest.fixture
 def metrics_consumer(kafka_consumer):
-    return lambda timeout=2: MetricsConsumer(timeout=timeout, *kafka_consumer("metrics"))
+    return lambda timeout=2: MetricsConsumer(
+        timeout=timeout, *kafka_consumer("metrics")
+    )
 
 
 class MetricsConsumer(ConsumerBase):

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -283,8 +283,8 @@ def metrics_consumer(kafka_consumer):
 
 
 class MetricsConsumer(ConsumerBase):
-    def get_metric(self):
-        message = self.poll()
+    def get_metric(self, timeout):
+        message = self.poll(timeout)
         assert message is not None
         assert message.error() is None
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -279,12 +279,12 @@ def sessions_consumer(kafka_consumer):
 
 @pytest.fixture
 def metrics_consumer(kafka_consumer):
-    return lambda: MetricsConsumer(*kafka_consumer("metrics"))
+    return lambda timeout=2: MetricsConsumer(timeout=timeout, *kafka_consumer("metrics"))
 
 
 class MetricsConsumer(ConsumerBase):
-    def get_metric(self, timeout):
-        message = self.poll(timeout)
+    def get_metric(self, timeout=None):
+        message = self.poll(timeout=timeout)
         assert message is not None
         assert message.error() is None
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,8 +1,18 @@
 from datetime import datetime, timezone
+import json
 
 
-def test_metrics(mini_sentry, relay_chain):
-    relay = relay_chain()
+TEST_CONFIG = {
+    "aggregator": {
+        "bucket_interval": 1,
+        "initial_delay": 0,
+        "debounce_delay": 0,
+    }
+}
+
+
+def test_metrics(mini_sentry, relay):
+    relay = relay(mini_sentry, options=TEST_CONFIG)
 
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
@@ -11,18 +21,21 @@ def test_metrics(mini_sentry, relay_chain):
     metrics_payload = f"foo:42|c|'{timestamp}\nbar:17|c|'{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.captured_events.get(timeout=2)
     assert len(envelope.items) == 1
 
     metrics_item = envelope.items[0]
-    assert metrics_item.type == "metrics"
+    assert metrics_item.type == "metric_buckets"
 
     received_metrics = metrics_item.get_bytes()
-    assert received_metrics.decode() == metrics_payload
+    assert json.loads(received_metrics.decode()) == [
+        {"timestamp": timestamp, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "name": "bar", "value": 17.0, "type": "c"},
+    ]
 
 
 def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_consumer):
-    relay = relay_with_processing()
+    relay = relay_with_processing(options=TEST_CONFIG)
     metrics_consumer = metrics_consumer()
 
     project_id = 42

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -3,11 +3,7 @@ import json
 
 
 TEST_CONFIG = {
-    "aggregator": {
-        "bucket_interval": 1,
-        "initial_delay": 0,
-        "debounce_delay": 0,
-    }
+    "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0,}
 }
 
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -45,7 +45,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     metrics_payload = f"foo:42|c|'{timestamp}\nbar:17|c|'{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
 
-    metric = metrics_consumer.get_metric(timeout=2)
+    metric = metrics_consumer.get_metric()
 
     assert metric == {
         "org_id": 1,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -45,7 +45,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     metrics_payload = f"foo:42|c|'{timestamp}\nbar:17|c|'{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
 
-    metric = metrics_consumer.get_metric()
+    metric = metrics_consumer.get_metric(timeout=2)
 
     assert metric == {
         "org_id": 1,


### PR DESCRIPTION
Uses the metrics aggregator from #958 to send batches of pre-aggregated
buckets to the upstream instead of forwarding individual metric values.
If sending fails for any reason, the metrics are merged back into the
aggregator, which will retry flushing after the next interval.

Metric envelopes are not queued like regular envelopes. Instead, they go
straight to the `EventProcessor` worker pool, where they are parsed,
normalized and sent to the project's aggregator. This ensures that
metric requests do not create long running futures that would slow down
the system. For mixed envelopes, metric items are split off and handled
separately.

Metrics aggregators are spawned on the projects thread, which runs the
project cache and manages all project state access. In the future,
metrics aggregation will have to be moved to a separate resource to
ensure that project state requests remain instant.