### PR TITLE
fix(metrics): Add session.status tag to session.duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Correctly validate timestamps for outcomes and sessions. ([#1086](https://github.com/getsentry/relay/pull/1086))
 - Run compression on a thread pool when sending to upstream. ([#1085](https://github.com/getsentry/relay/pull/1085))
 
+**Internal**:
+- Add session.status tag to extracted session.duration metric. ([#1087](https://github.com/getsentry/relay/pull/1087))
+
 ## 21.9.0
 
 **Features**:

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -551,7 +551,7 @@ fn extract_session_metrics(session: &SessionUpdate, target: &mut Vec<Metric>) {
                 unit: MetricUnit::Duration(DurationPrecision::Second),
                 value: MetricValue::Distribution(duration),
                 timestamp,
-                tags,
+                tags: with_tag(&tags, "session.status", session.status),
             });
         }
     }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -239,7 +239,11 @@ def test_session_metrics_non_processing(
             },
             {
                 "name": "session.duration",
-                "tags": {"environment": "production", "release": "sentry-test@1.0.0"},
+                "tags": {
+                    "environment": "production",
+                    "release": "sentry-test@1.0.0",
+                    "session.status": "exited",
+                },
                 "timestamp": ts,
                 "type": "d",
                 "unit": "s",
@@ -386,7 +390,11 @@ def test_session_metrics_processing(
         "type": "d",
         "unit": "s",
         "value": [1947.49],
-        "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
+        "tags": {
+            "environment": "production",
+            "release": "sentry-test@1.0.0",
+            "session.status": "exited",
+        },
     }
 
 


### PR DESCRIPTION
In session metric extraction, add the session status as a tag to the `session.duration` metric, such that we can group by status in release health.