### PR TITLE
fix(server): Use zlib for deflate content encoding [INGEST-618]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bug Fixes**:
 
-- Avoid unbounded decompression of encoded requests. A particular request crafted to inflate to large amounts of memory, such as a zip bomb, could put Relay out of memory. ([#1117](https://github.com/getsentry/relay/pull/1117))
+- Avoid unbounded decompression of encoded requests. A particular request crafted to inflate to large amounts of memory, such as a zip bomb, could put Relay out of memory. ([#1117](https://github.com/getsentry/relay/pull/1117), [#1122](https://github.com/getsentry/relay/pull/1122))
 
 **Internal**:
 

--- a/relay-server/src/extractors/decoder.rs
+++ b/relay-server/src/extractors/decoder.rs
@@ -6,7 +6,7 @@ use actix_web::http::header::CONTENT_ENCODING;
 use actix_web::{HttpMessage, HttpRequest};
 use brotli2::write::BrotliDecoder;
 use bytes::Bytes;
-use flate2::write::{DeflateDecoder, GzDecoder};
+use flate2::write::{GzDecoder, ZlibDecoder};
 use futures::{Async, Poll, Stream};
 use relay_config::HttpEncoding;
 
@@ -87,7 +87,7 @@ enum DecoderInner {
     Identity(Box<Sink>),
     Br(Box<BrotliDecoder<Sink>>),
     Gzip(Box<GzDecoder<Sink>>),
-    Deflate(Box<DeflateDecoder<Sink>>),
+    Deflate(Box<ZlibDecoder<Sink>>),
 }
 
 /// Stateful decoder for all supported [`HttpEncoding`]s.
@@ -124,7 +124,7 @@ impl Decoder {
             HttpEncoding::Identity => DecoderInner::Identity(Box::new(sink)),
             HttpEncoding::Br => DecoderInner::Br(Box::new(BrotliDecoder::new(sink))),
             HttpEncoding::Gzip => DecoderInner::Gzip(Box::new(GzDecoder::new(sink))),
-            HttpEncoding::Deflate => DecoderInner::Deflate(Box::new(DeflateDecoder::new(sink))),
+            HttpEncoding::Deflate => DecoderInner::Deflate(Box::new(ZlibDecoder::new(sink))),
         };
 
         Self { inner }


### PR DESCRIPTION
We were using the incorrect decoder for the "deflate" content encoding, causing requests to get rejected with status code 400. The encoding actually specifies a zlib structure with the zlib header.