### PR TITLE
ref(server): Remove noisy payload parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug Fixes**:
 
 - Remove connection metrics reported under `connector.*`. They have been fully disabled since version `21.3.0`. ([#1021](https://github.com/getsentry/relay/pull/1021))
+- Remove error logs for "failed to extract event" and "failed to store session". ([#1032](https://github.com/getsentry/relay/pull/1032))
 
 **Internal**:
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -991,11 +991,10 @@ impl EnvelopeProcessor {
         } else if let Some(mut item) = raw_security_item {
             relay_log::trace!("processing security report");
             state.sample_rates = item.take_sample_rates();
-            let result = self.event_from_security_report(item);
-            if let Err(ref error) = result {
-                relay_log::error!("failed to extract security report: {}", LogError(error));
-            }
-            result?
+            self.event_from_security_report(item).map_err(|error| {
+                relay_log::error!("failed to extract security report: {}", LogError(&error));
+                error
+            })?
         } else if attachment_item.is_some() || breadcrumbs1.is_some() || breadcrumbs2.is_some() {
             relay_log::trace!("extracting attached event data");
             Self::event_from_attachments(&self.config, attachment_item, breadcrumbs1, breadcrumbs2)?

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -521,14 +521,8 @@ impl EnvelopeProcessor {
             let mut session = match SessionUpdate::parse(&payload) {
                 Ok(session) => session,
                 Err(error) => {
-                    return relay_log::with_scope(
-                        |s| s.set_extra("session", String::from_utf8_lossy(&payload).into()),
-                        || {
-                            // Skip gracefully here to allow sending other sessions.
-                            relay_log::error!("failed to store session: {}", LogError(&error));
-                            false
-                        },
-                    );
+                    relay_log::trace!("skipping invalid session payload: {}", LogError(&error));
+                    return false;
                 }
             };
 
@@ -749,7 +743,7 @@ impl EnvelopeProcessor {
         };
 
         if let Err(json_error) = apply_result {
-            // logged at call site of extract_event
+            // logged in extract_event
             relay_log::configure_scope(|scope| {
                 scope.set_extra("payload", String::from_utf8_lossy(&data).into());
             });
@@ -997,7 +991,11 @@ impl EnvelopeProcessor {
         } else if let Some(mut item) = raw_security_item {
             relay_log::trace!("processing security report");
             state.sample_rates = item.take_sample_rates();
-            self.event_from_security_report(item)?
+            let result = self.event_from_security_report(item);
+            if let Err(ref error) = result {
+                relay_log::error!("failed to extract security report: {}", LogError(error));
+            }
+            result?
         } else if attachment_item.is_some() || breadcrumbs1.is_some() || breadcrumbs2.is_some() {
             relay_log::trace!("extracting attached event data");
             Self::event_from_attachments(&self.config, attachment_item, breadcrumbs1, breadcrumbs2)?
@@ -1416,10 +1414,7 @@ impl EnvelopeProcessor {
                 self.expand_unreal(&mut state)?;
             });
 
-            self.extract_event(&mut state).map_err(|error| {
-                relay_log::error!("failed to extract event: {}", LogError(&error));
-                error
-            })?;
+            self.extract_event(&mut state)?;
 
             if_processing!({
                 self.process_unreal(&mut state)?;

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -355,20 +355,16 @@ def test_session_release_required(
     timestamp = datetime.now(tz=timezone.utc)
     started = timestamp - timedelta(days=5, hours=1)
 
-    try:
-        relay.send_session(
-            project_id,
-            {
-                "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
-                "timestamp": timestamp.isoformat(),
-                "started": started.isoformat(),
-            },
-        )
+    relay.send_session(
+        project_id,
+        {
+            "sid": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "timestamp": timestamp.isoformat(),
+            "started": started.isoformat(),
+        },
+    )
 
-        sessions_consumer.assert_empty()
-        assert mini_sentry.test_failures
-    finally:
-        mini_sentry.test_failures.clear()
+    sessions_consumer.assert_empty()
 
 
 def test_session_quotas(mini_sentry, relay_with_processing, sessions_consumer):


### PR DESCRIPTION
Removes errors when event payloads or session payloads cannot be parsed. These
were reported as "failed to extract event" and "failed to store session",
respectively.

Such errors are completely expected when invalid payloads are sent into Relay.
They were originally introduced to debug broken SDKs, but in the way they are
being reported they are neither actionable to the Relay development team, nor
anyone running Relay onpremise.

Eventually, we will bring this back in form of a metric including the SDK
version, and potentially a mechanism to sample invalid payloads. For now, these
errors are not actionable, and drown real issues in Sentry.

