### PR TITLE
fix(pii): Fix roundtrip error when PII selector starts with number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-**Bug Fixes**:
-
-- Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
-
 **Features**:
 
 - Support the `frame.stack_start` field for chained async stack traces in Cocoa SDK v7. ([#981](https://github.com/getsentry/relay/pull/981))
+
+**Bug Fixes**:
+
+- Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
+
 ## 21.4.1
 
 **Bug Fixes**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add back `breadcrumb.event_id`. ([#977](https://github.com/getsentry/relay/pull/977))
+- Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
 
 ## 0.8.5
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Add back `breadcrumb.event_id`. ([#977](https://github.com/getsentry/relay/pull/977))
-- Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
 - Add `frame.stack_start` for chained async stack traces. ([#981](https://github.com/getsentry/relay/pull/981))
+- Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
 
 ## 0.8.5
 

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -1354,7 +1354,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         let pii_config = to_pii_config(&DataScrubbingConfig {
             sensitive_fields: vec!["special ,./<>?!@#$%^&*())'gärbage'".to_owned()],
-            exclude_fields: vec!["do not ,./<>?!@#$%^&*())'ßtrip'".to_owned()],
+            exclude_fields: vec![
+                "do not ,./<>?!@#$%^&*())'ßtrip'".to_owned(),
+                "2abc".to_owned(),
+            ],
             ..simple_enabled_config()
         });
 

--- a/relay-general/src/processor/selector.pest
+++ b/relay-general/src/processor/selector.pest
@@ -10,7 +10,7 @@ Or = _{ "||" | "|" }
 Not = _{ "~" | "!" }
 EscapedQuote = @{ "'" }
 
-UnquotedKey = @{ !ASCII_DIGIT ~ (ASCII_ALPHANUMERIC | "-" | "_") + }
+UnquotedKey = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "-" | "_") * }
 RootUnquotedKey = { SOI ~ UnquotedKey ~ EOI }
 QuotedCharacter = @{ ((!"'") ~ ANY) }
 QuotedKey = ${ (QuotedCharacter | ("'" ~ EscapedQuote))+ }

--- a/relay-general/src/processor/selector.pest
+++ b/relay-general/src/processor/selector.pest
@@ -10,7 +10,7 @@ Or = _{ "||" | "|" }
 Not = _{ "~" | "!" }
 EscapedQuote = @{ "'" }
 
-UnquotedKey = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "-" | "_") * }
+UnquotedKey = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "-" | "_") * }
 RootUnquotedKey = { SOI ~ UnquotedKey ~ EOI }
 QuotedCharacter = @{ ((!"'") ~ ANY) }
 QuotedKey = ${ (QuotedCharacter | ("'" ~ EscapedQuote))+ }

--- a/relay-general/src/processor/selector.pest
+++ b/relay-general/src/processor/selector.pest
@@ -10,7 +10,7 @@ Or = _{ "||" | "|" }
 Not = _{ "~" | "!" }
 EscapedQuote = @{ "'" }
 
-UnquotedKey = @{ (ASCII_ALPHANUMERIC | "-" | "_") + }
+UnquotedKey = @{ !ASCII_DIGIT ~ (ASCII_ALPHANUMERIC | "-" | "_") + }
 RootUnquotedKey = { SOI ~ UnquotedKey ~ EOI }
 QuotedCharacter = @{ ((!"'") ~ ANY) }
 QuotedKey = ${ (QuotedCharacter | ("'" ~ EscapedQuote))+ }


### PR DESCRIPTION
For disambiguous parsing, keys starting with numbers need to be quoted.