### PR TITLE
fix(sessions): Add comment that this metric is currently only partially used

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -25,8 +25,8 @@ use relay_general::pii::{PiiAttachmentsProcessor, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp,
-    IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionUpdate, Timestamp,
-    UserReport, Values,
+    IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionStatus, SessionUpdate,
+    Timestamp, UserReport, Values,
 };
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
@@ -544,14 +544,14 @@ fn extract_session_metrics(session: &SessionUpdate, target: &mut Vec<Metric>) {
         }
     }
 
-    if session.status.is_terminal() {
+    if matches!(session.status, SessionStatus::Exited) {
         if let Some(duration) = session.duration {
             target.push(Metric {
                 name: "session.duration".to_owned(),
                 unit: MetricUnit::Duration(DurationPrecision::Second),
                 value: MetricValue::Distribution(duration),
                 timestamp,
-                tags: with_tag(&tags, "session.status", session.status),
+                tags,
             });
         }
     }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -25,8 +25,8 @@ use relay_general::pii::{PiiAttachmentsProcessor, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp,
-    IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionStatus, SessionUpdate,
-    Timestamp, UserReport, Values,
+    IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionUpdate, Timestamp,
+    UserReport, Values,
 };
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -239,7 +239,11 @@ def test_session_metrics_non_processing(
             },
             {
                 "name": "session.duration",
-                "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
+                "tags": {
+                    "environment": "production",
+                    "release": "sentry-test@1.0.0",
+                    "session.status": "exited",
+                },
                 "timestamp": ts,
                 "type": "d",
                 "unit": "s",
@@ -386,7 +390,11 @@ def test_session_metrics_processing(
         "type": "d",
         "unit": "s",
         "value": [1947.49],
-        "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
+        "tags": {
+            "environment": "production",
+            "release": "sentry-test@1.0.0",
+            "session.status": "exited",
+        },
     }
 
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -239,11 +239,7 @@ def test_session_metrics_non_processing(
             },
             {
                 "name": "session.duration",
-                "tags": {
-                    "environment": "production",
-                    "release": "sentry-test@1.0.0",
-                    "session.status": "exited",
-                },
+                "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
                 "timestamp": ts,
                 "type": "d",
                 "unit": "s",
@@ -390,11 +386,7 @@ def test_session_metrics_processing(
         "type": "d",
         "unit": "s",
         "value": [1947.49],
-        "tags": {
-            "environment": "production",
-            "release": "sentry-test@1.0.0",
-            "session.status": "exited",
-        },
+        "tags": {"environment": "production", "release": "sentry-test@1.0.0",},
     }
 
 


### PR DESCRIPTION
By @swatinem:

> by definition we only want to have the duration for healthy sessions. the product feature is defined that way
> why: because for crashed sessions, you simply can’t know the duration precisely (maybe its possible to infer via filesystem times), but most of the time its not really possible

So we need to actually filter on session.status everywhere we use durations.

#skip-changelog