### PR TITLE
fix(breakdowns): Emit span breakdowns from trace context if there are no spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Remove unused item types. ([#1211](https://github.com/getsentry/relay/pull/1211))
+- Emit span breakdowns from trace context if there are no spans. ([#1212](https://github.com/getsentry/relay/pull/1212))
 
 ## 22.3.0
 


### PR DESCRIPTION
If a transaction has no spans, we may still be able to generate an op breakdown from the trace context. We can do this since transactions themselves are also spans.