### PR TITLE
ref(server): Remove redundant dynamic sampling processing on fast path (INGEST-330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Add new metrics on Relay's performance in dealing with buckets of metric aggregates, as well as the amount of aggregated buckets. ([#1070](https://github.com/getsentry/relay/pull/1070))
 - Add the exclusive time of a span. ([#1061](https://github.com/getsentry/relay/pull/1061))
+- Remove redundant dynamic sampling processing on fast path (INGEST-330). ([#1084](https://github.com/getsentry/relay/pull/1084))
 
 ## 21.8.0
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -2068,7 +2068,6 @@ impl Default for EnvelopeManager {
 pub struct QueueEnvelope {
     pub envelope: Envelope,
     pub project_key: ProjectKey,
-    pub sampling_project_key: Option<ProjectKey>,
     pub start_time: Instant,
 }
 
@@ -2093,7 +2092,6 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
         let QueueEnvelope {
             mut envelope,
             project_key,
-            sampling_project_key,
             start_time,
         } = message;
 
@@ -2129,7 +2127,6 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
             self.active_envelopes += 1;
             context.notify(HandleEnvelope {
                 envelope: event_envelope,
-                sampling_project_key,
                 project_key,
                 start_time,
             });
@@ -2141,7 +2138,6 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
             context.notify(HandleEnvelope {
                 envelope,
                 project_key,
-                sampling_project_key,
                 start_time,
             });
         }
@@ -2170,7 +2166,6 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
 struct HandleEnvelope {
     pub envelope: Envelope,
     pub project_key: ProjectKey,
-    pub sampling_project_key: Option<ProjectKey>,
     pub start_time: Instant,
 }
 
@@ -2206,8 +2201,9 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
             envelope,
             project_key,
             start_time,
-            sampling_project_key,
         } = message;
+
+        let sampling_project_key = envelope.trace_context().map(|tc| tc.public_key);
 
         let event_id = envelope.event_id();
         let envelope_context = Rc::new(RefCell::new(EnvelopeContext::from_envelope(&envelope)));


### PR DESCRIPTION
Remove dynamic sampling from Relay’s fast path, since the sampling decision is not returned to the client, and sampling always requires up-to-date project configs.

INGEST-330