### PR TITLE
meta(vscode): Update python extension settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,8 @@
     "bungcip.better-toml",
     // Rust language server
     "matklad.rust-analyzer",
+    // Python including Pylance
+    "ms-python.python",
     // Crates.io dependency versions
     "serayuzgur.crates",
     // Debugger support for Rust and native

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,8 +10,8 @@
   "files.insertFinalNewline": true,
 
   // Python configuration
-  "python.pythonPath": ".venv/bin/python",
-  "python.linting.enabled": false,
+  "python.defaultInterpreterPath": ".venv/bin/python",
+  "python.linting.enabled": true,
   "python.formatting.provider": "black",
 
   // Language-specific overrides


### PR DESCRIPTION
The python extension was updated. One of our settings has been deprecated.

#skip-changelog

