### PR TITLE
feat(metrics): Another statsd metric to measure bucket duplication [INGEST-421]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Another statsd metric to measure bucket duplication. ([#1128](https://github.com/getsentry/relay/pull/1128))
+
 ## 21.11.0
 
 **Features**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,11 +613,11 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3250,6 +3250,7 @@ name = "relay-metrics"
 version = "21.11.0"
 dependencies = [
  "actix",
+ "crc32fast",
  "criterion",
  "failure",
  "float-ord",

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -19,6 +19,7 @@ relay-statsd = { path = "../relay-statsd" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 failure = "0.1.8"
+crc32fast = "1.2.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -711,7 +711,7 @@ impl BucketKey {
     ///
     /// This is necessary for (and probably only useful for) reporting unique bucket keys in a
     /// cadence set metric, as cadence set metrics can only be constructed from values that
-    /// implement [`cadence::ext::ToSetValue`].  This type is only implemented for [`i64`], and
+    /// implement [`cadence::ext::ToSetValue`].  This trait is only implemented for [`i64`], and
     /// while we could implement it directly for [`BucketKey`] the documentation advises us not to
     /// interact with this trait.
     ///

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -1,4 +1,24 @@
-use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, SetMetric, TimerMetric};
+
+pub enum MetricSets {
+    /// Count the number of unique buckets created.
+    ///
+    /// This is a set of bucketing keys. The metric is basically equivalent to
+    /// `metrics.buckets.merge.miss` for a single Relay, but could be useful to determine how much
+    /// duplicate buckets there are when multiple instances are running.
+    ///
+    /// The hashing is platform-dependent at the moment, so all your relays that send this metric
+    /// should run on the same CPU architecture, otherwise this metric is not reliable.
+    UniqueBucketsCreated,
+}
+
+impl SetMetric for MetricSets {
+    fn name(&self) -> &'static str {
+        match *self {
+            Self::UniqueBucketsCreated => "metrics.buckets.created.unique",
+        }
+    }
+}
 
 /// Counter metrics for Relay Metrics.
 pub enum MetricCounters {


### PR DESCRIPTION
Add a set metric that measures the number of unique bucket keys observed at a point/interval in time. Combined with other metrics this can help us in measuring how much bucket duplication happens because of horizontal scaling.

This requires us to implement some way of hashing bucket keys such that statsd can consume them. BucketKey already implements Hash to be used in hashmaps. We cannot however use the std hasher:

* docs for DefaultHasher explicitly state that the hashes may change across rust releases (i guess this would not be too much of a blocker for our purpose, but it's annoying to keep in mind)

* SipHasher is deprecated (but could probably be used)

we already have crc32fast in our dependency tree so let's depend on it
explicitly and just use that

there's still one caveat in that the impls of Hash may call different methods depending on cpu architecture (as stated in https://docs.rs/deterministic-hash/1.0.1/deterministic_hash/), but I think we can live with that for now.