### PR TITLE
fix(metrics): Add units to metric buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 **Internal**:
 
 - Emit the `quantity` field for outcomes of events. This field describes the total size in bytes for attachments or the event count for all other categories. A separate outcome is emitted for attachments in a rejected envelope, if any, in addition to the event outcome. ([#942](https://github.com/getsentry/relay/pull/942))
-- Add experimental metrics ingestion with bucketing and pre-aggregation. ([#948](https://github.com/getsentry/relay/pull/948), [#952](https://github.com/getsentry/relay/pull/952), [#958](https://github.com/getsentry/relay/pull/958), [#966](https://github.com/getsentry/relay/pull/966))
+- Add experimental metrics ingestion with bucketing and pre-aggregation. ([#948](https://github.com/getsentry/relay/pull/948), [#952](https://github.com/getsentry/relay/pull/952), [#958](https://github.com/getsentry/relay/pull/958), [#966](https://github.com/getsentry/relay/pull/966), [#969](https://github.com/getsentry/relay/pull/969))
 - Change HTTP response for upstream timeouts from 502 to 504. ([#859](https://github.com/getsentry/relay/pull/859))
 - Add rule id to outcomes coming from transaction sampling. ([#953](https://github.com/getsentry/relay/pull/953))
 - Add support for breakdowns ingestion. ([#934](https://github.com/getsentry/relay/pull/934))

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -15,6 +15,9 @@
 //! endpoint.hits:1|c|'1615889449|#route:user_index
 //! ```
 //!
+//! The metric type is part of its signature just like the unit. Therefore, it is allowed to reuse a
+//! metric name for multiple metric types, which will result in multiple metrics being recorded.
+//!
 //! # Aggregation
 //!
 //! Relay accumulates all metrics in [time buckets](Bucket) before sending them onwards. Aggregation

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -10,7 +10,7 @@ pub use relay_common::UnixTimestamp;
 /// Time duration units used in [`MetricUnit::Duration`].
 ///
 /// Defaults to `ms`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum DurationPrecision {
     /// Nanosecond (`"ns"`).
     NanoSecond,
@@ -43,7 +43,7 @@ impl fmt::Display for DurationPrecision {
 /// measurements.
 ///
 /// Units and their precisions are uniquely represented by a string identifier.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum MetricUnit {
     /// A time duration, defaulting to milliseconds (`"ms"`).
     Duration(DurationPrecision),

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -322,7 +322,7 @@ impl StoreForwarder {
                 org_id,
                 project_id,
                 name: bucket.name,
-                unit: MetricUnit::default(),
+                unit: bucket.unit,
                 value: bucket.value,
                 timestamp: bucket.timestamp,
                 tags: bucket.tags,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -87,10 +87,11 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
     mini_sentry.add_full_project_config(project_id)
 
     # Send two events to downstream and one to upstream
-    downstream.send_metrics(project_id, "foo:7|c")
-    downstream.send_metrics(project_id, "foo:5|c")
+    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
+    downstream.send_metrics(project_id, f"foo:7|c|'{timestamp}")
+    downstream.send_metrics(project_id, f"foo:5|c|'{timestamp}")
 
-    upstream.send_metrics(project_id, "foo:3|c")
+    upstream.send_metrics(project_id, f"foo:3|c|'{timestamp}")
 
     metric = metrics_consumer.get_metric(timeout=4)
     metric.pop("timestamp")

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -38,7 +38,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     mini_sentry.add_full_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c|'{timestamp}\nbar:17|c|'{timestamp}"
+    metrics_payload = f"foo:42|c|'{timestamp}\nbar@s:17|c|'{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
 
     metric = metrics_consumer.get_metric()
@@ -59,11 +59,13 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
         "org_id": 1,
         "project_id": project_id,
         "name": "bar",
-        "unit": "",
+        "unit": "s",
         "value": 17.0,
         "type": "c",
         "timestamp": timestamp,
     }
+
+    metrics_consumer.assert_empty()
 
 
 def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consumer):
@@ -100,3 +102,5 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
         "value": 15.0,
         "type": "c",
     }
+
+    metrics_consumer.assert_empty()


### PR DESCRIPTION
Treats units as part of the metric signature, in addition to the type and name.
In future, we will convert between compatible units and allow merging values
with varying precision. For now, all unit precisions are handled in separate
buckets.
