### PR TITLE
fix(server): Validate release and environment attrs in sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**:
 
 - Explicitly declare reprocessing context. ([#1009](https://github.com/getsentry/relay/pull/1009))
+- Validate the environment attribute in sessions, and drop sessions with invalid releases. ([#1018](https://github.com/getsentry/relay/pull/1018))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,6 +3208,7 @@ dependencies = [
  "relay-general-derive",
  "schemars",
  "scroll",
+ "sentry-release-parser",
  "serde",
  "serde_json",
  "serde_urlencoded 0.5.5",
@@ -3737,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bfd3ce6bebc014c7261538b396793e9830d318c9d3608f119eb257d5e5c605"
+checksum = "d71f821f3087b0e0568f984b6e944e454dbe086c6ae463300bc1c5f2399009de"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71f821f3087b0e0568f984b6e944e454dbe086c6ae463300bc1c5f2399009de"
+checksum = "846b55bede1207d53b49824aca08578d58f9255b6e91fb5d164d91540a02dda0"
 dependencies = [
  "lazy_static",
  "regex",

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Bump release parser to 1.1.1. ([#1018](https://github.com/getsentry/relay/pull/1018))
+
 ## 0.8.7
 
 - Bump release parser to 1.0.0. ([#1013](https://github.com/getsentry/relay/pull/1013))

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -24,4 +24,4 @@ relay-common = { path = "../relay-common" }
 relay-ffi = { path = "../relay-ffi" }
 relay-general = { path = "../relay-general" }
 relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "1.1.0", features = ["serde"] }
+sentry-release-parser = { version = "1.1.1", features = ["serde"] }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -24,4 +24,4 @@ relay-common = { path = "../relay-common" }
 relay-ffi = { path = "../relay-ffi" }
 relay-general = { path = "../relay-general" }
 relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "1.0.0", features = ["serde"] }
+sentry-release-parser = { version = "1.1.0", features = ["serde"] }

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -30,7 +30,7 @@ relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
 scroll = "0.10.2"
-sentry-release-parser = { version = "1.1.0" }
+sentry-release-parser = { version = "1.1.1" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.5.5"

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -30,6 +30,7 @@ relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
 scroll = "0.10.2"
+sentry-release-parser = { version = "1.1.0" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.5.5"

--- a/relay-general/src/protocol/constants.rs
+++ b/relay-general/src/protocol/constants.rs
@@ -19,9 +19,3 @@ pub const VALID_PLATFORMS: &[&str] = &[
     "python",
     "ruby",
 ];
-
-/// Invalid environment strings (case sensitive).
-pub const INVALID_ENVIRONMENTS: &[&str] = &["none"];
-
-/// Invalid release version strings (case insensitive).
-pub const INVALID_RELEASES: &[&str] = &["latest", "..", "."];

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -27,10 +27,12 @@ mod types;
 mod user;
 mod user_report;
 
+pub use sentry_release_parser::{validate_environment, validate_release};
+
 pub use self::breadcrumb::Breadcrumb;
 pub use self::breakdowns::Breakdowns;
 pub use self::clientsdk::{ClientSdkInfo, ClientSdkPackage};
-pub use self::constants::{INVALID_ENVIRONMENTS, INVALID_RELEASES, VALID_PLATFORMS};
+pub use self::constants::VALID_PLATFORMS;
 pub use self::contexts::{
     AppContext, BrowserContext, Context, ContextInner, Contexts, DeviceContext, GpuContext,
     OperationType, OsContext, RuntimeContext, SpanId, SpanStatus, TraceContext, TraceId,

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -492,7 +492,9 @@ def test_session_invalid_release(mini_sentry, relay_with_processing, sessions_co
     sessions_consumer.assert_empty()
 
 
-def test_session_invalid_environment(mini_sentry, relay_with_processing, sessions_consumer):
+def test_session_invalid_environment(
+    mini_sentry, relay_with_processing, sessions_consumer
+):
     relay = relay_with_processing()
     sessions_consumer = sessions_consumer()
 


### PR DESCRIPTION
Validates the `release` and `environment` attributes in sessions. Invalid
releases drop the session, since releases are required. Invalid environments are
simply removed.

