### PR TITLE
feat(profiling): Handle 2 new ItemType for profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**
 
 - Add an option to dispatch billing outcomes to a dedicated topic. ([#1168](https://github.com/getsentry/relay/pull/1168))
+- Add new `ItemType` to handle profiling data. ([#1170](https://github.com/getsentry/relay/pull/1170))
 
 ## 22.1.0
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -756,6 +756,10 @@ pub enum KafkaTopic {
     Sessions,
     /// Aggregate Metrics.
     Metrics,
+    /// Profiling sessions
+    ProfilingSessions,
+    /// Profiling traces
+    ProfilingTraces,
 }
 
 /// Configuration for topics.
@@ -776,6 +780,10 @@ pub struct TopicAssignments {
     pub sessions: TopicAssignment,
     /// Metrics topic name.
     pub metrics: TopicAssignment,
+    /// Profiling sessions topic name
+    pub profiling_sessions: TopicAssignment,
+    /// Profiling traces topic name
+    pub profiling_traces: TopicAssignment,
 }
 
 impl TopicAssignments {
@@ -789,6 +797,8 @@ impl TopicAssignments {
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
             KafkaTopic::Metrics => &self.metrics,
+            KafkaTopic::ProfilingSessions => &self.profiling_sessions,
+            KafkaTopic::ProfilingTraces => &self.profiling_traces,
         }
     }
 }
@@ -803,6 +813,8 @@ impl Default for TopicAssignments {
             outcomes_billing: None,
             sessions: "ingest-sessions".to_owned().into(),
             metrics: "ingest-metrics".to_owned().into(),
+            profiling_sessions: "profiling-sessions".to_owned().into(),
+            profiling_traces: "profiling-traces".to_owned().into(),
         }
     }
 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -936,6 +936,17 @@ impl EnvelopeProcessor {
         }
     }
 
+    /// Remove profiling items if the feature flag is not enabled
+    fn process_profiling_items(&self, state: &mut ProcessEnvelopeState) {
+        let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
+        state.envelope.retain_items(|item| {
+            match item.ty() {
+                ItemType::ProfilingSession | ItemType::ProfilingTrace => profiling_enabled,
+                _ => true, // Keep all other item types
+            }
+        });
+    }
+
     /// Creates and initializes the processing state.
     ///
     /// This applies defaults to the envelope and initializes empty rate limits.
@@ -1745,6 +1756,7 @@ impl EnvelopeProcessor {
         self.process_sessions(state);
         self.process_client_reports(state);
         self.process_user_reports(state);
+        self.process_profiling_items(state);
 
         if state.creates_event() {
             if_processing!({

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1239,6 +1239,8 @@ impl EnvelopeProcessor {
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
+            ItemType::ProfilingSession => false,
+            ItemType::ProfilingTrace => false,
         }
     }
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -52,6 +52,9 @@ pub enum Feature {
     #[serde(rename = "organizations:metrics-extraction")]
     MetricsExtraction,
 
+    #[serde(rename = "organizations:profiling")]
+    Profiling,
+
     /// forward compatibility
     #[serde(other)]
     Unknown,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -429,7 +429,7 @@ impl StoreForwarder {
         item: &Item,
     ) -> Result<(), StoreError> {
         let message = ProfilingKafkaMessage {
-            organization_id: organization_id,
+            organization_id,
             payload: item.payload(),
         };
         relay_log::trace!("Sending profiling session item to kafka");
@@ -446,7 +446,7 @@ impl StoreForwarder {
         item: &Item,
     ) -> Result<(), StoreError> {
         let message = ProfilingKafkaMessage {
-            organization_id: organization_id,
+            organization_id,
             payload: item.payload(),
         };
         relay_log::trace!("Sending profiling trace item to kafka");

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -58,6 +58,8 @@ struct Producers {
     transactions: Producer,
     sessions: Producer,
     metrics: Producer,
+    profiling_sessions: Producer,
+    profiling_traces: Producer,
 }
 
 impl Producers {
@@ -74,6 +76,8 @@ impl Producers {
             }
             KafkaTopic::Sessions => Some(&self.sessions),
             KafkaTopic::Metrics => Some(&self.metrics),
+            KafkaTopic::ProfilingSessions => Some(&self.profiling_sessions),
+            KafkaTopic::ProfilingTraces => Some(&self.profiling_traces),
         }
     }
 }
@@ -130,6 +134,16 @@ impl StoreForwarder {
             transactions: make_producer(&*config, &mut reused_producers, KafkaTopic::Transactions)?,
             sessions: make_producer(&*config, &mut reused_producers, KafkaTopic::Sessions)?,
             metrics: make_producer(&*config, &mut reused_producers, KafkaTopic::Metrics)?,
+            profiling_sessions: make_producer(
+                &*config,
+                &mut reused_producers,
+                KafkaTopic::ProfilingSessions,
+            )?,
+            profiling_traces: make_producer(
+                &*config,
+                &mut reused_producers,
+                KafkaTopic::ProfilingTraces,
+            )?,
         };
 
         Ok(Self { config, producers })
@@ -408,6 +422,54 @@ impl StoreForwarder {
         );
         Ok(())
     }
+
+    fn produce_profiling_session_message(&self, item: &Item) -> Result<(), StoreError> {
+        let message = ProfilingKafkaMessage {
+            organization_id: item
+                .get_header("organization_id")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+            installation_id: item
+                .get_header("installation_id")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+            payload: item.payload(),
+        };
+        relay_log::trace!("Sending profiling session item to kafka");
+        self.produce(
+            KafkaTopic::ProfilingSessions,
+            KafkaMessage::ProfilingSession(message),
+        )?;
+        Ok(())
+    }
+
+    fn produce_profiling_trace_message(&self, item: &Item) -> Result<(), StoreError> {
+        let message = ProfilingKafkaMessage {
+            organization_id: item
+                .get_header("organization_id")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+            installation_id: item
+                .get_header("installation_id")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+            payload: item.payload(),
+        };
+        relay_log::trace!("Sending profiling trace item to kafka");
+        self.produce(
+            KafkaTopic::ProfilingTraces,
+            KafkaMessage::ProfilingTrace(message),
+        )?;
+        Ok(())
+    }
 }
 
 /// StoreMessageForwarder is an async actor since the only thing it does is put the messages
@@ -574,6 +636,13 @@ struct MetricKafkaMessage {
     tags: BTreeMap<String, String>,
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct ProfilingKafkaMessage {
+    organization_id: String,
+    installation_id: String,
+    payload: Bytes,
+}
+
 /// An enum over all possible ingest messages.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -585,6 +654,8 @@ enum KafkaMessage {
     UserReport(UserReportKafkaMessage),
     Session(SessionKafkaMessage),
     Metric(MetricKafkaMessage),
+    ProfilingSession(ProfilingKafkaMessage),
+    ProfilingTrace(ProfilingKafkaMessage),
 }
 
 impl KafkaMessage {
@@ -597,6 +668,8 @@ impl KafkaMessage {
             Self::UserReport(message) => message.event_id.0,
             Self::Session(message) => message.session_id,
             Self::Metric(_message) => Uuid::nil(), // TODO(ja): Determine a partitioning key
+            Self::ProfilingTrace(_message) => Uuid::nil(), // TODO(pierre): parse session_id as uuid
+            Self::ProfilingSession(_message) => Uuid::nil(), // TODO(pierre): parse session_id as uuid
         };
 
         if uuid.is_nil() {
@@ -705,6 +778,8 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                 ItemType::MetricBuckets => {
                     self.produce_metrics(scoping.organization_id, scoping.project_id, item)?
                 }
+                ItemType::ProfilingSession => self.produce_profiling_session_message(item)?,
+                ItemType::ProfilingTrace => self.produce_profiling_trace_message(item)?,
                 _ => {}
             }
         }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -102,6 +102,10 @@ pub enum ItemType {
     MetricBuckets,
     /// Client internal report (eg: outcomes).
     ClientReport,
+    /// Profiling session
+    ProfilingSession,
+    /// Profiling data
+    ProfilingTrace,
 }
 
 impl ItemType {
@@ -133,6 +137,8 @@ impl fmt::Display for ItemType {
             Self::Metrics => write!(f, "metrics"),
             Self::MetricBuckets => write!(f, "metric buckets"),
             Self::ClientReport => write!(f, "client report"),
+            Self::ProfilingSession => write!(f, "profiling session"),
+            Self::ProfilingTrace => write!(f, "profiling trace"),
         }
     }
 }
@@ -551,7 +557,9 @@ impl Item {
             | ItemType::Transaction
             | ItemType::Security
             | ItemType::RawSecurity
-            | ItemType::UnrealReport => true,
+            | ItemType::UnrealReport
+            | ItemType::ProfilingSession
+            | ItemType::ProfilingTrace => true,
 
             // Attachments are only event items if they are crash reports or if they carry partial
             // event payloads. Plain attachments never create event payloads.
@@ -598,6 +606,8 @@ impl Item {
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
+            ItemType::ProfilingSession => false,
+            ItemType::ProfilingTrace => false,
         }
     }
 }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -557,9 +557,7 @@ impl Item {
             | ItemType::Transaction
             | ItemType::Security
             | ItemType::RawSecurity
-            | ItemType::UnrealReport
-            | ItemType::ProfilingSession
-            | ItemType::ProfilingTrace => true,
+            | ItemType::UnrealReport => true,
 
             // Attachments are only event items if they are crash reports or if they carry partial
             // event payloads. Plain attachments never create event payloads.
@@ -584,7 +582,9 @@ impl Item {
             | ItemType::Sessions
             | ItemType::Metrics
             | ItemType::MetricBuckets
-            | ItemType::ClientReport => false,
+            | ItemType::ClientReport
+            | ItemType::ProfilingSession
+            | ItemType::ProfilingTrace => false,
         }
     }
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -103,6 +103,8 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
+        ItemType::ProfilingSession => None,
+        ItemType::ProfilingTrace => None,
         // the following items are "internal" item types.  From the perspective of the SDK
         // the use the "internal" data category however this data category is in fact never
         // supposed to be emitted by relay as internal items must not be rate limited.  As

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -26,7 +26,9 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool 
             | ItemType::Transaction
             | ItemType::Security
             | ItemType::RawSecurity
-            | ItemType::FormData => event_size += item.len(),
+            | ItemType::FormData
+            | ItemType::ProfilingSession
+            | ItemType::ProfilingTrace => event_size += item.len(),
             ItemType::Attachment | ItemType::UnrealReport => {
                 if item.len() > config.max_attachment_size() {
                     return false;


### PR DESCRIPTION
This PR seeks to add support for 2 new `ItemType` to help with the transition from the Specto to Sentry. These new types will be pushed to different Kafka topics and the rest of the processing will be handled by the Specto ingestion service for now.

The 2 new types are:
- `ProfilingSession`: contains information about device on which `ProfilingTrace` are collected.
- `ProfilingTrace`: contains the profiling data. The payload will be our own Protobuf structure sent as binary.
