### PR TITLE
feat(server): Support namespaced multipart payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Support self-contained envelopes without authentication headers or query parameters. ([#1000](https://github.com/getsentry/relay/pull/1000))
+- Support namespaced event payloads in multipart minidump submission for Electron Framework. The field has to follow the format `sentry___<namespace>`. ([#1012](https://github.com/getsentry/relay/pull/1012))
 
 **Bug Fixes**:
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -770,9 +770,9 @@ impl EnvelopeProcessor {
         let mut aggregator = ChunkedFormDataAggregator::new();
 
         for entry in FormDataIter::new(&payload) {
-            if entry.key() == "sentry" {
+            if entry.key() == "sentry" || entry.key().starts_with("sentry___") {
                 // Custom clients can submit longer payloads and should JSON encode event data into
-                // the optional `sentry` field.
+                // the optional `sentry` field or a `sentry___<namespace>` field.
                 match serde_json::from_str(entry.value()) {
                     Ok(event) => utils::merge_values(target, event),
                     Err(_) => relay_log::debug!("invalid json event payload in sentry form field"),

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -198,10 +198,7 @@ def test_minidump_sentry_namespace_json(mini_sentry, relay):
 
     event_json = '{"event_id":"2dd132e467174db48dbaddabd3cbed57"}'
     namespace_json = '{"user":{"id":"123"}}'
-    params = [
-        ("sentry", event_json),
-        ("sentry___global", namespace_json)
-    ]
+    params = [("sentry", event_json), ("sentry___global", namespace_json)]
 
     relay.send_minidump(project_id=project_id, files=attachments, params=params)
     envelope = mini_sentry.captured_events.get(timeout=1)

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -187,6 +187,37 @@ def test_minidump_sentry_json(mini_sentry, relay):
     assert event_item["user"]["id"] == "123"
 
 
+def test_minidump_sentry_namespace_json(mini_sentry, relay):
+    project_id = 42
+    relay = relay(mini_sentry)
+    mini_sentry.add_full_project_config(project_id)
+
+    attachments = [
+        (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
+    ]
+
+    event_json = '{"event_id":"2dd132e467174db48dbaddabd3cbed57"}'
+    namespace_json = '{"user":{"id":"123"}}'
+    params = [
+        ("sentry", event_json),
+        ("sentry___global", namespace_json)
+    ]
+
+    relay.send_minidump(project_id=project_id, files=attachments, params=params)
+    envelope = mini_sentry.captured_events.get(timeout=1)
+
+    assert envelope
+    assert_only_minidump(envelope)
+
+    # Check that the envelope assumes the given event id
+    assert envelope.headers.get("event_id") == "2dd132e467174db48dbaddabd3cbed57"
+
+    # Check that event payload is applied
+    event_item = envelope.get_event()
+    assert event_item["event_id"] == "2dd132e467174db48dbaddabd3cbed57"
+    assert event_item["user"]["id"] == "123"
+
+
 def test_minidump_sentry_json_chunked(mini_sentry, relay):
     project_id = 42
     relay = relay(mini_sentry)


### PR DESCRIPTION
In addition to the "sentry" multipart field containing an event payload, this
allows to send a "sentry___" field. All fields will be merged together into one
event.

This allows Electron Framework to register global static options before
initializing the SDK. These options are also propagated to crashes of sub
processes.
