### PR TITLE
ref(server): Introduce a shared payload type

### DIFF
--- a/relay-server/src/body/forward_body.rs
+++ b/relay-server/src/body/forward_body.rs
@@ -1,9 +1,11 @@
 use actix::ResponseFuture;
-use actix_web::{error::PayloadError, http::StatusCode, HttpMessage, HttpResponse, ResponseError};
+use actix_web::dev::Payload;
+use actix_web::{error::PayloadError, http::StatusCode, HttpRequest, HttpResponse, ResponseError};
 use bytes::{Bytes, BytesMut};
 use failure::Fail;
 use futures::prelude::*;
 
+use crate::extractors::SharedPayload;
 use crate::utils;
 
 /// A set of errors that can occur during parsing json payloads
@@ -42,18 +44,16 @@ impl From<PayloadError> for ForwardPayloadError {
 }
 
 /// Future that resolves to a complete store endpoint body.
-pub struct ForwardBody<T: HttpMessage> {
+pub struct ForwardBody {
     limit: usize,
-    stream: Option<T::Stream>,
+    stream: Option<Payload>,
     err: Option<ForwardPayloadError>,
     fut: Option<ResponseFuture<Bytes, ForwardPayloadError>>,
 }
 
-impl<T: HttpMessage> ForwardBody<T> {
+impl ForwardBody {
     /// Create `ForwardBody` for request.
-    pub fn new(req: &T, limit: usize) -> ForwardBody<T> {
-        // Check the content length first. If we detect an overflow from the content length header,
-        // keep the payload in the request to drain it correctly in the `ReadRequestMiddleware`.
+    pub fn new<S>(req: &HttpRequest<S>, limit: usize) -> Self {
         if let Some(length) = utils::get_content_length(req) {
             if length > limit {
                 return Self::err(ForwardPayloadError::Overflow);
@@ -62,7 +62,7 @@ impl<T: HttpMessage> ForwardBody<T> {
 
         ForwardBody {
             limit,
-            stream: Some(req.payload()),
+            stream: Some(SharedPayload::get(req)),
             err: None,
             fut: None,
         }
@@ -78,10 +78,7 @@ impl<T: HttpMessage> ForwardBody<T> {
     }
 }
 
-impl<T> Future for ForwardBody<T>
-where
-    T: HttpMessage + 'static,
-{
+impl Future for ForwardBody {
     type Item = Bytes;
     type Error = ForwardPayloadError;
 
@@ -95,27 +92,20 @@ where
         }
 
         let limit = self.limit;
-        let body = Some(BytesMut::with_capacity(8192));
-
         let future = self
             .stream
             .take()
             .expect("Can not be used second time")
             .map_err(ForwardPayloadError::from)
-            .fold(body, move |body_opt, chunk| {
-                Ok::<_, ForwardPayloadError>(body_opt.and_then(|mut body| {
-                    if (body.len() + chunk.len()) > limit {
-                        None
-                    } else {
-                        body.extend_from_slice(&chunk);
-                        Some(body)
-                    }
-                }))
+            .fold(BytesMut::with_capacity(8192), move |mut body, chunk| {
+                if (body.len() + chunk.len()) > limit {
+                    Err(ForwardPayloadError::Overflow)
+                } else {
+                    body.extend_from_slice(&chunk);
+                    Ok(body)
+                }
             })
-            .and_then(|bytes_opt| match bytes_opt {
-                Some(bytes) => Ok(bytes.freeze()),
-                None => Err(ForwardPayloadError::Overflow),
-            });
+            .map(BytesMut::freeze);
 
         self.fut = Some(Box::new(future));
 

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -2,8 +2,9 @@ use std::borrow::Cow;
 use std::io::{self, Read};
 
 use actix::ResponseFuture;
+use actix_web::dev::Payload;
 use actix_web::http::StatusCode;
-use actix_web::{error::PayloadError, HttpMessage, HttpRequest, HttpResponse, ResponseError};
+use actix_web::{error::PayloadError, HttpRequest, HttpResponse, ResponseError};
 use base64::DecodeError;
 use bytes::{Bytes, BytesMut};
 use failure::Fail;
@@ -14,6 +15,7 @@ use url::form_urlencoded;
 use relay_common::metric;
 
 use crate::actors::outcome::DiscardReason;
+use crate::extractors::SharedPayload;
 use crate::metrics::RelayHistograms;
 use crate::utils;
 
@@ -80,7 +82,7 @@ pub struct StoreBody {
     // These states are mutually exclusive:
     result: Option<Result<Bytes, StorePayloadError>>,
     fut: Option<ResponseFuture<Bytes, StorePayloadError>>,
-    stream: Option<<HttpRequest as HttpMessage>::Stream>,
+    stream: Option<Payload>,
 }
 
 impl StoreBody {
@@ -95,8 +97,6 @@ impl StoreBody {
             };
         }
 
-        // Check the content length first. If we detect an overflow from the content length header,
-        // keep the payload in the request to drain it correctly in the `ReadRequestMiddleware`.
         if let Some(length) = utils::get_content_length(req) {
             if length > limit {
                 return Self::err(StorePayloadError::Overflow);
@@ -107,7 +107,7 @@ impl StoreBody {
             limit,
             result: None,
             fut: None,
-            stream: Some(req.payload()),
+            stream: Some(SharedPayload::get(req)),
         }
     }
 
@@ -135,27 +135,20 @@ impl Future for StoreBody {
         }
 
         let limit = self.limit;
-        let body = Some(BytesMut::with_capacity(8192));
-
         let future = self
             .stream
             .take()
             .expect("Can not be used second time")
             .map_err(StorePayloadError::from)
-            .fold(body, move |body_opt, chunk| {
-                // Ensure that the stream is always fully consumed. Erroring here would leave a
-                // broken TCP stream that cannot be used with keep-alive connections.
-                Ok::<_, StorePayloadError>(body_opt.and_then(|mut body| {
-                    if (body.len() + chunk.len()) > limit {
-                        None
-                    } else {
-                        body.extend_from_slice(&chunk);
-                        Some(body)
-                    }
-                }))
+            .fold(BytesMut::with_capacity(8192), move |mut body, chunk| {
+                if (body.len() + chunk.len()) > limit {
+                    Err(StorePayloadError::Overflow)
+                } else {
+                    body.extend_from_slice(&chunk);
+                    Ok(body)
+                }
             })
-            .and_then(|body_opt| {
-                let body = body_opt.ok_or(StorePayloadError::Overflow)?;
+            .and_then(|body| {
                 metric!(histogram(RelayHistograms::RequestSizeBytesRaw) = body.len() as u64);
                 let decoded = decode_bytes(body.freeze())?;
                 metric!(

--- a/relay-server/src/extractors/mod.rs
+++ b/relay-server/src/extractors/mod.rs
@@ -4,11 +4,13 @@ use crate::service::ServiceState;
 
 mod forwarded_for;
 mod request_meta;
+mod shared_payload;
 mod signed_json;
 mod start_time;
 
 pub use self::forwarded_for::*;
 pub use self::request_meta::*;
+pub use self::shared_payload::*;
 pub use self::signed_json::*;
 pub use self::start_time::*;
 

--- a/relay-server/src/extractors/shared_payload.rs
+++ b/relay-server/src/extractors/shared_payload.rs
@@ -1,0 +1,53 @@
+use actix_web::dev::Payload;
+use actix_web::{FromRequest, HttpMessage, HttpRequest};
+use futures::{Poll, Stream};
+
+/// A shared reference to an actix request payload.
+///
+/// The reference to the stream can be cloned and be polled repeatedly, but it is not thread-safe.
+/// When the payload is exhaused, it no longer returns any data from.
+///
+/// To obtain a reference, call [`SharedPayload::get`]. The first time, this takes the body out of
+/// the request. Subsequent calls to `request.payload()` or `request.body()` will return empty. This
+/// type also implements [`FromRequest`] for the use in actix request handlers.
+#[derive(Clone)]
+pub struct SharedPayload(Payload);
+
+impl SharedPayload {
+    /// Extracts the shared clone of the request payload from the given request.
+    pub fn get<S>(request: &HttpRequest<S>) -> Payload {
+        Self::extract(request).into_inner()
+    }
+
+    /// Unwraps the shared clone of the request payload.
+    pub fn into_inner(self) -> Payload {
+        self.0
+    }
+}
+
+impl<S> FromRequest<S> for SharedPayload {
+    type Config = ();
+    type Result = Self;
+
+    fn from_request(request: &HttpRequest<S>, _config: &Self::Config) -> Self::Result {
+        let mut extensions = request.extensions_mut();
+
+        if let Some(payload) = extensions.get::<Self>() {
+            return payload.clone();
+        }
+
+        let payload = Self(request.payload());
+        extensions.insert(payload.clone());
+        payload
+    }
+}
+
+impl Stream for SharedPayload {
+    type Item = <Payload as Stream>::Item;
+    type Error = <Payload as Stream>::Error;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.0.poll()
+    }
+}

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -16,6 +16,7 @@ use relay_log::_sentry::{types::Uuid, Hub, Level, ScopeGuard};
 use relay_log::protocol::{ClientSdkPackage, Event, Request};
 
 use crate::constants::SERVER;
+use crate::extractors::SharedPayload;
 use crate::metrics::{RelayCounters, RelayTimers};
 use crate::utils::ApiErrorResponse;
 
@@ -109,8 +110,7 @@ pub struct ReadRequestMiddleware;
 
 impl<S> Middleware<S> for ReadRequestMiddleware {
     fn response(&self, req: &HttpRequest<S>, resp: HttpResponse) -> Result<Response, Error> {
-        let future = req
-            .payload()
+        let future = SharedPayload::get(req)
             .for_each(|_| Ok(()))
             .map(|_| resp)
             .map_err(Error::from);


### PR DESCRIPTION
To ensure connection keep-alive, Relay needs to consume all request
bodies before closing the connection. In the past, this was handled by
manually updating all code that streams request bodies to continue
streaming even on intermittent failure.

This PR introduces a type `SharedPayload` that takes the request payload
once and stores a shared reference. The constructor `get` can be called
several times, always returning a reference to the same underlying
payload. The request middleware finally consumes that shared reference.

#skip-changelog
