### PR TITLE
feat(schema): Log path through Relays in event

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -449,7 +449,7 @@ pub struct Event {
 
     /// Information about the Relays that processed this event during ingest.
     #[metastructure(bag_size = "medium")]
-    #[metastructure(skip_serialization = "empty")]
+    #[metastructure(skip_serialization = "empty", omit_from_schema)]
     pub ingest_path: Annotated<Array<RelayInfo>>,
 
     /// Errors encountered during processing. Intended to be phased out in favor of

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -12,7 +12,7 @@ use crate::processor::ProcessValue;
 use crate::protocol::{
     Breadcrumb, Breakdowns, ClientSdkInfo, Contexts, Csp, DebugMeta, Exception, ExpectCt,
     ExpectStaple, Fingerprint, Hpkp, LenientString, Level, LogEntry, Measurements, Metrics,
-    Request, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, User, Values,
+    RelayInfo, Request, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, User, Values,
 };
 use crate::types::{
     Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
@@ -446,6 +446,11 @@ pub struct Event {
     #[metastructure(field = "sdk")]
     #[metastructure(skip_serialization = "empty")]
     pub client_sdk: Annotated<ClientSdkInfo>,
+
+    /// Information about the Relays that processed this event during ingest.
+    #[metastructure(bag_size = "medium")]
+    #[metastructure(skip_serialization = "empty")]
+    pub ingest_path: Annotated<Array<RelayInfo>>,
 
     /// Errors encountered during processing. Intended to be phased out in favor of
     /// annotation/metadata system.

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -52,7 +52,7 @@ pub use self::logentry::{LogEntry, Message};
 pub use self::measurements::{Measurement, Measurements};
 pub use self::mechanism::{CError, MachException, Mechanism, MechanismMeta, PosixSignal};
 pub use self::metrics::{Metrics, SampleRate};
-pub use self::relayinfo::RelayInfo;
+pub use self::relay_info::RelayInfo;
 pub use self::request::{Cookies, HeaderName, HeaderValue, Headers, Query, Request};
 #[cfg(feature = "jsonschema")]
 pub use self::schema::event_json_schema;

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -13,6 +13,7 @@ mod logentry;
 mod measurements;
 mod mechanism;
 mod metrics;
+mod relayinfo;
 mod request;
 #[cfg(feature = "jsonschema")]
 mod schema;
@@ -51,6 +52,7 @@ pub use self::logentry::{LogEntry, Message};
 pub use self::measurements::{Measurement, Measurements};
 pub use self::mechanism::{CError, MachException, Mechanism, MechanismMeta, PosixSignal};
 pub use self::metrics::{Metrics, SampleRate};
+pub use self::relayinfo::RelayInfo;
 pub use self::request::{Cookies, HeaderName, HeaderValue, Headers, Query, Request};
 #[cfg(feature = "jsonschema")]
 pub use self::schema::event_json_schema;

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -13,7 +13,7 @@ mod logentry;
 mod measurements;
 mod mechanism;
 mod metrics;
-mod relayinfo;
+mod relay_info;
 mod request;
 #[cfg(feature = "jsonschema")]
 mod schema;

--- a/relay-general/src/protocol/relay_info.rs
+++ b/relay-general/src/protocol/relay_info.rs
@@ -4,13 +4,12 @@ use crate::types::{Annotated, Object, Value};
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct RelayInfo {
-    /// The version of the Relay. Required.
-    /// TODO
+    /// Version of the Relay. Required.
     #[metastructure(required = "true", max_chars = "symbol")]
     pub version: Annotated<String>,
 
-    /// TODO
-    #[metastructure()]
+    /// Public key of the Relay. Required.
+    #[metastructure(required = "true", max_chars = "symbol")]
     pub public_key: Annotated<String>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-general/src/protocol/relayinfo.rs
+++ b/relay-general/src/protocol/relayinfo.rs
@@ -1,0 +1,19 @@
+use crate::types::{Annotated, Object, Value};
+
+/// The Relay Interface describes a Sentry Relay and its configuration used to process an event during ingest.
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
+pub struct RelayInfo {
+    /// The version of the Relay. Required.
+    /// TODO
+    #[metastructure(required = "true", max_chars = "symbol")]
+    pub version: Annotated<String>,
+
+    /// TODO
+    #[metastructure()]
+    pub public_key: Annotated<String>,
+
+    /// Additional arbitrary fields for forwards compatibility.
+    #[metastructure(additional_properties)]
+    pub other: Object<Value>,
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ import pytest
 from .fixtures.gobetween import gobetween  # noqa
 from .fixtures.haproxy import haproxy  # noqa
 from .fixtures.mini_sentry import mini_sentry  # noqa
-from .fixtures.relay import relay, get_relay_binary  # noqa
+from .fixtures.relay import relay, get_relay_binary, latest_relay_version  # noqa
 from .fixtures.processing import (
     kafka_consumer,
     get_topic_name,

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -174,3 +174,12 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
         return relay
 
     return inner
+
+
+@pytest.fixture
+def latest_relay_version(get_relay_binary):
+    version_str = subprocess.check_output(
+        get_relay_binary() + ["--version"], universal_newlines=True
+    ).strip()
+    _the_word_relay, version = version_str.split(" ", 1)
+    return version

--- a/tests/integration/test_ingest_path.py
+++ b/tests/integration/test_ingest_path.py
@@ -1,5 +1,6 @@
-def test_ingest_path(mini_sentry, relay, latest_relay_version):
-    internal_keys = list(mini_sentry.iter_public_keys())
+def test_ingest_path(mini_sentry, relay, relay_with_processing, latest_relay_version):
+    internal_relay = relay_with_processing()
+    internal_keys = list(internal_relay.iter_public_keys())
     relay = relay(relay(relay(mini_sentry)))
     project_id = 42
     project_config = mini_sentry.add_basic_project_config(project_id)

--- a/tests/integration/test_ingest_path.py
+++ b/tests/integration/test_ingest_path.py
@@ -1,0 +1,15 @@
+def test_ingest_path(mini_sentry, relay, latest_relay_version):
+    internal_keys = list(mini_sentry.iter_public_keys())
+    relay = relay(relay(relay(mini_sentry)))
+    project_id = 42
+    project_config = mini_sentry.add_basic_project_config(project_id)
+    external_keys = [
+        key for key in relay.iter_public_keys() if key not in internal_keys
+    ]
+    project_config["config"]["trustedRelays"] = list(external_keys)
+
+    relay.send_event(project_id)
+    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    assert event["ingest_path"] == [
+        {"version": latest_relay_version, "public_key": key} for key in external_keys
+    ]

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -5,6 +5,7 @@ CSP_IGNORED_FIELDS = (
     "event_id",
     "timestamp",
     "received",
+    "ingest_path",
 )
 EXPECT_CT_IGNORED_FIELDS = ("event_id", "ingest_path")
 EXPECT_STAPLE_IGNORED_FIELDS = ("event_id", "ingest_path")

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -6,9 +6,9 @@ CSP_IGNORED_FIELDS = (
     "timestamp",
     "received",
 )
-EXPECT_CT_IGNORED_FIELDS = ("event_id",)
-EXPECT_STAPLE_IGNORED_FIELDS = ("event_id",)
-HPKP_IGNORED_FIELDS = ("event_id",)
+EXPECT_CT_IGNORED_FIELDS = ("event_id", "ingest_path")
+EXPECT_STAPLE_IGNORED_FIELDS = ("event_id", "ingest_path")
+HPKP_IGNORED_FIELDS = ("event_id", "ingest_path")
 
 
 def get_security_report(envelope):


### PR DESCRIPTION
We don't have control over external Relays we don't run, so it would be neat to at least know the versions being run.

This change adds a new property to the event called `ingest_path` and causes non-processing (external) Relays to append themselves to it, noting down their version and public key.