### PR TITLE
feat(metrics): Extract user satisfaction as tag [INGEST-589]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Tag transaction metrics by user satisfaction. ([#1197](https://github.com/getsentry/relay/pull/1197))
+
 **Internal**:
 
 - Spread out metric aggregation over the aggregation window to avoid concentrated waves of metrics requests to the upstream every 10 seconds. Relay now applies jitter to `initial_delay` to spread out requests more evenly over time. ([#1185](https://github.com/getsentry/relay/pull/1185))

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -26,6 +26,7 @@ pub use normalize::breakdowns::{
     get_breakdown_measurements, BreakdownConfig, BreakdownsConfig, SpanOperationsConfig,
 };
 pub use normalize::normalize_dist;
+pub use transactions::validate_timestamps;
 
 /// The config for store.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -22,15 +22,15 @@ pub fn validate_timestamps(
         }
         (_, None) => {
             // This invariant should be already guaranteed for regular error events.
-            return Err(ProcessingAction::InvalidTransaction(
+            Err(ProcessingAction::InvalidTransaction(
                 "timestamp hard-required for transaction events",
-            ));
+            ))
         }
         (None, _) => {
             // XXX: Maybe copy timestamp over?
-            return Err(ProcessingAction::InvalidTransaction(
+            Err(ProcessingAction::InvalidTransaction(
                 "start_timestamp hard-required for transaction events",
-            ));
+            ))
         }
     }
 }

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1,9 +1,39 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::protocol::{Context, ContextInner, Event, EventType, Span};
+use crate::protocol::{Context, ContextInner, Event, EventType, Span, Timestamp};
 use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult};
-
 /// Rejects transactions based on required fields.
 pub struct TransactionsProcessor;
