### PR TITLE
test(metrics): Increase timeouts to compensate for jitter [INGEST-953]

### DIFF
--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -274,7 +274,8 @@ def sessions_consumer(kafka_consumer):
 
 @pytest.fixture
 def metrics_consumer(kafka_consumer):
-    return lambda timeout=2: MetricsConsumer(
+    # The default timeout of 3 seconds compensates for delays and jitter
+    return lambda timeout=3: MetricsConsumer(
         timeout=timeout, *kafka_consumer("metrics")
     )
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -144,7 +144,7 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
 
     upstream.send_metrics(project_id, f"foo:3|c", timestamp)
 
-    metric = metrics_consumer.get_metric(timeout=4)
+    metric = metrics_consumer.get_metric(timeout=6)
     metric.pop("timestamp")
     assert metric == {
         "org_id": 1,


### PR DESCRIPTION
PR #1185 introduced additional delays when flushing metrics, which  appear to
have made the integration tests fail more often. This is an attempt to
compensate for the additional delays by adding 1s to all delays. With the
default `bucket_interval` used in integration tests, the additional delay
introduced by #1185 is always <=1.

#skip-changelog
