### PR TITLE
fix(metrics): Add more statsd metrics for relay metric bucketing [INGEST-637]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Internal**:
 
 - Aggregate client reports before sending them onwards. ([#1118](https://github.com/getsentry/relay/pull/1118))
+- Add more statsd metrics for relay metric bucketing. ([#1124](https://github.com/getsentry/relay/pull/1124))
 
 ## 21.10.0
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -985,7 +985,7 @@ impl Aggregator {
             Entry::Occupied(mut entry) => {
                 relay_statsd::metric!(
                     counter(MetricCounters::MergeHit) += 1,
-                    metric_type = &entry.key().metric_type.as_str(),
+                    metric_type = entry.key().metric_type.as_str(),
                     metric_name = &entry.key().metric_name
                 );
                 value.merge_into(&mut entry.get_mut().value)?;
@@ -993,7 +993,7 @@ impl Aggregator {
             Entry::Vacant(entry) => {
                 relay_statsd::metric!(
                     counter(MetricCounters::MergeMiss) += 1,
-                    metric_type = &entry.key().metric_type.as_str(),
+                    metric_type = entry.key().metric_type.as_str(),
                     metric_name = &entry.key().metric_name
                 );
                 let flush_at = self.config.get_flush_time(timestamp);

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -171,14 +171,21 @@ pub enum MetricType {
     Gauge,
 }
 
+impl MetricType {
+    /// Return the shortcode for this metric type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MetricType::Counter => "c",
+            MetricType::Distribution => "d",
+            MetricType::Set => "s",
+            MetricType::Gauge => "g",
+        }
+    }
+}
+
 impl fmt::Display for MetricType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MetricType::Counter => f.write_str("c"),
-            MetricType::Distribution => f.write_str("d"),
-            MetricType::Set => f.write_str("s"),
-            MetricType::Gauge => f.write_str("g"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -1,4 +1,32 @@
-use relay_statsd::{GaugeMetric, HistogramMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
+
+/// Counter metrics for Relay Metrics.
+pub enum MetricCounters {
+    /// Incremented for every metric that is inserted.
+    ///
+    /// Tagged by metric type and name.
+    InsertMetric,
+
+    /// Incremented every time two buckets or two metrics are merged.
+    ///
+    /// Tagged by metric type and name.
+    MergeHit,
+
+    /// Incremented every time a bucket is created.
+    ///
+    /// Tagged by metric type and name.
+    MergeMiss,
+}
+
+impl CounterMetric for MetricCounters {
+    fn name(&self) -> &'static str {
+        match *self {
+            Self::InsertMetric => "metrics.insert",
+            Self::MergeHit => "metrics.buckets.merge.hit",
+            Self::MergeMiss => "metrics.buckets.merge.miss",
+        }
+    }
+}
 
 /// Timer metrics for Relay Metrics.
 pub enum MetricTimers {


### PR DESCRIPTION
Add more statsd metrics for measuring our own metrics bucketing. We're
investigating bucketing efficiency at the moment, but this is generally
good to have.