### PR TITLE
ref(server): Clean error code returned on relay authenticated endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**:
 
 - Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
+- Clean error code returned on relay authenticated endpoints. ([#998](https://github.com/getsentry/relay/pull/998))
 
 **Internal**:
 


### PR DESCRIPTION
Previously when an endpoint using Relay Authentication failed to deserialize the input, either because there is a bad signature or because the input JSON didn't match the expected input we would return a `403 Unauthorized`.

This PR changes the return code for the case when we successfully validate the signature but there is a problem with the payload to `400 Bad Request`