### PR TITLE
fix(statsd): Emit specific event type tags for "processing.event.produced" metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Emit specific event type tags for "processing.event.produced" metric. ([#1270](https://github.com/getsentry/relay/pull/1270))
+
 ## 22.5.0
 
 **Features**:

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -780,7 +780,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
             self.produce(topic, event_message)?;
             metric!(
                 counter(RelayCounters::ProcessingMessageProduced) += 1,
-                event_type = "event"
+                event_type = &event_item.ty().to_string()
             );
         } else if !attachments.is_empty() {
             relay_log::trace!("Sending individual attachments of envelope to kafka");


### PR DESCRIPTION
This, for example, fixes the case when transactions are reported as generic "events".

Note: as discussed internally, `event_type` might not be the best name for this tag anymore, since "event" actually means "error" in some contexts.