+
+/// Returns start and end timestamps if they are both set and start <= end.
+pub fn validate_timestamps(
+    transaction_event: &Event,
+) -> Result<(&Timestamp, &Timestamp), ProcessingAction> {
+    match (
+        transaction_event.start_timestamp.value(),
+        transaction_event.timestamp.value(),
+    ) {
+        (Some(start), Some(end)) => {
+            if *end < *start {
+                return Err(ProcessingAction::InvalidTransaction(
+                    "end timestamp is smaller than start timestamp",
+                ));
+            }
+            Ok((start, end))
+        }
+        (_, None) => {
+            // This invariant should be already guaranteed for regular error events.
+            return Err(ProcessingAction::InvalidTransaction(
+                "timestamp hard-required for transaction events",
+            ));
+        }
+        (None, _) => {
+            // XXX: Maybe copy timestamp over?
+            return Err(ProcessingAction::InvalidTransaction(
+                "start_timestamp hard-required for transaction events",
+            ));
+        }
+    }
+}
 
 impl Processor for TransactionsProcessor {
     fn process_event(
@@ -27,27 +57,7 @@ impl Processor for TransactionsProcessor {
                 .set_value(Some("<unlabeled transaction>".to_owned()))
         }
 
-        match (event.start_timestamp.value(), event.timestamp.value_mut()) {
-            (Some(start), Some(end)) => {
-                if *end < *start {
-                    return Err(ProcessingAction::InvalidTransaction(
-                        "end timestamp is smaller than start timestamp",
-                    ));
-                }
-            }
-            (_, None) => {
-                // This invariant should be already guaranteed for regular error events.
-                return Err(ProcessingAction::InvalidTransaction(
-                    "timestamp hard-required for transaction events",
-                ));
-            }
-            (None, _) => {
-                // XXX: Maybe copy timestamp over?
-                return Err(ProcessingAction::InvalidTransaction(
-                    "start_timestamp hard-required for transaction events",
-                ));
-            }
-        }
+        validate_timestamps(event)?;
 
         let err_trace_context_required = Err(ProcessingAction::InvalidTransaction(
             "trace context hard-required for transaction events",

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -551,7 +551,7 @@ mod tests {
         {
             "type": "transaction",
             "transaction": "foo",
-            "start_timestamp": ""2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T08:00:00+0100",
             "timestamp": "2021-04-26T08:00:01+0100",
             "user": {
                 "id": "user123"

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -4,8 +4,10 @@ use std::collections::{BTreeMap, BTreeSet};
 #[cfg(feature = "processing")]
 use {
     relay_common::UnixTimestamp,
-    relay_general::protocol::{AsPair, Event, EventType},
-    relay_general::store::{get_breakdown_measurements, normalize_dist, BreakdownsConfig},
+    relay_general::protocol::{AsPair, Event, EventType, Timestamp},
+    relay_general::store::{
+        get_breakdown_measurements, normalize_dist, validate_timestamps, BreakdownsConfig,
+    },
     relay_metrics::{Metric, MetricUnit, MetricValue},
     std::fmt,
     std::fmt::Write,
@@ -124,24 +126,12 @@ impl UserSatisfaction {
 }
 
 /// Get duration from timestamp and `start_timestamp`.
-/// Every transaction has a duration, which defaults to zero. See
-///     https://github.com/getsentry/snuba/blob/b744ae896435af64dd3cf5ef36198285139310d4/snuba/migrations/snuba_migrations/transactions/0001_transactions.py#L35
-///     https://github.com/getsentry/snuba/blob/b744ae896435af64dd3cf5ef36198285139310d4/snuba/datasets/transactions_processor.py#L59
-/// This means that a transaction without `start_timestamp` or `timestamp` defaults to a duration
-/// of zero, and therefore counts towards the satisfied count used in the Apdex:
-/// https://github.com/getsentry/snuba/blob/b744ae896435af64dd3cf5ef36198285139310d4/snuba/query/processors/performance_expressions.py#L18
 #[cfg(feature = "processing")]
-fn get_duration_millis(transaction: &Event) -> Option<f64> {
-    let start = transaction.start_timestamp.value();
-    let end = transaction.timestamp.value();
-    match (start, end) {
-        (Some(start), Some(end)) => {
-            let start = start.timestamp_millis();
-            let end = end.timestamp_millis();
-            Some(end.saturating_sub(start) as f64)
-        }
-        _ => None,
-    }
+fn get_duration_millis(start: &Timestamp, end: &Timestamp) -> f64 {
+    let start = start.timestamp_millis();
+    let end = end.timestamp_millis();
+
+    end.saturating_sub(start) as f64
 }
 
 /// Get the value for a measurement, e.g. lcp -> event.measurements.lcp
@@ -165,6 +155,8 @@ fn get_measurement(transaction: &Event, name: &str) -> Option<f64> {
 fn extract_user_satisfaction(
     config: &Option<SatisfactionConfig>,
     transaction: &Event,
+    start_timestamp: &Timestamp,
+    end_timestamp: &Timestamp,
 ) -> Option<UserSatisfaction> {
     if let Some(config) = config {
         let threshold = transaction
@@ -173,7 +165,9 @@ fn extract_user_satisfaction(
             .and_then(|name| config.transaction_thresholds.get(name))
             .unwrap_or(&config.project_threshold);
         if let Some(value) = match threshold.metric {
-            SatisfactionMetric::Duration => get_duration_millis(transaction),
+            SatisfactionMetric::Duration => {
+                Some(get_duration_millis(start_timestamp, end_timestamp))
+            }
             SatisfactionMetric::Lcp => get_measurement(transaction, "lcp"),
             SatisfactionMetric::Unknown => None,
         } {
@@ -215,11 +209,14 @@ pub fn extract_transaction_metrics(
     #[allow(unused_variables)]
     let target = ();
 
-    let timestamp = match event
-        .timestamp
-        .value()
-        .and_then(|ts| UnixTimestamp::from_datetime(ts.into_inner()))
-    {
+    let (start_timestamp, end_timestamp) = match validate_timestamps(event) {
+        Ok(pair) => pair,
+        Err(_) => {
+            return false; // invalid transaction
+        }
+    };
+
+    let unix_timestamp = match UnixTimestamp::from_datetime(end_timestamp.into_inner()) {
         Some(ts) => ts,
         None => return false,
     };
@@ -272,7 +269,7 @@ pub fn extract_transaction_metrics(
                 name,
                 unit: MetricUnit::None,
                 value: MetricValue::Distribution(measurement),
-                timestamp,
+                timestamp: unix_timestamp,
                 tags,
             });
         }
@@ -291,30 +288,32 @@ pub fn extract_transaction_metrics(
                     name: metric_name(&["breakdowns", breakdown_name, measurement_name]),
                     unit: MetricUnit::None,
                     value: MetricValue::Distribution(measurement),
-                    timestamp,
+                    timestamp: unix_timestamp,
                     tags: tags.clone(),
                 });
             }
         }
     }
 
-    let user_satisfaction = extract_user_satisfaction(&config.satisfaction_thresholds, event);
+    let user_satisfaction = extract_user_satisfaction(
+        &config.satisfaction_thresholds,
+        event,
+        start_timestamp,
+        end_timestamp,
+    );
     let tags_with_satisfaction = match user_satisfaction {
         Some(satisfaction) => with_tag(&tags, "satisfaction", satisfaction),
         None => tags.clone(),
     };
 
     // Duration
-    let duration_millis = get_duration_millis(event).unwrap_or(0.0);
+    let duration_millis = get_duration_millis(start_timestamp, end_timestamp);
 
-    // We always push the duration even if it's 0, because we use count(transaction.duration)
-    // to get the total number of transactions.
-    // This may need to be changed if it turns out that this skews the duration metric.
     push_metric(Metric {
         name: metric_name(&["transaction.duration"]),
         unit: MetricUnit::Duration(DurationPrecision::MilliSecond),
         value: MetricValue::Distribution(duration_millis),
-        timestamp,
+        timestamp: unix_timestamp,
         tags: match extract_transaction_status(event) {
             Some(status) => with_tag(&tags, "transaction.status", status),
             None => tags_with_satisfaction.clone(),
@@ -328,7 +327,7 @@ pub fn extract_transaction_metrics(
                 name: metric_name(&["user"]),
                 unit: MetricUnit::None,
                 value: MetricValue::set_from_str(user_id),
-                timestamp,
+                timestamp: unix_timestamp,
                 // A single user might end up in multiple satisfaction buckets when they have
                 // some satisfying transactions and some frustrating transactions.
                 // This is OK as long as we do not add these numbers *after* aggregation:

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -296,7 +296,7 @@ pub fn extract_transaction_metrics(
     };
 
     // Duration
-    let duration_millis = get_duration_millis(&event).unwrap_or(0.0);
+    let duration_millis = get_duration_millis(event).unwrap_or(0.0);
 
     // We always push the duration even if it's 0, because we use count(transaction.duration)
     // to get the total number of transactions.
@@ -552,8 +552,10 @@ mod tests {
             "type": "transaction",
             "transaction": "foo",
             "start_timestamp": ""2021-04-26T08:00:00+0100",
-            "timestamp": ""2021-04-26T08:00:01+0100",
-            "user": {}
+            "timestamp": "2021-04-26T08:00:01+0100",
+            "user": {
+                "id": "user123"
+            }
         }
         "#;
 

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, fmt};
 
 #[cfg(feature = "processing")]
 use {
@@ -11,12 +11,37 @@ use {
     std::fmt::Write,
 };
 
-/// Configuration in relation to extracting metrics from transaction events.
+/// The metric on which the user satisfaction threshold is applied.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum SatisfactionMetric {
+    Duration,
+    Lcp,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SatisfactionThreshold {
+    metric: SatisfactionMetric,
+    threshold: f64,
+}
+
+/// Configuration for applying the user satisfaction threshold.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SatisfactionConfig {
+    /// The project-wide threshold to apply.
+    project_threshold: SatisfactionThreshold,
+    /// Transaction-specific overrides of the project-wide threshold.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    transaction_thresholds: BTreeMap<String, SatisfactionThreshold>,
+}
+
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct TransactionMetricsConfig {
     extract_metrics: BTreeSet<String>,
     extract_custom_tags: BTreeSet<String>,
+    satisfaction_thresholds: Option<SatisfactionConfig>,
 }
 
 #[cfg(feature = "processing")]
@@ -55,6 +80,90 @@ fn extract_dist(transaction: &Event) -> Option<String> {
     let mut dist = transaction.dist.0.clone();
     normalize_dist(&mut dist);
     dist
+}
+
+/// Satisfaction value used for Apdex and User Misery
+/// https://docs.sentry.io/product/performance/metrics/#apdex
+enum UserSatisfaction {
+    Satisfied,
+    Tolerated,
+    Frustrated,
+}
+
+impl fmt::Display for UserSatisfaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UserSatisfaction::Satisfied => write!(f, "satisfied"),
+            UserSatisfaction::Tolerated => write!(f, "tolerated"),
+            UserSatisfaction::Frustrated => write!(f, "frustrated"),
+        }
+    }
+}
+
+impl UserSatisfaction {
+    /// The frustration threshold is always four times the threshold
+    /// (see https://docs.sentry.io/product/performance/metrics/#apdex)
+    const FRUSTRATION_FACTOR: f64 = 4.0;
+
+    fn from_value(value: f64, threshold: f64) -> Self {
+        if value < threshold {
+            Self::Satisfied
+        } else if value < Self::FRUSTRATION_FACTOR * threshold {
+            Self::Tolerated
+        } else {
+            Self::Frustrated
+        }
+    }
+}
+
+#[cfg(feature = "processing")]
+fn get_duration_millis(transaction: &Event) -> Option<f64> {
+    let start = transaction.start_timestamp.value();
+    let end = transaction.timestamp.value();
+    match (start, end) {
+        (Some(start), Some(end)) => {
+            let start = start.timestamp_millis();
+            let end = end.timestamp_millis();
+            Some(end.saturating_sub(start) as f64)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(feature = "processing")]
+fn get_measurement(transaction: &Event, name: &str) -> Option<f64> {
+    if let Some(measurements) = transaction.measurements.value() {
+        for (measurement_name, annotated) in measurements.iter() {
+            if measurement_name == name {
+                if let Some(value) = annotated.value().and_then(|m| m.value.value()) {
+                    return Some(*value);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract the 'satisfaction' value given
+#[cfg(feature = "processing")]
+fn extract_user_satisfaction(
+    config: &Option<SatisfactionConfig>,
+    transaction: &Event,
+) -> Option<UserSatisfaction> {
+    if let Some(config) = config {
+        let threshold = transaction
+            .transaction
+            .value()
+            .and_then(|name| config.transaction_thresholds.get(name))
+            .unwrap_or(&config.project_threshold);
+        if let Some(value) = match threshold.metric {
+            SatisfactionMetric::Duration => get_duration_millis(transaction),
+            SatisfactionMetric::Lcp => get_measurement(transaction, "lcp"),
+        } {
+            return Some(UserSatisfaction::from_value(value, threshold.threshold));
+        }
+    }
+    None
 }
 
 #[cfg(feature = "processing")]
@@ -172,17 +281,14 @@ pub fn extract_transaction_metrics(
         }
     }
 
-    // Duration
-    let start = event.start_timestamp.value();
-    let end = event.timestamp.value();
-    let duration_millis = match (start, end) {
-        (Some(start), Some(end)) => {
-            let start = start.timestamp_millis();
-            let end = end.timestamp_millis();
-            end.saturating_sub(start)
-        }
-        _ => 0,
+    let user_satisfaction = extract_user_satisfaction(&config.satisfaction_thresholds, event);
+    let tags_with_satisfaction = match user_satisfaction {
+        Some(satisfaction) => with_tag(&tags, "satisfaction", satisfaction),
+        None => tags.clone(),
     };
+
+    // Duration
+    let duration_millis = get_duration_millis(&event).unwrap_or(0.0);
 
     // We always push the duration even if it's 0, because we use count(transaction.duration)
     // to get the total number of transactions.
@@ -194,19 +300,25 @@ pub fn extract_transaction_metrics(
         timestamp,
         tags: match extract_transaction_status(event) {
             Some(status) => with_tag(&tags, "transaction.status", status),
-            None => tags.clone(),
+            None => tags_with_satisfaction.clone(),
         },
     });
 
     // User
     if let Some(user) = event.user.value() {
         if let Some(user_id) = user.id.as_str() {
+            // TODO: If we have a transaction duration of 0 or no transaction at all, does the user count as satisfied?
             push_metric(Metric {
                 name: metric_name(&["user"]),
                 unit: MetricUnit::None,
                 value: MetricValue::set_from_str(user_id),
                 timestamp,
-                tags: tags.clone(),
+                // A single user might end up in multiple satisfaction buckets when they have
+                // some satisfying transactions and some frustrating transactions.
+                // This is OK as long as we do not add these numbers *after* aggregation:
+                //     <WRONG>total_users = uniqIf(user, satisfied) + uniqIf(user, tolerated) + uniqIf(user, frustrated)</WRONG>
+                //     <RIGHT>total_users = uniq(user)</RIGHT>
+                tags: tags_with_satisfaction,
             });
         }
     }
@@ -423,5 +535,48 @@ mod tests {
         assert_eq!(duration_metric.tags["transaction.status"], "ok");
         assert_eq!(duration_metric.tags["environment"], "fake_environment");
         assert_eq!(duration_metric.tags["transaction"], "mytransaction");
+    }
+
+    #[test]
+    fn test_user_satisfaction() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "transaction": "foo",
+            "start_timestamp": "2021-04-26T07:59:01+0100",
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "user": {
+                "id": "user123"
+            }
+        }
+        "#;
+
+        let event = Annotated::from_json(json).unwrap();
+
+        let config: TransactionMetricsConfig = serde_json::from_str(
+            r#"
+        {
+            "extractMetrics": [
+                "sentry.transactions.transaction.duration",
+                "sentry.transactions.user"
+            ],
+            "satisfactionThresholds": {
+                "projectThreshold": {
+                    "metric": "duration",
+                    "threshold": 300
+                }
+            }
+        }
+        "#,
+        )
+        .unwrap();
+        let mut metrics = vec![];
+        extract_transaction_metrics(&config, None, event.value().unwrap(), &mut metrics);
+        assert_eq!(metrics.len(), 2);
+
+        for metric in metrics {
+            assert_eq!(metric.tags.len(), 2);
+            assert_eq!(metric.tags["satisfaction"], "frustrated");
+        }
     }
 }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -49,7 +49,7 @@ def test_metrics(mini_sentry, relay):
     metrics_payload = f"foo:42|c\nbar:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
-    envelope = mini_sentry.captured_events.get(timeout=2)
+    envelope = mini_sentry.captured_events.get(timeout=3)
     assert len(envelope.items) == 1
 
     metrics_item = envelope.items[0]


### PR DESCRIPTION
Use the config exposed in https://github.com/getsentry/sentry/pull/32116 to extract user satisfaction tags for apdex and user misery.