### PR TITLE
feat(metrics): Flush aggregator on graceful shutdown [INGEST-539]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Metrics extraction config, custom tags. ([#1141](https://github.com/getsentry/relay/pull/1141))
 - Update the user agent parser (uap-core Feb 2020 to Nov 2021). This allows Relay and Sentry to infer more recent browsers, operating systems, and devices in events containing a user agent header. ([#1143](https://github.com/getsentry/relay/pull/1143), [#1145](https://github.com/getsentry/relay/pull/1145))
 - Improvements to Unity OS context parsing ([#1150](https://github.com/getsentry/relay/pull/1150))
+- Flush metrics and outcome aggregators on graceful shutdown. ([#1159](https://github.com/getsentry/relay/pull/1159))
 
 **Bug Fixes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,6 +3372,7 @@ dependencies = [
  "insta",
  "lazy_static",
  "relay-common",
+ "relay-common-actors",
  "relay-log",
  "relay-statsd",
  "relay-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "relay-common-actors"
+version = "21.12.0"
+dependencies = [
+ "actix",
+ "failure",
+ "futures 0.1.29",
+ "relay-log",
+]
+
+[[package]]
 name = "relay-config"
 version = "21.12.0"
 dependencies = [
@@ -3440,6 +3450,7 @@ dependencies = [
  "regex",
  "relay-auth",
  "relay-common",
+ "relay-common-actors",
  "relay-config",
  "relay-filter",
  "relay-general",

--- a/relay-common-actors/Cargo.toml
+++ b/relay-common-actors/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "relay-common-actors"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Actors used by multiple services in Relay"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+version = "21.12.0"
+edition = "2018"
+license-file = "../LICENSE"
+publish = false
+
+[dependencies]
+actix = "0.7.9"
+failure = "0.1.8"
+futures = "0.1.28"
+relay-log = { path = "../relay-log" }

--- a/relay-common-actors/src/controller.rs
+++ b/relay-common-actors/src/controller.rs
@@ -11,8 +11,6 @@ use ::actix::prelude::*;
 use futures::future;
 use futures::prelude::*;
 
-pub use crate::service::ServerError;
-
 /// Actor to start and gracefully stop an actix system.
 ///
 /// This actor contains a static `run` method which will run an actix system and block the current

--- a/relay-common-actors/src/lib.rs
+++ b/relay-common-actors/src/lib.rs
@@ -1,0 +1,8 @@
+//! Common actors for Relay services
+#![warn(missing_docs)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
+    html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
+)]
+
+pub mod controller;

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -14,6 +14,7 @@ actix = "0.7.9"
 float-ord = "0.3.1"
 hash32 = "0.1.1"
 relay-common = { path = "../relay-common" }
+relay-common-actors = { path = "../relay-common-actors" }
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
 serde = { version = "1.0.114", features = ["derive"] }

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1152,6 +1152,7 @@ impl Aggregator {
                             );
                             slf.merge_all(project_key, buckets).ok();
                         } else {
+                            // NOTE: This means we drop buckets if the project state is expired.
                             relay_log::trace!(
                                 "returned {} buckets from receiver, dropping",
                                 buckets.len()

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -49,6 +49,7 @@ rdkafka-sys = { version = "2.1.0", optional = true }
 regex = "1.5.4"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
+relay-common-actors = { path = "../relay-common-actors" }
 relay-config = { path = "../relay-config" }
 relay-filter = { path = "../relay-filter" }
 relay-general = { path = "../relay-general" }

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -8,9 +8,9 @@ use futures::prelude::*;
 use relay_config::{Config, RelayMode};
 use relay_statsd::metric;
 
-use crate::actors::controller::{Controller, Shutdown};
 use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
 use crate::statsd::RelayGauges;
+use relay_common_actors::controller::{Controller, Shutdown};
 
 pub struct Healthcheck {
     is_shutting_down: bool,

--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -31,7 +31,6 @@
 //! Controller::run(|| Server::start())
 //!     .expect("failed to start relay");
 //! ```
-pub mod controller;
 pub mod envelopes;
 pub mod healthcheck;
 pub mod outcome;

--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -1,9 +1,9 @@
 //! Defines all actors of the relay.
 //!
 //! Actors require an actix system to run. The system can be started using the
-//! [`Controller`](controller::Controller) actor, which will also listen for shutdown signals and
+//! [`Controller`](relay_common_actors::controller::Controller) actor, which will also listen for shutdown signals and
 //! trigger a graceful shutdown. Note that actors must implement a handler for the
-//! [`Shutdown`](controller::Shutdown) message and register with the controller to receive this
+//! [`Shutdown`](relay_common_actors::controller::Shutdown) message and register with the controller to receive this
 //! signal. See the struct level documentation for more information.
 //!
 //! The web server is wrapped by the [`Server`](server::Server) actor. It starts the actix http web

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -5,9 +5,9 @@ use futures::prelude::*;
 use relay_config::Config;
 use relay_statsd::metric;
 
-use crate::actors::controller::{Controller, Shutdown};
 use crate::service;
 use crate::statsd::RelayCounters;
+use relay_common_actors::controller::{Controller, Shutdown};
 
 pub use crate::service::ServerError;
 

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -267,10 +267,10 @@ mod utils;
 
 use relay_config::Config;
 
-use crate::actors::controller::Controller;
 use crate::actors::server::Server;
+use relay_common_actors::controller::Controller;
 
-pub use crate::actors::controller::ServerError;
+pub use crate::service::ServerError;
 
 /// Runs a relay web server and spawns all internal worker threads.
 ///

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -11,7 +11,6 @@ use relay_config::Config;
 use relay_metrics::Aggregator;
 use relay_redis::RedisPool;
 
-use crate::actors::controller::{Configure, Controller};
 use crate::actors::envelopes::{EnvelopeManager, EnvelopeProcessor};
 use crate::actors::healthcheck::Healthcheck;
 use crate::actors::outcome::OutcomeProducer;
@@ -23,6 +22,7 @@ use crate::endpoints;
 use crate::middlewares::{
     AddCommonHeaders, ErrorHandlers, Metrics, ReadRequestMiddleware, SentryMiddleware,
 };
+use relay_common_actors::controller::{Configure, Controller};
 
 /// Common error type for the relay server.
 #[derive(Debug)]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -505,7 +505,6 @@ def test_transaction_metrics(
 
 
 def test_graceful_shutdown(mini_sentry, relay):
-
     relay = relay(
         mini_sentry,
         options={

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 import json
 import signal
+from time import sleep
 
 import pytest
 import requests
@@ -511,8 +512,8 @@ def test_graceful_shutdown(mini_sentry, relay):
             "limits": {"shutdown_timeout": 2},
             "aggregator": {
                 "bucket_interval": 1,
-                "initial_delay": 10,  # Delay is longer than shutdown period
-                "debounce_delay": 10,
+                "initial_delay": 10,
+                "debounce_delay": 0,
             },
         },
     )
@@ -521,18 +522,42 @@ def test_graceful_shutdown(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c"
-    relay.send_metrics(project_id, metrics_payload, timestamp)
 
-    # Shutdown relay
+    # Backdated metric will be flushed immediately due to debounce delay
+    past_timestamp = timestamp - 1000
+    metrics_payload = f"foo:42|c"
+    relay.send_metrics(project_id, metrics_payload, past_timestamp)
+
+    # Future timestamp will not be flushed regularly, only through force flush
+    metrics_payload = f"bar:17|c"
+    future_timestamp = timestamp + 60
+    relay.send_metrics(project_id, metrics_payload, future_timestamp)
     relay.shutdown(sig=signal.SIGTERM)
 
     # Try to send another metric (will be rejected)
-    metrics_payload = f"bar:42|c"
+    metrics_payload = f"zap:666|c"
     with pytest.raises(requests.ConnectionError):
         relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=2)
     assert len(envelope.items) == 1
-
-    print(envelope)
+    metrics_item = envelope.items[0]
+    assert metrics_item.type == "metric_buckets"
+    received_metrics = json.loads(metrics_item.get_bytes().decode())
+    received_metrics = sorted(received_metrics, key=lambda x: x["name"])
+    assert received_metrics == [
+        {
+            "timestamp": future_timestamp,
+            "width": 1,
+            "name": "bar",
+            "value": 17.0,
+            "type": "c",
+        },
+        {
+            "timestamp": past_timestamp,
+            "width": 1,
+            "name": "foo",
+            "value": 42.0,
+            "type": "c",
+        },
+    ]

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -715,7 +715,6 @@ def test_outcomes_do_not_aggregate(
 
 
 def test_graceful_shutdown(relay, mini_sentry):
-    """Dynamic sampling is aggregated"""
     # Create project config
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1,8 +1,8 @@
-import random
 import uuid
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from queue import Empty
+import signal
 
 import requests
 import pytest
@@ -712,3 +712,67 @@ def test_outcomes_do_not_aggregate(
     }
     # Convert to dict to ignore sort order:
     assert {x["event_id"]: x for x in outcomes} == expected_outcomes
+
+
+def test_graceful_shutdown(relay, mini_sentry):
+    """Dynamic sampling is aggregated"""
+    # Create project config
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["dynamicSampling"] = {
+        "rules": [
+            {
+                "id": 1,
+                "sampleRate": 0.0,
+                "type": "error",
+                "condition": {
+                    "op": "eq",
+                    "name": "event.environment",
+                    "value": "production",
+                },
+            }
+        ]
+    }
+
+    relay = relay(
+        mini_sentry,
+        options={
+            "limits": {"shutdown_timeout": 1},
+            "outcomes": {
+                "emit_outcomes": True,
+                "batch_size": 1,
+                "batch_interval": 1,
+                "aggregator": {"flush_interval": 10,},
+            },
+        },
+    )
+
+    _send_event(relay, event_type="error")
+
+    # Give relay some time to handle event
+    time.sleep(0.1)
+
+    # Shutdown relay
+    relay.shutdown(sig=signal.SIGTERM)
+
+    # We should have outcomes almost immediately through force flush:
+    outcomes_batch = mini_sentry.captured_outcomes.get(timeout=0.2)
+    assert mini_sentry.captured_outcomes.qsize() == 0  # we had only one batch
+
+    outcomes = outcomes_batch.get("outcomes")
+    assert len(outcomes) == 1
+
+    outcome = outcomes[0]
+
+    del outcome["timestamp"]
+
+    expected_outcome = {
+        "org_id": 1,
+        "project_id": 42,
+        "key_id": 123,
+        "outcome": 1,
+        "reason": "Sampled:1",
+        "category": 1,
+        "quantity": 1,
+    }
+    assert outcome == expected_outcome


### PR DESCRIPTION
On shutdown, let both the metrics aggregator and the outcome aggregator flush all buckets unconditionally.

This PR also moves the `Controller` actor to a separate subcrate, so it can be used from both `relay-server` and `relay-metrics`.