### PR TITLE
ref: Remove metrics for internal project ids

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -12,7 +12,7 @@ use failure::{Backtrace, Context, Fail};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
-use relay_common::{ProjectId, Uuid};
+use relay_common::Uuid;
 use relay_metrics::AggregatorConfig;
 use relay_redis::RedisConfig;
 
@@ -771,9 +771,6 @@ pub struct Processing {
     /// Maximum rate limit to report to clients.
     #[serde(default = "default_max_rate_limit")]
     pub max_rate_limit: Option<u32>,
-    /// Projects for which to emit extra (high-noise) metrics.
-    #[serde(default)]
-    pub _internal_projects: Vec<ProjectId>,
 }
 
 impl Default for Processing {
@@ -791,7 +788,6 @@ impl Default for Processing {
             attachment_chunk_size: default_chunk_size(),
             projectconfig_cache_prefix: default_projectconfig_cache_prefix(),
             max_rate_limit: default_max_rate_limit(),
-            _internal_projects: Vec::new(),
         }
     }
 }
@@ -1505,11 +1501,6 @@ impl Config {
     /// True if the Relay should do processing.
     pub fn processing_enabled(&self) -> bool {
         self.values.processing.enabled
-    }
-
-    /// Set of internal project IDs for which to emit extra metrics.
-    pub fn processing_internal_projects(&self) -> &[ProjectId] {
-        &self.values.processing._internal_projects
     }
 
     /// The path to the GeoIp database required for event processing.

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -659,19 +659,6 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                 attachments,
             });
 
-            #[cfg(feature = "processing")]
-            if self
-                .config
-                .processing_internal_projects()
-                .contains(&scoping.project_id)
-            {
-                metric!(
-                    counter(RelayCounters::InternalCapturedEventStoreActor) += 1,
-                    event_item_type = &event_item.ty().to_string(),
-                    project = &scoping.project_id.value().to_string(),
-                );
-            }
-
             self.produce(topic, event_message)?;
             metric!(
                 counter(RelayCounters::ProcessingMessageProduced) += 1,

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -431,12 +431,6 @@ pub enum RelayCounters {
     ///    be used to ingest events. Once the grace period expires, the cache is evicted and new
     ///    requests wait for an update.
     EvictingStaleProjectCaches,
-    /// An event has been produced to Kafka for one of the configured "internal" projects.
-    #[cfg(feature = "processing")]
-    InternalCapturedEventStoreActor,
-    /// An event has been preliminarily accepted in the store endpoint for one of the configured
-    /// "internal" projects.
-    InternalCapturedEventEndpoint,
 }
 
 impl CounterMetric for RelayCounters {
@@ -462,9 +456,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
-            #[cfg(feature = "processing")]
-            RelayCounters::InternalCapturedEventStoreActor => "internal.captured.event.store_actor",
-            RelayCounters::InternalCapturedEventEndpoint => "internal.captured.event.endpoint",
         }
     }
 }


### PR DESCRIPTION
Effectively reverts #975 since we no longer require these metrics.

Fixes INGEST-234
#skip-changelog