### PR TITLE
ref(server): Remove actix from HTTP utils and errors

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -26,7 +26,7 @@ use std::time::Instant;
 
 use ::actix::fut;
 use ::actix::prelude::*;
-use actix_web::http::{header, Method, StatusCode};
+use actix_web::http::{header, Method};
 use failure::Fail;
 use futures::{future, prelude::*, sync::oneshot};
 use itertools::Itertools;
@@ -41,7 +41,7 @@ use relay_quotas::{
     DataCategories, QuotaScope, RateLimit, RateLimitScope, RateLimits, RetryAfter, Scoping,
 };
 
-use crate::http::{HttpError, Request, RequestBuilder, Response};
+use crate::http::{HttpError, Request, RequestBuilder, Response, StatusCode};
 use crate::metrics::{RelayHistograms, RelayTimers};
 use crate::utils::{self, ApiErrorResponse, IntoTracked, RelayErrorAction, TrackedFutureFinished};
 
@@ -602,8 +602,8 @@ impl UpstreamRelay {
         request: &UpstreamRequest,
         send_result: &Result<Response, UpstreamRequestError>,
     ) {
-        let sc: StatusCode;
-        let sc2: Option<reqwest::StatusCode>;
+        let sc;
+        let sc2;
 
         let (status_code, result) = match send_result {
             Ok(ref client_response) => {
@@ -614,8 +614,7 @@ impl UpstreamRelay {
                 (status_code.as_str(), "response_error")
             }
             Err(UpstreamRequestError::Http(HttpError::Io(_))) => ("-", "payload_failed"),
-            Err(UpstreamRequestError::Http(HttpError::ActixPayload(_))) => ("-", "payload_failed"),
-            Err(UpstreamRequestError::Http(HttpError::ActixJson(_))) => ("-", "invalid_json"),
+            Err(UpstreamRequestError::Http(HttpError::Json(_))) => ("-", "invalid_json"),
             Err(UpstreamRequestError::Http(HttpError::Reqwest(error))) => {
                 sc2 = error.status();
                 (
@@ -623,13 +622,13 @@ impl UpstreamRelay {
                     "reqwest_error",
                 )
             }
+            Err(UpstreamRequestError::Http(HttpError::Custom(_))) => ("-", "internal"),
 
             Err(UpstreamRequestError::SendFailed(_)) => ("-", "send_failed"),
             Err(UpstreamRequestError::RateLimited(_)) => ("-", "rate_limited"),
             Err(UpstreamRequestError::NoCredentials)
             | Err(UpstreamRequestError::ChannelClosed)
-            | Err(UpstreamRequestError::Http(HttpError::Overflow))
-            | Err(UpstreamRequestError::Http(HttpError::Actix(_))) => {
+            | Err(UpstreamRequestError::Http(HttpError::Overflow)) => {
                 // these are not errors caused when sending to upstream so we don't need to log anything
                 relay_log::error!("meter_result called for unsupported error");
                 return;
@@ -779,9 +778,7 @@ impl UpstreamRelay {
                 move |mut builder: RequestBuilder| {
                     builder.header("X-Sentry-Relay-Signature", signature.as_str().as_bytes());
                     builder.header(header::CONTENT_TYPE, b"application/json");
-                    builder
-                        .body(json.clone().into())
-                        .map_err(UpstreamRequestError::Http)
+                    builder.body(&*json).map_err(UpstreamRequestError::Http)
                 },
                 ctx,
             )

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -21,6 +21,7 @@ use crate::endpoints::statics;
 use crate::extractors::ForwardedFor;
 use crate::http::{HttpError, RequestBuilder, Response};
 use crate::service::{ServiceApp, ServiceState};
+use crate::utils::ApiErrorResponse;
 
 /// Headers that this endpoint must handle and cannot forward.
 static HOP_BY_HOP_HEADERS: &[HeaderName] = &[
@@ -71,10 +72,11 @@ impl ResponseError for ForwardedUpstreamRequestError {
                             .unwrap(),
                     )
                 }
-                HttpError::Actix(e) => e.as_response_error().error_response(),
                 HttpError::Io(_) => HttpResponse::BadGateway().finish(),
-                HttpError::ActixPayload(e) => e.error_response(),
-                HttpError::ActixJson(e) => e.error_response(),
+                HttpError::Json(e) => e.error_response(),
+                HttpError::Custom(e) => {
+                    HttpResponse::InternalServerError().json(&ApiErrorResponse::from_fail(e))
+                }
             },
             UpstreamRequestError::SendFailed(e) => {
                 if e.is_timeout() {
@@ -162,10 +164,7 @@ pub fn forward_upstream(
                     }
 
                     builder.header("X-Forwarded-For", forwarded_for.as_ref());
-
-                    builder
-                        .body(data.clone().into())
-                        .map_err(UpstreamRequestError::Http)
+                    builder.body(&data).map_err(UpstreamRequestError::Http)
                 })
                 .transform(move |response: Response| {
                     let status = response.status();
@@ -186,7 +185,8 @@ pub fn forward_upstream(
         })
         .and_then(move |result: Result<_, UpstreamRequestError>| {
             let (status, headers, body) = result.map_err(ForwardedUpstreamRequestError::from)?;
-            let mut forwarded_response = HttpResponse::build(status);
+            let actix_code = StatusCode::from_u16(status.as_u16()).unwrap();
+            let mut forwarded_response = HttpResponse::build(actix_code);
 
             let mut has_content_type = false;
 


### PR DESCRIPTION
Further cleanup of leftovers from when the actix_web client was used for client
requests.

#skip-changelog

