### PR TITLE
fix(test): Make integration tests fail faster [INGEST-790]

### DIFF
--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -171,7 +171,7 @@ class ConsumerBase(object):
         # Then, send a custom message to ensure we're not just timing out
         message = json.dumps({"__test__": uuid.uuid4().hex}).encode("utf8")
         self.test_producer.produce(self.topic_name, message)
-        self.test_producer.flush()
+        self.test_producer.flush(timeout=5)
 
         rv = self.poll(timeout=timeout)
         assert rv.error() is None


### PR DESCRIPTION
When Kafka is unavailable, tests seem to hang in `producer.flush()` for multiple minutes. Pass a timeout to this function to make the test fail earlier.

 #skip-changelog