### PR TITLE
feat(processing): Support multiple kafka clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Support multiple kafka cluster configurations ([#1101](https://github.com/getsentry/relay/pull/1101))
+
 ## 21.10.0
 
 **Bug Fixes**:

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -885,7 +885,7 @@ pub struct Processing {
     /// Additional kafka producer configurations.
     ///
     /// The `kafka_config` is the default producer configuration used for all topics. A secondary
-    /// kafka config `foo: ...` can be referenced in `topics:` like this:
+    /// kafka config can be referenced in `topics:` like this:
     ///
     /// ```yaml
     /// secondary_kafka_configs:

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -863,6 +863,9 @@ fn default_max_rate_limit() -> Option<u32> {
     Some(300) // 5 minutes
 }
 
+/// A mapping from "logical" topic to actual topic name and optionally a non-default kafka config.
+pub type TopicAssignments = TopicMap<TopicAssignment>;
+
 /// Controls Sentry-internal event processing.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Processing {
@@ -905,7 +908,7 @@ pub struct Processing {
     pub secondary_kafka_configs: BTreeMap<String, Vec<KafkaConfigParam>>,
     /// Kafka topic names.
     #[serde(default)]
-    pub topics: TopicMap<TopicAssignment>,
+    pub topics: TopicAssignments,
     /// Redis hosts to connect to for storing state for rate limits.
     #[serde(default)]
     pub redis: Option<RedisConfig>,

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -868,8 +868,8 @@ pub struct Processing {
     /// topics:
     ///   transactions: ingest-transactions
     ///   metrics:
-    ///     topic_name: ingest-metrics
-    ///     kafka_config_name: mycustomcluster
+    ///     name: ingest-metrics
+    ///     config: mycustomcluster
     /// ```
     ///
     /// Then metrics will be produced to an entirely different Kafka cluster.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -766,8 +766,10 @@ pub enum TopicAssignment {
     /// data to the given topic name.
     Secondary {
         /// The topic name to use.
+        #[serde(rename = "name")]
         topic_name: String,
         /// An identifier referencing one of the kafka configurations in `secondary_kafka_configs`.
+        #[serde(rename = "config")]
         kafka_config_name: String,
     },
 }

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -414,8 +414,9 @@ mod processing {
             let (future_producer, http_producer) = if config.processing_enabled() {
                 let mut client_config = ClientConfig::new();
                 for config_p in config
-                    .kafka_config(config.kafka_topics().get(KafkaTopic::Outcomes))
+                    .kafka_config(KafkaTopic::Outcomes)
                     .context(ServerErrorKind::KafkaError)?
+                    .1
                 {
                     client_config.set(config_p.name.as_str(), config_p.value.as_str());
                 }
@@ -465,14 +466,9 @@ mod processing {
             // kafka consumer groups.
             let key = message.event_id.unwrap_or_else(EventId::new).0;
 
-            let record = BaseRecord::to(
-                self.config
-                    .kafka_topics()
-                    .get(KafkaTopic::Outcomes)
-                    .topic_name(),
-            )
-            .payload(&payload)
-            .key(key.as_bytes().as_ref());
+            let record = BaseRecord::to(self.config.kafka_topic_name(KafkaTopic::Outcomes))
+                .payload(&payload)
+                .key(key.as_bytes().as_ref());
 
             match producer.send(record) {
                 Ok(_) => Ok(()),

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -76,10 +76,11 @@ impl StoreForwarder {
                 }
 
                 let mut client_config = ClientConfig::new();
-                for config_p in config
+                let kafka_config = config
                     .kafka_config(assignment)
-                    .context(ServerErrorKind::KafkaError)?
-                {
+                    .context(ServerErrorKind::KafkaError)?;
+
+                for config_p in kafka_config {
                     client_config.set(config_p.name.as_str(), config_p.value.as_str());
                 }
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -74,11 +74,6 @@ def relay_with_processing(relay, mini_sentry, processing_config):
 
     def inner(options=None):
         options = processing_config(options)
-
-        kafka_config = {}
-        for elm in options["processing"]["kafka_config"]:
-            kafka_config[elm["name"]] = elm["value"]
-
         return relay(mini_sentry, options=options)
 
     return inner

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -10,6 +10,7 @@ import time
 
 HOUR_MILLISEC = 1000 * 3600
 
+
 def test_outcomes_processing(relay_with_processing, mini_sentry, outcomes_consumer):
     """
     Tests outcomes are sent to the kafka outcome topic
@@ -50,7 +51,9 @@ def test_outcomes_processing(relay_with_processing, mini_sentry, outcomes_consum
     assert start <= event_emission <= end
 
 
-def test_outcomes_custom_topic(mini_sentry, outcomes_consumer, processing_config, relay, get_topic_name):
+def test_outcomes_custom_topic(
+    mini_sentry, outcomes_consumer, processing_config, relay, get_topic_name
+):
     """
     Tests outcomes are sent to the kafka outcome topic, but this
     time use secondary_kafka_configs to set up the outcomes topic.
@@ -60,16 +63,16 @@ def test_outcomes_custom_topic(mini_sentry, outcomes_consumer, processing_config
     effectively tests that the secondary config is used.
     """
     options = processing_config(None)
-    kafka_config = options['processing']['kafka_config']
+    kafka_config = options["processing"]["kafka_config"]
 
     # This kafka config becomes invalid, rdkafka warns on stdout that it will drop everything on this client
-    options['processing']['kafka_config'] = []
+    options["processing"]["kafka_config"] = []
 
-    options['processing']['secondary_kafka_configs'] = {}
-    options['processing']['secondary_kafka_configs']['foo'] = kafka_config 
+    options["processing"]["secondary_kafka_configs"] = {}
+    options["processing"]["secondary_kafka_configs"]["foo"] = kafka_config
 
     # ...however, we use a custom topic config to make it work again
-    options['processing']['topics']['outcomes'] = {
+    options["processing"]["topics"]["outcomes"] = {
         "topic_name": get_topic_name("outcomes"),
         "kafka_config_name": "foo",
     }

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -73,8 +73,8 @@ def test_outcomes_custom_topic(
 
     # ...however, we use a custom topic config to make it work again
     options["processing"]["topics"]["outcomes"] = {
-        "topic_name": get_topic_name("outcomes"),
-        "kafka_config_name": "foo",
+        "name": get_topic_name("outcomes"),
+        "config": "foo",
     }
 
     relay = relay(mini_sentry, options=options)

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -10,7 +10,6 @@ import time
 
 HOUR_MILLISEC = 1000 * 3600
 
-
 def test_outcomes_processing(relay_with_processing, mini_sentry, outcomes_consumer):
     """
     Tests outcomes are sent to the kafka outcome topic
@@ -19,6 +18,63 @@ def test_outcomes_processing(relay_with_processing, mini_sentry, outcomes_consum
     kafka outcomes topic and the event has the proper information.
     """
     relay = relay_with_processing()
+
+    outcomes_consumer = outcomes_consumer()
+
+    message_text = "some message {}".format(datetime.now())
+    event_id = "11122233344455566677788899900011"
+    start = datetime.utcnow()
+
+    relay.send_event(
+        42,
+        {
+            "event_id": event_id,
+            "message": message_text,
+            "extra": {"msg_text": message_text},
+        },
+    )
+
+    outcome = outcomes_consumer.get_outcome()
+    assert outcome["project_id"] == 42
+    assert outcome["event_id"] == event_id
+    assert outcome.get("org_id") is None
+    assert outcome.get("key_id") is None
+    assert outcome["outcome"] == 3
+    assert outcome["reason"] == "project_id"
+    assert outcome["remote_addr"] == "127.0.0.1"
+
+    # deal with the timestamp separately (we can't control it exactly)
+    timestamp = outcome.get("timestamp")
+    event_emission = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    end = datetime.utcnow()
+    assert start <= event_emission <= end
+
+
+def test_outcomes_custom_topic(mini_sentry, outcomes_consumer, processing_config, relay, get_topic_name):
+    """
+    Tests outcomes are sent to the kafka outcome topic, but this
+    time use secondary_kafka_configs to set up the outcomes topic.
+    Since we are unlikely to be able to run multiple kafka clusters,
+    we set the primary/default kafka config to some nonsense that for
+    sure won't work, so asserting that an outcome comes through
+    effectively tests that the secondary config is used.
+    """
+    options = processing_config(None)
+    kafka_config = options['processing']['kafka_config']
+
+    # This kafka config becomes invalid, rdkafka warns on stdout that it will drop everything on this client
+    options['processing']['kafka_config'] = []
+
+    options['processing']['secondary_kafka_configs'] = {}
+    options['processing']['secondary_kafka_configs']['foo'] = kafka_config 
+
+    # ...however, we use a custom topic config to make it work again
+    options['processing']['topics']['outcomes'] = {
+        "topic_name": get_topic_name("outcomes"),
+        "kafka_config_name": "foo",
+    }
+
+    relay = relay(mini_sentry, options=options)
 
     outcomes_consumer = outcomes_consumer()
 


### PR DESCRIPTION
This adds additional config to Relay to allow for using dedicated kafka clusters for, in our usecase, the metrics topic. See https://www.notion.so/sentry/Configure-multiple-Kafka-brokers-in-Relay-36fc942b889b429589e87097a02b16e4 for design doc.

Points of improvement (for the future, not sure if relevant right now)

* Unused kafka configs are not warned about in any way (but then we also don't warn about unrecognized keys anywhere in the config)
* kafka configs are generally very lazily validated. that already included the actual values we pass to rdkafka, but it now also includes the names of the secondary configs. so for example you can reference unknown kafka configs, and it doesn't matter for relay as long as you don't turn on processing mode
* the error messages on invalid topic assignments are atrocious because untagged enums in serde only provide generic error messages
* you can't do this:

  ```
  topics:
    metrics:
      topic_name: foo
   ```
   
   i.e. use the "verbose" form of metrics assignment without explicitly specifying both a topic name and a kafka config name. I think that's okay! if you don't want to specify a custom kafka config, simply write `metrics: foo` like before, if you don't want to specify a custom topic name while explicitly specifying a custom kafka config I guess you're out of luck.

