### PR TITLE
fix: Ensure measurement names are non-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Change HTTP response for upstream timeouts from 502 to 504. ([#859](https://github.com/getsentry/relay/pull/859))
 - Add rule id to outcomes coming from transaction sampling. ([#953](https://github.com/getsentry/relay/pull/953))
 - Add support for breakdowns ingestion. ([#934](https://github.com/getsentry/relay/pull/934))
+- Ensure empty strings are invalid measurement names. ([#968](https://github.com/getsentry/relay/pull/968))
 
 ## 21.3.0
 

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -72,8 +72,7 @@ impl DerefMut for Measurements {
 }
 
 fn is_valid_measurement_name(name: &str) -> bool {
-    !name.is_empty()
-        && name.starts_with(|c| matches!(c, 'a'..='z' | 'A'..='Z'))
+    name.starts_with(|c| matches!(c, 'a'..='z' | 'A'..='Z'))
         && name
             .chars()
             .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -72,8 +72,11 @@ impl DerefMut for Measurements {
 }
 
 fn is_valid_measurement_name(name: &str) -> bool {
-    name.chars()
-        .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
+    !name.is_empty()
+        && name.starts_with(|c| matches!(c, 'a'..='z' | 'A'..='Z'))
+        && name
+            .chars()
+            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
 }
 
 #[test]
@@ -88,7 +91,8 @@ fn test_measurements_serialization() {
         "cls": {"value": null},
         "fp": {"value": "im a first paint"},
         "Total Blocking Time": {"value": 3.14159},
-        "missing_value": "string"
+        "missing_value": "string",
+        "": {"value": 2.71828}
     }
 }"#;
 
@@ -115,6 +119,12 @@ fn test_measurements_serialization() {
     "measurements": {
       "": {
         "err": [
+          [
+            "invalid_data",
+            {
+              "reason": "measurement name '' can contain only characters a-z0-9.-_"
+            }
+          ],
           [
             "invalid_data",
             {
@@ -200,6 +210,10 @@ fn test_measurements_serialization() {
     }));
 
     let measurements_meta = measurements.meta_mut();
+
+    measurements_meta.add_error(Error::invalid(
+        "measurement name '' can contain only characters a-z0-9.-_",
+    ));
 
     measurements_meta.add_error(Error::invalid(
         "measurement name 'Total Blocking Time' can contain only characters a-z0-9.-_",

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -33,7 +33,12 @@ impl FromValue for Measurements {
                 .filter_map(|(name, object)| {
                     let name = name.trim();
 
-                    if is_valid_measurement_name(name) {
+                    if name.is_empty() {
+                        processing_errors.push(Error::invalid(format!(
+                            "measurement name '{}' cannot be empty",
+                            name
+                        )));
+                    } else if is_valid_measurement_name(name) {
                         return Some((name.to_lowercase(), object));
                     } else {
                         processing_errors.push(Error::invalid(format!(
@@ -121,7 +126,7 @@ fn test_measurements_serialization() {
           [
             "invalid_data",
             {
-              "reason": "measurement name '' can contain only characters a-z0-9.-_"
+              "reason": "measurement name '' cannot be empty"
             }
           ],
           [
@@ -210,9 +215,7 @@ fn test_measurements_serialization() {
 
     let measurements_meta = measurements.meta_mut();
 
-    measurements_meta.add_error(Error::invalid(
-        "measurement name '' can contain only characters a-z0-9.-_",
-    ));
+    measurements_meta.add_error(Error::invalid("measurement name '' cannot be empty"));
 
     measurements_meta.add_error(Error::invalid(
         "measurement name 'Total Blocking Time' can contain only characters a-z0-9.-_",


### PR DESCRIPTION
Currently, `is_valid_measurement_name()` will vacuously be `true` for empty strings. Refactoring this function to ensure empty strings are invalid measurement strings. 