### PR TITLE
fix: Apply clippy 1.54 suggestions

### DIFF
--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -225,7 +225,7 @@ impl SecretKey {
         // this can only fail if we deal with badly formed data.  In that case we
         // consider that a panic.  Should not happen.
         let json = serde_json::to_vec(&data).expect("attempted to pack non json safe data");
-        let sig = self.sign_with_header(&json, &header);
+        let sig = self.sign_with_header(&json, header);
         (json, sig)
     }
 }
@@ -333,8 +333,8 @@ impl PublicKey {
         data: &[u8],
         signature: &str,
     ) -> Result<(SignatureHeader, D), UnpackError> {
-        if let Some(header) = self.verify_meta(&data, signature) {
-            serde_json::from_slice(&data)
+        if let Some(header) = self.verify_meta(data, signature) {
+            serde_json::from_slice(data)
                 .map(|data| (header, data))
                 .map_err(UnpackError::BadPayload)
         } else {
@@ -749,7 +749,7 @@ fn test_signatures() {
 
     let bad_sig =
         "jgubwSf2wb2wuiRpgt2H9_bdDSMr88hXLp5zVuhbr65EGkSxOfT5ILIWr623twLgLd0bDgHg6xzOaUCX7XvUCw";
-    assert!(!pk.verify(data, &bad_sig));
+    assert!(!pk.verify(data, bad_sig));
 }
 
 #[test]

--- a/relay-common/src/cell.rs
+++ b/relay-common/src/cell.rs
@@ -51,7 +51,7 @@ impl<T> UpsertingLazyCell<T> {
 
     /// Try to get a cached value or create one by calling `f()`.
     pub fn get_or_insert_with(&self, f: impl FnOnce() -> T) -> LazyCellRef<'_, T> {
-        if let Some(ref value) = self.0.borrow() {
+        if let Some(value) = self.0.borrow() {
             return LazyCellRef::Borrowed(value);
         }
 
@@ -66,7 +66,7 @@ impl<T> UpsertingLazyCell<T> {
 
         // The lazy cell was filled successfully, so the `borrow()` should never fail.
         match self.0.borrow() {
-            Some(ref value) => LazyCellRef::Borrowed(value),
+            Some(value) => LazyCellRef::Borrowed(value),
             None => unreachable!(),
         }
     }

--- a/relay-common/src/glob.rs
+++ b/relay-common/src/glob.rs
@@ -118,7 +118,7 @@ fn test_globs() {
     test_glob!("foo\nbar", "foo*", true, {allow_newline: true});
     test_glob!("1.18.4.2153-2aa83397b", "1.18.[0-4].*", true, {});
 
-    let mut long_string = std::iter::repeat('x').take(1_000_000).collect::<String>();
+    let mut long_string = "x".repeat(1_000_000);
     long_string.push_str(".PY");
     test_glob!(&long_string, "*************************.py", true, {double_star: true, case_insensitive: true, path_normalize: true});
     test_glob!(&long_string, "*************************.js", false, {double_star: true, case_insensitive: true, path_normalize: true});

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -52,7 +52,7 @@ impl GlobPatterns {
         let mut globs = Vec::with_capacity(self.patterns.len());
 
         for pattern in &self.patterns {
-            let glob_result = GlobBuilder::new(&pattern)
+            let glob_result = GlobBuilder::new(pattern)
                 .case_insensitive(true)
                 .backslash_escape(true)
                 .build();

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -94,7 +94,7 @@ impl Serialize for LegacyBrowser {
             LegacyBrowser::OperaMiniPre8 => "opera_mini_pre_8",
             LegacyBrowser::AndroidPre4 => "android_pre_4",
             LegacyBrowser::SafariPre6 => "safari_pre_6",
-            LegacyBrowser::Unknown(string) => &string,
+            LegacyBrowser::Unknown(string) => string,
         })
     }
 }

--- a/relay-filter/src/localhost.rs
+++ b/relay-filter/src/localhost.rs
@@ -85,7 +85,7 @@ mod tests {
             get_event_with_ip_addr("127.0.0.1"),
             get_event_with_domain("localhost"),
         ] {
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: false });
+            let filter_result = should_filter(event, &FilterConfig { is_enabled: false });
             assert_eq!(
                 filter_result,
                 Ok(()),

--- a/relay-general/derive/src/empty.rs
+++ b/relay-general/derive/src/empty.rs
@@ -10,7 +10,7 @@ pub fn derive_empty(mut s: synstructure::Structure<'_>) -> TokenStream {
         let mut is_tuple_struct = false;
         let mut cond = quote!(true);
         for (index, bi) in variant.bindings().iter().enumerate() {
-            let field_attrs = parse_field_attributes(index, &bi.ast(), &mut is_tuple_struct);
+            let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct);
             let ident = &bi.binding;
             if field_attrs.additional_properties {
                 cond = quote! {
@@ -37,7 +37,7 @@ pub fn derive_empty(mut s: synstructure::Structure<'_>) -> TokenStream {
         let mut cond = quote!(true);
         let mut is_tuple_struct = false;
         for (index, bi) in variant.bindings().iter().enumerate() {
-            let field_attrs = parse_field_attributes(index, &bi.ast(), &mut is_tuple_struct);
+            let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct);
             let ident = &bi.binding;
             let skip_serialization_attr = field_attrs.skip_serialization.as_tokens();
 

--- a/relay-general/derive/src/jsonschema.rs
+++ b/relay-general/derive/src/jsonschema.rs
@@ -47,7 +47,7 @@ pub fn derive_jsonschema(mut s: synstructure::Structure<'_>) -> TokenStream {
         // parse_variant_attributes currently cannot deal with struct attributes. Structs are
         // represented as single-variant enums in synstructure.
         if !is_single_variant {
-            let variant_attrs = parse_variant_attributes(&variant.ast().attrs);
+            let variant_attrs = parse_variant_attributes(variant.ast().attrs);
 
             if variant_attrs.omit_from_schema {
                 continue;
@@ -59,7 +59,7 @@ pub fn derive_jsonschema(mut s: synstructure::Structure<'_>) -> TokenStream {
         let mut is_tuple_struct = false;
 
         for (index, bi) in variant.bindings().iter().enumerate() {
-            let field_attrs = parse_field_attributes(index, &bi.ast(), &mut is_tuple_struct);
+            let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct);
             let name = field_attrs.field_name;
 
             let mut ast = bi.ast().clone();

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -69,7 +69,7 @@ fn derive_newtype_metastructure(
 
     let _process_func_call_tokens = type_attrs.process_func_call_tokens();
 
-    let field_attrs = parse_field_attributes(0, &s.variants()[0].bindings()[0].ast(), &mut true);
+    let field_attrs = parse_field_attributes(0, s.variants()[0].bindings()[0].ast(), &mut true);
     let skip_serialization_attr = field_attrs.skip_serialization.as_tokens();
     let _field_attrs_tokens = field_attrs.as_tokens(Some(quote!(parent_attrs)));
 
@@ -140,7 +140,7 @@ fn derive_enum_metastructure(
     let mut extract_child_meta_body = TokenStream::new();
 
     for variant in s.variants() {
-        let variant_attrs = parse_variant_attributes(&variant.ast().attrs);
+        let variant_attrs = parse_variant_attributes(variant.ast().attrs);
         let variant_name = &variant.ast().ident;
         let tag = variant_attrs
             .tag_override
@@ -294,7 +294,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
     let mut is_tuple_struct = false;
 
     for (index, bi) in variant.bindings().iter().enumerate() {
-        let field_attrs = parse_field_attributes(index, &bi.ast(), &mut is_tuple_struct);
+        let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct);
         let field_name = field_attrs.field_name.clone();
 
         let skip_serialization_attr = field_attrs.skip_serialization.as_tokens();
@@ -346,7 +346,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
                 .to_tokens(&mut from_value_body);
 
                 for legacy_alias in &field_attrs.legacy_aliases {
-                    let legacy_field_name = LitStr::new(&legacy_alias, Span::call_site());
+                    let legacy_field_name = LitStr::new(legacy_alias, Span::call_site());
                     (quote! {
                         let #bi = #bi.or(__obj.remove(#legacy_field_name));
                     })
@@ -554,7 +554,7 @@ struct TypeAttrs {
 impl TypeAttrs {
     fn process_func_call_tokens(&self) -> TokenStream {
         if let Some(ref func_name) = self.process_func {
-            let func_name = Ident::new(&func_name, Span::call_site());
+            let func_name = Ident::new(func_name, Span::call_site());
             quote! {
                 __processor.#func_name(self, __meta, __state)?;
             }

--- a/relay-general/derive/src/process.rs
+++ b/relay-general/derive/src/process.rs
@@ -73,7 +73,7 @@ pub fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
 
         let mut body = TokenStream::new();
         for (index, bi) in variant.bindings().iter().enumerate() {
-            let field_attrs = parse_field_attributes(index, &bi.ast(), &mut is_tuple_struct);
+            let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct);
             let ident = &bi.binding;
             let field_attrs_name = Ident::new(&format!("FIELD_ATTRS_{}", index), Span::call_site());
             let field_name = field_attrs.field_name.clone();

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -391,7 +391,7 @@ impl<'a> PiiAttachmentsProcessor<'a> {
         let mut changed = false;
 
         for (selector, rules) in &self.compiled_config.applications {
-            if state.path().matches_selector(&selector) {
+            if state.path().matches_selector(selector) {
                 for rule in rules {
                     // Note:
                     //

--- a/relay-general/src/pii/compiledconfig.rs
+++ b/relay-general/src/pii/compiledconfig.rs
@@ -20,7 +20,7 @@ impl CompiledPiiConfig {
             #[allow(clippy::mutable_key_type)]
             let mut rule_set = BTreeSet::default();
             for rule_id in rules {
-                collect_rules(config, &mut rule_set, &rule_id, None);
+                collect_rules(config, &mut rule_set, rule_id, None);
             }
             applications.push((selector.clone(), rule_set));
         }
@@ -68,7 +68,7 @@ fn collect_rules(
                 None
             };
             for rule_id in &m.rules {
-                collect_rules(config, rules, &rule_id, parent.clone());
+                collect_rules(config, rules, rule_id, parent.clone());
             }
         }
         RuleType::Alias(ref a) => {

--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -226,6 +226,6 @@ impl PiiConfig {
     /// else.
     #[inline]
     pub fn compiled_uncached(&self) -> CompiledPiiConfig {
-        CompiledPiiConfig::new(&self)
+        CompiledPiiConfig::new(self)
     }
 }

--- a/relay-general/src/pii/legacy.rs
+++ b/relay-general/src/pii/legacy.rs
@@ -69,6 +69,6 @@ impl DataScrubbingConfig {
     /// else.
     #[inline]
     pub fn pii_config_uncached(&self) -> Option<PiiConfig> {
-        convert::to_pii_config(&self)
+        convert::to_pii_config(self)
     }
 }

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -297,15 +297,15 @@ fn apply_regex_to_chunks<'a>(
                                 &mut rv,
                                 &mut replacement_chunks,
                             );
-                            insert_replacement_chunks(&rule, g.as_str(), &mut rv);
+                            insert_replacement_chunks(rule, g.as_str(), &mut rv);
                             pos = g.end();
                         }
                     }
                 }
             }
             ReplaceBehavior::Value => {
-                process_text(&"", &mut rv, &mut replacement_chunks);
-                insert_replacement_chunks(&rule, &search_string, &mut rv);
+                process_text("", &mut rv, &mut replacement_chunks);
+                insert_replacement_chunks(rule, &search_string, &mut rv);
                 pos = search_string.len();
                 break;
             }

--- a/relay-general/src/pii/utils.rs
+++ b/relay-general/src/pii/utils.rs
@@ -19,7 +19,7 @@ pub fn process_pairlist<P: Processor, T: ProcessValue + AsPair>(
     for (idx, annotated) in value.iter_mut().enumerate() {
         if let Some(ref mut pair) = annotated.value_mut() {
             let (ref mut key, ref mut value) = pair.as_pair_mut();
-            if let Some(ref key_name) = key.as_str() {
+            if let Some(key_name) = key.as_str() {
                 // if the pair has no key name, we skip over it for PII stripping. It is
                 // still processed with index-based path in the invocation of
                 // `process_child_values`.

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -322,7 +322,7 @@ enum PathItem<'a> {
 impl<'a> PartialEq for PathItem<'a> {
     fn eq(&self, other: &PathItem<'a>) -> bool {
         match *self {
-            PathItem::StaticKey(ref s) => other.key() == Some(s),
+            PathItem::StaticKey(s) => other.key() == Some(s),
             PathItem::Index(value) => other.index() == Some(value),
         }
     }
@@ -467,7 +467,7 @@ impl<'a> ProcessingState<'a> {
 
     /// Returns the path in the processing state.
     pub fn path(&'a self) -> Path<'a> {
-        Path(&self)
+        Path(self)
     }
 
     pub fn value_type(&self) -> EnumSet<ValueType> {
@@ -477,7 +477,7 @@ impl<'a> ProcessingState<'a> {
     /// Returns the field attributes.
     pub fn attrs(&self) -> &FieldAttrs {
         match self.attrs {
-            Some(ref cow) => &cow,
+            Some(ref cow) => cow,
             None => &DEFAULT_FIELD_ATTRS,
         }
     }
@@ -511,7 +511,7 @@ impl<'a> ProcessingState<'a> {
     ///
     /// This is `false` when we entered a newtype struct.
     pub fn entered_anything(&'a self) -> bool {
-        if let Some(ref parent) = self.parent {
+        if let Some(parent) = self.parent {
             parent.depth() != self.depth()
         } else {
             true

--- a/relay-general/src/processor/chunks.rs
+++ b/relay-general/src/processor/chunks.rs
@@ -54,8 +54,8 @@ impl<'a> Chunk<'a> {
     /// The text of this chunk.
     pub fn as_str(&self) -> &str {
         match self {
-            Chunk::Text { text } => &text,
-            Chunk::Redaction { text, .. } => &text,
+            Chunk::Text { text } => text,
+            Chunk::Redaction { text, .. } => text,
         }
     }
 
@@ -161,7 +161,7 @@ pub fn process_chunked_value<F>(value: &mut String, meta: &mut Meta, f: F)
 where
     F: FnOnce(Vec<Chunk>) -> Vec<Chunk>,
 {
-    let chunks = split_chunks(&value, meta.iter_remarks());
+    let chunks = split_chunks(value, meta.iter_remarks());
     let (new_value, remarks) = join_chunks(f(chunks));
 
     if new_value != *value {

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -220,7 +220,7 @@ impl FromValue for HeaderValue {
                             header_value.push(',');
                         }
 
-                        header_value.push_str(&string);
+                        header_value.push_str(string);
                     }
                 }
 

--- a/relay-general/src/protocol/security_report.rs
+++ b/relay-general/src/protocol/security_report.rs
@@ -360,7 +360,7 @@ impl CspRaw {
         // Now we need to stitch on a scheme to the value, but let's not stitch on the boring
         // values.
         let original_uri = match self.document_uri {
-            Some(ref u) => &u,
+            Some(ref u) => u,
             None => "",
         };
 

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -107,7 +107,7 @@ impl<'a> NormalizeProcessor<'a> {
     fn normalize_breakdowns(&self, event: &mut Event) {
         match &self.config.breakdowns {
             None => {}
-            Some(breakdowns_config) => breakdowns::normalize_breakdowns(event, &breakdowns_config),
+            Some(breakdowns_config) => breakdowns::normalize_breakdowns(event, breakdowns_config),
         }
     }
 
@@ -371,7 +371,7 @@ impl<'a> NormalizeProcessor<'a> {
     }
 
     fn normalize_exceptions(&self, event: &mut Event) -> ProcessingResult {
-        let os_hint = mechanism::OsHint::from_event(&event);
+        let os_hint = mechanism::OsHint::from_event(event);
 
         if let Some(exception_values) = event.exceptions.value_mut() {
             if let Some(exceptions) = exception_values.values.value_mut() {
@@ -446,7 +446,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
 
         // Validate basic attributes
         event.platform.apply(|platform, _| {
-            if is_valid_platform(&platform) {
+            if is_valid_platform(platform) {
                 Ok(())
             } else {
                 Err(ProcessingAction::DeleteValueSoft)
@@ -454,7 +454,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         })?;
 
         event.environment.apply(|environment, meta| {
-            if protocol::validate_environment(&environment).is_ok() {
+            if protocol::validate_environment(environment).is_ok() {
                 Ok(())
             } else {
                 meta.add_error(ErrorKind::InvalidData);
@@ -463,7 +463,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         })?;
 
         event.release.apply(|release, meta| {
-            if protocol::validate_release(&release).is_ok() {
+            if protocol::validate_release(release).is_ok() {
                 Ok(())
             } else {
                 meta.add_error(ErrorKind::InvalidData);
@@ -544,7 +544,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
 
         // Infer user.geo from user.ip_address
         if user.geo.value().is_none() {
-            if let Some(ref geoip_lookup) = self.geoip_lookup {
+            if let Some(geoip_lookup) = self.geoip_lookup {
                 if let Some(ip_address) = user.ip_address.value() {
                     if let Ok(Some(geo)) = geoip_lookup.lookup(ip_address.as_str()) {
                         user.geo.set_value(Some(geo));

--- a/relay-general/src/store/normalize/breakdowns.rs
+++ b/relay-general/src/store/normalize/breakdowns.rs
@@ -244,7 +244,7 @@ pub fn normalize_breakdowns(event: &mut Event, breakdowns_config: &BreakdownsCon
 
     for (breakdown_name, breakdown_config) in breakdowns_config.iter() {
         // TODO: move this to deserialization in a follow-up.
-        if !Breakdowns::is_valid_breakdown_name(&breakdown_name) {
+        if !Breakdowns::is_valid_breakdown_name(breakdown_name) {
             continue;
         }
 

--- a/relay-general/src/store/normalize/request.rs
+++ b/relay-general/src/store/normalize/request.rs
@@ -79,7 +79,7 @@ fn normalize_url(request: &mut Request) {
 fn normalize_method(method: &mut String, meta: &mut Meta) -> ProcessingResult {
     method.make_ascii_uppercase();
 
-    if !meta.has_errors() && !METHOD_RE.is_match(&method) {
+    if !meta.has_errors() && !METHOD_RE.is_match(method) {
         meta.add_error(ErrorKind::InvalidData);
         return Err(ProcessingAction::DeleteValueSoft);
     }
@@ -151,7 +151,7 @@ fn normalize_data(request: &mut Request) {
             .headers
             .value()
             .and_then(|headers| headers.get_header("Content-Type"))
-            .map(|value| value.split(';').next().unwrap_or(&value).to_string())
+            .map(|value| value.split(';').next().unwrap_or(value).to_string())
             .into();
     }
 }

--- a/relay-general/src/store/schema.rs
+++ b/relay-general/src/store/schema.rs
@@ -12,9 +12,9 @@ impl Processor for SchemaProcessor {
         meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        value_trim_whitespace(value, meta, &state);
-        verify_value_nonempty(value, meta, &state)?;
-        verify_value_characters(value, meta, &state)?;
+        value_trim_whitespace(value, meta, state);
+        verify_value_nonempty(value, meta, state)?;
+        verify_value_characters(value, meta, state)?;
         Ok(())
     }
 

--- a/relay-general/src/store/trimming.rs
+++ b/relay-general/src/store/trimming.rs
@@ -422,18 +422,17 @@ fn test_basic_trimming() {
     use crate::types::Annotated;
 
     use crate::processor::MaxChars;
-    use std::iter::repeat;
 
     let mut processor = TrimmingProcessor::new();
 
     let mut event = Annotated::new(Event {
-        culprit: Annotated::new(repeat("x").take(300).collect::<String>()),
+        culprit: Annotated::new("x".repeat(300)),
         ..Default::default()
     });
 
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
-    let mut expected = Annotated::new(repeat("x").take(300).collect::<String>());
+    let mut expected = Annotated::new("x".repeat(300));
     expected
         .apply(|v, m| {
             trim_string(v, m, MaxChars::Culprit);
@@ -521,7 +520,6 @@ fn test_databag_array_stripping() {
     use crate::protocol::{Event, ExtraValue};
     use crate::types::{Annotated, SerializableAnnotated, Value};
     use insta::assert_ron_snapshot;
-    use std::iter::repeat;
 
     let mut processor = TrimmingProcessor::new();
 
@@ -530,9 +528,7 @@ fn test_databag_array_stripping() {
         for idx in 0..100 {
             map.insert(
                 format!("key_{}", idx),
-                Annotated::new(ExtraValue(Value::String(
-                    repeat("x").take(50000).collect::<String>(),
-                ))),
+                Annotated::new(ExtraValue(Value::String("x".repeat(50000)))),
             );
         }
         map
@@ -552,15 +548,14 @@ fn test_databag_array_stripping() {
 fn test_tags_stripping() {
     use crate::protocol::{Event, TagEntry, Tags};
     use crate::types::Annotated;
-    use std::iter::repeat;
 
     let mut processor = TrimmingProcessor::new();
 
     let mut event = Annotated::new(Event {
         tags: Annotated::new(Tags(
             vec![Annotated::new(TagEntry(
-                Annotated::new(repeat("x").take(200).collect()),
-                Annotated::new(repeat("x").take(300).collect()),
+                Annotated::new("x".repeat(200)),
+                Annotated::new("x".repeat(300)),
             ))]
             .into(),
         )),
@@ -644,8 +639,6 @@ fn test_databag_state_leak() {
 
 #[test]
 fn test_custom_context_trimming() {
-    use std::iter::repeat;
-
     use crate::protocol::{Context, ContextInner, Contexts};
     use crate::types::{Annotated, Object, Value};
 
@@ -655,11 +648,11 @@ fn test_custom_context_trimming() {
             let mut context = Object::new();
             context.insert(
                 "foo".to_string(),
-                Annotated::new(Value::String(repeat('a').take(4000).collect())),
+                Annotated::new(Value::String("a".repeat(4000))),
             );
             context.insert(
                 "bar".to_string(),
-                Annotated::new(Value::String(repeat('a').take(5000).collect())),
+                Annotated::new(Value::String("a".repeat(5000))),
             );
             Annotated::new(ContextInner(Context::Other(context)))
         });

--- a/relay-general/src/types/meta.rs
+++ b/relay-general/src/types/meta.rs
@@ -191,7 +191,7 @@ impl ErrorKind {
             ErrorKind::PastTimestamp => "past_timestamp",
             ErrorKind::FutureTimestamp => "future_timestamp",
             ErrorKind::ClockDrift => "clock_drift",
-            ErrorKind::Unknown(error) => &error,
+            ErrorKind::Unknown(error) => error,
         }
     }
 }

--- a/relay-general/src/user_agent.rs
+++ b/relay-general/src/user_agent.rs
@@ -21,7 +21,7 @@ use crate::protocol::{Event, Headers};
 fn get_user_agent_from_headers(headers: &Headers) -> Option<&str> {
     for item in headers.iter() {
         if let Some((ref o_k, ref v)) = item.value() {
-            if let Some(ref k) = o_k.as_str() {
+            if let Some(k) = o_k.as_str() {
                 if k.to_lowercase() == "user-agent" {
                     return v.as_str();
                 }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -53,7 +53,7 @@ pub struct ItemScoping<'a> {
 
 impl AsRef<Scoping> for ItemScoping<'_> {
     fn as_ref(&self) -> &Scoping {
-        &self.scoping
+        self.scoping
     }
 }
 
@@ -61,7 +61,7 @@ impl std::ops::Deref for ItemScoping<'_> {
     type Target = Scoping;
 
     fn deref(&self) -> &Self::Target {
-        &self.scoping
+        self.scoping
     }
 }
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -360,11 +360,11 @@ impl FieldValueProvider for Event {
                     }
                 })
             }),
-            "event.is_local_ip" => Value::Bool(relay_filter::localhost::matches(&self)),
+            "event.is_local_ip" => Value::Bool(relay_filter::localhost::matches(self)),
             "event.has_bad_browser_extensions" => {
-                Value::Bool(relay_filter::browser_extensions::matches(&self))
+                Value::Bool(relay_filter::browser_extensions::matches(self))
             }
-            "event.web_crawlers" => Value::Bool(relay_filter::web_crawlers::matches(&self)),
+            "event.web_crawlers" => Value::Bool(relay_filter::web_crawlers::matches(self)),
             _ => Value::Null,
         }
     }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -771,7 +771,7 @@ impl EnvelopeProcessor {
         if let Err(json_error) = apply_result {
             // logged in extract_event
             relay_log::configure_scope(|scope| {
-                scope.set_extra("payload", String::from_utf8_lossy(&data).into());
+                scope.set_extra("payload", String::from_utf8_lossy(data).into());
             });
 
             return Err(ProcessingError::InvalidSecurityReport(json_error));

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -545,7 +545,7 @@ impl UpstreamRelay {
         builder.header("Host", host_header.as_bytes());
 
         if request.config.set_relay_id {
-            if let Some(ref credentials) = self.config.credentials() {
+            if let Some(credentials) = self.config.credentials() {
                 builder.header("X-Sentry-Relay-Id", credentials.id.to_string().as_bytes());
             }
         }

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -18,7 +18,7 @@ fn extract_envelope(
     meta: RequestMeta,
 ) -> ResponseFuture<Envelope, BadStoreRequest> {
     let max_payload_size = request.state().config().max_envelope_size();
-    let future = StoreBody::new(&request, max_payload_size)
+    let future = StoreBody::new(request, max_payload_size)
         .map_err(BadStoreRequest::PayloadError)
         .and_then(move |data| {
             if data.is_empty() {

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -25,7 +25,7 @@ fn extract_envelope(
     params: SecurityReportParams,
 ) -> ResponseFuture<Envelope, BadStoreRequest> {
     let max_payload_size = request.state().config().max_event_size();
-    let future = StoreBody::new(&request, max_payload_size)
+    let future = StoreBody::new(request, max_payload_size)
         .map_err(BadStoreRequest::PayloadError)
         .and_then(move |data| {
             if data.is_empty() {

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -79,7 +79,7 @@ fn extract_envelope(
         content_type => ContentType::from(content_type),
     };
 
-    let future = StoreBody::new(&request, max_payload_size)
+    let future = StoreBody::new(request, max_payload_size)
         .map_err(BadStoreRequest::PayloadError)
         .and_then(move |data| {
             if data.is_empty() {

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -168,7 +168,7 @@ impl ContentType {
             Self::Minidump => "application/x-dmp",
             Self::Xml => "text/xml",
             Self::Envelope => self::CONTENT_TYPE,
-            Self::Other(ref other) => &other,
+            Self::Other(ref other) => other,
         }
     }
 
@@ -206,7 +206,7 @@ impl From<String> for ContentType {
 
 impl From<&'_ str> for ContentType {
     fn from(content_type: &str) -> Self {
-        Self::from_str(&content_type)
+        Self::from_str(content_type)
             .unwrap_or_else(|| ContentType::Other(content_type.to_ascii_lowercase()))
     }
 }
@@ -1041,8 +1041,7 @@ mod tests {
         assert_eq!(envelope.len(), 0);
         assert!(envelope.is_empty());
 
-        let items: Vec<_> = envelope.items().collect();
-        assert!(items.is_empty());
+        assert!(envelope.items().next().is_none());
     }
 
     #[test]

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -56,7 +56,7 @@ impl<S> Middleware<S> for Metrics {
         );
         metric!(
             counter(RelayCounters::ResponsesStatusCodes) += 1,
-            status_code = &resp.status().as_str(),
+            status_code = resp.status().as_str(),
             route = req.resource().name(),
             method = req.method().as_str()
         );
@@ -204,7 +204,7 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
                     let with_pii = client
                         .as_ref()
                         .map_or(false, |x| x.options().send_default_pii);
-                    *cached_data = Some(extract_request(&req.get(), with_pii));
+                    *cached_data = Some(extract_request(req.get(), with_pii));
                 }
 
                 if let Some((ref transaction, ref req)) = *cached_data {

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -121,7 +121,7 @@ impl ServiceState {
 
         let redis_pool = match config.redis() {
             Some(redis_config) if config.processing_enabled() => {
-                Some(RedisPool::new(&redis_config).context(ServerErrorKind::RedisError)?)
+                Some(RedisPool::new(redis_config).context(ServerErrorKind::RedisError)?)
             }
             _ => None,
         };

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -39,7 +39,7 @@ pub fn should_keep_event(
         Some(EventId(id)) => id,
     };
 
-    let ty = rule_type_for_event(&event);
+    let ty = rule_type_for_event(event);
     if let Some(rule) = get_matching_event_rule(sampling_config, event, ip_addr, ty) {
         let random_number = pseudo_random_from_uuid(event_id);
         if random_number < rule.sample_rate {

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -101,11 +101,11 @@ impl<'a> FormDataEntry<'a> {
     }
 
     pub fn key(&self) -> &'a str {
-        &self.0
+        self.0
     }
 
     pub fn value(&self) -> &'a str {
-        &self.1
+        self.1
     }
 
     fn to_writer<W: io::Write>(&self, mut writer: W) {

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -23,10 +23,10 @@ pub fn execute() -> Result<(), Error> {
     // Commands that do not need to load the config:
     if let Some(matches) = matches.subcommand_matches("config") {
         if let Some(matches) = matches.subcommand_matches("init") {
-            return init_config(&config_path, &matches);
+            return init_config(&config_path, matches);
         }
     } else if let Some(matches) = matches.subcommand_matches("generate-completions") {
-        return generate_completions(&matches);
+        return generate_completions(matches);
     }
 
     // Commands that need a loaded config:
@@ -37,14 +37,14 @@ pub fn execute() -> Result<(), Error> {
 
     relay_log::init(config.logging(), config.sentry());
     if let Some(matches) = matches.subcommand_matches("config") {
-        manage_config(&config, &matches)
+        manage_config(&config, matches)
     } else if let Some(matches) = matches.subcommand_matches("credentials") {
-        manage_credentials(config, &matches)
+        manage_credentials(config, matches)
     } else if let Some(matches) = matches.subcommand_matches("run") {
         // override config with run command args
         let arg_config = extract_config_args(matches);
         config.apply_override(arg_config)?;
-        run(config, &matches)
+        run(config, matches)
     } else {
         unreachable!();
     }
@@ -201,7 +201,7 @@ pub fn manage_credentials(mut config: Config, matches: &ArgMatches) -> Result<()
 
 pub fn manage_config<'a>(config: &Config, matches: &ArgMatches<'a>) -> Result<(), Error> {
     if let Some(matches) = matches.subcommand_matches("init") {
-        init_config(config.path(), &matches)
+        init_config(config.path(), matches)
     } else if let Some(matches) = matches.subcommand_matches("show") {
         match matches.value_of("format").unwrap() {
             "debug" => println!("{:#?}", &config),

--- a/tools/document-metrics/src/main.rs
+++ b/tools/document-metrics/src/main.rs
@@ -326,7 +326,7 @@ mod tests {
             }
         "#;
 
-        let metrics = parse_metrics(&source)?;
+        let metrics = parse_metrics(source)?;
         insta::assert_debug_snapshot!(metrics, @r###"
         [
             Metric {


### PR DESCRIPTION
This changes the name of the `Outdated` enum to `Expiry`. Other than that, there
are mostly syntactic changes for redundant borrowing.

#skip-changelog
