### PR TITLE
feat(protocol): Add frame.stack_start for async stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Support the `frame.stack_start` field for chained async stack traces in Cocoa SDK v7. ([#981](https://github.com/getsentry/relay/pull/981))
+
 ## 21.4.1
 
 **Bug Fixes**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add back `breadcrumb.event_id`. ([#977](https://github.com/getsentry/relay/pull/977))
+- Add `frame.stack_start` for chained async stack traces. ([#981](https://github.com/getsentry/relay/pull/981))
 
 ## 0.8.5
 

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -154,6 +154,17 @@ pub struct Frame {
     #[metastructure(omit_from_schema)]
     pub lang: Annotated<String>,
 
+    /// Marks this frame as the bottom of a chained stack trace.
+    ///
+    /// Stack traces from asynchronous code consist of several sub traces that are chained together
+    /// into one large list. This flag indicates the root function of a chained stack trace.
+    /// Depending on the runtime and thread, this is either the `main` function or a thread base
+    /// stub.
+    ///
+    /// This field should only be specified when true.
+    #[metastructure(skip_serialization = "null")]
+    pub stack_start: Annotated<bool>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,
@@ -388,6 +399,7 @@ fn test_frame_roundtrip() {
   "symbol_addr": "0x404",
   "trust": "69",
   "lang": "rust",
+  "stack_start": true,
   "other": "value"
 }"#;
     let frame = Annotated::new(Frame {
@@ -423,6 +435,7 @@ fn test_frame_roundtrip() {
         symbol_addr: Annotated::new(Addr(0x404)),
         trust: Annotated::new("69".into()),
         lang: Annotated::new("rust".into()),
+        stack_start: Annotated::new(true),
         other: {
             let mut vars = Object::new();
             vars.insert(

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1484,7 +1484,7 @@ expression: event_json_schema()
               ]
             },
             "stack_start": {
-              "description": " Marks this frame as the bottom of a sub stack trace.\n\n Stack traces from asynchronous code consist of several sub traces that are chained together\n into one large list. This flag indicates the root function of a sub stack trace. Depending\n on the runtime and thread, this is either the `main` function or a thread base stub.\n\n This field should only be specified when true.",
+              "description": " Marks this frame as the bottom of a chained stack trace.\n\n Stack traces from asynchronous code consist of several sub traces that are chained together\n into one large list. This flag indicates the root function of a chained stack trace.\n Depending on the runtime and thread, this is either the `main` function or a thread base\n stub.\n\n This field should only be specified when true.",
               "default": null,
               "type": [
                 "boolean",

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1483,6 +1483,14 @@ expression: event_json_schema()
                 "null"
               ]
             },
+            "stack_start": {
+              "description": " Marks this frame as the bottom of a sub stack trace.\n\n Stack traces from asynchronous code consist of several sub traces that are chained together\n into one large list. This flag indicates the root function of a sub stack trace. Depending\n on the runtime and thread, this is either the `main` function or a thread base stub.\n\n This field should only be specified when true.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "symbol": {
               "description": " Potentially mangled name of the symbol as it appears in an executable.\n\n This is different from a function name by generally being the mangled\n name that appears natively in the binary.  This is relevant for languages\n like Swift, C++ or Rust.",
               "default": null,


### PR DESCRIPTION
Stack traces from asynchronous code consist of several sub traces that are chained together
into one large list. This flag indicates the root function of a chained stack trace.
Depending on the runtime and thread, this is either the `main` function or a thread base
stub.