### PR TITLE
ref(metrics): Add custom and more builtin units [INGEST-939]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove unused item types. ([#1211](https://github.com/getsentry/relay/pull/1211))
 - Pin click dependency in requirements-dev.txt. ([#1214](https://github.com/getsentry/relay/pull/1214))
 - Use fully qualified metric resource identifiers (MRI) for metrics ingestion. For example, the sessions duration is now called `d:sessions/duration@s`. ([#1215](https://github.com/getsentry/relay/pull/1215))
+- Introduce metric units for rates and information, add support for custom user-declared units, and rename duration units to self-explanatory identifiers such as `second`. ([#1217](https://github.com/getsentry/relay/pull/1217))
 
 ## 22.3.0
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -616,7 +616,7 @@ pub struct ParseBucketError(#[cause] serde_json::Error);
 ///     "timestamp": 1615889440,
 ///     "name": "endpoint.response_time",
 ///     "type": "d",
-///     "unit": "ms",
+///     "unit": "millisecond",
 ///     "value": [36, 49, 57, 68],
 ///     "tags": {
 ///       "route": "user_index"
@@ -1365,7 +1365,7 @@ mod tests {
 
     use super::*;
 
-    use crate::{DurationPrecision, MetricUnit};
+    use crate::{DurationUnit, MetricUnit};
 
     struct BucketCountInquiry;
 
@@ -1520,7 +1520,7 @@ mod tests {
         let json = r#"[
           {
             "name": "endpoint.response_time",
-            "unit": "ms",
+            "unit": "millisecond",
             "value": [36, 49, 57, 68],
             "type": "d",
             "timestamp": 1615889440,
@@ -1877,7 +1877,7 @@ mod tests {
         let metric1 = some_metric();
 
         let mut metric2 = metric1.clone();
-        metric2.unit = MetricUnit::Duration(DurationPrecision::Second);
+        metric2.unit = MetricUnit::Duration(DurationUnit::Second);
 
         // It's OK to have same metric with different units:
         aggregator.insert(project_key, metric1).unwrap();

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -11,7 +11,7 @@
 //! looks like this:
 //!
 //! ```text
-//! endpoint.response_time@ms:57|d|#route:user_index
+//! endpoint.response_time@millisecond:57|d|#route:user_index
 //! endpoint.hits:1|c|#route:user_index
 //! ```
 //!
@@ -26,7 +26,7 @@
 //! ```text
 //! {}
 //! {"type": "metrics", "timestamp": 1615889440, ...}
-//! endpoint.response_time@ms:57|d|#route:user_index
+//! endpoint.response_time@millisecond:57|d|#route:user_index
 //! ...
 //! ```
 //!

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -48,7 +48,7 @@
 //! [
 //!   {
 //!     "name": "endpoint.response_time",
-//!     "unit": "ms",
+//!     "unit": "millisecond",
 //!     "value": [36, 49, 57, 68],
 //!     "type": "d",
 //!     "timestamp": 1615889440,
@@ -71,34 +71,22 @@
 //! # Ingestion
 //!
 //! Processing Relays write aggregate buckets into the ingestion Kafka stream. The schema is similar
-//! to the aggregation payload, with the addition of scoping information:
+//! to the aggregation payload, with the addition of scoping information. Each bucket is sent in a
+//! separate message:
 //!
 //! ```json
-//! [
-//!   {
-//!     "org_id": 1,
-//!     "project_id": 42,
-//!     "name": "endpoint.response_time",
-//!     "unit": "ms",
-//!     "value": [36, 49, 57, 68],
-//!     "type": "d",
-//!     "timestamp": 1615889440,
-//!     "tags": {
-//!       "route": "user_index"
-//!     }
-//!   },
-//!   {
-//!     "org_id": 1,
-//!     "project_id": 42,
-//!     "name": "endpoint.hits",
-//!     "value": 4,
-//!     "type": "c",
-//!     "timestamp": 1615889440,
-//!     "tags": {
-//!       "route": "user_index"
-//!     }
+//! {
+//!   "org_id": 1,
+//!   "project_id": 42,
+//!   "name": "endpoint.response_time",
+//!   "unit": "millisecond",
+//!   "value": [36, 49, 57, 68],
+//!   "type": "d",
+//!   "timestamp": 1615889440,
+//!   "tags": {
+//!     "route": "user_index"
 //!   }
-//! ]
+//! }
 //! ```
 #![warn(missing_docs)]
 #![doc(

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -238,7 +238,7 @@ impl fmt::Display for MetricUnit {
             MetricUnit::Information(u) => u.fmt(f),
             MetricUnit::Fraction(u) => u.fmt(f),
             MetricUnit::Custom(u) => u.fmt(f),
-            MetricUnit::None => f.write_str(""), // TODO: Change?
+            MetricUnit::None => f.write_str("none"),
         }
     }
 }
@@ -513,7 +513,7 @@ fn parse_tags(string: &str) -> Option<BTreeMap<String, String>> {
 /// submission looks like this:
 ///
 /// ```text
-/// endpoint.response_time@ms:57|d|#route:user_index
+/// endpoint.response_time@millisecond:57|d|#route:user_index
 /// endpoint.hits:1|c|#route:user_index
 /// ```
 ///
@@ -655,7 +655,7 @@ impl Metric {
     /// ```
     /// use relay_metrics::{Metric, UnixTimestamp};
     ///
-    /// let metric = Metric::parse(b"response_time@ms:57|d", UnixTimestamp::now())
+    /// let metric = Metric::parse(b"response_time@millisecond:57|d", UnixTimestamp::now())
     ///     .expect("metric should parse");
     /// ```
     pub fn parse(slice: &[u8], timestamp: UnixTimestamp) -> Result<Self, ParseMetricError> {
@@ -678,7 +678,7 @@ impl Metric {
     /// use relay_metrics::{Metric, UnixTimestamp};
     ///
     /// let data = br#"
-    /// endpoint.response_time@ms:57|d
+    /// endpoint.response_time@millisecond:57|d
     /// endpoint.hits:1|c
     /// "#;
     ///

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -155,6 +155,7 @@ impl CustomUnit {
 
         let mut unit = Self(Default::default());
         unit.0.copy_from_slice(s.as_bytes());
+        unit.0.make_ascii_lowercase();
         Ok(unit)
     }
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -198,7 +198,7 @@ impl std::ops::Deref for CustomUnit {
 /// The [unit](Metric::unit) of measurement of a metric [value](Metric::value).
 ///
 /// Units augment metric values by giving them a magnitude and semantics. There are certain types of
-/// units that are subdivided in their precision, such as the [`DurationPrecision`] for time
+/// units that are subdivided in their precision, such as the [`DurationUnit`] for time
 /// measurements.
 ///
 /// Units and their precisions are uniquely represented by a string identifier.
@@ -570,8 +570,8 @@ pub struct Metric {
     /// The unit of the metric value.
     ///
     /// Units augment metric values by giving them a magnitude and semantics. There are certain
-    /// types of units that are subdivided in their precision, such as the [`DurationPrecision`] for
-    /// time measurements.
+    /// types of units that are subdivided in their precision, such as the [`DurationUnit`] for time
+    /// measurements.
     ///
     /// The unit can be omitted and defaults to [`MetricUnit::None`].
     #[serde(default, skip_serializing_if = "MetricUnit::is_none")]

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -204,13 +204,13 @@ impl std::ops::Deref for CustomUnit {
 /// Units and their precisions are uniquely represented by a string identifier.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum MetricUnit {
-    /// A time duration, defaulting to milliseconds (`"millisecond"`).
+    /// A time duration, defaulting to `"millisecond"`.
     Duration(DurationUnit),
-    /// TODO: Doc
+    /// Size of information derived from bytes, defaulting to `"byte"`.
     Information(InformationUnit),
-    /// TODO: Doc
+    /// Fractions such as percentages, defaulting to `"ratio"`.
     Fraction(FractionUnit),
-    /// TODO: Doc
+    /// user-defined units without builtin conversion or default.
     Custom(CustomUnit),
     /// Untyped value without a unit (`""`).
     None,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -9,30 +9,189 @@ pub use relay_common::UnixTimestamp;
 
 /// Time duration units used in [`MetricUnit::Duration`].
 ///
-/// Defaults to `ms`.
+/// Defaults to `millisecond`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum DurationPrecision {
-    /// Nanosecond (`"ns"`).
+pub enum DurationUnit {
+    /// Nanosecond (`"nanosecond"`), 10^-9 seconds.
     NanoSecond,
-    /// Millisecond (`"ms"`).
+    /// Microsecond (`"microsecond"`), 10^-6 seconds.
+    MicroSecond,
+    /// Millisecond (`"millisecond"`), 10^-3 seconds.
     MilliSecond,
-    /// Full second (`"s"`).
+    /// Full second (`"second"`).
     Second,
+    /// Minute (`"minute"`), 60 seconds.
+    Minute,
+    /// Hour (`"hour"`), 3600 seconds.
+    Hour,
+    /// Day (`"day"`), 86,400 seconds.
+    Day,
+    /// Week (`"week"`), 604,800 seconds.
+    Week,
 }
 
-impl Default for DurationPrecision {
+impl Default for DurationUnit {
     fn default() -> Self {
         Self::MilliSecond
     }
 }
 
-impl fmt::Display for DurationPrecision {
+impl fmt::Display for DurationUnit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NanoSecond => f.write_str("ns"),
-            Self::MilliSecond => f.write_str("ms"),
-            Self::Second => f.write_str("s"),
+            Self::NanoSecond => f.write_str("nanosecond"),
+            Self::MicroSecond => f.write_str("microsecond"),
+            Self::MilliSecond => f.write_str("millisecond"),
+            Self::Second => f.write_str("second"),
+            Self::Minute => f.write_str("minute"),
+            Self::Hour => f.write_str("hour"),
+            Self::Day => f.write_str("day"),
+            Self::Week => f.write_str("week"),
         }
+    }
+}
+
+/// Size of information derived from bytes, used in [`MetricUnit::Information`].
+///
+/// Defaults to `byte`. See also [Units of
+/// information](https://en.wikipedia.org/wiki/Units_of_information).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum InformationUnit {
+    /// Bit (`"bit"`), corresponding to 1/8 of a byte.
+    ///
+    /// Note that there are computer systems with a different number of bits per byte.
+    Bit,
+    /// Byte (`"byte"`).
+    Byte,
+    /// Kilobyte (`"kilobyte"`), 10^3 bytes.
+    KiloByte,
+    /// Kibibyte (`"kibibyte"`), 2^10 bytes.
+    KibiByte,
+    /// Megabyte (`"megabyte"`), 10^6 bytes.
+    MegaByte,
+    /// Mebibyte (`"mebibyte"`), 2^20 bytes.
+    MebiByte,
+    /// Gigabyte (`"gigabyte"`), 10^9 bytes.
+    GigaByte,
+    /// Gibibyte (`"gibibyte"`), 2^30 bytes.
+    GibiByte,
+    /// Terabyte (`"terabyte"`), 10^12 bytes.
+    TeraByte,
+    /// Tebibyte (`"tebibyte"`), 2^40 bytes.
+    TebiByte,
+    /// Petabyte (`"petabyte"`), 10^15 bytes.
+    PetaByte,
+    /// Pebibyte (`"pebibyte"`), 2^50 bytes.
+    PebiByte,
+    /// Exabyte (`"exabyte"`), 10^18 bytes.
+    ExaByte,
+    /// Exbibyte (`"exbibyte"`), 2^60 bytes.
+    ExbiByte,
+}
+
+impl Default for InformationUnit {
+    fn default() -> Self {
+        Self::Byte
+    }
+}
+
+impl fmt::Display for InformationUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bit => f.write_str("bit"),
+            Self::Byte => f.write_str("byte"),
+            Self::KiloByte => f.write_str("kilobyte"),
+            Self::KibiByte => f.write_str("kibibyte"),
+            Self::MegaByte => f.write_str("megabyte"),
+            Self::MebiByte => f.write_str("mebibyte"),
+            Self::GigaByte => f.write_str("gigabyte"),
+            Self::GibiByte => f.write_str("gibibyte"),
+            Self::TeraByte => f.write_str("terabyte"),
+            Self::TebiByte => f.write_str("tebibyte"),
+            Self::PetaByte => f.write_str("petabyte"),
+            Self::PebiByte => f.write_str("pebibyte"),
+            Self::ExaByte => f.write_str("exabyte"),
+            Self::ExbiByte => f.write_str("exbibyte"),
+        }
+    }
+}
+
+/// Units of fraction used in [`MetricUnit::Fraction`].
+///
+/// Defaults to `ratio`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum FractionUnit {
+    /// Floating point fraction of `1`.
+    Ratio,
+    /// Ratio expressed as a fraction of `100`. `100%` equals a ratio of `1.0`.
+    Percent,
+}
+
+impl Default for FractionUnit {
+    fn default() -> Self {
+        Self::Ratio
+    }
+}
+
+impl fmt::Display for FractionUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ratio => f.write_str("ratio"),
+            Self::Percent => f.write_str("percent"),
+        }
+    }
+}
+
+/// Custom user-defined units without builtin conversion.
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct CustomUnit([u8; 15]);
+
+impl CustomUnit {
+    /// Parses a `CustomUnit` from a string.
+    pub fn parse(s: &str) -> Result<Self, ParseMetricError> {
+        if s.len() > 15 || !s.is_ascii() {
+            return Err(ParseMetricError(()));
+        }
+
+        let mut unit = Self(Default::default());
+        unit.0.copy_from_slice(s.as_bytes());
+        Ok(unit)
+    }
+
+    /// Returns the string representation of this unit.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        // Safety: The string is already validated to be of length 32 and valid ASCII when
+        // constructing `ProjectKey`.
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+impl fmt::Debug for CustomUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl fmt::Display for CustomUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl std::str::FromStr for CustomUnit {
+    type Err = ParseMetricError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl std::ops::Deref for CustomUnit {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
     }
 }
 
@@ -45,11 +204,19 @@ impl fmt::Display for DurationPrecision {
 /// Units and their precisions are uniquely represented by a string identifier.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum MetricUnit {
-    /// A time duration, defaulting to milliseconds (`"ms"`).
-    Duration(DurationPrecision),
+    /// A time duration, defaulting to milliseconds (`"millisecond"`).
+    Duration(DurationUnit),
+    /// TODO: Doc
+    Information(InformationUnit),
+    /// TODO: Doc
+    Fraction(FractionUnit),
+    /// TODO: Doc
+    Custom(CustomUnit),
     /// Untyped value without a unit (`""`).
     None,
 }
+
+// TODO: Test sizeof and alignof
 
 impl MetricUnit {
     /// Returns `true` if the metric_unit is [`None`].
@@ -67,8 +234,11 @@ impl Default for MetricUnit {
 impl fmt::Display for MetricUnit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MetricUnit::Duration(precision) => precision.fmt(f),
-            MetricUnit::None => f.write_str(""),
+            MetricUnit::Duration(u) => u.fmt(f),
+            MetricUnit::Information(u) => u.fmt(f),
+            MetricUnit::Fraction(u) => u.fmt(f),
+            MetricUnit::Custom(u) => u.fmt(f),
+            MetricUnit::None => f.write_str(""), // TODO: Change?
         }
     }
 }
@@ -78,11 +248,35 @@ impl std::str::FromStr for MetricUnit {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "ns" => Self::Duration(DurationPrecision::NanoSecond),
-            "ms" => Self::Duration(DurationPrecision::MilliSecond),
-            "s" => Self::Duration(DurationPrecision::Second),
+            "nanosecond" | "ns" => Self::Duration(DurationUnit::NanoSecond),
+            "microsecond" => Self::Duration(DurationUnit::MicroSecond),
+            "millisecond" | "ms" => Self::Duration(DurationUnit::MilliSecond),
+            "second" | "s" => Self::Duration(DurationUnit::Second),
+            "minute" => Self::Duration(DurationUnit::Minute),
+            "hour" => Self::Duration(DurationUnit::Hour),
+            "day" => Self::Duration(DurationUnit::Day),
+            "week" => Self::Duration(DurationUnit::Week),
+
+            "bit" => Self::Information(InformationUnit::Bit),
+            "byte" => Self::Information(InformationUnit::Byte),
+            "kilobyte" => Self::Information(InformationUnit::KiloByte),
+            "kibibyte" => Self::Information(InformationUnit::KibiByte),
+            "megabyte" => Self::Information(InformationUnit::MegaByte),
+            "mebibyte" => Self::Information(InformationUnit::MebiByte),
+            "gigabyte" => Self::Information(InformationUnit::GigaByte),
+            "gibibyte" => Self::Information(InformationUnit::GibiByte),
+            "terabyte" => Self::Information(InformationUnit::TeraByte),
+            "tebibyte" => Self::Information(InformationUnit::TebiByte),
+            "petabyte" => Self::Information(InformationUnit::PetaByte),
+            "pebibyte" => Self::Information(InformationUnit::PebiByte),
+            "exabyte" => Self::Information(InformationUnit::ExaByte),
+            "exbibyte" => Self::Information(InformationUnit::ExbiByte),
+
+            "ratio" => Self::Fraction(FractionUnit::Ratio),
+            "percent" => Self::Fraction(FractionUnit::Percent),
+
             "" | "unit" | "none" => Self::None,
-            _ => return Err(ParseMetricError(())),
+            _ => Self::Custom(CustomUnit::parse(s)?),
         })
     }
 }
@@ -334,7 +528,7 @@ fn parse_tags(string: &str) -> Option<BTreeMap<String, String>> {
 /// ```json
 /// {
 ///   "name": "endpoint.response_time",
-///   "unit": "ms",
+///   "unit": "millisecond",
 ///   "value": 57,
 ///   "type": "d",
 ///   "timestamp": 1615889449,
@@ -636,10 +830,18 @@ mod tests {
 
     #[test]
     fn test_parse_unit() {
+        let s = "foo@second:17.5|d";
+        let timestamp = UnixTimestamp::from_secs(4711);
+        let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
+        assert_eq!(metric.unit, MetricUnit::Duration(DurationUnit::Second));
+    }
+
+    #[test]
+    fn test_parse_unit_regression() {
         let s = "foo@s:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        assert_eq!(metric.unit, MetricUnit::Duration(DurationPrecision::Second));
+        assert_eq!(metric.unit, MetricUnit::Duration(DurationUnit::Second));
     }
 
     #[test]
@@ -683,7 +885,7 @@ mod tests {
     fn test_serde_json() {
         let json = r#"{
   "name": "foo",
-  "unit": "s",
+  "unit": "second",
   "type": "c",
   "value": 42.0,
   "timestamp": 4711,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -217,8 +217,6 @@ pub enum MetricUnit {
     None,
 }
 
-// TODO: Test sizeof and alignof
-
 impl MetricUnit {
     /// Returns `true` if the metric_unit is [`None`].
     pub fn is_none(&self) -> bool {
@@ -740,6 +738,12 @@ impl FusedIterator for ParseMetrics<'_> {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sizeof_unit() {
+        assert_eq!(std::mem::size_of::<MetricUnit>(), 16);
+        assert_eq!(std::mem::align_of::<MetricUnit>(), 1);
+    }
 
     #[test]
     fn test_parse_garbage() {

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -215,14 +215,14 @@ mod tests {
 
         let session_metric = &metrics[0];
         assert_eq!(session_metric.timestamp, started());
-        assert_eq!(session_metric.name, "c:sessions/session@");
+        assert_eq!(session_metric.name, "c:sessions/session@none");
         assert!(matches!(session_metric.value, MetricValue::Counter(_)));
         assert_eq!(session_metric.tags["session.status"], "init");
         assert_eq!(session_metric.tags["release"], "1.0.0");
 
         let user_metric = &metrics[1];
         assert_eq!(session_metric.timestamp, started());
-        assert_eq!(user_metric.name, "s:sessions/user@");
+        assert_eq!(user_metric.name, "s:sessions/user@none");
         assert!(matches!(user_metric.value, MetricValue::Set(_)));
         assert_eq!(session_metric.tags["session.status"], "init");
         assert_eq!(user_metric.tags["release"], "1.0.0");
@@ -286,13 +286,13 @@ mod tests {
 
             let session_metric = &metrics[expected_metrics - 2];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(session_metric.name, "s:sessions/error@");
+            assert_eq!(session_metric.name, "s:sessions/error@none");
             assert!(matches!(session_metric.value, MetricValue::Set(_)));
             assert_eq!(session_metric.tags.len(), 1); // Only the release tag
 
             let user_metric = &metrics[expected_metrics - 1];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(user_metric.name, "s:sessions/user@");
+            assert_eq!(user_metric.name, "s:sessions/user@none");
             assert!(matches!(user_metric.value, MetricValue::Set(_)));
             assert_eq!(user_metric.tags["session.status"], "errored");
             assert_eq!(user_metric.tags["release"], "1.0.0");
@@ -322,19 +322,19 @@ mod tests {
 
             assert_eq!(metrics.len(), 4);
 
-            assert_eq!(metrics[0].name, "s:sessions/error@");
-            assert_eq!(metrics[1].name, "s:sessions/user@");
+            assert_eq!(metrics[0].name, "s:sessions/error@none");
+            assert_eq!(metrics[1].name, "s:sessions/user@none");
             assert_eq!(metrics[1].tags["session.status"], "errored");
 
             let session_metric = &metrics[2];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(session_metric.name, "c:sessions/session@");
+            assert_eq!(session_metric.name, "c:sessions/session@none");
             assert!(matches!(session_metric.value, MetricValue::Counter(_)));
             assert_eq!(session_metric.tags["session.status"], status.to_string());
 
             let user_metric = &metrics[3];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(user_metric.name, "s:sessions/user@");
+            assert_eq!(user_metric.name, "s:sessions/user@none");
             assert!(matches!(user_metric.value, MetricValue::Set(_)));
             assert_eq!(user_metric.tags["session.status"], status.to_string());
         }
@@ -407,7 +407,7 @@ mod tests {
         insta::assert_debug_snapshot!(metrics, @r###"
         [
             Metric {
-                name: "c:sessions/session@",
+                name: "c:sessions/session@none",
                 unit: None,
                 value: Counter(
                     135.0,
@@ -420,7 +420,7 @@ mod tests {
                 },
             },
             Metric {
-                name: "c:sessions/session@",
+                name: "c:sessions/session@none",
                 unit: None,
                 value: Counter(
                     5.0,
@@ -433,7 +433,7 @@ mod tests {
                 },
             },
             Metric {
-                name: "c:sessions/session@",
+                name: "c:sessions/session@none",
                 unit: None,
                 value: Counter(
                     7.0,
@@ -446,7 +446,7 @@ mod tests {
                 },
             },
             Metric {
-                name: "c:sessions/session@",
+                name: "c:sessions/session@none",
                 unit: None,
                 value: Counter(
                     15.0,
@@ -459,7 +459,7 @@ mod tests {
                 },
             },
             Metric {
-                name: "s:sessions/user@",
+                name: "s:sessions/user@none",
                 unit: None,
                 value: Set(
                     3097475539,
@@ -472,7 +472,7 @@ mod tests {
                 },
             },
             Metric {
-                name: "c:sessions/session@",
+                name: "c:sessions/session@none",
                 unit: None,
                 value: Counter(
                     3.0,
@@ -485,7 +485,7 @@ mod tests {
                 },
             },
             Metric {
-                name: "s:sessions/user@",
+                name: "s:sessions/user@none",
                 unit: None,
                 value: Set(
                     3097475539,

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use relay_common::{UnixTimestamp, Uuid};
 use relay_general::protocol::{SessionAttributes, SessionErrored, SessionLike, SessionStatus};
-use relay_metrics::{DurationPrecision, Metric, MetricUnit, MetricValue};
+use relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue};
 
 use super::utils::with_tag;
 
@@ -149,7 +149,7 @@ pub fn extract_session_metrics<T: SessionLike>(
         target.push(Metric::new_mri(
             METRIC_NAMESPACE,
             "duration",
-            MetricUnit::Duration(DurationPrecision::Second),
+            MetricUnit::Duration(DurationUnit::Second),
             MetricValue::Distribution(duration),
             timestamp,
             with_tag(&tags, "session.status", status),
@@ -364,7 +364,7 @@ mod tests {
         assert_eq!(metrics.len(), 1);
 
         let duration_metric = &metrics[0];
-        assert_eq!(duration_metric.name, "d:sessions/duration@s");
+        assert_eq!(duration_metric.name, "d:sessions/duration@second");
         assert!(matches!(
             duration_metric.value,
             MetricValue::Distribution(_)

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -171,7 +171,7 @@ pub fn extract_transaction_metrics(
     event: &Event,
     target: &mut Vec<Metric>,
 ) -> bool {
-    use relay_metrics::DurationPrecision;
+    use relay_metrics::DurationUnit;
 
     use crate::metrics_extraction::utils::with_tag;
 
@@ -300,7 +300,7 @@ pub fn extract_transaction_metrics(
     push_metric(Metric::new_mri(
         METRIC_NAMESPACE,
         "duration",
-        MetricUnit::Duration(DurationPrecision::MilliSecond),
+        MetricUnit::Duration(DurationUnit::MilliSecond),
         MetricValue::Distribution(duration_millis),
         unix_timestamp,
         match extract_transaction_status(event) {
@@ -360,7 +360,7 @@ mod tests {
 
     use relay_general::store::BreakdownsConfig;
     use relay_general::types::Annotated;
-    use relay_metrics::DurationPrecision;
+    use relay_metrics::DurationUnit;
 
     #[test]
     fn test_extract_transaction_metrics() {
@@ -521,7 +521,7 @@ mod tests {
         assert_eq!(duration_metric.name, "d:transactions/duration@ms");
         assert_eq!(
             duration_metric.unit,
-            MetricUnit::Duration(DurationPrecision::MilliSecond)
+            MetricUnit::Duration(DurationUnit::MilliSecond)
         );
         if let MetricValue::Distribution(value) = duration_metric.value {
             assert_eq!(value, 59000.0); // millis

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -425,11 +425,11 @@ mod tests {
             r#"
         {
             "extractMetrics": [
-                "d:transactions/measurements.foo@",
-                "d:transactions/measurements.lcp@",
-                "d:transactions/breakdowns.span_ops.ops.react.mount@",
-                "d:transactions/duration@ms",
-                "s:transactions/user@"
+                "d:transactions/measurements.foo@none",
+                "d:transactions/measurements.lcp@none",
+                "d:transactions/breakdowns.span_ops.ops.react.mount@none",
+                "d:transactions/duration@millisecond",
+                "s:transactions/user@none"
             ],
             "extractCustomTags": ["fOO"]
         }
@@ -447,15 +447,15 @@ mod tests {
 
         assert_eq!(metrics.len(), 5, "{:?}", metrics);
 
-        assert_eq!(metrics[0].name, "d:transactions/measurements.foo@");
-        assert_eq!(metrics[1].name, "d:transactions/measurements.lcp@");
+        assert_eq!(metrics[0].name, "d:transactions/measurements.foo@none");
+        assert_eq!(metrics[1].name, "d:transactions/measurements.lcp@none");
         assert_eq!(
             metrics[2].name,
-            "d:transactions/breakdowns.span_ops.ops.react.mount@"
+            "d:transactions/breakdowns.span_ops.ops.react.mount@none"
         );
 
         let duration_metric = &metrics[3];
-        assert_eq!(duration_metric.name, "d:transactions/duration@ms");
+        assert_eq!(duration_metric.name, "d:transactions/duration@millisecond");
         if let MetricValue::Distribution(value) = duration_metric.value {
             assert_eq!(value, 59000.0);
         } else {
@@ -463,7 +463,7 @@ mod tests {
         }
 
         let user_metric = &metrics[4];
-        assert_eq!(user_metric.name, "s:transactions/user@");
+        assert_eq!(user_metric.name, "s:transactions/user@none");
         assert!(matches!(user_metric.value, MetricValue::Set(_)));
 
         assert_eq!(metrics[1].tags["measurement_rating"], "meh");
@@ -506,7 +506,7 @@ mod tests {
             r#"
         {
             "extractMetrics": [
-                "d:transactions/duration@ms"
+                "d:transactions/duration@millisecond"
             ]
         }
         "#,
@@ -518,7 +518,7 @@ mod tests {
         assert_eq!(metrics.len(), 1);
 
         let duration_metric = &metrics[0];
-        assert_eq!(duration_metric.name, "d:transactions/duration@ms");
+        assert_eq!(duration_metric.name, "d:transactions/duration@millisecond");
         assert_eq!(
             duration_metric.unit,
             MetricUnit::Duration(DurationUnit::MilliSecond)
@@ -556,8 +556,8 @@ mod tests {
             r#"
         {
             "extractMetrics": [
-                "d:transactions/duration@ms",
-                "s:transactions/user@"
+                "d:transactions/duration@millisecond",
+                "s:transactions/user@none"
             ],
             "satisfactionThresholds": {
                 "projectThreshold": {
@@ -600,7 +600,7 @@ mod tests {
             r#"
         {
             "extractMetrics": [
-                "d:transactions/duration@ms"
+                "d:transactions/duration@millisecond"
             ],
             "satisfactionThresholds": {
                 "projectThreshold": {
@@ -648,7 +648,7 @@ mod tests {
             r#"
         {
             "extractMetrics": [
-                "d:transactions/duration@ms"
+                "d:transactions/duration@millisecond"
             ],
             "satisfactionThresholds": {
                 "projectThreshold": {

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -231,7 +231,7 @@ def test_session_metrics_non_processing(
         ts = int(started.timestamp())
         assert session_metrics == [
             {
-                "name": "c:sessions/session@",
+                "name": "c:sessions/session@none",
                 "tags": {
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
@@ -256,7 +256,7 @@ def test_session_metrics_non_processing(
                 "value": [1947.49],
             },
             {
-                "name": "s:sessions/user@",
+                "name": "s:sessions/user@none",
                 "tags": {
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
@@ -317,7 +317,7 @@ def test_metrics_extracted_only_once(
     metrics = metrics_by_name(metrics_consumer, 3, timeout=6)
 
     # if it is not 1 it means the session was extracted multiple times
-    assert metrics["c:sessions/session@"]["value"] == 1.0
+    assert metrics["c:sessions/session@none"]["value"] == 1.0
 
     # if the vector contains multiple duration we have the session extracted multiple times
     assert len(metrics["d:sessions/duration@second"]["value"]) == 1
@@ -360,11 +360,11 @@ def test_session_metrics_processing(
     metrics = metrics_by_name(metrics_consumer, 3)
 
     expected_timestamp = int(started.timestamp())
-    assert metrics["c:sessions/session@"] == {
+    assert metrics["c:sessions/session@none"] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
-        "name": "c:sessions/session@",
+        "name": "c:sessions/session@none",
         "type": "c",
         "unit": "",
         "value": 1.0,
@@ -375,11 +375,11 @@ def test_session_metrics_processing(
         },
     }
 
-    assert metrics["s:sessions/user@"] == {
+    assert metrics["s:sessions/user@none"] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
-        "name": "s:sessions/user@",
+        "name": "s:sessions/user@none",
         "type": "s",
         "unit": "",
         "value": [1617781333],
@@ -464,10 +464,10 @@ def test_transaction_metrics(
     elif extract_metrics:
         config["transactionMetrics"] = {
             "extractMetrics": [
-                "d:transactions/measurements.foo@",
-                "d:transactions/measurements.bar@",
-                "d:transactions/breakdowns.span_ops.total.time@",
-                "d:transactions/breakdowns.span_ops.ops.react.mount@",
+                "d:transactions/measurements.foo@none",
+                "d:transactions/measurements.bar@none",
+                "d:transactions/breakdowns.span_ops.total.time@none",
+                "d:transactions/breakdowns.span_ops.ops.react.mount@none",
             ]
         }
 
@@ -512,33 +512,33 @@ def test_transaction_metrics(
         "tags": {"transaction": "/organizations/:orgId/performance/:eventSlug/"},
     }
 
-    assert metrics["d:transactions/measurements.foo@"] == {
+    assert metrics["d:transactions/measurements.foo@none"] == {
         **common,
-        "name": "d:transactions/measurements.foo@",
+        "name": "d:transactions/measurements.foo@none",
         "type": "d",
         "unit": "",
         "value": [1.2, 2.2],
     }
 
-    assert metrics["d:transactions/measurements.bar@"] == {
+    assert metrics["d:transactions/measurements.bar@none"] == {
         **common,
-        "name": "d:transactions/measurements.bar@",
+        "name": "d:transactions/measurements.bar@none",
         "type": "d",
         "unit": "",
         "value": [1.3],
     }
 
-    assert metrics["d:transactions/breakdowns.span_ops.ops.react.mount@"] == {
+    assert metrics["d:transactions/breakdowns.span_ops.ops.react.mount@none"] == {
         **common,
-        "name": "d:transactions/breakdowns.span_ops.ops.react.mount@",
+        "name": "d:transactions/breakdowns.span_ops.ops.react.mount@none",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],
     }
 
-    assert metrics["d:transactions/breakdowns.span_ops.total.time@"] == {
+    assert metrics["d:transactions/breakdowns.span_ops.total.time@none"] == {
         **common,
-        "name": "d:transactions/breakdowns.span_ops.total.time@",
+        "name": "d:transactions/breakdowns.span_ops.total.time@none",
         "type": "d",
         "unit": "",
         "value": [9.910106, 9.910106],

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -102,7 +102,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
         "org_id": 1,
         "project_id": project_id,
         "name": "foo",
-        "unit": "",
+        "unit": "none",
         "value": 42.0,
         "type": "c",
         "timestamp": timestamp,
@@ -150,7 +150,7 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
         "org_id": 1,
         "project_id": project_id,
         "name": "foo",
-        "unit": "",
+        "unit": "none",
         "value": 15.0,
         "type": "c",
     }
@@ -366,7 +366,7 @@ def test_session_metrics_processing(
         "timestamp": expected_timestamp,
         "name": "c:sessions/session@none",
         "type": "c",
-        "unit": "",
+        "unit": "none",
         "value": 1.0,
         "tags": {
             "environment": "production",
@@ -381,7 +381,7 @@ def test_session_metrics_processing(
         "timestamp": expected_timestamp,
         "name": "s:sessions/user@none",
         "type": "s",
-        "unit": "",
+        "unit": "none",
         "value": [1617781333],
         "tags": {
             "environment": "production",
@@ -516,7 +516,7 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/measurements.foo@none",
         "type": "d",
-        "unit": "",
+        "unit": "none",
         "value": [1.2, 2.2],
     }
 
@@ -524,7 +524,7 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/measurements.bar@none",
         "type": "d",
-        "unit": "",
+        "unit": "none",
         "value": [1.3],
     }
 
@@ -532,7 +532,7 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/breakdowns.span_ops.ops.react.mount@none",
         "type": "d",
-        "unit": "",
+        "unit": "none",
         "value": [9.910106, 9.910106],
     }
 
@@ -540,7 +540,7 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/breakdowns.span_ops.total.time@none",
         "type": "d",
-        "unit": "",
+        "unit": "none",
         "value": [9.910106, 9.910106],
     }
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -93,7 +93,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     mini_sentry.add_full_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\nbar@s:17|c"
+    metrics_payload = f"foo:42|c\nbar@second:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     metrics = metrics_by_name(metrics_consumer, 2)
@@ -112,7 +112,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
         "org_id": 1,
         "project_id": project_id,
         "name": "bar",
-        "unit": "s",
+        "unit": "second",
         "value": 17.0,
         "type": "c",
         "timestamp": timestamp,
@@ -243,7 +243,7 @@ def test_session_metrics_non_processing(
                 "value": 1.0,
             },
             {
-                "name": "d:sessions/duration@s",
+                "name": "d:sessions/duration@second",
                 "tags": {
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
@@ -252,7 +252,7 @@ def test_session_metrics_non_processing(
                 "timestamp": ts,
                 "width": 1,
                 "type": "d",
-                "unit": "s",
+                "unit": "second",
                 "value": [1947.49],
             },
             {
@@ -320,7 +320,7 @@ def test_metrics_extracted_only_once(
     assert metrics["c:sessions/session@"]["value"] == 1.0
 
     # if the vector contains multiple duration we have the session extracted multiple times
-    assert len(metrics["d:sessions/duration@s"]["value"]) == 1
+    assert len(metrics["d:sessions/duration@second"]["value"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -390,13 +390,13 @@ def test_session_metrics_processing(
         },
     }
 
-    assert metrics["d:sessions/duration@s"] == {
+    assert metrics["d:sessions/duration@second"] == {
         "org_id": 1,
         "project_id": 42,
         "timestamp": expected_timestamp,
-        "name": "d:sessions/duration@s",
+        "name": "d:sessions/duration@second",
         "type": "d",
-        "unit": "s",
+        "unit": "second",
         "value": [1947.49],
         "tags": {
             "environment": "production",


### PR DESCRIPTION
Adds a number of grouped builtin units and a "custom unit" variant.

## Builtin Unit Groups

Units within the same group are considered convertible. Each group has a default canonical unit, for instance `byte` for information units. In the future, Relay can streamline incoming metrics by converting to the canonical unit within the respective group. The currently defined builtin units are:

- **Duration** — `nanosecond` / `microsecond` / `millisecond` / `second` / `minute` / `hour` / `day` / `week`
- **Information** — `bit` / `byte` / `kibibyte` / `mebibyte` / `gibibyte` / `tebibyte` / `pebibyte` / `exbibyte`
- **Fraction** — `percent` / `ratio`
- **None** — `none`, `""` (used for: *counts*)

## Custom Units 

For forward compatibility, clients can send custom unit names of up to 15 ASCII characters. Beyond ASCII lowercasing, these units do not count as convertible. An example for such a unit would be `frame` to track the frame rate of a user interface or game.

## Follow-Ups

- Define units for all extracted metrics.
- Remove the unit field from the aggregation protocol and rely on units in the MRI.

## Notes

Based on #1215, will be rebased once merged.
cc @sl0thentr0py 