### PR TITLE
feat(metrics): Track memory footprint of metrics buckets [INGEST-1132]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add support for profile outcomes. ([#1272](https://github.com/getsentry/relay/pull/1272))
 - Avoid potential panics when scrubbing minidumps. ([#1282](https://github.com/getsentry/relay/pull/1282))
 - Fix typescript profile validation. ([#1283](https://github.com/getsentry/relay/pull/1283))
+- Track memory footprint of metrics buckets. ([#1284](https://github.com/getsentry/relay/pull/1284))
 
 ## 22.5.0
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1046,7 +1046,7 @@ enum AggregatorState {
 #[derive(Debug, Default)]
 struct CostTracker {
     total_cost: usize,
-    // Chosing a BTreeMap instead of a HashMap here, under the assumption that a BTreeMap
+    // Choosing a BTreeMap instead of a HashMap here, under the assumption that a BTreeMap
     // is still more efficient for the number of project keys we store.
     cost_per_project_key: BTreeMap<ProjectKey, usize>,
 }
@@ -1970,7 +1970,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bucket_value_size() {
+    fn test_bucket_value_cost() {
         let counter = BucketValue::Counter(123.0);
         assert_eq!(counter.cost(), 8);
         let set = BucketValue::Set(vec![1, 2, 3, 4, 5].into_iter().collect());

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -103,6 +103,11 @@ pub enum MetricHistograms {
     ///  - `backdated`: A flag indicating whether the metric was reported within the `initial_delay`
     ///    time period (`false`) or after the initial delay has expired (`true`).
     BucketsDelay,
+
+    /// The storage cost of metrics buckets stored Relay's metrics aggregator, for a project key.
+    ///
+    /// See also [`MetricGauges::BucketsCost`].
+    BucketsCostPerProjectKey,
 }
 
 impl HistogramMetric for MetricHistograms {
@@ -112,6 +117,7 @@ impl HistogramMetric for MetricHistograms {
             Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
             Self::BucketRelativeSize => "metrics.buckets.relative_bucket_size",
             Self::BucketsDelay => "metrics.buckets.delay",
+            Self::BucketsCostPerProjectKey => "metrics.buckets.cost_per_project_key",
         }
     }
 }
@@ -128,7 +134,7 @@ impl GaugeMetric for MetricGauges {
     fn name(&self) -> &'static str {
         match *self {
             Self::Buckets => "metrics.buckets",
-            Self::BucketsCost => "metrics.bucket_cost",
+            Self::BucketsCost => "metrics.buckets.cost",
         }
     }
 }

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -120,12 +120,15 @@ impl HistogramMetric for MetricHistograms {
 pub enum MetricGauges {
     /// The total number of metric buckets in Relay's metrics aggregator.
     Buckets,
+    /// The total storage cost of metric buckets in Relay's metrics aggregator.
+    BucketsCost,
 }
 
 impl GaugeMetric for MetricGauges {
     fn name(&self) -> &'static str {
         match *self {
             Self::Buckets => "metrics.buckets",
+            Self::BucketsCost => "metrics.bucket_cost",
         }
     }
 }


### PR DESCRIPTION
To be able to limit the memory footprint of metrics buckets in the aggregator, we need to keep track of the number of elements we store. Instead of measuring the actual memory consumption, we apply a simple model, roughly measuring the bytes needed to encode a bucket:

* counter buckets: 8 bytes (`f64`)
* set buckets: number of unique elements * 4 (`f32`)
* distribution buckets: number of unique elements * 12 (`f64` + `u32`)
* gauge: 40 bytes (5 * `f64`)

To avoid iterating over all the buckets every time we want to query the memory footprint, we keep a map of counters per project key (plus one total count) that is incremented with the footprint delta on every insert.

**Not in this PR:** Enforcements of limits.