### PR TITLE
build: Bump sentry-relay in dev dependencies to 0.8.9

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,4 @@ redis==3.4.1
 requests==2.23.0
 git+https://github.com/getsentry/sentry-python@e234998ae82a9cffa6fb3718801c55ba24a86bab#egg=sentry_sdk
 werkzeug==2.0.1
-sentry-relay==0.8.5
+sentry-relay==0.8.9


### PR DESCRIPTION
Most notably, this version includes a macOS ARM wheel, which removes the need to
build sentry-relay from source when installing test dependencies.

#skip-changelog
