### PR TITLE
fix(metrics): Remove/reject nul-bytes from metric strings [ingest-1204]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add platform, op, http.method and status tag to all extracted transaction metrics. ([#1227](https://github.com/getsentry/relay/pull/1227))
 - Add units in built-in measurements. ([#1229](https://github.com/getsentry/relay/pull/1229))
 
+**Internal**:
+
+- Remove/reject nul-bytes from metric strings. ([#1235](https://github.com/getsentry/relay/pull/1235))
+
 ## 22.4.0
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal**:
 
 * Add sampling + tagging by event platform and transaction op. Some (unused) tagging rules from 22.4.0 have been renamed. ([#1231](https://github.com/getsentry/relay/pull/1231))
+- Refactor aggregation error, recover from errors more gracefully. ([#1240](https://github.com/getsentry/relay/pull/1240))
 
 ## 22.4.0
 

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -343,7 +343,7 @@ pub struct Event {
     /// can be the git SHA for the given project, or a product identifier with a semantic version.
     #[metastructure(
         max_chars = "tag_value",  // release ends in tag
-        deny_chars = "\r\n\x0c\t/\\",
+        // release allowed chars are validated in the sentry-release-parser crate!
         required = "false",
         trim_whitespace = "true",
         nonempty = "true",
@@ -374,7 +374,7 @@ pub struct Event {
     /// ```
     #[metastructure(
         max_chars = "environment",
-        deny_chars = "\r\n\x0C/",
+        // environment allowed chars are validated in the sentry-release-parser crate!
         nonempty = "true",
         required = "false",
         trim_whitespace = "true"

--- a/relay-general/src/store/schema.rs
+++ b/relay-general/src/store/schema.rs
@@ -105,7 +105,7 @@ fn verify_value_characters(
 mod tests {
     use super::SchemaProcessor;
     use crate::processor::{process_value, ProcessingState};
-    use crate::types::{Annotated, Array, Error, Object, Value};
+    use crate::types::{Annotated, Array, Error, Object};
 
     fn assert_nonempty_base<T>()
     where
@@ -146,29 +146,6 @@ mod tests {
     #[test]
     fn test_nonempty_object() {
         assert_nonempty_base::<Object<u64>>();
-    }
-
-    #[test]
-    fn test_release_invalid_newlines() {
-        use crate::protocol::Event;
-
-        let mut event = Annotated::new(Event {
-            release: Annotated::new("a\nb".to_string().into()),
-            ..Default::default()
-        });
-
-        process_value(&mut event, &mut SchemaProcessor, ProcessingState::root()).unwrap();
-
-        assert_eq_dbg!(
-            event,
-            Annotated::new(Event {
-                release: Annotated::from_error(
-                    Error::invalid("invalid character \'\\n\'"),
-                    Some(Value::String("a\nb".into())),
-                ),
-                ..Default::default()
-            })
-        );
     }
 
     #[test]

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -2127,8 +2127,9 @@ mod tests {
                 // strip out NUL-bytes instead of dropping the tag such that those values line up
                 // again across sessions and events. Should that cause too high cardinality we'll
                 // have to drop tags.
-                // Note that releases are validated separately against much 
-                // stricter character set, but the above idea should still apply to other tags.
+                //
+                // Note that releases are validated separately against much stricter character set,
+                // but the above idea should still apply to other tags.
                 tags.insert(
                     "is_it_garbage".to_owned(),
                     "a\0b\0s\0o\0l\0u\0t\0e\0l\0y".to_owned(),

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1167,7 +1167,7 @@ impl Aggregator {
         I: IntoIterator<Item = Bucket>,
     {
         for bucket in buckets.into_iter() {
-            self.merge(project_key, bucket)?;
+            let _result = self.merge(project_key, bucket);
         }
 
         Ok(())

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1070,7 +1070,7 @@ impl Aggregator {
     ///
     /// Returns `Err` if the metric should be dropped.
     fn validate_bucket_key(mut key: BucketKey) -> Result<BucketKey, AggregateMetricsError> {
-        if !protocol::is_valid_name(&key.metric_name) {
+        if !protocol::is_valid_mri(&key.metric_name) {
             relay_log::debug!("invalid metric name {:?}", key.metric_name);
             return Err(AggregateMetricsErrorKind::InvalidCharacters.into());
         }

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -2139,7 +2139,7 @@ mod tests {
         let bucket_key = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "hergus.bergus".to_owned(),
+            metric_name: "c:hergus.bergus".to_owned(),
             metric_type: MetricType::Counter,
             metric_unit: MetricUnit::None,
             tags: {

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -2127,6 +2127,8 @@ mod tests {
                 // strip out NUL-bytes instead of dropping the tag such that those values line up
                 // again across sessions and events. Should that cause too high cardinality we'll
                 // have to drop tags.
+                // Note that releases are validated separately against much 
+                // stricter character set, but the above idea should still apply to other tags.
                 tags.insert(
                     "is_it_garbage".to_owned(),
                     "a\0b\0s\0o\0l\0u\0t\0e\0l\0y".to_owned(),

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1484,7 +1484,7 @@ mod tests {
 
     fn some_metric() -> Metric {
         Metric {
-            name: "foo".to_owned(),
+            name: "c:foo".to_owned(),
             unit: MetricUnit::None,
             value: MetricValue::Counter(42.),
             timestamp: UnixTimestamp::from_secs(999994711),
@@ -1810,7 +1810,7 @@ mod tests {
                 BucketKey {
                     project_key: ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"),
                     timestamp: UnixTimestamp(999994711),
-                    metric_name: "foo",
+                    metric_name: "c:foo",
                     metric_type: Counter,
                     metric_unit: None,
                     tags: {},
@@ -1859,7 +1859,7 @@ mod tests {
                 BucketKey {
                     project_key: ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"),
                     timestamp: UnixTimestamp(999994710),
-                    metric_name: "foo",
+                    metric_name: "c:foo",
                     metric_type: Counter,
                     metric_unit: None,
                     tags: {},
@@ -1872,7 +1872,7 @@ mod tests {
                 BucketKey {
                     project_key: ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"),
                     timestamp: UnixTimestamp(999994720),
-                    metric_name: "foo",
+                    metric_name: "c:foo",
                     metric_type: Counter,
                     metric_unit: None,
                     tags: {},

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -728,6 +728,7 @@ impl From<AggregateMetricsErrorKind> for AggregateMetricsError {
 }
 
 #[derive(Debug, Fail)]
+#[allow(clippy::enum_variant_names)]
 enum AggregateMetricsErrorKind {
     /// A metric bucket had invalid characters in the metric name.
     #[fail(display = "found invalid characters")]

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1071,6 +1071,7 @@ impl Aggregator {
     /// Returns `Err` if the metric should be dropped.
     fn validate_bucket_key(mut key: BucketKey) -> Result<BucketKey, AggregateMetricsError> {
         if !protocol::is_valid_name(&key.metric_name) {
+            relay_log::debug!("invalid metric name {:?}", key.metric_name);
             return Err(AggregateMetricsErrorKind::InvalidCharacters.into());
         }
 
@@ -1078,7 +1079,7 @@ impl Aggregator {
             if protocol::is_valid_tag_key(tag_key) {
                 true
             } else {
-                relay_log::error!("invalid metric tag key {:?}", tag_key);
+                relay_log::debug!("invalid metric tag key {:?}", tag_key);
                 false
             }
         });

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -408,10 +408,10 @@ impl fmt::Display for ParseMetricError {
     }
 }
 
-/// Validates a metric name.
+/// Validates a metric name. This is the statsd name, i.e. without type or unit.
 ///
 /// Metric names cannot be empty, must begin with a letter and can consist of ASCII alphanumerics,
-/// underscores and periods.
+/// underscores, slashes and periods.
 fn is_valid_name(name: &str) -> bool {
     let mut iter = name.as_bytes().iter();
     if let Some(first_byte) = iter.next() {

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -416,7 +416,7 @@ fn is_valid_name(name: &str) -> bool {
     let mut iter = name.as_bytes().iter();
     if let Some(first_byte) = iter.next() {
         if first_byte.is_ascii_alphabetic() {
-            return iter.all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_'));
+            return iter.all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'/'));
         }
     }
     false
@@ -629,7 +629,7 @@ impl Metric {
         let (name, unit, value) = parse_name_unit_value(name_value_str, ty)?;
 
         let mut metric = Self {
-            name,
+            name: format!("{}:{}", ty, name),
             unit,
             value,
             timestamp,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -760,7 +760,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "c:foo",
             unit: None,
             value: Counter(
                 42.0,
@@ -778,7 +778,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "d:foo",
             unit: None,
             value: Distribution(
                 17.5,
@@ -804,7 +804,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "s:foo",
             unit: None,
             value: Set(
                 4267882815,
@@ -822,7 +822,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "g:foo",
             unit: None,
             value: Gauge(
                 42.0,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -610,7 +610,7 @@ pub struct Metric {
     /// The name of the metric without its unit.
     ///
     /// Metric names cannot be empty, must start with a letter and can consist of ASCII
-    /// alphanumerics, underscores and periods.
+    /// alphanumerics, underscores, slashes, @s and periods.
     pub name: String,
     /// The unit of the metric value.
     ///

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -58,8 +58,20 @@ def test_metrics(mini_sentry, relay):
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
     assert received_metrics == [
-        {"timestamp": timestamp, "width": 1, "name": "c:bar", "value": 17.0, "type": "c"},
-        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:bar",
+            "value": 17.0,
+            "type": "c",
+        },
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:foo",
+            "value": 42.0,
+            "type": "c",
+        },
     ]
 
 
@@ -81,7 +93,13 @@ def test_metrics_backdated(mini_sentry, relay):
 
     received_metrics = metrics_item.get_bytes()
     assert json.loads(received_metrics.decode()) == [
-        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:foo",
+            "value": 42.0,
+            "type": "c",
+        },
     ]
 
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -58,8 +58,8 @@ def test_metrics(mini_sentry, relay):
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
     assert received_metrics == [
-        {"timestamp": timestamp, "width": 1, "name": "bar", "value": 17.0, "type": "c"},
-        {"timestamp": timestamp, "width": 1, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "c:bar", "value": 17.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
     ]
 
 
@@ -81,7 +81,7 @@ def test_metrics_backdated(mini_sentry, relay):
 
     received_metrics = metrics_item.get_bytes()
     assert json.loads(received_metrics.decode()) == [
-        {"timestamp": timestamp, "width": 1, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
     ]
 
 
@@ -98,20 +98,20 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
 
     metrics = metrics_by_name(metrics_consumer, 2)
 
-    assert metrics["foo"] == {
+    assert metrics["c:foo"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "foo",
+        "name": "c:foo",
         "unit": "none",
         "value": 42.0,
         "type": "c",
         "timestamp": timestamp,
     }
 
-    assert metrics["bar"] == {
+    assert metrics["c:bar"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "bar",
+        "name": "c:bar",
         "unit": "second",
         "value": 17.0,
         "type": "c",
@@ -149,7 +149,7 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
     assert metric == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "foo",
+        "name": "c:foo",
         "unit": "none",
         "value": 15.0,
         "type": "c",
@@ -592,14 +592,14 @@ def test_graceful_shutdown(mini_sentry, relay):
         {
             "timestamp": future_timestamp,
             "width": 1,
-            "name": "bar",
+            "name": "c:bar",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": past_timestamp,
             "width": 1,
-            "name": "foo",
+            "name": "c:foo",
             "value": 42.0,
             "type": "c",
         },


### PR DESCRIPTION
We are observing release names which are UTF-16 strings reinterpreted as
UTF-8. This is causing issues downstream and does not line up with the
releases that end up in the event payload, which for some reason are
totally correct.

In order to counteract this, we strip NUL-bytes from release values.

In other string types (tag keys, metrics), there are "fewer excuses" for
not getting those strings right, so we just drop them.