### PR TITLE
fix(pii): Don't redact already redacted text [INGEST-109]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Bug Fixes**:
 
 - Fix regression in CSP report parsing. ([#1174](https://github.com/getsentry/relay/pull/1174))
+- Don't redact already redacted text. ([#1177](https://github.com/getsentry/relay/pull/1177))
 
 ## 22.1.0
 

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -240,11 +240,20 @@ fn apply_regex_to_chunks<'a>(
     // on the chunks, but the `regex` crate does not support that.
 
     let mut search_string = String::new();
+    let mut text_present = false;
     for chunk in &chunks {
         match chunk {
-            Chunk::Text { text } => search_string.push_str(&text.replace("\x00", "")),
+            Chunk::Text { text } => {
+                search_string.push_str(&text.replace("\x00", ""));
+                text_present = true;
+            }
             Chunk::Redaction { .. } => search_string.push('\x00'),
         }
+    }
+
+    // Early exit if there isn't any text to be redacted
+    if !text_present {
+        return chunks;
     }
 
     // Early exit if this regex does not match and return the original chunks.


### PR DESCRIPTION
If one relay redacts the whole text chunk and forwards it to the next relay
they don't have to re-redact the text again, so we can early exit when there's
no text to redact. This is causing an assertion to fail cases where the whole
text has already been redacted.

Without this patch, the method correctly returns the chunks, but there's
unnecessary work done, and the last assertion (`replacement_chunks.is_empty()`)
fails. This patch makes that method exit as early as possible removing that
unnecessary work, including not even reaching the failing assertion.

Fixes https://github.com/getsentry/relay/issues/1095.