### PR TITLE
build: Update libc to compile on arm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,9 +1810,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libz-sys"


### PR DESCRIPTION
Fixes compilation on Apple M1. Original error message was:

```
  = note: Undefined symbols for architecture arm64:
            "_fstat$INODE64", referenced from:
                listenfd::unix::is_sock::hdf6296f6525598e0 in liblistenfd-13da6c06d9b0563d.rlib(listenfd-13da6c06d9b0563d.listenfd.9kqorjim-cgu.8.rcgu.o)
          ld: symbol(s) not found for architecture arm64
```

#skip-changelog