### PR TITLE
add missing net48 release value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug Fixes**:
 
 - Support Unreal Engine 5 crash reports. ([#1132](https://github.com/getsentry/relay/pull/1132))
+- Add missing .NET 4.8 release value. ([#1142](https://github.com/getsentry/relay/pull/1142))
 
 **Internal**:
 

--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -61,6 +61,7 @@ fn normalize_runtime_context(runtime: &mut RuntimeContext) {
                     "528049" => Some("4.8".to_string()),
                     "528209" => Some("4.8".to_string()),
                     "528372" => Some("4.8".to_string()),
+                    "528449" => Some("4.8".to_string()),
                     _ => None,
                 };
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#minimum-version

> On Windows 11 and Windows Server 2022: 528449
