### PR TITLE
feat(metrics): Log number of dropped buckets as a statsd counter [INGEST-784]

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1157,6 +1157,9 @@ impl Aggregator {
                                 "returned {} buckets from receiver, dropping",
                                 buckets.len()
                             );
+                            relay_statsd::metric!(
+                                counter(MetricCounters::BucketsDropped) += buckets.len() as i64
+                            );
                         }
                     }
                     fut::ok(())

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -36,6 +36,11 @@ pub enum MetricCounters {
     ///
     /// Tagged by metric type and name.
     MergeMiss,
+
+    /// Incremented every time a bucket is dropped.
+    ///
+    /// This should only happen when a project state is invalid during graceful shutdown.
+    BucketsDropped,
 }
 
 impl CounterMetric for MetricCounters {
@@ -44,6 +49,7 @@ impl CounterMetric for MetricCounters {
             Self::InsertMetric => "metrics.insert",
             Self::MergeHit => "metrics.buckets.merge.hit",
             Self::MergeMiss => "metrics.buckets.merge.miss",
+            Self::BucketsDropped => "metrics.buckets.dropped",
         }
     }
 }


### PR DESCRIPTION
Make sure we know how many buckets we drop deliberately, so we can investigate missing metrics data.

#skip-changelog