### PR TITLE
feat(ci): Add musl-based static build for Linux

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -9,6 +9,14 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        libc: [gnu, musl]
+        include:
+          - libc: gnu
+            suffix: ""
+          - libc: musl
+            suffix: "-musl"
 
     steps:
       - uses: actions/checkout@v2
@@ -19,18 +27,19 @@ jobs:
         run: scripts/docker-build-linux.sh
         env:
           BUILD_ARCH: x86_64
+          BUILD_LIBC: ${{ matrix.libc }}
           RELAY_FEATURES: ssl
 
       - name: Bundle Debug File
         run: |
-          cd target/x86_64-unknown-linux-gnu/release/
-          zip relay-Linux-x86_64-debug.zip relay.debug
-          mv relay relay-Linux-x86_64
+          cd target/x86_64-unknown-linux-${{ matrix.libc }}/release/
+          zip relay-Linux${{ matrix.suffix }}-x86_64-debug.zip relay.debug
+          mv relay relay-Linux${{ matrix.suffix }}-x86_64
 
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
-          path: target/x86_64-unknown-linux-gnu/release/relay-Linux-x86_64*
+          path: target/x86_64-unknown-linux-${{ matrix.libc }}/release/relay-Linux${{ matrix.suffix }}-x86_64*
 
   macos:
     name: macOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DOCKER_ARCH=amd64
 ### Deps stage ###
 ##################
 
-FROM $DOCKER_ARCH/rust:slim-buster AS relay-deps
+FROM $DOCKER_ARCH/rust:alpine AS relay-deps
 
 ARG DOCKER_ARCH
 ARG BUILD_ARCH=x86_64
@@ -12,13 +12,9 @@ ARG BUILD_ARCH=x86_64
 ENV DOCKER_ARCH=${DOCKER_ARCH}
 ENV BUILD_ARCH=${BUILD_ARCH}
 
-ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
+ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-musl
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-    curl build-essential git zip cmake \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl gcc g++ git cmake make bash musl-dev perl zip
 
 WORKDIR /work
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,76 @@
+ARG DOCKER_ARCH=amd64
+
+##################
+### Deps stage ###
+##################
+
+FROM $DOCKER_ARCH/rust:alpine AS relay-deps
+
+ARG DOCKER_ARCH
+ARG BUILD_ARCH=x86_64
+
+ENV DOCKER_ARCH=${DOCKER_ARCH}
+ENV BUILD_ARCH=${BUILD_ARCH}
+
+ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-musl
+
+RUN apk add --no-cache curl gcc g++ git cmake make bash musl-dev perl zip
+
+WORKDIR /work
+
+#####################
+### Builder stage ###
+#####################
+
+FROM getsentry/sentry-cli:1 AS sentry-cli
+FROM relay-deps AS relay-builder
+
+ARG RELAY_FEATURES=ssl,processing
+ENV RELAY_FEATURES=${RELAY_FEATURES}
+
+COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
+COPY . .
+
+# BUILD IT!
+RUN make build-linux-release TARGET=${BUILD_TARGET} RELAY_FEATURES=${RELAY_FEATURES}
+
+RUN cp ./target/$BUILD_TARGET/release/relay /bin/relay \
+    && zip /opt/relay-debug.zip target/$BUILD_TARGET/release/relay.debug
+
+# Collect source bundle
+RUN sentry-cli --version \
+    && sentry-cli difutil bundle-sources ./target/$BUILD_TARGET/release/relay.debug \
+    && mv ./target/$BUILD_TARGET/release/relay.src.zip /opt/relay.src.zip
+
+###################
+### Final stage ###
+###################
+
+FROM debian:buster-slim
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates gosu curl --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV \
+    RELAY_UID=10001 \
+    RELAY_GID=10001
+
+# Create a new user and group with fixed uid/gid
+RUN groupadd --system relay --gid $RELAY_GID \
+    && useradd --system --gid relay --uid $RELAY_UID relay
+
+RUN mkdir /work /etc/relay \
+    && chown relay:relay /work /etc/relay
+VOLUME ["/work", "/etc/relay"]
+WORKDIR /work
+
+EXPOSE 3000
+
+COPY --from=relay-builder /bin/relay /bin/relay
+COPY --from=relay-builder /opt/relay-debug.zip /opt/relay.src.zip /opt/
+
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]
+CMD ["run"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -4,7 +4,7 @@ ARG DOCKER_ARCH=amd64
 ### Deps stage ###
 ##################
 
-FROM $DOCKER_ARCH/rust:alpine AS relay-deps
+FROM $DOCKER_ARCH/rust:slim-buster AS relay-deps
 
 ARG DOCKER_ARCH
 ARG BUILD_ARCH=x86_64
@@ -12,9 +12,13 @@ ARG BUILD_ARCH=x86_64
 ENV DOCKER_ARCH=${DOCKER_ARCH}
 ENV BUILD_ARCH=${BUILD_ARCH}
 
-ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-musl
+ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
 
-RUN apk add --no-cache curl gcc g++ git cmake make bash musl-dev perl zip
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+    curl build-essential git zip cmake \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
 

--- a/scripts/docker-build-linux.sh
+++ b/scripts/docker-build-linux.sh
@@ -10,7 +10,7 @@ else
   exit 1
 fi
 
-BUILD_LIBC="${BUILD_LIBC:-gnu}"
+BUILD_LIBC="${BUILD_LIBC:-musl}"
 if [ "${BUILD_LIBC}" = "gnu" ]; then
   DOCKERFILE="Dockerfile"
 elif [ "${BUILD_LIBC}" = "musl" ]; then

--- a/scripts/docker-build-linux.sh
+++ b/scripts/docker-build-linux.sh
@@ -12,9 +12,9 @@ fi
 
 BUILD_LIBC="${BUILD_LIBC:-musl}"
 if [ "${BUILD_LIBC}" = "gnu" ]; then
-  DOCKERFILE="Dockerfile"
+  DOCKERFILE="Dockerfile.debian"
 elif [ "${BUILD_LIBC}" = "musl" ]; then
-  DOCKERFILE="Dockerfile.alpine"
+  DOCKERFILE="Dockerfile"
 else
   echo "Invalid libc: ${BUILD_LIBC}"
   exit 1


### PR DESCRIPTION
Up until now, CI builds of Relay were only performed on Ubuntu with glibc. Musl libc is better suited for static builds, which can then be run in more environments.

#skip-changelog