### PR TITLE
build: Update symbolic to 8.7.0 [INGEST-1161]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Prevent potential OOM panics when handling corrupt Unreal Engine crashes. ([#1216](https://github.com/getsentry/relay/pull/1216))
+
 **Internal**:
 
 - Remove unused item types. ([#1211](https://github.com/getsentry/relay/pull/1211))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,9 +1011,9 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "elementtree"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c5d32d0ab83734d2d7452047ef901c105991044b7b07da30fe82371a149a25"
+checksum = "5f6319c9433cf1e95c60c8533978bccf0614f27f03bb4e514253468eeeaa7fe3"
 dependencies = [
  "string_cache",
  "xml-rs",
@@ -2084,7 +2084,7 @@ dependencies = [
  "minidump-common",
  "num-traits 0.2.12",
  "range-map",
- "scroll 0.11.0",
+ "scroll",
  "thiserror",
  "time 0.3.7",
  "uuid 0.8.1",
@@ -2102,7 +2102,7 @@ dependencies = [
  "log",
  "num-traits 0.2.12",
  "range-map",
- "scroll 0.11.0",
+ "scroll",
  "smart-default",
 ]
 
@@ -3735,31 +3735,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive 0.10.2",
-]
-
-[[package]]
-name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 dependencies = [
- "scroll_derive 0.11.0",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.58",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -4231,9 +4211,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "symbolic"
-version = "8.5.0"
+version = "8.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b3be4c272aaef995fca595a89355caf49993b84a964013e4a94447f13c779"
+checksum = "9454739e3e4c88a799270421f28cbfe79b30856f888f177d645e78d3ce8934c1"
 dependencies = [
  "symbolic-common",
  "symbolic-unreal",
@@ -4241,12 +4221,12 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.5.0"
+version = "8.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc8618f0f31ed048f8e66aa2caecedfbdbbca962ff9ad87107ba4171de0742b"
+checksum = "52ca6f4079d985e79702d1cce708bdd03ac570e220bcf87105d86f5a8ebb26be"
 dependencies = [
  "debugid",
- "memmap",
+ "memmap2",
  "serde",
  "stable_deref_trait",
  "uuid 0.8.1",
@@ -4254,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unreal"
-version = "8.5.0"
+version = "8.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd9f80568417c0204980bbf0836693fe91fd40d3d2deb954b767d1bd670d7f2"
+checksum = "9f3a20ab50992e68a5d15b11ce8a62d984c40511258bd594317e8aae26251194"
 dependencies = [
  "anylog",
  "bytes 1.1.0",
@@ -4265,9 +4245,10 @@ dependencies = [
  "flate2",
  "lazy_static",
  "regex",
- "scroll 0.10.2",
+ "scroll",
  "serde",
  "thiserror",
+ "time 0.3.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,9 +4211,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "symbolic"
-version = "8.6.1"
+version = "8.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9454739e3e4c88a799270421f28cbfe79b30856f888f177d645e78d3ce8934c1"
+checksum = "3fb7f79d0216069be1326a604e8cc483c3c2c08bf8ac6061db40e9f4a2319d91"
 dependencies = [
  "symbolic-common",
  "symbolic-unreal",
@@ -4221,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.6.1"
+version = "8.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ca6f4079d985e79702d1cce708bdd03ac570e220bcf87105d86f5a8ebb26be"
+checksum = "ac6aac7b803adc9ee75344af7681969f76d4b38e4723c6eaacf3b28f5f1d87ff"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4234,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unreal"
-version = "8.6.1"
+version = "8.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3a20ab50992e68a5d15b11ce8a62d984c40511258bd594317e8aae26251194"
+checksum = "57e355e20fa321130ba3aba0027a8933d923d3eeff25c93c48bbe041a460d9b1"
 dependencies = [
  "anylog",
  "bytes 1.1.0",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic = { version = "8.5.0", optional = true, default-features=false, features=["unreal-serde"] }
+symbolic = { version = "8.6.1", optional = true, default-features=false, features=["unreal-serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic = { version = "8.6.1", optional = true, default-features=false, features=["unreal-serde"] }
+symbolic = { version = "8.7.0", optional = true, default-features=false, features=["unreal-serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -1,8 +1,9 @@
-use relay_config::Config;
+use chrono::{TimeZone, Utc};
 use symbolic::unreal::{
     Unreal4Context, Unreal4Crash, Unreal4Error, Unreal4ErrorKind, Unreal4FileType, Unreal4LogEntry,
 };
 
+use relay_config::Config;
 use relay_general::protocol::{
     AsPair, Breadcrumb, ClientSdkInfo, Context, Contexts, DeviceContext, Event, EventId,
     GpuContext, LenientString, LogEntry, Message, OsContext, TagEntry, Tags, Timestamp, User,
@@ -133,8 +134,12 @@ fn merge_unreal_logs(event: &mut Event, data: &[u8]) -> Result<(), Unreal4Error>
         .get_or_insert_with(Array::default);
 
     for log in logs {
+        let timestamp = log
+            .timestamp
+            .map(|ts| Timestamp(Utc.timestamp(ts.unix_timestamp(), 0)));
+
         breadcrumbs.push(Annotated::new(Breadcrumb {
-            timestamp: Annotated::from(log.timestamp.map(Timestamp)),
+            timestamp: Annotated::from(timestamp),
             category: Annotated::from(log.component),
             message: Annotated::new(log.message),
             ..Breadcrumb::default()

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -136,7 +136,7 @@ fn merge_unreal_logs(event: &mut Event, data: &[u8]) -> Result<(), Unreal4Error>
     for log in logs {
         let timestamp = log
             .timestamp
-            .map(|ts| Timestamp(Utc.timestamp(ts.unix_timestamp(), 0)));
+            .map(|ts| Timestamp(Utc.timestamp(ts.unix_timestamp(), ts.nanosecond())));
 
         breadcrumbs.push(Annotated::new(Breadcrumb {
             timestamp: Annotated::from(timestamp),


### PR DESCRIPTION
Contains https://github.com/getsentry/symbolic/pull/480, which fixes a potential OOM with corrupt unreal engine crashes.

Symbolic 8.6.0 changed the signature of UE4 log entries by switching from `chrono` to `time`. We map back to chrono by using the unix timestamp value. This mapping currently drops sub-second granularity, which I yet have to validate if it's relevant.

Fixes [RELAY-1S4](https://sentry.my.sentry.io/organizations/sentry/issues/298135/)