### PR TITLE
ref(metrics): Refactor aggregation error, recover from errors more gracefully [ingest-1204]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal**:
 
 * Add sampling + tagging by event platform and transaction op. Some (unused) tagging rules from 22.4.0 have been renamed. ([#1231](https://github.com/getsentry/relay/pull/1231))
+- Refactor aggregation error, recover from errors more gracefully. ([#1240](https://github.com/getsentry/relay/pull/1240))
 
 ## 22.4.0
 


### PR DESCRIPTION
See discussion in https://github.com/getsentry/relay/pull/1235

This PR introduces variants to aggregation error, and skips over broken buckets instead of dropping the entire batch.