### PR TITLE
fix(config): Use correct argument name for port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Use correct commandline argument name for setting Relay port. ([#1059](https://github.com/getsentry/relay/pull/1059))
+
 ## 21.8.0
 
 - No documented changes.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -78,7 +78,7 @@ steps:
       echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
       ./install.sh
       ./test.sh || docker-compose logs nginx web relay
-    timeout: 450s
+    timeout: 600s
 
   - name: 'gcr.io/cloud-builders/docker'
     secretEnv: ['DOCKER_PASSWORD']

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -63,7 +63,7 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
     OverridableConfig {
         upstream: matches.value_of("upstream").map(str::to_owned),
         host: matches.value_of("host").map(str::to_owned),
-        port: matches.value_of("redis_url").map(str::to_owned),
+        port: matches.value_of("port").map(str::to_owned),
         processing,
         kafka_url: matches.value_of("kafka_broker_url").map(str::to_owned),
         redis_url: matches.value_of("redis_url").map(str::to_owned),


### PR DESCRIPTION
Also bump onpremise integration tests timeout up to 10 minutes, because they have some nasty variance.