### PR TITLE
feat: Log extra metrics for internal project ids

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -715,6 +715,9 @@ pub struct Processing {
     /// Maximum rate limit to report to clients.
     #[serde(default = "default_max_rate_limit")]
     pub max_rate_limit: Option<u32>,
+    /// Projects for which to emit extra (high-noise) metrics.
+    #[serde(default)]
+    pub _internal_projects: Vec<u64>,
 }
 
 impl Default for Processing {
@@ -732,6 +735,7 @@ impl Default for Processing {
             attachment_chunk_size: default_chunk_size(),
             projectconfig_cache_prefix: default_projectconfig_cache_prefix(),
             max_rate_limit: default_max_rate_limit(),
+            _internal_projects: Vec::new(),
         }
     }
 }
@@ -1362,6 +1366,11 @@ impl Config {
     /// True if the Relay should do processing.
     pub fn processing_enabled(&self) -> bool {
         self.values.processing.enabled
+    }
+
+    /// Set of internal project IDs for which to emit extra metrics.
+    pub fn processing_internal_projects(&self) -> &[u64] {
+        &self.values.processing.internal_projects
     }
 
     /// The path to the GeoIp database required for event processing.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1370,7 +1370,7 @@ impl Config {
 
     /// Set of internal project IDs for which to emit extra metrics.
     pub fn processing_internal_projects(&self) -> &[u64] {
-        &self.values.processing.internal_projects
+        &self.values.processing._internal_projects
     }
 
     /// The path to the GeoIp database required for event processing.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -12,7 +12,7 @@ use failure::{Backtrace, Context, Fail};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
-use relay_common::Uuid;
+use relay_common::{ProjectId, Uuid};
 use relay_metrics::AggregatorConfig;
 use relay_redis::RedisConfig;
 
@@ -717,7 +717,7 @@ pub struct Processing {
     pub max_rate_limit: Option<u32>,
     /// Projects for which to emit extra (high-noise) metrics.
     #[serde(default)]
-    pub _internal_projects: Vec<u64>,
+    pub _internal_projects: Vec<ProjectId>,
 }
 
 impl Default for Processing {
@@ -1369,7 +1369,7 @@ impl Config {
     }
 
     /// Set of internal project IDs for which to emit extra metrics.
-    pub fn processing_internal_projects(&self) -> &[u64] {
+    pub fn processing_internal_projects(&self) -> &[ProjectId] {
         &self.values.processing._internal_projects
     }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -649,6 +649,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                 attachments,
             });
 
+            #[cfg(feature = "processing")]
             if self
                 .config
                 .processing_internal_projects()
@@ -657,6 +658,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                 metric!(
                     counter(RelayCounters::InternalCapturedEventStoreActor) += 1,
                     event_item_type = &event_item.ty().to_string(),
+                    project = &scoping.project_id.value().to_string(),
                 );
             }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -649,6 +649,17 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                 attachments,
             });
 
