### PR TITLE
ref(metrics): Use MRI for metrics extraction [INGEST-939]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove unused item types. ([#1211](https://github.com/getsentry/relay/pull/1211))
 - Pin click dependency in requirements-dev.txt. ([#1214](https://github.com/getsentry/relay/pull/1214))
+- Use fully qualified metric resource identifiers (MRI) for metrics ingestion. For example, the sessions duration is now called `d:sessions/duration@s`. ([#1215](https://github.com/getsentry/relay/pull/1215))
 
 ## 22.3.0
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -1,6 +1,6 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::iter::FusedIterator;
-use std::{collections::BTreeMap, fmt::Display};
 
 use hash32::{FnvHasher, Hasher};
 use serde::{Deserialize, Serialize};
@@ -412,8 +412,8 @@ impl Metric {
     /// MRI is the metric resource identifier in the format `<type>:<ns>/<name>@<unit>`. This name
     /// ensures that just the name determines correct bucketing of metrics with name collisions.
     pub fn new_mri(
-        namespace: impl Display,
-        name: impl Display,
+        namespace: impl fmt::Display,
+        name: impl fmt::Display,
         unit: MetricUnit,
         value: MetricValue,
         timestamp: UnixTimestamp,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -407,8 +407,11 @@ pub struct Metric {
 }
 
 impl Metric {
-    /// TODO: Doc
-    pub fn from_basename(
+    /// Creates a new metric using the MRI naming format.
+    ///
+    /// MRI is the metric resource identifier in the format `<type>:<ns>/<name>@<unit>`. This name
+    /// ensures that just the name determines correct bucketing of metrics with name collisions.
+    pub fn new_mri(
         namespace: impl Display,
         name: impl Display,
         unit: MetricUnit,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -1,6 +1,6 @@
-use std::collections::BTreeMap;
 use std::fmt;
 use std::iter::FusedIterator;
+use std::{collections::BTreeMap, fmt::Display};
 
 use hash32::{FnvHasher, Hasher};
 use serde::{Deserialize, Serialize};
@@ -407,6 +407,24 @@ pub struct Metric {
 }
 
 impl Metric {
+    /// TODO: Doc
+    pub fn from_basename(
+        namespace: impl Display,
+        name: impl Display,
+        unit: MetricUnit,
+        value: MetricValue,
+        timestamp: UnixTimestamp,
+        tags: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            name: format!("{}:{}/{}@{}", value.ty(), namespace, name, unit),
+            unit,
+            value,
+            timestamp,
+            tags,
+        }
+    }
+
     fn parse_str(string: &str, timestamp: UnixTimestamp) -> Option<Self> {
         let mut components = string.split('|');
 

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -42,7 +42,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     // Always capture with "init" tag for the first session update of a session. This is used
     // for adoption and as baseline for crash rates.
     if session.total_count() > 0 {
-        target.push(Metric::from_basename(
+        target.push(Metric::new_mri(
             METRIC_NAMESPACE,
             "session",
             MetricUnit::None,
@@ -52,7 +52,7 @@ pub fn extract_session_metrics<T: SessionLike>(
         ));
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
-            target.push(Metric::from_basename(
+            target.push(Metric::new_mri(
                 METRIC_NAMESPACE,
                 "user",
                 MetricUnit::None,
@@ -66,7 +66,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     // Mark the session as errored, which includes fatal sessions.
     if let Some(errors) = session.errors() {
         target.push(match errors {
-            SessionErrored::Individual(session_id) => Metric::from_basename(
+            SessionErrored::Individual(session_id) => Metric::new_mri(
                 METRIC_NAMESPACE,
                 "error",
                 MetricUnit::None,
@@ -74,7 +74,7 @@ pub fn extract_session_metrics<T: SessionLike>(
                 timestamp,
                 tags.clone(),
             ),
-            SessionErrored::Aggregated(count) => Metric::from_basename(
+            SessionErrored::Aggregated(count) => Metric::new_mri(
                 METRIC_NAMESPACE,
                 "session",
                 MetricUnit::None,
@@ -85,7 +85,7 @@ pub fn extract_session_metrics<T: SessionLike>(
         });
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
-            target.push(Metric::from_basename(
+            target.push(Metric::new_mri(
                 METRIC_NAMESPACE,
                 "user",
                 MetricUnit::None,
@@ -99,7 +99,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     // Record fatal sessions for crash rate computation. This is a strict subset of errored
     // sessions above.
     if session.abnormal_count() > 0 {
-        target.push(Metric::from_basename(
+        target.push(Metric::new_mri(
             METRIC_NAMESPACE,
             "session",
             MetricUnit::None,
@@ -109,7 +109,7 @@ pub fn extract_session_metrics<T: SessionLike>(
         ));
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
-            target.push(Metric::from_basename(
+            target.push(Metric::new_mri(
                 METRIC_NAMESPACE,
                 "user",
                 MetricUnit::None,
@@ -121,7 +121,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     }
 
     if session.crashed_count() > 0 {
-        target.push(Metric::from_basename(
+        target.push(Metric::new_mri(
             METRIC_NAMESPACE,
             "session",
             MetricUnit::None,
@@ -131,7 +131,7 @@ pub fn extract_session_metrics<T: SessionLike>(
         ));
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
-            target.push(Metric::from_basename(
+            target.push(Metric::new_mri(
                 METRIC_NAMESPACE,
                 "user",
                 MetricUnit::None,
@@ -146,7 +146,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     // really only use durations from session.status=exited, but decided it may be worth ingesting
     // this data in case we need it. If we need to cut cost, this is one place to start though.
     if let Some((duration, status)) = session.final_duration() {
-        target.push(Metric::from_basename(
+        target.push(Metric::new_mri(
             METRIC_NAMESPACE,
             "duration",
             MetricUnit::Duration(DurationPrecision::Second),

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -264,7 +264,7 @@ pub fn extract_transaction_metrics(
 
     // Breakdowns
     if let Some(breakdowns_config) = breakdowns_config {
-        for (_breakdown, measurements) in get_breakdown_measurements(event, breakdowns_config) {
+        for (breakdown, measurements) in get_breakdown_measurements(event, breakdowns_config) {
             for (measurement_name, annotated) in measurements.iter() {
                 let measurement = match annotated.value().and_then(|m| m.value.value()) {
                     Some(measurement) => *measurement,
@@ -273,7 +273,7 @@ pub fn extract_transaction_metrics(
 
                 push_metric(Metric::new_mri(
                     METRIC_NAMESPACE,
-                    format_args!("breakdowns.{}", measurement_name),
+                    format_args!("breakdowns.{}.{}", breakdown, measurement_name),
                     MetricUnit::None,
                     MetricValue::Distribution(measurement),
                     unix_timestamp,
@@ -427,7 +427,7 @@ mod tests {
             "extractMetrics": [
                 "d:transactions/measurements.foo@",
                 "d:transactions/measurements.lcp@",
-                "d:transactions/breakdowns.ops.react.mount@",
+                "d:transactions/breakdowns.span_ops.ops.react.mount@",
                 "d:transactions/duration@ms",
                 "s:transactions/user@"
             ],
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(metrics[1].name, "d:transactions/measurements.lcp@");
         assert_eq!(
             metrics[2].name,
-            "d:transactions/breakdowns.ops.react.mount@"
+            "d:transactions/breakdowns.span_ops.ops.react.mount@"
         );
 
         let duration_metric = &metrics[3];

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -251,7 +251,7 @@ pub fn extract_transaction_metrics(
                 tags.insert("measurement_rating".to_owned(), rating);
             }
 
-            push_metric(Metric::from_basename(
+            push_metric(Metric::new_mri(
                 METRIC_NAMESPACE,
                 format_args!("measurements.{}", measurement_name),
                 MetricUnit::None,
@@ -271,7 +271,7 @@ pub fn extract_transaction_metrics(
                     None => continue,
                 };
 
-                push_metric(Metric::from_basename(
+                push_metric(Metric::new_mri(
                     METRIC_NAMESPACE,
                     format_args!("breakdowns.{}", measurement_name),
                     MetricUnit::None,
@@ -297,7 +297,7 @@ pub fn extract_transaction_metrics(
     // Duration
     let duration_millis = get_duration_millis(start_timestamp, end_timestamp);
 
-    push_metric(Metric::from_basename(
+    push_metric(Metric::new_mri(
         METRIC_NAMESPACE,
         "duration",
         MetricUnit::Duration(DurationPrecision::MilliSecond),
@@ -312,7 +312,7 @@ pub fn extract_transaction_metrics(
     // User
     if let Some(user) = event.user.value() {
         if let Some(user_id) = user.id.as_str() {
-            push_metric(Metric::from_basename(
+            push_metric(Metric::new_mri(
                 METRIC_NAMESPACE,
                 "user",
                 MetricUnit::None,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -317,10 +317,10 @@ def test_metrics_extracted_only_once(
     metrics = metrics_by_name(metrics_consumer, 3, timeout=6)
 
     # if it is not 1 it means the session was extracted multiple times
-    assert metrics["sentry.sessions.session"]["value"] == 1.0
+    assert metrics["c:sessions/session@"]["value"] == 1.0
 
     # if the vector contains multiple duration we have the session extracted multiple times
-    assert len(metrics["sentry.sessions.session.duration"]["value"]) == 1
+    assert len(metrics["d:sessions/duration@s"]["value"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -360,7 +360,7 @@ def test_session_metrics_processing(
     metrics = metrics_by_name(metrics_consumer, 3)
 
     expected_timestamp = int(started.timestamp())
-    assert metrics["sentry.sessions.session"] == {
+    assert metrics["c:sessions/session@"] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
@@ -375,7 +375,7 @@ def test_session_metrics_processing(
         },
     }
 
-    assert metrics["sentry.sessions.user"] == {
+    assert metrics["s:sessions/user@"] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
@@ -390,7 +390,7 @@ def test_session_metrics_processing(
         },
     }
 
-    assert metrics["sentry.sessions.session.duration"] == {
+    assert metrics["d:sessions/duration@s"] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
@@ -464,10 +464,10 @@ def test_transaction_metrics(
     elif extract_metrics:
         config["transactionMetrics"] = {
             "extractMetrics": [
-                "sentry.transactions.measurements.foo",
-                "sentry.transactions.measurements.bar",
-                "sentry.transactions.breakdowns.span_ops.total.time",
-                "sentry.transactions.breakdowns.span_ops.ops.react.mount",
+                "d:transactions/measurements.foo@",
+                "d:transactions/measurements.bar@",
+                "d:transactions/breakdowns.total.time@",
+                "d:transactions/breakdowns.ops.react.mount@",
             ]
         }
 
@@ -512,33 +512,33 @@ def test_transaction_metrics(
         "tags": {"transaction": "/organizations/:orgId/performance/:eventSlug/"},
     }
 
-    assert metrics["sentry.transactions.measurements.foo"] == {
+    assert metrics["d:transactions/measurements.foo"] == {
         **common,
-        "name": "sentry.transactions.measurements.foo",
+        "name": "d:transactions/measurements.foo",
         "type": "d",
         "unit": "",
         "value": [1.2, 2.2],
     }
 
-    assert metrics["sentry.transactions.measurements.bar"] == {
+    assert metrics["d:transactions/measurements.bar"] == {
         **common,
-        "name": "sentry.transactions.measurements.bar",
+        "name": "d:transactions/measurements.bar",
         "type": "d",
         "unit": "",
         "value": [1.3],
     }
 
-    assert metrics["sentry.transactions.breakdowns.span_ops.ops.react.mount"] == {
+    assert metrics["transactions/breakdowns.ops.react.mount@"] == {
         **common,
-        "name": "sentry.transactions.breakdowns.span_ops.ops.react.mount",
+        "name": "transactions/breakdowns.ops.react.mount@",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],
     }
 
-    assert metrics["sentry.transactions.breakdowns.span_ops.total.time"] == {
+    assert metrics["transactions/breakdowns.total.time@"] == {
         **common,
-        "name": "sentry.transactions.breakdowns.span_ops.total.time",
+        "name": "transactions/breakdowns.total.time@",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -231,7 +231,7 @@ def test_session_metrics_non_processing(
         ts = int(started.timestamp())
         assert session_metrics == [
             {
-                "name": "sentry.sessions.session",
+                "name": "c:sessions/session@",
                 "tags": {
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
@@ -243,7 +243,7 @@ def test_session_metrics_non_processing(
                 "value": 1.0,
             },
             {
-                "name": "sentry.sessions.session.duration",
+                "name": "d:sessions/duration@s",
                 "tags": {
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
@@ -256,7 +256,7 @@ def test_session_metrics_non_processing(
                 "value": [1947.49],
             },
             {
-                "name": "sentry.sessions.user",
+                "name": "s:sessions/user@",
                 "tags": {
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
@@ -364,7 +364,7 @@ def test_session_metrics_processing(
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
-        "name": "sentry.sessions.session",
+        "name": "c:sessions/session@",
         "type": "c",
         "unit": "",
         "value": 1.0,
@@ -379,7 +379,7 @@ def test_session_metrics_processing(
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
-        "name": "sentry.sessions.user",
+        "name": "s:sessions/user@",
         "type": "s",
         "unit": "",
         "value": [1617781333],
@@ -394,7 +394,7 @@ def test_session_metrics_processing(
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
-        "name": "sentry.sessions.session.duration",
+        "name": "d:sessions/duration@s",
         "type": "d",
         "unit": "s",
         "value": [1947.49],
@@ -512,33 +512,33 @@ def test_transaction_metrics(
         "tags": {"transaction": "/organizations/:orgId/performance/:eventSlug/"},
     }
 
-    assert metrics["d:transactions/measurements.foo"] == {
+    assert metrics["d:transactions/measurements.foo@"] == {
         **common,
-        "name": "d:transactions/measurements.foo",
+        "name": "d:transactions/measurements.foo@",
         "type": "d",
         "unit": "",
         "value": [1.2, 2.2],
     }
 
-    assert metrics["d:transactions/measurements.bar"] == {
+    assert metrics["d:transactions/measurements.bar@"] == {
         **common,
-        "name": "d:transactions/measurements.bar",
+        "name": "d:transactions/measurements.bar@",
         "type": "d",
         "unit": "",
         "value": [1.3],
     }
 
-    assert metrics["transactions/breakdowns.ops.react.mount@"] == {
+    assert metrics["d:transactions/breakdowns.ops.react.mount@"] == {
         **common,
-        "name": "transactions/breakdowns.ops.react.mount@",
+        "name": "d:transactions/breakdowns.ops.react.mount@",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],
     }
 
-    assert metrics["transactions/breakdowns.total.time@"] == {
+    assert metrics["d:transactions/breakdowns.total.time@"] == {
         **common,
-        "name": "transactions/breakdowns.total.time@",
+        "name": "d:transactions/breakdowns.total.time@",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -466,8 +466,8 @@ def test_transaction_metrics(
             "extractMetrics": [
                 "d:transactions/measurements.foo@",
                 "d:transactions/measurements.bar@",
-                "d:transactions/breakdowns.total.time@",
-                "d:transactions/breakdowns.ops.react.mount@",
+                "d:transactions/breakdowns.span_ops.total.time@",
+                "d:transactions/breakdowns.span_ops.ops.react.mount@",
             ]
         }
 
@@ -528,17 +528,17 @@ def test_transaction_metrics(
         "value": [1.3],
     }
 
-    assert metrics["d:transactions/breakdowns.ops.react.mount@"] == {
+    assert metrics["d:transactions/breakdowns.span_ops.ops.react.mount@"] == {
         **common,
-        "name": "d:transactions/breakdowns.ops.react.mount@",
+        "name": "d:transactions/breakdowns.span_ops.ops.react.mount@",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],
     }
 
-    assert metrics["d:transactions/breakdowns.total.time@"] == {
+    assert metrics["d:transactions/breakdowns.span_ops.total.time@"] == {
         **common,
-        "name": "d:transactions/breakdowns.total.time@",
+        "name": "d:transactions/breakdowns.span_ops.total.time@",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],


### PR DESCRIPTION
Introduces Metric Resource Identifiers (MRI) for metrics extraction from sessions and transactions.

## Background

MRIs follow three core principles:

1. **Robustness:** Metrics must be addressed via a stable identifier. During ingestion in Relay and Snuba, metrics are preaggregated and bucketed based on this identifier, so it cannot change over time without breaking bucketing.
2. **Uniqueness:** The identifier for metrics must be unique across variations of units and metric types, within and across use cases, as well as between projects and organizations. 
3. **Abstraction:** The user-facing product changes its terminology over time, and splits concepts into smaller parts. The internal metric identifiers must abstract from that, and offer sufficient granularity to allow for such changes.

## Schema

MRIs have the format `<type>:<ns>/<name>@<unit>`, comprising the following components:
- **Type:** counter (`c`), set (`s`), distribution (`d`), gauge (`g`), and evaluated (`e`) for derived numeric metrics.
- **Namespace:** Identifying the product entity and use case affiliation of the metric.
- **Name:** The display name of the metric in the allowed character set.
- **Unit:** The verbatim unit name.

Note that the `/` character could cause troubles when not properly escaped in URL path parameters. Ingestion will mostly place the MRIs in query strings and POST bodies, where this should not be an issue. The user-facing APIs do not expose MRIs.

## Namespaces

Namespaces allow to identify the product entity that the metric got extracted from, and/or identify the use case that the metric belongs to. These namespaces **cannot** be defined freely, instead they are defined by Sentry. Over time, there should be more namespaces. 

Some namespaces can be considered internal. These would not be allowed on the public ingestion endpoints, and would not be exposed via the user-facing Metrics API by default. Relay obtains a form of ACL (access control list) that determines which namespaces can be ingested. 

The initial namespaces are:

- Performance monitoring (**public**): `transactions`
- Errors (**public**): `errors`
- Issues (*internal*): `issues`
- Release Health (**public**): `sessions`
- Alerting (*internal*): `alerts`
- Custom user-defined metrics (**public**): `custom`

## Next Steps

- Update the allow list in Sentry. See also https://github.com/getsentry/sentry/pull/33044
- Update the aggregation protocol and rely on the unit in the metric name. Also, introduce a helper to parse and validate the namespace in the metric name.
- Normalize and sanitize metric names and tag names, replacing invalid characters.
- Rename units and define units for all extracted metrics.