### PR TITLE
feat(metrics): Log statsd metrics for bucket flushing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p document-metrics -- -o relay_metrics.json relay-server/src/statsd.rs
+          args: -p document-metrics -- -o relay_metrics.json relay-server/src/statsd.rs relay-metrics/src/statsd.rs
 
       - name: Deploy
         if: github.ref == 'refs/heads/master'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Use correct commandline argument name for setting Relay port. ([#1059](https://github.com/getsentry/relay/pull/1059))
 
+**Internal**:
+
+- Add new metrics on Relay's performance in dealing with buckets of metric aggregates, as well as the amount of aggregated buckets. ([#1070](https://github.com/getsentry/relay/pull/1070))
+
 ## 21.8.0
 
 - No documented changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,6 +3271,7 @@ dependencies = [
  "insta",
  "relay-common",
  "relay-log",
+ "relay-statsd",
  "relay-test",
  "serde",
  "serde_json",

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -16,6 +16,7 @@ fnv = "1.0.7"
 hash32 = "0.1.1"
 relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log" }
+relay-statsd = { path = "../relay-statsd" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 
+use crate::statsd::{MetricGauges, MetricHistograms, MetricTimers};
 use crate::{Metric, MetricType, MetricUnit, MetricValue};
 
 /// Contains the numeric value corresponding to a metrics tag name, tag key or tag value.
@@ -1057,29 +1058,43 @@ impl Aggregator {
     ///
     /// If the receiver returns buckets, they are merged back into the cache.
     fn try_flush(&mut self, context: &mut <Self as Actor>::Context) {
-        let mut buckets = HashMap::<ProjectKey, Vec<Bucket>>::new();
+        relay_statsd::metric!(gauge(MetricGauges::Buckets) = self.buckets.len() as u64);
+        let mut flush_buckets = HashMap::<ProjectKey, Vec<Bucket>>::new();
 
-        self.buckets.retain(|key, entry| {
-            if entry.elapsed() {
-                // Take the value and leave a placeholder behind. It'll be removed right after.
-                let value = std::mem::replace(&mut entry.value, BucketValue::Counter(0.0));
-                let bucket = Bucket::from_parts(key.clone(), value);
-                buckets.entry(key.project_key).or_default().push(bucket);
-                false
-            } else {
-                true
-            }
+        relay_statsd::metric!(timer(MetricTimers::BucketsScanDuration), {
+            self.buckets.retain(|key, entry| {
+                if entry.elapsed() {
+                    // Take the value and leave a placeholder behind. It'll be removed right after.
+                    let value = std::mem::replace(&mut entry.value, BucketValue::Counter(0.0));
+                    let bucket = Bucket::from_parts(key.clone(), value);
+                    flush_buckets
+                        .entry(key.project_key)
+                        .or_default()
+                        .push(bucket);
+                    false
+                } else {
+                    true
+                }
+            });
         });
 
-        if buckets.is_empty() {
+        if flush_buckets.is_empty() {
             return;
         }
 
-        relay_log::trace!("flushing {} buckets to receiver", buckets.len());
+        relay_log::trace!("flushing {} buckets to receiver", flush_buckets.len());
+        relay_statsd::metric!(
+            histogram(MetricHistograms::BucketsFlushed) = flush_buckets.len() as u64
+        );
 
-        for (project_key, buckets) in buckets.into_iter() {
+        for (project_key, project_buckets) in flush_buckets.into_iter() {
+            relay_statsd::metric!(
+                histogram(MetricHistograms::BucketsFlushedPerProject) =
+                    project_buckets.len() as u64
+            );
+
             self.receiver
-                .send(FlushBuckets::new(project_key, buckets))
+                .send(FlushBuckets::new(project_key, project_buckets))
                 .into_actor(self)
                 .and_then(move |result, slf, _ctx| {
                     if let Err(buckets) = result {

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -108,6 +108,7 @@
 
 mod aggregation;
 mod protocol;
+mod statsd;
 
 pub use aggregation::*;
 pub use protocol::*;

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -1,0 +1,55 @@
+use relay_statsd::{GaugeMetric, HistogramMetric, TimerMetric};
+
+/// Timer metrics for Relay Metrics.
+pub enum MetricTimers {
+    /// Time in milliseconds spent scanning metric buckets to flush.
+    ///
+    /// Relay scans metric buckets in regular intervals and flushes expired buckets. This timer
+    /// shows the time it takes to perform this scan and remove the buckets from the internal cache.
+    /// Sending the metric buckets to upstream is outside of this timer.
+    BucketsScanDuration,
+}
+
+impl TimerMetric for MetricTimers {
+    fn name(&self) -> &'static str {
+        match *self {
+            Self::BucketsScanDuration => "metrics.buckets.scan_duration",
+        }
+    }
+}
+
+/// Histogram metrics for Relay Metrics.
+pub enum MetricHistograms {
+    /// The total number of metric buckets flushed in a cycle across all projects.
+    BucketsFlushed,
+
+    /// The number of metric buckets flushed in a cycle for each project.
+    ///
+    /// Relay scans metric buckets in regular intervals and flushes expired buckets. This histogram
+    /// is logged for each project that is being flushed. The count of the histogram values is
+    /// equivalent to the number of projects being flushed.
+    BucketsFlushedPerProject,
+}
+
+impl HistogramMetric for MetricHistograms {
+    fn name(&self) -> &'static str {
+        match *self {
+            Self::BucketsFlushed => "metrics.buckets.flushed",
+            Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
+        }
+    }
+}
+
+/// Gauge metrics for Relay Metrics.
+pub enum MetricGauges {
+    /// The total number of metric buckets in Relay's metrics aggregator.
+    Buckets,
+}
+
+impl GaugeMetric for MetricGauges {
+    fn name(&self) -> &'static str {
+        match *self {
+            Self::Buckets => "metrics.buckets",
+        }
+    }
+}


### PR DESCRIPTION
Introduces new internal metrics to measure the pressure and performance
on the metric bucket flush cycle:

1. `metrics.buckets.scan_duration`: Time in milliseconds spent scanning
   metric buckets to flush.
2. `metrics.buckets.flushed`: The total number of metric buckets flushed
   in a cycle across all projects.
3. `metrics.buckets.flushed_per_project`: The number of metric buckets
   flushed in a cycle for each project.
4. `metrics.buckets`: The total number of metric buckets in Relay's
   metrics aggregator.