### PR TITLE
feat(general): Update uap-core to v0.15.0 [INGEST-669]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Extract measurement ratings, port from frontend. ([#1130](https://github.com/getsentry/relay/pull/1130))
 - External Relays perform dynamic sampling and emit outcomes as client reports. This feature is now enabled *by default*. ([#1119](https://github.com/getsentry/relay/pull/1119))
+- Update the user agent parser (uap-core Feb 2020 to Nov 2021). This allows Relay and Sentry to infer more recent browsers, operating systems, and devices in events containing a user agent header. ([#1143](https://github.com/getsentry/relay/pull/1143))
 
 **Bug Fixes**:
 

--- a/relay-general/src/user_agent.rs
+++ b/relay-general/src/user_agent.rs
@@ -1,7 +1,10 @@
-//! Utility functions for working with the event user-agent.
+//! Utility functions for working with user agents.
+
 use lazy_static::lazy_static;
-pub use uaparser::{Device, UserAgent, OS};
 use uaparser::{Parser, UserAgentParser};
+
+#[doc(inline)]
+pub use uaparser::{Device, UserAgent, OS};
 
 lazy_static! {
     /// The global [`UserAgentParser`] already configured with a user agent database.
@@ -11,7 +14,7 @@ lazy_static! {
         let ua_regexes = include_bytes!("../uap-core/regexes.yaml");
         UserAgentParser::from_bytes(ua_regexes).expect(
             "Could not create UserAgent. \
-             You are probably using a bad build of 'relay-common'. ",
+             You are probably using a bad build of 'relay-general'. ",
         )
     };
 }
@@ -32,21 +35,42 @@ fn get_user_agent_from_headers(headers: &Headers) -> Option<&str> {
     None
 }
 
-/// Returns the user agent from an event (if available) or None (if not present).
+/// Initializes the user agent parser.
+///
+/// This loads and compiles user agent patterns, which takes a few seconds to complete. The user
+/// agent parser initializes on-demand when using one of the parse methods. This function forces
+/// initialization at a convenient point without introducing unwanted delays.
+pub fn init_parser() {
+    lazy_static::initialize(&UA_PARSER);
+}
+
+/// Returns the user agent string from an `event`.
+///
+/// Returns `Some` if the event's request interface contains a `user-agent` header. Returns `None`
+/// otherwise.
 pub fn get_user_agent(event: &Event) -> Option<&str> {
     let request = event.request.value()?;
     let headers = request.headers.value()?;
     get_user_agent_from_headers(headers)
 }
 
+/// Returns the family and version of a user agent client.
+///
+/// Defaults to an empty user agent.
 pub fn parse_user_agent(user_agent: &str) -> UserAgent {
     UA_PARSER.parse_user_agent(user_agent)
 }
 
+/// Returns the family, brand, and model of the device of the requesting client.
+///
+/// Defaults to an empty device.
 pub fn parse_device(user_agent: &str) -> Device {
     UA_PARSER.parse_device(user_agent)
 }
 
+/// Returns the family and version of the operating system of the requesting client.
+///
+/// Defaults to an empty operating system.
 pub fn parse_os(user_agent: &str) -> OS {
     UA_PARSER.parse_os(user_agent)
 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -545,8 +545,6 @@ impl EnvelopeProcessor {
 
         #[cfg(feature = "processing")]
         {
-            relay_general::user_agent::init_parser();
-
             let geoip_lookup = match config.geoip_path() {
                 Some(p) => Some(Arc::new(
                     GeoIpLookup::open(p).context(ServerErrorKind::GeoIpError)?,

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -545,6 +545,8 @@ impl EnvelopeProcessor {
 
         #[cfg(feature = "processing")]
         {
+            relay_general::user_agent::init_parser();
+
             let geoip_lookup = match config.geoip_path() {
                 Some(p) => Some(Arc::new(
                     GeoIpLookup::open(p).context(ServerErrorKind::GeoIpError)?,

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -58,7 +58,8 @@ def test_security_report_with_processing(
     test_case,
     json_fixture_provider,
 ):
-    events_consumer = events_consumer(timeout=5)
+    # UA parsing introduces higher latency in debug mode
+    events_consumer = events_consumer(timeout=10)
 
     fixture_provider = json_fixture_provider(__file__)
     test_name, ignored_properties = test_case

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -119,7 +119,7 @@ def test_web_crawlers_filter_are_applied(
     filter_settings["webCrawlers"] = {"isEnabled": is_enabled}
 
     # UA parsing introduces higher latency in debug mode
-    events_consumer = events_consumer(timeout=5)
+    events_consumer = events_consumer(timeout=10)
 
     # create a unique message so we can make sure we don't test with stale data
     now = datetime.datetime.utcnow()


### PR DESCRIPTION
This bumps `uap-core` from 0.8.0 (Feb 2020) to 0.15.0 (Nov 2021).