### PR TITLE
ci(gcb): Increase timeout for self-hosted integration test

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -78,7 +78,7 @@ steps:
       echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
       ./install.sh
       ./test.sh || docker-compose logs nginx web relay
-    timeout: 600s
+    timeout: 900s
 
   - name: 'gcr.io/cloud-builders/docker'
     secretEnv: ['DOCKER_PASSWORD']


### PR DESCRIPTION
The self-hosted integration test running in Google Cloud Build has started
failing recently by running into the 10 minute timeout on the docker-compose
step.

This PR increases the timeout from 10m to 15m.

#skip-changelog

