### PR TITLE
fix(server): Properly fuse shared payloads on error

### DIFF
--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -293,9 +293,13 @@ class SentryLike(object):
         response.raise_for_status()
         return response
 
-    def request(self, method, path, **kwargs):
+    def request(self, method, path, timeout=None, **kwargs):
         assert path.startswith("/")
-        return session.request(method, self.url + path, **kwargs)
+
+        if timeout is None:
+            timeout = 10
+
+        return session.request(method, self.url + path, timeout=timeout, **kwargs)
 
     def post(self, path, **kwargs):
         return self.request("post", path, **kwargs)

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -940,3 +940,19 @@ def test_buffer_events_during_outage(relay, mini_sentry):
     # sanity test that we got the event we sent
     event = mini_sentry.captured_events.get(timeout=1).get_event()
     assert event["logentry"] == {"formatted": "123"}
+
+
+def test_store_invalid_gzip(mini_sentry, relay_chain):
+    relay = relay_chain()
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    headers = {
+        "Content-Encoding": "gzip",
+        "X-Sentry-Auth": relay.get_auth_header(project_id),
+    }
+
+    url = "/api/%s/store/" % project_id
+
+    response = relay.post(url, headers=headers)
+    assert response.status_code == 400


### PR DESCRIPTION
Corrects an invalid fix submitted in #1006. Instead of cloning the boolean done flag, the shared payload also needs to share the flag between instances. The added test case additionally validates that encoding errors terminate the stream.

Since this is a plain boolean flag used in a thread-local stream, we can use atomic bool with relaxed ordering to avoid memory fences.

#skip-changelog