### PR TITLE
fix(monitoring): Implement failure instead of std error for proper cause chains [INGEST-251]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,7 @@ version = "21.10.0"
 dependencies = [
  "actix",
  "criterion",
+ "failure",
  "float-ord",
  "futures 0.1.29",
  "hash32",

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -18,6 +18,7 @@ relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
+failure = "0.1.8"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
When logging this parsing error using LogError, we view this std error
as a Fail in order to walk through its causes/sources. However, the
blanket impl that allows us to do so does not implement `cause()` at
all, in fact it does not implement a single method at all:
https://github.com/rust-lang-deprecated/failure/blob/135e2a3b9af422d9a9dc37ce7c69354c9b36e94b/src/lib.rs#L273

Therefore the resulting logs are useless: They tell you that parsing the
bucket failed and show the Display of the ParseBucketError, but they
don't print the serde error where all the interesting information about
this parsing error is.

We also have no way of implementing both std error and fail ourselves
because of conflicting trait impls, so let's revert this change for now,
make everything stay on Fail and come up with a proper migration
proposal, potentially just having one big PR that migrates everything to
std error at once and gets rid of the failure crate, or as a first step
changing LogError to take a std error.

There are other usages of std error in relay that I did not touch because
they do not store a cause/source error, so it doesn't matter.

#skip-changelog