### PR TITLE
test: Ability to test multiple relay versions in one chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,4 +230,4 @@ jobs:
       - name: Run tests
         run: pytest tests -n auto -v
         env:
-          RELAY_VERSION_CHAIN=20.6.0,latest
+          RELAY_VERSION_CHAIN: '20.6.0,latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,14 @@ jobs:
         run: pytest -v py
 
   test_integration:
-    name: Integration Tests
+    name: Integration Tests ${{ matrix.relay_version_chain }}
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        relay_version_chain:
+          - "20.6.0,latest"
+          - ""
 
     # Skip redundant checks for library releases
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"
@@ -228,4 +234,4 @@ jobs:
         run: pip install -U -r requirements-test.txt
 
       - name: Run tests
-        run: pytest tests -n auto -v
+        run: RELAY_VERSION_CHAIN=${{ matrix.relay_version_chain }} pytest tests -n auto -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,6 @@ jobs:
     name: Integration Tests ${{ matrix.relay_version_chain }}
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        relay_version_chain:
-          - "20.6.0,latest"
-          - ""
-
     # Skip redundant checks for library releases
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"
 
@@ -234,4 +228,6 @@ jobs:
         run: pip install -U -r requirements-test.txt
 
       - name: Run tests
-        run: RELAY_VERSION_CHAIN=${{ matrix.relay_version_chain }} pytest tests -n auto -v
+        run: pytest tests -n auto -v
+        env:
+          RELAY_VERSION_CHAIN=20.6.0,latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
         run: pytest -v py
 
   test_integration:
-    name: Integration Tests ${{ matrix.relay_version_chain }}
+    name: Integration Tests
     runs-on: ubuntu-latest
 
     # Skip redundant checks for library releases

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,9 +87,7 @@ def relay_chain(request, mini_sentry, relay, gobetween, haproxy):  # noqa
         if not configured_versions:
             versions_iter = itertools.repeat("latest")
         else:
-            configured_versions.reverse()
-            configured_versions.append("latest")
-            versions_iter = iter(configured_versions)
+            versions_iter = iter(reversed(configured_versions))
 
         def relay_with_version(upstream, **kwargs):
             version = next(versions_iter)

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -200,7 +200,9 @@ def mini_sentry(request):
         if relay_id not in sentry.known_relays:
             abort(403, "unknown relay")
 
-        if version != CURRENT_VERSION:
+        registered_version = sentry.known_relays[relay_id]['version']
+
+        if version != registered_version and not (registered_version == "latest" and version == CURRENT_VERSION):
             abort(403, "outdated version")
 
         authenticated_relays[relay_id] = sentry.known_relays[relay_id]

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -200,9 +200,11 @@ def mini_sentry(request):
         if relay_id not in sentry.known_relays:
             abort(403, "unknown relay")
 
-        registered_version = sentry.known_relays[relay_id]['version']
+        registered_version = sentry.known_relays[relay_id]["version"]
 
-        if version != registered_version and not (registered_version == "latest" and version == CURRENT_VERSION):
+        if version != registered_version and not (
+            registered_version == "latest" and version == CURRENT_VERSION
+        ):
             abort(403, "outdated version")
 
         authenticated_relays[relay_id] = sentry.known_relays[relay_id]

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -21,6 +21,13 @@ with open(os.path.join(os.path.dirname(__file__), "../../../relay/Cargo.toml")) 
     CURRENT_VERSION = _version_re.search(f.read()).group(1)
 
 
+def _parse_version(version):
+    if version == "latest":
+        return (float("inf"),)
+
+    return tuple(map(int, version.split(".")))
+
+
 class Sentry(SentryLike):
     def __init__(self, server_address, app):
         super(Sentry, self).__init__(server_address)
@@ -193,21 +200,27 @@ def mini_sentry(request):
     @app.route("/api/0/relays/register/challenge/", methods=["POST"])
     def get_challenge():
         relay_id = flask_request.json["relay_id"]
-        public_key = flask_request.json["public_key"]
-        version = flask_request.json["version"]
-
         assert relay_id == flask_request.headers["x-sentry-relay-id"]
+
         if relay_id not in sentry.known_relays:
             abort(403, "unknown relay")
 
-        registered_version = sentry.known_relays[relay_id]["version"]
+        relay_info = sentry.known_relays[relay_id]
 
-        if version != registered_version and not (
+        public_key = flask_request.json["public_key"]
+        version = flask_request.json.get("version")
+        registered_version = relay_info["version"]
+
+        if version is None:
+            if _parse_version(registered_version) >= (20, 8):
+                abort(400, "missing version")
+
+        elif version != registered_version and not (
             registered_version == "latest" and version == CURRENT_VERSION
         ):
             abort(403, "outdated version")
 
-        authenticated_relays[relay_id] = sentry.known_relays[relay_id]
+        authenticated_relays[relay_id] = relay_info
         return jsonify({"token": "123", "relay_id": relay_id})
 
     @app.route("/api/0/relays/register/response/", methods=["POST"])

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import signal
 import stat
 import requests
@@ -53,7 +54,13 @@ def get_relay_binary():
         if version == "latest":
             return RELAY_BIN
 
-        filename = "relay-Darwin-x86_64"  # TODO
+        if sys.platform == "linux" or sys.platform == "linux2":
+            filename = "relay-Linux-x86_64"
+        elif sys.platform == "darwin":
+            filename = "relay-Darwin-x86_64"
+        elif sys.platform == "win32":
+            filename = "relay-Windows-x86_64.exe"
+
         download_path = f"target/relay_releases_cache/{filename}_{version}"
 
         if not os.path.exists(download_path):
@@ -144,6 +151,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
         mini_sentry.known_relays[relay_id] = {
             "publicKey": public_key,
             "internal": not external,
+            "version": version,
         }
 
         process = background_process(relay_bin + ["-c", str(dir), "run"])

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -117,7 +117,7 @@ def test_normalize_measurement_interface(
 
 
 def test_empty_measurement_interface(mini_sentry, relay_chain):
-    relay = relay_chain()
+    relay = relay_chain(min_relay_version="20.10.0")
     mini_sentry.add_basic_project_config(42)
 
     transaction_item = generate_transaction_item()
@@ -282,7 +282,7 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
 
 
 def test_sample_rates(mini_sentry, relay_chain):
-    relay = relay_chain()
+    relay = relay_chain(min_relay_version="21.1.0")
     mini_sentry.add_basic_project_config(42)
 
     sample_rates = [

--- a/tests/integration/test_forwarding.py
+++ b/tests/integration/test_forwarding.py
@@ -38,7 +38,7 @@ def test_forwarding_content_encoding(
 
         return Response(_data, headers=headers)
 
-    relay = relay_chain()
+    relay = relay_chain(min_relay_version="21.6.1")
 
     headers = {"Content-Type": "application/octet-stream"}
 

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -943,7 +943,7 @@ def test_buffer_events_during_outage(relay, mini_sentry):
 
 
 def test_store_invalid_gzip(mini_sentry, relay_chain):
-    relay = relay_chain()
+    relay = relay_chain(min_relay_version="21.6.0")
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
 


### PR DESCRIPTION
Add second CI target that runs older Relays in combination with newer ones. This is supposed to test general compatibility between Relay versions.

See https://getsentry.atlassian.net/browse/INGEST-71 for more details.

Some tests have been added in later Relay versions. Those tests need to specify `min_relay_version` such that we don't run a newer regression test against an older Relay version, or a feature test against a Relay version where the feature is not implemented.

Relay binaries are used instead of Docker because Docker for Mac is annoying to configure for networking.

#skip-changelog