### PR TITLE
feat: Bump release parser to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Internal**:
 
 - Gather metrics for corrupted Events with unprintable fields. ([#1008](https://github.com/getsentry/relay/pull/1008))
+- Bump release parser to 1.0.0. ([#1013](https://github.com/getsentry/relay/pull/1013))
 
 ## 21.5.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "0.6.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3922f28bac40e0edf372875bb64836bfe22013f5dd1b241846fec2ad6dca28"
+checksum = "99bfd3ce6bebc014c7261538b396793e9830d318c9d3608f119eb257d5e5c605"
 dependencies = [
  "lazy_static",
  "regex",

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -165,6 +165,8 @@ def test_parse_release():
             "minor": 0,
             "patch": 0,
             "pre": "rc1",
+            "raw_quad": ["1", "0", None, None],
+            "revision": 0,
         },
         "version_raw": "1.0rc1+20200101100",
     }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -24,4 +24,4 @@ relay-common = { path = "../relay-common" }
 relay-ffi = { path = "../relay-ffi" }
 relay-general = { path = "../relay-general" }
 relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "0.6.0", features = ["serde"] }
+sentry-release-parser = { version = "1.0.0", features = ["serde"] }


### PR DESCRIPTION
We need the newer version of the release parser for the improved semver support.