### PR TITLE
ref(constants): Remove the unused "internal" data category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add sampling + tagging by event platform and transaction op. Some (unused) tagging rules from 22.4.0 have been renamed. ([#1231](https://github.com/getsentry/relay/pull/1231))
 - Refactor aggregation error, recover from errors more gracefully. ([#1240](https://github.com/getsentry/relay/pull/1240))
 - Remove/reject nul-bytes from metric strings. ([#1235](https://github.com/getsentry/relay/pull/1235))
+- Remove the unused "internal" data category. ([#1245](https://github.com/getsentry/relay/pull/1245))
 
 ## 22.4.0
 

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -107,8 +107,6 @@ pub enum DataCategory {
     Attachment = 4,
     /// Session updates. Quantity is the number of updates in the batch.
     Session = 5,
-    /// Reserved data category that shall not appear in the outcomes.
-    Internal = -2,
     /// Any other data category not known by this Relay.
     #[serde(other)]
     Unknown = -1,
@@ -124,7 +122,6 @@ impl DataCategory {
             "security" => Self::Security,
             "attachment" => Self::Attachment,
             "session" => Self::Session,
-            "internal" => Self::Internal,
             _ => Self::Unknown,
         }
     }
@@ -138,7 +135,6 @@ impl DataCategory {
             Self::Security => "security",
             Self::Attachment => "attachment",
             Self::Session => "session",
-            Self::Internal => "internal",
             Self::Unknown => "unknown",
         }
     }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -106,7 +106,7 @@ impl CategoryUnit {
             | DataCategory::Security => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
             DataCategory::Session => Some(Self::Batched),
-            DataCategory::Internal | DataCategory::Unknown => None,
+            DataCategory::Unknown => None,
         }
     }
 }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -104,12 +104,6 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::FormData => None,
         ItemType::UserReport => None,
         ItemType::Profile => None,
-        // the following items are "internal" item types.  From the perspective of the SDK
-        // the use the "internal" data category however this data category is in fact never
-        // supposed to be emitted by relay as internal items must not be rate limited.  As
-        // such we do not emit a data category here.  An SDK however is supposed to assume
-        // that such item types use the reserved "internal" data category to not accidentally
-        // assume another rate limit (such as default).
         ItemType::ClientReport => None,
     }
 }


### PR DESCRIPTION
`DataCategory::Internal` was originally introduced to handle client reports, but
did not end up used. Instead, client reports like many other items do are not
rate limited and as such do not have any data category.

This PR removes the unused variant and the only reference to it from a code
comment.
