### PR TITLE
ci: Bump sentry-integration python to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Run tests
         run: pytest tests -n auto -v
         env:
-          RELAY_VERSION_CHAIN: '20.6.0,latest'
+          RELAY_VERSION_CHAIN: "20.6.0,latest"
 
   sentry-relay-integration-tests:
     name: Sentry-Relay Integration Tests
@@ -267,7 +267,7 @@ jobs:
         with:
           workdir: sentry
           cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
-          python-version: 3.6
+          python-version: 3.8
           snuba: true
           kafka: true
 


### PR DESCRIPTION
Updates Sentry E2E tests since Sentry now requires Python 3.8.

#skip-changelog
