### PR TITLE
fix(metrics): Count crashed+abnormal towards errored_preaggr [INGEST-1343]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Compatibility:** This version of Relay requires Sentry server `22.6.0` or newer.
 
+**Features**:
+
+- Session metrics extraction: Count crashed+abnormal towards errored_preaggr. ([#1274](https://github.com/getsentry/relay/pull/1274))
+
 **Internal**:
 
 - Add version 3 to the project configs endpoint. This allows returning pending results which need to be polled later and avoids blocking batched requests on single slow entries. ([#1263](https://github.com/getsentry/relay/pull/1263))

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -106,7 +106,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     }
 
     // Mark the session as errored, which includes fatal sessions.
-    if let Some(errors) = session.errors() {
+    if let Some(errors) = session.all_errors() {
         target.push(match errors {
             SessionErrored::Individual(session_id) => Metric::new_mri(
                 METRIC_NAMESPACE,
@@ -464,6 +464,20 @@ mod tests {
                     "release": "my-project-name@1.0.0",
                     "sdk": "sentry-test/1.0",
                     "session.status": "init",
+                },
+            },
+            Metric {
+                name: "c:sessions/session@none",
+                unit: None,
+                value: Counter(
+                    12.0,
+                ),
+                timestamp: UnixTimestamp(1581084960),
+                tags: {
+                    "environment": "development",
+                    "release": "my-project-name@1.0.0",
+                    "sdk": "sentry-test/1.0",
+                    "session.status": "errored_preaggr",
                 },
             },
             Metric {


### PR DESCRIPTION
The product expects `errored_preaggr` to contain crashed and abnormal sessions as well, see for example https://github.com/getsentry/sentry/blob/53232338eafe0ed0b9713e629fd8c56766db2f81/src/sentry/snuba/metrics/fields/base.py#L941-L961.

This was correctly implemented for individual sessions but not for aggregate sessions.

Adding crashed and abnormal to `errored_preaggr` also matches the original sessions implementation, see https://github.com/getsentry/snuba/blob/c45f2a8636f9ea3dfada4e2d0ae5efef6c6248de/snuba/migrations/snuba_migrations/sessions/0003_sessions_matview.py#L80-L81.