### PR TITLE
ref(config): Rename envelope buffer config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Support the `frame.stack_start` field for chained async stack traces in Cocoa SDK v7. ([#981](https://github.com/getsentry/relay/pull/981))
+- Rename configuration fields `cache.event_buffer_size` to `cache.envelope_buffer_size` and `cache.event_expiry` to `cache.envelope_expiry`. The former names are still supported by Relay. ([#985](https://github.com/getsentry/relay/pull/985))
 
 **Internal**:
 


### PR DESCRIPTION
Renames two configuration fields since they apply to all envelopes. The former naming is still supported and soft-deprecated:

- `cache.event_buffer_size` -> `cache.envelope_buffer_size`
- `cache.event_expiry` -> `cache.envelope_expiry`

See also #984 for related changes
This will require an update in sentry-docs