### PR TITLE
ci(macos): Force dSYM creation on release builds

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Run Cargo Build
         uses: actions-rs/cargo@v1
+        env:
+          CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
         with:
           command: build
           args: --manifest-path=relay/Cargo.toml --release --features ssl


### PR DESCRIPTION
Fixes the release branch builds like https://github.com/getsentry/relay/runs/2975323304. GitHub Actions runners upgrded Rust to 1.53, which comes with https://github.com/rust-lang/cargo/pull/9298, a breaking change for us since we expect to have the dSYM file for our builds.

#skip-changelog