### PR TITLE
fix(metrics): Enforce metric name length limit [INGEST-1205]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
 - Add platform, op, http.method and status tag to all extracted transaction metrics. ([#1227](https://github.com/getsentry/relay/pull/1227))
 - Add units in built-in measurements. ([#1229](https://github.com/getsentry/relay/pull/1229))
 
+**Bug fixes**:
+
+- Return error when metric name is large. ([#1233](https://github.com/getsentry/relay/pull/1233))
+
 **Internal**:
 
-* Add sampling + tagging by event platform and transaction op. Some (unused) tagging rules from 22.4.0 have been renamed. ([#1231](https://github.com/getsentry/relay/pull/1231))
+- Add sampling + tagging by event platform and transaction op. Some (unused) tagging rules from 22.4.0 have been renamed. ([#1231](https://github.com/getsentry/relay/pull/1231))
 
 ## 22.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bug fixes**:
 
-- Return error when metric name is large. ([#1233](https://github.com/getsentry/relay/pull/1233))
+- Enforce metric name length limit. ([#1233](https://github.com/getsentry/relay/pull/1233))
 
 **Internal**:
 

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -917,7 +917,8 @@ mod tests {
                     tags.insert("platform".to_owned(), "other".to_owned());
                     tags
                 }
-            )]
+            )
+            .unwrap()]
         );
     }
 
@@ -998,7 +999,8 @@ mod tests {
                     tags.insert("platform".to_owned(), "other".to_owned());
                     tags
                 }
-            )]
+            )
+            .unwrap()]
         );
     }
 }


### PR DESCRIPTION
Attempts to create metrics from names that are too large will return an
error (with the length that was attempted the creation) and they will be
ignored and not collected. Short metric names don't produce any
errors, and the metric is returned.

A metric name is considered large if it exceeds the 200 character
threshold.