### PR TITLE
feat(metrics): Support dedicated topics per metrics usecase, drop metrics from unknown usecases [INGEST-1309]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add support for profile outcomes. ([#1272](https://github.com/getsentry/relay/pull/1272))
 - Avoid potential panics when scrubbing minidumps. ([#1282](https://github.com/getsentry/relay/pull/1282))
 - Fix typescript profile validation. ([#1283](https://github.com/getsentry/relay/pull/1283))
+- Support dedicated topics per metrics usecase, drop metrics from unknown usecases. ([#1285](https://github.com/getsentry/relay/pull/1285))
 
 ## 22.5.0
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -775,6 +775,8 @@ pub enum KafkaTopic {
     OutcomesBilling,
     /// Session health updates.
     Sessions,
+    /// The default topic for metrics. We use this mainly for tests at the moment.
+    MetricsDefault,
     /// Any metric that is extracted from sessions.
     MetricsSessions,
     /// Any metric that is extracted from transactions.
@@ -821,6 +823,7 @@ impl TopicAssignments {
             KafkaTopic::Outcomes => &self.outcomes,
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
+            KafkaTopic::MetricsDefault => &self.metrics,
             KafkaTopic::MetricsSessions => self.metrics_sessions.as_ref().unwrap_or(&self.metrics),
             KafkaTopic::MetricsTransactions => {
                 self.metrics_transactions.as_ref().unwrap_or(&self.metrics)

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -775,8 +775,10 @@ pub enum KafkaTopic {
     OutcomesBilling,
     /// Session health updates.
     Sessions,
-    /// Aggregate Metrics.
-    Metrics,
+    /// Any metric that is extracted from sessions.
+    MetricsSessions,
+    /// Any metric that is extracted from transactions.
+    MetricsTransactions,
     /// Profiles
     Profiles,
 }
@@ -797,8 +799,14 @@ pub struct TopicAssignments {
     pub outcomes_billing: Option<TopicAssignment>,
     /// Session health topic name.
     pub sessions: TopicAssignment,
-    /// Metrics topic name.
+    /// Default topic name for all aggregate metrics. Specialized topics for session-based and
+    /// transaction-based metrics can be configured via `metrics_sessions` and
+    /// `metrics_transactions` each.
     pub metrics: TopicAssignment,
+    /// Topic name for metrics extracted from sessions. Defaults to the assignment of `metrics`.
+    pub metrics_sessions: Option<TopicAssignment>,
+    /// Topic name for metrics extracted from transactions. Defaults to the assignment of `metrics`.
+    pub metrics_transactions: Option<TopicAssignment>,
     /// Stacktrace topic name
     pub profiles: TopicAssignment,
 }
@@ -813,7 +821,10 @@ impl TopicAssignments {
             KafkaTopic::Outcomes => &self.outcomes,
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
-            KafkaTopic::Metrics => &self.metrics,
+            KafkaTopic::MetricsSessions => self.metrics_sessions.as_ref().unwrap_or(&self.metrics),
+            KafkaTopic::MetricsTransactions => {
+                self.metrics_transactions.as_ref().unwrap_or(&self.metrics)
+            }
             KafkaTopic::Profiles => &self.profiles,
         }
     }
@@ -829,6 +840,8 @@ impl Default for TopicAssignments {
             outcomes_billing: None,
             sessions: "ingest-sessions".to_owned().into(),
             metrics: "ingest-metrics".to_owned().into(),
+            metrics_sessions: None,
+            metrics_transactions: None,
             profiles: "profiles".to_owned().into(),
         }
     }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -775,8 +775,6 @@ pub enum KafkaTopic {
     OutcomesBilling,
     /// Session health updates.
     Sessions,
-    /// The default topic for metrics. We use this mainly for tests at the moment.
-    MetricsDefault,
     /// Any metric that is extracted from sessions.
     MetricsSessions,
     /// Any metric that is extracted from transactions.
@@ -823,7 +821,6 @@ impl TopicAssignments {
             KafkaTopic::Outcomes => &self.outcomes,
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
-            KafkaTopic::MetricsDefault => &self.metrics,
             KafkaTopic::MetricsSessions => self.metrics_sessions.as_ref().unwrap_or(&self.metrics),
             KafkaTopic::MetricsTransactions => {
                 self.metrics_transactions.as_ref().unwrap_or(&self.metrics)

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -18,7 +18,7 @@ use relay_system::{Controller, Shutdown};
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
 use crate::{
     protocol, CounterType, DistributionType, GaugeType, Metric, MetricNamespace,
-    MetricResourceIdentifier, MetricType, MetricUnit, MetricValue, SetType,
+    MetricResourceIdentifier, MetricType, MetricValue, SetType,
 };
 
 /// Interval for the flush cycle of the [`Aggregator`].

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -14,7 +14,7 @@ use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 use relay_system::{Controller, Shutdown};
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
-use crate::{protocol, Metric, MetricResourceIdentifier, MetricType, MetricUnit, MetricValue};
+use crate::{protocol, Metric, MetricMri, MetricType, MetricUnit, MetricValue};
 
 /// Interval for the flush cycle of the [`Aggregator`].
 const FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -1129,7 +1129,7 @@ impl Aggregator {
             return Err(AggregateMetricsErrorKind::InvalidStringLength.into());
         }
 
-        if key.metric_name.parse::<MetricResourceIdentifier>().is_err() {
+        if key.metric_name.parse::<MetricMri>().is_err() {
             relay_log::debug!("invalid metric name {:?}", key.metric_name);
             relay_log::configure_scope(|scope| {
                 scope.set_extra(

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -14,7 +14,7 @@ use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 use relay_system::{Controller, Shutdown};
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
-use crate::{protocol, Metric, MetricNamespace, MetricMri, MetricType, MetricValue};
+use crate::{protocol, Metric, MetricMri, MetricNamespace, MetricType, MetricValue};
 
 /// Interval for the flush cycle of the [`Aggregator`].
 const FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -1138,7 +1138,7 @@ impl Aggregator {
                     return Err(AggregateMetricsErrorKind::InvalidNamespace.into());
                 }
                 mri.to_string()
-            },
+            }
             Err(_) => {
                 relay_log::debug!("invalid metric name {:?}", key.metric_name);
                 relay_log::configure_scope(|scope| {
@@ -1975,31 +1975,6 @@ mod tests {
             ),
         ]
         "###);
-    }
-
-    #[test]
-    fn test_aggregator_mixed_types() {
-        relay_test::setup();
-
-        let config = AggregatorConfig {
-            bucket_interval: 10,
-            ..test_config()
-        };
-
-        let receiver = TestReceiver::start_default().recipient();
-        let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
-
-        let mut aggregator = Aggregator::new(config, receiver);
-
-        let metric1 = some_metric();
-
-        let mut metric2 = metric1.clone();
-        metric2.value = MetricValue::Set(123);
-
-        // It's OK to have same name for different types:
-        aggregator.insert(project_key, metric1).unwrap();
-        aggregator.insert(project_key, metric2).unwrap();
-        assert_eq!(aggregator.buckets.len(), 2);
     }
 
     #[test]

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1312,7 +1312,7 @@ impl Aggregator {
     }
 
     fn normalize_metric_name(key: &mut BucketKey) -> Result<(), AggregateMetricsError> {
-        key.metric_name = match MetricResourceIdentifier::from_str(&key.metric_name) {
+        key.metric_name = match MetricResourceIdentifier::parse(&key.metric_name) {
             Ok(mri) => {
                 if matches!(mri.namespace, MetricNamespace::Unsupported) {
                     relay_log::debug!("invalid metric namespace {:?}", key.metric_name);

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -14,7 +14,7 @@ use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 use relay_system::{Controller, Shutdown};
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
-use crate::{protocol, Metric, MetricMri, MetricType, MetricUnit, MetricValue};
+use crate::{protocol, Metric, MetricResourceIdentifier, MetricType, MetricUnit, MetricValue};
 
 /// Interval for the flush cycle of the [`Aggregator`].
 const FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -1129,7 +1129,7 @@ impl Aggregator {
             return Err(AggregateMetricsErrorKind::InvalidStringLength.into());
         }
 
-        if key.metric_name.parse::<MetricMri>().is_err() {
+        if key.metric_name.parse::<MetricResourceIdentifier>().is_err() {
             relay_log::debug!("invalid metric name {:?}", key.metric_name);
             relay_log::configure_scope(|scope| {
                 scope.set_extra(

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -14,7 +14,7 @@ use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 use relay_system::{Controller, Shutdown};
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
-use crate::{protocol, Metric, MetricMri, MetricNamespace, MetricType, MetricValue};
+use crate::{protocol, Metric, MetricNamespace, MetricResourceIdentifier, MetricType, MetricValue};
 
 /// Interval for the flush cycle of the [`Aggregator`].
 const FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -1124,7 +1124,7 @@ impl Aggregator {
             return Err(AggregateMetricsErrorKind::InvalidStringLength.into());
         }
 
-        key.metric_name = match key.metric_name.parse::<MetricMri>() {
+        key.metric_name = match key.metric_name.parse::<MetricResourceIdentifier>() {
             Ok(mri) => {
                 if matches!(mri.namespace, MetricNamespace::Unsupported) {
                     relay_log::debug!("invalid metric namespace {:?}", key.metric_name);

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -30,6 +30,9 @@
 //! ...
 //! ```
 //!
+//! Note that the name format used in the statsd protocol is different from the MRI: Metric names
+//! are not prefixed with `<ty>:` as the type is somewhere else in the protocol.
+//!
 //! The timestamp in the item header is used to send backdated metrics. If it is omitted,
 //! the `received` time of the envelope is assumed.
 //!

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -152,9 +152,9 @@ fn is_valid_name(name: &str) -> bool {
     false
 }
 
-/// A metric name parsed as MRI, a naming scheme which includes most of the metric's bucket key
+/// A metric name as MRI, a naming scheme which includes most of the metric's bucket key
 /// (excl. timestamp and tags).
-pub struct MetricMri {
+pub struct MetricResourceIdentifier {
     /// The metric type.
     pub ty: MetricType,
     /// The namespace/usecase for this metric. For example `sessions` or `transactions`.
@@ -165,7 +165,7 @@ pub struct MetricMri {
     pub unit: MetricUnit,
 }
 
-impl std::str::FromStr for MetricMri {
+impl std::str::FromStr for MetricResourceIdentifier {
     type Err = ParseMetricError;
 
     /// Parses and validates an MRI of the form `<ty>:<ns>/<name>@<unit>`

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -231,7 +231,7 @@ pub struct MetricResourceIdentifier<'a> {
 
 impl<'a> MetricResourceIdentifier<'a> {
     /// Parses and validates an MRI of the form `<ty>:<ns>/<name>@<unit>`
-    pub fn from_str(name: &'a str) -> Result<Self, ParseMetricError> {
+    pub fn parse(name: &'a str) -> Result<Self, ParseMetricError> {
         let (raw_ty, rest) = name.split_once(':').ok_or(ParseMetricError(()))?;
         let ty = raw_ty.parse()?;
 
@@ -241,7 +241,7 @@ impl<'a> MetricResourceIdentifier<'a> {
         Ok(Self {
             ty,
             namespace: raw_namespace.parse()?,
-            name: name.into(),
+            name,
             unit,
         })
     }
@@ -723,7 +723,7 @@ mod tests {
         let s = "transactions/foo@second:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        let mri = MetricResourceIdentifier::from_str(&metric.name).unwrap();
+        let mri = MetricResourceIdentifier::parse(&metric.name).unwrap();
         assert_eq!(mri.unit, MetricUnit::Duration(DurationUnit::Second));
     }
 
@@ -732,7 +732,7 @@ mod tests {
         let s = "transactions/foo@s:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        let mri = MetricResourceIdentifier::from_str(&metric.name).unwrap();
+        let mri = MetricResourceIdentifier::parse(&metric.name).unwrap();
         assert_eq!(mri.unit, MetricUnit::Duration(DurationUnit::Second));
     }
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -152,9 +152,9 @@ fn is_valid_name(name: &str) -> bool {
     false
 }
 
-/// A metric name as MRI, a naming scheme which includes most of the metric's bucket key
+/// A metric name parsed as MRI, a naming scheme which includes most of the metric's bucket key
 /// (excl. timestamp and tags).
-pub struct MetricResourceIdentifier {
+pub struct MetricMri {
     /// The metric type.
     pub ty: MetricType,
     /// The namespace/usecase for this metric. For example `sessions` or `transactions`.
@@ -165,7 +165,7 @@ pub struct MetricResourceIdentifier {
     pub unit: MetricUnit,
 }
 
-impl std::str::FromStr for MetricResourceIdentifier {
+impl std::str::FromStr for MetricMri {
     type Err = ParseMetricError;
 
     /// Parses and validates an MRI of the form `<ty>:<ns>/<name>@<unit>`

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -180,7 +180,7 @@ pub enum MetricNamespace {
     Sessions,
     /// Metrics extracted from transaction events.
     Transactions,
-    /// Metrics that relay either doesn't know or recognize the namespace of, and will drop before
+    /// Metrics that relay either doesn't know or recognize the namespace of, will be dropped before
     /// aggregating. For instance, an MRI of `c:something_new/foo@none` has the namespace
     /// `something_new`, but as Relay doesn't support that namespace, it gets deserialized into
     /// this variant.

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -200,7 +200,7 @@ impl fmt::Display for MetricNamespace {
 /// (excl. timestamp and tags).
 ///
 /// For more information see [`Metric::name`].
-pub struct MetricMri<'a> {
+pub struct MetricResourceIdentifier<'a> {
     /// The metric type.
     pub ty: MetricType,
     /// The namespace/usecase for this metric. For example `sessions` or `transactions`.
@@ -211,7 +211,7 @@ pub struct MetricMri<'a> {
     pub unit: MetricUnit,
 }
 
-impl<'a> std::str::FromStr for MetricMri<'a> {
+impl<'a> std::str::FromStr for MetricResourceIdentifier<'a> {
     type Err = ParseMetricError;
 
     /// Parses and validates an MRI of the form `<ty>:<ns>/<name>@<unit>`
@@ -231,7 +231,7 @@ impl<'a> std::str::FromStr for MetricMri<'a> {
     }
 }
 
-impl<'a> fmt::Display for MetricMri<'a> {
+impl<'a> fmt::Display for MetricResourceIdentifier<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // `<ty>:<ns>/<name>@<unit>`
         write!(
@@ -422,7 +422,7 @@ pub struct Metric {
     /// * `name` cannot be empty, must start with a letter and can consist of ASCII alphanumerics, underscores, slashes, @s and periods.
     /// * `unit` is one of the values representable by `MetricUnit`.
     ///
-    /// For parsing and normalization, the [`MetricMri`] struct is used in the aggregator. It is
+    /// For parsing and normalization, the [`MetricResourceIdentifier`] struct is used in the aggregator. It is
     /// also used in the kafka producer to route certain namespaces to certain topics.
     ///
     /// Note that the format used in the statsd protocol is different: Metric names are not prefixed
@@ -468,7 +468,7 @@ impl Metric {
         tags: BTreeMap<String, String>,
     ) -> Self {
         Self {
-            name: MetricMri {
+            name: MetricResourceIdentifier {
                 ty: value.ty(),
                 name: name.to_string().into(),
                 namespace,
@@ -697,7 +697,7 @@ mod tests {
         let s = "transactions/foo@second:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        let mri: MetricMri = metric.name.parse().unwrap();
+        let mri: MetricResourceIdentifier = metric.name.parse().unwrap();
         assert_eq!(mri.unit, MetricUnit::Duration(DurationUnit::Second));
     }
 
@@ -706,7 +706,7 @@ mod tests {
         let s = "transactions/foo@s:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        let mri: MetricMri = metric.name.parse().unwrap();
+        let mri: MetricResourceIdentifier = metric.name.parse().unwrap();
         assert_eq!(mri.unit, MetricUnit::Duration(DurationUnit::Second));
     }
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -221,7 +221,9 @@ impl fmt::Display for MetricNamespace {
 pub struct MetricResourceIdentifier<'a> {
     /// The metric type.
     pub ty: MetricType,
-    /// The namespace/usecase for this metric. For example `sessions` or `transactions`.
+    /// The namespace/usecase for this metric. For example `sessions` or `transactions`. In the
+    /// case of the statsd protocol, a missing namespace is converted into the valueconverted into
+    /// the value `"custom"`.
     pub namespace: MetricNamespace,
     /// The actual name, such as `duration` as part of `d:transactions/duration@ms`
     pub name: &'a str,
@@ -439,15 +441,19 @@ pub struct Metric {
     ///
     /// MRIs have the format `<type>:<ns>/<name>@<unit>`, comprising the following components:
     ///
-    /// * **Type:** counter (`c`), set (`s`), distribution (`d`), gauge (`g`), and evaluated (`e`) for derived numeric metrics. See [`MetricType`].
+    /// * **Type:** counter (`c`), set (`s`), distribution (`d`), gauge (`g`), and evaluated (`e`)
+    ///   for derived numeric metrics (the latter is a pure query-time construct and is not relevant
+    ///   to Relay or ingestion). See [`MetricType`].
     /// * **Namespace:** Identifying the product entity and use case affiliation of the metric. See
     /// [`MetricNamespace`].
     /// * **Name:** The display name of the metric in the allowed character set.
     /// * **Unit:** The verbatim unit name. See [`MetricUnit`].
     ///
-    /// For parsing, construction and normalization, the [`MetricResourceIdentifier`] struct is used in the aggregator. It is
-    /// also used in the kafka producer to route certain namespaces to certain topics.
-    ///
+    /// Parsing a metric (or set of metrics) should not fail hard if the MRI is invalid, so this is
+    /// typed as string. Later in the metrics aggregator, the MRI is parsed using
+    /// [`MetricResourceIdentifier`] and validated for invalid characters as well.
+    /// [`MetricResourceIdentifier`] is also used in the kafka producer to route certain namespaces
+    /// to certain topics.
     pub name: String,
     /// The value of the metric.
     ///

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -176,7 +176,7 @@ impl std::str::FromStr for MetricResourceIdentifier {
         let (raw_ty, rest) = name.split_once(':').ok_or(ParseMetricError(()))?;
         let ty = raw_ty.parse()?;
 
-        let (raw_namespace, rest) = rest.split_once('/').unwrap_or(("custom", rest));
+        let (raw_namespace, rest) = rest.split_once('/').ok_or(ParseMetricError(()))?;
         let namespace = raw_namespace.to_owned();
 
         let (name, unit) = parse_name_unit(rest).ok_or(ParseMetricError(()))?;
@@ -552,12 +552,12 @@ mod tests {
 
     #[test]
     fn test_parse_counter() {
-        let s = "foo:42|c";
+        let s = "transactions/foo:42|c";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "c:foo",
+            name: "c:transactions/foo",
             unit: None,
             value: Counter(
                 42.0,
@@ -570,12 +570,12 @@ mod tests {
 
     #[test]
     fn test_parse_distribution() {
-        let s = "foo:17.5|d";
+        let s = "transactions/foo:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "d:foo",
+            name: "d:transactions/foo",
             unit: None,
             value: Distribution(
                 17.5,
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_parse_histogram() {
-        let s = "foo:17.5|h"; // common alias for distribution
+        let s = "transactions/foo:17.5|h"; // common alias for distribution
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         assert_eq!(metric.value, MetricValue::Distribution(17.5));
@@ -596,12 +596,12 @@ mod tests {
 
     #[test]
     fn test_parse_set() {
-        let s = "foo:e2546e4c-ecd0-43ad-ae27-87960e57a658|s";
+        let s = "transactions/foo:e2546e4c-ecd0-43ad-ae27-87960e57a658|s";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "s:foo",
+            name: "s:transactions/foo",
             unit: None,
             value: Set(
                 4267882815,
@@ -614,12 +614,12 @@ mod tests {
 
     #[test]
     fn test_parse_gauge() {
-        let s = "foo:42|g";
+        let s = "transactions/foo:42|g";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric, @r###"
         Metric {
-            name: "g:foo",
+            name: "g:transactions/foo",
             unit: None,
             value: Gauge(
                 42.0,
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_parse_unit() {
-        let s = "foo@second:17.5|d";
+        let s = "transactions/foo@second:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         assert_eq!(metric.unit, MetricUnit::Duration(DurationUnit::Second));
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_parse_unit_regression() {
-        let s = "foo@s:17.5|d";
+        let s = "transactions/foo@s:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         assert_eq!(metric.unit, MetricUnit::Duration(DurationUnit::Second));
@@ -648,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_parse_tags() {
-        let s = "foo:17.5|d|#foo,bar:baz";
+        let s = "transactions/foo:17.5|d|#foo,bar:baz";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
         insta::assert_debug_snapshot!(metric.tags, @r###"
@@ -745,7 +745,7 @@ mod tests {
 
     #[test]
     fn test_parse_all() {
-        let s = "foo:42|c\nbar:17|c";
+        let s = "transactions/foo:42|c\nbar:17|c";
         let timestamp = UnixTimestamp::from_secs(4711);
 
         let metrics: Vec<Metric> = Metric::parse_all(s.as_bytes(), timestamp)
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn test_parse_all_crlf() {
-        let s = "foo:42|c\r\nbar:17|c";
+        let s = "transactions/foo:42|c\r\nbar:17|c";
         let timestamp = UnixTimestamp::from_secs(4711);
 
         let metrics: Vec<Metric> = Metric::parse_all(s.as_bytes(), timestamp)
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     fn test_parse_all_empty_lines() {
-        let s = "foo:42|c\n\n\nbar:17|c";
+        let s = "transactions/foo:42|c\n\n\nbar:17|c";
         let timestamp = UnixTimestamp::from_secs(4711);
 
         let metric_count = Metric::parse_all(s.as_bytes(), timestamp).count();
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_parse_all_trailing() {
-        let s = "foo:42|c\nbar:17|c\n";
+        let s = "transactions/foo:42|c\nbar:17|c\n";
         let timestamp = UnixTimestamp::from_secs(4711);
 
         let metric_count = Metric::parse_all(s.as_bytes(), timestamp).count();

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -18,7 +18,7 @@ use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
 use relay_general::protocol::{self, EventId, SessionAggregates, SessionStatus, SessionUpdate};
 use relay_log::LogError;
-use relay_metrics::{Bucket, BucketValue, MetricNamespace, MetricMri, MetricUnit};
+use relay_metrics::{Bucket, BucketValue, MetricMri, MetricNamespace};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 
@@ -386,12 +386,14 @@ impl StoreForwarder {
 
     fn send_metric_message(&self, message: MetricKafkaMessage) -> Result<(), StoreError> {
         let topic = match message.name.parse() {
-            Ok(MetricMri { namespace: MetricNamespace::Transactions, .. }) => {
-                KafkaTopic::MetricsTransactions
-            }
-            Ok(MetricMri { namespace: MetricNamespace::Sessions, .. }) => {
-                KafkaTopic::MetricsSessions
-            }
+            Ok(MetricMri {
+                namespace: MetricNamespace::Transactions,
+                ..
+            }) => KafkaTopic::MetricsTransactions,
+            Ok(MetricMri {
+                namespace: MetricNamespace::Sessions,
+                ..
+            }) => KafkaTopic::MetricsSessions,
             _ => {
                 relay_log::configure_scope(|scope| {
                     scope.set_extra("metric_message.name", message.name.into());

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -57,6 +57,7 @@ struct Producers {
     attachments: Producer,
     transactions: Producer,
     sessions: Producer,
+    metrics_default: Producer,
     metrics_sessions: Producer,
     metrics_transactions: Producer,
     profiles: Producer,
@@ -75,6 +76,7 @@ impl Producers {
                 None
             }
             KafkaTopic::Sessions => Some(&self.sessions),
+            KafkaTopic::MetricsDefault => Some(&self.metrics_default),
             KafkaTopic::MetricsSessions => Some(&self.metrics_sessions),
             KafkaTopic::MetricsTransactions => Some(&self.metrics_transactions),
             KafkaTopic::Profiles => Some(&self.profiles),
@@ -133,6 +135,11 @@ impl StoreForwarder {
             events: make_producer(&*config, &mut reused_producers, KafkaTopic::Events)?,
             transactions: make_producer(&*config, &mut reused_producers, KafkaTopic::Transactions)?,
             sessions: make_producer(&*config, &mut reused_producers, KafkaTopic::Sessions)?,
+            metrics_default: make_producer(
+                &*config,
+                &mut reused_producers,
+                KafkaTopic::MetricsDefault,
+            )?,
             metrics_sessions: make_producer(
                 &*config,
                 &mut reused_producers,
@@ -392,13 +399,7 @@ impl StoreForwarder {
             Ok(MetricResourceIdentifier { namespace, .. }) if namespace == "sessions" => {
                 KafkaTopic::MetricsSessions
             }
-            _ => {
-                relay_log::configure_scope(|scope| {
-                    scope.set_extra("metric_message.name", message.name.into());
-                });
-                relay_log::error!("Dropping unknown metric usecase");
-                return Ok(());
-            }
+            _ => KafkaTopic::MetricsDefault,
         };
 
         relay_log::trace!("Sending metric message to kafka");

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -18,7 +18,7 @@ use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
 use relay_general::protocol::{self, EventId, SessionAggregates, SessionStatus, SessionUpdate};
 use relay_log::LogError;
-use relay_metrics::{Bucket, BucketValue, MetricMri, MetricUnit};
+use relay_metrics::{Bucket, BucketValue, MetricResourceIdentifier, MetricUnit};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 
@@ -386,10 +386,10 @@ impl StoreForwarder {
 
     fn send_metric_message(&self, message: MetricKafkaMessage) -> Result<(), StoreError> {
         let topic = match message.name.parse() {
-            Ok(MetricMri { namespace, .. }) if namespace == "transactions" => {
+            Ok(MetricResourceIdentifier { namespace, .. }) if namespace == "transactions" => {
                 KafkaTopic::MetricsTransactions
             }
-            Ok(MetricMri { namespace, .. }) if namespace == "sessions" => {
+            Ok(MetricResourceIdentifier { namespace, .. }) if namespace == "sessions" => {
                 KafkaTopic::MetricsSessions
             }
             _ => {

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -385,7 +385,7 @@ impl StoreForwarder {
     }
 
     fn send_metric_message(&self, message: MetricKafkaMessage) -> Result<(), StoreError> {
-        let mri = MetricResourceIdentifier::from_str(&message.name);
+        let mri = MetricResourceIdentifier::parse(&message.name);
         let topic = match mri.map(|mri| mri.namespace) {
             Ok(MetricNamespace::Transactions) => KafkaTopic::MetricsTransactions,
             Ok(MetricNamespace::Sessions) => KafkaTopic::MetricsSessions,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -18,7 +18,7 @@ use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
 use relay_general::protocol::{self, EventId, SessionAggregates, SessionStatus, SessionUpdate};
 use relay_log::LogError;
-use relay_metrics::{Bucket, BucketValue, MetricMri, MetricNamespace};
+use relay_metrics::{Bucket, BucketValue, MetricNamespace, MetricResourceIdentifier};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 
@@ -386,11 +386,11 @@ impl StoreForwarder {
 
     fn send_metric_message(&self, message: MetricKafkaMessage) -> Result<(), StoreError> {
         let topic = match message.name.parse() {
-            Ok(MetricMri {
+            Ok(MetricResourceIdentifier {
                 namespace: MetricNamespace::Transactions,
                 ..
             }) => KafkaTopic::MetricsTransactions,
-            Ok(MetricMri {
+            Ok(MetricResourceIdentifier {
                 namespace: MetricNamespace::Sessions,
                 ..
             }) => KafkaTopic::MetricsSessions,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -18,7 +18,7 @@ use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
 use relay_general::protocol::{self, EventId, SessionAggregates, SessionStatus, SessionUpdate};
 use relay_log::LogError;
-use relay_metrics::{Bucket, BucketValue, MetricResourceIdentifier, MetricUnit};
+use relay_metrics::{Bucket, BucketValue, MetricMri, MetricUnit};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 
@@ -386,10 +386,10 @@ impl StoreForwarder {
 
     fn send_metric_message(&self, message: MetricKafkaMessage) -> Result<(), StoreError> {
         let topic = match message.name.parse() {
-            Ok(MetricResourceIdentifier { namespace, .. }) if namespace == "transactions" => {
+            Ok(MetricMri { namespace, .. }) if namespace == "transactions" => {
                 KafkaTopic::MetricsTransactions
             }
-            Ok(MetricResourceIdentifier { namespace, .. }) if namespace == "sessions" => {
+            Ok(MetricMri { namespace, .. }) if namespace == "sessions" => {
                 KafkaTopic::MetricsSessions
             }
             _ => {

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use relay_common::{UnixTimestamp, Uuid};
 use relay_general::protocol::{SessionAttributes, SessionErrored, SessionLike, SessionStatus};
-use relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue, MetricNamespace};
+use relay_metrics::{DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue};
 
 use super::utils::with_tag;
 
@@ -482,7 +482,6 @@ mod tests {
         [
             Metric {
                 name: "c:sessions/session@none",
-                unit: None,
                 value: Counter(
                     135.0,
                 ),
@@ -496,7 +495,6 @@ mod tests {
             },
             Metric {
                 name: "c:sessions/session@none",
-                unit: None,
                 value: Counter(
                     12.0,
                 ),
@@ -510,7 +508,6 @@ mod tests {
             },
             Metric {
                 name: "c:sessions/session@none",
-                unit: None,
                 value: Counter(
                     5.0,
                 ),
@@ -524,7 +521,6 @@ mod tests {
             },
             Metric {
                 name: "c:sessions/session@none",
-                unit: None,
                 value: Counter(
                     7.0,
                 ),
@@ -538,7 +534,6 @@ mod tests {
             },
             Metric {
                 name: "c:sessions/session@none",
-                unit: None,
                 value: Counter(
                     15.0,
                 ),
@@ -552,7 +547,6 @@ mod tests {
             },
             Metric {
                 name: "s:sessions/user@none",
-                unit: None,
                 value: Set(
                     3097475539,
                 ),
@@ -566,7 +560,6 @@ mod tests {
             },
             Metric {
                 name: "c:sessions/session@none",
-                unit: None,
                 value: Counter(
                     3.0,
                 ),
@@ -580,7 +573,6 @@ mod tests {
             },
             Metric {
                 name: "s:sessions/user@none",
-                unit: None,
                 value: Set(
                     3097475539,
                 ),

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeMap;
 
 use relay_common::{UnixTimestamp, Uuid};
 use relay_general::protocol::{SessionAttributes, SessionErrored, SessionLike, SessionStatus};
-use relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue};
+use relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue, MetricNamespace};
 
 use super::utils::with_tag;
 
 /// Namespace of session metricsfor the MRI.
-const METRIC_NAMESPACE: &str = "sessions";
+const METRIC_NAMESPACE: MetricNamespace = MetricNamespace::Sessions;
 
 /// Current version of metrics extraction.
 const EXTRACT_VERSION: u16 = 1;

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -11,7 +11,7 @@ use {
     relay_general::protocol::{Context, ContextInner},
     relay_general::store,
     relay_general::types::Annotated,
-    relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue, MetricNamespace},
+    relay_metrics::{DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue},
     std::fmt,
 };
 

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -336,7 +336,7 @@ fn extract_transaction_metrics_inner(
 
             push_metric(Metric::new_mri(
                 METRIC_NAMESPACE,
-                format_args!("measurements.{}", name),
+                format!("measurements.{}", name),
                 stated_unit.or(default_unit).unwrap_or_default(),
                 MetricValue::Distribution(value),
                 unix_timestamp,
@@ -364,7 +364,7 @@ fn extract_transaction_metrics_inner(
 
                 push_metric(Metric::new_mri(
                     METRIC_NAMESPACE,
-                    format_args!("breakdowns.{}.{}", breakdown, measurement_name),
+                    format!("breakdowns.{}.{}", breakdown, measurement_name),
                     unit.copied().unwrap_or(MetricUnit::None),
                     MetricValue::Distribution(value),
                     unix_timestamp,

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -11,7 +11,7 @@ use {
     relay_general::protocol::{Context, ContextInner},
     relay_general::store,
     relay_general::types::Annotated,
-    relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue},
+    relay_metrics::{DurationUnit, Metric, MetricUnit, MetricValue, MetricNamespace},
     std::fmt,
 };
 
@@ -53,7 +53,7 @@ pub struct TransactionMetricsConfig {
 }
 
 #[cfg(feature = "processing")]
-const METRIC_NAMESPACE: &str = "transactions";
+const METRIC_NAMESPACE: MetricNamespace = MetricNamespace::Transactions;
 
 #[cfg(feature = "processing")]
 fn get_trace_context(event: &Event) -> Option<&TraceContext> {
@@ -552,16 +552,8 @@ mod tests {
             "d:transactions/measurements.lcp@millisecond"
         );
         assert_eq!(
-            metrics[2].unit,
-            MetricUnit::Duration(DurationUnit::MilliSecond)
-        );
-        assert_eq!(
             metrics[2].name,
             "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond"
-        );
-        assert_eq!(
-            metrics[2].unit,
-            MetricUnit::Duration(DurationUnit::MilliSecond)
         );
 
         let duration_metric = &metrics[3];
@@ -636,26 +628,18 @@ mod tests {
             "{:?}",
             metrics[0]
         );
-        assert_eq!(
-            metrics[0].unit,
-            MetricUnit::Duration(DurationUnit::MilliSecond),
-            "{:?}",
-            metrics[0]
-        );
 
         assert_eq!(
             metrics[1].name, "d:transactions/measurements.foo@none",
             "{:?}",
             metrics[1]
         );
-        assert_eq!(metrics[1].unit, MetricUnit::None, "{:?}", metrics[1]);
 
         assert_eq!(
             metrics[2].name, "d:transactions/measurements.stall_count@none",
             "{:?}",
             metrics[2]
         );
-        assert_eq!(metrics[2].unit, MetricUnit::None, "{:?}", metrics[2]);
     }
 
     #[test]
@@ -688,11 +672,9 @@ mod tests {
         assert_eq!(metrics.len(), 2);
 
         assert_eq!(metrics[0].name, "d:transactions/measurements.fcp@second");
-        assert_eq!(metrics[0].unit, MetricUnit::Duration(DurationUnit::Second));
 
         // None is an override, too.
         assert_eq!(metrics[1].name, "d:transactions/measurements.lcp@none");
-        assert_eq!(metrics[1].unit, MetricUnit::None);
     }
 
     #[test]
@@ -733,10 +715,6 @@ mod tests {
 
         let duration_metric = &metrics[0];
         assert_eq!(duration_metric.name, "d:transactions/duration@millisecond");
-        assert_eq!(
-            duration_metric.unit,
-            MetricUnit::Duration(DurationUnit::MilliSecond)
-        );
         if let MetricValue::Distribution(value) = duration_metric.value {
             assert_eq!(value, 59000.0); // millis
         } else {

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -61,14 +61,14 @@ def test_metrics(mini_sentry, relay):
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:transactions/bar",
+            "name": "c:transactions/bar@none",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:transactions/foo",
+            "name": "c:transactions/foo@none",
             "value": 42.0,
             "type": "c",
         },
@@ -96,7 +96,7 @@ def test_metrics_backdated(mini_sentry, relay):
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:transactions/foo",
+            "name": "c:transactions/foo@none",
             "value": 42.0,
             "type": "c",
         },
@@ -116,21 +116,19 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
 
     metrics = metrics_by_name(metrics_consumer, 2)
 
-    assert metrics["c:transactions/foo"] == {
+    assert metrics["c:transactions/foo@none"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:transactions/foo",
-        "unit": "none",
+        "name": "c:transactions/foo@none",
         "value": 42.0,
         "type": "c",
         "timestamp": timestamp,
     }
 
-    assert metrics["c:transactions/bar"] == {
+    assert metrics["c:transactions/bar@second"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:transactions/bar",
-        "unit": "second",
+        "name": "c:transactions/bar@second",
         "value": 17.0,
         "type": "c",
         "timestamp": timestamp,
@@ -167,8 +165,7 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
     assert metric == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:transactions/foo",
-        "unit": "none",
+        "name": "c:transactions/foo@none",
         "value": 15.0,
         "type": "c",
     }
@@ -272,7 +269,6 @@ def test_session_metrics_non_processing(
                 "timestamp": ts,
                 "width": 1,
                 "type": "d",
-                "unit": "second",
                 "value": [1947.49],
             },
             {
@@ -387,7 +383,6 @@ def test_session_metrics_processing(
         "timestamp": expected_timestamp,
         "name": "c:sessions/session@none",
         "type": "c",
-        "unit": "none",
         "value": 1.0,
         "tags": {
             "sdk": "raven-node/2.6.3",
@@ -403,7 +398,6 @@ def test_session_metrics_processing(
         "timestamp": expected_timestamp,
         "name": "s:sessions/user@none",
         "type": "s",
-        "unit": "none",
         "value": [1617781333],
         "tags": {
             "sdk": "raven-node/2.6.3",
@@ -419,7 +413,6 @@ def test_session_metrics_processing(
         "timestamp": expected_timestamp,
         "name": "d:sessions/duration@second",
         "type": "d",
-        "unit": "second",
         "value": [1947.49],
         "tags": {
             "sdk": "raven-node/2.6.3",
@@ -544,7 +537,6 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/measurements.foo@none",
         "type": "d",
-        "unit": "none",
         "value": [1.2, 2.2],
     }
 
@@ -552,7 +544,6 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/measurements.bar@none",
         "type": "d",
-        "unit": "none",
         "value": [1.3],
     }
 
@@ -562,7 +553,6 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond",
         "type": "d",
-        "unit": "millisecond",
         "value": [9.910106, 9.910106],
     }
 
@@ -570,7 +560,6 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/breakdowns.span_ops.total.time@millisecond",
         "type": "d",
-        "unit": "millisecond",
         "value": [9.910106, 9.910106],
     }
 
@@ -619,14 +608,14 @@ def test_graceful_shutdown(mini_sentry, relay):
         {
             "timestamp": future_timestamp,
             "width": 1,
-            "name": "c:transactions/bar",
+            "name": "c:transactions/bar@none",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": past_timestamp,
             "width": 1,
-            "name": "c:transactions/foo",
+            "name": "c:transactions/foo@none",
             "value": 42.0,
             "type": "c",
         },

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -46,7 +46,7 @@ def test_metrics(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"transactions/foo:42|c\ntransactions/bar:17|c"
+    metrics_payload = f"foo:42|c\ntransactions/bar:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=3)
@@ -61,14 +61,14 @@ def test_metrics(mini_sentry, relay):
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:transactions/bar",
+            "name": "c:bar",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:transactions/foo",
+            "name": "c:foo",
             "value": 42.0,
             "type": "c",
         },
@@ -82,7 +82,7 @@ def test_metrics_backdated(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp()) - 24 * 60 * 60
-    metrics_payload = f"transactions/foo:42|c"
+    metrics_payload = f"foo:42|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=2)
@@ -96,7 +96,7 @@ def test_metrics_backdated(mini_sentry, relay):
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:transactions/foo",
+            "name": "c:foo",
             "value": 42.0,
             "type": "c",
         },
@@ -111,25 +111,25 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     mini_sentry.add_full_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"transactions/foo:42|c\ntransactions/bar@second:17|c"
+    metrics_payload = f"foo:42|c\ntransactions/bar@second:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     metrics = metrics_by_name(metrics_consumer, 2)
 
-    assert metrics["c:transactions/foo"] == {
+    assert metrics["c:foo"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:transactions/foo",
+        "name": "c:foo",
         "unit": "none",
         "value": 42.0,
         "type": "c",
         "timestamp": timestamp,
     }
 
-    assert metrics["c:transactions/bar"] == {
+    assert metrics["c:bar"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:transactions/bar",
+        "name": "c:bar",
         "unit": "second",
         "value": 17.0,
         "type": "c",
@@ -157,17 +157,17 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
 
     # Send two events to downstream and one to upstream
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    downstream.send_metrics(project_id, f"transactions/foo:7|c", timestamp)
-    downstream.send_metrics(project_id, f"transactions/foo:5|c", timestamp)
+    downstream.send_metrics(project_id, f"foo:7|c", timestamp)
+    downstream.send_metrics(project_id, f"foo:5|c", timestamp)
 
-    upstream.send_metrics(project_id, f"transactions/foo:3|c", timestamp)
+    upstream.send_metrics(project_id, f"foo:3|c", timestamp)
 
     metric = metrics_consumer.get_metric(timeout=6)
     metric.pop("timestamp")
     assert metric == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:transactions/foo",
+        "name": "c:foo",
         "unit": "none",
         "value": 15.0,
         "type": "c",
@@ -595,17 +595,17 @@ def test_graceful_shutdown(mini_sentry, relay):
 
     # Backdated metric will be flushed immediately due to debounce delay
     past_timestamp = timestamp - 1000
-    metrics_payload = f"transactions/foo:42|c"
+    metrics_payload = f"foo:42|c"
     relay.send_metrics(project_id, metrics_payload, past_timestamp)
 
     # Future timestamp will not be flushed regularly, only through force flush
-    metrics_payload = f"transactions/bar:17|c"
+    metrics_payload = f"bar:17|c"
     future_timestamp = timestamp + 60
     relay.send_metrics(project_id, metrics_payload, future_timestamp)
     relay.shutdown(sig=signal.SIGTERM)
 
     # Try to send another metric (will be rejected)
-    metrics_payload = f"transactions/zap:666|c"
+    metrics_payload = f"zap:666|c"
     with pytest.raises(requests.ConnectionError):
         relay.send_metrics(project_id, metrics_payload, timestamp)
 
@@ -619,14 +619,14 @@ def test_graceful_shutdown(mini_sentry, relay):
         {
             "timestamp": future_timestamp,
             "width": 1,
-            "name": "c:transactions/bar",
+            "name": "c:bar",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": past_timestamp,
             "width": 1,
-            "name": "c:transactions/foo",
+            "name": "c:foo",
             "value": 42.0,
             "type": "c",
         },

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -46,7 +46,7 @@ def test_metrics(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\nbar:17|c"
+    metrics_payload = f"foo:42|c\ntransactions/bar:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=3)
@@ -111,7 +111,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     mini_sentry.add_full_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\nbar@second:17|c"
+    metrics_payload = f"foo:42|c\ntransactions/bar@second:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     metrics = metrics_by_name(metrics_consumer, 2)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -46,7 +46,7 @@ def test_metrics(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\ntransactions/bar:17|c"
+    metrics_payload = f"foo:42|c\nbar:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=3)
@@ -111,7 +111,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     mini_sentry.add_full_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\ntransactions/bar@second:17|c"
+    metrics_payload = f"foo:42|c\nbar@second:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     metrics = metrics_by_name(metrics_consumer, 2)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -46,7 +46,7 @@ def test_metrics(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\nbar:17|c"
+    metrics_payload = f"transactions/foo:42|c\ntransactions/bar:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=3)
@@ -61,14 +61,14 @@ def test_metrics(mini_sentry, relay):
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:bar",
+            "name": "c:transactions/bar",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:foo",
+            "name": "c:transactions/foo",
             "value": 42.0,
             "type": "c",
         },
@@ -82,7 +82,7 @@ def test_metrics_backdated(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp()) - 24 * 60 * 60
-    metrics_payload = f"foo:42|c"
+    metrics_payload = f"transactions/foo:42|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     envelope = mini_sentry.captured_events.get(timeout=2)
@@ -96,7 +96,7 @@ def test_metrics_backdated(mini_sentry, relay):
         {
             "timestamp": timestamp,
             "width": 1,
-            "name": "c:foo",
+            "name": "c:transactions/foo",
             "value": 42.0,
             "type": "c",
         },
@@ -111,25 +111,25 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     mini_sentry.add_full_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"foo:42|c\nbar@second:17|c"
+    metrics_payload = f"transactions/foo:42|c\ntransactions/bar@second:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     metrics = metrics_by_name(metrics_consumer, 2)
 
-    assert metrics["c:foo"] == {
+    assert metrics["c:transactions/foo"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:foo",
+        "name": "c:transactions/foo",
         "unit": "none",
         "value": 42.0,
         "type": "c",
         "timestamp": timestamp,
     }
 
-    assert metrics["c:bar"] == {
+    assert metrics["c:transactions/bar"] == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:bar",
+        "name": "c:transactions/bar",
         "unit": "second",
         "value": 17.0,
         "type": "c",
@@ -157,17 +157,17 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
 
     # Send two events to downstream and one to upstream
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    downstream.send_metrics(project_id, f"foo:7|c", timestamp)
-    downstream.send_metrics(project_id, f"foo:5|c", timestamp)
+    downstream.send_metrics(project_id, f"transactions/foo:7|c", timestamp)
+    downstream.send_metrics(project_id, f"transactions/foo:5|c", timestamp)
 
-    upstream.send_metrics(project_id, f"foo:3|c", timestamp)
+    upstream.send_metrics(project_id, f"transactions/foo:3|c", timestamp)
 
     metric = metrics_consumer.get_metric(timeout=6)
     metric.pop("timestamp")
     assert metric == {
         "org_id": 1,
         "project_id": project_id,
-        "name": "c:foo",
+        "name": "c:transactions/foo",
         "unit": "none",
         "value": 15.0,
         "type": "c",
@@ -595,17 +595,17 @@ def test_graceful_shutdown(mini_sentry, relay):
 
     # Backdated metric will be flushed immediately due to debounce delay
     past_timestamp = timestamp - 1000
-    metrics_payload = f"foo:42|c"
+    metrics_payload = f"transactions/foo:42|c"
     relay.send_metrics(project_id, metrics_payload, past_timestamp)
 
     # Future timestamp will not be flushed regularly, only through force flush
-    metrics_payload = f"bar:17|c"
+    metrics_payload = f"transactions/bar:17|c"
     future_timestamp = timestamp + 60
     relay.send_metrics(project_id, metrics_payload, future_timestamp)
     relay.shutdown(sig=signal.SIGTERM)
 
     # Try to send another metric (will be rejected)
-    metrics_payload = f"zap:666|c"
+    metrics_payload = f"transactions/zap:666|c"
     with pytest.raises(requests.ConnectionError):
         relay.send_metrics(project_id, metrics_payload, timestamp)
 
@@ -619,14 +619,14 @@ def test_graceful_shutdown(mini_sentry, relay):
         {
             "timestamp": future_timestamp,
             "width": 1,
-            "name": "c:bar",
+            "name": "c:transactions/bar",
             "value": 17.0,
             "type": "c",
         },
         {
             "timestamp": past_timestamp,
             "width": 1,
-            "name": "c:foo",
+            "name": "c:transactions/foo",
             "value": 42.0,
             "type": "c",
         },


### PR DESCRIPTION
Implement routing metrics to separate topics based on their usecase. We
currently have exactly two usecases (Session- and transaction metrics)
so those are just hardcoded as known usecases. The config format is
backwards-compatible, and by default both usecases still go to the
ingest-metrics topic.

This change is breaking in that metrics from unknown usecases
(outside of release health and metrics-enhanced performance) are dropped
in processing relays.

External and PoP-relays continue to forward arbitrary metrics... as
long as they have a usecase (any string).

As part of that, refactor MRI validation into actual MRI _parsing_,
which now also means that all metrics have to have a usecase.