### PR TITLE
docs(event): Clarify SDK non-use of culprit field

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -243,6 +243,8 @@ pub struct Event {
     pub fingerprint: Annotated<Fingerprint>,
 
     /// Custom culprit of the event.
+    ///
+    /// This field is deprecated and shall not be set by client SDKs.
     #[metastructure(max_chars = "culprit", pii = "maybe")]
     pub culprit: Annotated<String>,
 

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -49,7 +49,7 @@ expression: event_json_schema()
           ]
         },
         "culprit": {
-          "description": " Custom culprit of the event.",
+          "description": " Custom culprit of the event.\n\n This field is deprecated and shall not be set by client SDKs.",
           "default": null,
           "type": [
             "string",


### PR DESCRIPTION
The culprit field is deprecated and should not be used by SDKs.  Or so
the wisdom of the sentry slack channels concludes.

#skip-changelog