### PR TITLE
fix(logging): Demote parsing error to debug level

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1912,7 +1912,7 @@ impl Handler<ProcessMetrics> for EnvelopeProcessor {
                         project_cache.do_send(MergeBuckets::new(public_key, buckets));
                     }
                     Err(error) => {
-                        relay_log::error!("failed to parse metric bucket: {}", LogError(&error));
+                        relay_log::debug!("failed to parse metric bucket: {}", LogError(&error));
                         metric!(counter(RelayCounters::MetricBucketsParsingFailed) += 1);
                     }
                 }


### PR DESCRIPTION
This was temporarily logged as error to investigate what's going on in
production, but this is really not a fatal error.

#skip-changelog