### PR TITLE
feat(metrics): Add bucket width to bucket protocol [INGEST-350]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Features**
+
+- Add bucket width to bucket protocol. ([#1103](https://github.com/getsentry/relay/pull/1103))
+
+
 ## 21.10.0
 
 **Bug Fixes**:

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1385,6 +1385,7 @@ mod tests {
             "value": [36, 49, 57, 68],
             "type": "d",
             "timestamp": 1615889440,
+            "width": 10,
             "tags": {
                 "route": "user_index"
             }
@@ -1396,6 +1397,7 @@ mod tests {
         [
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
+                width: 10,
                 name: "endpoint.response_time",
                 unit: Duration(
                     MilliSecond,
@@ -1423,7 +1425,8 @@ mod tests {
             "name": "endpoint.hits",
             "value": 4,
             "type": "c",
-            "timestamp": 1615889440
+            "timestamp": 1615889440,
+            "width": 10
           }
         ]"#;
 
@@ -1432,6 +1435,7 @@ mod tests {
         [
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
+                width: 10,
                 name: "endpoint.hits",
                 unit: None,
                 value: Counter(
@@ -1448,6 +1452,7 @@ mod tests {
         let json = r#"[
   {
     "timestamp": 1615889440,
+    "width": 10,
     "name": "endpoint.response_time",
     "type": "d",
     "value": [
@@ -1462,6 +1467,7 @@ mod tests {
   },
   {
     "timestamp": 1615889440,
+    "width": 10,
     "name": "endpoint.hits",
     "type": "c",
     "value": 4.0,
@@ -1471,6 +1477,7 @@ mod tests {
   },
   {
     "timestamp": 1615889440,
+    "width": 10,
     "name": "endpoint.parallel_requests",
     "type": "g",
     "value": {
@@ -1483,6 +1490,7 @@ mod tests {
   },
   {
     "timestamp": 1615889440,
+    "width": 10,
     "name": "endpoint.users",
     "type": "s",
     "value": [

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -728,6 +728,7 @@ struct BucketKey {
 
 /// Parameters used by the [`Aggregator`].
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct AggregatorConfig {
     /// Determines the wall clock time interval for buckets in seconds.
     ///
@@ -806,7 +807,7 @@ impl AggregatorConfig {
 
         let output_timestamp = UnixTimestamp::from_secs(ts);
 
-        if timestamp < min_timestamp || timestamp > max_timestamp {
+        if output_timestamp < min_timestamp || output_timestamp > max_timestamp {
             return Err(AggregateMetricsError);
         }
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1889,6 +1889,8 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
 
                     relay_log::trace!("merging metric buckets into project cache");
                     project_cache.do_send(MergeBuckets::new(public_key, buckets));
+                } else {
+                    metric!(counter(RelayCounters::MetricBucketsParsingFailed) += 1);
                 }
             } else {
                 relay_log::error!(

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
+use std::cmp::max;
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::rc::Rc;
@@ -1863,7 +1864,7 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
         } = message;
 
         let received = relay_common::instant_to_date_time(start_time);
-        let default_timestamp = UnixTimestamp::from_secs(received.timestamp() as u64);
+        let received_timestamp = UnixTimestamp::from_secs(received.timestamp() as u64);
 
         let project_cache = ProjectCache::from_registry();
         let clock_drift_processor =
@@ -1872,15 +1873,20 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
         for item in items {
             let payload = item.payload();
             if item.ty() == ItemType::Metrics {
-                let timestamp = item.timestamp().unwrap_or(default_timestamp);
-                let metrics = Metric::parse_all(&payload, timestamp).filter_map(|result| {
-                    let mut metric = result.ok()?;
-                    clock_drift_processor.process_timestamp(&mut metric.timestamp);
-                    Some(metric)
-                });
+                let mut timestamp = item.timestamp().unwrap_or(received_timestamp);
+                clock_drift_processor.process_timestamp(&mut timestamp);
 
-                relay_log::trace!("inserting metrics into project cache");
-                project_cache.do_send(InsertMetrics::new(public_key, metrics));
+                let min_timestamp =
+                    max(0, received.timestamp() - self.config.max_secs_in_past()) as u64;
+                let max_timestamp =
+                    (received.timestamp() + self.config.max_secs_in_future()) as u64;
+                if min_timestamp <= timestamp.as_secs() && timestamp.as_secs() <= max_timestamp {
+                    let metrics =
+                        Metric::parse_all(&payload, timestamp).filter_map(|result| result.ok());
+
+                    relay_log::trace!("inserting metrics into project cache");
+                    project_cache.do_send(InsertMetrics::new(public_key, metrics));
+                }
             } else if item.ty() == ItemType::MetricBuckets {
                 if let Ok(mut buckets) = Bucket::parse_all(&payload) {
                     for bucket in &mut buckets {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1876,8 +1876,10 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
                 let mut timestamp = item.timestamp().unwrap_or(received_timestamp);
                 clock_drift_processor.process_timestamp(&mut timestamp);
 
-                let min_timestamp =
-                    max(0, received.timestamp() - self.config.max_secs_in_past()) as u64;
+                let min_timestamp = max(
+                    0,
+                    received.timestamp() - self.config.max_session_secs_in_past(),
+                ) as u64;
                 let max_timestamp =
                     (received.timestamp() + self.config.max_secs_in_future()) as u64;
                 if min_timestamp <= timestamp.as_secs() && timestamp.as_secs() <= max_timestamp {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -431,6 +431,8 @@ pub enum RelayCounters {
     ///    be used to ingest events. Once the grace period expires, the cache is evicted and new
     ///    requests wait for an update.
     EvictingStaleProjectCaches,
+    /// Number of times that parsing a metrics bucket item from an envelope fails.
+    MetricBucketsParsingFailed,
 }
 
 impl CounterMetric for RelayCounters {
@@ -456,6 +458,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
+            RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
         }
     }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -431,7 +431,7 @@ pub enum RelayCounters {
     ///    be used to ingest events. Once the grace period expires, the cache is evicted and new
     ///    requests wait for an update.
     EvictingStaleProjectCaches,
-    /// Number of times that parsing a metrics bucket item from an envelope fails.
+    /// Number of times that parsing a metrics bucket item from an envelope failed.
     MetricBucketsParsingFailed,
 }
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -6,11 +6,7 @@ import pytest
 from .test_envelope import generate_transaction_item
 
 TEST_CONFIG = {
-    "aggregator": {
-        "bucket_interval": 1,
-        "initial_delay": 0,
-        "debounce_delay": 0,
-    }
+    "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0,}
 }
 
 
@@ -23,12 +19,13 @@ def _session_payload(timestamp: datetime, started: datetime):
         "timestamp": timestamp.isoformat(),
         "started": started.isoformat(),
         "duration": 1947.49,
-        "status": "exited",
+        "status": "exited",if now > self.max_age {
+            now - self.max_age
+        } else {
+            0
+        }
         "errors": 0,
-        "attrs": {
-            "release": "sentry-test@1.0.0",
-            "environment": "production",
-        },
+        "attrs": {"release": "sentry-test@1.0.0", "environment": "production",},
     }
 
 
@@ -438,11 +435,7 @@ def test_transaction_metrics(
         "foo": {"value": 1.2},
         "bar": {"value": 1.3},
     }
-    transaction["breakdowns"] = {
-        "breakdown1": {
-            "baz": {"value": 1.4},
-        }
-    }
+    transaction["breakdowns"] = {"breakdown1": {"baz": {"value": 1.4},}}
 
     #: The `metrics_extracted` header is ignored for transactions for now.
     #: This means that transaction metrics are extracted regardless of the header.
@@ -454,11 +447,7 @@ def test_transaction_metrics(
     transaction["measurements"] = {
         "foo": {"value": 2.2},
     }
-    transaction["breakdowns"] = {
-        "breakdown1": {
-            "baz": {"value": 2.4},
-        }
-    }
+    transaction["breakdowns"] = {"breakdown1": {"baz": {"value": 2.4},}}
     relay.send_transaction(42, transaction, item_headers=item_headers)
 
     if not extract_metrics:

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -19,11 +19,7 @@ def _session_payload(timestamp: datetime, started: datetime):
         "timestamp": timestamp.isoformat(),
         "started": started.isoformat(),
         "duration": 1947.49,
-        "status": "exited",if now > self.max_age {
-            now - self.max_age
-        } else {
-            0
-        }
+        "status": "exited",
         "errors": 0,
         "attrs": {"release": "sentry-test@1.0.0", "environment": "production",},
     }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -6,7 +6,11 @@ import pytest
 from .test_envelope import generate_transaction_item
 
 TEST_CONFIG = {
-    "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0,}
+    "aggregator": {
+        "bucket_interval": 1,
+        "initial_delay": 0,
+        "debounce_delay": 0,
+    }
 }
 
 
@@ -21,7 +25,10 @@ def _session_payload(timestamp: datetime, started: datetime):
         "duration": 1947.49,
         "status": "exited",
         "errors": 0,
-        "attrs": {"release": "sentry-test@1.0.0", "environment": "production",},
+        "attrs": {
+            "release": "sentry-test@1.0.0",
+            "environment": "production",
+        },
     }
 
 
@@ -54,8 +61,8 @@ def test_metrics(mini_sentry, relay):
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
     assert received_metrics == [
-        {"timestamp": timestamp, "name": "bar", "value": 17.0, "type": "c"},
-        {"timestamp": timestamp, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "bar", "value": 17.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "foo", "value": 42.0, "type": "c"},
     ]
 
 
@@ -77,7 +84,7 @@ def test_metrics_backdated(mini_sentry, relay):
 
     received_metrics = metrics_item.get_bytes()
     assert json.loads(received_metrics.decode()) == [
-        {"timestamp": timestamp, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "foo", "value": 42.0, "type": "c"},
     ]
 
 
@@ -164,10 +171,10 @@ def test_session_metrics_non_processing(
     mini_sentry, relay, extract_metrics, metrics_extracted
 ):
     """
-        Tests metrics extraction in  a non processing relay
+    Tests metrics extraction in  a non processing relay
 
-        If and only if the metrics-extraction feature is enabled and the metrics from the session were not already
-        extracted the relay should extract the metrics from the session and mark the session item as "metrics extracted"
+    If and only if the metrics-extraction feature is enabled and the metrics from the session were not already
+    extracted the relay should extract the metrics from the session and mark the session item as "metrics extracted"
     """
 
     relay = relay(mini_sentry, options=TEST_CONFIG)
@@ -234,6 +241,7 @@ def test_session_metrics_non_processing(
                     "session.status": "init",
                 },
                 "timestamp": ts,
+                "width": 1,
                 "type": "c",
                 "value": 1.0,
             },
@@ -245,6 +253,7 @@ def test_session_metrics_non_processing(
                     "session.status": "exited",
                 },
                 "timestamp": ts,
+                "width": 1,
                 "type": "d",
                 "unit": "s",
                 "value": [1947.49],
@@ -257,6 +266,7 @@ def test_session_metrics_non_processing(
                     "session.status": "init",
                 },
                 "timestamp": ts,
+                "width": 1,
                 "type": "s",
                 "value": [1617781333],
             },
@@ -323,8 +333,8 @@ def test_session_metrics_processing(
     mini_sentry, relay_with_processing, metrics_consumer, metrics_extracted
 ):
     """
-        Tests that a processing relay with metrics-extraction enabled creates metrics
-        from sessions if the metrics were not already extracted before.
+    Tests that a processing relay with metrics-extraction enabled creates metrics
+    from sessions if the metrics were not already extracted before.
     """
     relay = relay_with_processing(options=TEST_CONFIG)
     project_id = 42
@@ -428,7 +438,11 @@ def test_transaction_metrics(
         "foo": {"value": 1.2},
         "bar": {"value": 1.3},
     }
-    transaction["breakdowns"] = {"breakdown1": {"baz": {"value": 1.4},}}
+    transaction["breakdowns"] = {
+        "breakdown1": {
+            "baz": {"value": 1.4},
+        }
+    }
 
     #: The `metrics_extracted` header is ignored for transactions for now.
     #: This means that transaction metrics are extracted regardless of the header.
@@ -440,7 +454,11 @@ def test_transaction_metrics(
     transaction["measurements"] = {
         "foo": {"value": 2.2},
     }
-    transaction["breakdowns"] = {"breakdown1": {"baz": {"value": 2.4},}}
+    transaction["breakdowns"] = {
+        "breakdown1": {
+            "baz": {"value": 2.4},
+        }
+    }
     relay.send_transaction(42, transaction, item_headers=item_headers)
 
     if not extract_metrics:


### PR DESCRIPTION
Previously, incoming metrics buckets' timestamps were not checked at all, so it was possible to have overlapping buckets in the aggregator. This PR:

* Adds a `width` field to the bucket protocol, so the upstream relay can decide what to do with bucket widths different than its own.
* Adds logic to merge incoming buckets of any form into the target bucket corresponding to its center.
* Adds sanity checks to the timestamps of both incoming raw metrics and incoming metrics buckets.

See also https://www.notion.so/sentry/Extension-to-the-bucket-protocol-6e7eb432e73f44eba868b6007d711b6c.