### PR TITLE
ref(server): Minor refactor sampling interface

### DIFF
--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -1,7 +1,6 @@
 //! Functionality for calculating if a trace should be processed or dropped.
 
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fmt::{self, Display, Formatter};
 use std::net::IpAddr;
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -562,8 +562,8 @@ fn get_matching_trace_rule<'a>(
 /// The return is deterministic, always generates the same number from the same id.
 pub fn pseudo_random_from_uuid(id: Uuid) -> f64 {
     let big_seed = id.as_u128();
-    let seed: u64 = big_seed.overflowing_shr(64).0.try_into().unwrap();
-    let stream: u64 = (big_seed & 0xffffffff00000000).try_into().unwrap();
+    let seed = big_seed >> 64 as u64;
+    let stream = big_seed as u64;
     let mut generator = Pcg32::new(seed, stream);
     let dist = Uniform::new(0f64, 1f64);
     generator.sample(dist)

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -569,6 +569,7 @@ pub fn pseudo_random_from_uuid(id: Uuid) -> f64 {
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr as NetIpAddr, Ipv4Addr};
+    use std::str::FromStr;
 
     use insta::assert_ron_snapshot;
 
@@ -1424,9 +1425,18 @@ mod tests {
     }
 
     #[test]
+    /// Test that we can convert the full range of UUID into a number without panicking
+    fn test_id_range() {
+        let highest = Uuid::from_str("ffffffff-ffff-ffff-ffff-ffffffffffff").unwrap();
+        pseudo_random_from_uuid(highest);
+        let lowest = Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap();
+        pseudo_random_from_uuid(lowest);
+    }
+
+    #[test]
     /// Test that the we get the same sampling decision from the same trace id
     fn test_repeatable_sampling_decision() {
-        let id = Uuid::new_v4();
+        let id = Uuid::from_str("4a106cf6-b151-44eb-9131-ae7db1a157a3").unwrap();
 
         let val1 = pseudo_random_from_uuid(id);
         let val2 = pseudo_random_from_uuid(id);

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -562,9 +562,7 @@ fn get_matching_trace_rule<'a>(
 /// The return is deterministic, always generates the same number from the same id.
 pub fn pseudo_random_from_uuid(id: Uuid) -> f64 {
     let big_seed = id.as_u128();
-    let seed = big_seed >> 64 as u64;
-    let stream = big_seed as u64;
-    let mut generator = Pcg32::new(seed, stream);
+    let mut generator = Pcg32::new((big_seed >> 64) as u64, big_seed as u64);
     let dist = Uniform::new(0f64, 1f64);
     generator.sample(dist)
 }

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -1433,7 +1433,6 @@ mod tests {
 
         let val1 = pseudo_random_from_uuid(id);
         let val2 = pseudo_random_from_uuid(id);
-
-        assert_eq!(val1, val2);
+        assert!(val1 + f64::EPSILON > val2 && val2 + f64::EPSILON > val1);
     }
 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -39,12 +39,11 @@ pub fn should_keep_event(
 
     let ty = rule_type_for_event(&event);
     if let Some(rule) = get_matching_event_rule(sampling_config, event, ip_addr, ty) {
-        if let Some(random_number) = pseudo_random_from_uuid(event_id) {
-            if random_number < rule.sample_rate {
-                return SamplingResult::Keep;
-            }
-            return SamplingResult::Drop(rule.id);
+        let random_number = pseudo_random_from_uuid(event_id);
+        if random_number < rule.sample_rate {
+            return SamplingResult::Keep;
         }
+        return SamplingResult::Drop(rule.id);
     }
     // if there are no matching rules there is not enough info to make a sampling decision
     SamplingResult::NoDecision


### PR DESCRIPTION
Minor refactor of function interface.

Used to return Option when it received a string that was converted to an IID
Now it receives an IID but the return was left as Option
 #skip-changelog 