### PR TITLE
fix(csp): Parse 'violated-directive: default-src' [INGEST-912]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add an option to dispatch billing outcomes to a dedicated topic. ([#1168](https://github.com/getsentry/relay/pull/1168))
 
+**Bug Fixes**
+
+- Fix regression in CSP report parsing. ([#1174](https://github.com/getsentry/relay/pull/1174))
+
 ## 22.1.0
 
 **Features**


### PR DESCRIPTION
It seems that a use case reported in https://github.com/getsentry/sentry/issues/31433
does not work since https://github.com/getsentry/relay/pull/1144.

This PR attempts to revert those changes while keeping clippy happy.