### PR TITLE
feat(general): Map Windows version from raw_description to name [INGEST-1047]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Map Windows version from raw_description to version name (XP, Vista, 11, ...). ([#1219](https://github.com/getsentry/relay/pull/1219))
+
 **Bug Fixes**:
 
 - Prevent potential OOM panics when handling corrupt Unreal Engine crashes. ([#1216](https://github.com/getsentry/relay/pull/1216))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Map Windows version from raw_description to version name (XP, Vista, 11, ...). ([#1219](https://github.com/getsentry/relay/pull/1219))
+
 - Update the user agent parser (uap-core Feb 2020 to Nov 2021). ([#1143](https://github.com/getsentry/relay/pull/1143), [#1145](https://github.com/getsentry/relay/pull/1145))
 
 ## 0.8.9

--- a/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -243,7 +243,7 @@ request:
 contexts:
   server-os:
     name: Windows
-    version: 10.0.17134
+    version: "10"
     raw_description: "Microsoft Windows 10.0.17134 "
     type: os
   server-runtime:

--- a/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -244,6 +244,7 @@ contexts:
   server-os:
     name: Windows
     version: "10"
+    build: 10.0.17134
     raw_description: "Microsoft Windows 10.0.17134 "
     type: os
   server-runtime:

--- a/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -244,7 +244,7 @@ contexts:
   server-os:
     name: Windows
     version: "10"
-    build: 10.0.17134
+    build: "17134"
     raw_description: "Microsoft Windows 10.0.17134 "
     type: os
   server-runtime:


### PR DESCRIPTION
Parsing the Windows version from `os.raw_description` would previously return the raw version in the form of `<major>.<minor>.<build-number>`. This PR attempts to map the build number to well known version names like "Vista" or "11" instead. In case the build number is not in the list of known builds, we fall back to the raw version again.

Fixes https://github.com/getsentry/relay/issues/1201.
