### PR TITLE
fix(auth): Respond with bad json on signed requests [INGEST-407]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Correctly validate timestamps for outcomes and sessions. ([#1086](https://github.com/getsentry/relay/pull/1086))
 - Run compression on a thread pool when sending to upstream. ([#1085](https://github.com/getsentry/relay/pull/1085))
+- Report proper status codes and error messages when sending invalid JSON payloads to an endpoint with a `X-Sentry-Relay-Signature` header. ([#1090](https://github.com/getsentry/relay/pull/1090))
 
 **Internal**:
 - Add the exclusive time of the transaction's root span. ([#1083](https://github.com/getsentry/relay/pull/1083))

--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -1,4 +1,5 @@
 use actix_web::actix::*;
+use actix_web::http::StatusCode;
 use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use failure::Fail;
 use futures::prelude::*;
@@ -36,7 +37,12 @@ enum SignatureError {
 
 impl ResponseError for SignatureError {
     fn error_response(&self) -> HttpResponse {
-        HttpResponse::Unauthorized().json(&ApiErrorResponse::from_fail(self))
+        let status = match self {
+            SignatureError::InvalidJson(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::UNAUTHORIZED,
+        };
+
+        HttpResponse::build(status).json(&ApiErrorResponse::from_fail(self))
     }
 }
 

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -98,10 +98,13 @@ def test_dynamic_relays(mini_sentry, relay, caller, projects):
 def test_invalid_json(mini_sentry, relay):
     relay = relay(mini_sentry, wait_healthcheck=True)
 
+    body = "{}"  # missing the required `public_keys` field
+    packed, signature = SecretKey.parse(relay.secret_key).pack(body)
+
     resp = relay.post(
         "/api/0/relays/projectconfigs/?version=2",
-        data="{}",  # missing the required `public_keys` field
-        headers={"X-Sentry-Relay-Id": relay.relay_id, "X-Sentry-Relay-Signature": "doesnt_matter"},
+        data=packed,
+        headers={"X-Sentry-Relay-Id": relay.relay_id, "X-Sentry-Relay-Signature": signature},
     )
 
     assert resp.status_code == 400  # Bad Request

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -104,7 +104,10 @@ def test_invalid_json(mini_sentry, relay):
     resp = relay.post(
         "/api/0/relays/projectconfigs/?version=2",
         data=packed,
-        headers={"X-Sentry-Relay-Id": relay.relay_id, "X-Sentry-Relay-Signature": signature},
+        headers={
+            "X-Sentry-Relay-Id": relay.relay_id,
+            "X-Sentry-Relay-Signature": signature,
+        },
     )
 
     assert resp.status_code == 400  # Bad Request
@@ -117,7 +120,10 @@ def test_invalid_signature(mini_sentry, relay):
     resp = relay.post(
         "/api/0/relays/projectconfigs/?version=2",
         data='{"public_keys":[]}',
-        headers={"X-Sentry-Relay-Id": relay.relay_id, "X-Sentry-Relay-Signature": "broken"},
+        headers={
+            "X-Sentry-Relay-Id": relay.relay_id,
+            "X-Sentry-Relay-Signature": "broken",
+        },
     )
 
     assert resp.status_code == 401  # Unauthorized

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -101,7 +101,7 @@ def test_invalid_json(mini_sentry, relay):
     body = "{}"  # missing the required `public_keys` field
     packed, signature = SecretKey.parse(relay.secret_key).pack(body)
 
-    resp = relay.post(
+    response = relay.post(
         "/api/0/relays/projectconfigs/?version=2",
         data=packed,
         headers={
@@ -110,14 +110,14 @@ def test_invalid_json(mini_sentry, relay):
         },
     )
 
-    assert resp.status_code == 400  # Bad Request
-    assert "JSON" in resp.body
+    assert response.status_code == 400  # Bad Request
+    assert "JSON" in response.text
 
 
 def test_invalid_signature(mini_sentry, relay):
     relay = relay(mini_sentry, wait_healthcheck=True)
 
-    resp = relay.post(
+    response = relay.post(
         "/api/0/relays/projectconfigs/?version=2",
         data='{"public_keys":[]}',
         headers={
@@ -126,5 +126,5 @@ def test_invalid_signature(mini_sentry, relay):
         },
     )
 
-    assert resp.status_code == 401  # Unauthorized
-    assert "signature" in resp.body
+    assert response.status_code == 401  # Unauthorized
+    assert "signature" in response.text

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -117,5 +117,5 @@ def test_invalid_signature(mini_sentry, relay):
         headers={"X-Sentry-Relay-Id": relay.relay_id, "X-Sentry-Relay-Signature": "broken"},
     )
 
-    assert resp.status_code == 403  # Unauthorized
+    assert resp.status_code == 401  # Unauthorized
     assert "signature" in resp.body


### PR DESCRIPTION
Responds with `400 Bad Request` and a descriptive error message when 
sending invalid JSON payloads on endpoints requiring `SignedJson`. 
Previously, this would just result in a misleading "invalid relay 
signature" error.