### PR TITLE
feat(metrics): Extract session metrics from session aggregates [INGEST-678] [INGEST-253]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 **Bug Fixes**:
 
 - Support Unreal Engine 5 crash reports. ([#1132](https://github.com/getsentry/relay/pull/1132))
-- Perform same validation for aggregate sessions as for individual sessions. ([#1140]https://github.com/getsentry/relay/pull/1140))
+- Perform same validation for aggregate sessions as for individual sessions. ([#1140](https://github.com/getsentry/relay/pull/1140))
 
 **Internal**:
 
@@ -18,7 +18,7 @@
 - Add an internal option to capture minidumps for hard crashes. This has to be enabled via the `sentry._crash_db` config parameter. ([#1127](https://github.com/getsentry/relay/pull/1127))
 - Fold processing vs non-processing into single actor. ([#1133](https://github.com/getsentry/relay/pull/1133))
 - Aggregate outcomes for dynamic sampling, invalid project ID, and rate limits. ([#1134](https://github.com/getsentry/relay/pull/1134))
-- Extract session metrics from aggregate sessions. ([#1140]https://github.com/getsentry/relay/pull/1140))
+- Extract session metrics from aggregate sessions. ([#1140](https://github.com/getsentry/relay/pull/1140))
 
 ## 21.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug Fixes**:
 
 - Support Unreal Engine 5 crash reports. ([#1132](https://github.com/getsentry/relay/pull/1132))
+- Perform same validation for aggregate sessions as for individual sessions. ([#1140]https://github.com/getsentry/relay/pull/1140))
 
 **Internal**:
 
@@ -17,6 +18,7 @@
 - Add an internal option to capture minidumps for hard crashes. This has to be enabled via the `sentry._crash_db` config parameter. ([#1127](https://github.com/getsentry/relay/pull/1127))
 - Fold processing vs non-processing into single actor. ([#1133](https://github.com/getsentry/relay/pull/1133))
 - Aggregate outcomes for dynamic sampling, invalid project ID, and rate limits. ([#1134](https://github.com/getsentry/relay/pull/1134))
+- Extract session metrics from aggregate sessions. ([#1140]https://github.com/getsentry/relay/pull/1140))
 
 ## 21.11.0
 

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -61,7 +61,7 @@ pub use self::schema::event_json_schema;
 pub use self::security_report::{Csp, ExpectCt, ExpectStaple, Hpkp, SecurityReportType};
 pub use self::session::{
     ParseSessionStatusError, SessionAggregateItem, SessionAggregates, SessionAttributes,
-    SessionLike, SessionStatus, SessionUpdate,
+    SessionError, SessionLike, SessionStatus, SessionUpdate,
 };
 pub use self::span::Span;
 pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrace};

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -61,7 +61,7 @@ pub use self::schema::event_json_schema;
 pub use self::security_report::{Csp, ExpectCt, ExpectStaple, Hpkp, SecurityReportType};
 pub use self::session::{
     ParseSessionStatusError, SessionAggregateItem, SessionAggregates, SessionAttributes,
-    SessionStatus, SessionUpdate,
+    SessionLike, SessionStatus, SessionUpdate,
 };
 pub use self::span::Span;
 pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrace};

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -61,7 +61,7 @@ pub use self::schema::event_json_schema;
 pub use self::security_report::{Csp, ExpectCt, ExpectStaple, Hpkp, SecurityReportType};
 pub use self::session::{
     ParseSessionStatusError, SessionAggregateItem, SessionAggregates, SessionAttributes,
-    SessionError, SessionLike, SessionStatus, SessionUpdate,
+    SessionErrored, SessionLike, SessionStatus, SessionUpdate,
 };
 pub use self::span::Span;
 pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrace};

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -92,14 +92,6 @@ fn is_false(val: &bool) -> bool {
     !val
 }
 
-/// Generalization of SessionUpdate
-pub trait SessionLike {
-    fn sequence(&self) -> u64;
-    fn started(&self) -> DateTime<Utc>;
-    fn timestamp(&mut self) -> &mut DateTime<Utc>;
-    fn attributes(&mut self) -> &mut SessionAttributes;
-}
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionUpdate {
     /// The session identifier.
@@ -142,24 +134,6 @@ impl SessionUpdate {
     /// Serializes a session update back into JSON.
     pub fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
         serde_json::to_vec(self)
-    }
-}
-
-impl SessionLike for SessionUpdate {
-    fn sequence(&self) -> u64 {
-        self.sequence
-    }
-
-    fn started(&self) -> DateTime<Utc> {
-        self.started
-    }
-
-    fn timestamp(&mut self) -> &mut DateTime<Utc> {
-        &mut self.timestamp
-    }
-
-    fn attributes(&mut self) -> &mut SessionAttributes {
-        &mut self.attributes
     }
 }
 

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -92,8 +92,11 @@ fn is_false(val: &bool) -> bool {
     !val
 }
 
-pub enum SessionError {
-    Distinct(Uuid),
+/// Contains information about errored sessions. See [`SessionLike`].
+pub enum SessionErrored {
+    /// Contains the UUID for a single errored session.
+    Individual(Uuid),
+    /// Contains the number of errored sessions in an aggregate.
     Aggregated(u32),
 }
 
@@ -104,7 +107,7 @@ pub trait SessionLike {
     fn total_count(&self) -> u32;
     fn abnormal_count(&self) -> u32;
     fn crashed_count(&self) -> u32;
-    fn errors(&self) -> Option<SessionError>;
+    fn errors(&self) -> Option<SessionErrored>;
     fn final_duration(&self) -> Option<(f64, SessionStatus)>;
 }
 
@@ -193,9 +196,9 @@ impl SessionLike for SessionUpdate {
         None
     }
 
-    fn errors(&self) -> Option<SessionError> {
+    fn errors(&self) -> Option<SessionErrored> {
         if self.errors > 0 || self.status.is_error() {
-            Some(SessionError::Distinct(self.session_id))
+            Some(SessionErrored::Individual(self.session_id))
         } else {
             None
         }
@@ -253,9 +256,9 @@ impl SessionLike for SessionAggregateItem {
         None
     }
 
-    fn errors(&self) -> Option<SessionError> {
+    fn errors(&self) -> Option<SessionErrored> {
         if self.errored > 0 {
-            Some(SessionError::Aggregated(self.errored))
+            Some(SessionErrored::Aggregated(self.errored))
         } else {
             None
         }

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -92,6 +92,14 @@ fn is_false(val: &bool) -> bool {
     !val
 }
 
+/// Generalization of SessionUpdate
+pub trait SessionLike {
+    fn sequence(&self) -> u64;
+    fn started(&self) -> DateTime<Utc>;
+    fn timestamp(&mut self) -> &mut DateTime<Utc>;
+    fn attributes(&mut self) -> &mut SessionAttributes;
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionUpdate {
     /// The session identifier.
@@ -134,6 +142,24 @@ impl SessionUpdate {
     /// Serializes a session update back into JSON.
     pub fn serialize(&self) -> Result<Vec<u8>, serde_json::Error> {
         serde_json::to_vec(self)
+    }
+}
+
+impl SessionLike for SessionUpdate {
+    fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    fn started(&self) -> DateTime<Utc> {
+        self.started
+    }
+
+    fn timestamp(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
+    fn attributes(&mut self) -> &mut SessionAttributes {
+        &mut self.attributes
     }
 }
 

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -103,7 +103,7 @@ impl ClockDriftProcessor {
         }
     }
 
-    /// Processes the given session.
+    /// Processes the given [`DateTime`].
     pub fn process_datetime(&self, datetime: &mut DateTime<Utc>) {
         if let Some(correction) = self.correction {
             *datetime = *datetime + correction.drift;
@@ -283,5 +283,18 @@ mod tests {
         processor.process_timestamp(&mut timestamp);
 
         assert_eq!(timestamp.as_secs(), now.timestamp() as u64);
+    }
+
+    #[test]
+    fn test_process_datetime() {
+        let sent_at = Utc.ymd(2000, 1, 2).and_hms(0, 0, 0);
+        let drift = SignedDuration::days(1);
+        let now = sent_at + drift;
+
+        let processor = ClockDriftProcessor::new(Some(sent_at), now);
+        let mut datetime = Utc.ymd(2021, 11, 29).and_hms(0, 0, 0);
+        processor.process_datetime(&mut datetime);
+
+        assert_eq!(datetime, Utc.ymd(2021, 11, 30).and_hms(0, 0, 0));
     }
 }

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Duration as SignedDuration, Utc};
 use relay_common::UnixTimestamp;
 
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::protocol::{Event, SessionUpdate, Timestamp};
+use crate::protocol::{Event, Timestamp};
 use crate::types::{Error, ErrorKind, Meta, ProcessingResult};
 
 /// A signed correction that contains the sender's timestamp as well as the drift to the receiver.
@@ -104,10 +104,9 @@ impl ClockDriftProcessor {
     }
 
     /// Processes the given session.
-    pub fn process_session(&self, session: &mut SessionUpdate) {
+    pub fn process_datetime(&self, datetime: &mut DateTime<Utc>) {
         if let Some(correction) = self.correction {
-            session.timestamp = session.timestamp + correction.drift;
-            session.started = session.started + correction.drift;
+            *datetime = *datetime + correction.drift;
         }
     }
 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -3334,19 +3334,22 @@ mod tests {
 
     #[test]
     fn test_nil_to_none() {
-        assert!(nil_to_none(&None).is_none());
+        assert!(nil_to_none(None).is_none());
 
         let asdf = Some("asdf".to_owned());
-        assert_eq!(nil_to_none(&asdf).unwrap(), "asdf");
+        assert_eq!(nil_to_none(asdf.as_ref()).unwrap(), "asdf");
 
         let nil = Some("00000000-0000-0000-0000-000000000000".to_owned());
-        assert!(nil_to_none(&nil).is_none());
+        assert!(nil_to_none(nil.as_ref()).is_none());
 
         let nil2 = Some("00000000000000000000000000000000".to_owned());
-        assert!(nil_to_none(&nil2).is_none());
+        assert!(nil_to_none(nil2.as_ref()).is_none());
 
         let not_nil = Some("00000000-0000-0000-0000-000000000123".to_owned());
-        assert_eq!(nil_to_none(&not_nil).unwrap(), not_nil.as_ref().unwrap());
+        assert_eq!(
+            nil_to_none(not_nil.as_ref()).unwrap(),
+            not_nil.as_ref().unwrap()
+        );
     }
 
     #[test]
@@ -3367,7 +3370,7 @@ mod tests {
         )
         .unwrap();
 
-        extract_session_metrics(&session, &mut metrics);
+        extract_session_metrics(&session.attributes, &session, &mut metrics);
 
         assert_eq!(metrics.len(), 2);
 
@@ -3403,7 +3406,7 @@ mod tests {
         )
         .unwrap();
 
-        extract_session_metrics(&session, &mut metrics);
+        extract_session_metrics(&session.attributes, &session, &mut metrics);
 
         // A none-initial update will not trigger any metric if it's not errored/crashed
         assert_eq!(metrics.len(), 0);
@@ -3472,7 +3475,7 @@ mod tests {
             (update3, 2),
         ] {
             let mut metrics = vec![];
-            extract_session_metrics(&update, &mut metrics);
+            extract_session_metrics(&update.attributes, &update, &mut metrics);
 
             assert_eq!(metrics.len(), expected_metrics);
 
@@ -3510,7 +3513,7 @@ mod tests {
 
             let mut metrics = vec![];
 
-            extract_session_metrics(&session, &mut metrics);
+            extract_session_metrics(&session.attributes, &session, &mut metrics);
 
             assert_eq!(metrics.len(), 4);
 
@@ -3598,7 +3601,7 @@ mod tests {
         )
         .unwrap();
 
-        extract_session_metrics(&session, &mut metrics);
+        extract_session_metrics(&session.attributes, &session, &mut metrics);
 
         assert_eq!(metrics.len(), 1);
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -688,111 +688,13 @@ impl EnvelopeProcessor {
         self
     }
 
-    /// Returns true if the session should be retained
-    fn process_session(
-        &self,
-        received: DateTime<Utc>,
-        client_addr: &Option<net::IpAddr>,
-        clock_drift_processor: &ClockDriftProcessor,
-        metrics_extraction_enabled: bool,
-        // Output parameters:
-        session: &mut SessionUpdate,
-        item: &mut Item,
-        extracted_metrics: &mut Vec<Metric>,
-    ) -> bool {
-        let mut changed = false;
-
-        if session.sequence == u64::MAX {
-            relay_log::trace!("skipping session due to sequence overflow");
-            return false;
-        }
-
-        if clock_drift_processor.is_drifted() {
-            relay_log::trace!("applying clock drift correction to session");
-            clock_drift_processor.process_session(session);
-            changed = true;
-        }
-
-        if session.timestamp < session.started {
-            relay_log::trace!("fixing session timestamp to {}", session.timestamp);
-            session.timestamp = session.started;
-            changed = true;
-        }
-
-        let max_age = SignedDuration::seconds(self.config.max_session_secs_in_past());
-
-        // Log the timestamp delay for all sessions after clock drift correction.
-        let session_delay = received - session.timestamp;
-        if session_delay > SignedDuration::minutes(1) {
-            metric!(
-                timer(RelayTimers::TimestampDelay) = session_delay.to_std().unwrap(),
-                category = "session",
-            );
-        }
-
-        if (received - session.started) > max_age || (received - session.timestamp) > max_age {
-            relay_log::trace!("skipping session older than {} days", max_age.num_days());
-            return false;
-        }
-
-        let max_future = SignedDuration::seconds(self.config.max_secs_in_future());
-        if (session.started - received) > max_future || (session.timestamp - received) > max_future
-        {
-            relay_log::trace!(
-                "skipping session more than {}s in the future",
-                max_future.num_seconds()
-            );
-            return false;
-        }
-
-        let release = &session.attributes.release;
-        if let Err(e) = protocol::validate_release(release) {
-            relay_log::trace!("skipping session with invalid release '{}': {}", release, e);
-            return false;
-        }
-
-        if let Some(ref env) = session.attributes.environment {
-            if let Err(e) = protocol::validate_environment(env) {
-                relay_log::trace!("removing invalid environment '{}': {}", env, e);
-                session.attributes.environment = None;
-                changed = true;
-            }
-        }
-
-        if let Some(ref ip_address) = session.attributes.ip_address {
-            if ip_address.is_auto() {
-                session.attributes.ip_address = client_addr.map(IpAddr::from);
-                changed = true;
-            }
-        }
-
-        if metrics_extraction_enabled && !item.metrics_extracted() {
-            extract_session_metrics(&session, extracted_metrics);
-            item.set_metrics_extracted(true);
-        }
-
-        if changed {
-            let json_string = match serde_json::to_string(&session) {
-                Ok(json) => json,
-                Err(err) => {
-                    relay_log::error!("failed to serialize session: {}", LogError(&err));
-                    return false;
-                }
-            };
-
-            item.set_payload(ContentType::Json, json_string);
-        }
-
-        true
-    }
-
     /// Validates all sessions in the envelope, if any.
     ///
     /// Sessions are removed from the envelope if they contain invalid JSON or if their timestamps
     /// are out of range after clock drift correction.
     fn process_sessions(&self, state: &mut ProcessEnvelopeState) {
         let received = state.envelope_context.received_at;
-        let extracted_metrics = &mut state.extracted_metrics;
+        let _extracted_metrics = &mut state.extracted_metrics;
         let metrics_extraction_enabled =
             state.project_state.has_feature(Feature::MetricsExtraction);
         let envelope = &mut state.envelope;
@@ -806,6 +708,7 @@ impl EnvelopeProcessor {
                 return true;
             }
 
+            let mut changed = false;
             let payload = item.payload();
 
             let mut session = match SessionUpdate::parse(&payload) {
@@ -816,15 +719,89 @@ impl EnvelopeProcessor {
                 }
             };
 
-            self.process_session(
-                received,
-                &client_addr,
-                &clock_drift_processor,
-                metrics_extraction_enabled,
-                &mut session,
-                item,
-                extracted_metrics,
-            )
+            if session.sequence == u64::MAX {
+                relay_log::trace!("skipping session due to sequence overflow");
+                return false;
+            }
+
+            if clock_drift_processor.is_drifted() {
+                relay_log::trace!("applying clock drift correction to session");
+                clock_drift_processor.process_session(&mut session);
+                changed = true;
+            }
+
+            if session.timestamp < session.started {
+                relay_log::trace!("fixing session timestamp to {}", session.timestamp);
+                session.timestamp = session.started;
+                changed = true;
+            }
+
+            let max_age = SignedDuration::seconds(self.config.max_session_secs_in_past());
+
+            // Log the timestamp delay for all sessions after clock drift correction.
+            let session_delay = received - session.timestamp;
+            if session_delay > SignedDuration::minutes(1) {
+                metric!(
+                    timer(RelayTimers::TimestampDelay) = session_delay.to_std().unwrap(),
+                    category = "session",
+                );
+            }
+
+            if (received - session.started) > max_age || (received - session.timestamp) > max_age {
+                relay_log::trace!("skipping session older than {} days", max_age.num_days());
+                return false;
+            }
+
+            let max_future = SignedDuration::seconds(self.config.max_secs_in_future());
+            if (session.started - received) > max_future
+                || (session.timestamp - received) > max_future
+            {
+                relay_log::trace!(
+                    "skipping session more than {}s in the future",
+                    max_future.num_seconds()
+                );
+                return false;
+            }
+
+            let release = &session.attributes.release;
+            if let Err(e) = protocol::validate_release(release) {
+                relay_log::trace!("skipping session with invalid release '{}': {}", release, e);
+                return false;
+            }
+
+            if let Some(ref env) = session.attributes.environment {
+                if let Err(e) = protocol::validate_environment(env) {
+                    relay_log::trace!("removing invalid environment '{}': {}", env, e);
+                    session.attributes.environment = None;
+                    changed = true;
+                }
+            }
+
+            if let Some(ref ip_address) = session.attributes.ip_address {
+                if ip_address.is_auto() {
+                    session.attributes.ip_address = client_addr.map(IpAddr::from);
+                    changed = true;
+                }
+            }
+
+            if metrics_extraction_enabled && !item.metrics_extracted() {
+                extract_session_metrics(&session, _extracted_metrics);
+                item.set_metrics_extracted(true);
+            }
+
+            if changed {
+                let json_string = match serde_json::to_string(&session) {
+                    Ok(json) => json,
+                    Err(err) => {
+                        relay_log::error!("failed to serialize session: {}", LogError(&err));
+                        return false;
+                    }
+                };
+
+                item.set_payload(ContentType::Json, json_string);
+            }
+
+            true
         });
     }
 


### PR DESCRIPTION
Extract session metrics from [session aggregates](https://develop.sentry.dev/sdk/sessions/#session-aggregates-payload), just like we do for individual session updates.

Also in this PR: Apply the same validation (timestamp, attributes) to aggregates as to individual session updates.