### PR TITLE
ref(server): Cleanup send_envelope

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1734,6 +1734,7 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
 
 /// Error returned from [`EnvelopeManager::send_envelope`].
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 enum SendEnvelopeError {
     #[cfg(feature = "processing")]
     ScheduleFailed,

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1812,16 +1812,16 @@ impl UpstreamRequest for SendEnvelope {
                             self.project_key,
                             upstream_limits.clone().scope(&self.scoping),
                         ));
-                        sender.map(|sender| {
+                        if let Some(sender) = sender {
                             sender
                                 .send(Err(UpstreamRequestError::RateLimited(upstream_limits)))
                                 .ok();
-                        });
+                        }
                     }
                     error => {
-                        sender.map(|sender| {
+                        if let Some(sender) = sender {
                             sender.send(Err(error)).ok();
-                        });
+                        }
                     }
                 };
                 Box::new(future::err(()))

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -1205,14 +1205,18 @@ impl<T: UpstreamQuery> UpstreamRequest for UpstreamQueryRequest<T> {
                     .json(self.max_response_size)
                     .map_err(UpstreamRequestError::Http)
                     .then(|result| {
-                        sender.map(|sender| sender.send(result));
+                        if let Some(sender) = sender {
+                            sender.send(result).ok();
+                        }
                         Ok(())
                     });
 
                 Box::new(future)
             }
             Err(error) => {
-                sender.map(|sender| sender.send(Err(error)));
+                if let Some(sender) = sender {
+                    sender.send(Err(error)).ok();
+                }
                 Box::new(future::err(()))
             }
         }

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -151,7 +151,7 @@ enum EnqueuePosition {
 ///
 /// These limits do not carry scope information. Use `UpstreamRateLimits::scope` to attach scope
 /// identifiers and return a fully populated `RateLimits` instance.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UpstreamRateLimits {
     retry_after: RetryAfter,
     rate_limits: String,

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -203,14 +203,18 @@ impl UpstreamRequest for ForwardRequest {
                     .and_then(move |body| Ok((status, headers, body)))
                     .map_err(UpstreamRequestError::Http)
                     .then(|result| {
-                        sender.map(|sender| sender.send(result));
+                        if let Some(sender) = sender {
+                            sender.send(result).ok();
+                        }
                         Ok(())
                     });
 
                 Box::new(future)
             }
             Err(e) => {
-                sender.map(|sender| sender.send(Err(e)));
+                if let Some(sender) = sender {
+                    sender.send(Err(e)).ok();
+                }
                 Box::new(future::err(()))
             }
         }


### PR DESCRIPTION
This is a cleanup task.

Moves send_envelope post processing in the UpstreaRequest::respond handler for SendEnvelope .
JIRA: INGEST-258
#skip-changelog 