### PR TITLE
fix(relay): Remove any mention of isEnabled for DSNs [ISSUE-1383]

### DIFF
--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -61,9 +61,7 @@ class Sentry(SentryLike):
             s += "> %s: %s\n" % (route, error)
         return s
 
-    def add_dsn_key_to_project(
-        self, project_id, dsn_public_key=None, numeric_id=None
-    ):
+    def add_dsn_key_to_project(self, project_id, dsn_public_key=None, numeric_id=None):
         if project_id not in self.project_configs:
             raise Exception("trying to add dsn public key to nonexisting project")
 

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -62,7 +62,7 @@ class Sentry(SentryLike):
         return s
 
     def add_dsn_key_to_project(
-        self, project_id, dsn_public_key=None, numeric_id=None, is_enabled=True
+        self, project_id, dsn_public_key=None, numeric_id=None
     ):
         if project_id not in self.project_configs:
             raise Exception("trying to add dsn public key to nonexisting project")
@@ -84,7 +84,6 @@ class Sentry(SentryLike):
 
         key_entry = {
             "publicKey": dsn_public_key,
-            "isEnabled": is_enabled,
             "numericId": numeric_id,
         }
         public_keys.append(key_entry)
@@ -95,7 +94,6 @@ class Sentry(SentryLike):
         if dsn_public_key is None:
             dsn_public_key = {
                 "publicKey": uuid.uuid4().hex,
-                "isEnabled": True,
                 "numericId": 123,
             }
 

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -83,6 +83,8 @@ class Sentry(SentryLike):
         key_entry = {
             "publicKey": dsn_public_key,
             "numericId": numeric_id,
+            # For backwards compat, not required by newer relays
+            "isEnabled": True,
         }
         public_keys.append(key_entry)
 
@@ -92,6 +94,8 @@ class Sentry(SentryLike):
         if dsn_public_key is None:
             dsn_public_key = {
                 "publicKey": uuid.uuid4().hex,
+                # For backwards compat, newer relays do not need it
+                "isEnabled": True,
                 "numericId": 123,
             }
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/31109, this flag is
entirely unused and misleading when it comes to relay's behavior.

#skip-changelog