### PR TITLE
fix(protocol): Add back breadcrumb.event_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Allow the `event_id` attribute on breadcrumbs to link between Sentry events. ([#977](https://github.com/getsentry/relay/pull/977))
+
 ## 21.4.0
 
 **Bug Fixes**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add back `breadcrumb.event_id`. ([#977](https://github.com/getsentry/relay/pull/977))
+
 ## 0.8.5
 
 - Skip serializing some null values in frames interface. ([#944](https://github.com/getsentry/relay/pull/944))

--- a/relay-general/src/protocol/breadcrumb.rs
+++ b/relay-general/src/protocol/breadcrumb.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use chrono::{TimeZone, Utc};
 
-use crate::protocol::{Level, Timestamp};
+use crate::protocol::{EventId, Level, Timestamp};
 use crate::types::{Annotated, Object, Value};
 
 /// The Breadcrumbs Interface specifies a series of application events, or "breadcrumbs", that
@@ -109,6 +109,13 @@ pub struct Breadcrumb {
     #[metastructure(skip_serialization = "empty")]
     pub data: Annotated<Object<Value>>,
 
+    /// Identifier of the event this breadcrumb belongs to.
+    ///
+    /// Sentry events can appear as breadcrumbs in other events as long as they have occurred in the
+    /// same organization. This identifier links to the original event.
+    #[metastructure(skip_serialization = "null")]
+    pub event_id: Annotated<EventId>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,
@@ -127,6 +134,7 @@ fn test_breadcrumb_roundtrip() {
   "data": {
     "a": "b"
   },
+  "event_id": "52df9022835246eeb317dbd739ccd059",
   "c": "d"
 }"#;
 
@@ -139,6 +147,7 @@ fn test_breadcrumb_roundtrip() {
   "data": {
     "a": "b"
   },
+  "event_id": "52df9022835246eeb317dbd739ccd059",
   "c": "d"
 }"#;
 
@@ -156,6 +165,7 @@ fn test_breadcrumb_roundtrip() {
             );
             Annotated::new(map)
         },
+        event_id: Annotated::new("52df9022835246eeb317dbd739ccd059".parse().unwrap()),
         other: {
             let mut map = Map::new();
             map.insert(

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -569,6 +569,18 @@ expression: event_json_schema()
               ],
               "additionalProperties": true
             },
+            "event_id": {
+              "description": " Identifier of the event this breadcrumb belongs to.\n\n Sentry events can appear as breadcrumbs in other events as long as they have occurred in the\n same organization. This identifier links to the original event.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EventId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "level": {
               "description": " Severity level of the breadcrumb. _Optional._\n\n Allowed values are, from highest to lowest: `fatal`, `error`, `warning`, `info`, and\n `debug`. Levels are used in the UI to emphasize and deemphasize the crumb. Defaults to\n `info`.",
               "default": null,


### PR DESCRIPTION
The `breadcrumb.event_id` attribute was wrongly removed in #522. It is used to
link to other Sentry issues from within the breadcrumbs list.

