### PR TITLE
docs(changelog): Add instructions for changelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,20 @@ There are two separate projects to publish:
 - **Relay Python library** along with the C-ABI are released from the `py/`
   subfolder. Change into that directory and run `craft prepare` and `craft publish`. We use [Semantic Versioning](https://semver.org/) and release during
   the development cycle.
+
+### Instructions for changelogs
+
+For changes exposed to the _Python package_, add an entry to `py/CHANGELOG.md`. This includes, but is not limited to, event normalization, PII scrubbing, and the protocol.
+For changes to the _Relay server_, please add an entry to `CHANGELOG.md` under the following heading:
+
+1. `Features`: for new user-visible functionality.
+2. `Bug Fixes`: for user-visible bug fixes.
+3. `Internal`: for features and bug fixes in internal operation, especially processing mode.
+
+To the changelog entry, please add a link to this PR (consider a more descriptive message):
+
+```md
+- ${getCleanTitle()}. (${PR_LINK})
+```
+
+If none of the above apply, you can opt out by adding `#skip-changelog` to the PR description.


### PR DESCRIPTION
Every PR must take an action regarding the changelogs. If no action is taken CI
fails and the danger bot will comment on the PR the instructions, but these
aren't documented in a way a contributor can know before opening a PR.

The instructions are basically a copy-paste from [the
message](https://github.com/getsentry/relay/blob/master/dangerfile.js#L17-L39)
the danger bot posts.

#skip-changelog