### PR TITLE
fix(ci): Use correct trigger condition for CLA

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -8,6 +8,7 @@ on:
       - release-library/**
 
   pull_request:
+    branches: [master]
 
 jobs:
   enforce-license-compliance:

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,15 +2,18 @@ name: Enforce License Compliance
 
 on:
   push:
-    branches: [master, release/*]
+    branches:
+      - master
+      - release/**
+      - release-library/**
+
   pull_request:
-    branches: [master]
 
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Enforce License Compliance'
+      - name: "Enforce License Compliance"
         uses: getsentry/action-enforce-license-compliance@main
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
~CLA checks did not run in pull requests because they were seemingly restricted to run just on the master branch. The [GitHub docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request) on triggers are ambiguous. On one hand, they mention that `branches` filters for the _target_ branch, and later in a note mention that it filters the branch they are opened on.~

~See https://github.com/getsentry/relay/pull/1263 for an example where this is currently not working.~

This PR enables CLA checks on library release branches.

#skip-changelog