### PR TITLE
fix(server): Skip invalid project keys in batch request [INGEST-406]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 - Report proper status codes and error messages when sending invalid JSON payloads to an endpoint with a `X-Sentry-Relay-Signature` header. ([#1090](https://github.com/getsentry/relay/pull/1090))
 
 **Internal**:
+
 - Add the exclusive time of the transaction's root span. ([#1083](https://github.com/getsentry/relay/pull/1083))
 - Add session.status tag to extracted session.duration metric. ([#1087](https://github.com/getsentry/relay/pull/1087))
+- Serve project configs for batched requests where one of the project keys cannot be parsed. ([#1093](https://github.com/getsentry/relay/pull/1093))
 
 ## 21.9.0
 

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -35,13 +35,15 @@ mod _macro {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+/// A query to retrieve a batch of project states from upstream.
+///
+/// This query does not implement `Deserialize`. To parse the query, use a wrapper that skips
+/// invalid project keys instead of failing the entire batch.
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetProjectStates {
     pub public_keys: Vec<ProjectKey>,
-    #[serde(default)]
     pub full_config: bool,
-    #[serde(default)]
     pub no_cache: bool,
 }
 

--- a/relay-server/src/utils/error_boundary.rs
+++ b/relay-server/src/utils/error_boundary.rs
@@ -60,6 +60,14 @@ impl<T> ErrorBoundary<T> {
     }
 
     #[inline]
+    pub fn ok(self) -> Option<T> {
+        match self {
+            ErrorBoundary::Err(_) => None,
+            ErrorBoundary::Ok(value) => Some(value),
+        }
+    }
+
+    #[inline]
     pub fn unwrap_or_else<F>(self, op: F) -> T
     where
         F: FnOnce(&dyn Fail) -> T,

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -136,12 +136,14 @@ def test_broken_projectkey(mini_sentry, relay):
     mini_sentry.add_basic_project_config(42)
     public_key = mini_sentry.get_dsn_public_key(42)
 
-    body = {"public_keys": [
-        public_key,    # valid
-        "deadbeef",    # wrong length
-        42,            # wrong type
-        "/?$äß000000000000000000000000000", # invalid characters
-    ]}
+    body = {
+        "public_keys": [
+            public_key,  # valid
+            "deadbeef",  # wrong length
+            42,  # wrong type
+            "/?$äß000000000000000000000000000",  # invalid characters
+        ]
+    }
     packed, signature = SecretKey.parse(relay.secret_key).pack(body)
 
     response = relay.post(

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -137,7 +137,7 @@ def test_broken_projectkey(mini_sentry, relay):
     public_key = mini_sentry.get_dsn_public_key(42)
 
     body = {
-        "public_keys": [
+        "publicKeys": [
             public_key,  # valid
             "deadbeef",  # wrong length
             42,  # wrong type


### PR DESCRIPTION
Instead of failing a project config batch request during deserialization, skip invalid keys and serve valid ones. The downstream Relay assumes missing responses as `ProjectState::missing`. This is done [here](https://github.com/getsentry/relay/blob/ed59bb40d70b6409246e429d3c16687bc26344f2/relay-server/src/actors/project_upstream.rs#L250) by creating a `None` entry, and then setting it to missing [here](https://github.com/getsentry/relay/blob/ed59bb40d70b6409246e429d3c16687bc26344f2/relay-server/src/actors/project_upstream.rs#L260).
