### PR TITLE
build(make): Install venv without pip or easy_install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,8 @@ clean-target-dir:
 # Dependencies
 
 .venv/bin/python: Makefile
-	@rm -rf .venv
-	@which virtualenv || sudo pip install virtualenv
-	virtualenv -p $$RELAY_PYTHON_VERSION .venv
+	rm -rf .venv
+	$$RELAY_PYTHON_VERSION -m venv .venv
 
 .git/hooks/pre-commit:
 	@cd .git/hooks && ln -sf ../../scripts/git-precommit-hook pre-commit


### PR DESCRIPTION
With python 3 and `venv`, it is possible to bootstrap a virtual environment
without installing `virtualenv` or even requiring `pip` on the machine. This
reduces requirements on the development machine.

This replays #533, and the same has been changed on symbolicator already.

#skip-changelog

