### PR TITLE
ref(server) : Changes TrackOutcome from using Instant to using DateTime

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -2096,9 +2096,10 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
 
                 let envelope_summary = envelope_summary.borrow();
                 if let Some(outcome) = outcome {
+                    let timestamp = relay_common::instant_to_date_time(start_time);
                     if let Some(category) = envelope_summary.event_category {
                         outcome_producer.do_send(TrackOutcome {
-                            timestamp: Instant::now(),
+                            timestamp,
                             scoping: *scoping.borrow(),
                             outcome: outcome.clone(),
                             event_id,
@@ -2110,7 +2111,7 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
 
                     if envelope_summary.attachment_quantity > 0 {
                         outcome_producer.do_send(TrackOutcome {
-                            timestamp: start_time,
+                            timestamp,
                             scoping: *scoping.borrow(),
                             outcome,
                             event_id,

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -8,11 +8,10 @@ use std::borrow::Cow;
 use std::mem;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::Instant;
 
 use actix::prelude::*;
 use actix_web::http::Method;
-use chrono::SecondsFormat;
+use chrono::{DateTime, SecondsFormat, Utc};
 use futures::future::Future;
 use serde::{Deserialize, Serialize};
 
@@ -73,7 +72,7 @@ pub struct SendOutcomesResponse {
 #[derive(Clone, Debug)]
 pub struct TrackOutcome {
     /// The timespan of the event outcome.
-    pub timestamp: Instant,
+    pub timestamp: DateTime<Utc>,
     /// Scoping of the request.
     pub scoping: Scoping,
     /// The outcome.
@@ -326,11 +325,10 @@ pub struct TrackRawOutcome {
 impl TrackRawOutcome {
     fn from_outcome(msg: TrackOutcome, config: &Config) -> Self {
         let reason = msg.outcome.to_reason().map(|reason| reason.to_string());
-        let date_time = relay_common::instant_to_date_time(msg.timestamp);
 
         // convert to a RFC 3339 formatted date with the shape YYYY-MM-DDTHH:MM:SS.mmmmmmZ
         // e.g. something like: "2019-09-29T09:46:40.123456Z"
-        let timestamp = date_time.to_rfc3339_opts(SecondsFormat::Micros, true);
+        let timestamp = msg.timestamp.to_rfc3339_opts(SecondsFormat::Micros, true);
 
         let org_id = match msg.scoping.organization_id {
             0 => None,

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -530,9 +530,10 @@ where
 
             let envelope_summary = envelope_summary.borrow();
             if let Some(outcome) = error.to_outcome() {
+                let timestamp = relay_common::instant_to_date_time(start_time);
                 if let Some(category) = envelope_summary.event_category {
                     outcome_producer.do_send(TrackOutcome {
-                        timestamp: start_time,
+                        timestamp,
                         scoping: *scoping.borrow(),
                         outcome: outcome.clone(),
                         event_id: *event_id.borrow(),
@@ -544,7 +545,7 @@ where
 
                 if envelope_summary.attachment_quantity > 0 {
                     outcome_producer.do_send(TrackOutcome {
-                        timestamp: start_time,
+                        timestamp,
                         scoping: *scoping.borrow(),
                         outcome,
                         event_id: *event_id.borrow(),

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -239,8 +239,9 @@ impl Enforcement {
         // Do not report outcomes for sessions.
         for limit in std::array::IntoIter::new([self.event, self.attachments]) {
             if limit.is_active() {
+                let timestamp = relay_common::instant_to_date_time(envelope.meta().start_time());
                 producer.do_send(TrackOutcome {
-                    timestamp: envelope.meta().start_time(),
+                    timestamp,
                     scoping: *scoping,
                     outcome: Outcome::RateLimited(limit.reason_code),
                     event_id: envelope.event_id(),


### PR DESCRIPTION
This change was added to Simplify handling of Outcomes in future PRs.

#skip-changelog