### PR TITLE
fix(metrics): Stop logging statsd metric per project key [INGEST-1132]

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1518,11 +1518,6 @@ impl Aggregator {
         relay_statsd::metric!(
             gauge(MetricGauges::BucketsCost) = self.cost_tracker.total_cost as u64
         );
-        for cost in self.cost_tracker.cost_per_project_key.values() {
-            relay_statsd::metric!(
-                histogram(MetricHistograms::BucketsCostPerProjectKey) = *cost as f64
-            );
-        }
 
         let mut buckets = HashMap::<ProjectKey, Vec<Bucket>>::new();
 

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -103,11 +103,6 @@ pub enum MetricHistograms {
     ///  - `backdated`: A flag indicating whether the metric was reported within the `initial_delay`
     ///    time period (`false`) or after the initial delay has expired (`true`).
     BucketsDelay,
-
-    /// The storage cost of metrics buckets stored Relay's metrics aggregator, for a project key.
-    ///
-    /// See also [`MetricGauges::BucketsCost`].
-    BucketsCostPerProjectKey,
 }
 
 impl HistogramMetric for MetricHistograms {
@@ -117,7 +112,6 @@ impl HistogramMetric for MetricHistograms {
             Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
             Self::BucketRelativeSize => "metrics.buckets.relative_bucket_size",
             Self::BucketsDelay => "metrics.buckets.delay",
-            Self::BucketsCostPerProjectKey => "metrics.buckets.cost_per_project_key",
         }
     }
 }


### PR DESCRIPTION
It seems that we hit a limit by submitting too many statsd metrics, so let's stop emitting `BucketCostPerProjectKey`.

#skip-changelog