### PR TITLE
deps: Update symbolic to pull in Unreal parser fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix(metrics): Enforce metric name length limit. ([#1238](https://github.com/getsentry/relay/pull/1238))
 - Accept and forward unknown Envelope items. In processing mode, drop items individually rather than rejecting the entire request. This allows SDKs to send new data in combined Envelopes in the future. ([#1246](https://github.com/getsentry/relay/pull/1246))
 - Stop extracting metrics with outdated names from sessions. ([#1251](https://github.com/getsentry/relay/pull/1251), [#1252](https://github.com/getsentry/relay/pull/1252))
+- Update symbolic to pull in fixed Unreal parser that now correctly handles zero-length files. ([#1266](https://github.com/getsentry/relay/pull/1266))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,7 +3492,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "smallvec 1.4.0",
- "symbolic",
+ "symbolic-common",
+ "symbolic-unreal",
  "take_mut",
  "tokio 1.0.1",
  "tokio-timer",
@@ -4210,16 +4211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
-name = "symbolic"
-version = "8.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d106718e554ccee68ddf0aba37a583ae993965946e78f3f3525ae73a5f8034af"
-dependencies = [
- "symbolic-common",
- "symbolic-unreal",
-]
-
-[[package]]
 name = "symbolic-common"
 version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,7 +4218,6 @@ checksum = "65098afa1f1ca8991e4c6f4a6c03a661838e8f464c8bbafab9c2f1a3fa913b7f"
 dependencies = [
  "debugid",
  "memmap2",
- "serde",
  "stable_deref_trait",
  "uuid 0.8.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,9 +4211,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "symbolic"
-version = "8.7.0"
+version = "8.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb7f79d0216069be1326a604e8cc483c3c2c08bf8ac6061db40e9f4a2319d91"
+checksum = "d106718e554ccee68ddf0aba37a583ae993965946e78f3f3525ae73a5f8034af"
 dependencies = [
  "symbolic-common",
  "symbolic-unreal",
@@ -4221,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.7.0"
+version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6aac7b803adc9ee75344af7681969f76d4b38e4723c6eaacf3b28f5f1d87ff"
+checksum = "65098afa1f1ca8991e4c6f4a6c03a661838e8f464c8bbafab9c2f1a3fa913b7f"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4234,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unreal"
-version = "8.7.0"
+version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e355e20fa321130ba3aba0027a8933d923d3eeff25c93c48bbe041a460d9b1"
+checksum = "26122a242f752060f8844a583c9ef085fe214ac708adb0053ccd02b29a64726b"
 dependencies = [
  "anylog",
  "bytes 1.1.0",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic = { version = "8.7.0", optional = true, default-features=false, features=["unreal-serde"] }
+symbolic = { version = "8.7.2", optional = true, default-features=false, features=["unreal-serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -21,7 +21,8 @@ processing = [
     "relay-config/processing",
     "relay-quotas/redis",
     "relay-redis/impl",
-    "symbolic",
+    "symbolic-unreal",
+    "symbolic-common",
 ]
 
 [dependencies]
@@ -66,7 +67,8 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic = { version = "8.7.2", optional = true, default-features=false, features=["unreal-serde"] }
+symbolic-common = { version = "8.7.2", optional = true, default-features=false }
+symbolic-unreal = { version = "8.7.2", optional = true, default-features=false, features=["serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -68,7 +68,7 @@ use {
     failure::ResultExt,
     relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
     relay_quotas::{RateLimitingError, RedisRateLimiter},
-    symbolic::unreal::{Unreal4Error, Unreal4ErrorKind},
+    symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
 };
 
 /// The minimum clock drift for correction to apply.

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -345,18 +345,18 @@ pub enum AttachmentType {
     /// This is a binary attachment present in Unreal 4 events containing event context information.
     ///
     /// This can be deserialized using the `symbolic` crate see
-    /// [`symbolic::unreal::Unreal4Context`].
+    /// [`symbolic_unreal::Unreal4Context`].
     ///
-    /// [`symbolic::unreal::Unreal4Context`]: https://docs.rs/symbolic/*/symbolic/unreal/struct.Unreal4Context.html
+    /// [`symbolic_unreal::Unreal4Context`]: https://docs.rs/symbolic/*/symbolic/unreal/struct.Unreal4Context.html
     #[serde(rename = "unreal.context")]
     UnrealContext,
 
     /// This is a binary attachment present in Unreal 4 events containing event Logs.
     ///
     /// This can be deserialized using the `symbolic` crate see
-    /// [`symbolic::unreal::Unreal4LogEntry`].
+    /// [`symbolic_unreal::Unreal4LogEntry`].
     ///
-    /// [`symbolic::unreal::Unreal4LogEntry`]: https://docs.rs/symbolic/*/symbolic/unreal/struct.Unreal4LogEntry.html
+    /// [`symbolic_unreal::Unreal4LogEntry`]: https://docs.rs/symbolic/*/symbolic/unreal/struct.Unreal4LogEntry.html
     #[serde(rename = "unreal.logs")]
     UnrealLogs,
 }

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -136,7 +136,7 @@ fn write_crashpad_annotations(
         // context type must be set explicitly in this case, which will render in Sentry as
         // "Module.dll (crashpad)".
         let code_file = module.code_file();
-        let (_, module_name) = symbolic::common::split_path(&code_file);
+        let (_, module_name) = symbolic_common::split_path(&code_file);
 
         let mut module_context = BTreeMap::new();
         module_context.insert(

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -1,5 +1,5 @@
 use chrono::{TimeZone, Utc};
-use symbolic::unreal::{
+use symbolic_unreal::{
     Unreal4Context, Unreal4Crash, Unreal4Error, Unreal4ErrorKind, Unreal4FileType, Unreal4LogEntry,
 };
 


### PR DESCRIPTION
The updated Unreal parser can now correctly parse Unreal Archives with zero-length files.

Requires https://github.com/getsentry/publish/issues/1070