### PR TITLE
fix(breakdown): Account root span in span op breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove unused item types. ([#1211](https://github.com/getsentry/relay/pull/1211))
 - Pin click dependency in requirements-dev.txt. ([#1214](https://github.com/getsentry/relay/pull/1214))
+- Account root span in span op breakdown. ([#1213](https://github.com/getsentry/relay/pull/1213))
 
 ## 22.3.0
 

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -207,6 +207,16 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
     transaction_item = generate_transaction_item()
     transaction_item.update(
         {
+            "start_timestamp": 0,
+            "timestamp": 5000,
+            "contexts": {
+                "trace": {
+                    "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
+                    "span_id": "FA90FDEAD5F74052",
+                    "type": "trace",
+                    "op": "db",
+                }
+            },
             "spans": [
                 {
                     "description": "GET /api/0/organizations/?member=1",
@@ -241,7 +251,7 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
                     "parent_span_id": "8f5a2b8768cafb4f",
                     "span_id": "bd429c44b67a3eb7",
                     "start_timestamp": 500.001,
-                    "timestamp": 600.002003,
+                    "timestamp": 600.002005,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                 },
                 {
@@ -267,14 +277,16 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
     assert "breakdowns" in event, event
     assert event["breakdowns"] == {
         "span_ops": {
+            "ops.db": {"value": 5000000.0},
             "ops.http": {"value": 2000000.0},
-            "ops.resource": {"value": 100001.003},
-            "total.time": {"value": 2200001.003},
+            "ops.resource": {"value": pytest.approx(100001.005)},
+            "total.time": {"value": pytest.approx(7200001.005)},
         },
         "span_ops_2": {
+            "ops.db": {"value": 5000000.0},
             "ops.http": {"value": 2000000.0},
-            "ops.resource": {"value": 100001.003},
-            "total.time": {"value": 2200001.003},
+            "ops.resource": {"value": pytest.approx(100001.005)},
+            "total.time": {"value": pytest.approx(7200001.005)},
         },
     }
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -472,7 +472,9 @@ def test_transaction_metrics(
         }
 
     transaction = generate_transaction_item()
-    transaction["timestamp"] = timestamp.isoformat()
+    end_timestamp = datetime.now(tz=timezone.utc)
+    transaction["timestamp"] = end_timestamp.isoformat()
+    transaction["start_timestamp"] = (end_timestamp - timedelta(seconds=10)).isoformat()
     transaction["measurements"] = {
         "foo": {"value": 1.2},
         "bar": {"value": 1.3},
@@ -493,7 +495,7 @@ def test_transaction_metrics(
         assert event["breakdowns"] == {
             "span_ops": {
                 "ops.react.mount": {"value": 9.910106},
-                "total.time": {"value": 9.910106},
+                "total.time": {"value": 10009.910106},
             }
         }
 


### PR DESCRIPTION
This is an alternative to https://github.com/getsentry/relay/pull/1212.

For span operation breakdowns, we should account for the root span. The root span was intentionally omitted during the initial breakdown implementation, since it would've "blow up" the `span.total.time` field. This was reflected on the client-side implementation of the span operation breakdowns for the span view; of which the breakdown implementation in Relay was based upon.

We can do this today since the `span.total.time` field is currently un-used in the product today. Its usage in the product was removed in:

- https://github.com/getsentry/sentry/pull/26481
- https://github.com/getsentry/sentry/pull/27545