### PR TITLE
fix(schema): Fix processing error for ingest path from static Relays

### DIFF
--- a/relay-general/src/protocol/relay_info.rs
+++ b/relay-general/src/protocol/relay_info.rs
@@ -8,8 +8,8 @@ pub struct RelayInfo {
     #[metastructure(required = "true", max_chars = "symbol")]
     pub version: Annotated<String>,
 
-    /// Public key of the Relay. Required.
-    #[metastructure(required = "true", max_chars = "symbol")]
+    /// Public key of the Relay.
+    #[metastructure(required = "false", max_chars = "symbol")]
     pub public_key: Annotated<String>,
 
     /// Additional arbitrary fields for forwards compatibility.


### PR DESCRIPTION
Static Relays do processing, but don't fill the public key field
in ingest path.

#skip-changelog