### PR TITLE
feat(metrics): Shift bucket flush based on project keys [INGEST-953]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Spread out metric aggregation over the aggregation window to avoid concentrated waves of metrics requests to the upstream every 10 seconds. Relay now applies jitter to `initial_delay` to spread out requests more evenly over time. ([#1185](https://github.com/getsentry/relay/pull/1185))
+
 ## 22.2.0
 
 **Features**:

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -754,7 +754,7 @@ pub struct AggregatorConfig {
     /// before sending such a backdated bucket to the upsteam. This should be lower than
     /// `initial_delay`.
     ///
-    /// Other than `initial_delay`, the debounce delay starts with the exact moment the first metric
+    /// Unlike `initial_delay`, the debounce delay starts with the exact moment the first metric
     /// is added to a backdated bucket.
     pub debounce_delay: u64,
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1892,8 +1892,9 @@ mod tests {
                     Ok(())
                 })
                 .and_then(|_| {
-                    // Wait until flush delay has passed
-                    relay_test::delay(Duration::from_millis(1500)).map_err(|_| ())
+                    // Wait until flush delay has passed. It is up to 2s: 1s for the current bucket
+                    // and 1s for the flush shift. Adding 100ms buffer.
+                    relay_test::delay(Duration::from_millis(2100)).map_err(|_| ())
                 })
                 .and_then(|_| {
                     // After the flush delay has passed, the receiver should have the bucket:


### PR DESCRIPTION
To avoid flushing too many buckets when they expire at 10s boundaries, this PR
introduces variable shift. Based on the project key, each bucket is shifted
within 10s (`bucket_interval`) after it expires. However, buckets of the same
project key receive the same shift, so that they end up in the same upstream
request.

Additionally, this PR reduces the flush cycle from 500ms to 100ms, to create
even smaller batches.

Both these measures should reduce recurring pressure on the EnvelopeManager and
the UpstreamRelay queues.
