### PR TITLE
build: Use Centos 7 as base image for the linux build [INGEST-1340]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Compatibility:** This version of Relay requires Sentry server `22.6.0` or newer.
 
+**Features**:
+
+- Relay is now compatible with CentOS 7 and Red Hat Enterprise Linux 7 onward (kernel version _2.6.32_), depending on _glibc 2.17_ or newer. The `crash-handler` feature, which is currently enabled in the build published to DockerHub, additionally requires _curl 7.29_ or newer. ([#1279](https://github.com/getsentry/relay/pull/1279))
+
 **Bug Fixes**:
 
 - Session metrics extraction: Count distinct_ids from all session updates to prevent undercounting users. ([#1275](https://github.com/getsentry/relay/pull/1275))

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ ENV BUILD_ARCH=${BUILD_ARCH}
 ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
 
 RUN yum -y update \
-    && yum -y install cmake curl gcc git make zip \
+    && yum -y install epel-release \
+    && yum -y install cmake3 curl gcc git make zip \
     # below required for sentry-native
     clang libcurl-devel \
     && yum clean all \
-    && rm -rf /var/cache/yum
+    && rm -rf /var/cache/yum \
+    && ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG DOCKER_ARCH=amd64
 ### Deps stage ###
 ##################
 
+FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM $DOCKER_ARCH/centos:7 AS relay-deps
 
 ARG DOCKER_ARCH
@@ -30,19 +31,19 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
+COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
+
 WORKDIR /work
 
 #####################
 ### Builder stage ###
 #####################
 
-FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM relay-deps AS relay-builder
 
 ARG RELAY_FEATURES=ssl,processing,crash-handler
 ENV RELAY_FEATURES=${RELAY_FEATURES}
 
-COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 COPY . .
 
 # Build with the modern compiler toolchain enabled

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DOCKER_ARCH=amd64
 ### Deps stage ###
 ##################
 
-FROM $DOCKER_ARCH/rust:slim-buster AS relay-deps
+FROM $DOCKER_ARCH/centos:7 AS relay-deps
 
 ARG DOCKER_ARCH
 ARG BUILD_ARCH=x86_64
@@ -14,13 +14,18 @@ ENV BUILD_ARCH=${BUILD_ARCH}
 
 ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-    curl build-essential git zip cmake \
+RUN yum -y update \
+    && yum -y install cmake curl gcc git make zip \
     # below required for sentry-native
-    clang libcurl4-openssl-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    clang libcurl-devel \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
 WORKDIR /work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
 
 RUN yum -y update \
     && yum -y install epel-release \
-    && yum -y install cmake3 curl gcc git make zip \
+    && yum -y install cmake3 curl gcc gcc-c++ git make zip \
     # below required for sentry-native
     clang libcurl-devel \
     && yum clean all \

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ requires an up-to-date Sentry development environment.
 
 ### Building and Running
 
-The easiest way to rebuild and run Relay is using `cargo`. Depending on the
-configuration, you may need to have a local instance of Sentry running.
+The easiest way to rebuild and run Relay for development is using `cargo`.
+Depending on the configuration, you may need to have a local instance of Sentry
+running.
 
 ```bash
 # Initialize Relay for the first time
@@ -108,6 +109,10 @@ used for Relays operating as proxys. There are two optional features:
   will perform full event normalization, filtering, and rate limiting.
 
 - **`ssl`**: Enables SSL support in the Server.
+
+- **`crash-handler`**: Allows native crash reporting for segfaults and
+  out-of-memory situations when internal error reporting to Sentry is enabled.
+  This requires `curl` development headers and libraries on the build system.
 
 To enable a feature, pass it to the cargo invocation. For example, to run tests
 across all workspace crates with the `processing` feature enabled, run:

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -27,6 +27,9 @@ fn main() {
         // disable additional targets
         .define("SENTRY_BUILD_TESTS", "OFF")
         .define("SENTRY_BUILD_EXAMPLES", "OFF")
+        // cmake sets the install dir to `lib64` on some platforms. since we are not installing to
+        // `/usr` or `/usr/local`, we can choose a stable directory for the link-search below.
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .build();
 
     println!(


### PR DESCRIPTION
Moves docker builds to a container based on CentOS 7, which is currently the oldest long-term supported Linux still under maintenance along with RHEL 7. This makes Relay compatible with glibc 2.17 or newer. Apart from CentOS and RHEL, this change also makes Relay compatible with the current AWS lambda runtime.

The main docker container published to the DockerHub registry continues to include `processing` and `crash-handling`, which comes with an additional dependency to `curl`. To make this work under CentOS, there was a fix necessary in the `relay-crash` native build to ensure the static library gets installed into the correct directory.

A build with all binaries can be seen [here](https://github.com/getsentry/relay/actions/runs/2372485866) ([download artifacts](https://github.com/getsentry/relay/suites/6623274152/artifacts/249548565)).

Fixes https://github.com/getsentry/relay/issues/1137

cc @antonpirker 