### PR TITLE
feat(metrics): Treat nil distinct_ids the same as None distinct_ids [INGEST-464]

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -523,7 +523,7 @@ fn extract_session_metrics(session: &SessionUpdate, target: &mut Vec<Metric>) {
             tags: tags.clone(),
         });
 
-        if let Some(ref distinct_id) = get_distinct_id(&session.distinct_id) {
+        if let Some(distinct_id) = get_distinct_id(&session.distinct_id) {
             target.push(Metric {
                 name: "user".to_owned(),
                 unit: MetricUnit::None,
@@ -545,7 +545,7 @@ fn extract_session_metrics(session: &SessionUpdate, target: &mut Vec<Metric>) {
             tags: with_tag(&tags, "session.status", session.status),
         });
 
-        if let Some(ref distinct_id) = get_distinct_id(&session.distinct_id) {
+        if let Some(distinct_id) = get_distinct_id(&session.distinct_id) {
             target.push(Metric {
                 name: "user".to_owned(),
                 unit: MetricUnit::None,

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -39,6 +39,7 @@ class Sentry(SentryLike):
         self.test_failures = []
         self.hits = {}
         self.known_relays = {}
+        self.fail_on_relay_error = True
 
     @property
     def internal_error_dsn(self):
@@ -257,7 +258,7 @@ def mini_sentry(request):
         envelope = Envelope.deserialize(flask_request.data)
         event = envelope.get_event()
 
-        if event is not None:
+        if event is not None and sentry.fail_on_relay_error:
             error = AssertionError("Relay sent us event: " + get_error_message(event))
             sentry.test_failures.append(("/api/666/envelope/", error))
 

--- a/tests/integration/test_forwarding.py
+++ b/tests/integration/test_forwarding.py
@@ -106,15 +106,13 @@ def test_limits(mini_sentry, relay):
 
 
 def test_timeouts(mini_sentry, relay):
+    mini_sentry.fail_on_relay_error = False
+
     @mini_sentry.app.route("/api/test/timeout")
     def hi():
         time.sleep(60)
 
-    try:
-        relay = relay(mini_sentry)
+    relay = relay(mini_sentry)
 
-        response = relay.get("/api/test/timeout")
-        assert response.status_code == 504
-
-    finally:
-        mini_sentry.test_failures.clear()
+    response = relay.get("/api/test/timeout")
+    assert response.status_code == 504


### PR DESCRIPTION
In sessions-based release health, nil UUIDs never count toward user metrics:
https://github.com/getsentry/snuba/blob/master/snuba/migrations/snuba_migrations/sessions/matview.py#L48

This means that in metrics-based release health, they should not either. At the point where we extract session metrics, the `distinct_id` is a string and not a UUID, so we have to attempt to parse it as UUID, then convert to `None` if it is nil.

#skip-changelog