### PR TITLE
feat(profiling): Add a profile data category and count profiles in an envelope to apply rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add the client and version as `sdk` tag to extracted session metrics in the format `name/version`. ([#1248](https://github.com/getsentry/relay/pull/1248))
 - Expose `shutdown_timeout` in `OverridableConfig` ([#1247](https://github.com/getsentry/relay/pull/1247))
 - Raise a new InvalidCompression Outcome for invalid Unreal compression. ([#1237](https://github.com/getsentry/relay/pull/1237))
+- Add a profile data category and count profiles in an envelope to apply rate limits. ([#1259](https://github.com/getsentry/relay/pull/1259))
 
 ## 22.4.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add protocol support for custom units on transaction measurements. ([#1256](https://github.com/getsentry/relay/pull/1256))
+- Add a profile data category and count profiles in an envelope to apply rate limits. ([#1259](https://github.com/getsentry/relay/pull/1259))
 
 ## 0.8.10
 

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -107,6 +107,8 @@ pub enum DataCategory {
     Attachment = 4,
     /// Session updates. Quantity is the number of updates in the batch.
     Session = 5,
+    /// A profile
+    Profile = 6,
     /// Any other data category not known by this Relay.
     #[serde(other)]
     Unknown = -1,
@@ -122,6 +124,7 @@ impl DataCategory {
             "security" => Self::Security,
             "attachment" => Self::Attachment,
             "session" => Self::Session,
+            "profile" => Self::Profile,
             _ => Self::Unknown,
         }
     }
@@ -135,6 +138,7 @@ impl DataCategory {
             Self::Security => "security",
             Self::Attachment => "attachment",
             Self::Session => "session",
+            Self::Profile => "profile",
             Self::Unknown => "unknown",
         }
     }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -103,7 +103,8 @@ impl CategoryUnit {
             DataCategory::Default
             | DataCategory::Error
             | DataCategory::Transaction
-            | DataCategory::Security => Some(Self::Count),
+            | DataCategory::Security
+            | DataCategory::Profile => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
             DataCategory::Session => Some(Self::Batched),
             DataCategory::Unknown => None,

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -647,7 +647,7 @@ impl Item {
             ItemType::Metrics => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
-            ItemType::Profile => false,
+            ItemType::Profile => true,
 
             // Since this Relay cannot interpret the semantics of this item, it does not know
             // whether it requires an event or not. Depending on the strategy, this can cause two

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -103,7 +103,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
-        ItemType::Profile => Some(DataCategory::Profile),
+        ItemType::Profile => None,
         ItemType::ClientReport => None,
         ItemType::Unknown(_) => None,
     }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -103,7 +103,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
-        ItemType::Profile => None,
+        ItemType::Profile => Some(DataCategory::Profile),
         ItemType::ClientReport => None,
         ItemType::Unknown(_) => None,
     }
@@ -124,6 +124,9 @@ pub struct EnvelopeSummary {
 
     /// The number of all session updates.
     pub session_quantity: usize,
+
+    /// The number of profiles.
+    pub profile_quantity: usize,
 
     /// Indicates that the envelope contains regular attachments that do not create event payloads.
     pub has_plain_attachments: bool,
@@ -156,6 +159,7 @@ impl EnvelopeSummary {
             match item.ty() {
                 ItemType::Attachment => summary.attachment_quantity += item.len().max(1),
                 ItemType::Session => summary.session_quantity += 1,
+                ItemType::Profile => summary.profile_quantity += 1,
                 _ => (),
             }
         }
@@ -228,6 +232,8 @@ pub struct Enforcement {
     attachments: CategoryLimit,
     /// The combined session item rate limit.
     sessions: CategoryLimit,
+    /// The combined profile item rate limit.
+    profiles: CategoryLimit,
 }
 
 impl Enforcement {
@@ -400,6 +406,17 @@ where
                 session_limits.longest(),
             );
             rate_limits.merge(session_limits);
+        }
+
+        if summary.profile_quantity > 0 {
+            let item_scoping = scoping.item(DataCategory::Profile);
+            let profile_limits = (self.check)(item_scoping, summary.profile_quantity)?;
+            enforcement.profiles = CategoryLimit::new(
+                DataCategory::Profile,
+                summary.profile_quantity,
+                profile_limits.longest(),
+            );
+            rate_limits.merge(profile_limits);
         }
 
         Ok((enforcement, rate_limits))


### PR DESCRIPTION
This PR aims to add the necessary code to count and apply rate limits to profiles. Right now, we don't want to apply any as we're in beta but we'd like to be ready for when we'd want to rate limit.

Ref https://github.com/getsentry/relay/issues/1258