### PR TITLE
ref(log): Remove excessive info `done` log for each request

### DIFF
--- a/relay-server/src/extractors/shared_payload.rs
+++ b/relay-server/src/extractors/shared_payload.rs
@@ -54,7 +54,6 @@ impl Stream for SharedPayload {
     #[inline]
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         if self.done.load(Ordering::Relaxed) {
-            relay_log::info!("done");
             return Ok(Async::Ready(None));
         }
 


### PR DESCRIPTION
#skip-changelog