### PR TITLE
build: Update regex to 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**:
 
+- CVE-2022-24713: Prevent denial of service through untrusted regular expressions used for PII scrubbing. ([#1207](https://github.com/getsentry/relay/pull/1207))
 - Prevent dropping metrics during Relay shutdown if the project is outdated or not cached at time of the shutdown. ([#1205](https://github.com/getsentry/relay/pull/1205))
 
 **Internal**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,9 +3120,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 lazycell = "1.2.1"
 lru = "0.4.0"
 parking_lot = "0.10.0"
-regex = "1.5.4"
+regex = "1.5.5"
 relay-log = { path = "../relay-log" }
 sentry-types = "0.20.0"
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 globset = "0.4.5"
 ipnetwork = "0.14.0"
 lazy_static = "1.4.0"
-regex = "1.5.4"
+regex = "1.5.5"
 relay-general = { path = "../relay-general" }
 relay-common = { path = "../relay-common" }
 serde = { version = "1.0.114", features = ["derive"] }

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -25,7 +25,7 @@ minidump = "0.9.6"
 num-traits = "0.2.12"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-regex = "1.3.9"
+regex = "1.5.5"
 relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -46,7 +46,7 @@ native-tls = { version = "0.2.4", optional = true }
 parking_lot = "0.10.0"
 rdkafka = { version = "0.24", optional = true }
 rdkafka-sys = { version = "2.1.0", optional = true }
-regex = "1.5.4"
+regex = "1.5.5"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
 relay-common-actors = { path = "../relay-common-actors" }


### PR DESCRIPTION
Fixes [CVE-2022-24713](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html).
