### PR TITLE
ref(metrics): Replace per-project aggregators with single system service

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -11,7 +11,7 @@ use actix::prelude::*;
 use float_ord::FloatOrd;
 use serde::{Deserialize, Serialize};
 
-use relay_common::{clone, MonotonicResult, ProjectKey, UnixTimestamp};
+use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 
 use crate::{Metric, MetricType, MetricUnit, MetricValue};
 
@@ -1082,7 +1082,7 @@ impl Aggregator {
             self.receiver
                 .send(FlushBuckets::new(project_key, buckets))
                 .into_actor(self)
-                .and_then(clone!(project_key, |result, slf, _ctx| {
+                .and_then(move |result, slf, _ctx| {
                     if let Err(buckets) = result {
                         relay_log::trace!(
                             "returned {} buckets from receiver, merging back",
@@ -1091,7 +1091,7 @@ impl Aggregator {
                         slf.merge_all(project_key, buckets).ok();
                     }
                     fut::ok(())
-                }))
+                })
                 .drop_err()
                 .spawn(context);
         }

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1698,6 +1698,28 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregator_mixed_projects() {
+        relay_test::setup();
+
+        let config = AggregatorConfig {
+            bucket_interval: 10,
+            ..AggregatorConfig::default()
+        };
+
+        let receiver = TestReceiver::start_default().recipient();
+        let project_key1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
+        let project_key2 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
+
+        let mut aggregator = Aggregator::new(config, receiver);
+
+        // It's OK to have same metric with different projects:
+        aggregator.insert(project_key1, some_metric()).unwrap();
+        aggregator.insert(project_key2, some_metric()).unwrap();
+
+        assert_eq!(aggregator.buckets.len(), 2);
+    }
+
+    #[test]
     fn test_flush_bucket() {
         relay_test::setup();
         let receiver = TestReceiver::default();

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -11,7 +11,7 @@ use actix::prelude::*;
 use float_ord::FloatOrd;
 use serde::{Deserialize, Serialize};
 
-use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
+use relay_common::{clone, MonotonicResult, ProjectKey, UnixTimestamp};
 
 use crate::{Metric, MetricType, MetricUnit, MetricValue};
 
@@ -736,6 +736,7 @@ impl Error for AggregateMetricsError {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct BucketKey {
+    project_key: ProjectKey,
     timestamp: UnixTimestamp,
     metric_name: String,
     metric_type: MetricType,
@@ -945,7 +946,6 @@ impl Message for FlushBuckets {
 /// }
 /// ```
 pub struct Aggregator {
-    project_key: ProjectKey,
     config: AggregatorConfig,
     buckets: HashMap<BucketKey, BucketValue>,
     queue: BinaryHeap<QueuedBucket>,
@@ -957,13 +957,8 @@ impl Aggregator {
     ///
     /// The aggregator will flush a list of buckets to the receiver in regular intervals based on
     /// the given `config`.
-    pub fn new(
-        project_key: ProjectKey,
-        config: AggregatorConfig,
-        receiver: Recipient<FlushBuckets>,
-    ) -> Self {
+    pub fn new(config: AggregatorConfig, receiver: Recipient<FlushBuckets>) -> Self {
         Self {
-            project_key,
             config,
             buckets: HashMap::new(),
             queue: BinaryHeap::new(),
@@ -1009,8 +1004,13 @@ impl Aggregator {
     /// Inserts a metric into the corresponding bucket in this aggregator.
     ///
     /// If no bucket exists for the given bucket key, a new bucket will be created.
-    pub fn insert(&mut self, metric: Metric) -> Result<(), AggregateMetricsError> {
+    pub fn insert(
+        &mut self,
+        project_key: ProjectKey,
+        metric: Metric,
+    ) -> Result<(), AggregateMetricsError> {
         let key = BucketKey {
+            project_key,
             timestamp: self.get_bucket_timestamp(metric.timestamp),
             metric_name: metric.name,
             metric_type: metric.value.ty(),
@@ -1023,8 +1023,13 @@ impl Aggregator {
     /// Merge a preaggregated bucket into this aggregator.
     ///
     /// If no bucket exists for the given bucket key, a new bucket will be created.
-    pub fn merge(&mut self, bucket: Bucket) -> Result<(), AggregateMetricsError> {
+    pub fn merge(
+        &mut self,
+        project_key: ProjectKey,
+        bucket: Bucket,
+    ) -> Result<(), AggregateMetricsError> {
         let key = BucketKey {
+            project_key,
             timestamp: bucket.timestamp,
             metric_name: bucket.name,
             metric_type: bucket.value.ty(),
@@ -1037,12 +1042,16 @@ impl Aggregator {
     /// Merges all given `buckets` into this aggregator.
     ///
     /// Buckets that do not exist yet will be created.
-    pub fn merge_all<I>(&mut self, buckets: I) -> Result<(), AggregateMetricsError>
+    pub fn merge_all<I>(
+        &mut self,
+        project_key: ProjectKey,
+        buckets: I,
+    ) -> Result<(), AggregateMetricsError>
     where
         I: IntoIterator<Item = Bucket>,
     {
         for bucket in buckets.into_iter() {
-            self.merge(bucket)?;
+            self.merge(project_key, bucket)?;
         }
 
         Ok(())
@@ -1052,12 +1061,15 @@ impl Aggregator {
     ///
     /// If the receiver returns buckets, they are merged back into the cache.
     fn try_flush(&mut self, context: &mut <Self as Actor>::Context) {
-        let mut buckets = Vec::new();
+        let mut buckets = HashMap::<ProjectKey, Vec<Bucket>>::new();
 
         while self.queue.peek().map_or(false, |flush| flush.elapsed()) {
             let flush = self.queue.pop().unwrap();
             let value = self.buckets.remove(&flush.key).unwrap();
-            buckets.push(Bucket::from_parts(flush.key, value));
+            buckets
+                .entry(flush.key.project_key)
+                .or_default()
+                .push(Bucket::from_parts(flush.key, value));
         }
 
         if buckets.is_empty() {
@@ -1066,21 +1078,23 @@ impl Aggregator {
 
         relay_log::trace!("flushing {} buckets to receiver", buckets.len());
 
-        self.receiver
-            .send(FlushBuckets::new(self.project_key, buckets))
-            .into_actor(self)
-            .and_then(|result, slf, _ctx| {
-                if let Err(buckets) = result {
-                    relay_log::trace!(
-                        "returned {} buckets from receiver, merging back",
-                        buckets.len()
-                    );
-                    slf.merge_all(buckets).ok();
-                }
-                fut::ok(())
-            })
-            .drop_err()
-            .spawn(context);
+        for (project_key, buckets) in buckets.into_iter() {
+            self.receiver
+                .send(FlushBuckets::new(project_key, buckets))
+                .into_actor(self)
+                .and_then(clone!(project_key, |result, slf, _ctx| {
+                    if let Err(buckets) = result {
+                        relay_log::trace!(
+                            "returned {} buckets from receiver, merging back",
+                            buckets.len()
+                        );
+                        slf.merge_all(project_key, buckets).ok();
+                    }
+                    fut::ok(())
+                }))
+                .drop_err()
+                .spawn(context);
+        }
     }
 }
 
@@ -1110,19 +1124,31 @@ impl Actor for Aggregator {
     }
 }
 
+impl Default for Aggregator {
+    fn default() -> Self {
+        unimplemented!("register with the SystemRegistry instead")
+    }
+}
+
+impl Supervised for Aggregator {}
+
+impl SystemService for Aggregator {}
+
 /// A message containing a list of [`Metric`]s to be inserted into the aggregator.
 #[derive(Debug)]
 pub struct InsertMetrics {
+    project_key: ProjectKey,
     metrics: Vec<Metric>,
 }
 
 impl InsertMetrics {
     /// Creates a new message containing a list of [`Metric`]s.
-    pub fn new<I>(metrics: I) -> Self
+    pub fn new<I>(project_key: ProjectKey, metrics: I) -> Self
     where
         I: IntoIterator<Item = Metric>,
     {
         Self {
+            project_key,
             metrics: metrics.into_iter().collect(),
         }
     }
@@ -1137,7 +1163,7 @@ impl Handler<InsertMetrics> for Aggregator {
 
     fn handle(&mut self, msg: InsertMetrics, _ctx: &mut Self::Context) -> Self::Result {
         for metric in msg.metrics {
-            self.insert(metric)?;
+            self.insert(msg.project_key, metric)?;
         }
 
         Ok(())
@@ -1147,13 +1173,17 @@ impl Handler<InsertMetrics> for Aggregator {
 /// A message containing a list of [`Bucket`]s to be inserted into the aggregator.
 #[derive(Debug)]
 pub struct MergeBuckets {
+    project_key: ProjectKey,
     buckets: Vec<Bucket>,
 }
 
 impl MergeBuckets {
     /// Creates a new message containing a list of [`Bucket`]s.
-    pub fn new(buckets: Vec<Bucket>) -> Self {
-        Self { buckets }
+    pub fn new(project_key: ProjectKey, buckets: Vec<Bucket>) -> Self {
+        Self {
+            project_key,
+            buckets,
+        }
     }
 }
 
@@ -1165,7 +1195,7 @@ impl Handler<MergeBuckets> for Aggregator {
     type Result = Result<(), AggregateMetricsError>;
 
     fn handle(&mut self, msg: MergeBuckets, _ctx: &mut Self::Context) -> Self::Result {
-        self.merge_all(msg.buckets)
+        self.merge_all(msg.project_key, msg.buckets)
     }
 }
 
@@ -1533,18 +1563,19 @@ mod tests {
 
         let config = AggregatorConfig::default();
         let receiver = TestReceiver::start_default().recipient();
-        let mut aggregator = Aggregator::new(project_key, config, receiver);
+        let mut aggregator = Aggregator::new(config, receiver);
 
         let metric1 = some_metric();
 
         let mut metric2 = metric1.clone();
         metric2.value = MetricValue::Counter(43.);
-        aggregator.insert(metric1).unwrap();
-        aggregator.insert(metric2).unwrap();
+        aggregator.insert(project_key, metric1).unwrap();
+        aggregator.insert(project_key, metric2).unwrap();
 
         insta::assert_debug_snapshot!(aggregator.buckets, @r###"
         {
             BucketKey {
+                project_key: ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"),
                 timestamp: UnixTimestamp(4710),
                 metric_name: "foo",
                 metric_type: Counter,
@@ -1567,7 +1598,7 @@ mod tests {
         let receiver = TestReceiver::start_default().recipient();
         let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
 
-        let mut aggregator = Aggregator::new(project_key, config, receiver);
+        let mut aggregator = Aggregator::new(config, receiver);
 
         let metric1 = some_metric();
 
@@ -1576,9 +1607,9 @@ mod tests {
 
         let mut metric3 = metric1.clone();
         metric3.timestamp = UnixTimestamp::from_secs(4721);
-        aggregator.insert(metric1).unwrap();
-        aggregator.insert(metric2).unwrap();
-        aggregator.insert(metric3).unwrap();
+        aggregator.insert(project_key, metric1).unwrap();
+        aggregator.insert(project_key, metric2).unwrap();
+        aggregator.insert(project_key, metric3).unwrap();
 
         let mut buckets: Vec<(BucketKey, BucketValue)> = aggregator.buckets.into_iter().collect();
         buckets.sort_by(|a, b| a.0.timestamp.cmp(&b.0.timestamp));
@@ -1586,6 +1617,7 @@ mod tests {
         [
             (
                 BucketKey {
+                    project_key: ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"),
                     timestamp: UnixTimestamp(4710),
                     metric_name: "foo",
                     metric_type: Counter,
@@ -1598,6 +1630,7 @@ mod tests {
             ),
             (
                 BucketKey {
+                    project_key: ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"),
                     timestamp: UnixTimestamp(4720),
                     metric_name: "foo",
                     metric_type: Counter,
@@ -1624,7 +1657,7 @@ mod tests {
         let receiver = TestReceiver::start_default().recipient();
         let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
 
-        let mut aggregator = Aggregator::new(project_key, config, receiver);
+        let mut aggregator = Aggregator::new(config, receiver);
 
         let metric1 = some_metric();
 
@@ -1632,8 +1665,8 @@ mod tests {
         metric2.value = MetricValue::Set(123);
 
         // It's OK to have same name for different types:
-        aggregator.insert(metric1).unwrap();
-        aggregator.insert(metric2).unwrap();
+        aggregator.insert(project_key, metric1).unwrap();
+        aggregator.insert(project_key, metric2).unwrap();
         assert_eq!(aggregator.buckets.len(), 2);
     }
 
@@ -1649,7 +1682,7 @@ mod tests {
         let receiver = TestReceiver::start_default().recipient();
         let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
 
-        let mut aggregator = Aggregator::new(project_key, config, receiver);
+        let mut aggregator = Aggregator::new(config, receiver);
 
         let metric1 = some_metric();
 
@@ -1657,8 +1690,8 @@ mod tests {
         metric2.unit = MetricUnit::Duration(DurationPrecision::Second);
 
         // It's OK to have same metric with different units:
-        aggregator.insert(metric1).unwrap();
-        aggregator.insert(metric2).unwrap();
+        aggregator.insert(project_key, metric1).unwrap();
+        aggregator.insert(project_key, metric2).unwrap();
 
         // TODO: This should convert if units are convertible
         assert_eq!(aggregator.buckets.len(), 2);
@@ -1676,12 +1709,13 @@ mod tests {
             };
             let recipient = receiver.clone().start().recipient();
             let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
-            let aggregator = Aggregator::new(project_key, config, recipient).start();
+            let aggregator = Aggregator::new(config, recipient).start();
 
             let mut metric = some_metric();
             metric.timestamp = UnixTimestamp::now();
             aggregator
                 .send(InsertMetrics {
+                    project_key,
                     metrics: vec![metric],
                 })
                 .and_then(move |_| aggregator.send(BucketCountInquiry))
@@ -1724,12 +1758,13 @@ mod tests {
             let recipient = receiver.clone().start().recipient();
             let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
 
-            let aggregator = Aggregator::new(project_key, config, recipient).start();
+            let aggregator = Aggregator::new(config, recipient).start();
 
             let mut metric = some_metric();
             metric.timestamp = UnixTimestamp::now();
             aggregator
                 .send(InsertMetrics {
+                    project_key,
                     metrics: vec![metric],
                 })
                 .map_err(|_| ())

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1711,7 +1711,7 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
                     Some(metric)
                 });
 
-                relay_log::trace!("inserting metrics into project aggregator");
+                relay_log::trace!("inserting metrics into project cache");
                 project_cache.do_send(InsertMetrics::new(public_key, metrics));
             } else if item.ty() == ItemType::MetricBuckets {
                 if let Ok(mut buckets) = Bucket::parse_all(&payload) {
@@ -1719,7 +1719,7 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
                         clock_drift_processor.process_timestamp(&mut bucket.timestamp);
                     }
 
-                    relay_log::trace!("merging metric buckets into project aggregator");
+                    relay_log::trace!("merging metric buckets into project cache");
                     project_cache.do_send(MergeBuckets::new(public_key, buckets));
                 }
             } else {

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -448,22 +448,6 @@ impl StateChannel {
     }
 }
 
-/// States for the metrics [`Aggregator`] within a [`Project`].
-///
-/// This allows to initialize an aggregator on demand and permanently disable it during project
-/// state updates.
-#[derive(Debug)]
-enum AggregatorState {
-    /// The aggregator has not been initialized.
-    Unknown,
-
-    /// The aggregator is initialized and available.
-    Available(Addr<Aggregator>),
-
-    /// The aggregator is disabled and metrics should be dropped.
-    Unavailable,
-}
-
 /// Structure representing organization and project configuration for a project key.
 ///
 /// This structure no longer uniquely identifies a project. Instead, it identifies a project key.
@@ -472,7 +456,6 @@ pub struct Project {
     last_updated_at: Instant,
     project_key: ProjectKey,
     config: Arc<Config>,
-    aggregator: AggregatorState,
     state: Option<Arc<ProjectState>>,
     state_channel: Option<StateChannel>,
     rate_limits: RateLimits,
@@ -486,11 +469,17 @@ impl Project {
             last_updated_at: Instant::now(),
             project_key: key,
             config,
-            aggregator: AggregatorState::Unknown,
             state: None,
             state_channel: None,
             rate_limits: RateLimits::new(),
             last_no_cache: Instant::now(),
+        }
+    }
+
+    fn metrics_allowed(&self) -> bool {
+        match self.state() {
+            Some(state) => state.check_disabled(&self.config).is_ok(),
+            None => false,
         }
     }
 
@@ -520,63 +509,17 @@ impl Project {
         self.last_updated_at = Instant::now();
     }
 
-    /// Creates the aggregator if it is uninitialized and returns it.
-    ///
-    /// Returns `None` if the aggregator is permanently disabled, primarily for disabled projects.
-    fn get_or_create_aggregator(&mut self) -> Option<Addr<Aggregator>> {
-        if matches!(self.aggregator, AggregatorState::Unknown) {
-            let aggregator = Aggregator::new(
-                self.project_key,
-                self.config.aggregator_config(),
-                ProjectCache::from_registry().recipient(),
-            );
-            // TODO: This starts the aggregator on the project arbiter, but we want a separate
-            // thread or thread pool for this.
-            self.aggregator = AggregatorState::Available(aggregator.start());
-        }
-
-        if let AggregatorState::Available(ref aggregator) = self.aggregator {
-            Some(aggregator.clone())
-        } else {
-            None
-        }
-    }
-
     pub fn merge_buckets(&mut self, buckets: Vec<Bucket>) {
-        if let Some(aggregator) = self.get_or_create_aggregator() {
-            aggregator.do_send(relay_metrics::MergeBuckets::new(buckets));
+        if self.metrics_allowed() {
+            Aggregator::from_registry()
+                .do_send(relay_metrics::MergeBuckets::new(self.project_key, buckets));
         }
     }
 
     pub fn insert_metrics(&mut self, metrics: Vec<Metric>) {
-        if let Some(aggregator) = self.get_or_create_aggregator() {
-            aggregator.do_send(relay_metrics::InsertMetrics::new(metrics));
-        }
-    }
-
-    /// Updates the aggregator based on updates to the project state.
-    ///
-    /// Changes to the aggregator depend on the project state:
-    ///
-    ///  1. The project state is missing: In this case, the project has not been loaded, so the
-    ///     aggregator remains unmodified.
-    ///  2. The project state is valid: Create an aggregator if it has previously been marked as
-    ///     `Unavailable`, but leave it uninitialized otherwise.
-    ///  3. The project state is disabled or invalid: Mark the aggregator as `Unavailable`,
-    ///     potentially removing an existing aggregator.
-    ///
-    /// If the aggregator is not stopped immediately. Existing requests can continue and the
-    /// aggregator will be stopped when the last reference drops.
-    fn update_aggregator(&mut self) {
-        let metrics_allowed = match self.state() {
-            Some(state) => state.check_disabled(&self.config).is_ok(),
-            None => return,
-        };
-
-        if metrics_allowed && matches!(self.aggregator, AggregatorState::Unavailable) {
-            self.get_or_create_aggregator();
-        } else if !metrics_allowed {
-            self.aggregator = AggregatorState::Unavailable;
+        if self.metrics_allowed() {
+            Aggregator::from_registry()
+                .do_send(relay_metrics::InsertMetrics::new(self.project_key, metrics));
         }
     }
 
@@ -665,7 +608,6 @@ impl Project {
 
         self.state_channel = None;
         self.state = state_result.map(|resp| resp.state);
-        self.update_aggregator();
 
         if let Some(ref state) = self.state {
             relay_log::debug!("project state {} updated", self.project_key);

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -8,6 +8,7 @@ use failure::{Backtrace, Context, Fail};
 use listenfd::ListenFd;
 
 use relay_config::Config;
+use relay_metrics::Aggregator;
 use relay_redis::RedisPool;
 
 use crate::actors::controller::{Configure, Controller};
@@ -133,6 +134,14 @@ impl ServiceState {
         registry.set(ProjectCache::new(config.clone(), redis_pool).start());
         registry.set(Healthcheck::new(config.clone()).start());
         registry.set(RelayCache::new(config.clone()).start());
+
+        registry.set(
+            Aggregator::new(
+                config.aggregator_config(),
+                ProjectCache::from_registry().recipient(),
+            )
+            .start(),
+        );
 
         Ok(ServiceState { config })
     }


### PR DESCRIPTION
Changes the aggregator so that it becomes a system-level singleton. Most notably, this creates a single flush loop for all metrics rather than one per project, which reduces scheduling overheads.

In this PR:

- [x] Make `ProjectKey` part of `BucketKey`
- [x] Make aggregator a `SystemService` 

Not implemented yet:

- [ ] Measure how long every flush cycle takes
- [ ] Get rid of Aggregator::queue, just iterate over Aggregator::buckets in every cycle.
- [ ] In-process benchmark test of aggregator 

https://getsentry.atlassian.net/browse/INGEST-302

#skip-changelog