### PR TITLE
fix(relay-quotas): Avoid overflow panic for large retry-after durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**:
 
 - Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
+- Avoid overflow panic for large retry-after durations. ([#992](https://github.com/getsentry/relay/pull/992))
 
 **Internal**:
 

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -387,6 +387,8 @@ mod tests {
         // invalid strings cause parse error
         "".parse::<RetryAfter>().expect_err("error RetryAfter");
         "nope".parse::<RetryAfter>().expect_err("error RetryAfter");
+        " 2 ".parse::<RetryAfter>().expect_err("error RetryAfter");
+        "6 0".parse::<RetryAfter>().expect_err("error RetryAfter");
     }
 
     #[test]

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -378,7 +378,7 @@ mod tests {
         assert!(retry_after.expired());
 
         // large inputs that would overflow are treated as zero
-        let retry_after = "100000000000000000"
+        let retry_after = "100000000000000000000"
             .parse::<RetryAfter>()
             .expect("parse RetryAfter");
         assert_eq!(retry_after.remaining_seconds(), 0);

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -20,7 +20,8 @@ impl RetryAfter {
     /// Creates a retry after instance.
     #[inline]
     pub fn from_secs(seconds: u64) -> Self {
-        let when = Instant::now() + Duration::from_secs(seconds);
+        let now = Instant::now();
+        let when = now.checked_add(Duration::from_secs(seconds)).unwrap_or(now);
         Self { when }
     }
 
@@ -347,7 +348,10 @@ mod tests {
 
     #[test]
     fn test_parse_retry_after() {
-        // positive float
+        // positive float always rounds up to the next integer
+        let retry_after = "17.1".parse::<RetryAfter>().expect("parse RetryAfter");
+        assert_eq!(retry_after.remaining_seconds(), 18);
+        assert!(!retry_after.expired());
         let retry_after = "17.7".parse::<RetryAfter>().expect("parse RetryAfter");
         assert_eq!(retry_after.remaining_seconds(), 18);
         assert!(!retry_after.expired());
@@ -357,12 +361,31 @@ mod tests {
         assert_eq!(retry_after.remaining_seconds(), 17);
         assert!(!retry_after.expired());
 
-        // negative number
+        // negative numbers are treated as zero
         let retry_after = "-2".parse::<RetryAfter>().expect("parse RetryAfter");
         assert_eq!(retry_after.remaining_seconds(), 0);
         assert!(retry_after.expired());
+        let retry_after = "-inf".parse::<RetryAfter>().expect("parse RetryAfter");
+        assert_eq!(retry_after.remaining_seconds(), 0);
+        assert!(retry_after.expired());
 
-        // invalid string
+        // inf and NaN are valid input and treated as zero
+        let retry_after = "inf".parse::<RetryAfter>().expect("parse RetryAfter");
+        assert_eq!(retry_after.remaining_seconds(), 0);
+        assert!(retry_after.expired());
+        let retry_after = "NaN".parse::<RetryAfter>().expect("parse RetryAfter");
+        assert_eq!(retry_after.remaining_seconds(), 0);
+        assert!(retry_after.expired());
+
+        // large inputs that would overflow are treated as zero
+        let retry_after = "100000000000000000"
+            .parse::<RetryAfter>()
+            .expect("parse RetryAfter");
+        assert_eq!(retry_after.remaining_seconds(), 0);
+        assert!(retry_after.expired());
+
+        // invalid strings cause parse error
+        "".parse::<RetryAfter>().expect_err("error RetryAfter");
         "nope".parse::<RetryAfter>().expect_err("error RetryAfter");
     }
 


### PR DESCRIPTION
The parsing logic must be replicated by SDKs, thus this change documents the current behavior with a few extra edge case tests and additionally handles large durations as to ignore them instead of panicking.

I'd be fine if the preferred behavior for large durations is something else, as long as we pick some defined behavior.