### PR TITLE
fix(meta): Update codeowners for the release actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,4 @@
 /LICENSE  @getsentry/owners-legal
 
 # Build & Releases
-/.github/workflows/release*.yml  @getsentry/releases
-
+/.github/workflows/release*.yml  @getsentry/release-approvers


### PR DESCRIPTION
The team name has changed.

#skip-changelog

