### PR TITLE
ref(metrics): Remove the aggregator queue

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -189,8 +189,16 @@ def test_session_metrics(mini_sentry, relay_with_processing, metrics_consumer):
 
     relay.send_session(project_id, session_payload)
 
-    metric = metrics_consumer.get_metric()
-    assert metric == {
+    metrics = sorted(
+        [
+            metrics_consumer.get_metric(),
+            metrics_consumer.get_metric(),
+            metrics_consumer.get_metric(),
+        ],
+        key=lambda x: x["name"],
+    )
+
+    assert metrics[0] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": int(timestamp.timestamp()),
@@ -205,8 +213,18 @@ def test_session_metrics(mini_sentry, relay_with_processing, metrics_consumer):
         },
     }
 
-    metric = metrics_consumer.get_metric()
-    assert metric == {
+    assert metrics[1] == {
+        "org_id": 1,
+        "project_id": 42,
+        "timestamp": int(timestamp.timestamp()),
+        "name": "session.duration",
+        "type": "d",
+        "unit": "s",
+        "value": [1947.49],
+        "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
+    }
+
+    assert metrics[2] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": int(timestamp.timestamp()),
@@ -219,18 +237,6 @@ def test_session_metrics(mini_sentry, relay_with_processing, metrics_consumer):
             "release": "sentry-test@1.0.0",
             "session.status": "init",
         },
-    }
-
-    metric = metrics_consumer.get_metric()
-    assert metric == {
-        "org_id": 1,
-        "project_id": 42,
-        "timestamp": int(timestamp.timestamp()),
-        "name": "session.duration",
-        "type": "d",
-        "unit": "s",
-        "value": [1947.49],
-        "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
     }
 
     metrics_consumer.assert_empty()

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -35,10 +35,11 @@ def test_metrics(mini_sentry, relay):
     metrics_item = envelope.items[0]
     assert metrics_item.type == "metric_buckets"
 
-    received_metrics = metrics_item.get_bytes()
-    assert json.loads(received_metrics.decode()) == [
-        {"timestamp": timestamp, "name": "foo", "value": 42.0, "type": "c"},
+    received_metrics = json.loads(metrics_item.get_bytes().decode())
+    received_metrics = sorted(received_metrics, key=lambda x: x["name"])
+    assert received_metrics == [
         {"timestamp": timestamp, "name": "bar", "value": 17.0, "type": "c"},
+        {"timestamp": timestamp, "name": "foo", "value": 42.0, "type": "c"},
     ]
 
 


### PR DESCRIPTION
To simplify metrics aggregation, remove the `Aggregator`'s internal queue.
Instead, poll the entire list of buckets every time. By default, this will
remove about 10% of the full list of buckets in every flush cycle.

As opposed to a dedicated queue, filtering the buckets might be slightly slower.
However, the bulk of the work is then performed outside of the aggregator. In
turn, we use less memory on the second queue structure.

#skip-changelog

