### PR TITLE
doc: Release management with github actions [INGEST-1224]

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ http://<key>@localhost:3001/<id>
 We use GitHub actions to release new versions.
 There are two separate projects to publish:
 
-- **Relay binary** is released with the ["Release" action](https://github.com/getsentry/relay/actions/workflows/release_binary.yml). Make sure that [`CHANGELOG.md`](./CHANGELOG.md) is up-to-date before running the action. Hit "Run workflow" and choose a new version. We use [Calendar Versioning](https://calver.org/) and coordinate releases with Sentry.
+- **Relay binary** is released with the ["Release" action](https://github.com/getsentry/relay/actions/workflows/release_binary.yml). Make sure that [`CHANGELOG.md`](./CHANGELOG.md) is up-to-date before running the action. Press "Run workflow" and choose a new version. We use [Calendar Versioning](https://calver.org/) and coordinate releases with Sentry.
 
 - **Relay Python library** along with the C-ABI are released with the ["Release Library" action](https://github.com/getsentry/relay/actions/workflows/release_library.yml). Make sure that [`py/CHANGELOG.md`](./py/CHANGELOG.md) is up-to-date before running the action. Hit "Run workflow" and choose a new version. We use [Semantic Versioning](https://semver.org/) and release during the development cycle.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ There are two separate projects to publish:
 
 - **Relay binary** is automatically released using [Calendar Versioning](https://calver.org/) on a monthly basis together with `sentry` (see https://develop.sentry.dev/self-hosted/releases/), so there should be no reason to create a release manually. That said, manual releases are possible with the ["Release" action](https://github.com/getsentry/relay/actions/workflows/release_binary.yml). Make sure that [`CHANGELOG.md`](./CHANGELOG.md) is up-to-date before running the action.
 
-- **Relay Python library** along with the C-ABI are released with the ["Release Library" action](https://github.com/getsentry/relay/actions/workflows/release_library.yml). Make sure that [`py/CHANGELOG.md`](./py/CHANGELOG.md) is up-to-date before running the action. Hit "Run workflow" and choose a new version. We use [Semantic Versioning](https://semver.org/) and release during the development cycle.
+- **Relay Python library** along with the C-ABI are released with the ["Release Library" action](https://github.com/getsentry/relay/actions/workflows/release_library.yml). Make sure that [`py/CHANGELOG.md`](./py/CHANGELOG.md) is up-to-date before running the action. Press "Run workflow" and choose a new version. We use [Semantic Versioning](https://semver.org/) and release during the development cycle.
 
 ### Instructions for changelogs
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ http://<key>@localhost:3001/<id>
 We use GitHub actions to release new versions.
 There are two separate projects to publish:
 
-- **Relay binary** is released with the ["Release" action](https://github.com/getsentry/relay/actions/workflows/release_binary.yml). Make sure that [`CHANGELOG.md`](./CHANGELOG.md) is up-to-date before running the action. Press "Run workflow" and choose a new version. We use [Calendar Versioning](https://calver.org/) and coordinate releases with Sentry.
+- **Relay binary** is automatically released using [Calendar Versioning](https://calver.org/) on a monthly basis together with `sentry` (see https://develop.sentry.dev/self-hosted/releases/), so there should be no reason to create a release manually. That said, manual releases are possible with the ["Release" action](https://github.com/getsentry/relay/actions/workflows/release_binary.yml). Make sure that [`CHANGELOG.md`](./CHANGELOG.md) is up-to-date before running the action.
 
 - **Relay Python library** along with the C-ABI are released with the ["Release Library" action](https://github.com/getsentry/relay/actions/workflows/release_library.yml). Make sure that [`py/CHANGELOG.md`](./py/CHANGELOG.md) is up-to-date before running the action. Hit "Run workflow" and choose a new version. We use [Semantic Versioning](https://semver.org/) and release during the development cycle.
 

--- a/README.md
+++ b/README.md
@@ -245,17 +245,12 @@ http://<key>@localhost:3001/<id>
 
 ### Release Management
 
-We use [craft](https://github.com/getsentry/craft) to release new versions.
+We use GitHub actions to release new versions.
 There are two separate projects to publish:
 
-- **Relay binary** is released from the root folder. Run `craft prepare` and
-  `craft publish` in that directory to create a release build and publish it,
-  respectively. We use [Calendar Versioning](https://calver.org/) and coordinate
-  releases with Sentry.
+- **Relay binary** is released with the ["Release" action](https://github.com/getsentry/relay/actions/workflows/release_binary.yml). Make sure that [`CHANGELOG.md`](./CHANGELOG.md) is up-to-date before running the action. Hit "Run workflow" and choose a new version. We use [Calendar Versioning](https://calver.org/) and coordinate releases with Sentry.
 
-- **Relay Python library** along with the C-ABI are released from the `py/`
-  subfolder. Change into that directory and run `craft prepare` and `craft publish`. We use [Semantic Versioning](https://semver.org/) and release during
-  the development cycle.
+- **Relay Python library** along with the C-ABI are released with the ["Release Library" action](https://github.com/getsentry/relay/actions/workflows/release_library.yml). Make sure that [`py/CHANGELOG.md`](./py/CHANGELOG.md) is up-to-date before running the action. Hit "Run workflow" and choose a new version. We use [Semantic Versioning](https://semver.org/) and release during the development cycle.
 
 ### Instructions for changelogs
 


### PR DESCRIPTION
Update documentation on how to release relay and librelay.

#skip-changelog