### PR TITLE
fix(metrics): Fix MRI validation in statsd protocol [ingest-1204]

### DIFF
--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -408,10 +408,10 @@ impl fmt::Display for ParseMetricError {
     }
 }
 
-/// Validates a metric name.
+/// Validates a metric name. This is the statsd name, i.e. without type or unit.
 ///
 /// Metric names cannot be empty, must begin with a letter and can consist of ASCII alphanumerics,
-/// underscores and periods.
+/// underscores, slashes and periods.
 fn is_valid_name(name: &str) -> bool {
     let mut iter = name.as_bytes().iter();
     if let Some(first_byte) = iter.next() {

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -416,7 +416,7 @@ fn is_valid_name(name: &str) -> bool {
     let mut iter = name.as_bytes().iter();
     if let Some(first_byte) = iter.next() {
         if first_byte.is_ascii_alphabetic() {
-            return iter.all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_'));
+            return iter.all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'/'));
         }
     }
     false
@@ -629,7 +629,7 @@ impl Metric {
         let (name, unit, value) = parse_name_unit_value(name_value_str, ty)?;
 
         let mut metric = Self {
-            name,
+            name: format!("{}:{}", ty, name),
             unit,
             value,
             timestamp,

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -760,7 +760,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "c:foo",
             unit: None,
             value: Counter(
                 42.0,
@@ -778,7 +778,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "d:foo",
             unit: None,
             value: Distribution(
                 17.5,
@@ -804,7 +804,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "s:foo",
             unit: None,
             value: Set(
                 4267882815,
@@ -822,7 +822,7 @@ mod tests {
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "foo",
+            name: "g:foo",
             unit: None,
             value: Gauge(
                 42.0,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -58,8 +58,20 @@ def test_metrics(mini_sentry, relay):
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
     assert received_metrics == [
-        {"timestamp": timestamp, "width": 1, "name": "c:bar", "value": 17.0, "type": "c"},
-        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:bar",
+            "value": 17.0,
+            "type": "c",
+        },
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:foo",
+            "value": 42.0,
+            "type": "c",
+        },
     ]
 
 
@@ -81,7 +93,13 @@ def test_metrics_backdated(mini_sentry, relay):
 
     received_metrics = metrics_item.get_bytes()
     assert json.loads(received_metrics.decode()) == [
-        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:foo",
+            "value": 42.0,
+            "type": "c",
+        },
     ]
 
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -58,8 +58,8 @@ def test_metrics(mini_sentry, relay):
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
     assert received_metrics == [
-        {"timestamp": timestamp, "width": 1, "name": "bar", "value": 17.0, "type": "c"},
-        {"timestamp": timestamp, "width": 1, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "c:bar", "value": 17.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
     ]
 
 
@@ -81,7 +81,7 @@ def test_metrics_backdated(mini_sentry, relay):
 
     received_metrics = metrics_item.get_bytes()
     assert json.loads(received_metrics.decode()) == [
-        {"timestamp": timestamp, "width": 1, "name": "foo", "value": 42.0, "type": "c"},
+        {"timestamp": timestamp, "width": 1, "name": "c:foo", "value": 42.0, "type": "c"},
     ]
 
 
@@ -98,20 +98,20 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
 
     metrics = metrics_by_name(metrics_consumer, 2)
 
-    assert metrics["foo"] == {
+    assert metrics["c:foo"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "foo",
+        "name": "c:foo",
         "unit": "none",
         "value": 42.0,
         "type": "c",
         "timestamp": timestamp,
     }
 
-    assert metrics["bar"] == {
+    assert metrics["c:bar"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "bar",
+        "name": "c:bar",
         "unit": "second",
         "value": 17.0,
         "type": "c",
@@ -149,7 +149,7 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
     assert metric == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "foo",
+        "name": "c:foo",
         "unit": "none",
         "value": 15.0,
         "type": "c",
@@ -592,14 +592,14 @@ def test_graceful_shutdown(mini_sentry, relay):
         {
             "timestamp": future_timestamp,
             "width": 1,
-            "name": "bar",
+            "name": "c:bar",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": past_timestamp,
             "width": 1,
-            "name": "foo",
+            "name": "c:foo",
             "value": 42.0,
             "type": "c",
         },


### PR DESCRIPTION
Split out of #1235 to adjust statsd parsing to work with the new MRI naming scheme. Minimal changeset necessary to adhere to the DACI at https://www.notion.so/sentry/Metric-Resource-Identifiers-MRI-58c6293d924448f085835c0b4df2fcf5?d=0aa54b074b2142ceb43e41322af53fed#5546f947c0de4cc7bd452c4025b40094=

#skip-changelog