### PR TITLE
ref: More compact repr of projectkey

### DIFF
--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1105,7 +1105,7 @@ mod tests {
         assert_eq!(*meta.dsn(), dsn);
         assert_eq!(meta.project_id(), Some(ProjectId::new(42)));
         assert_eq!(
-            meta.public_key().as_str(),
+            meta.public_key().to_string(),
             "e12d836b15bb49d7bbf99e64295d995b"
         );
         assert_eq!(meta.client(), Some("sentry/javascript"));
@@ -1268,7 +1268,7 @@ mod tests {
         assert_eq!(*meta.dsn(), dsn);
         assert_eq!(meta.project_id(), Some(ProjectId::new(42)));
         assert_eq!(
-            meta.public_key().as_str(),
+            meta.public_key().to_string(),
             "e12d836b15bb49d7bbf99e64295d995b"
         );
         assert_eq!(meta.client(), Some("sentry/client"));


### PR DESCRIPTION
We should be able to represent all DSNs with half the bytes. I validated
that we don't have non-hex DSNs in prod, this returns 0:

select count(*) from sentry_projectkey where encode(decode(public_key, 'hex'), 'hex') != public_key

This should solve the concern voiced by Jan in https://github.com/getsentry/relay/pull/795

#skip-changelog