### PR TITLE
feat(mep): Expose new tagging rules interface for metrics extracted from transactions [INGEST-947] [INGEST-541]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Introduce metric units for rates and information, add support for custom user-declared units, and rename duration units to self-explanatory identifiers such as `second`. ([#1217](https://github.com/getsentry/relay/pull/1217))
 - Increase the max profile size to accomodate a new platform. ([#1223](https://github.com/getsentry/relay/pull/1223))
 - Set environment as optional when parsing a profile so we get a null value later on. ([#1224](https://github.com/getsentry/relay/pull/1224))
+- Expose new tagging rules interface for metrics extracted from transactions. ([#1225](https://github.com/getsentry/relay/pull/1225))
 
 ## 22.3.0
 

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -26,7 +26,7 @@ pub use normalize::breakdowns::{
     get_breakdown_measurements, BreakdownConfig, BreakdownsConfig, SpanOperationsConfig,
 };
 pub use normalize::normalize_dist;
-pub use transactions::validate_timestamps;
+pub use transactions::{get_measurement, validate_timestamps};
 
 /// The config for store.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -4,6 +4,14 @@ use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult};
 /// Rejects transactions based on required fields.
 pub struct TransactionsProcessor;
 
+/// Get the value for a measurement, e.g. lcp -> event.measurements.lcp
+pub fn get_measurement(transaction: &Event, name: &str) -> Option<f64> {
+    let measurements = transaction.measurements.value()?;
+    let annotated = measurements.get(name)?;
+    let value = annotated.value().and_then(|m| m.value.value())?;
+    Some(*value)
+}
+
 /// Returns start and end timestamps if they are both set and start <= end.
 pub fn validate_timestamps(
     transaction_event: &Event,

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -11,11 +11,12 @@ use std::net::IpAddr;
 use rand::{distributions::Uniform, Rng};
 use rand_pcg::Pcg32;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Number, Value};
 
 use relay_common::{EventType, ProjectKey, Uuid};
 use relay_filter::GlobPatterns;
 use relay_general::protocol::Event;
+use relay_general::store::{get_measurement, validate_timestamps};
 
 /// Defines the type of dynamic rule, i.e. to which type of events it will be applied and how.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -114,6 +115,51 @@ impl EqCondition {
         }
     }
 }
+
+macro_rules! impl_cmp_condition {
+    ($struct_name:ident, $operator:tt) => {
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct $struct_name {
+            pub name: String,
+            pub value: Number,
+        }
+
+        impl $struct_name {
+            fn matches_event(&self, event: &Event) -> bool {
+                self.matches(event)
+            }
+            fn matches_trace(&self, trace: &TraceContext) -> bool {
+                self.matches(trace)
+            }
+
+            fn matches<T: FieldValueProvider>(&self, value_provider: &T) -> bool {
+                let value = match value_provider.get_value(self.name.as_str()) {
+                    Value::Number(x) => x,
+                    _ => return false
+                };
+
+                // Try various conversion functions in order of expensiveness and likelihood
+                // - as_i64 is not really fast, but most values in sampling rules can be i64, so we could
+                //   return early
+                // - f64 is more likely to succeed than u64, but we might lose precision
+                if let (Some(a), Some(b)) = (value.as_i64(), self.value.as_i64()) {
+                    a $operator b
+                } else if let (Some(a), Some(b)) = (value.as_u64(), self.value.as_u64()) {
+                    a $operator b
+                } else if let (Some(a), Some(b)) = (value.as_f64(), self.value.as_f64()) {
+                    a $operator b
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+impl_cmp_condition!(GteCondition, >=);
+impl_cmp_condition!(LteCondition, <=);
+impl_cmp_condition!(LtCondition, <);
+impl_cmp_condition!(GtCondition, >);
 
 /// A condition that uses glob matching.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -235,6 +281,10 @@ impl NotCondition {
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum RuleCondition {
     Eq(EqCondition),
+    Gte(GteCondition),
+    Lte(LteCondition),
+    Lt(LtCondition),
+    Gt(GtCondition),
     Glob(GlobCondition),
     Or(OrCondition),
     And(AndCondition),
@@ -252,7 +302,12 @@ impl RuleCondition {
         match self {
             RuleCondition::Unsupported => false,
             // we have a known condition
-            RuleCondition::Eq(_) | RuleCondition::Glob(_) => true,
+            RuleCondition::Gte(_)
+            | RuleCondition::Lte(_)
+            | RuleCondition::Gt(_)
+            | RuleCondition::Lt(_)
+            | RuleCondition::Eq(_)
+            | RuleCondition::Glob(_) => true,
             // dig down for embedded conditions
             RuleCondition::And(rules) => rules.supported(),
             RuleCondition::Or(rules) => rules.supported(),
@@ -260,9 +315,13 @@ impl RuleCondition {
             RuleCondition::Custom(_) => true,
         }
     }
-    fn matches_event(&self, event: &Event, ip_addr: Option<IpAddr>) -> bool {
+    pub fn matches_event(&self, event: &Event, ip_addr: Option<IpAddr>) -> bool {
         match self {
             RuleCondition::Eq(condition) => condition.matches_event(event),
+            RuleCondition::Lte(condition) => condition.matches_event(event),
+            RuleCondition::Gte(condition) => condition.matches_event(event),
+            RuleCondition::Gt(condition) => condition.matches_event(event),
+            RuleCondition::Lt(condition) => condition.matches_event(event),
             RuleCondition::Glob(condition) => condition.matches_event(event),
             RuleCondition::And(conditions) => conditions.matches_event(event, ip_addr),
             RuleCondition::Or(conditions) => conditions.matches_event(event, ip_addr),
@@ -271,9 +330,13 @@ impl RuleCondition {
             RuleCondition::Custom(condition) => condition.matches_event(event, ip_addr),
         }
     }
-    fn matches_trace(&self, trace: &TraceContext, ip_addr: Option<IpAddr>) -> bool {
+    pub fn matches_trace(&self, trace: &TraceContext, ip_addr: Option<IpAddr>) -> bool {
         match self {
             RuleCondition::Eq(condition) => condition.matches_trace(trace),
+            RuleCondition::Gte(condition) => condition.matches_trace(trace),
+            RuleCondition::Lte(condition) => condition.matches_trace(trace),
+            RuleCondition::Gt(condition) => condition.matches_trace(trace),
+            RuleCondition::Lt(condition) => condition.matches_trace(trace),
             RuleCondition::Glob(condition) => condition.matches_trace(trace),
             RuleCondition::And(conditions) => conditions.matches_trace(trace, ip_addr),
             RuleCondition::Or(conditions) => conditions.matches_trace(trace, ip_addr),
@@ -369,6 +432,23 @@ impl FieldValueProvider for Event {
                 None => Value::Null,
                 Some(s) => s.as_str().into(),
             },
+            "transaction.duration" => match (self.ty.value(), validate_timestamps(self)) {
+                (Some(&EventType::Transaction), Ok((start, end))) => {
+                    let start = start.timestamp_millis();
+                    let end = end.timestamp_millis();
+
+                    Value::Number(end.saturating_sub(start).into())
+                }
+                _ => Value::Null,
+            },
+            x if x.starts_with("transaction.measurements.") => {
+                let measurement_name = &x["transaction.measurements.".len()..];
+                if let Some(value) = get_measurement(self, measurement_name) {
+                    value.into()
+                } else {
+                    Value::Null
+                }
+            }
             _ => Value::Null,
         }
     }

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -441,8 +441,8 @@ impl FieldValueProvider for Event {
                 }
                 _ => Value::Null,
             },
-            x if x.starts_with("transaction.measurements.") => {
-                let measurement_name = &x["transaction.measurements.".len()..];
+            field_name if field_name.starts_with("transaction.measurements.") => {
+                let measurement_name = &field_name["transaction.measurements.".len()..];
                 if let Some(value) = get_measurement(self, measurement_name) {
                     value.into()
                 } else {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1626,6 +1626,11 @@ impl EnvelopeProcessor {
         };
 
         let breakdowns_config = state.project_state.config.breakdowns_v2.as_ref();
+        let conditional_tagging_config = state
+            .project_state
+            .config
+            .metric_conditional_tagging
+            .as_slice();
 
         if let Some(event) = state.event.value() {
             let extracted_anything;
@@ -1638,6 +1643,7 @@ impl EnvelopeProcessor {
                     extracted_anything = extract_transaction_metrics(
                         config,
                         breakdowns_config,
+                        conditional_tagging_config,
                         event,
                         &mut state.extracted_metrics,
                     );

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -30,6 +30,7 @@ use crate::actors::project_cache::{
 use crate::envelope::Envelope;
 use crate::extractors::RequestMeta;
 use crate::metrics_extraction::transactions::TransactionMetricsConfig;
+use crate::metrics_extraction::TaggingRule;
 use crate::statsd::RelayCounters;
 use crate::utils::{EnvelopeLimiter, ErrorBoundary, Response};
 
@@ -90,12 +91,14 @@ pub struct ProjectConfig {
     /// Configuration for operation breakdown. Will be emitted only if present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub breakdowns_v2: Option<BreakdownsConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Configuration in relation to extracting metrics from transaction events.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_metrics: Option<ErrorBoundary<TransactionMetricsConfig>>,
     /// The span attributes configuration.
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub span_attributes: BTreeSet<SpanAttribute>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub metric_conditional_tagging: Vec<TaggingRule>,
     /// Exposable features enabled for this project
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub features: BTreeSet<Feature>,
@@ -116,6 +119,7 @@ impl Default for ProjectConfig {
             breakdowns_v2: None,
             transaction_metrics: None,
             span_attributes: BTreeSet::new(),
+            metric_conditional_tagging: Vec::new(),
             features: BTreeSet::new(),
         }
     }

--- a/relay-server/src/metrics_extraction/conditional_tagging.rs
+++ b/relay-server/src/metrics_extraction/conditional_tagging.rs
@@ -28,9 +28,15 @@ pub fn run_conditional_tagging(event: &Event, config: &[TaggingRule], metrics: &
 
         // XXX(slow): this is a double-for-loop, but we extract like 6 metrics per transaction
         for metric in &mut *metrics {
-            if !rule.target_metrics.contains(&metric.name)
-                || metric.tags.contains_key(&rule.target_tag)
-            {
+            if !rule.target_metrics.contains(&metric.name) {
+                // this metric should not be updated as part of this rule
+                continue;
+            }
+
+            if metric.tags.contains_key(&rule.target_tag) {
+                // the metric tag already exists, and we are supposed to skip over rules if the tag
+                // is already set. This behavior helps with building specific rules and fallback
+                // rules.
                 continue;
             }
 

--- a/relay-server/src/metrics_extraction/conditional_tagging.rs
+++ b/relay-server/src/metrics_extraction/conditional_tagging.rs
@@ -1,0 +1,42 @@
+use std::collections::BTreeSet;
+
+use relay_sampling::RuleCondition;
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "processing")]
+use {relay_general::protocol::Event, relay_metrics::Metric};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaggingRule {
+    // note: could add relay_sampling::RuleType here, but right now we only support transaction
+    // events
+    pub condition: RuleCondition,
+    pub target_metrics: BTreeSet<String>,
+    pub target_tag: String,
+    pub tag_value: String,
+}
+
+#[cfg(feature = "processing")]
+pub fn run_conditional_tagging(event: &Event, config: &[TaggingRule], metrics: &mut [Metric]) {
+    for rule in config {
+        if !rule.condition.supported()
+            || rule.target_metrics.is_empty()
+            || !rule.condition.matches_event(event, None)
+        {
+            continue;
+        }
+
+        // XXX(slow): this is a double-for-loop, but we extract like 6 metrics per transaction
+        for metric in &mut *metrics {
+            if !rule.target_metrics.contains(&metric.name)
+                || metric.tags.contains_key(&rule.target_tag)
+            {
+                continue;
+            }
+
+            metric
+                .tags
+                .insert(rule.target_tag.clone(), rule.tag_value.clone());
+        }
+    }
+}

--- a/relay-server/src/metrics_extraction/mod.rs
+++ b/relay-server/src/metrics_extraction/mod.rs
@@ -1,3 +1,6 @@
+mod conditional_tagging;
 pub mod sessions;
 pub mod transactions;
 mod utils;
+
+pub use conditional_tagging::TaggingRule;

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -3,12 +3,15 @@ use std::collections::{BTreeMap, BTreeSet};
 
 #[cfg(feature = "processing")]
 use {
+    crate::metrics_extraction::conditional_tagging::run_conditional_tagging,
+    crate::metrics_extraction::{utils, TaggingRule},
     relay_common::UnixTimestamp,
     relay_general::protocol::{AsPair, Event, EventType, Timestamp},
     relay_general::store::{
-        get_breakdown_measurements, normalize_dist, validate_timestamps, BreakdownsConfig,
+        get_breakdown_measurements, get_measurement, normalize_dist, validate_timestamps,
+        BreakdownsConfig,
     },
-    relay_metrics::{Metric, MetricUnit, MetricValue},
+    relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue},
     std::fmt,
 };
 
@@ -121,21 +124,6 @@ fn get_duration_millis(start: &Timestamp, end: &Timestamp) -> f64 {
     end.saturating_sub(start) as f64
 }
 
-/// Get the value for a measurement, e.g. lcp -> event.measurements.lcp
-#[cfg(feature = "processing")]
-fn get_measurement(transaction: &Event, name: &str) -> Option<f64> {
-    if let Some(measurements) = transaction.measurements.value() {
-        for (measurement_name, annotated) in measurements.iter() {
-            if measurement_name == name {
-                if let Some(value) = annotated.value().and_then(|m| m.value.value()) {
-                    return Some(*value);
-                }
-            }
-        }
-    }
-    None
-}
-
 /// Extract the the satisfaction value depending on the actual measurement/duration value
 /// and the configured threshold.
 #[cfg(feature = "processing")]
@@ -168,23 +156,18 @@ fn extract_user_satisfaction(
 pub fn extract_transaction_metrics(
     config: &TransactionMetricsConfig,
     breakdowns_config: Option<&BreakdownsConfig>,
+    conditional_tagging_config: &[TaggingRule],
     event: &Event,
     target: &mut Vec<Metric>,
 ) -> bool {
-    use relay_metrics::DurationUnit;
-
-    use crate::metrics_extraction::utils::with_tag;
-
-    if event.ty.value() != Some(&EventType::Transaction) {
-        return false;
-    }
-
     if config.extract_metrics.is_empty() {
         relay_log::trace!("dropping all transaction metrics because of empty allow-list");
         return false;
     }
 
-    let mut push_metric = move |metric: Metric| {
+    let before_len = target.len();
+
+    let push_metric = |metric: Metric| {
         if config.extract_metrics.contains(&metric.name) {
             target.push(metric);
         } else {
@@ -192,23 +175,37 @@ pub fn extract_transaction_metrics(
         }
     };
 
-    // Every metric push should go through push_metric, so let's shadow the identifier
-    #[allow(unused_variables)]
-    let target = ();
+    extract_transaction_metrics_inner(config, breakdowns_config, event, push_metric);
+
+    let added_slice = &mut target[before_len..];
+    run_conditional_tagging(event, conditional_tagging_config, added_slice);
+    !added_slice.is_empty()
+}
+
+#[cfg(feature = "processing")]
+fn extract_transaction_metrics_inner(
+    config: &TransactionMetricsConfig,
+    breakdowns_config: Option<&BreakdownsConfig>,
+    event: &Event,
+    mut push_metric: impl FnMut(Metric) -> (),
+) {
+    if event.ty.value() != Some(&EventType::Transaction) {
+        return;
+    }
 
     let (start_timestamp, end_timestamp) = match validate_timestamps(event) {
         Ok(pair) => pair,
         Err(_) => {
-            return false; // invalid transaction
+            return; // invalid transaction
         }
     };
 
     let unix_timestamp = match UnixTimestamp::from_datetime(end_timestamp.into_inner()) {
         Some(ts) => ts,
-        None => return false,
+        None => return,
     };
 
-    let mut tags = BTreeMap::new();
+    let mut tags = BTreeMap::<String, String>::new();
     if let Some(release) = event.release.as_str() {
         tags.insert("release".to_owned(), release.to_owned());
     }
@@ -290,7 +287,7 @@ pub fn extract_transaction_metrics(
         end_timestamp,
     );
     let tags_with_satisfaction = match user_satisfaction {
-        Some(satisfaction) => with_tag(&tags, "satisfaction", satisfaction),
+        Some(satisfaction) => utils::with_tag(&tags, "satisfaction", satisfaction),
         None => tags.clone(),
     };
 
@@ -304,7 +301,7 @@ pub fn extract_transaction_metrics(
         MetricValue::Distribution(duration_millis),
         unix_timestamp,
         match extract_transaction_status(event) {
-            Some(status) => with_tag(&tags, "transaction.status", status),
+            Some(status) => utils::with_tag(&tags, "transaction.status", status),
             None => tags_with_satisfaction.clone(),
         },
     ));
@@ -327,8 +324,6 @@ pub fn extract_transaction_metrics(
             ));
         }
     }
-
-    true
 }
 
 #[cfg(feature = "processing")]
@@ -358,6 +353,7 @@ fn get_measurement_rating(name: &str, value: f64) -> Option<String> {
 mod tests {
     use super::*;
 
+    use crate::metrics_extraction::TaggingRule;
     use relay_general::store::BreakdownsConfig;
     use relay_general::types::Annotated;
     use relay_metrics::DurationUnit;
@@ -416,6 +412,7 @@ mod tests {
         extract_transaction_metrics(
             &TransactionMetricsConfig::default(),
             Some(&breakdowns_config),
+            &[],
             event.value().unwrap(),
             &mut metrics,
         );
@@ -441,6 +438,7 @@ mod tests {
         extract_transaction_metrics(
             &config,
             Some(&breakdowns_config),
+            &[],
             event.value().unwrap(),
             &mut metrics,
         );
@@ -513,7 +511,7 @@ mod tests {
         )
         .unwrap();
         let mut metrics = vec![];
-        extract_transaction_metrics(&config, None, event.value().unwrap(), &mut metrics);
+        extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
 
         assert_eq!(metrics.len(), 1);
 
@@ -571,7 +569,7 @@ mod tests {
         )
         .unwrap();
         let mut metrics = vec![];
-        extract_transaction_metrics(&config, None, event.value().unwrap(), &mut metrics);
+        extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
         assert_eq!(metrics.len(), 2);
 
         for metric in metrics {
@@ -619,7 +617,7 @@ mod tests {
         )
         .unwrap();
         let mut metrics = vec![];
-        extract_transaction_metrics(&config, None, event.value().unwrap(), &mut metrics);
+        extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
         assert_eq!(metrics.len(), 1);
 
         for metric in metrics {
@@ -661,12 +659,91 @@ mod tests {
         )
         .unwrap();
         let mut metrics = vec![];
-        extract_transaction_metrics(&config, None, event.value().unwrap(), &mut metrics);
+        extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
         assert_eq!(metrics.len(), 1);
 
         for metric in metrics {
             assert_eq!(metric.tags.len(), 1);
             assert!(!metric.tags.contains_key("satisfaction"));
         }
+    }
+
+    #[test]
+    fn test_conditional_tagging() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "transaction": "foo",
+            "start_timestamp": "2021-04-26T08:00:00+0100",
+            "timestamp": "2021-04-26T08:00:02+0100",
+            "measurements": {
+                "lcp": {"value": 41}
+            }
+        }
+        "#;
+
+        let event = Annotated::from_json(json).unwrap();
+
+        let config: TransactionMetricsConfig = serde_json::from_str(
+            r#"
+        {
+            "extractMetrics": [
+                "d:transactions/duration@millisecond"
+            ]
+        }
+        "#,
+        )
+        .unwrap();
+
+        let tagging_config: Vec<TaggingRule> = serde_json::from_str(
+            r#"
+        [
+            {
+                "condition": {"op": "gte", "name": "transaction.duration", "value": 9001},
+                "targetMetrics": ["d:transactions/duration@millisecond"],
+                "targetTag": "satisfaction",
+                "tagValue": "frustrated"
+            },
+            {
+                "condition": {"op": "gte", "name": "transaction.duration", "value": 666},
+                "targetMetrics": ["d:transactions/duration@millisecond"],
+                "targetTag": "satisfaction",
+                "tagValue": "tolerated"
+            },
+            {
+                "condition": {"op": "and", "inner": []},
+                "targetMetrics": ["d:transactions/duration@millisecond"],
+                "targetTag": "satisfaction",
+                "tagValue": "satisfied"
+            }
+        ]
+        "#,
+        )
+        .unwrap();
+
+        let mut metrics = vec![];
+        extract_transaction_metrics(
+            &config,
+            None,
+            &tagging_config,
+            event.value().unwrap(),
+            &mut metrics,
+        );
+        assert_eq!(
+            metrics,
+            &[Metric::new_mri(
+                METRIC_NAMESPACE,
+                "duration",
+                MetricUnit::Duration(DurationUnit::MilliSecond),
+                MetricValue::Distribution(2000.0),
+                UnixTimestamp::from_secs(1619420402),
+                {
+                    let mut tags = BTreeMap::new();
+                    tags.insert("satisfaction".to_owned(), "tolerated".to_owned());
+                    tags.insert("transaction".to_owned(), "foo".to_owned());
+                    tags
+                }
+            )]
+        );
     }
 }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -187,7 +187,7 @@ fn extract_transaction_metrics_inner(
     config: &TransactionMetricsConfig,
     breakdowns_config: Option<&BreakdownsConfig>,
     event: &Event,
-    mut push_metric: impl FnMut(Metric) -> (),
+    mut push_metric: impl FnMut(Metric),
 ) {
     if event.ty.value() != Some(&EventType::Transaction) {
         return;


### PR DESCRIPTION
We're building this such that we can supersede certain kinds of duration-range based tagging we do in metrics extraction right now.

https://www.notion.so/sentry/Metrics-outlier-filtering-in-Relay-93c1a9a8c6c24277a2c9e8d61876f968?d=d1035fca98804ef697997439d14a06b2#3e08fc7f89a24de8a8c85b7d717d35f6=

