### PR TITLE
fix(test): Find librdkafka on Apple M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,19 @@ clean-target-dir:
 
 .venv/bin/python: Makefile
 	rm -rf .venv
+
 	@# --copies is necessary because OS X make checks the mtime of the symlink
 	@# target (/usr/local/bin/python), which is always much older than the
 	@# Makefile, and then proceeds to unconditionally rebuild the venv.
 	$$RELAY_PYTHON_VERSION -m venv --copies .venv
+	.venv/bin/pip install -U pip wheel
+
+	@# Work around https://github.com/confluentinc/confluent-kafka-python/issues/1190
+	if [ "$$(uname -sm)" = "Darwin arm64" ]; then \
+		echo "Using 'librdkafka' from homebrew to build confluent-kafka"; \
+		export C_INCLUDE_PATH="$$(brew --prefix librdkafka)/include"; \
+		export LIBRARY_PATH="$$(brew --prefix librdkafka)/lib"; \
+	fi; \
 	.venv/bin/pip install -U -r requirements-dev.txt
 
 .git/hooks/pre-commit:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ workspace with multiple features, so when running building or running tests
 always make sure to pass the `--all` and `--all-features` flags.
 The `processing` feature additionally requires a C compiler and CMake.
 
+To install the development environment, librdkafka must be installed and on the
+path. On macOS, we require to install it with `brew install librdkafka`, as the installation script uses `brew --prefix` to determine the correct location.
+
 We use VSCode for development. This repository contains settings files
 configuring code style, linters, and useful features. When opening the project
 for the first time, make sure to _install the Recommended Extensions_, as they
@@ -55,9 +58,10 @@ development:
   also performed in CI.
 - `make clean`: Removes all build artifacts, the virtualenv and cached files.
 
-For a lot of tests you will need Redis and Kafka running in their respective
-default configuration. `sentry devservices` from
-[sentry](https://github.com/getsentry/sentry) does this for you.
+Integration tests require Redis and Kafka running in their default
+configuration. The most convenient way to get all required services is via
+[`sentry devservices`](https://develop.sentry.dev/services/devservices/), which
+requires an up-to-date Sentry development environment.
 
 ### Building and Running
 


### PR DESCRIPTION
Uses `brew --prefix` to locate `librdkafka` on macOS ARM builds. The homebrew
location differs on ARM and puts libraries in a non-standard location. There is
a similar workaround in the sentry development environment, except that it
writes exports to the zshrc / bashrc files.

See https://github.com/confluentinc/confluent-kafka-python/issues/1190

As part of this change, I've also updated the README to list `librdkafka` as
development dependency and upgrade `pip` and `wheel` during the venv setup
process.

#skip-changelog