+            if self
+                .config
+                .processing_internal_projects()
+                .contains(&scoping.project_id.value())
+            {
+                metric!(
+                    counter(RelayCounters::InternalCapturedEventStoreActor) += 1,
+                    event_item_type = &event_item.ty().to_string(),
+                );
+            }
+
             self.produce(topic, event_message)?;
             metric!(
                 counter(RelayCounters::ProcessingMessageProduced) += 1,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -653,7 +653,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
             if self
                 .config
                 .processing_internal_projects()
-                .contains(&scoping.project_id.value())
+                .contains(&scoping.project_id)
             {
                 metric!(
                     counter(RelayCounters::InternalCapturedEventStoreActor) += 1,

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -409,7 +409,7 @@ where
     let config = request.state().config();
     let processing_enabled = config.processing_enabled();
 
-    let project_id = meta.project_id().unwrap_or(ProjectId::new(0));
+    let project_id = meta.project_id().unwrap_or_else(|| ProjectId::new(0));
     let is_internal = config.processing_internal_projects().contains(&project_id);
 
     let future = project_manager

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -11,7 +11,7 @@ use failure::Fail;
 use futures::prelude::*;
 use serde::Deserialize;
 
-use relay_common::{clone, metric, tryf, DataCategory};
+use relay_common::{clone, metric, tryf, DataCategory, ProjectId};
 use relay_config::Config;
 use relay_general::protocol::{EventId, EventType};
 use relay_log::LogError;
@@ -409,7 +409,7 @@ where
     let config = request.state().config();
     let processing_enabled = config.processing_enabled();
 
-    let project_id = meta.project_id().map(|id| id.value()).unwrap_or_default();
+    let project_id = meta.project_id().unwrap_or(ProjectId::new(0));
     let is_internal = config.processing_internal_projects().contains(&project_id);
 
     let future = project_manager

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -448,7 +448,12 @@ pub enum RelayCounters {
     /// Number of upstream connections that experienced a timeout.
     ConnectorTimeouts,
     /// An event has been produced to Kafka for one of the configured "internal" projects.
+    #[cfg(feature = "processing")]
     InternalCapturedEventStoreActor,
+    /// An event has been preliminarily accepted in the store endpoint for one of the configured
+    /// "internal" projects.
+    #[cfg(feature = "processing")]
+    InternalCapturedEventEndpoint,
 }
 
 impl CounterMetric for RelayCounters {
@@ -479,6 +484,8 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ConnectorTimeouts => "connector.timeouts",
             #[cfg(feature = "processing")]
             RelayCounters::InternalCapturedEventStoreActor => "internal.captured.event.store_actor",
+            #[cfg(feature = "processing")]
+            RelayCounters::InternalCapturedEventEndpoint => "internal.captured.event.endpoint",
         }
     }
 }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -452,7 +452,6 @@ pub enum RelayCounters {
     InternalCapturedEventStoreActor,
     /// An event has been preliminarily accepted in the store endpoint for one of the configured
     /// "internal" projects.
-    #[cfg(feature = "processing")]
     InternalCapturedEventEndpoint,
 }
 
@@ -484,7 +483,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ConnectorTimeouts => "connector.timeouts",
             #[cfg(feature = "processing")]
             RelayCounters::InternalCapturedEventStoreActor => "internal.captured.event.store_actor",
-            #[cfg(feature = "processing")]
             RelayCounters::InternalCapturedEventEndpoint => "internal.captured.event.endpoint",
         }
     }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -447,6 +447,8 @@ pub enum RelayCounters {
     ConnectorErrors,
     /// Number of upstream connections that experienced a timeout.
     ConnectorTimeouts,
+    /// An event has been produced to Kafka for one of the configured "internal" projects.
+    InternalCapturedEventStoreActor,
 }
 
 impl CounterMetric for RelayCounters {
@@ -475,6 +477,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ConnectorClosed => "connector.closed",
             RelayCounters::ConnectorErrors => "connector.errors",
             RelayCounters::ConnectorTimeouts => "connector.timeouts",
+            RelayCounters::InternalCapturedEventStoreActor => "internal.captured.event.store_actor",
         }
     }
 }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -477,6 +477,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ConnectorClosed => "connector.closed",
             RelayCounters::ConnectorErrors => "connector.errors",
             RelayCounters::ConnectorTimeouts => "connector.timeouts",
+            #[cfg(feature = "processing")]
             RelayCounters::InternalCapturedEventStoreActor => "internal.captured.event.store_actor",
         }
     }


### PR DESCRIPTION
We are observing a large amount of broken traces due to missing transactions. Together with https://github.com/getsentry/sentry/pull/25188 this should make it more clear where they are dropped. We still need a PR from @wmak and @k-fish to make it clearer how many transactions the SDK sent, because we were previously counting envelopes that include sessions.

#skip-changelog