### PR TITLE
ci: Change machineType for Google Cloud Build to E2_HIGHCPU_8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -106,7 +106,7 @@ images:
 timeout: 3600s
 options:
   # Run on bigger machines
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
 secrets:
 - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
   secretEnv:


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/31950 for more details.

#skip-changelog