### PR TITLE
build: Update symbolic to support UE5 [NATIVE-386]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Extract measurement ratings, port from frontend. ([#1130](https://github.com/getsentry/relay/pull/1130))
 - External Relays perform dynamic sampling and emit outcomes as client reports. This feature is now enabled *by default*. ([#1119](https://github.com/getsentry/relay/pull/1119))
 
+**Bug Fixes**:
+
+- Support Unreal Engine 5 crash reports. ([#1132](https://github.com/getsentry/relay/pull/1132))
+
 **Internal**:
 
 - Add more statsd metrics for relay metric bucketing. ([#1124](https://github.com/getsentry/relay/pull/1124), [#1128](https://github.com/getsentry/relay/pull/1128))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,9 +4049,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "symbolic"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdee51d8cb63a5bed678d0a1dbb181fb19b8b1ee682ef239e2db1eb544c8c6f6"
+checksum = "bf0b3be4c272aaef995fca595a89355caf49993b84a964013e4a94447f13c779"
 dependencies = [
  "symbolic-common",
  "symbolic-unreal",
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f544125aace169c385db21fc22f38b77710138e90e3f57077c98344b38d5880"
+checksum = "cfc8618f0f31ed048f8e66aa2caecedfbdbbca962ff9ad87107ba4171de0742b"
 dependencies = [
  "debugid",
  "memmap",
@@ -4072,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unreal"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21ca8876cd1288ec18f166a48f6c6cb2eddf88e6978a82d4bbcf85f1df4fed1"
+checksum = "1fd9f80568417c0204980bbf0836693fe91fd40d3d2deb954b767d1bd670d7f2"
 dependencies = [
  "anylog",
  "bytes 1.1.0",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -64,7 +64,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic = { version = "8.4.0", optional = true, default-features=false, features=["unreal-serde"] }
+symbolic = { version = "8.5.0", optional = true, default-features=false, features=["unreal-serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"


### PR DESCRIPTION
The development version of Unreal Engine 5 added magic bytes to their
crash archive format. This PR updates `symbolic` to support the new
format.

See https://github.com/getsentry/symbolic/pull/449
Fixes https://github.com/getsentry/sentry/issues/29940

