### PR TITLE
fix(metrics): Accumulate session metrics on session start time

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -224,7 +224,7 @@ def test_session_metrics_non_processing(
         session_metrics = json.loads(metrics_item.get_bytes().decode())
         session_metrics = sorted(session_metrics, key=lambda x: x["name"])
 
-        ts = int(timestamp.timestamp())
+        ts = int(started.timestamp())
         assert session_metrics == [
             {
                 "name": "session",
@@ -352,10 +352,11 @@ def test_session_metrics_processing(
 
     metrics = metrics_by_name(metrics_consumer, 3)
 
+    expected_timestamp = int(started.timestamp())
     assert metrics["session"] == {
         "org_id": 1,
         "project_id": 42,
-        "timestamp": int(timestamp.timestamp()),
+        "timestamp": expected_timestamp,
         "name": "session",
         "type": "c",
         "unit": "",
@@ -370,7 +371,7 @@ def test_session_metrics_processing(
     assert metrics["user"] == {
         "org_id": 1,
         "project_id": 42,
-        "timestamp": int(timestamp.timestamp()),
+        "timestamp": expected_timestamp,
         "name": "user",
         "type": "s",
         "unit": "",
@@ -385,7 +386,7 @@ def test_session_metrics_processing(
     assert metrics["session.duration"] == {
         "org_id": 1,
         "project_id": 42,
-        "timestamp": int(timestamp.timestamp()),
+        "timestamp": expected_timestamp,
         "name": "session.duration",
         "type": "d",
         "unit": "s",


### PR DESCRIPTION
Fix session metrics extraction such that session metrics are always emitted with the session start time.

We treat the number of _started_ sessions in each time bucket as the total session count for that time bucket, and compute the crash rate, for example, by dividing by this total. It is therefore necessary to emit all consequent session updates into the same time bucket. This was always the intention but must have slipped during the initial implementation.

See also https://www.notion.so/sentry/Modeling-Release-Health-with-Metrics-486d189c23de4bf88f37a12620467a45.

