### PR TITLE
fix(processing): Correctly validate timestamps for outcomes and sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+- Correctly validate timestamps for outcomes and sessions. ([#1086](https://github.com/getsentry/relay/pull/1086))
+
 ## 21.9.0
 
 **Features**:

--- a/tests/integration/test_client_report.py
+++ b/tests/integration/test_client_report.py
@@ -64,7 +64,6 @@ def test_client_reports(relay, mini_sentry):
 
 def test_client_reports_bad_timestamps(relay, mini_sentry):
     config = {
-        # too far int the future
         "outcomes": {
             "emit_outcomes": True,
             "batch_size": 1,
@@ -79,6 +78,7 @@ def test_client_reports_bad_timestamps(relay, mini_sentry):
     timestamp = datetime.now(tz=timezone.utc) + timedelta(days=300)
 
     report_payload = {
+        # too far into the future
         "timestamp": timestamp.isoformat(),
         "discarded_events": [
             {"reason": "queue_overflow", "category": "error", "quantity": 42},


### PR DESCRIPTION
This fixes a bug in the session code which validated against `max_age`
rather than `max_future` and adds missing timestamp validation code
for client outcomes.

Relay can deal with timestamps much larger than what Python can do so
accidentally emitting very large timestamps can cause issues on the
consumer side if the consumer does not skip over items with widely
incorrect timestamps.