### PR TITLE
build: Update to stable rust-minidump release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -1100,13 +1100,13 @@ dependencies = [
 
 [[package]]
 name = "enum-primitive-derive"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
+checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
 dependencies = [
- "num-traits 0.1.43",
- "quote 0.3.15",
- "syn 0.11.11",
+ "num-traits 0.2.12",
+ "quote 1.0.7",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2046,13 +2046,14 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.2.0"
-source = "git+https://github.com/luser/rust-minidump?rev=dedd6715af3a22f5fff9c065e7c4b22c44fef320#dedd6715af3a22f5fff9c065e7c4b22c44fef320"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0f06e24debf89a5ed527f0c06422c0c6c112aa28e78c20ac3ed626823c3bc"
 dependencies = [
  "chrono",
  "encoding",
  "failure",
- "libc",
+ "log",
  "memmap",
  "minidump-common",
  "num-traits 0.2.12",
@@ -2062,12 +2063,12 @@ dependencies = [
 
 [[package]]
 name = "minidump-common"
-version = "0.2.0"
-source = "git+https://github.com/luser/rust-minidump?rev=dedd6715af3a22f5fff9c065e7c4b22c44fef320#dedd6715af3a22f5fff9c065e7c4b22c44fef320"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e0e0bb43d6a2a4fe9ab129bc8a5107df5e0f2c2869279983932dd222ca03fb"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",
- "libc",
  "log",
  "num-traits 0.2.12",
  "range-map",
@@ -2770,12 +2771,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -4078,12 +4073,13 @@ dependencies = [
 
 [[package]]
 name = "smart-default"
-version = "0.2.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7392ae8cdf79428cc98170bf264af7219887def8a30bb61d7ad2200313e88d"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -4217,17 +4213,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -4246,15 +4231,6 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -4938,12 +4914,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.8.2"
 lazy_static = "1.4.0"
 maxminddb = "0.13.0"
 memmap = { version = "0.7.0", optional = true }
-minidump = { git = "https://github.com/luser/rust-minidump", rev = "dedd6715af3a22f5fff9c065e7c4b22c44fef320" }
+minidump = "0.9.6"
 num-traits = "0.2.12"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -41,7 +41,7 @@ itertools = "0.8.2"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
 lazy_static = "1.4.0"
 listenfd = "0.3.3"
-minidump = { git = "https://github.com/luser/rust-minidump", rev = "dedd6715af3a22f5fff9c065e7c4b22c44fef320", optional = true }
+minidump = { version = "0.9.6", optional = true }
 native-tls = { version = "0.2.4", optional = true }
 parking_lot = "0.10.0"
 rdkafka = { version = "0.24", optional = true }


### PR DESCRIPTION
Brings in fixes from the latest rust-minidump releases. Note that the OOM
fix from luser/rust-minidump#404 is still missing and will be integrated once
released.

#skip-changelog
cc @Swatinem 