### PR TITLE
fix: Raise a new InvalidCompression Outcome for invalid Unreal compression [ISSUE-1454]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Remove the unused "internal" data category. ([#1245](https://github.com/getsentry/relay/pull/1245))
 - Add the client and version as `sdk` tag to extracted session metrics in the format `name/version`. ([#1248](https://github.com/getsentry/relay/pull/1248))
 - Expose `shutdown_timeout` in `OverridableConfig` ([#1247](https://github.com/getsentry/relay/pull/1247))
+- Raise a new InvalidCompression Outcome for invalid Unreal compression. ([#1237](https://github.com/getsentry/relay/pull/1237))
 
 ## 22.4.0
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -181,6 +181,12 @@ impl ProcessingError {
 
             // Processing-only outcomes (Sentry-internal Relays)
             #[cfg(feature = "processing")]
+            Self::InvalidUnrealReport(ref err)
+                if err.kind() == Unreal4ErrorKind::BadCompression =>
+            {
+                Some(Outcome::Invalid(DiscardReason::InvalidCompression))
+            }
+            #[cfg(feature = "processing")]
             Self::InvalidUnrealReport(_) => Some(Outcome::Invalid(DiscardReason::ProcessUnreal)),
 
             #[cfg(feature = "processing")]

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -281,6 +281,9 @@ pub enum DiscardReason {
     /// (Relay) Parsing an event envelope failed (likely missing a required header).
     InvalidEnvelope,
 
+    /// (Relay) The payload had an invalid compression stream.
+    InvalidCompression,
+
     /// (Relay) A project state returned by the upstream could not be parsed.
     ProjectState,
 
@@ -333,6 +336,7 @@ impl DiscardReason {
             DiscardReason::InvalidMsgpack => "invalid_msgpack",
             DiscardReason::InvalidTransaction => "invalid_transaction",
             DiscardReason::InvalidEnvelope => "invalid_envelope",
+            DiscardReason::InvalidCompression => "invalid_compression",
             DiscardReason::ProjectState => "project_state",
             DiscardReason::DuplicateItem => "duplicate_item",
             DiscardReason::NoEventPayload => "no_event_payload",


### PR DESCRIPTION
Not entirely sure this is the right thing to do, however as much as I can tell [ISSUE-1454](https://getsentry.atlassian.net/browse/ISSUE-1454) looks like the Unreal reporter is sending invalid compression payloads. Might be good to distinguish those from *actual* Unreal parse errors.