### PR TITLE
fix: Limit decompression of UE4 crashes [INGEST-565]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 **Bug Fixes**:
 
 - Avoid unbounded decompression of encoded requests. A particular request crafted to inflate to large amounts of memory, such as a zip bomb, could put Relay out of memory. ([#1117](https://github.com/getsentry/relay/pull/1117))
+- Avoid unbounded decompression of UE4 crash reports. Some crash reports could inflate to large amounts of memory before being checked for size, which could put Relay out of memory. ([#1121](https://github.com/getsentry/relay/pull/1121))
+
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cadence"
@@ -1452,7 +1452,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1552,7 +1552,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "http 0.2.1",
 ]
 
@@ -1589,7 +1589,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1613,7 +1613,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "hyper",
  "native-tls",
  "tokio 1.0.1",
@@ -3399,7 +3399,7 @@ checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4048,9 +4048,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "symbolic"
-version = "8.0.4"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b310ad97bccd25ba55a28ce7092932bb1fa3c5e013b9e0c1c4051bcdc81e239"
+checksum = "cdee51d8cb63a5bed678d0a1dbb181fb19b8b1ee682ef239e2db1eb544c8c6f6"
 dependencies = [
  "symbolic-common",
  "symbolic-unreal",
@@ -4058,9 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.0.4"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4134bb33c9218a30385930788864e6e8f73e9711674ccdd0542ccca9de18159"
+checksum = "5f544125aace169c385db21fc22f38b77710138e90e3f57077c98344b38d5880"
 dependencies = [
  "debugid",
  "memmap",
@@ -4071,12 +4071,12 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unreal"
-version = "8.0.4"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c79daf4018a191f9913303aae527e16f3794cc052d156a3012b58bbb70e625"
+checksum = "f21ca8876cd1288ec18f166a48f6c6cb2eddf88e6978a82d4bbcf85f1df4fed1"
 dependencies = [
  "anylog",
- "bytes 0.5.6",
+ "bytes 1.1.0",
  "chrono",
  "elementtree",
  "flate2",
@@ -4326,7 +4326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
 dependencies = [
  "autocfg 1.0.0",
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "libc",
  "memchr",
  "mio 0.7.7",
@@ -4561,7 +4561,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
 dependencies = [
- "bytes 1.0.0",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "log",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -64,7 +64,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic = { version = "8.0.4", optional = true, default-features=false, features=["unreal-serde"] }
+symbolic = { version = "8.4.0", optional = true, default-features=false, features=["unreal-serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -18,7 +18,6 @@ use flate2::Compression;
 use futures::{future, prelude::*, sync::oneshot};
 use lazy_static::lazy_static;
 use serde_json::Value as SerdeValue;
-use symbolic::unreal::{Unreal4Error, Unreal4ErrorKind};
 
 use relay_auth::RelayVersion;
 use relay_common::{clone, ProjectId, ProjectKey, UnixTimestamp, Uuid};
@@ -65,6 +64,7 @@ use {
     relay_filter::FilterStatKey,
     relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
     relay_quotas::{RateLimitingError, RedisRateLimiter},
+    symbolic::unreal::{Unreal4Error, Unreal4ErrorKind},
 };
 
 /// The minimum clock drift for correction to apply.
@@ -86,7 +86,7 @@ enum ProcessingError {
 
     #[cfg(feature = "processing")]
     #[fail(display = "invalid unreal crash report")]
-    InvalidUnrealReport(#[cause] symbolic::unreal::Unreal4Error),
+    InvalidUnrealReport(#[cause] Unreal4Error),
 
     #[fail(display = "event payload too large")]
     PayloadTooLarge,
@@ -203,6 +203,7 @@ impl ProcessingError {
     }
 }
 
+#[cfg(feature = "processing")]
 impl From<Unreal4Error> for ProcessingError {
     fn from(err: Unreal4Error) -> Self {
         match err.kind() {


### PR DESCRIPTION
Applies the maximum Envelope size to limit decompression of UE4 crash archives. This a potential unbounded buffer allocation during decompression.

Ref https://github.com/getsentry/symbolic/pull/447