### PR TITLE
ref(profiling): Set environment as optional so we get a null value later on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Use fully qualified metric resource identifiers (MRI) for metrics ingestion. For example, the sessions duration is now called `d:sessions/duration@s`. ([#1215](https://github.com/getsentry/relay/pull/1215))
 - Introduce metric units for rates and information, add support for custom user-declared units, and rename duration units to self-explanatory identifiers such as `second`. ([#1217](https://github.com/getsentry/relay/pull/1217))
 - Increase the max profile size to accomodate a new platform. ([#1223](https://github.com/getsentry/relay/pull/1223))
+- Set environment as optional when parsing a profile so we get a null value later on. ([#1224](https://github.com/getsentry/relay/pull/1224))
 
 ## 22.3.0
 

--- a/relay-server/src/utils/profile.rs
+++ b/relay-server/src/utils/profile.rs
@@ -28,7 +28,7 @@ struct AndroidProfile {
     device_os_version: String,
     device_physical_memory_bytes: String,
     duration_ns: String,
-    environment: String,
+    environment: Option<String>,
     platform: String,
     profile_id: String,
     trace_id: String,


### PR DESCRIPTION
This would end up sending a empty string as a value and I'd rather have a null value.