### PR TITLE
fix(build): Use cli git to save ram with cargo

### DIFF
--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -16,6 +16,12 @@ if [ "$AUDITWHEEL_ARCH" == "i686" ]; then
   LINUX32=linux32
 fi
 
+# Reduce memory consumption by avoiding cargo's libgit2
+cat > ~/.cargo/config <<EOF
+[net]
+git-fetch-with-cli = true
+EOF
+
 $LINUX32 /opt/python/cp37-cp37m/bin/python setup.py bdist_wheel
 
 # Audit wheels


### PR DESCRIPTION
Courtesy of @asottile-sentry in getsentry/symbolic#585. Reduces memory
consumption of docker builds.

Build runs: https://github.com/getsentry/relay/runs/6535776617?check_suite_focus=true

#skip-changelog

