### PR TITLE
feat(metrics): Extract measurement ratings, port from frontend [INGEST-542]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Extract measurement ratings, port from frontend. ([#1130](https://github.com/getsentry/relay/pull/1130))
+
 ## 21.11.0
 
 **Features**:

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -3326,7 +3326,6 @@ mod tests {
         assert_eq!(metrics[3].name, "breakdown.breakdown2.baz");
         assert_eq!(metrics[4].name, "breakdown.breakdown2.zap");
 
-        assert_eq!(metrics[0].tags["measurement_rating"], "unknown");
         assert_eq!(metrics[1].tags["measurement_rating"], "meh");
 
         for metric in metrics {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -470,7 +470,7 @@ fn extract_transaction_metrics(event: &Event, target: &mut Vec<Metric>) {
             let name = format!("measurement.{}", name);
             let mut tags = tags.clone();
             if let Some(rating) = get_measurement_rating(&name, measurement) {
-                tags.insert("measurement_rating".to_owned());
+                tags.insert("measurement_rating".to_owned(), rating);
             }
 
             target.push(Metric {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -471,7 +471,7 @@ fn extract_transaction_metrics(event: &Event, target: &mut Vec<Metric>) {
             let name = format!("measurement.{}", name);
             tags.insert(
                 "measurement_rating".to_owned(),
-                get_measurement_rating(name, measurement),
+                get_measurement_rating(&name, measurement),
             );
 
             target.push(Metric {
@@ -3319,13 +3319,16 @@ mod tests {
         let mut metrics = vec![];
         extract_transaction_metrics(event.value().unwrap(), &mut metrics);
 
-        assert_eq!(metrics.len(), 4);
+        assert_eq!(metrics.len(), 5);
 
         assert_eq!(metrics[0].name, "measurement.foo");
         assert_eq!(metrics[1].name, "measurement.lcp");
-        assert_eq!(metrics[1].name, "breakdown.breakdown1.bar");
-        assert_eq!(metrics[2].name, "breakdown.breakdown2.baz");
-        assert_eq!(metrics[3].name, "breakdown.breakdown2.zap");
+        assert_eq!(metrics[2].name, "breakdown.breakdown1.bar");
+        assert_eq!(metrics[3].name, "breakdown.breakdown2.baz");
+        assert_eq!(metrics[4].name, "breakdown.breakdown2.zap");
+
+        assert_eq!(metrics[0].tags["measurement_rating"], "unknown");
+        assert_eq!(metrics[1].tags["measurement_rating"], "meh");
 
         for metric in metrics {
             assert!(matches!(metric.value, MetricValue::Distribution(_)));
@@ -3333,9 +3336,6 @@ mod tests {
             assert_eq!(metric.tags["environment"], "fake_environment");
             assert_eq!(metric.tags["transaction"], "mytransaction");
         }
-
-        assert_eq!(metrics[0].tags["measurement_rating"], "unknown");
-        assert_eq!(metrics[1].tags["measurement_rating"], "meh");
     }
 
     #[test]


### PR DESCRIPTION
We need to tag those in metrics because we probably don't have
sufficient querying capabilities to query for thresholds/histograms from
metric distributions.

"rating" is a made-up term, I couldn't find prior art for a term that
describes "the thing coming from thresholds".

Extracted from: https://github.com/getsentry/sentry/blob/bff64dcf2722dec969d0b9e82366855382238930/static/app/views/performance/landing/widgets/widgetDefinitions.tsx#L94-L133