### PR TITLE
fix(metrics): Track memory footprint more accurately [INGEST-1132]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Add support for profile outcomes. ([#1272](https://github.com/getsentry/relay/pull/1272))
 - Avoid potential panics when scrubbing minidumps. ([#1282](https://github.com/getsentry/relay/pull/1282))
 - Fix typescript profile validation. ([#1283](https://github.com/getsentry/relay/pull/1283))
-- Track memory footprint of metrics buckets. ([#1284](https://github.com/getsentry/relay/pull/1284))
+- Track memory footprint of metrics buckets. ([#1284](https://github.com/getsentry/relay/pull/1284), [#1288](https://github.com/getsentry/relay/pull/1288)).
 
 ## 22.5.0
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1421,7 +1421,8 @@ impl Aggregator {
                 if force || entry.elapsed() {
                     // Take the value and leave a placeholder behind. It'll be removed right after.
                     let value = mem::replace(&mut entry.value, BucketValue::Counter(0.0));
-                    cost_tracker.subtract_cost(key.project_key, key.cost() + value.cost());
+                    cost_tracker.subtract_cost(key.project_key, key.cost());
+                    cost_tracker.subtract_cost(key.project_key, value.cost());
                     let bucket = Bucket::from_parts(key.clone(), bucket_interval, value);
                     buckets.entry(key.project_key).or_default().push(bucket);
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1048,9 +1048,7 @@ enum AggregatorState {
 #[derive(Debug, Default)]
 struct CostTracker {
     total_cost: usize,
-    // Choosing a BTreeMap instead of a HashMap here, under the assumption that a BTreeMap
-    // is still more efficient for the number of project keys we store.
-    cost_per_project_key: BTreeMap<ProjectKey, usize>,
+    cost_per_project_key: HashMap<ProjectKey, usize>,
 }
 
 impl CostTracker {
@@ -1062,12 +1060,12 @@ impl CostTracker {
 
     fn subtract_cost(&mut self, project_key: ProjectKey, cost: usize) {
         match self.cost_per_project_key.entry(project_key) {
-            btree_map::Entry::Vacant(_) => {
+            Entry::Vacant(_) => {
                 relay_log::error!(
                     "Trying to subtract cost for a project key that has not been tracked"
                 );
             }
-            btree_map::Entry::Occupied(mut entry) => {
+            Entry::Occupied(mut entry) => {
                 // Handle per-project cost:
                 let project_cost = entry.get_mut();
                 if cost > *project_cost {

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -12,26 +12,38 @@ pub use relay_common::{
     CustomUnit, DurationUnit, FractionUnit, InformationUnit, MetricUnit, ParseMetricUnitError,
 };
 
+/// Type used for Counter metric
+pub type CounterType = f64;
+
+/// Type of distribution entries
+pub type DistributionType = f64;
+
+/// Type used for set elements in Set metric
+pub type SetType = u32;
+
+/// Type used for Gauge entries
+pub type GaugeType = f64;
+
 /// The [typed value](Metric::value) of a metric.
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type", content = "value")]
 pub enum MetricValue {
     /// Counts instances of an event. See [`MetricType::Counter`].
     #[serde(rename = "c")]
-    Counter(f64),
+    Counter(CounterType),
     /// Builds a statistical distribution over values reported. See [`MetricType::Distribution`].
     #[serde(rename = "d")]
-    Distribution(f64),
+    Distribution(DistributionType),
     /// Counts the number of unique reported values. See [`MetricType::Set`].
     ///
     /// Set values can be specified as strings in the submission protocol. They are always hashed
     /// into a 32-bit value and the original value is dropped. If the submission protocol contains a
     /// 32-bit integer, it will be used directly, instead.
     #[serde(rename = "s")]
-    Set(u32),
+    Set(SetType),
     /// Stores absolute snapshots of values. See [`MetricType::Gauge`].
     #[serde(rename = "g")]
-    Gauge(f64),
+    Gauge(GaugeType),
 }
 
 impl MetricValue {


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/1284 introduced a cost model for measuring the memory footprint of metrics buckets stored in the aggregator. It has two flaws:

1. It did not take into account the fixed size overhead of a `BucketValue` (only looked at the values inside).
2. It did not take into account the size overhead of storing the `BucketKey`.

This PR attempts to fix both issues.