### PR TITLE
ref(profiling): Increase the max profile size to accomodate a new platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Pin click dependency in requirements-dev.txt. ([#1214](https://github.com/getsentry/relay/pull/1214))
 - Use fully qualified metric resource identifiers (MRI) for metrics ingestion. For example, the sessions duration is now called `d:sessions/duration@s`. ([#1215](https://github.com/getsentry/relay/pull/1215))
 - Introduce metric units for rates and information, add support for custom user-declared units, and rename duration units to self-explanatory identifiers such as `second`. ([#1217](https://github.com/getsentry/relay/pull/1217))
+- Increase the max profile size to accomodate a new platform. ([#1223](https://github.com/getsentry/relay/pull/1223))
 
 ## 22.3.0
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -564,7 +564,7 @@ impl Default for Limits {
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
-            max_profile_size: ByteSize::mebibytes(1),
+            max_profile_size: ByteSize::mebibytes(10),
             max_thread_count: num_cpus::get(),
             query_timeout: 30,
             max_connection_rate: 256,


### PR DESCRIPTION
We're starting to ingest profiles from Typescript and given the amount of data we need to ingest, we need to upgrade this limit.