### PR TITLE
fix(metrics): Do not create aggregators without metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Do not leak resources when projects or DSNs are idle. ([#1003](https://github.com/getsentry/relay/pull/1003))
+
 ## 21.5.0
 
 **Features**:

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1062,14 +1062,14 @@ impl Actor for Aggregator {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        relay_log::info!("aggregator started");
+        relay_log::debug!("aggregator started");
 
         // TODO: Consider a better approach than busy polling
         ctx.run_interval(Duration::from_millis(500), Self::try_flush);
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        relay_log::info!("aggregator stopped");
+        relay_log::debug!("aggregator stopped");
     }
 }
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1062,14 +1062,14 @@ impl Actor for Aggregator {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        relay_log::debug!("aggregator started");
+        relay_log::info!("aggregator started");
 
         // TODO: Consider a better approach than busy polling
         ctx.run_interval(Duration::from_millis(500), Self::try_flush);
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        relay_log::debug!("aggregator stopped");
+        relay_log::info!("aggregator stopped");
     }
 }
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1999,9 +1999,11 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                     project.do_send(UpdateRateLimits(rate_limits.clone()));
                 }
 
-                // Capture extracted metrics in the project's aggregator, independent of dropped
-                // items. This allows us to retain metrics while also sampling.
-                project.do_send(InsertMetrics::new(processed.metrics));
+                if !processed.metrics.is_empty() {
+                    // Capture extracted metrics in the project's aggregator, independent of dropped
+                    // items. This allows us to retain metrics while also sampling.
+                    project.do_send(InsertMetrics::new(processed.metrics));
+                }
 
                 match processed.envelope {
                     Some(envelope) => {


### PR DESCRIPTION
This is a first workaround to avoid overloading the project arbiter with too many aggregators. This only avoids creating aggregators. The leak itself still exists.

Follow-ups:
- Move metrics aggregation to its own arbiter
- Use a better approach than busy polling for metrics

Fixes a regression in https://github.com/getsentry/relay/pull/986