### PR TITLE
feat(core): Add option to control allocation sizes [INGEST-562]

### DIFF
--- a/relay-common/src/alloc.rs
+++ b/relay-common/src/alloc.rs
@@ -1,0 +1,40 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct RelayAllocator {
+    max_size: AtomicUsize,
+}
+
+unsafe impl GlobalAlloc for RelayAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let max_size = self.max_size.load(Ordering::Relaxed);
+        if max_size > 0 && layout.size() > max_size {
+            panic!(
+                "attempted to allocate {} bytes, crashing thread",
+                layout.size()
+            );
+        }
+
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: RelayAllocator = RelayAllocator {
+    max_size: AtomicUsize::new(0),
+};
+
+/// Set a max allocation size, default is to have none.
+pub fn set_max_alloc_size(max_size: Option<usize>) {
+    let max_size = match max_size {
+        Some(0) => panic!("max_size should probably be None"),
+        Some(x) => x,
+        None => 0,
+    };
+
+    GLOBAL.max_size.store(max_size, Ordering::Relaxed);
+}

--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -8,6 +8,7 @@
 #[macro_use]
 mod macros;
 
+mod alloc;
 mod cell;
 mod constants;
 mod glob;
@@ -16,6 +17,7 @@ mod retry;
 mod time;
 mod utils;
 
+pub use crate::alloc::*;
 pub use crate::cell::*;
 pub use crate::constants::*;
 pub use crate::glob::*;

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -534,6 +534,11 @@ struct Limits {
     /// The maximum number of seconds to wait for pending envelopes after receiving a shutdown
     /// signal.
     shutdown_timeout: u64,
+    /// The maximum memory allocation Relay can make, in bytes.
+    ///
+    /// Purposefully undocumented because we don't know yet how feasible this is.
+    #[serde(rename = "_max_alloc_size")]
+    max_alloc_size: Option<ByteSize>,
 }
 
 impl Default for Limits {
@@ -556,6 +561,7 @@ impl Default for Limits {
             max_pending_connections: 2048,
             max_connections: 25_000,
             shutdown_timeout: 10,
+            max_alloc_size: None,
         }
     }
 }
@@ -1453,6 +1459,15 @@ impl Config {
     /// Returns logging configuration.
     pub fn sentry(&self) -> &relay_log::SentryConfig {
         &self.values.sentry
+    }
+
+    /// The maximum allocation size relay can make.
+    pub fn max_alloc_size(&self) -> Option<usize> {
+        self.values
+            .limits
+            .max_alloc_size
+            .as_ref()
+            .map(ByteSize::as_bytes)
     }
 
     /// Returns the socket addresses for statsd.

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -47,6 +47,8 @@ pub fn execute() -> Result<(), Error> {
     config.apply_override(env_config)?;
 
     relay_log::init(config.logging(), config.sentry());
+    relay_common::set_max_alloc_size(config.max_alloc_size());
+
     if let Some(matches) = matches.subcommand_matches("config") {
         manage_config(&config, matches)
     } else if let Some(matches) = matches.subcommand_matches("credentials") {

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -133,3 +133,14 @@ def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     if should_be_allowed:
         mini_sentry.captured_events.get(timeout=1).get_event()
     assert mini_sentry.captured_events.empty()
+
+
+def test_relay_applies_malloc_limit(mini_sentry, relay):
+    project_id = 42
+    config = mini_sentry.add_basic_project_config(project_id)
+
+    relay = relay(mini_sentry, options={"limits": {"_max_alloc_size": 1}})
+
+    relay.send_event(project_id)
+
+    pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -1,6 +1,7 @@
 import queue
 import pytest
 import signal
+import subprocess
 
 
 def test_graceful_shutdown(mini_sentry, relay):
@@ -139,8 +140,5 @@ def test_relay_applies_malloc_limit(mini_sentry, relay):
     project_id = 42
     config = mini_sentry.add_basic_project_config(project_id)
 
-    relay = relay(mini_sentry, options={"limits": {"_max_alloc_size": 1}})
-
-    relay.send_event(project_id)
-
-    pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+    with pytest.raises(subprocess.CalledProcessError):
+        relay(mini_sentry, options={"limits": {"_max_alloc_size": 1}})


### PR DESCRIPTION
Add a config option to control the maximum allowed allocation size. On
failed allocation the thread will crash, and actix will maybe restart
it, but clearly not crash the entire process.

This was done in response to us finding a problem with actix's handling
of content encoding, where it would decompress a <1MB zipbomb into
multiple gigabytes allocated in a contiguous buffer.

There really should not be a reason to ever allocate 1GB,
at least not on a whim and for a single event.

One concern is regexes: those take a lot of memory and we're fine with
that, because we assume that them taking more space would shave off CPU
load. I think we'd be fine with a regex taking 1GB of RAM under certain
circumstances, but right now they don't so it's fine.

#skip-changelog