### PR TITLE
build: Update rust-minidump to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - CVE-2022-24713: Prevent denial of service through untrusted regular expressions used for PII scrubbing. ([#1207](https://github.com/getsentry/relay/pull/1207))
 - Prevent dropping metrics during Relay shutdown if the project is outdated or not cached at time of the shutdown. ([#1205](https://github.com/getsentry/relay/pull/1205))
+- Prevent a potential OOM when validating corrupted or exceptional minidumps. ([#1209](https://github.com/getsentry/relay/pull/1209))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "sha1",
  "slab",
  "smallvec 0.6.13",
- "time",
+ "time 0.1.43",
  "tokio 0.1.22",
  "tokio-current-thread",
  "tokio-io",
@@ -487,7 +487,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.12",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi 0.3.8",
 ]
 
@@ -628,7 +628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5795cda0897252e34380a27baf884c53aa7ad9990329cdad96d4c5d027015d44"
 dependencies = [
  "percent-encoding 2.1.0",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -637,7 +637,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "time",
+ "time 0.1.43",
  "url 1.7.2",
 ]
 
@@ -812,7 +812,7 @@ checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.6",
  "ryu",
  "serde",
 ]
@@ -882,9 +882,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debugid"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
+checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "serde",
  "uuid 0.8.1",
@@ -1599,7 +1599,7 @@ checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
  "bytes 0.4.12",
  "fnv",
- "itoa",
+ "itoa 0.4.6",
 ]
 
 [[package]]
@@ -1610,7 +1610,7 @@ checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "itoa",
+ "itoa 0.4.6",
 ]
 
 [[package]]
@@ -1671,7 +1671,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.6",
  "pin-project 1.0.4",
  "socket2",
  "tokio 1.0.1",
@@ -1827,6 +1827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "js-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,9 +1886,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libloading"
@@ -2032,6 +2038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,33 +2073,36 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0f06e24debf89a5ed527f0c06422c0c6c112aa28e78c20ac3ed626823c3bc"
+checksum = "da059e37532e5950e6ec8dcf0a43f9164c287408dc8d5cde4f941b488a59af98"
 dependencies = [
- "chrono",
+ "debugid",
  "encoding",
- "failure",
  "log",
- "memmap",
+ "memmap2",
  "minidump-common",
  "num-traits 0.2.12",
  "range-map",
- "scroll",
+ "scroll 0.11.0",
+ "thiserror",
+ "time 0.3.7",
+ "uuid 0.8.1",
 ]
 
 [[package]]
 name = "minidump-common"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e0e0bb43d6a2a4fe9ab129bc8a5107df5e0f2c2869279983932dd222ca03fb"
+checksum = "d618971de3c26a0e3aaa89bb579e97bdc711cbfbb05761a2963dee38cec69444"
 dependencies = [
  "bitflags",
+ "debugid",
  "enum-primitive-derive",
  "log",
  "num-traits 0.2.12",
  "range-map",
- "scroll",
+ "scroll 0.11.0",
  "smart-default",
 ]
 
@@ -2286,6 +2304,15 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.58",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3113,7 +3140,7 @@ dependencies = [
  "dtoa",
  "futures-executor",
  "futures-util",
- "itoa",
+ "itoa 0.4.6",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.1.7",
  "r2d2",
@@ -3324,7 +3351,6 @@ dependencies = [
  "relay-common",
  "relay-general-derive",
  "schemars",
- "scroll",
  "sentry-release-parser",
  "serde",
  "serde_json",
@@ -3713,7 +3739,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 dependencies = [
- "scroll_derive",
+ "scroll_derive 0.10.2",
+]
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive 0.11.0",
 ]
 
 [[package]]
@@ -3721,6 +3756,17 @@ name = "scroll_derive"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3958,7 +4004,7 @@ version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
- "itoa",
+ "itoa 0.4.6",
  "ryu",
  "serde",
 ]
@@ -3979,7 +4025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 dependencies = [
  "dtoa",
- "itoa",
+ "itoa 0.4.6",
  "serde",
  "url 1.7.2",
 ]
@@ -3991,7 +4037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.6",
  "ryu",
  "serde",
 ]
@@ -4219,7 +4265,7 @@ dependencies = [
  "flate2",
  "lazy_static",
  "regex",
- "scroll",
+ "scroll 0.10.2",
  "serde",
  "thiserror",
 ]
@@ -4346,18 +4392,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4372,6 +4418,17 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.8.2"
 lazy_static = "1.4.0"
 maxminddb = "0.13.0"
 memmap = { version = "0.7.0", optional = true }
-minidump = "0.9.6"
+minidump = "0.10.0"
 num-traits = "0.2.12"
 pest = "2.1.3"
 pest_derive = "2.1.0"
@@ -29,7 +29,6 @@ regex = "1.5.5"
 relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
-scroll = "0.10.2"
 sentry-release-parser = { version = "1.1.1" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -11,10 +11,10 @@ use minidump::format::{
     CvSignature, MINIDUMP_LOCATION_DESCRIPTOR, MINIDUMP_STREAM_TYPE as StreamType,
 };
 use minidump::{
-    Error as MinidumpError, Minidump, MinidumpMemoryList, MinidumpModuleList, MinidumpThreadList,
+    Endian, Error as MinidumpError, Minidump, MinidumpMemoryList, MinidumpModuleList,
+    MinidumpThreadList,
 };
 use num_traits::FromPrimitive;
-use scroll::Endian;
 use utf16string::{Utf16Error, WStr};
 
 use crate::pii::{PiiAttachmentsProcessor, ScrubEncodings};
@@ -222,9 +222,8 @@ impl<'a> MinidumpData<'a> {
 
 /// Read a u32 from the start of a byte-slice.
 ///
-/// This uses the [Endian] indicator as used by scroll.  It is exceedingly close in
-/// functionality to `bytes.pread_with(0, endian)` from scroll directly, only differing in
-/// the error type.
+/// This function is exceedingly close in functionality to `bytes.pread_with(0, endian)` from scroll
+/// directly, only differing in the error type.
 fn u32_from_bytes(bytes: &[u8], endian: Endian) -> Result<u32, ScrubMinidumpError> {
     let mut buf = [0u8; 4];
     buf.copy_from_slice(bytes.get(..4).ok_or(ScrubMinidumpError::InvalidAddress)?);

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -42,7 +42,7 @@ itertools = "0.8.2"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
 lazy_static = "1.4.0"
 listenfd = "0.3.3"
-minidump = { version = "0.9.6", optional = true }
+minidump = { version = "0.10.0", optional = true }
 native-tls = { version = "0.2.4", optional = true }
 parking_lot = "0.10.0"
 rdkafka = { version = "0.24", optional = true }


### PR DESCRIPTION
Contains the OOM fix from luser/rust-minidump#404 which limits large
allocations while parsing minidumps with corrupted or exceptional
headers.

By updating the `minidump` crate, we now have a few duplicate
dependencies in the lockfile. However, upgrading everything else
requires a few unrelated code changes, which I prefer to keep separate
of this PR.

Fixes RELAY-1RT