### PR TITLE
test: Update flask and werkzeug to resolve deprecation warning

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 confluent-kafka==1.6.0
-flask==1.1.1
+flask==2.0.1
 msgpack==1.0.0
 pytest-localserver==0.5.0
 pytest-sentry==0.1.1
@@ -8,5 +8,5 @@ pytest==5.3.5
 redis==3.4.1
 requests==2.23.0
 git+git://github.com/getsentry/sentry-python@e234998ae82a9cffa6fb3718801c55ba24a86bab#egg=sentry_sdk
-werkzeug==0.15.5
+werkzeug==2.0.1
 sentry-relay==0.8.5


### PR DESCRIPTION
Fixes this warning:

```
flask/json/__init__.py:253: DeprecationWarning: Importing 'itsdangerous.json' is deprecated and will be removed in ItsDangerous 2.1. Use Python's 'json' module instead.
    return _json.loads(s, **kwargs)

.venv/lib/python3.9/site-packages/flask/json/__init__.py:211
```

#skip-changelog