### PR TITLE
ref: Use Duration to compute breakdowns and span durations [INGEST-1131]

### DIFF
--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -48,6 +48,16 @@ pub fn duration_to_millis(duration: Duration) -> f64 {
 /// let millis = relay_common::signed_duration_to_millis(duration);
 /// assert_eq!(millis, 2.125);
 /// ```
+///
+/// Negative durations are clamped to `0`:
+///
+/// ```
+/// use chrono::Duration;
+///
+/// let duration = Duration::nanoseconds(-2_125_000);
+/// let millis = relay_common::signed_duration_to_millis(duration);
+/// assert_eq!(millis, 0.0);
+/// ```
 pub fn signed_duration_to_millis(duration: chrono::Duration) -> f64 {
     duration_to_millis(duration.to_std().unwrap_or_default())
 }

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -18,8 +18,7 @@ pub fn instant_to_date_time(instant: Instant) -> chrono::DateTime<chrono::Utc> {
 
 /// Returns the number of milliseconds contained by this `Duration` as `f64`.
 ///
-/// The returned value does include the fractional (nanosecond) part of the duration. Precision of
-/// returned numbers is capped at microseconds to prevent rounding artifacts.
+/// The returned value does include the fractional (nanosecond) part of the duration.
 ///
 /// # Example
 ///
@@ -31,7 +30,7 @@ pub fn instant_to_date_time(instant: Instant) -> chrono::DateTime<chrono::Utc> {
 /// assert_eq!(millis, 2.125);
 /// ```
 pub fn duration_to_millis(duration: Duration) -> f64 {
-    (duration.as_secs_f64() * 1_000_000f64).round() / 1_000f64
+    (duration.as_secs_f64() * 1_000_000_000f64).round() / 1_000_000f64
 }
 
 /// Returns the positive number of milliseconds contained by this `Duration` as `f64`.
@@ -49,7 +48,7 @@ pub fn duration_to_millis(duration: Duration) -> f64 {
 /// assert_eq!(millis, 2.125);
 /// ```
 ///
-/// Negative durations are clamped to `0`:
+/// Negative durations are clamped to `0.0`:
 ///
 /// ```
 /// use chrono::Duration;

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -16,6 +16,42 @@ pub fn instant_to_date_time(instant: Instant) -> chrono::DateTime<chrono::Utc> {
     instant_to_system_time(instant).into()
 }
 
+/// Returns the number of milliseconds contained by this `Duration` as `f64`.
+///
+/// The returned value does include the fractional (nanosecond) part of the duration. Precision of
+/// returned numbers is capped at microseconds to prevent rounding artifacts.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+///
+/// let duration = Duration::from_nanos(2_125_000);
+/// let millis = relay_common::duration_to_millis(duration);
+/// assert_eq!(millis, 2.125);
+/// ```
+pub fn duration_to_millis(duration: Duration) -> f64 {
+    (duration.as_secs_f64() * 1_000_000f64).round() / 1_000f64
+}
+
+/// Returns the positive number of milliseconds contained by this `Duration` as `f64`.
+///
+/// The returned value does include the fractional (nanosecond) part of the duration. If the
+/// duration is negative, this returns `0.0`;
+///
+/// # Example
+///
+/// ```
+/// use chrono::Duration;
+///
+/// let duration = Duration::nanoseconds(2_125_000);
+/// let millis = relay_common::signed_duration_to_millis(duration);
+/// assert_eq!(millis, 2.125);
+/// ```
+pub fn signed_duration_to_millis(duration: chrono::Duration) -> f64 {
+    duration_to_millis(duration.to_std().unwrap_or_default())
+}
+
 /// The conversion result of [`UnixTimestamp::to_instant`].
 ///
 /// If the time is outside of what can be represented in an [`Instant`], this is `Past` or

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -44,7 +44,7 @@ pub fn duration_to_millis(duration: Duration) -> f64 {
 /// use chrono::Duration;
 ///
 /// let duration = Duration::nanoseconds(2_125_000);
-/// let millis = relay_common::signed_duration_to_millis(duration);
+/// let millis = relay_common::chrono_to_positive_millis(duration);
 /// assert_eq!(millis, 2.125);
 /// ```
 ///
@@ -54,10 +54,10 @@ pub fn duration_to_millis(duration: Duration) -> f64 {
 /// use chrono::Duration;
 ///
 /// let duration = Duration::nanoseconds(-2_125_000);
-/// let millis = relay_common::signed_duration_to_millis(duration);
+/// let millis = relay_common::chrono_to_positive_millis(duration);
 /// assert_eq!(millis, 0.0);
 /// ```
-pub fn signed_duration_to_millis(duration: chrono::Duration) -> f64 {
+pub fn chrono_to_positive_millis(duration: chrono::Duration) -> f64 {
     duration_to_millis(duration.to_std().unwrap_or_default())
 }
 

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::iter::{FromIterator, IntoIterator};
 use std::net;
-use std::ops::{Add, Deref, DerefMut};
+use std::ops::{Add, Sub};
 use std::str::FromStr;
 
 use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDateTime, TimeZone, Utc};
@@ -892,25 +892,19 @@ impl From<DateTime<Utc>> for Timestamp {
     }
 }
 
-impl Deref for Timestamp {
-    type Target = DateTime<Utc>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Timestamp {
-    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
-        &mut self.0
-    }
-}
-
 impl Add<Duration> for Timestamp {
     type Output = Self;
 
     fn add(self, duration: Duration) -> Self::Output {
         Timestamp(self.0 + duration)
+    }
+}
+
+impl Sub<Timestamp> for Timestamp {
+    type Output = chrono::Duration;
+
+    fn sub(self, rhs: Timestamp) -> Self::Output {
+        self.into_inner() - rhs.into_inner()
     }
 }
 

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -171,7 +171,7 @@ impl<'a> NormalizeProcessor<'a> {
             Ok(())
         })?;
 
-        ClockDriftProcessor::new(sent_at.map(|x| *x), received_at)
+        ClockDriftProcessor::new(sent_at.map(|ts| ts.into_inner()), received_at)
             .error_kind(error_kind)
             .process_event(event, meta, state)?;
 

--- a/relay-general/src/store/normalize/spans.rs
+++ b/relay-general/src/store/normalize/spans.rs
@@ -19,8 +19,7 @@ fn interval_exclusive_time(mut parent: TimeWindowSpan, intervals: &[TimeWindowSp
         }
 
         // Add time in the parent before the start of the current interval to the exclusive time
-        let start = interval.start.min(parent.end);
-        if let Ok(start_offset) = (start - parent.start).to_std() {
+        if let Ok(start_offset) = (interval.start - parent.start).to_std() {
             exclusive_time += start_offset;
         }
 

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -23,13 +23,13 @@ pub fn get_transaction_op(transaction: &Event) -> Option<&str> {
 /// Returns start and end timestamps if they are both set and start <= end.
 pub fn validate_timestamps(
     transaction_event: &Event,
-) -> Result<(&Timestamp, &Timestamp), ProcessingAction> {
+) -> Result<(Timestamp, Timestamp), ProcessingAction> {
     match (
         transaction_event.start_timestamp.value(),
         transaction_event.timestamp.value(),
     ) {
-        (Some(start), Some(end)) => {
-            if *end < *start {
+        (Some(&start), Some(&end)) => {
+            if end < start {
                 return Err(ProcessingAction::InvalidTransaction(
                     "end timestamp is smaller than start timestamp",
                 ));

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -434,10 +434,10 @@ impl FieldValueProvider for Event {
             },
             "event.duration" => match (self.ty.value(), store::validate_timestamps(self)) {
                 (Some(&EventType::Transaction), Ok((start, end))) => {
-                    let start = start.timestamp_millis();
-                    let end = end.timestamp_millis();
-
-                    Value::Number(end.saturating_sub(start).into())
+                    match Number::from_f64(relay_common::signed_duration_to_millis(end - start)) {
+                        Some(num) => Value::Number(num),
+                        None => Value::Null,
+                    }
                 }
                 _ => Value::Null,
             },

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -434,7 +434,7 @@ impl FieldValueProvider for Event {
             },
             "event.duration" => match (self.ty.value(), store::validate_timestamps(self)) {
                 (Some(&EventType::Transaction), Ok((start, end))) => {
-                    match Number::from_f64(relay_common::signed_duration_to_millis(end - start)) {
+                    match Number::from_f64(relay_common::chrono_to_positive_millis(end - start)) {
                         Some(num) => Value::Number(num),
                         None => Value::Null,
                     }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -131,23 +131,14 @@ impl UserSatisfaction {
     }
 }
 
-/// Get duration from timestamp and `start_timestamp`.
-#[cfg(feature = "processing")]
-fn get_duration_millis(start: &Timestamp, end: &Timestamp) -> f64 {
-    let start = start.timestamp_millis();
-    let end = end.timestamp_millis();
-
-    end.saturating_sub(start) as f64
-}
-
 /// Extract the the satisfaction value depending on the actual measurement/duration value
 /// and the configured threshold.
 #[cfg(feature = "processing")]
 fn extract_user_satisfaction(
     config: &Option<SatisfactionConfig>,
     transaction: &Event,
-    start_timestamp: &Timestamp,
-    end_timestamp: &Timestamp,
+    start_timestamp: Timestamp,
+    end_timestamp: Timestamp,
 ) -> Option<UserSatisfaction> {
     if let Some(config) = config {
         let threshold = transaction
@@ -156,9 +147,9 @@ fn extract_user_satisfaction(
             .and_then(|name| config.transaction_thresholds.get(name))
             .unwrap_or(&config.project_threshold);
         if let Some(value) = match threshold.metric {
-            SatisfactionMetric::Duration => {
-                Some(get_duration_millis(start_timestamp, end_timestamp))
-            }
+            SatisfactionMetric::Duration => Some(relay_common::signed_duration_to_millis(
+                end_timestamp - start_timestamp,
+            )),
             SatisfactionMetric::Lcp => store::get_measurement(transaction, "lcp"),
             SatisfactionMetric::Unknown => None,
         } {
@@ -395,7 +386,7 @@ fn extract_transaction_metrics_inner(
     };
 
     // Duration
-    let duration_millis = get_duration_millis(start_timestamp, end_timestamp);
+    let duration_millis = relay_common::signed_duration_to_millis(end_timestamp - start_timestamp);
 
     push_metric(Metric::new_mri(
         METRIC_NAMESPACE,

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -147,7 +147,7 @@ fn extract_user_satisfaction(
             .and_then(|name| config.transaction_thresholds.get(name))
             .unwrap_or(&config.project_threshold);
         if let Some(value) = match threshold.metric {
-            SatisfactionMetric::Duration => Some(relay_common::signed_duration_to_millis(
+            SatisfactionMetric::Duration => Some(relay_common::chrono_to_positive_millis(
                 end_timestamp - start_timestamp,
             )),
             SatisfactionMetric::Lcp => store::get_measurement(transaction, "lcp"),
@@ -386,7 +386,7 @@ fn extract_transaction_metrics_inner(
     };
 
     // Duration
-    let duration_millis = relay_common::signed_duration_to_millis(end_timestamp - start_timestamp);
+    let duration_millis = relay_common::chrono_to_positive_millis(end_timestamp - start_timestamp);
 
     push_metric(Metric::new_mri(
         METRIC_NAMESPACE,


### PR DESCRIPTION
Instead of using raw `f64`, this PR switches to using `Duration` for computing span durations and breakdowns. This allows to pass the values around without the additional knowledge in which unit they are. Currently, this was _only_ described in comments.

As part of this refactor, I'm simplifying the actual computation algorithm. There are two repeated changes:
- Remove redundant code. Especially in time_spent, there were redundant allocations when collecting spans.
- When converting durations to float milliseconds, do not drop the sub-millisecond part. 
- Use interval clamping rather than a series of comparisons.

It was actually not necessary to perform this refactor just for introducing custom units because breakdowns are always created as milliseconds within Relay.

This is a follow-up to #1256
#skip-changelog