### PR TITLE
build(py): Build and publish arm64 wheels

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -70,6 +70,8 @@ jobs:
           pip install wheel
           python setup.py bdist_wheel -p ${{ matrix.py-platform }}
         working-directory: py
+        env:
+          CARGO_BUILD_TARGET: ${{ matrix.target }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release-library/**
+      - build/** # TODO: Remove. Temporary to test library builds
 
 jobs:
   linux:

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           submodules: recursive
 
+      - if: matrix.build-arch == 'manylinux2014_aarch64'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: Build in Docker
         run: scripts/docker-manylinux.sh
         env:

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-arch: [i686, x86_64]
+        build-arch:
+          - manylinux2010_i686
+          - manylinux2010_x86_64
+          - manylinux2014_aarch64
 
     name: Python Linux ${{ matrix.build-arch }}
     runs-on: ubuntu-latest
@@ -31,8 +34,19 @@ jobs:
           path: py/dist/*
 
   macos:
-    name: Python macOS
-    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - macos-version: "10.15"
+            target: x86_64-apple-darwin
+            py-platform: macosx-10_15_x86_64
+          - macos-version: "11.0"
+            target: aarch64-apple-darwin
+            py-platform: macosx-11_0_arm64
+
+    name: Python macOS ${{ matrix.py-platform }}
+    runs-on: macos-${{ matrix.macos-version }}
 
     steps:
       - uses: actions/checkout@v2
@@ -42,6 +56,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: ${{ matrix.target }}
           profile: minimal
           override: true
 
@@ -52,7 +67,7 @@ jobs:
       - name: Build Wheel
         run: |
           pip install wheel
-          python setup.py bdist_wheel
+          python setup.py bdist_wheel -p ${{ matrix.py-platform }}
         working-directory: py
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -75,6 +75,7 @@ jobs:
           python setup.py bdist_wheel -p ${{ matrix.py-platform }}
         working-directory: py
         env:
+          # consumed by cargo and setup.py to obtain the target dir
           CARGO_BUILD_TARGET: ${{ matrix.target }}
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - release-library/**
-      - build/** # TODO: Remove. Temporary to test library builds
 
 jobs:
   linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.55"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"

--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -16,6 +16,9 @@ targets:
 
 requireNames:
   - /^sentry_relay-.*-py2\.py3-none-macosx_10_15_x86_64.whl$/
+  - /^sentry_relay-.*-py2\.py3-none-macosx_11_0_arm64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_i686.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_x86_64.*\.whl$/
+  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_x86_64.*\.whl$/
+  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_aarch64.*\.whl$/
   - /^sentry-relay-.*\.zip$/

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Build and publish binary wheels for `arm64` / `aarch64` on macOS and Linux. ([#1100](https://github.com/getsentry/relay/pull/1100))
+
 ## 0.8.8
 
 - Bump release parser to 1.3.0 and add ability to compare versions. ([#1038](https://github.com/getsentry/relay/pull/1038))

--- a/py/setup.py
+++ b/py/setup.py
@@ -72,12 +72,24 @@ def build_native(spec):
     # Step 1: build the rust library
     build = spec.add_external_build(cmd=cmd, path=rust_path)
 
+    def find_dylib():
+        try:
+            return build.find_dylib("relay_cabi", in_path="target/%s" % target)
+        except LookupError as e:
+            cargo_target = os.environ.get("CARGO_BUILD_TARGET")
+            if cargo_target:
+                return build.find_dylib(
+                    "relay_cabi", in_path="target/%s/%s" % (cargo_target, target)
+                )
+            else:
+                raise e
+
     rtld_flags = ["NOW"]
     if sys.platform == "darwin":
         rtld_flags.append("NODELETE")
     spec.add_cffi_module(
         module_path="sentry_relay._lowlevel",
-        dylib=lambda: build.find_dylib("relay_cabi", in_path="target/%s" % target),
+        dylib=find_dylib,
         header_filename=lambda: build.find_header(
             "relay.h", in_path="relay-cabi/include"
         ),

--- a/py/setup.py
+++ b/py/setup.py
@@ -73,16 +73,12 @@ def build_native(spec):
     build = spec.add_external_build(cmd=cmd, path=rust_path)
 
     def find_dylib():
-        try:
-            return build.find_dylib("relay_cabi", in_path="target/%s" % target)
-        except LookupError as e:
-            cargo_target = os.environ.get("CARGO_BUILD_TARGET")
-            if cargo_target:
-                return build.find_dylib(
-                    "relay_cabi", in_path="target/%s/%s" % (cargo_target, target)
-                )
-            else:
-                raise e
+        cargo_target = os.environ.get("CARGO_BUILD_TARGET")
+        if cargo_target:
+            in_path = "target/%s/%s" % (cargo_target, target)
+        else:
+            in_path = "target/%s" % target
+        return build.find_dylib("relay_cabi", in_path=in_path)
 
     rtld_flags = ["NOW"]
     if sys.platform == "darwin":

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -6,7 +6,7 @@ BUILD_DIR="/work"
 docker run \
         -w /work/py \
         -v `pwd`:/work \
-        quay.io/pypa/manylinux2010_${BUILD_ARCH} \
+        quay.io/pypa/${BUILD_ARCH} \
         sh manylinux.sh
 
 # Fix permissions for shared directories


### PR DESCRIPTION
This adds builds for macOS and Linux arm64 wheels. The linux wheels are practically still manylinux_2010 compliant, however we're not able to build them as easily since there's no Docker container for that upstream.