### PR TITLE
feat: New buckets flushed counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add bucket width to bucket protocol. ([#1103](https://github.com/getsentry/relay/pull/1103))
 
+**Internal**:
+
+- Change `metrics.buckets.flushed` metric to counter, and move old histogram to `metrics.buckets.flushed_per_cycle`. ([#1106](https://github.com/getsentry/relay/pull/1106))
+
 
 ## 21.10.0
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 
-use crate::statsd::{MetricGauges, MetricHistograms, MetricTimers};
+use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricTimers};
 use crate::{Metric, MetricType, MetricUnit, MetricValue};
 
 /// A snapshot of values within a [`Bucket`].
@@ -1135,7 +1135,10 @@ impl Aggregator {
                 .spawn(context);
         }
 
-        relay_statsd::metric!(histogram(MetricHistograms::BucketsFlushed) = total_bucket_count);
+        relay_statsd::metric!(
+            histogram(MetricHistograms::BucketsFlushedPerCycle) = total_bucket_count
+        );
+        relay_statsd::metric!(counter(MetricCounters::BucketsFlushed) += total_bucket_count as i64);
     }
 }
 

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{GaugeMetric, HistogramMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
 
 /// Timer metrics for Relay Metrics.
 pub enum MetricTimers {
@@ -21,7 +21,7 @@ impl TimerMetric for MetricTimers {
 /// Histogram metrics for Relay Metrics.
 pub enum MetricHistograms {
     /// The total number of metric buckets flushed in a cycle across all projects.
-    BucketsFlushed,
+    BucketsFlushedPerCycle,
 
     /// The number of metric buckets flushed in a cycle for each project.
     ///
@@ -34,7 +34,7 @@ pub enum MetricHistograms {
 impl HistogramMetric for MetricHistograms {
     fn name(&self) -> &'static str {
         match *self {
-            Self::BucketsFlushed => "metrics.buckets.flushed",
+            Self::BucketsFlushedPerCycle => "metrics.buckets.flushed_per_cycle",
             Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
         }
     }
@@ -50,6 +50,19 @@ impl GaugeMetric for MetricGauges {
     fn name(&self) -> &'static str {
         match *self {
             Self::Buckets => "metrics.buckets",
+        }
+    }
+}
+
+pub enum MetricCounters {
+    /// Number of metric buckets flushed (all cycles, all projects).
+    BucketsFlushed,
+}
+
+impl CounterMetric for MetricCounters {
+    fn name(&self) -> &'static str {
+        match *self {
+            MetricCounters::BucketsFlushed => "metrics.buckets.flushed",
         }
     }
 }


### PR DESCRIPTION
I want to count how many buckets we are flushing per second.

Our current `metrics.flushed` metric produces `metrics.flushed.avg` and
`metrics.flushed.sum`. You can approximate the counter in this commit
with those two metrics in two different ways, however the math seems
handwavy to me and I'd rather not rely on it.

`avg` shows you the average amount of buckets in a flush cycle. Since we
know that the flush cycle happens every 500ms, this means that `2 * avg`
is basically our buckets/s. However this assumes that the flush is
happening exactly every 500ms which already assumes a lot about
well-behavedness of Relay.

`sum` can probably be used too somehow? I'd need to know over which
timerange we are summing up. I don't think you're supposed to use
histograms this way.
