### PR TITLE
fix(schema): Explicitly declare reprocessing context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Explicitly declare reprocessing context. ([#1009](https://github.com/getsentry/relay/pull/1009))
+
 ## 21.5.1
 
 **Bug Fixes**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add back `breadcrumb.event_id`. ([#977](https://github.com/getsentry/relay/pull/977))
 - Add `frame.stack_start` for chained async stack traces. ([#981](https://github.com/getsentry/relay/pull/981))
 - Fix roundtrip error when PII selector starts with number. ([#982](https://github.com/getsentry/relay/pull/982))
+- Explicitly declare reprocessing context. ([#1009](https://github.com/getsentry/relay/pull/1009))
 
 ## 0.8.5
 

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -983,6 +983,7 @@ fn parse_field_attributes(
 
 #[derive(Default)]
 struct VariantAttrs {
+    omit_from_schema: bool,
     tag_override: Option<String>,
     fallback_variant: bool,
 }
@@ -1009,11 +1010,15 @@ fn parse_variant_attributes(attrs: &[syn::Attribute]) -> VariantAttrs {
                     NestedMeta::Lit(..) => panic!("unexpected literal attribute"),
                     NestedMeta::Meta(meta) => match meta {
                         Meta::Path(path) => {
-                            if path.get_ident().map_or(false, |x| x == "fallback_variant") {
+                            let ident = path.get_ident().expect("Unexpected path");
+
+                            if ident == "fallback_variant" {
                                 rv.tag_override = None;
                                 rv.fallback_variant = true;
+                            } else if ident == "omit_from_schema" {
+                                rv.omit_from_schema = true;
                             } else {
-                                panic!("Unknown attribute {:?}", path);
+                                panic!("Unknown attribute {}", ident);
                             }
                         }
                         Meta::NameValue(name_value) => {

--- a/relay-general/src/processor/traits.rs
+++ b/relay-general/src/processor/traits.rs
@@ -91,6 +91,7 @@ pub trait Processor: Sized {
     process_method!(process_span, crate::protocol::Span);
     process_method!(process_trace_context, crate::protocol::TraceContext);
     process_method!(process_native_image_path, crate::protocol::NativeImagePath);
+    process_method!(process_contexts, crate::protocol::Contexts);
 
     fn process_other(
         &mut self,


### PR DESCRIPTION
Reprocessing adds context data to an event that helps in finding those
events based on their previous issue ID. We have observed that, since
this is event data coming out of processing, it can happen that
datascrubbing (invoked at the end of process_event) removes this vital
information, or more specifically, replaces the original_primary_hash
with a SHA1 hash due to a PII rule. This SHA1 hash is passed to Snuba
which fails to parse it as UUID. This caused the Snuba consumer to
crash, hotfix at https://github.com/getsentry/snuba/pull/1896

To fix this I define the reprocessing context explicitly, set pii=false,
and make sure it is omitted from the exported JSON schema.  This commit
also contains changes to make it possible to omit an entire enum variant
from the schema. Previously it was only possible to omit fields.

In the store normalizer I make sure the reprocessing context is
removed. NormalizeProcessor is not invoked as part of renormalization in
Sentry, only in Relay.

While building this I also noticed that the process_trace_context was
never wired up correctly, so I fixed that too.