### PR TITLE
ref(outcomes): Fold processing vs non-processing into single actor [INGEST-247]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Internal**:
 
 - Add more statsd metrics for relay metric bucketing. ([#1124](https://github.com/getsentry/relay/pull/1124), [#1128](https://github.com/getsentry/relay/pull/1128))
+- Fold processing vs non-processing into single actor. ([#1133](https://github.com/getsentry/relay/pull/1133))
 
 ## 21.11.0
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1755,7 +1755,7 @@ impl EnvelopeProcessor {
         mut state: ProcessEnvelopeState,
     ) -> Result<ProcessEnvelopeResponse, ProcessingError> {
         macro_rules! if_processing {
-            ($if_true:block $(, $if_not:block)?) => {
+            ($if_true:block) => {
                 #[cfg(feature = "processing")] {
                     if self.config.processing_enabled() $if_true
                 }

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -649,9 +649,9 @@ mod processing {
 pub enum OutcomeError {}
 
 struct HttpOutcomeProducer {
-    pub(super) config: Arc<Config>,
-    pub(super) unsent_outcomes: Vec<TrackRawOutcome>,
-    pub(super) pending_flush_handle: Option<SpawnHandle>,
+    config: Arc<Config>,
+    unsent_outcomes: Vec<TrackRawOutcome>,
+    pending_flush_handle: Option<SpawnHandle>,
 }
 
 impl HttpOutcomeProducer {

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -44,11 +44,6 @@ use crate::statsd::RelayCounters;
 use crate::utils::{CaptureErrorContext, ThreadedProducer};
 use crate::ServerError;
 
-// Choose the outcome module implementation (either processing or non-processing).
-// Processing outcome implementation
-#[cfg(feature = "processing")]
-pub use self::processing::*;
-
 /// Defines the structure of the HTTP outcomes requests
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SendOutcomes {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -334,7 +334,6 @@ pub enum RelayCounters {
     ///    the Sentry plan quota. The reason contains the rate limit or quota that was exceeded.
     ///  - `invalid`: Data was considered invalid and could not be recovered. The reason indicates
     ///    the validation that failed.
-    #[cfg(feature = "processing")]
     Outcomes,
     /// Number of times a project state is looked up from the cache.
     ///
@@ -445,7 +444,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EventCorrupted => "event.corrupted",
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",
-            #[cfg(feature = "processing")]
             RelayCounters::Outcomes => "events.outcomes",
             RelayCounters::ProjectStateGet => "project_state.get",
             RelayCounters::ProjectStateRequest => "project_state.request",


### PR DESCRIPTION
Remove the inner private processing module and move all outcomes handling into one large enum.

This is a bit cleaner than the multiple options we have had lying around in NonProcessingActor and ProcessingActor.

A known user-visible change is that some metrics related to outcomes are now emitted in non-processing mode as well. This might have been intentional or an oversight, not sure.

What I did not do is to fold the http and clientreport actors into the main actor, as they each have batching implemented one would have to constantly destructure the enum to get to their batched data.

We could think about folding clientreport actor and http actor into one, not sure though.
