### PR TITLE
feat(client-reports): Protocol support for client reports 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add sampling based on transaction name. ([#1058](https://github.com/getsentry/relay/pull/1058))
 - Support running Relay without config directory. The most important configuration, including Relay mode and credentials, can now be provided through commandline arguments or environment variables alone. ([#1055](https://github.com/getsentry/relay/pull/1055)
+- Protocol support for client reports. ([#1074](https://github.com/getsentry/relay/pull/1074))
 
 **Bug Fixes**:
 

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -332,3 +332,16 @@ impl fmt::Display for SpanStatus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internal_data_category() {
+        assert_eq!(
+            DataCategory::from_str("internal"),
+            Ok(DataCategory::Default)
+        );
+    }
+}

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -96,6 +96,10 @@ impl fmt::Display for EventType {
 #[repr(i8)]
 pub enum DataCategory {
     /// Reserved and unused.
+    ///
+    /// There is a reserved `internal` data category which also maps to `Default`.  Relays
+    /// will never emit rate limits for `internal` but client SDKs can assume a data category
+    /// of `internal` for envelopes carrying internal messages for instance SDK outcomes.
     Default = 0,
     /// Error events and Events with an `event_type` not explicitly listed below.
     Error = 1,
@@ -116,7 +120,7 @@ impl DataCategory {
     /// Returns the data category corresponding to the given name.
     pub fn from_name(string: &str) -> Self {
         match string {
-            "default" => Self::Default,
+            "default" | "internal" => Self::Default,
             "error" => Self::Error,
             "transaction" => Self::Transaction,
             "security" => Self::Security,

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::time::{Duration, Instant, SystemTime};
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Converts an `Instant` into a `SystemTime`.
@@ -81,6 +81,11 @@ impl UnixTimestamp {
     /// Returns the number of seconds since the UNIX epoch start.
     pub fn as_secs(self) -> u64 {
         self.0
+    }
+
+    /// Returns the timestamp as chrono datetime.
+    pub fn as_datetime(self) -> DateTime<Utc> {
+        DateTime::from_utc(NaiveDateTime::from_timestamp(self.0 as i64, 0), Utc)
     }
 
     /// Converts the UNIX timestamp into an `Instant` based on the current system timestamp.

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -144,6 +144,7 @@ impl std::ops::Sub for UnixTimestamp {
     }
 }
 
+#[derive(Debug)]
 /// An error returned from parsing [`UnixTimestamp`].
 pub struct ParseUnixTimestampError(());
 
@@ -151,6 +152,12 @@ impl std::str::FromStr for UnixTimestamp {
     type Err = ParseUnixTimestampError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(datetime) = s.parse::<DateTime<Utc>>() {
+            let timestamp = datetime.timestamp();
+            if timestamp >= 0 {
+                return Ok(UnixTimestamp(timestamp as u64));
+            }
+        }
         let ts = s.parse().or(Err(ParseUnixTimestampError(())))?;
         Ok(Self(ts))
     }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -501,6 +501,8 @@ struct Limits {
     max_attachment_size: ByteSize,
     /// The maximum combined size for all attachments in an envelope or request.
     max_attachments_size: ByteSize,
+    /// The maximum combined size for all client reports in an envelope or request.
+    max_client_reports_size: ByteSize,
     /// The maximum payload size for an entire envelopes. Individual limits still apply.
     max_envelope_size: ByteSize,
     /// The maximum number of session items per envelope.
@@ -539,6 +541,7 @@ impl Default for Limits {
             max_event_size: ByteSize::mebibytes(1),
             max_attachment_size: ByteSize::mebibytes(100),
             max_attachments_size: ByteSize::mebibytes(100),
+            max_client_reports_size: ByteSize::kibibytes(4),
             max_envelope_size: ByteSize::mebibytes(100),
             max_session_count: 100,
             max_api_payload_size: ByteSize::mebibytes(20),
@@ -1449,6 +1452,11 @@ impl Config {
     /// (minidump, unreal, standalone attachments) in bytes.
     pub fn max_attachments_size(&self) -> usize {
         self.values.limits.max_attachments_size.as_bytes()
+    }
+
+    /// Returns the maxmium combined size of client reports in bytes.
+    pub fn max_client_reports_size(&self) -> usize {
+        self.values.limits.max_client_reports_size.as_bytes()
     }
 
     /// Returns the maximum size of an envelope payload in bytes.

--- a/relay-general/src/protocol/client_report.rs
+++ b/relay-general/src/protocol/client_report.rs
@@ -1,0 +1,22 @@
+use relay_common::{DataCategory, UnixTimestamp};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ClientReport {
+    /// The timestamp of when the report was created.
+    pub timestamp: Option<UnixTimestamp>,
+    /// Discard reason counters.
+    pub discarded_events: Vec<(String, DataCategory, u32)>,
+}
+
+impl ClientReport {
+    /// Parses a client report update from JSON.
+    pub fn parse(payload: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(payload)
+    }
+
+    /// Serializes a client report update back into JSON.
+    pub fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+}

--- a/relay-general/src/protocol/client_report.rs
+++ b/relay-general/src/protocol/client_report.rs
@@ -2,11 +2,18 @@ use relay_common::{DataCategory, UnixTimestamp};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DiscardedEvent {
+    pub reason: String,
+    pub category: DataCategory,
+    pub quantity: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ClientReport {
     /// The timestamp of when the report was created.
     pub timestamp: Option<UnixTimestamp>,
     /// Discard reason counters.
-    pub discarded_events: Vec<(String, DataCategory, u32)>,
+    pub discarded_events: Vec<DiscardedEvent>,
 }
 
 impl ClientReport {
@@ -30,32 +37,40 @@ mod tests {
         let json = r#"{
   "timestamp": "2020-02-07T15:17:00Z",
   "discarded_events": [
-    ["foo_reason", "error", 42],
-    ["foo_reason", "transaction", 23]
+    {"reason": "foo_reason", "category": "error", "quantity": 42},
+    {"reason": "foo_reason", "category": "transaction", "quantity": 23}
   ]
 }"#;
 
         let output = r#"{
   "timestamp": 1581088620,
   "discarded_events": [
-    [
-      "foo_reason",
-      "error",
-      42
-    ],
-    [
-      "foo_reason",
-      "transaction",
-      23
-    ]
+    {
+      "reason": "foo_reason",
+      "category": "error",
+      "quantity": 42
+    },
+    {
+      "reason": "foo_reason",
+      "category": "transaction",
+      "quantity": 23
+    }
   ]
 }"#;
 
         let update = ClientReport {
             timestamp: Some("2020-02-07T15:17:00Z".parse().unwrap()),
             discarded_events: vec![
-                ("foo_reason".into(), DataCategory::Error, 42),
-                ("foo_reason".into(), DataCategory::Transaction, 23),
+                DiscardedEvent {
+                    reason: "foo_reason".into(),
+                    category: DataCategory::Error,
+                    quantity: 42,
+                },
+                DiscardedEvent {
+                    reason: "foo_reason".into(),
+                    category: DataCategory::Transaction,
+                    quantity: 23,
+                },
             ],
         };
 

--- a/relay-general/src/protocol/client_report.rs
+++ b/relay-general/src/protocol/client_report.rs
@@ -20,3 +20,47 @@ impl ClientReport {
         serde_json::to_vec(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_report_roundtrip() {
+        let json = r#"{
+  "timestamp": "2020-02-07T15:17:00Z",
+  "discarded_events": [
+    ["foo_reason", "error", 42],
+    ["foo_reason", "transaction", 23]
+  ]
+}"#;
+
+        let output = r#"{
+  "timestamp": 1581088620,
+  "discarded_events": [
+    [
+      "foo_reason",
+      "error",
+      42
+    ],
+    [
+      "foo_reason",
+      "transaction",
+      23
+    ]
+  ]
+}"#;
+
+        let update = ClientReport {
+            timestamp: Some("2020-02-07T15:17:00Z".parse().unwrap()),
+            discarded_events: vec![
+                ("foo_reason".into(), DataCategory::Error, 42),
+                ("foo_reason".into(), DataCategory::Transaction, 23),
+            ],
+        };
+
+        let parsed = ClientReport::parse(json.as_bytes()).unwrap();
+        assert_eq_dbg!(update, parsed);
+        assert_eq_str!(output, serde_json::to_string_pretty(&update).unwrap());
+    }
+}

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -2,6 +2,7 @@
 
 mod breadcrumb;
 mod breakdowns;
+mod client_report;
 mod clientsdk;
 mod constants;
 mod contexts;
@@ -32,6 +33,7 @@ pub use sentry_release_parser::{validate_environment, validate_release};
 
 pub use self::breadcrumb::Breadcrumb;
 pub use self::breakdowns::Breakdowns;
+pub use self::client_report::ClientReport;
 pub use self::clientsdk::{ClientSdkInfo, ClientSdkPackage};
 pub use self::constants::VALID_PLATFORMS;
 pub use self::contexts::{

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -106,7 +106,7 @@ impl CategoryUnit {
             | DataCategory::Security => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
             DataCategory::Session => Some(Self::Batched),
-            DataCategory::Unknown => None,
+            DataCategory::Internal | DataCategory::Unknown => None,
         }
     }
 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -817,7 +817,7 @@ impl EnvelopeProcessor {
         for ((reason, category), quantity) in discarded_events.into_iter() {
             producer.do_send(TrackOutcome {
                 timestamp: timestamp.as_datetime(),
-                scoping: state.envelope_context.scoping.clone(),
+                scoping: state.envelope_context.scoping,
                 outcome: Outcome::ClientDiscard(reason),
                 event_id: None,
                 remote_addr: state.envelope_context.remote_addr,

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -789,12 +789,14 @@ impl EnvelopeProcessor {
             };
             match ClientReport::parse(&item.payload()) {
                 Ok(report) => {
-                    for (reason, category, quantity) in report.discarded_events.into_iter() {
-                        if reason.len() > 200 {
+                    for discarded_event in report.discarded_events.into_iter() {
+                        if discarded_event.reason.len() > 200 {
                             relay_log::trace!("ignored client outcome with an overlong reason");
                             continue;
                         }
-                        *discarded_events.entry((reason, category)).or_insert(0) += quantity;
+                        *discarded_events
+                            .entry((discarded_event.reason, discarded_event.category))
+                            .or_insert(0) += discarded_event.quantity;
                     }
                     if let Some(ts) = report.timestamp {
                         timestamp.get_or_insert(ts);

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -807,16 +807,16 @@ impl EnvelopeProcessor {
             false
         });
 
+        if discarded_events.is_empty() {
+            return;
+        }
+
         let timestamp =
             timestamp.get_or_insert_with(|| UnixTimestamp::from_secs(received.timestamp() as u64));
 
         if clock_drift_processor.is_drifted() {
             relay_log::trace!("applying clock drift correction to client report");
             clock_drift_processor.process_timestamp(timestamp);
-        }
-
-        if discarded_events.is_empty() {
-            return;
         }
 
         let producer = OutcomeProducer::from_registry();

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -20,9 +20,9 @@ use relay_config::{Config, HttpEncoding, RelayMode};
 use relay_general::pii::{PiiAttachmentsProcessor, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
-    self, Breadcrumb, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp, IpAddr,
-    LenientString, Metrics, RelayInfo, SecurityReportType, SessionUpdate, Timestamp, UserReport,
-    Values,
+    self, Breadcrumb, ClientReport, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp,
+    IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionUpdate, Timestamp,
+    UserReport, Values,
 };
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
@@ -273,7 +273,10 @@ impl EnvelopeContext {
                 event_id: self.event_id,
                 remote_addr: self.remote_addr,
                 category: DataCategory::Attachment,
-                quantity: self.summary.attachment_quantity,
+                // XXX: attachment_quantity is usize which lets us go all the way to
+                // 64bit on our machines, but the protocl and data store can only
+                // do 32.
+                quantity: self.summary.attachment_quantity as u32,
             });
         }
     }
@@ -765,6 +768,65 @@ impl EnvelopeProcessor {
         });
     }
 
+    /// Validates and extracts client reports.
+    ///
+    /// At the moment client reports are primarily used to transfer outcomes from
+    /// client SDKs.  The outcomes are removed here and sent directly to the outcomes
+    /// system.
+    fn process_client_reports(&self, state: &mut ProcessEnvelopeState) {
+        let mut timestamp = None;
+        let mut discarded_events = BTreeMap::new();
+        let received = state.envelope_context.received_at;
+
+        let clock_drift_processor = ClockDriftProcessor::new(state.envelope.sent_at(), received)
+            .at_least(MINIMUM_CLOCK_DRIFT);
+
+        // we're going through all client reports but we're effectively just merging
+        // them into the first one.
+        state.envelope.retain_items(|item| {
+            if item.ty() != ItemType::ClientReport {
+                return true;
+            };
+            match ClientReport::parse(&item.payload()) {
+                Ok(report) => {
+                    for (reason, category, quantity) in report.discarded_events.into_iter() {
+                        if reason.len() > 200 {
+                            relay_log::trace!("ignored client outcome with an overlong reason");
+                            continue;
+                        }
+                        *discarded_events.entry((reason, category)).or_insert(0) += quantity;
+                    }
+                    if let Some(ts) = report.timestamp {
+                        timestamp.get_or_insert(ts);
+                    }
+                }
+                Err(err) => relay_log::trace!("invalid client report received: {}", LogError(&err)),
+            }
+            false
+        });
+
+        let timestamp =
+            timestamp.get_or_insert_with(|| UnixTimestamp::from_secs(received.timestamp() as u64));
+
+        if clock_drift_processor.is_drifted() {
+            relay_log::trace!("applying clock drift correction to client report");
+            clock_drift_processor.process_timestamp(timestamp);
+        }
+
+        let producer = OutcomeProducer::from_registry();
+        for ((reason, category), quantity) in discarded_events.into_iter() {
+            producer.do_send(TrackOutcome {
+                timestamp: timestamp.as_datetime(),
+                scoping: state.envelope_context.scoping.clone(),
+                outcome: Outcome::ClientDiscard(reason),
+                event_id: None,
+                remote_addr: state.envelope_context.remote_addr,
+                category,
+                quantity,
+            });
+        }
+    }
+
     /// Creates and initializes the processing state.
     ///
     /// This applies defaults to the envelope and initializes empty rate limits.
@@ -1064,6 +1126,7 @@ impl EnvelopeProcessor {
             ItemType::Sessions => false,
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
+            ItemType::ClientReport => false,
         }
     }
 
@@ -1553,6 +1616,7 @@ impl EnvelopeProcessor {
         }
 
         self.process_sessions(&mut state);
+        self.process_client_reports(&mut state);
         self.process_user_reports(&mut state);
 
         if state.creates_event() {

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -84,7 +84,7 @@ pub struct TrackOutcome {
     /// The event's data category.
     pub category: DataCategory,
     /// The number of events or total attachment size in bytes.
-    pub quantity: usize,
+    pub quantity: u32,
 }
 
 impl Message for TrackOutcome {
@@ -114,6 +114,9 @@ pub enum Outcome {
     /// The event has been discarded because of invalid data.
     Invalid(DiscardReason),
 
+    /// The event has already been discarded on the client side.
+    ClientDiscard(String),
+
     /// Reserved but unused in Sentry.
     #[allow(dead_code)]
     Abuse,
@@ -127,6 +130,7 @@ impl Outcome {
             Outcome::RateLimited(_) => 2,
             Outcome::Invalid(_) => 3,
             Outcome::Abuse => 4,
+            Outcome::ClientDiscard(_) => 5,
         }
     }
 
@@ -140,6 +144,7 @@ impl Outcome {
             Outcome::RateLimited(code_opt) => code_opt
                 .as_ref()
                 .map(|code| Cow::Owned(code.as_str().into())),
+            Outcome::ClientDiscard(ref discard_reason) => Some(Cow::Borrowed(discard_reason)),
             Outcome::Abuse => None,
         }
     }
@@ -319,7 +324,7 @@ pub struct TrackRawOutcome {
     pub category: Option<u8>,
     /// The number of events or total attachment size in bytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub quantity: Option<usize>,
+    pub quantity: Option<u32>,
 }
 
 impl TrackRawOutcome {

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -335,6 +335,7 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
     let mut event_size = 0;
     let mut attachments_size = 0;
     let mut session_count = 0;
+    let mut client_reports_size = 0;
 
     for item in envelope.items() {
         match item.ty() {
@@ -355,12 +356,14 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
             ItemType::UserReport => (),
             ItemType::Metrics => (),
             ItemType::MetricBuckets => (),
+            ItemType::ClientReport => client_reports_size += item.len(),
         }
     }
 
     event_size <= config.max_event_size()
         && attachments_size <= config.max_attachments_size()
         && session_count <= config.max_session_count()
+        && client_reports_size <= config.max_client_reports_size()
 }
 
 /// Handles Sentry events.

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -100,6 +100,8 @@ pub enum ItemType {
     Metrics,
     /// Buckets of preaggregated metrics encoded as JSON.
     MetricBuckets,
+    /// Client internal report (eg: outcomes).
+    ClientReport,
 }
 
 impl ItemType {
@@ -130,6 +132,7 @@ impl fmt::Display for ItemType {
             Self::Sessions => write!(f, "aggregated sessions"),
             Self::Metrics => write!(f, "metrics"),
             Self::MetricBuckets => write!(f, "metric buckets"),
+            Self::ClientReport => write!(f, "client report"),
         }
     }
 }
@@ -548,7 +551,8 @@ impl Item {
             | ItemType::Session
             | ItemType::Sessions
             | ItemType::Metrics
-            | ItemType::MetricBuckets => false,
+            | ItemType::MetricBuckets
+            | ItemType::ClientReport => false,
         }
     }
 
@@ -569,6 +573,7 @@ impl Item {
             ItemType::Sessions => false,
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
+            ItemType::ClientReport => false,
         }
     }
 }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -102,6 +102,13 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
+        // the following items are "internal" item types.  From the perspective of the SDK
+        // the use the "internal" data category however this data category is in fact never
+        // supposed to be emitted by relay as internal items must not be rate limited.  As
+        // such we do not emit a data category here.  An SDK however is supposed to assume
+        // that such item types use the reserved "internal" data category to not accidentally
+        // assume another rate limit (such as default).
+        ItemType::ClientReport => None,
     }
 }
 
@@ -242,7 +249,9 @@ impl Enforcement {
                     event_id: envelope.event_id(),
                     remote_addr: envelope.meta().remote_addr(),
                     category: limit.category,
-                    quantity: limit.quantity,
+                    // XXX: on the limiter we have quantity of usize, but in the protocol
+                    // and data store we're limited to u32.
+                    quantity: limit.quantity as u32,
                 });
             }
         }

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -112,6 +112,16 @@ where
     })
 }
 
+/// Runs the provided function with an active actix system.
+///
+/// This function otherwise functions exactly as [`block_fn`].
+pub fn with_system<F, R>(func: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    block_fn(move || future::ok::<_, ()>(func())).unwrap()
+}
+
 /// Returns a future which completes after the requested delay.
 /// ```
 /// use std::time::Duration;

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -180,6 +180,11 @@ class SentryLike(object):
         envelope.add_item(Item(payload=PayloadRef(json=payload), type="sessions"))
         self.send_envelope(project_id, envelope)
 
+    def send_client_report(self, project_id, payload):
+        envelope = Envelope()
+        envelope.add_item(Item(PayloadRef(json=payload), type="client_report"))
+        self.send_envelope(project_id, envelope)
+
     def send_metrics(self, project_id, payload, timestamp=None):
         envelope = Envelope()
         envelope.add_item(

--- a/tests/integration/test_client_report.py
+++ b/tests/integration/test_client_report.py
@@ -19,8 +19,8 @@ def test_client_reports(relay, mini_sentry):
     report_payload = {
         "timestamp": timestamp.isoformat(),
         "discarded_events": [
-            ["queue_full", "error", 42],
-            ["queue_full", "transaction", 1231],
+            ["queue_overflow", "error", 42],
+            ["queue_overflow", "transaction", 1231],
         ],
     }
 
@@ -39,7 +39,7 @@ def test_client_reports(relay, mini_sentry):
             "project_id": 42,
             "key_id": 123,
             "outcome": 5,
-            "reason": "queue_full",
+            "reason": "queue_overflow",
             "remote_addr": "127.0.0.1",
             "source": "my-layer",
             "category": 1,
@@ -51,7 +51,7 @@ def test_client_reports(relay, mini_sentry):
             "project_id": 42,
             "key_id": 123,
             "outcome": 5,
-            "reason": "queue_full",
+            "reason": "queue_overflow",
             "remote_addr": "127.0.0.1",
             "source": "my-layer",
             "category": 2,

--- a/tests/integration/test_client_report.py
+++ b/tests/integration/test_client_report.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+
+
+def test_client_reports(relay, mini_sentry):
+    config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+            "source": "my-layer",
+        }
+    }
+
+    relay = relay(mini_sentry, config)
+
+    project_id = 42
+    timestamp = datetime.now(tz=timezone.utc)
+
+    report_payload = {
+        "timestamp": timestamp.isoformat(),
+        "discarded_events": [
+            ["queue_full", "error", 42],
+            ["queue_full", "transaction", 1231],
+        ],
+    }
+
+    mini_sentry.add_full_project_config(project_id)
+    relay.send_client_report(project_id, report_payload)
+
+    outcomes = []
+    for _ in range(2):
+        outcomes.extend(mini_sentry.captured_outcomes.get(timeout=0.2)["outcomes"])
+
+    timestamp_formatted = timestamp.isoformat().split(".")[0] + ".000000Z"
+    assert outcomes == [
+        {
+            "timestamp": timestamp_formatted,
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 5,
+            "reason": "queue_full",
+            "remote_addr": "127.0.0.1",
+            "source": "my-layer",
+            "category": 1,
+            "quantity": 42,
+        },
+        {
+            "timestamp": timestamp_formatted,
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 5,
+            "reason": "queue_full",
+            "remote_addr": "127.0.0.1",
+            "source": "my-layer",
+            "category": 2,
+            "quantity": 1231,
+        },
+    ]

--- a/tests/integration/test_client_report.py
+++ b/tests/integration/test_client_report.py
@@ -19,8 +19,8 @@ def test_client_reports(relay, mini_sentry):
     report_payload = {
         "timestamp": timestamp.isoformat(),
         "discarded_events": [
-            ["queue_overflow", "error", 42],
-            ["queue_overflow", "transaction", 1231],
+            {"reason": "queue_overflow", "category": "error", "quantity": 42},
+            {"reason": "queue_overflow", "category": "transaction", "quantity": 1231},
         ],
     }
 


### PR DESCRIPTION
This adds support for client reports from the SDKs. This feature is primarily used to allow client SDKs to emit outcomes.

The way this is currently implemented is that we add a new envelope item type called `client_report` which contains these outcomes. The envelope item type is intentionally kept flexible for future expansion as we already discussed emitting other internal debug information upstream which is unrelated to outcomes (eg: number of breadcrumbs discarded and configuration errors).

Because of how SDKs are currently implemented we now reserve `internal` as data category for such metric items. Relay however will never emit such a data category as we do not want to communicate actual rate limits for such envelope items.

From the relay perspective any outcome reason that an SDK emits is acceptable and upstreamed. It's up to the snuba consumer to whitelist these outcomes to avoid writing bad data into the kafka topic. This way SDKs can send more outcomes even if relays have not been updated.

Refs  INGEST-343