### PR TITLE
feat: Extract normalized dist as metric [INGEST-335]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Extract session metrics from aggregate sessions. ([#1140](https://github.com/getsentry/relay/pull/1140))
 - Prefix names of extracted metrics by `sentry.sessions.` or `sentry.transactions.`. ([#1147](https://github.com/getsentry/relay/pull/1147))
 - Extract transaction duration as metric. ([#1148](https://github.com/getsentry/relay/pull/1148))
+- Extract normalized dist as metric. ([#1158](https://github.com/getsentry/relay/pull/1158))
 
 ## 21.11.0
 

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -23,6 +23,7 @@ mod trimming;
 pub use self::clock_drift::ClockDriftProcessor;
 pub use self::geo::{GeoIpError, GeoIpLookup};
 pub use normalize::breakdowns::BreakdownsConfig;
+pub use normalize::normalize_dist;
 
 /// The config for store.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -1611,7 +1611,7 @@ fn test_past_timestamp() {
 
 #[test]
 fn test_normalize_dist_none() {
-    let mut dist = Option::None;
+    let mut dist = None;
     normalize_dist(&mut dist);
     assert_eq!(dist, None);
 }

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -1618,21 +1618,21 @@ fn test_normalize_dist_none() {
 
 #[test]
 fn test_normalize_dist_empty() {
-    let mut dist = Option::Some("".to_owned());
+    let mut dist = Some("".to_owned());
     normalize_dist(&mut dist);
     assert_eq!(dist, None);
 }
 
 #[test]
 fn test_normalize_dist_trim() {
-    let mut dist = Option::Some(" foo  ".to_owned());
+    let mut dist = Some(" foo  ".to_owned());
     normalize_dist(&mut dist);
     assert_eq!(dist.unwrap(), "foo");
 }
 
 #[test]
 fn test_normalize_dist_whitespace() {
-    let mut dist = Option::Some(" ".to_owned());
+    let mut dist = Some(" ".to_owned());
     normalize_dist(&mut dist);
     assert_eq!(dist.unwrap(), ""); // Not sure if this is what we want
 }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -98,7 +98,7 @@ pub fn extract_transaction_metrics(
     if let Some(release) = event.release.as_str() {
         tags.insert("release".to_owned(), release.to_owned());
     }
-    if let Some(dist) = extract_dist(&event) {
+    if let Some(dist) = extract_dist(event) {
         tags.insert("dist".to_owned(), dist);
     }
     if let Some(environment) = event.environment.as_str() {

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -52,7 +52,9 @@ fn extract_transaction_status(transaction: &Event) -> Option<String> {
 
 #[cfg(feature = "processing")]
 fn extract_dist(transaction: &Event) -> Option<String> {
-    normalize_release_dist(transaction)
+    let mut dist = transaction.dist.0.clone();
+    normalize_dist(&mut dist);
+    dist
 }
 
 #[cfg(feature = "processing")]
@@ -234,6 +236,7 @@ mod tests {
             "type": "transaction",
             "timestamp": "2021-04-26T08:00:00+0100",
             "release": "1.2.3",
+            "dist": "foo ",
             "environment": "fake_environment",
             "transaction": "mytransaction",
             "tags": {
@@ -320,6 +323,7 @@ mod tests {
         for metric in metrics {
             assert!(matches!(metric.value, MetricValue::Distribution(_)));
             assert_eq!(metric.tags["release"], "1.2.3");
+            assert_eq!(metric.tags["dist"], "foo");
             assert_eq!(metric.tags["environment"], "fake_environment");
             assert_eq!(metric.tags["transaction"], "mytransaction");
             assert_eq!(metric.tags["fOO"], "bar");
@@ -378,6 +382,7 @@ mod tests {
         }
 
         assert_eq!(duration_metric.tags.len(), 4);
+        assert_eq!(duration_metric.tags["release"], "1.2.3");
         assert_eq!(duration_metric.tags["transaction.status"], "ok");
         assert_eq!(duration_metric.tags["environment"], "fake_environment");
         assert_eq!(duration_metric.tags["transaction"], "mytransaction");


### PR DESCRIPTION
Apply normalization to `event.dist` and add as tag to every transaction metric.

There is no further normalization in sentry python code as far as I can see: The dist is accepted in event_manager unaltered:

https://github.com/getsentry/sentry/blob/44d7aa211d67b64884230d833f6e485a96357ad6/src/sentry/event_manager.py#L674