### PR TITLE
ref(system): Rename and test Controller in relay-system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,16 +3256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "relay-common-actors"
-version = "22.4.0"
-dependencies = [
- "actix",
- "failure",
- "futures 0.1.29",
- "relay-log",
-]
-
-[[package]]
 name = "relay-config"
 version = "22.4.0"
 dependencies = [
@@ -3405,9 +3395,9 @@ dependencies = [
  "insta",
  "lazy_static",
  "relay-common",
- "relay-common-actors",
  "relay-log",
  "relay-statsd",
+ "relay-system",
  "relay-test",
  "serde",
  "serde_json",
@@ -3485,7 +3475,6 @@ dependencies = [
  "regex",
  "relay-auth",
  "relay-common",
- "relay-common-actors",
  "relay-config",
  "relay-filter",
  "relay-general",
@@ -3495,6 +3484,7 @@ dependencies = [
  "relay-redis",
  "relay-sampling",
  "relay-statsd",
+ "relay-system",
  "relay-test",
  "reqwest",
  "rmp-serde",
@@ -3518,6 +3508,16 @@ dependencies = [
  "lazy_static",
  "parking_lot 0.10.2",
  "rand 0.7.3",
+ "relay-log",
+]
+
+[[package]]
+name = "relay-system"
+version = "22.4.0"
+dependencies = [
+ "actix",
+ "failure",
+ "futures 0.1.29",
  "relay-log",
 ]
 

--- a/relay-common-actors/src/lib.rs
+++ b/relay-common-actors/src/lib.rs
@@ -1,8 +1,0 @@
-//! Common actors for Relay services
-#![warn(missing_docs)]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
-    html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
-)]
-
-pub mod controller;

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -14,9 +14,9 @@ actix = "0.7.9"
 float-ord = "0.3.1"
 hash32 = "0.1.1"
 relay-common = { path = "../relay-common" }
-relay-common-actors = { path = "../relay-common-actors" }
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
+relay-system = { path = "../relay-system" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 failure = "0.1.8"

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -8,10 +8,10 @@ use actix::prelude::*;
 use failure::Fail;
 use float_ord::FloatOrd;
 use hash32::{FnvHasher, Hasher};
-use relay_common_actors::controller::{Controller, Shutdown};
 use serde::{Deserialize, Serialize};
 
 use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
+use relay_system::{Controller, Shutdown};
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
 use crate::{protocol, Metric, MetricType, MetricUnit, MetricValue};

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -50,7 +50,6 @@ rdkafka-sys = { version = "2.1.0", optional = true }
 regex = "1.5.5"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
-relay-common-actors = { path = "../relay-common-actors" }
 relay-config = { path = "../relay-config" }
 relay-filter = { path = "../relay-filter" }
 relay-general = { path = "../relay-general" }
@@ -60,6 +59,7 @@ relay-quotas = { path = "../relay-quotas" }
 relay-redis = { path = "../relay-redis" }
 relay-sampling = { path = "../relay-sampling" }
 relay-statsd = { path = "../relay-statsd" }
+relay-system = { path = "../relay-system" }
 reqwest = { version = "0.11.1", features = ["gzip", "stream", "trust-dns", "native-tls-vendored"] }
 rmp-serde = "0.14.3"
 serde = { version = "1.0.114", features = ["derive"] }

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -7,10 +7,10 @@ use futures::prelude::*;
 
 use relay_config::{Config, RelayMode};
 use relay_statsd::metric;
+use relay_system::{Controller, Shutdown};
 
 use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
 use crate::statsd::RelayGauges;
-use relay_common_actors::controller::{Controller, Shutdown};
 
 pub struct Healthcheck {
     is_shutting_down: bool,

--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -1,10 +1,7 @@
 //! Defines all actors of the relay.
 //!
-//! Actors require an actix system to run. The system can be started using the
-//! [`Controller`](relay_common_actors::controller::Controller) actor, which will also listen for shutdown signals and
-//! trigger a graceful shutdown. Note that actors must implement a handler for the
-//! [`Shutdown`](relay_common_actors::controller::Shutdown) message and register with the controller to receive this
-//! signal. See the struct level documentation for more information.
+//! Actors require an actix system to run, see [`relay_system`] and particularly
+//! [`Controller`](relay_system::Controller) for more information.
 //!
 //! The web server is wrapped by the [`Server`](server::Server) actor. It starts the actix http web
 //! server and relays the graceful shutdown signal. Internally, it creates several other actors

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -1,19 +1,20 @@
 //! This module contains the outcomes aggregator, which collects similar outcomes into groups
 //! and flushed them periodically.
 
-use std::{collections::HashMap, net::IpAddr};
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::Duration;
 
 use actix::{Actor, AsyncContext, Context, Handler, Recipient, Supervised, SystemService};
+
 use relay_common::{DataCategory, UnixTimestamp};
-use relay_common_actors::controller::{Controller, Shutdown};
 use relay_config::{Config, EmitOutcomes};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
-use std::time::Duration;
+use relay_system::{Controller, Shutdown};
 
-use crate::{actors::outcome::DiscardReason, statsd::RelayTimers};
-
-use super::outcome::{Outcome, OutcomeError, TrackOutcome};
+use crate::actors::outcome::{DiscardReason, Outcome, OutcomeError, TrackOutcome};
+use crate::statsd::RelayTimers;
 
 /// Contains everything to construct a `TrackOutcome`, except quantity
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -4,10 +4,10 @@ use futures::prelude::*;
 
 use relay_config::Config;
 use relay_statsd::metric;
+use relay_system::{Controller, Shutdown};
 
 use crate::service;
 use crate::statsd::RelayCounters;
-use relay_common_actors::controller::{Controller, Shutdown};
 
 pub use crate::service::ServerError;
 

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -266,9 +266,9 @@ mod statsd;
 mod utils;
 
 use relay_config::Config;
+use relay_system::Controller;
 
 use crate::actors::server::Server;
-use relay_common_actors::controller::Controller;
 
 pub use crate::service::ServerError;
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -10,6 +10,7 @@ use listenfd::ListenFd;
 use relay_config::Config;
 use relay_metrics::Aggregator;
 use relay_redis::RedisPool;
+use relay_system::{Configure, Controller};
 
 use crate::actors::envelopes::{EnvelopeManager, EnvelopeProcessor};
 use crate::actors::healthcheck::Healthcheck;
@@ -22,7 +23,6 @@ use crate::endpoints;
 use crate::middlewares::{
     AddCommonHeaders, ErrorHandlers, Metrics, ReadRequestMiddleware, SentryMiddleware,
 };
-use relay_common_actors::controller::{Configure, Controller};
 
 /// Common error type for the relay server.
 #[derive(Debug)]

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "relay-common-actors"
+name = "relay-system"
 authors = ["Sentry <oss@sentry.io>"]
-description = "Actors used by multiple services in Relay"
+description = "Foundational system components for Relay's services"
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"
 version = "22.4.0"

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -1,13 +1,9 @@
-//! Defines an actor to control system run and shutdown.
-//!
-//! See the [`Controller`] struct for more information.
-
 use std::fmt;
 use std::time::Duration;
 
-use ::actix::actors::signal;
-use ::actix::fut;
-use ::actix::prelude::*;
+use actix::actors::signal;
+use actix::fut;
+use actix::prelude::*;
 use futures::future;
 use futures::prelude::*;
 
@@ -26,8 +22,10 @@ use futures::prelude::*;
 ///
 /// ### Example
 ///
-/// ```ignore
-/// # use ::actix::prelude::*;
+/// ```
+/// use actix::prelude::*;
+/// use relay_system::{Controller, Shutdown};
+///
 /// struct MyActor;
 ///
 /// impl Actor for MyActor {
@@ -47,10 +45,12 @@ use futures::prelude::*;
 ///     }
 /// }
 ///
-/// Controller::run(|| {
+///
+/// Controller::run(|| -> Result<(), ()> {
 ///     MyActor.start();
-///     # System::current().stop()
-/// })
+///     # System::current().stop();
+///     Ok(())
+/// }).unwrap();
 /// ```
 pub struct Controller {
     /// Configured timeout for graceful shutdowns.

--- a/relay-system/src/lib.rs
+++ b/relay-system/src/lib.rs
@@ -1,0 +1,18 @@
+//! Foundational system components for Relay's services.
+//!
+//! Actors require an actix system to run. The system can be started using the [`Controller`] actor,
+//! which will also listen for shutdown signals and trigger a graceful shutdown. Note that actors
+//! must implement a handler for the [`Shutdown`] message and register with the controller to
+//! receive this signal. See the struct level documentation for more information.
+//!
+//! See the [`Controller`] struct for more information.
+
+#![warn(missing_docs)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
+    html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
+)]
+
+mod controller;
+
+pub use self::controller::*;

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -46,6 +46,7 @@
 //!  - [`relay-sampling`]: Dynamic sampling functionality.
 //!  - [`relay-statsd`]: High-level StatsD metric client for internal measurements.
 //!  - [`relay-server`]: Endpoints and services.
+//!  - [`relay-system`]: Foundational system components for Relay's services.
 //!  - [`relay-test`]: Helpers for testing the web server and services.
 //!
 //! # Tools
@@ -75,6 +76,7 @@
 //! [`relay-sampling`]: ../relay_sampling/index.html
 //! [`relay-statsd`]: ../relay_statsd/index.html
 //! [`relay-server`]: ../relay_server/index.html
+//! [`relay-system`]: ../relay_system/index.html
 //! [`relay-test`]: ../relay_test/index.html
 //! [`document-metrics`]: ../document_metrics/index.html
 //! [`generate-schema`]: ../generate_schema/index.html


### PR DESCRIPTION
Renames the `relay-common-actors` crate to `relay-system`, updates exports, and re-enables the doc test. Going forward, this crate can become the place for foundational system utilities and logic. 

#skip-changelog