### PR TITLE
feat(config): Add a flag to always mark Relay as healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support the `frame.stack_start` field for chained async stack traces in Cocoa SDK v7. ([#981](https://github.com/getsentry/relay/pull/981))
 - Rename configuration fields `cache.event_buffer_size` to `cache.envelope_buffer_size` and `cache.event_expiry` to `cache.envelope_expiry`. The former names are still supported by Relay. ([#985](https://github.com/getsentry/relay/pull/985))
+- Add a configuraton flag `relay.ready: always` to mark Relay ready in healthchecks immediately after starting without requiring a health check. ([#989](https://github.com/getsentry/relay/pull/989))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support the `frame.stack_start` field for chained async stack traces in Cocoa SDK v7. ([#981](https://github.com/getsentry/relay/pull/981))
 - Rename configuration fields `cache.event_buffer_size` to `cache.envelope_buffer_size` and `cache.event_expiry` to `cache.envelope_expiry`. The former names are still supported by Relay. ([#985](https://github.com/getsentry/relay/pull/985))
-- Add a configuraton flag `relay.ready: always` to mark Relay ready in healthchecks immediately after starting without requiring a health check. ([#989](https://github.com/getsentry/relay/pull/989))
+- Add a configuraton flag `relay.ready: always` to mark Relay ready in healthchecks immediately after starting without requiring to authenticate. ([#989](https://github.com/getsentry/relay/pull/989))
 
 **Bug Fixes**:
 

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -79,7 +79,7 @@ impl Handler<IsHealthy> for Healthcheck {
             IsHealthy::Readiness => {
                 if self.is_shutting_down {
                     Box::new(future::ok(false))
-                } else if self.config.relay_mode() == RelayMode::Managed {
+                } else if self.config.requires_auth() {
                     Box::new(self.upstream.send(IsAuthenticated).map_err(|_| ()))
                 } else {
                     Box::new(future::ok(true))

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -6,7 +6,7 @@ import time
 
 
 def failing_check_challenge(*args, **kwargs):
-    return 'fail', 400
+    return "fail", 400
 
 
 def wait_get(server, path):
@@ -60,12 +60,15 @@ def test_readiness_flag(mini_sentry, relay):
     mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge
 
     try:
-        relay = relay(mini_sentry, {"relay": {"ready": "always"}}, wait_healthcheck=False)
+        relay = relay(
+            mini_sentry, {"relay": {"ready": "always"}}, wait_healthcheck=False
+        )
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         assert response.status_code == 200
     finally:
         # Authentication failures would fail the test
         mini_sentry.test_failures.clear()
+
 
 def test_readiness_proxy(mini_sentry, relay):
     mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -2,6 +2,25 @@
 Test the health check endpoints
 """
 
+import time
+
+
+def failing_check_challenge(*args, **kwargs):
+    return 'fail', 400
+
+
+def wait_get(server, path):
+    """Waits until the server listens to requests and returns the response."""
+    backoff = 0.1
+    while True:
+        try:
+            return server.get(path)
+        except Exception:
+            time.sleep(backoff)
+            if backoff > 2:
+                raise
+            backoff *= 2
+
 
 def test_live(mini_sentry, relay):
     """Internal endpoint used by kubernetes """
@@ -17,10 +36,44 @@ def test_external_live(mini_sentry, relay):
     assert response.status_code == 200
 
 
-def test_is_healthy(mini_sentry, relay):
+def test_readiness(mini_sentry, relay):
     """Internal endpoint used by kubernetes """
-    relay = relay(mini_sentry)
-    # NOTE this is redundant but palced here to clearly show the exposed endpoint
-    # (internally the relay fixture waits for the ready health check anyway)
-    response = relay.get("/api/relay/healthcheck/ready/")
-    assert response.status_code == 200
+    original_check_challenge = mini_sentry.app.view_functions["check_challenge"]
+    mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge
+
+    try:
+        relay = relay(mini_sentry, wait_healthcheck=False)
+        response = wait_get(relay, "/api/relay/healthcheck/ready/")
+        assert response.status_code == 503
+
+        mini_sentry.app.view_functions["check_challenge"] = original_check_challenge
+
+        relay.wait_relay_healthcheck()
+        response = relay.get("/api/relay/healthcheck/ready/")
+        assert response.status_code == 200
+    finally:
+        # Authentication failures would fail the test
+        mini_sentry.test_failures.clear()
+
+
+def test_readiness_flag(mini_sentry, relay):
+    mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge
+
+    try:
+        relay = relay(mini_sentry, {"relay": {"ready": "always"}}, wait_healthcheck=False)
+        response = wait_get(relay, "/api/relay/healthcheck/ready/")
+        assert response.status_code == 200
+    finally:
+        # Authentication failures would fail the test
+        mini_sentry.test_failures.clear()
+
+def test_readiness_proxy(mini_sentry, relay):
+    mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge
+
+    try:
+        relay = relay(mini_sentry, {"relay": {"mode": "proxy"}}, wait_healthcheck=False)
+        response = wait_get(relay, "/api/relay/healthcheck/ready/")
+        assert response.status_code == 200
+    finally:
+        # Authentication failures would fail the test
+        mini_sentry.test_failures.clear()


### PR DESCRIPTION
Adds a flag to override behavior of the readiness healthcheck. The default is "authenticated", which requires authentication in managed mode, but not in proxy mode. When set to "always", Relay is healthy immediately without authentication. 