### PR TITLE
feat(profiling): Add support for profile outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Add version 3 to the project configs endpoint. This allows returning pending results which need to be polled later and avoids blocking batched requests on single slow entries. ([#1263](https://github.com/getsentry/relay/pull/1263))
 - Emit specific event type tags for "processing.event.produced" metric. ([#1270](https://github.com/getsentry/relay/pull/1270))
+- Add support for profile outcomes. ([#1272](https://github.com/getsentry/relay/pull/1272))
 
 ## 22.5.0
 

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -73,7 +73,7 @@ take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
 tokio-timer = "0.2.13"
 url = { version = "2.1.1", features = ["serde"] }
-uuid = { version = "0.8.1", features = ["v5", "serde"] }
+uuid = { version = "0.8.1", features = ["v5"] }
 
 [target."cfg(not(windows))".dependencies]
 libc = "0.2.71"

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -998,20 +998,20 @@ impl EnvelopeProcessor {
                     if self.config.processing_enabled() {
                         if self.parse_profile(item).is_err() {
                             let outcome_aggregator = OutcomeAggregator::from_registry();
-                       
+
                             outcome_aggregator.do_send(TrackOutcome {
                                 timestamp: context.received_at,
                                 scoping: context.scoping,
                                 outcome: Outcome::Invalid(DiscardReason::ProcessProfile),
                                 event_id: context.event_id,
                                 remote_addr: context.remote_addr,
-                                category:DataCategory::Profile,
+                                category: DataCategory::Profile,
                                 quantity: 1,
                             });
 
                             return false;
                         }
-                        true;
+                        return true;
                     }
                     true
                 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -321,7 +321,7 @@ impl EnvelopeContext {
             outcome_aggregator.do_send(TrackOutcome {
                 timestamp: self.received_at,
                 scoping: self.scoping,
-                outcome,
+                outcome: outcome.clone(),
                 event_id: self.event_id,
                 remote_addr: self.remote_addr,
                 category: DataCategory::Attachment,
@@ -330,6 +330,18 @@ impl EnvelopeContext {
                 // do 32.
                 quantity: self.summary.attachment_quantity as u32,
             });
+        }
+
+        if self.summary.profile_quantity > 0 {
+            outcome_aggregator.do_send(TrackOutcome {
+                timestamp: self.received_at,
+                scoping: self.scoping,
+                outcome,
+                event_id: self.event_id,
+                remote_addr: self.remote_addr,
+                category: DataCategory::Profile,
+                quantity: self.summary.profile_quantity as u32,
+            })
         }
     }
 }
@@ -976,6 +988,7 @@ impl EnvelopeProcessor {
     /// Remove profiles if the feature flag is not enabled
     fn process_profiles(&self, state: &mut ProcessEnvelopeState) {
         let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
+        let context = state.envelope_context;
         state.envelope.retain_items(|item| {
             match item.ty() {
                 ItemType::Profile => {
@@ -983,7 +996,22 @@ impl EnvelopeProcessor {
                         return false;
                     }
                     if self.config.processing_enabled() {
-                        return self.parse_profile(item).is_ok();
+                        if self.parse_profile(item).is_err() {
+                            let outcome_aggregator = OutcomeAggregator::from_registry();
+                       
+                            outcome_aggregator.do_send(TrackOutcome {
+                                timestamp: context.received_at,
+                                scoping: context.scoping,
+                                outcome: Outcome::Invalid(DiscardReason::ProcessProfile),
+                                event_id: context.event_id,
+                                remote_addr: context.remote_addr,
+                                category:DataCategory::Profile,
+                                quantity: 1,
+                            });
+
+                            return false;
+                        }
+                        true;
                     }
                     true
                 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -160,10 +160,6 @@ enum ProcessingError {
 
     #[fail(display = "event dropped by sampling rule {}", _0)]
     EventSampled(RuleId),
-
-    #[cfg(feature = "processing")]
-    #[fail(display = "invalid profile")]
-    InvalidProfile(#[cause] ProfileError),
 }
 
 impl ProcessingError {
@@ -188,9 +184,6 @@ impl ProcessingError {
             }
             #[cfg(feature = "processing")]
             Self::InvalidUnrealReport(_) => Some(Outcome::Invalid(DiscardReason::ProcessUnreal)),
-
-            #[cfg(feature = "processing")]
-            Self::InvalidProfile(_) => Some(Outcome::Invalid(DiscardReason::ProcessProfile)),
 
             // Internal errors
             Self::SerializeFailed(_)
@@ -231,13 +224,6 @@ impl From<Unreal4Error> for ProcessingError {
             Unreal4ErrorKind::TooLarge => Self::PayloadTooLarge,
             _ => ProcessingError::InvalidUnrealReport(err),
         }
-    }
-}
-
-#[cfg(feature = "processing")]
-impl From<ProfileError> for ProcessingError {
-    fn from(err: ProfileError) -> Self {
-        ProcessingError::InvalidProfile(err)
     }
 }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -420,12 +420,14 @@ impl StoreForwarder {
         &self,
         organization_id: u64,
         project_id: ProjectId,
+        key_id: Option<u64>,
         start_time: Instant,
         item: &Item,
     ) -> Result<(), StoreError> {
         let message = ProfileKafkaMessage {
             organization_id,
             project_id,
+            key_id,
             received: UnixTimestamp::from_instant(start_time).as_secs(),
             payload: item.payload(),
         };
@@ -607,6 +609,7 @@ struct MetricKafkaMessage {
 struct ProfileKafkaMessage {
     organization_id: u64,
     project_id: ProjectId,
+    key_id: Option<u64>,
     received: u64,
     payload: Bytes,
 }
@@ -759,6 +762,7 @@ impl Handler<StoreEnvelope> for StoreForwarder {
                 ItemType::Profile => self.produce_profile(
                     scoping.organization_id,
                     scoping.project_id,
+                    scoping.key_id,
                     start_time,
                     item,
                 )?,

--- a/relay-server/src/utils/profile.rs
+++ b/relay-server/src/utils/profile.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 
 use android_trace_log::AndroidTraceLog;
 use serde::{de, Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::envelope::{ContentType, Item};
 use relay_general::protocol::{Addr, DebugId, EventId, NativeImagePath};
@@ -58,8 +57,8 @@ where
 struct AndroidProfile {
     android_api_level: u16,
 
-    #[serde(default, skip_serializing_if = "Uuid::is_nil")]
-    build_id: Uuid,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    build_id: String,
 
     device_cpu_frequencies: Vec<u32>,
     device_is_emulator: bool,
@@ -79,8 +78,8 @@ struct AndroidProfile {
     environment: String,
 
     platform: String,
-    profile_id: Uuid,
-    trace_id: Uuid,
+    profile_id: EventId,
+    trace_id: EventId,
     transaction_id: EventId,
     transaction_name: String,
     version_code: String,
@@ -226,9 +225,9 @@ struct CocoaProfile {
     environment: String,
 
     platform: String,
-    profile_id: Uuid,
+    profile_id: EventId,
     sampled_profile: SampledProfile,
-    trace_id: Uuid,
+    trace_id: EventId,
     transaction_id: EventId,
     transaction_name: String,
     version_code: String,

--- a/relay-server/src/utils/profile.rs
+++ b/relay-server/src/utils/profile.rs
@@ -8,7 +8,7 @@ use serde::{de, Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::envelope::{ContentType, Item};
-use relay_general::protocol::{Addr, DebugId, NativeImagePath};
+use relay_general::protocol::{Addr, DebugId, EventId, NativeImagePath};
 
 #[derive(Debug, Fail)]
 pub enum ProfileError {
@@ -81,7 +81,7 @@ struct AndroidProfile {
     platform: String,
     profile_id: Uuid,
     trace_id: Uuid,
-    transaction_id: Uuid,
+    transaction_id: EventId,
     transaction_name: String,
     version_code: String,
     version_name: String,
@@ -229,7 +229,7 @@ struct CocoaProfile {
     profile_id: Uuid,
     sampled_profile: SampledProfile,
     trace_id: Uuid,
-    transaction_id: Uuid,
+    transaction_id: EventId,
     transaction_name: String,
     version_code: String,
     version_name: String,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -242,7 +242,7 @@ impl Enforcement {
     /// Relay generally does not emit outcomes for sessions, so those are skipped.
     pub fn track_outcomes(self, envelope: &Envelope, scoping: &Scoping) {
         // Do not report outcomes for sessions.
-        for limit in [self.event, self.attachments] {
+        for limit in [self.event, self.attachments, self.profiles] {
             if limit.is_active() {
                 let timestamp = relay_common::instant_to_date_time(envelope.meta().start_time());
                 OutcomeAggregator::from_registry().do_send(TrackOutcome {


### PR DESCRIPTION
This PR aims to add support for profile outcomes.

More specifically, here  the `RateLimited` and `Invalid` outcomes are taken care of while the `Accepted` outcome is handled in the `Sentry` code (PR will follow).

I'm currently using `event_id` when emitting the outcome.  I'm open to discuss whether we should go with `profile_id` instead or not.