### PR TITLE
feat(server): Add a flag to override project IDs [INGEST-927]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,27 @@
 
 ## Unreleased
 
-**Internal**
+**Features**:
+
+- Add the `relay.override_project_ids` configuration flag to support migrating projects from self-hosted to Sentry SaaS. ([#1175](https://github.com/getsentry/relay/pull/1175))
+
+**Internal**:
 
 - Add an option to dispatch billing outcomes to a dedicated topic. ([#1168](https://github.com/getsentry/relay/pull/1168))
 
-**Bug Fixes**
+**Bug Fixes**:
 
 - Fix regression in CSP report parsing. ([#1174](https://github.com/getsentry/relay/pull/1174))
 
 ## 22.1.0
 
-**Features**
+**Features**:
+
 - Flush metrics and outcome aggregators on graceful shutdown. ([#1159](https://github.com/getsentry/relay/pull/1159))
 - Extract metrics from sampled transactions. ([#1161](https://github.com/getsentry/relay/pull/1161))
 
-**Internal**
+**Internal**:
+
 - Extract normalized dist as metric. ([#1158](https://github.com/getsentry/relay/pull/1158))
 - Extract transaction user as metric. ([#1164](https://github.com/getsentry/relay/pull/1164))
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -262,9 +262,9 @@ impl ProjectState {
     /// If the project state has not been loaded, this check is skipped because the project
     /// identifier is not yet known. Likewise, this check is skipped for the legacy store endpoint
     /// which comes without a project ID. The id is later overwritten in `check_envelope`.
-    pub fn is_valid_project_id(&self, stated_id: Option<ProjectId>) -> bool {
-        match (self.project_id, stated_id) {
-            (Some(actual_id), Some(stated_id)) => actual_id == stated_id,
+    pub fn is_valid_project_id(&self, stated_id: Option<ProjectId>, config: &Config) -> bool {
+        match (self.project_id, stated_id, config.override_project_ids()) {
+            (Some(actual_id), Some(stated_id), false) => actual_id == stated_id,
             _ => true,
         }
     }
@@ -387,7 +387,7 @@ impl ProjectState {
     pub fn check_request(&self, meta: &RequestMeta, config: &Config) -> Result<(), DiscardReason> {
         // Verify that the stated project id in the DSN matches the public key used to retrieve this
         // project state.
-        if !self.is_valid_project_id(meta.project_id()) {
+        if !self.is_valid_project_id(meta.project_id(), config) {
             return Err(DiscardReason::ProjectId);
         }
 


### PR DESCRIPTION
This flag can be used to migrate from self-hosted to SaaS, where public keys match but the project ID needs to be rewritten. Relay supported this already, but there was a mandatory validation step that can now be disabled. 

Config:

```yaml
relay:
   # ...
   override_project_ids: true
```

Minimum requirements for this are:
- A Sentry _business plan_ for managed Relays
- Migrating from Sentry self-hosted _20.10.0 or later_