### PR TITLE
Update to Cadence 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,11 +404,11 @@ checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
 
 [[package]]
 name = "cadence"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6281d1200ac3293fd08be899c9a0c17b83cda0672221fcbe1fefc886a555e35e"
+checksum = "a7685b737fff763407351ce3a0d18c980a68e154b36f2d0b0fafebbac47de032"
 dependencies = [
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel 0.5.1",
 ]
 
 [[package]]
@@ -668,12 +668,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -731,6 +731,16 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 backoff = "0.1.6"
-cadence = "0.22.0"
+cadence = "0.26.0"
 chrono = "0.4.11"
 failure = "0.1.8"
 globset = "0.4.5"

--- a/relay-common/src/metrics.rs
+++ b/relay-common/src/metrics.rs
@@ -536,7 +536,7 @@ macro_rules! metric {
         $crate::metrics::with_client(|client| {
             use $crate::metrics::_pred::*;
             client.send_metric(
-                client.time_duration_with_tags(&$crate::metrics::TimerMetric::name(&$id), $value)
+                client.time_with_tags(&$crate::metrics::TimerMetric::name(&$id), $value)
                     $(.with_tag(stringify!($k), $v))*
             )
         })
@@ -549,7 +549,7 @@ macro_rules! metric {
         $crate::metrics::with_client(|client| {
             use $crate::metrics::_pred::*;
             client.send_metric(
-                client.time_duration_with_tags(&$crate::metrics::TimerMetric::name(&$id), now.elapsed())
+                client.time_with_tags(&$crate::metrics::TimerMetric::name(&$id), now.elapsed())
                     $(.with_tag(stringify!($k), $v))*
             )
         });

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -646,7 +646,7 @@ impl UpstreamRelay {
         }
 
         metric!(
-            histogram(RelayHistograms::UpstreamRetries) = request.previous_retries.into(),
+            histogram(RelayHistograms::UpstreamRetries) = request.previous_retries as u64,
             result = result,
             status_code = status_code,
             route = request.route_name(),


### PR DESCRIPTION
Update to Cadence 0.26 which includes a breaking change and deprecation of type-specific methods

Signed-off-by: Nick Pillitteri <nick@56quarters.xyz>

#skip-changelog