### PR TITLE
chore: Bump sentry-release-parser [ingest-1204]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95074247cedb462192eee901d85e2c43c8afef58c6bc2d5c0a4f376edb361466"
+checksum = "96c337b2564b136475f056ca1e5c958a58acdc3a6c48a6a02064f749f87acb18"
 dependencies = [
  "lazy_static",
  "regex",

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -24,4 +24,4 @@ relay-common = { path = "../relay-common" }
 relay-ffi = { path = "../relay-ffi" }
 relay-general = { path = "../relay-general" }
 relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "1.3.0", features = ["serde"] }
+sentry-release-parser = { version = "1.3.1", features = ["serde"] }

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1.5.5"
 relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
-sentry-release-parser = { version = "1.1.1" }
+sentry-release-parser = { version = "1.3.1" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.5.5"


### PR DESCRIPTION
In order for https://github.com/getsentry/relay/pull/1235 to land, we
need the latest release parser that actually rejects control characters
in release names.

#skip-changelog