### PR TITLE
ci(craft): Remove duplicated `requiresName` line

### DIFF
--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -19,6 +19,5 @@ requireNames:
   - /^sentry_relay-.*-py2\.py3-none-macosx_11_0_arm64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_i686.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_x86_64.*\.whl$/
-  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_x86_64.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_aarch64.*\.whl$/
   - /^sentry-relay-.*\.zip$/


### PR DESCRIPTION
looks like this was accidentally added in #1100

#skip-changelog