### PR TITLE
fix(ci): Update APT caches before installing libcurl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
 
     steps:
       - name: Install libcurl-dev
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: actions/checkout@v2
         with:
@@ -117,7 +119,9 @@ jobs:
 
     steps:
       - name: Install libcurl-dev
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: actions/checkout@v2
         with:
@@ -216,7 +220,9 @@ jobs:
 
     steps:
       - name: Install libcurl-dev
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - name: Install libcurl-dev
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
CI is failing because it's trying to install a version of libcurl not available anymore. We need to update the package list to fix it. Usually, GitHub would publish a new version so that might just be a temporary fix.

#skip-changelog
