### PR TITLE
feat(client-reports): Protocol support for client reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add sampling based on transaction name. ([#1058](https://github.com/getsentry/relay/pull/1058))
 - Support running Relay without config directory. The most important configuration, including Relay mode and credentials, can now be provided through commandline arguments or environment variables alone. ([#1055](https://github.com/getsentry/relay/pull/1055)
-- Protocol support for client reports. ([#1074](https://github.com/getsentry/relay/pull/1074))
+- Protocol support for client reports. ([#1081](https://github.com/getsentry/relay/pull/1081))
 - Extract session metrics in non processing relays. ([#1073](https://github.com/getsentry/relay/pull/1073))
 
 **Bug Fixes**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add sampling based on transaction name. ([#1058](https://github.com/getsentry/relay/pull/1058))
 - Support running Relay without config directory. The most important configuration, including Relay mode and credentials, can now be provided through commandline arguments or environment variables alone. ([#1055](https://github.com/getsentry/relay/pull/1055)
+- Protocol support for client reports. ([#1074](https://github.com/getsentry/relay/pull/1074))
 - Extract session metrics in non processing relays. ([#1073](https://github.com/getsentry/relay/pull/1073))
 
 **Bug Fixes**:

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -107,6 +107,8 @@ pub enum DataCategory {
     Attachment = 4,
     /// Session updates. Quantity is the number of updates in the batch.
     Session = 5,
+    /// Reserved data category that shall not appear in the outcomes.
+    Internal = -2,
     /// Any other data category not known by this Relay.
     #[serde(other)]
     Unknown = -1,
@@ -122,6 +124,7 @@ impl DataCategory {
             "security" => Self::Security,
             "attachment" => Self::Attachment,
             "session" => Self::Session,
+            "internal" => Self::Internal,
             _ => Self::Unknown,
         }
     }
@@ -135,6 +138,7 @@ impl DataCategory {
             Self::Security => "security",
             Self::Attachment => "attachment",
             Self::Session => "session",
+            Self::Internal => "internal",
             Self::Unknown => "unknown",
         }
     }
@@ -146,6 +150,8 @@ impl DataCategory {
 
     /// Returns the numeric value for this outcome.
     pub fn value(self) -> Option<u8> {
+        // negative values (Internal and Unknown) cannot be sent as
+        // outcomes (internally so!)
         (self as i8).try_into().ok()
     }
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -501,6 +501,8 @@ struct Limits {
     max_attachment_size: ByteSize,
     /// The maximum combined size for all attachments in an envelope or request.
     max_attachments_size: ByteSize,
+    /// The maximum combined size for all client reports in an envelope or request.
+    max_client_reports_size: ByteSize,
     /// The maximum payload size for an entire envelopes. Individual limits still apply.
     max_envelope_size: ByteSize,
     /// The maximum number of session items per envelope.
@@ -539,6 +541,7 @@ impl Default for Limits {
             max_event_size: ByteSize::mebibytes(1),
             max_attachment_size: ByteSize::mebibytes(100),
             max_attachments_size: ByteSize::mebibytes(100),
+            max_client_reports_size: ByteSize::kibibytes(4),
             max_envelope_size: ByteSize::mebibytes(100),
             max_session_count: 100,
             max_api_payload_size: ByteSize::mebibytes(20),
@@ -1449,6 +1452,11 @@ impl Config {
     /// (minidump, unreal, standalone attachments) in bytes.
     pub fn max_attachments_size(&self) -> usize {
         self.values.limits.max_attachments_size.as_bytes()
+    }
+
+    /// Returns the maxmium combined size of client reports in bytes.
+    pub fn max_client_reports_size(&self) -> usize {
+        self.values.limits.max_client_reports_size.as_bytes()
     }
 
     /// Returns the maximum size of an envelope payload in bytes.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -827,6 +827,8 @@ pub struct Outcomes {
     /// Controls whether outcomes will be emitted when processing is disabled.
     /// Processing relays always emit outcomes (for backwards compatibility).
     pub emit_outcomes: bool,
+    /// Controls wheather client reported outcomes should be emitted.
+    pub emit_client_outcomes: bool,
     /// The maximum number of outcomes that are batched before being sent
     /// via http to the upstream (only applies to non processing relays).
     pub batch_size: usize,
@@ -842,6 +844,7 @@ impl Default for Outcomes {
     fn default() -> Self {
         Outcomes {
             emit_outcomes: false,
+            emit_client_outcomes: true,
             batch_size: 1000,
             batch_interval: 500,
             source: None,
@@ -1308,6 +1311,13 @@ impl Config {
     /// in processing mode.
     pub fn emit_outcomes(&self) -> bool {
         self.values.outcomes.emit_outcomes || self.values.processing.enabled
+    }
+
+    /// Returns whether this Relay should emit client outcomes
+    ///
+    /// This is `true` when `outcomes.emit_client_outcomes` is enabled and this relay emits outcomes.
+    pub fn emit_client_outcomes(&self) -> bool {
+        self.emit_outcomes() && self.values.outcomes.emit_client_outcomes
     }
 
     /// Returns the maximum number of outcomes that are batched before being sent

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1023,6 +1023,18 @@ impl Config {
         Ok(config)
     }
 
+    /// Creates a config from a JSON value.
+    ///
+    /// This is mostly useful for tests.
+    pub fn from_json_value(value: serde_json::Value) -> Result<Config, ConfigError> {
+        Ok(Config {
+            values: serde_json::from_value(value)
+                .map_err(|err| ConfigError::wrap(err, ConfigErrorKind::BadJson))?,
+            credentials: None,
+            path: PathBuf::new(),
+        })
+    }
+
     /// Override configuration with values coming from other sources (e.g. env variables or
     /// command line parameters)
     pub fn apply_override(

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1327,11 +1327,15 @@ impl Config {
 
     /// Returns whether this Relay should emit client outcomes
     ///
-    /// This is `true` when `outcomes.emit_client_outcomes` is enabled and this relay emits
-    /// outcomes.  Relays that do not emit client outcomes will forward client recieved outcomes
-    /// directly to the next relay in the chain as client report envelope.
+    /// Relays that do not emit client outcomes will forward client recieved outcomes
+    /// directly to the next relay in the chain as client report envelope.  This is only done
+    /// if this relay emits outcomes at all. A relay that will not emit outcomes
+    /// will forward the envelope unchanged.
+    ///
+    /// This flag can be explicitly disabled on processing relays as well to prevent the
+    /// emitting of client outcomes to the kafka topic.
     pub fn emit_client_outcomes(&self) -> bool {
-        self.emit_outcomes() && self.values.outcomes.emit_client_outcomes
+        self.values.outcomes.emit_client_outcomes
     }
 
     /// Returns the maximum number of outcomes that are batched before being sent

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1315,7 +1315,9 @@ impl Config {
 
     /// Returns whether this Relay should emit client outcomes
     ///
-    /// This is `true` when `outcomes.emit_client_outcomes` is enabled and this relay emits outcomes.
+    /// This is `true` when `outcomes.emit_client_outcomes` is enabled and this relay emits
+    /// outcomes.  Relays that do not emit client outcomes will forward client recieved outcomes
+    /// directly to the next relay in the chain as client report envelope.
     pub fn emit_client_outcomes(&self) -> bool {
         self.emit_outcomes() && self.values.outcomes.emit_client_outcomes
     }

--- a/relay-general/src/protocol/client_report.rs
+++ b/relay-general/src/protocol/client_report.rs
@@ -1,0 +1,81 @@
+use relay_common::{DataCategory, UnixTimestamp};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DiscardedEvent {
+    pub reason: String,
+    pub category: DataCategory,
+    pub quantity: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ClientReport {
+    /// The timestamp of when the report was created.
+    pub timestamp: Option<UnixTimestamp>,
+    /// Discard reason counters.
+    pub discarded_events: Vec<DiscardedEvent>,
+}
+
+impl ClientReport {
+    /// Parses a client report update from JSON.
+    pub fn parse(payload: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(payload)
+    }
+
+    /// Serializes a client report update back into JSON.
+    pub fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_report_roundtrip() {
+        let json = r#"{
+  "timestamp": "2020-02-07T15:17:00Z",
+  "discarded_events": [
+    {"reason": "foo_reason", "category": "error", "quantity": 42},
+    {"reason": "foo_reason", "category": "transaction", "quantity": 23}
+  ]
+}"#;
+
+        let output = r#"{
+  "timestamp": 1581088620,
+  "discarded_events": [
+    {
+      "reason": "foo_reason",
+      "category": "error",
+      "quantity": 42
+    },
+    {
+      "reason": "foo_reason",
+      "category": "transaction",
+      "quantity": 23
+    }
+  ]
+}"#;
+
+        let update = ClientReport {
+            timestamp: Some("2020-02-07T15:17:00Z".parse().unwrap()),
+            discarded_events: vec![
+                DiscardedEvent {
+                    reason: "foo_reason".into(),
+                    category: DataCategory::Error,
+                    quantity: 42,
+                },
+                DiscardedEvent {
+                    reason: "foo_reason".into(),
+                    category: DataCategory::Transaction,
+                    quantity: 23,
+                },
+            ],
+        };
+
+        let parsed = ClientReport::parse(json.as_bytes()).unwrap();
+        assert_eq_dbg!(update, parsed);
+        assert_eq_str!(output, serde_json::to_string_pretty(&update).unwrap());
+    }
+}

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -2,6 +2,7 @@
 
 mod breadcrumb;
 mod breakdowns;
+mod client_report;
 mod clientsdk;
 mod constants;
 mod contexts;
@@ -32,6 +33,7 @@ pub use sentry_release_parser::{validate_environment, validate_release};
 
 pub use self::breadcrumb::Breadcrumb;
 pub use self::breakdowns::Breakdowns;
+pub use self::client_report::ClientReport;
 pub use self::clientsdk::{ClientSdkInfo, ClientSdkPackage};
 pub use self::constants::VALID_PLATFORMS;
 pub use self::contexts::{

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -106,7 +106,7 @@ impl CategoryUnit {
             | DataCategory::Security => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
             DataCategory::Session => Some(Self::Batched),
-            DataCategory::Unknown => None,
+            DataCategory::Internal | DataCategory::Unknown => None,
         }
     }
 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -2796,7 +2796,7 @@ mod tests {
         });
 
         let envelope = envelope_response.envelope.unwrap();
-        let item = envelope.items().nth(0).unwrap();
+        let item = envelope.items().next().unwrap();
         assert_eq!(item.ty(), ItemType::ClientReport);
     }
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -770,6 +770,16 @@ impl EnvelopeProcessor {
     /// client SDKs.  The outcomes are removed here and sent directly to the outcomes
     /// system.
     fn process_client_reports(&self, state: &mut ProcessEnvelopeState) {
+        // if client outcomes are disabled we just remove the client reports entirely
+        // for now and bail.  If at a later point we transfer additional information
+        // this will have to just ignore the outcomes.
+        if !self.config.emit_client_outcomes() {
+            state
+                .envelope
+                .retain_items(|item| item.ty() != ItemType::ClientReport);
+            return;
+        }
+
         let mut timestamp = None;
         let mut discarded_events = BTreeMap::new();
         let received = state.envelope_context.received_at;

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -770,13 +770,9 @@ impl EnvelopeProcessor {
     /// client SDKs.  The outcomes are removed here and sent directly to the outcomes
     /// system.
     fn process_client_reports(&self, state: &mut ProcessEnvelopeState) {
-        // if client outcomes are disabled we just remove the client reports entirely
-        // for now and bail.  If at a later point we transfer additional information
-        // this will have to just ignore the outcomes.
+        // if client outcomes are disabled we leave the the client reports unprocessed
+        // and pass them on.
         if !self.config.emit_client_outcomes() {
-            state
-                .envelope
-                .retain_items(|item| item.ty() != ItemType::ClientReport);
             return;
         }
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -84,7 +84,7 @@ pub struct TrackOutcome {
     /// The event's data category.
     pub category: DataCategory,
     /// The number of events or total attachment size in bytes.
-    pub quantity: usize,
+    pub quantity: u32,
 }
 
 impl Message for TrackOutcome {
@@ -114,6 +114,9 @@ pub enum Outcome {
     /// The event has been discarded because of invalid data.
     Invalid(DiscardReason),
 
+    /// The event has already been discarded on the client side.
+    ClientDiscard(String),
+
     /// Reserved but unused in Sentry.
     #[allow(dead_code)]
     Abuse,
@@ -127,6 +130,7 @@ impl Outcome {
             Outcome::RateLimited(_) => 2,
             Outcome::Invalid(_) => 3,
             Outcome::Abuse => 4,
+            Outcome::ClientDiscard(_) => 5,
         }
     }
 
@@ -140,6 +144,7 @@ impl Outcome {
             Outcome::RateLimited(code_opt) => code_opt
                 .as_ref()
                 .map(|code| Cow::Owned(code.as_str().into())),
+            Outcome::ClientDiscard(ref discard_reason) => Some(Cow::Borrowed(discard_reason)),
             Outcome::Abuse => None,
         }
     }
@@ -319,7 +324,7 @@ pub struct TrackRawOutcome {
     pub category: Option<u8>,
     /// The number of events or total attachment size in bytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub quantity: Option<usize>,
+    pub quantity: Option<u32>,
 }
 
 impl TrackRawOutcome {

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -335,6 +335,7 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
     let mut event_size = 0;
     let mut attachments_size = 0;
     let mut session_count = 0;
+    let mut client_reports_size = 0;
 
     for item in envelope.items() {
         match item.ty() {
@@ -355,12 +356,14 @@ fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
             ItemType::UserReport => (),
             ItemType::Metrics => (),
             ItemType::MetricBuckets => (),
+            ItemType::ClientReport => client_reports_size += item.len(),
         }
     }
 
     event_size <= config.max_event_size()
         && attachments_size <= config.max_attachments_size()
         && session_count <= config.max_session_count()
+        && client_reports_size <= config.max_client_reports_size()
 }
 
 /// Handles Sentry events.

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -100,6 +100,8 @@ pub enum ItemType {
     Metrics,
     /// Buckets of preaggregated metrics encoded as JSON.
     MetricBuckets,
+    /// Client internal report (eg: outcomes).
+    ClientReport,
 }
 
 impl ItemType {
@@ -130,6 +132,7 @@ impl fmt::Display for ItemType {
             Self::Sessions => write!(f, "aggregated sessions"),
             Self::Metrics => write!(f, "metrics"),
             Self::MetricBuckets => write!(f, "metric buckets"),
+            Self::ClientReport => write!(f, "client report"),
         }
     }
 }
@@ -572,7 +575,8 @@ impl Item {
             | ItemType::Session
             | ItemType::Sessions
             | ItemType::Metrics
-            | ItemType::MetricBuckets => false,
+            | ItemType::MetricBuckets
+            | ItemType::ClientReport => false,
         }
     }
 
@@ -593,6 +597,7 @@ impl Item {
             ItemType::Sessions => false,
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
+            ItemType::ClientReport => false,
         }
     }
 }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -102,6 +102,13 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
+        // the following items are "internal" item types.  From the perspective of the SDK
+        // the use the "internal" data category however this data category is in fact never
+        // supposed to be emitted by relay as internal items must not be rate limited.  As
+        // such we do not emit a data category here.  An SDK however is supposed to assume
+        // that such item types use the reserved "internal" data category to not accidentally
+        // assume another rate limit (such as default).
+        ItemType::ClientReport => None,
     }
 }
 
@@ -242,7 +249,9 @@ impl Enforcement {
                     event_id: envelope.event_id(),
                     remote_addr: envelope.meta().remote_addr(),
                     category: limit.category,
-                    quantity: limit.quantity,
+                    // XXX: on the limiter we have quantity of usize, but in the protocol
+                    // and data store we're limited to u32.
+                    quantity: limit.quantity as u32,
                 });
             }
         }

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -112,6 +112,16 @@ where
     })
 }
 
+/// Runs the provided function with an active actix system.
+///
+/// This function otherwise functions exactly as [`block_fn`].
+pub fn with_system<F, R>(func: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    block_fn(move || future::ok::<_, ()>(func())).unwrap()
+}
+
 /// Returns a future which completes after the requested delay.
 /// ```
 /// use std::time::Duration;

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -191,6 +191,11 @@ class SentryLike(object):
         envelope.add_item(Item(payload=PayloadRef(json=payload), type="sessions"))
         self.send_envelope(project_id, envelope)
 
+    def send_client_report(self, project_id, payload):
+        envelope = Envelope()
+        envelope.add_item(Item(PayloadRef(json=payload), type="client_report"))
+        self.send_envelope(project_id, envelope)
+
     def send_metrics(self, project_id, payload, timestamp=None):
         envelope = Envelope()
         envelope.add_item(

--- a/tests/integration/test_client_report.py
+++ b/tests/integration/test_client_report.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+
+
+def test_client_reports(relay, mini_sentry):
+    config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+            "source": "my-layer",
+        }
+    }
+
+    relay = relay(mini_sentry, config)
+
+    project_id = 42
+    timestamp = datetime.now(tz=timezone.utc)
+
+    report_payload = {
+        "timestamp": timestamp.isoformat(),
+        "discarded_events": [
+            {"reason": "queue_overflow", "category": "error", "quantity": 42},
+            {"reason": "queue_overflow", "category": "transaction", "quantity": 1231},
+        ],
+    }
+
+    mini_sentry.add_full_project_config(project_id)
+    relay.send_client_report(project_id, report_payload)
+
+    outcomes = []
+    for _ in range(2):
+        outcomes.extend(mini_sentry.captured_outcomes.get(timeout=0.2)["outcomes"])
+
+    timestamp_formatted = timestamp.isoformat().split(".")[0] + ".000000Z"
+    assert outcomes == [
+        {
+            "timestamp": timestamp_formatted,
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 5,
+            "reason": "queue_overflow",
+            "remote_addr": "127.0.0.1",
+            "source": "my-layer",
+            "category": 1,
+            "quantity": 42,
+        },
+        {
+            "timestamp": timestamp_formatted,
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 5,
+            "reason": "queue_overflow",
+            "remote_addr": "127.0.0.1",
+            "source": "my-layer",
+            "category": 2,
+            "quantity": 1231,
+        },
+    ]


### PR DESCRIPTION
Second attempt of #1074.

This adds support for client reports from the SDKs. This feature is primarily
used to allow client SDKs to emit outcomes.

The way this is currently implemented is that we add a new envelope item
type called `client_report` which contains these outcomes. The envelope item
type is intentionally kept flexible for future expansion as we already discussed
emitting other internal debug information upstream which is unrelated to
outcomes (eg: number of breadcrumbs discarded and configuration errors).

Because of how SDKs are currently implemented we now reserve internal
as data category for such metric items. Relay however will never emit
such a data category as we do not want to communicate actual rate limits
for such envelope items.

From the relay perspective any outcome reason that an SDK emits is
acceptable and upstreamed. It's up to the snuba consumer to whitelist
these outcomes to avoid writing bad data into the kafka topic. This
way SDKs can send more outcomes even if relays have not been updated.

The emitting of client outcomes can be disabled with the `emit_client_outcomes`
flag which is also honored on processing relay stop the flow of data to the
kafka topic.