### PR TITLE
feat(cabi): Bump release parser to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce4fa96e25a44f5182858170f9603807b723f4e9c5806c11bf825b63eb80c5c"
+checksum = "9786829b8a55e9f9d46920d594ed351b6344aa9c2d0996ba886f0a5eae2724d3"
 dependencies = [
  "lazy_static",
  "regex",

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bump release parser to 1.1.2. ([#1023](https://github.com/getsentry/relay/pull/1023))
+- Bump release parser to 1.1.4. ([#1031](https://github.com/getsentry/relay/pull/1031))
 
 ## 0.8.7
 

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -24,4 +24,4 @@ relay-common = { path = "../relay-common" }
 relay-ffi = { path = "../relay-ffi" }
 relay-general = { path = "../relay-general" }
 relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "1.1.2", features = ["serde"] }
+sentry-release-parser = { version = "1.1.4", features = ["serde"] }


### PR DESCRIPTION
Bumps the release parser to 1.1.4 which includes bugfixes to version parsing of hashes.