### PR TITLE
feat(server): Support envelopes without auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Support self-contained envelopes without authentication headers or query parameters. ([#1000](https://github.com/getsentry/relay/pull/1000))
+
 ## 21.5.1
 
 **Bug Fixes**:

--- a/relay-server/src/body/mod.rs
+++ b/relay-server/src/body/mod.rs
@@ -1,5 +1,7 @@
 mod forward_body;
+mod peek_line;
 mod store_body;
 
 pub use self::forward_body::*;
+pub use self::peek_line::*;
 pub use self::store_body::*;

--- a/relay-server/src/body/peek_line.rs
+++ b/relay-server/src/body/peek_line.rs
@@ -1,5 +1,5 @@
 use bytes::{Bytes, BytesMut};
-use futures::{Async, Poll, Stream};
+use futures::{Async, Future, Poll, Stream};
 use smallvec::SmallVec;
 
 use crate::extractors::SharedPayload;
@@ -58,6 +58,8 @@ impl PeekLine {
         while let Some(chunk) = self.chunks.pop() {
             self.payload.unread_data(chunk);
         }
+
+        self.len = 0;
     }
 
     fn concatenate(&self, mut len: usize) -> Bytes {
@@ -86,7 +88,7 @@ impl PeekLine {
     }
 }
 
-impl futures::Future for PeekLine {
+impl Future for PeekLine {
     type Item = Option<Bytes>;
     type Error = <SharedPayload as Stream>::Error;
 

--- a/relay-server/src/body/peek_line.rs
+++ b/relay-server/src/body/peek_line.rs
@@ -1,0 +1,187 @@
+use actix_web::dev::Payload;
+use bytes::{Bytes, BytesMut};
+use futures::{Async, Poll, Stream};
+use smallvec::SmallVec;
+
+use crate::extractors::SharedPayload;
+
+/// A request body adapter that peeks the first line of a multi-line body.
+///
+/// `PeekLine` is a future created from a request's [`Payload`]. It is especially designed to be
+/// used together with [`SharedPayload`](crate::extractors::SharedPayload), since it polls an
+/// underlying payload and places the polled chunks back into the payload when completing.
+///
+/// If the payload does not contain a newline, the entire payload is returned by the future. To
+/// contrain this, use `limit` to set a maximum size returned by the future.
+///
+/// Resolves to `Some(Bytes)` if a newline is found within the size limit, or the entire payload is
+/// smaller than the size limit. Otherwise, resolves to `None`. Any errors on the underlying stream
+/// are returned without change.
+pub struct PeekLine {
+    payload: Payload,
+    chunks: SmallVec<[Bytes; 3]>,
+    len: usize,
+    limit: Option<usize>,
+}
+
+impl PeekLine {
+    /// Creates a new peek line future from the given payload.
+    pub fn new(payload: Payload) -> Self {
+        Self {
+            payload,
+            chunks: SmallVec::new(),
+            len: 0,
+            limit: None,
+        }
+    }
+
+    /// Adds a maximum size of the future return value.
+    ///
+    /// Note that the underlying stream may return more data than the configured limit. The future
+    /// will still never resolve more than the limit set.
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    fn len_exceeded(&self, len: usize) -> bool {
+        if let Some(limit) = self.limit {
+            if len > limit {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn revert_chunks(&mut self) {
+        // unread in reverse order
+        while let Some(chunk) = self.chunks.pop() {
+            self.payload.unread_data(chunk);
+        }
+    }
+
+    fn concatenate(&self, mut len: usize) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(len);
+        for chunk in &self.chunks {
+            let remaining = if len > chunk.len() { chunk.len() } else { len };
+            bytes.extend_from_slice(&chunk[..remaining]);
+            len -= remaining;
+        }
+        bytes.freeze()
+    }
+
+    fn finish(&mut self, len: usize) -> Async<Option<Bytes>> {
+        if len == 0 {
+            return Async::Ready(None);
+        }
+
+        let line = if len == 0 || self.len_exceeded(len) {
+            None
+        } else {
+            Some(self.concatenate(len))
+        };
+
+        self.revert_chunks();
+        Async::Ready(line)
+    }
+}
+
+impl futures::Future for PeekLine {
+    type Item = Option<Bytes>;
+    type Error = <SharedPayload as Stream>::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let chunk = match self.payload.poll() {
+                Ok(Async::Ready(Some(chunk))) => chunk,
+                Ok(Async::Ready(None)) => return Ok(self.finish(self.len)),
+                result => return result,
+            };
+
+            self.chunks.push(chunk.clone());
+            if let Some(pos) = chunk.iter().position(|b| *b == b'\n') {
+                return Ok(self.finish(self.len + pos));
+            }
+
+            self.len += chunk.len();
+            if self.len_exceeded(self.len) {
+                self.revert_chunks();
+                return Ok(Async::Ready(None));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::HttpMessage;
+    use relay_test::TestRequest;
+
+    #[test]
+    fn test_empty() {
+        relay_test::setup();
+
+        let request = TestRequest::with_state(())
+            .set_payload("".to_string())
+            .finish();
+
+        let opt = relay_test::block_fn(move || PeekLine::new(request.payload())).unwrap();
+        assert_eq!(opt, None);
+    }
+
+    #[test]
+    fn test_one_line() {
+        relay_test::setup();
+
+        let request = TestRequest::with_state(())
+            .set_payload("test".to_string())
+            .finish();
+
+        let opt = relay_test::block_fn(move || PeekLine::new(request.payload())).unwrap();
+        assert_eq!(opt, Some("test".into()));
+    }
+
+    #[test]
+    fn test_linebreak() {
+        relay_test::setup();
+
+        let request = TestRequest::with_state(())
+            .set_payload("test\ndone".to_string())
+            .finish();
+
+        let opt = relay_test::block_fn(move || PeekLine::new(request.payload())).unwrap();
+        assert_eq!(opt, Some("test".into()));
+    }
+
+    #[test]
+    fn test_limit_satisfied() {
+        relay_test::setup();
+
+        let payload = "test\ndone";
+        let request = TestRequest::with_state(())
+            .set_payload(payload.to_string())
+            .finish();
+
+        let opt = relay_test::block_fn(move || PeekLine::new(request.payload()).limit(4)).unwrap();
+        assert_eq!(opt, Some("test".into()));
+    }
+
+    #[test]
+    fn test_limit_exceeded() {
+        relay_test::setup();
+
+        let payload = "test\ndone";
+        let request = TestRequest::with_state(())
+            .set_payload(payload.to_string())
+            .finish();
+
+        let opt = relay_test::block_fn(move || PeekLine::new(request.payload()).limit(3)).unwrap();
+        assert_eq!(opt, None);
+    }
+
+    // NB: Repeat polls cannot be tested unfortunately, since `Payload::set_read_buffer_capacity`
+    // does not take effect in test requests, and the sender returned by `Payload::new` does not
+    // have a public interface.
+}

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -10,7 +10,7 @@ use relay_general::protocol::EventId;
 use crate::body::StoreBody;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::Envelope;
-use crate::extractors::RequestMeta;
+use crate::extractors::{EnvelopeMeta, RequestMeta};
 use crate::service::{ServiceApp, ServiceState};
 
 fn extract_envelope(
@@ -43,9 +43,10 @@ fn create_response(id: Option<EventId>) -> HttpResponse {
 
 /// Handler for the envelope store endpoint.
 fn store_envelope(
-    meta: RequestMeta,
+    envelope_meta: EnvelopeMeta,
     request: HttpRequest<ServiceState>,
 ) -> ResponseFuture<HttpResponse, BadStoreRequest> {
+    let meta = envelope_meta.into_inner();
     common::handle_store_like_request(meta, request, extract_envelope, create_response, true)
 }
 

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -123,9 +123,6 @@ fn store_event(
 
     common::handle_store_like_request(
         meta,
-        // XXX: This is wrong. In case of external relays, store can receive event-less envelopes.
-        // We need to fix this before external relays go live or we will create outcomes and rate
-        // limits for individual attachment requests.
         request,
         extract_envelope,
         move |id| create_response(id, is_get_request),

--- a/relay-server/src/extractors/shared_payload.rs
+++ b/relay-server/src/extractors/shared_payload.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use actix_web::dev::Payload;
 use actix_web::{FromRequest, HttpMessage, HttpRequest};
+use bytes::Bytes;
 use futures::{Async, Poll, Stream};
 
 /// A shared reference to an actix request payload.
@@ -35,6 +36,14 @@ impl SharedPayload {
 
         extensions.insert(payload.clone());
         payload
+    }
+
+    /// Puts unused data back into the payload to be consumed again.
+    ///
+    /// The chunk will be prepended to the stream. When called multiple times, data will be polled
+    /// in reverse order from unreading.
+    pub fn unread_data(&mut self, chunk: Bytes) {
+        self.inner.unread_data(chunk);
     }
 }
 

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -65,6 +65,11 @@ class SentryLike(object):
 
         return key_config["publicKey"]
 
+    def get_dsn(self, project_id, index=0):
+        dsn_key = self.get_dsn_public_key(project_id, index)
+        host, port = self.server_address
+        return f"http://{dsn_key}:@{host}:{port}/{project_id}"
+
     @property
     def url(self):
         return "http://{}:{}".format(*self.server_address)


### PR DESCRIPTION
Envelopes contain authentication information in their header. In fact,
they share the same `RequestMeta` structure that is also used by
endpoint extractors.

This PR refactors the auth extractors and introduces `EnvelopeMeta`, a
wrapper type for request meta that additionally looks into the first
line of the request body -- the envelope headers -- when explicit auth
headers are missing.

Based on #999.