### PR TITLE
ref(breakdowns): All fields in breakdown config should be camelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Update internal representation of distribution metrics. ([#979](https://github.com/getsentry/relay/pull/979))
 - Extract metrics for transaction breakdowns and sessions when the feature is enabled for the organizaiton. ([#986](https://github.com/getsentry/relay/pull/986))
 - Assign explicit values to DataCategory enum. ([#987](https://github.com/getsentry/relay/pull/987))
+- All fields in breakdown config should be camelCase. ([#993](https://github.com/getsentry/relay/pull/993))
 
 ## 21.4.1
 

--- a/relay-general/src/store/normalize/breakdowns.rs
+++ b/relay-general/src/store/normalize/breakdowns.rs
@@ -94,7 +94,7 @@ pub trait EmitBreakdowns {
 
 /// Configuration to define breakdowns based on span operation name.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 pub struct SpanOperationsConfig {
     /// Operation names are matched against an array of strings. The match is successful if the span
     /// operation name starts with any string in the array. If any string in the array has at least

--- a/relay-general/src/store/normalize/breakdowns.rs
+++ b/relay-general/src/store/normalize/breakdowns.rs
@@ -204,7 +204,7 @@ impl EmitBreakdowns for SpanOperationsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum BreakdownConfig {
-    #[serde(alias="span_operations")]
+    #[serde(alias = "span_operations")]
     SpanOperations(SpanOperationsConfig),
 }
 

--- a/relay-general/src/store/normalize/breakdowns.rs
+++ b/relay-general/src/store/normalize/breakdowns.rs
@@ -202,8 +202,9 @@ impl EmitBreakdowns for SpanOperationsConfig {
 
 /// Configuration to define breakdown to be generated based on properties and breakdown type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum BreakdownConfig {
+    #[serde(alias="span_operations")]
     SpanOperations(SpanOperationsConfig),
 }
 

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -158,7 +158,7 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
                 "matches": ["http", "db", "browser", "resource"],
             },
             "span_ops_2": {
-                "type": "span_operations",
+                "type": "spanOperations",
                 "matches": ["http", "db", "browser", "resource"],
             },
         },


### PR DESCRIPTION


As recommended by @untitaker in https://github.com/getsentry/sentry/pull/25886#issuecomment-833335578