### PR TITLE
fix(server): Update fields in LimitedProjectConfig [INGEST-1303]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - fix(metrics): Enforce metric name length limit. ([#1238](https://github.com/getsentry/relay/pull/1238))
 - Accept and forward unknown Envelope items. In processing mode, drop items individually rather than rejecting the entire request. This allows SDKs to send new data in combined Envelopes in the future. ([#1246](https://github.com/getsentry/relay/pull/1246))
-- Stop extracting metrics with outdated names from sessions. ([#1251](https://github.com/getsentry/relay/pull/1251))
+- Stop extracting metrics with outdated names from sessions. ([#1251](https://github.com/getsentry/relay/pull/1251), [#1252](https://github.com/getsentry/relay/pull/1252))
 
 **Internal**:
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -142,9 +142,15 @@ pub struct LimitedProjectConfig {
     pub allowed_domains: Vec<String>,
     pub trusted_relays: Vec<PublicKey>,
     pub pii_config: Option<PiiConfig>,
+    #[serde(skip_serializing_if = "DataScrubbingConfig::is_disabled")]
     pub datascrubbing_settings: DataScrubbingConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_sampling: Option<SamplingConfig>,
+    #[serde(skip_serializing_if = "SessionMetricsConfig::is_disabled")]
+    pub session_metrics: SessionMetricsConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_metrics: Option<ErrorBoundary<TransactionMetricsConfig>>,
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub features: BTreeSet<Feature>,
 }
 


### PR DESCRIPTION
Adds the recently added `session_metrics` field to
`LimitedProjectConfig`, which allows this field to be exposed to
untrusted Relays. In addition to that, this PR adds serde's
`skip_serializing_if` directive to skip empty fields in the reduced
project config format.