### PR TITLE
build(ci): Fix sentry integration test due to refactored actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
           echo "::set-output name=relay-test-image::$RELAY_TEST_IMAGE"
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions
-          cp -r sentry/.github/actions/*
+          cp -r sentry/.github/actions/* .github/actions
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,8 +248,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: getsentry/sentry
-          # XXX: Testing
-          ref: build/ci/fix-setup-sentry-inputs
           path: sentry
 
       - name: Setup steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,6 @@ jobs:
           repository: getsentry/sentry
           path: sentry
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-
       - name: Setup steps
         id: setup
         run: |
@@ -261,23 +257,16 @@ jobs:
           RELAY_TEST_IMAGE=us.gcr.io/sentryio/relay:${{ github.event.pull_request.head.sha || github.sha }}
           echo "We expected GCB to push this image $RELAY_TEST_IMAGE"
           echo "::set-output name=relay-test-image::$RELAY_TEST_IMAGE"
-          pip install --upgrade pip wheel
-          echo "::set-output name=pip-cache-dir::$(pip cache dir)"
           # We cannot execute actions that are not placed under .github of the main repo
-          mkdir -p .github/actions/setup-sentry/
-          cp sentry/.github/actions/setup-sentry/action.yml .github/actions/setup-sentry/action.yml
-
-      - name: Sentry's pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.setup.outputs.pip-cache-dir }}
-          key: sentry-deps-${{ hashFiles('sentry/requirements**.txt') }}
-          restore-keys: sentry-deps-
+          mkdir -p .github/actions
+          cp -r sentry/.github/actions/*
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry
         with:
           workdir: sentry
+          cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
+          python-version: 3.6
           snuba: true
           kafka: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,8 @@ jobs:
           echo "::set-output name=relay-test-image::$RELAY_TEST_IMAGE"
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions
-          cp -r sentry/.github/actions/* .github/actions
+          cp -r sentry/.github/actions/setup-sentry .github/actions/
+          cp -r sentry/.github/actions/setup-python .github/actions/
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: getsentry/sentry
+          # XXX: Testing
+          ref: build/ci/fix-setup-sentry-inputs
           path: sentry
 
       - name: Setup steps


### PR DESCRIPTION
We refactored [`setup-sentry`](https://github.com/getsentry/sentry/pull/28281) to be able to compose actions better. This workflow was only copying `setup-sentry` which now include `setup-python`.

#skip-changelog
