### PR TITLE
ref(server): Make global actors system services

### DIFF
--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -114,16 +114,14 @@ impl ProjectStateChannel {
 pub struct UpstreamProjectSource {
     backoff: RetryBackoff,
     config: Arc<Config>,
-    upstream: Addr<UpstreamRelay>,
     state_channels: HashMap<ProjectKey, ProjectStateChannel>,
 }
 
 impl UpstreamProjectSource {
-    pub fn new(config: Arc<Config>, upstream: Addr<UpstreamRelay>) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         UpstreamProjectSource {
             backoff: RetryBackoff::new(config.http_max_retry_interval()),
             config,
-            upstream,
             state_channels: HashMap::new(),
         }
     }
@@ -214,7 +212,7 @@ impl UpstreamProjectSource {
                 // count number of http requests for project states
                 metric!(counter(RelayCounters::ProjectStateRequest) += 1);
 
-                self.upstream
+                UpstreamRelay::from_registry()
                     .send(SendQuery(query))
                     .map_err(ProjectError::ScheduleFailed)
                     .map(move |response| (channels_batch, response))

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -1,22 +1,17 @@
 //! Returns captured events.
 
-use ::actix::prelude::*;
+use actix_web::actix::*;
 use actix_web::{http::Method, HttpResponse, Path};
 use futures::future::Future;
 
-use crate::actors::envelopes::GetCapturedEnvelope;
+use crate::actors::envelopes::{EnvelopeManager, GetCapturedEnvelope};
 use crate::envelope;
-use crate::extractors::CurrentServiceState;
 use crate::service::ServiceApp;
 
 use relay_general::protocol::EventId;
 
-fn get_captured_event(
-    state: CurrentServiceState,
-    event_id: Path<EventId>,
-) -> ResponseFuture<HttpResponse, actix::MailboxError> {
-    let future = state
-        .envelope_manager()
+fn get_captured_event(event_id: Path<EventId>) -> ResponseFuture<HttpResponse, MailboxError> {
+    let future = EnvelopeManager::from_registry()
         .send(GetCapturedEnvelope {
             event_id: *event_id,
         })

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -1,6 +1,7 @@
+use actix_web::actix::SystemService;
 use actix_web::HttpResponse;
 
-use crate::actors::outcome::{SendOutcomes, SendOutcomesResponse};
+use crate::actors::outcome::{OutcomeProducer, SendOutcomes, SendOutcomesResponse};
 use crate::extractors::{CurrentServiceState, SignedJson};
 use crate::service::ServiceApp;
 
@@ -9,8 +10,9 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
         return HttpResponse::Forbidden().finish();
     }
 
+    let producer = OutcomeProducer::from_registry();
     for outcome in body.inner.outcomes {
-        state.outcome_producer().do_send(outcome);
+        producer.do_send(outcome);
     }
 
     HttpResponse::Accepted().json(SendOutcomesResponse {})

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -1,17 +1,12 @@
-use actix::ResponseFuture;
-use actix_web::{Error, Json};
+use actix_web::{actix::*, Error, Json};
 use futures::prelude::*;
 
-use crate::actors::relays::{GetRelays, GetRelaysResult};
-use crate::extractors::{CurrentServiceState, SignedJson};
+use crate::actors::relays::{GetRelays, GetRelaysResult, RelayCache};
+use crate::extractors::SignedJson;
 use crate::service::ServiceApp;
 
-fn get_public_keys(
-    state: CurrentServiceState,
-    body: SignedJson<GetRelays>,
-) -> ResponseFuture<Json<GetRelaysResult>, Error> {
-    let future = state
-        .relay_cache()
+fn get_public_keys(body: SignedJson<GetRelays>) -> ResponseFuture<Json<GetRelaysResult>, Error> {
+    let future = RelayCache::from_registry()
         .send(body.inner)
         .map_err(Error::from)
         .and_then(|x| x.map_err(Error::from).map(Json));

--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -1,4 +1,4 @@
-use ::actix::prelude::*;
+use actix_web::actix::*;
 use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use failure::Fail;
 use futures::prelude::*;
@@ -9,7 +9,7 @@ use relay_common::tryf;
 use relay_config::RelayInfo;
 use relay_log::Hub;
 
-use crate::actors::relays::GetRelay;
+use crate::actors::relays::{GetRelay, RelayCache};
 use crate::middlewares::ActixWebHubExt;
 use crate::service::ServiceState;
 use crate::utils::ApiErrorResponse;
@@ -66,9 +66,7 @@ impl<T: DeserializeOwned + 'static> FromRequest<ServiceState> for SignedJson<T> 
 
         let relay_sig = extract_header!("X-Sentry-Relay-Signature").to_owned();
 
-        let future = req
-            .state()
-            .relay_cache()
+        let future = RelayCache::from_registry()
             .send(GetRelay { relay_id })
             .map_err(Error::from)
             .and_then(|result| {


### PR DESCRIPTION
Most actors are singletons within the running actix system. To avoid passing
their addresses around and prevent circular references, make them system
services. This allows each actor to talk to every other actor.

#skip-changelog

