### PR TITLE
ref(metrics): Ability to use static strs in metrics

### DIFF
--- a/relay-metrics/benches/aggregator.rs
+++ b/relay-metrics/benches/aggregator.rs
@@ -46,7 +46,7 @@ impl MetricInput {
             let key_id = i % self.num_project_keys;
             let metric_name = format!("foo{}", i % self.num_metric_names);
             let mut metric = self.metric.clone();
-            metric.name = metric_name;
+            metric.name = metric_name.into();
             let key = ProjectKey::parse(&format!("{:0width$x}", key_id, width = 32)).unwrap();
             rv.push((key, metric));
         }
@@ -70,7 +70,7 @@ impl fmt::Display for MetricInput {
 
 lazy_static::lazy_static! {
     static ref COUNTER_METRIC: Metric = Metric {
-        name: "foo".to_owned(),
+        name: "foo".into(),
         unit: MetricUnit::None,
         value: MetricValue::Counter(42.),
         timestamp: UnixTimestamp::now(),

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricTimers};
-use crate::{Metric, MetricType, MetricUnit, MetricValue};
+use crate::{Metric, MetricType, MetricUnit, MetricValue, Str};
 
 /// A snapshot of values within a [`Bucket`].
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
@@ -645,7 +645,7 @@ pub struct Bucket {
     /// The name of the metric without its unit.
     ///
     /// See [`Metric::name`].
-    pub name: String,
+    pub name: Str,
     /// The unit of the metric value.
     ///
     /// See [`Metric::unit`].
@@ -660,7 +660,7 @@ pub struct Bucket {
     ///
     /// See [`Metric::tags`]. Every combination of tags results in a different bucket.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub tags: BTreeMap<String, String>,
+    pub tags: BTreeMap<Str, Str>,
 }
 
 impl Bucket {
@@ -700,10 +700,10 @@ pub struct AggregateMetricsError;
 struct BucketKey {
     project_key: ProjectKey,
     timestamp: UnixTimestamp,
-    metric_name: String,
+    metric_name: Str,
     metric_type: MetricType,
     metric_unit: MetricUnit,
-    tags: BTreeMap<String, String>,
+    tags: BTreeMap<Str, Str>,
 }
 
 /// Parameters used by the [`Aggregator`].
@@ -1310,7 +1310,7 @@ mod tests {
 
     fn some_metric() -> Metric {
         Metric {
-            name: "foo".to_owned(),
+            name: "foo".into(),
             unit: MetricUnit::None,
             value: MetricValue::Counter(42.),
             timestamp: UnixTimestamp::from_secs(999994711),

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -427,15 +427,15 @@ fn extract_transaction_metrics(event: &Event, target: &mut Vec<Metric>) {
         None => return,
     };
 
-    let mut tags = BTreeMap::new();
+    let mut tags: BTreeMap<MetricStr, MetricStr> = BTreeMap::new();
     if let Some(release) = event.release.as_str() {
-        tags.insert("release".to_owned(), release.to_owned());
+        tags.insert("release".into(), release.to_owned().into());
     }
     if let Some(environment) = event.environment.as_str() {
-        tags.insert("environment".to_owned(), environment.to_owned());
+        tags.insert("environment".into(), environment.to_owned().into());
     }
     if let Some(transaction) = event.transaction.as_str() {
-        tags.insert("transaction".to_owned(), transaction.to_owned());
+        tags.insert("transaction".into(), transaction.to_owned().into());
     }
 
     if let Some(measurements) = event.measurements.value() {
@@ -446,7 +446,7 @@ fn extract_transaction_metrics(event: &Event, target: &mut Vec<Metric>) {
             };
 
             target.push(Metric {
-                name: format!("measurement.{}", name),
+                name: format!("measurement.{}", name).into(),
                 unit: MetricUnit::None,
                 value: MetricValue::Distribution(measurement),
                 timestamp,
@@ -469,7 +469,7 @@ fn extract_transaction_metrics(event: &Event, target: &mut Vec<Metric>) {
                 };
 
                 target.push(Metric {
-                    name: format!("breakdown.{}.{}", breakdown, name),
+                    name: format!("breakdown.{}.{}", breakdown, name).into(),
                     unit: MetricUnit::None,
                     value: MetricValue::Distribution(measurement),
                     timestamp,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -18,7 +18,7 @@ use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
 use relay_general::protocol::{self, EventId, SessionAggregates, SessionStatus, SessionUpdate};
 use relay_log::LogError;
-use relay_metrics::{Bucket, BucketValue, MetricUnit};
+use relay_metrics::{Bucket, BucketValue, MetricUnit, Str as MetricStr};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 
@@ -565,13 +565,13 @@ struct SessionKafkaMessage {
 struct MetricKafkaMessage {
     org_id: u64,
     project_id: ProjectId,
-    name: String,
+    name: MetricStr,
     unit: MetricUnit,
     #[serde(flatten)]
     value: BucketValue,
     timestamp: UnixTimestamp,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    tags: BTreeMap<String, String>,
+    tags: BTreeMap<MetricStr, MetricStr>,
 }
 
 /// An enum over all possible ingest messages.


### PR DESCRIPTION
This is usually marginally better than using String everywhere (e.g. for
events it would not be very useful, we'd need more dynamic string
interning there), but in the particular case where we extract metrics
from sessions, a lot of our tags and metric names come from static
strings.

The insert_metrics microbenchmark suite for the metrics aggregator
registers an improvement of 5% across the board (consistently for all
benchmarks, so I would think this is not just noise). But the benchmark
is meaningless, we really need to measure session extraction.

Alternative to this would be smartstring which would inline short metric
names and tags into the struct.

I think the biggest question however is whether we want to start fragmenting
our string types like this at all. My feeling is that we have to start
somewhere (metrics) and get used to it if we ever hope of doing it across
the entire codebase.

Better benchmarks tbd before considering merge.