### PR TITLE
WIP: feat: Gather metrics for unprintable fields

### DIFF
--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -18,6 +18,7 @@ mod remove_other;
 mod schema;
 mod transactions;
 mod trimming;
+mod unprintable_fields;
 
 pub use self::clock_drift::ClockDriftProcessor;
 pub use self::geo::{GeoIpError, GeoIpLookup};
@@ -120,6 +121,8 @@ impl<'a> Processor for StoreProcessor<'a> {
             // Trim large strings and databags down
             trimming::TrimmingProcessor::new().process_event(event, meta, state)?;
         }
+
+        unprintable_fields::UnprintableFieldsProcessor::new().process_event(event, meta, state)?;
 
         Ok(())
     }

--- a/relay-general/src/store/unprintable_fields.rs
+++ b/relay-general/src/store/unprintable_fields.rs
@@ -1,0 +1,80 @@
+use crate::processor::{ProcessValue, ProcessingState, Processor};
+use crate::types::{Meta, ProcessingResult};
+
+#[derive(Default)]
+pub struct UnprintableFieldsProcessor {
+    has_unprintable_fields: bool,
+}
+
+impl UnprintableFieldsProcessor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Processor for UnprintableFieldsProcessor {
+    fn process_string(
+        &mut self,
+        value: &mut String,
+        _meta: &mut Meta,
+        _state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        if !self.has_unprintable_fields {
+            self.has_unprintable_fields = value.chars().any(|c| {
+                c == '\u{fffd}' // unicode replacement character
+                || (c.is_control() && !c.is_whitespace()) // non-whitespace control characters
+            });
+        }
+        Ok(())
+    }
+
+    fn process_event(
+        &mut self,
+        value: &mut crate::protocol::Event,
+        _meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        value.process_child_values(self, state)?;
+
+        if self.has_unprintable_fields {
+            // TODO: capture metric
+        }
+
+        Ok(())
+    }
+}
+
+#[test]
+fn test_unprintable_environments() {
+    use crate::processor::process_value;
+    use crate::protocol::Event;
+    use crate::types::Annotated;
+
+    let failures = [
+        "�9�~YY���)�����9�~YY���)�����9�~YY���)�����9�~YY���)�����",
+        "���7��#1G����7��#1G����7��#1G����7��#1G����7��#",
+    ];
+    let successes = ["production", "make with\t some\n normal\r\nwhitespace"];
+
+    for fail in &failures {
+        let mut event = Annotated::new(Event {
+            environment: Annotated::new(fail.to_string()),
+            ..Default::default()
+        });
+
+        let mut processor = UnprintableFieldsProcessor::new();
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+        assert!(processor.has_unprintable_fields);
+    }
+
+    for success in &successes {
+        let mut event = Annotated::new(Event {
+            environment: Annotated::new(success.to_string()),
+            ..Default::default()
+        });
+
+        let mut processor = UnprintableFieldsProcessor::new();
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+        assert!(!processor.has_unprintable_fields);
+    }
+}


### PR DESCRIPTION
We know that the native SDK, mostly in combination with Android can sometimes produce corrupted environment or release strings. We would like to get a measure of how bad this situation actually is.