### PR TITLE
fix(server): Do not wait on request data after error

### DIFF
--- a/relay-server/src/body/forward_body.rs
+++ b/relay-server/src/body/forward_body.rs
@@ -1,5 +1,4 @@
 use actix::ResponseFuture;
-use actix_web::dev::Payload;
 use actix_web::{error::PayloadError, http::StatusCode, HttpRequest, HttpResponse, ResponseError};
 use bytes::{Bytes, BytesMut};
 use failure::Fail;
@@ -46,7 +45,7 @@ impl From<PayloadError> for ForwardPayloadError {
 /// Future that resolves to a complete store endpoint body.
 pub struct ForwardBody {
     limit: usize,
-    stream: Option<Payload>,
+    stream: Option<SharedPayload>,
     err: Option<ForwardPayloadError>,
     fut: Option<ResponseFuture<Bytes, ForwardPayloadError>>,
 }

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::io::{self, Read};
 
 use actix::ResponseFuture;
-use actix_web::dev::Payload;
 use actix_web::http::StatusCode;
 use actix_web::{error::PayloadError, HttpRequest, HttpResponse, ResponseError};
 use base64::DecodeError;
@@ -82,7 +81,7 @@ pub struct StoreBody {
     // These states are mutually exclusive:
     result: Option<Result<Bytes, StorePayloadError>>,
     fut: Option<ResponseFuture<Bytes, StorePayloadError>>,
-    stream: Option<Payload>,
+    stream: Option<SharedPayload>,
 }
 
 impl StoreBody {

--- a/relay-server/src/extractors/shared_payload.rs
+++ b/relay-server/src/extractors/shared_payload.rs
@@ -1,6 +1,6 @@
 use actix_web::dev::Payload;
 use actix_web::{FromRequest, HttpMessage, HttpRequest};
-use futures::{Poll, Stream};
+use futures::{Async, Poll, Stream};
 
 /// A shared reference to an actix request payload.
 ///
@@ -10,18 +10,28 @@ use futures::{Poll, Stream};
 /// To obtain a reference, call [`SharedPayload::get`]. The first time, this takes the body out of
 /// the request. Subsequent calls to `request.payload()` or `request.body()` will return empty. This
 /// type also implements [`FromRequest`] for the use in actix request handlers.
-#[derive(Clone)]
-pub struct SharedPayload(Payload);
+#[derive(Clone, Debug)]
+pub struct SharedPayload {
+    inner: Payload,
+    done: bool,
+}
 
 impl SharedPayload {
-    /// Extracts the shared clone of the request payload from the given request.
-    pub fn get<S>(request: &HttpRequest<S>) -> Payload {
-        Self::extract(request).into_inner()
-    }
+    /// Extracts the shared request payload from the given request.
+    pub fn get<S>(request: &HttpRequest<S>) -> Self {
+        let mut extensions = request.extensions_mut();
 
-    /// Unwraps the shared clone of the request payload.
-    pub fn into_inner(self) -> Payload {
-        self.0
+        if let Some(payload) = extensions.get::<Self>() {
+            return payload.clone();
+        }
+
+        let payload = Self {
+            inner: request.payload(),
+            done: false,
+        };
+
+        extensions.insert(payload.clone());
+        payload
     }
 }
 
@@ -30,15 +40,7 @@ impl<S> FromRequest<S> for SharedPayload {
     type Result = Self;
 
     fn from_request(request: &HttpRequest<S>, _config: &Self::Config) -> Self::Result {
-        let mut extensions = request.extensions_mut();
-
-        if let Some(payload) = extensions.get::<Self>() {
-            return payload.clone();
-        }
-
-        let payload = Self(request.payload());
-        extensions.insert(payload.clone());
-        payload
+        Self::get(request)
     }
 }
 
@@ -48,6 +50,19 @@ impl Stream for SharedPayload {
 
     #[inline]
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.0.poll()
+        if self.done {
+            return Ok(Async::Ready(None));
+        }
+
+        let poll = self.inner.poll();
+
+        self.done = match poll {
+            Ok(Async::NotReady) => false,
+            Ok(Async::Ready(Some(_))) => false,
+            Ok(Async::Ready(None)) => true,
+            Err(_) => true,
+        };
+
+        poll
     }
 }


### PR DESCRIPTION
Streams in `futures 0.1` are allowed to resume after emitting an error. It appears that the actix payload type locks up when being polled after erroring since it does not signal EOF in all error cases. To avoid this, we remove all use of the raw `Payload` in favor of a fully fused `SharedPayload`.

Follow-up to #999 

#skip-changelog