### PR TITLE
Extract and upload system symbols while Relay deployment

### DIFF
--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -37,7 +37,7 @@ tar xf libs.tar
 echo 'Uploading debug information and source bundle...'
 sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
 
-echo "Uploading system symbols..."
+echo 'Uploading system symbols...'
 sentry-cli upload-dif lib/x86_64-linux-gnu
 
 echo 'Creating a new deploy in Sentry...'

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -31,9 +31,14 @@ docker pull "${DOCKER_IMAGE}"
 
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/relay-debug.zip > relay-debug.zip
 docker run --rm --entrypoint cat "${DOCKER_IMAGE}" /opt/relay.src.zip > relay.src.zip
+docker run --rm --entrypoint tar "${DOCKER_IMAGE}" -cf - /lib/x86_64-linux-gnu > libs.tar
+tar xf libs.tar
 
 echo 'Uploading debug information and source bundle...'
 sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
+
+echo "Uploading system symbols..."
+sentry-cli upload-dif lib/x86_64-linux-gnu
 
 echo 'Creating a new deploy in Sentry...'
 sentry-cli releases new "${VERSION}"


### PR DESCRIPTION
- Extract and upload system symbols while Relay deployment. ([#1139](https://github.com/getsentry/relay/pull/1139))

#skip-changelog