### PR TITLE
ref(profiling): Remove unused item types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Remove unused item types. ([#1211](https://github.com/getsentry/relay/pull/1211))
+
 ## 22.3.0
 
 **Features**:

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -765,10 +765,6 @@ pub enum KafkaTopic {
     Sessions,
     /// Aggregate Metrics.
     Metrics,
-    /// Profiling sessions
-    ProfilingSessions,
-    /// Profiling traces
-    ProfilingTraces,
     /// Profiles
     Profiles,
 }
@@ -791,10 +787,6 @@ pub struct TopicAssignments {
     pub sessions: TopicAssignment,
     /// Metrics topic name.
     pub metrics: TopicAssignment,
-    /// Profiling sessions topic name
-    pub profiling_sessions: TopicAssignment,
-    /// Profiling traces topic name
-    pub profiling_traces: TopicAssignment,
     /// Stacktrace topic name
     pub profiles: TopicAssignment,
 }
@@ -810,8 +802,6 @@ impl TopicAssignments {
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
             KafkaTopic::Metrics => &self.metrics,
-            KafkaTopic::ProfilingSessions => &self.profiling_sessions,
-            KafkaTopic::ProfilingTraces => &self.profiling_traces,
             KafkaTopic::Profiles => &self.profiles,
         }
     }
@@ -827,8 +817,6 @@ impl Default for TopicAssignments {
             outcomes_billing: None,
             sessions: "ingest-sessions".to_owned().into(),
             metrics: "ingest-metrics".to_owned().into(),
-            profiling_sessions: "profiling-sessions".to_owned().into(),
-            profiling_traces: "profiling-traces".to_owned().into(),
             profiles: "profiles".to_owned().into(),
         }
     }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -951,12 +951,11 @@ impl EnvelopeProcessor {
         }
     }
 
-    /// Remove profiling items if the feature flag is not enabled
-    fn process_profiling_items(&self, state: &mut ProcessEnvelopeState) {
+    /// Remove profiles if the feature flag is not enabled
+    fn process_profiles(&self, state: &mut ProcessEnvelopeState) {
         let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
         state.envelope.retain_items(|item| {
             match item.ty() {
-                ItemType::ProfilingSession | ItemType::ProfilingTrace => profiling_enabled,
                 ItemType::Profile => {
                     if !profiling_enabled {
                         return false;
@@ -1282,8 +1281,6 @@ impl EnvelopeProcessor {
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
-            ItemType::ProfilingSession => false,
-            ItemType::ProfilingTrace => false,
             ItemType::Profile => false,
         }
     }
@@ -1789,7 +1786,7 @@ impl EnvelopeProcessor {
         self.process_sessions(state);
         self.process_client_reports(state);
         self.process_user_reports(state);
-        self.process_profiling_items(state);
+        self.process_profiles(state);
 
         if state.creates_event() {
             if_processing!({

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -102,10 +102,6 @@ pub enum ItemType {
     MetricBuckets,
     /// Client internal report (eg: outcomes).
     ClientReport,
-    /// Profiling session
-    ProfilingSession,
-    /// Profiling data
-    ProfilingTrace,
     /// Profile event payload encoded in JSON
     Profile,
 }
@@ -139,8 +135,6 @@ impl fmt::Display for ItemType {
             Self::Metrics => write!(f, "metrics"),
             Self::MetricBuckets => write!(f, "metric buckets"),
             Self::ClientReport => write!(f, "client report"),
-            Self::ProfilingSession => write!(f, "profiling session"),
-            Self::ProfilingTrace => write!(f, "profiling trace"),
             Self::Profile => write!(f, "profile"),
         }
     }
@@ -586,8 +580,6 @@ impl Item {
             | ItemType::Metrics
             | ItemType::MetricBuckets
             | ItemType::ClientReport
-            | ItemType::ProfilingSession
-            | ItemType::ProfilingTrace
             | ItemType::Profile => false,
         }
     }
@@ -610,8 +602,6 @@ impl Item {
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
-            ItemType::ProfilingSession => false,
-            ItemType::ProfilingTrace => false,
             ItemType::Profile => false,
         }
     }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -103,8 +103,6 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
-        ItemType::ProfilingSession => None,
-        ItemType::ProfilingTrace => None,
         ItemType::Profile => None,
         // the following items are "internal" item types.  From the perspective of the SDK
         // the use the "internal" data category however this data category is in fact never

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -40,7 +40,7 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool 
             ItemType::Metrics => (),
             ItemType::MetricBuckets => (),
             ItemType::ClientReport => client_reports_size += item.len(),
-            ItemType::ProfilingSession | ItemType::ProfilingTrace | ItemType::Profile => {
+            ItemType::Profile => {
                 if item.len() > config.max_profile_size() {
                     return false;
                 }


### PR DESCRIPTION
We don't need these item types anymore since we transition to using the Sentry SDKs exclusively (and PRs for iOS and Android were merged earlier this week).