### PR TITLE
feat(sampling): Support custom tags and more contexts [TET-23]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Normalize all profiles and reject invalid ones. ([#1250](https://github.com/getsentry/relay/pull/1250))
 - Raise a new InvalidCompression Outcome for invalid Unreal compression. ([#1237](https://github.com/getsentry/relay/pull/1237))
 - Add a profile data category and count profiles in an envelope to apply rate limits. ([#1259](https://github.com/getsentry/relay/pull/1259))
+- Support dynamic sampling by custom tags, operating system name and version, as well as device name and family. ([#1268](https://github.com/getsentry/relay/pull/1268))
 
 ## 22.4.0
 

--- a/relay-general/src/protocol/tags.rs
+++ b/relay-general/src/protocol/tags.rs
@@ -46,6 +46,18 @@ impl FromValue for TagEntry {
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct Tags(pub PairList<TagEntry>);
 
+impl Tags {
+    /// Returns a reference to the value of the tag, if it exists.
+    ///
+    /// If the tag with the specified key exists multiple times, the first instance is returned. If
+    /// no tag with the given key exists or the tag entry is erroneous, `None` is returned`.
+    ///
+    /// To retrieve the [`Annotated`] wrapper of the tag value, use [`PairList::get`] instead.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.0.get_value(key).map(String::as_str)
+    }
+}
+
 impl std::ops::Deref for Tags {
     type Target = Array<TagEntry>;
 

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -211,6 +211,33 @@ where
             .position(|entry| entry.as_pair().0.as_str() == Some(key))
     }
 
+    /// Returns a reference to the annotated value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the pairlist's key type. If there are multiple entries
+    /// with the same key, the first is returned.
+    pub fn get<'a, Q>(&'a self, key: Q) -> Option<&Annotated<V>>
+    where
+        Q: AsRef<str>,
+        K: 'a,
+    {
+        self.position(key)
+            .and_then(|pos| self.0.get(pos))
+            .and_then(Annotated::value)
+            .map(|pair| pair.as_pair().1)
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the pairlist's key type. If there are multiple entries
+    /// with the same key, the first is returned.
+    pub fn get_value<'a, Q>(&'a self, key: Q) -> Option<&V>
+    where
+        Q: AsRef<str>,
+        K: 'a,
+    {
+        self.get(key).and_then(Annotated::value)
+    }
+
     /// Returns `true` if the pair list contains a value for the specified key.
     pub fn contains<Q>(&self, key: Q) -> bool
     where


### PR DESCRIPTION
Adds the capability to run dynamic sampling for individual events on the
following fields:

- `contexts.os.name`
- `contexts.os.version`
- `contexts.device.name`
- `contexts.device.family`
- `tags.*`

cc @matejminar 