### PR TITLE
ref(metrics): Add max, min, sum, and count to gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Emit outcomes for rate limited attachments. ([#951](https://github.com/getsentry/relay/pull/951))
+- Add max, min, sum, and count to gauge metrics. ([#974](https://github.com/getsentry/relay/pull/974))
 
 ## 21.3.1
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -156,8 +156,8 @@ pub enum MetricType {
     Set,
     /// Stores absolute snapshots of values.
     ///
-    /// Contrary to [counters](Self::Counter), which allow relative changes, gauges always store the
-    /// last absolute value submitted.
+    /// In addition to plain [counters](Self::Counter), gauges store a snapshot of the maximum,
+    /// minimum and sum of all values, as well as the last reported value.
     Gauge,
 }
 


### PR DESCRIPTION
Adds additional snapshot state to gauges, effectively making them a superset of counters. This changes the schema of gauge buckets for submission and in Kafka.