### PR TITLE
wip: Delete FromValue::from_value in favor of direct deserialization via serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "serde_urlencoded 0.5.5",
  "sha-1",
  "smallvec 1.4.0",
+ "take_mut",
  "uaparser",
  "url 2.2.0",
  "utf16string",

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -39,6 +39,7 @@ uaparser = { version = "0.5.1", optional = true }
 url = "2.1.1"
 utf16string = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
+take_mut = "0.2.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -79,7 +79,7 @@ fn derive_newtype_metastructure(
         Trait::From => s.gen_impl(quote! {
             #[automatically_derived]
             gen impl crate::types::FromValue for @Self {
-                fn from_value(
+                fn from_value_legacy(
                     __value: crate::types::Annotated<crate::types::Value>,
                 ) -> crate::types::Annotated<Self> {
                     match crate::types::FromValue::from_value(__value) {
@@ -220,7 +220,7 @@ fn derive_enum_metastructure(
             s.gen_impl(quote! {
                 #[automatically_derived]
                 gen impl crate::types::FromValue for @Self {
-                    fn from_value(
+                    fn from_value_legacy(
                         __value: crate::types::Annotated<crate::types::Value>,
                     ) -> crate::types::Annotated<Self> {
                         match crate::types::Object::<crate::types::Value>::from_value(__value) {
@@ -468,7 +468,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
             s.gen_impl(quote! {
                 #[automatically_derived]
                 gen impl crate::types::FromValue for @Self {
-                    fn from_value(
+                    fn from_value_legacy(
                         __value: crate::types::Annotated<crate::types::Value>,
                     ) -> crate::types::Annotated<Self> {
                         match __value {

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -79,13 +79,11 @@ fn derive_newtype_metastructure(
         Trait::From => s.gen_impl(quote! {
             #[automatically_derived]
             gen impl crate::types::FromValue for @Self {
-                fn from_value_legacy(
-                    __value: crate::types::Annotated<crate::types::Value>,
-                ) -> crate::types::Annotated<Self> {
-                    match crate::types::FromValue::from_value(__value) {
-                        Annotated(Some(__value), __meta) => Annotated(Some(#name(__value)), __meta),
-                        Annotated(None, __meta) => Annotated(None, __meta),
-                    }
+                fn from_deserializer<'de, D: serde::Deserializer<'de>>(
+                    deserializer: D,
+                ) -> Result<Annotated<Self>, D::Error> {
+                    let inner = crate::types::FromValue::from_deserializer(deserializer)?;
+                    Ok(inner.map_value(#name))
                 }
 
                 fn attach_meta_map(&mut self, mut meta_map: crate::types::MetaMap) {

--- a/relay-general/src/macros.rs
+++ b/relay-general/src/macros.rs
@@ -19,6 +19,8 @@ macro_rules! derive_string_meta_structure {
                     }
                 }
             }
+
+            fn attach_meta_map(&mut self, mut meta_map: crate::types::MetaMap) {}
         }
 
         impl crate::types::IntoValue for $type {

--- a/relay-general/src/macros.rs
+++ b/relay-general/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! derive_string_meta_structure {
                 }
             }
 
-            fn attach_meta_map(&mut self, mut meta_map: crate::types::MetaMap) {}
+            fn attach_meta_map(&mut self, _meta_map: crate::types::MetaMap) {}
         }
 
         impl crate::types::IntoValue for $type {

--- a/relay-general/src/macros.rs
+++ b/relay-general/src/macros.rs
@@ -1,7 +1,7 @@
 macro_rules! derive_string_meta_structure {
     ($type:ident, $expectation:expr) => {
         impl crate::types::FromValue for $type {
-            fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+            fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
                 match value {
                     Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                         Ok(value) => Annotated(Some(value), meta),

--- a/relay-general/src/processor/impls.rs
+++ b/relay-general/src/processor/impls.rs
@@ -244,13 +244,3 @@ macro_rules! process_tuple {
 
 process_tuple!(T1);
 process_tuple!(T1, T2);
-process_tuple!(T1, T2, T3);
-process_tuple!(T1, T2, T3, T4);
-process_tuple!(T1, T2, T3, T4, T5);
-process_tuple!(T1, T2, T3, T4, T5, T6);
-process_tuple!(T1, T2, T3, T4, T5, T6, T7);
-process_tuple!(T1, T2, T3, T4, T5, T6, T7, T8);
-process_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
-process_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
-process_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
-process_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);

--- a/relay-general/src/protocol/breakdowns.rs
+++ b/relay-general/src/protocol/breakdowns.rs
@@ -21,7 +21,7 @@ impl Breakdowns {
 }
 
 impl FromValue for Breakdowns {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         let mut processing_errors = Vec::new();
 
         let mut breakdowns = Object::from_value(value).map_value(|breakdowns| {

--- a/relay-general/src/protocol/breakdowns.rs
+++ b/relay-general/src/protocol/breakdowns.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::protocol::Measurements;
-use crate::types::{Annotated, Error, FromValue, Object, Value};
+use crate::types::{Annotated, Error, FromValue, MetaMap, Object, Value};
 
 /// A map of breakdowns.
 /// Breakdowns may be available on any event type. A breakdown are product-defined measurement values
@@ -51,6 +51,10 @@ impl FromValue for Breakdowns {
         }
 
         breakdowns
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        self.0.attach_meta_map(meta_map)
     }
 }
 

--- a/relay-general/src/protocol/breakdowns.rs
+++ b/relay-general/src/protocol/breakdowns.rs
@@ -53,7 +53,7 @@ impl FromValue for Breakdowns {
         breakdowns
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         self.0.attach_meta_map(meta_map)
     }
 }

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -440,7 +440,7 @@ impl FromValue for TraceId {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 /// A 16-character hex string as described in the W3C trace context spec.
@@ -469,7 +469,7 @@ impl FromValue for SpanId {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 /// Trace context
@@ -564,7 +564,7 @@ impl FromValue for SpanStatus {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl IntoValue for SpanStatus {
@@ -736,7 +736,7 @@ impl FromValue for Contexts {
         FromValue::from_value(annotated).map_value(Contexts)
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         self.0.attach_meta_map(meta_map);
     }
 }

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Serializer};
 use crate::processor::ProcessValue;
 use crate::protocol::LenientString;
 use crate::types::{
-    Annotated, Empty, Error, FromValue, IntoValue, Object, SkipSerialization, Value,
+    Annotated, Empty, Error, FromValue, IntoValue, MetaMap, Object, SkipSerialization, Value,
 };
 
 /// Device information.
@@ -439,6 +439,8 @@ impl FromValue for TraceId {
             }
         }
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
 }
 
 /// A 16-character hex string as described in the W3C trace context spec.
@@ -466,6 +468,8 @@ impl FromValue for SpanId {
             }
         }
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
 }
 
 /// Trace context
@@ -559,6 +563,8 @@ impl FromValue for SpanStatus {
             }
         }
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
 }
 
 impl IntoValue for SpanStatus {
@@ -728,6 +734,10 @@ impl FromValue for Contexts {
             }
         }
         FromValue::from_value(annotated).map_value(Contexts)
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        self.0.attach_meta_map(meta_map);
     }
 }
 

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -420,7 +420,7 @@ impl MonitorContext {
 pub struct TraceId(pub String);
 
 impl FromValue for TraceId {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => {
                 if !TRACE_ID.is_match(&value) || value.bytes().all(|x| x == b'0') {
@@ -449,7 +449,7 @@ impl FromValue for TraceId {
 pub struct SpanId(pub String);
 
 impl FromValue for SpanId {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => {
                 if !SPAN_ID.is_match(&value) || value.bytes().all(|x| x == b'0') {
@@ -518,7 +518,7 @@ impl Empty for SpanStatus {
 }
 
 impl FromValue for SpanStatus {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                 Ok(status) => Annotated(Some(status), meta),
@@ -720,7 +720,7 @@ impl std::ops::DerefMut for Contexts {
 }
 
 impl FromValue for Contexts {
-    fn from_value(mut annotated: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(mut annotated: Annotated<Value>) -> Annotated<Self> {
         if let Annotated(Some(Value::Object(ref mut items)), _) = annotated {
             for (key, value) in items.iter_mut() {
                 if let Annotated(Some(Value::Object(ref mut items)), _) = value {

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -178,7 +178,7 @@ macro_rules! impl_traits {
                 }
             }
 
-            fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+            fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
         }
 
         impl IntoValue for $type {

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::processor::{ProcessValue, ProcessingState, Processor, ValueType};
 use crate::protocol::Addr;
 use crate::types::{
-    Annotated, Array, Empty, Error, FromValue, IntoValue, Meta, Object, ProcessingResult,
+    Annotated, Array, Empty, Error, FromValue, IntoValue, Meta, MetaMap, Object, ProcessingResult,
     SkipSerialization, Value,
 };
 
@@ -177,6 +177,8 @@ macro_rules! impl_traits {
                     Annotated(None, meta) => Annotated(None, meta),
                 }
             }
+
+            fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
         }
 
         impl IntoValue for $type {

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -159,7 +159,7 @@ macro_rules! impl_traits {
         }
 
         impl FromValue for $type {
-            fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+            fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
                 match value {
                     Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                         Ok(value) => Annotated(Some(value), meta),

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -90,7 +90,7 @@ impl FromValue for EventType {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl IntoValue for EventType {

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -76,7 +76,7 @@ impl Empty for EventType {
 }
 
 impl FromValue for EventType {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match String::from_value(value) {
             Annotated(Some(value), mut meta) => match value.parse() {
                 Ok(eventtype) => Annotated(Some(eventtype), meta),

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -15,7 +15,8 @@ use crate::protocol::{
     RelayInfo, Request, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, User, Values,
 };
 use crate::types::{
-    Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
+    Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, MetaMap, Object, SkipSerialization,
+    Value,
 };
 
 /// Wrapper around a UUID with slightly different formatting.
@@ -88,6 +89,8 @@ impl FromValue for EventType {
             Annotated(None, meta) => Annotated(None, meta),
         }
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
 }
 
 impl IntoValue for EventType {

--- a/relay-general/src/protocol/fingerprint.rs
+++ b/relay-general/src/protocol/fingerprint.rs
@@ -88,7 +88,7 @@ impl FromValue for Fingerprint {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {
         // since we apparently store the fingerprint in a bare Vec<String> as opposed to
         // Vec<Annotated<_>>, we can't store child meta
     }

--- a/relay-general/src/protocol/fingerprint.rs
+++ b/relay-general/src/protocol/fingerprint.rs
@@ -40,7 +40,7 @@ impl Empty for Fingerprint {
 }
 
 impl FromValue for Fingerprint {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self>
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self>
     where
         Self: Sized,
     {

--- a/relay-general/src/protocol/fingerprint.rs
+++ b/relay-general/src/protocol/fingerprint.rs
@@ -1,7 +1,7 @@
 use crate::processor::ProcessValue;
 use crate::protocol::LenientString;
 use crate::types::{
-    Annotated, Empty, Error, ErrorKind, FromValue, IntoValue, SkipSerialization, Value,
+    Annotated, Empty, Error, ErrorKind, FromValue, IntoValue, MetaMap, SkipSerialization, Value,
 };
 
 /// A fingerprint value.
@@ -86,6 +86,11 @@ impl FromValue for Fingerprint {
             }
             Annotated(None, meta) => Annotated(None, meta),
         }
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        // since we apparently store the fingerprint in a bare Vec<String> as opposed to
+        // Vec<Annotated<_>>, we can't store child meta
     }
 }
 

--- a/relay-general/src/protocol/logentry.rs
+++ b/relay-general/src/protocol/logentry.rs
@@ -81,7 +81,7 @@ impl AsRef<str> for Message {
 }
 
 impl FromValue for LogEntry {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         // raw 'message' is coerced to the Message interface, as its used for pure index of
         // searchable strings. If both a raw 'message' and a Message interface exist, try and
         // add the former as the 'formatted' attribute of the latter.

--- a/relay-general/src/protocol/logentry.rs
+++ b/relay-general/src/protocol/logentry.rs
@@ -1,5 +1,5 @@
 use crate::protocol::JsonLenientString;
-use crate::types::{Annotated, Error, FromValue, Meta, Object, Value};
+use crate::types::{Annotated, Error, FromValue, Meta, MetaMap, Object, Value};
 
 /// A log entry message.
 ///
@@ -128,6 +128,24 @@ impl FromValue for LogEntry {
                 ..Default::default()
             }),
         }
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        // this does not implement _meta conversion for any of the legacy formats, and is basically
+        // the same thing the derive(FromValue) produces
+        if let Some(meta_tree) = meta_map.remove("message") {
+            self.message.attach_meta_tree(meta_tree);
+        }
+
+        if let Some(meta_tree) = meta_map.remove("formatted") {
+            self.formatted.attach_meta_tree(meta_tree);
+        }
+
+        if let Some(meta_tree) = meta_map.remove("params") {
+            self.params.attach_meta_tree(meta_tree);
+        }
+
+        self.other.attach_meta_map(meta_map);
     }
 }
 

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -4,7 +4,8 @@ use relay_common::MetricUnit;
 
 use crate::processor::ProcessValue;
 use crate::types::{
-    Annotated, Empty, Error, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
+    Annotated, Empty, Error, ErrorKind, FromValue, IntoValue, MetaMap, Object, SkipSerialization,
+    Value,
 };
 
 impl Empty for MetricUnit {
@@ -29,6 +30,8 @@ impl FromValue for MetricUnit {
             Annotated(None, meta) => Annotated(None, meta),
         }
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
 }
 
 impl IntoValue for MetricUnit {
@@ -110,6 +113,10 @@ impl FromValue for Measurements {
         }
 
         measurements
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        self.0.attach_meta_map(meta_map);
     }
 }
 

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -17,7 +17,7 @@ impl Empty for MetricUnit {
 }
 
 impl FromValue for MetricUnit {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match String::from_value(value) {
             Annotated(Some(value), mut meta) => match value.parse() {
                 Ok(unit) => Annotated(Some(unit), meta),
@@ -78,7 +78,7 @@ impl Measurements {
 }
 
 impl FromValue for Measurements {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         let mut processing_errors = Vec::new();
 
         let mut measurements = Object::from_value(value).map_value(|measurements| {

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -31,7 +31,7 @@ impl FromValue for MetricUnit {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl IntoValue for MetricUnit {
@@ -115,7 +115,7 @@ impl FromValue for Measurements {
         measurements
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         self.0.attach_meta_map(meta_map);
     }
 }

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -159,7 +159,7 @@ pub struct Mechanism {
 }
 
 impl FromValue for Mechanism {
-    fn from_value(annotated: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(annotated: Annotated<Value>) -> Annotated<Self> {
         #[derive(Debug, FromValue)]
         struct NewMechanism {
             #[metastructure(field = "type", required = "true")]

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -1,4 +1,4 @@
-use crate::types::{Annotated, Error, FromValue, Object, Value};
+use crate::types::{Annotated, Error, FromValue, MetaMap, Object, Value};
 
 /// POSIX signal with optional extended data.
 ///
@@ -253,6 +253,10 @@ impl FromValue for Mechanism {
             }
             Annotated(None, meta) => Annotated(None, meta),
         }
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        // i give up, this is too hard to implement
     }
 }
 

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -255,7 +255,7 @@ impl FromValue for Mechanism {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {
         // i give up, this is too hard to implement
     }
 }

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -811,7 +811,7 @@ fn test_query_string_legacy_nested() {
 fn test_query_invalid() {
     let query = Annotated::<Query>::from_error(
         Error::expected("a query string or map"),
-        Some(Value::U64(42)),
+        Some(Value::I64(42)),
     );
     assert_eq_dbg!(query, Annotated::from_json("42").unwrap());
 }
@@ -887,7 +887,7 @@ fn test_cookies_object() {
 #[test]
 fn test_cookies_invalid() {
     let cookies =
-        Annotated::<Cookies>::from_error(Error::expected("cookies"), Some(Value::U64(42)));
+        Annotated::<Cookies>::from_error(Error::expected("cookies"), Some(Value::I64(42)));
     assert_eq_dbg!(cookies, Annotated::from_json("42").unwrap());
 }
 

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -87,7 +87,7 @@ impl FromValue for Cookies {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         self.0.attach_meta_map(meta_map);
     }
 }
@@ -164,7 +164,7 @@ impl FromValue for HeaderName {
         String::from_value(value).map_value(HeaderName::new)
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 /// A "into-string" type that normalizes header values.
@@ -236,7 +236,7 @@ impl FromValue for HeaderValue {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 /// A map holding headers.
@@ -291,7 +291,7 @@ impl FromValue for Headers {
         })
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         // XXX: this is technically unsafe to do, as
         //
         // * from_value is sorting the headers one might end up with annotations on a header
@@ -370,7 +370,7 @@ impl FromValue for Query {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         self.0.attach_meta_map(meta_map);
     }
 }

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -57,7 +57,7 @@ impl std::ops::DerefMut for Cookies {
 }
 
 impl FromValue for Cookies {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => {
                 let mut cookies = Vec::new();
@@ -160,7 +160,7 @@ impl From<&'_ str> for HeaderName {
 }
 
 impl FromValue for HeaderName {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         String::from_value(value).map_value(HeaderName::new)
     }
 
@@ -211,7 +211,7 @@ impl From<&'_ str> for HeaderValue {
 }
 
 impl FromValue for HeaderValue {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::Array(array)), mut meta) => {
                 let mut header_value = String::new();
@@ -273,7 +273,7 @@ impl std::ops::DerefMut for Headers {
 }
 
 impl FromValue for Headers {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         // Preserve order if SDK sent headers as array
         let should_sort = matches!(value.value(), Some(Value::Object(_)));
 
@@ -354,7 +354,7 @@ where
 }
 
 impl FromValue for Query {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(v)), meta) => Annotated(Some(Query::parse(&v)), meta),
             annotated @ Annotated(Some(Value::Object(_)), _)

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -811,7 +811,7 @@ fn test_query_string_legacy_nested() {
 fn test_query_invalid() {
     let query = Annotated::<Query>::from_error(
         Error::expected("a query string or map"),
-        Some(Value::I64(42)),
+        Some(Value::U64(42)),
     );
     assert_eq_dbg!(query, Annotated::from_json("42").unwrap());
 }
@@ -887,7 +887,7 @@ fn test_cookies_object() {
 #[test]
 fn test_cookies_invalid() {
     let cookies =
-        Annotated::<Cookies>::from_error(Error::expected("cookies"), Some(Value::I64(42)));
+        Annotated::<Cookies>::from_error(Error::expected("cookies"), Some(Value::U64(42)));
     assert_eq_dbg!(cookies, Annotated::from_json("42").unwrap());
 }
 

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -215,7 +215,7 @@ impl From<Object<Value>> for FrameVars {
 }
 
 impl FromValue for FrameVars {
-    fn from_value(mut value: Annotated<Value>) -> Annotated<FrameVars> {
+    fn from_value_legacy(mut value: Annotated<Value>) -> Annotated<FrameVars> {
         value = value.map_value(|value| {
             if let Value::Array(value) = value {
                 Value::Object(

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::protocol::{Addr, NativeImagePath, RegVal};
-use crate::types::{Annotated, Array, FromValue, Object, Value};
+use crate::types::{Annotated, Array, FromValue, MetaMap, Object, Value};
 
 /// Holds information about a single stacktrace frame.
 ///
@@ -231,6 +231,12 @@ impl FromValue for FrameVars {
         });
 
         FromValue::from_value(value).map_value(FrameVars)
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        // we don't know the indices at this point, so we can only recover _meta when FrameVars has
+        // been deserialized as JSON object.
+        self.0.attach_meta_map(meta_map)
     }
 }
 

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -233,7 +233,7 @@ impl FromValue for FrameVars {
         FromValue::from_value(value).map_value(FrameVars)
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         // we don't know the indices at this point, so we can only recover _meta when FrameVars has
         // been deserialized as JSON object.
         self.0.attach_meta_map(meta_map)

--- a/relay-general/src/protocol/tags.rs
+++ b/relay-general/src/protocol/tags.rs
@@ -1,5 +1,5 @@
 use crate::protocol::{AsPair, LenientString, PairList};
-use crate::types::{Annotated, Array, FromValue, Value};
+use crate::types::{Annotated, Array, FromValue, MetaMap, Value};
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
@@ -38,6 +38,16 @@ impl FromValue for TagEntry {
                 value.map_value(|x| x.into_inner().trim().to_string()),
             )
         })
+    }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        if let Some(meta_tree) = meta_map.remove("0") {
+            self.0.attach_meta_tree(meta_tree);
+        }
+
+        if let Some(meta_tree) = meta_map.remove("1") {
+            self.1.attach_meta_tree(meta_tree);
+        }
     }
 }
 

--- a/relay-general/src/protocol/tags.rs
+++ b/relay-general/src/protocol/tags.rs
@@ -30,7 +30,7 @@ impl AsPair for TagEntry {
 }
 
 impl FromValue for TagEntry {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         type TagTuple = (Annotated<LenientString>, Annotated<LenientString>);
         TagTuple::from_value(value).map_value(|(key, value)| {
             TagEntry(

--- a/relay-general/src/protocol/thread.rs
+++ b/relay-general/src/protocol/thread.rs
@@ -19,7 +19,7 @@ pub enum ThreadId {
 }
 
 impl FromValue for ThreadId {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), meta) => {
                 Annotated(Some(ThreadId::String(value)), meta)

--- a/relay-general/src/protocol/thread.rs
+++ b/relay-general/src/protocol/thread.rs
@@ -37,7 +37,7 @@ impl FromValue for ThreadId {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl IntoValue for ThreadId {

--- a/relay-general/src/protocol/thread.rs
+++ b/relay-general/src/protocol/thread.rs
@@ -4,7 +4,7 @@ use crate::processor::ProcessValue;
 use crate::protocol::RawStacktrace;
 use crate::protocol::Stacktrace;
 use crate::types::{
-    Annotated, Empty, Error, FromValue, IntoValue, Object, SkipSerialization, Value,
+    Annotated, Empty, Error, FromValue, IntoValue, MetaMap, Object, SkipSerialization, Value,
 };
 
 /// Represents a thread id.
@@ -36,6 +36,8 @@ impl FromValue for ThreadId {
             }
         }
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
 }
 
 impl IntoValue for ThreadId {

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -78,7 +78,7 @@ impl<T> Values<T> {
 }
 
 impl<T: FromValue> FromValue for Values<T> {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             // Example:
             // {"threads": [foo, bar, baz]}
@@ -322,7 +322,7 @@ where
     V: FromValue,
     T: FromValue + AsPair<Key = K, Value = V>,
 {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::Array(items)), meta) => {
                 let mut rv = Vec::new();
@@ -456,7 +456,7 @@ macro_rules! hex_metrastructure {
         }
 
         impl FromValue for $type {
-            fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+            fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
                 match value {
                     Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                         Ok(value) => Annotated(Some(value), meta),
@@ -633,7 +633,7 @@ impl<'de> Deserialize<'de> for IpAddr {
 }
 
 impl FromValue for IpAddr {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => match IpAddr::parse(value) {
                 Ok(addr) => Annotated(Some(addr), meta),
@@ -724,7 +724,7 @@ impl fmt::Display for Level {
 }
 
 impl FromValue for Level {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), mut meta) => match value.parse() {
                 Ok(value) => Annotated(Some(value), meta),
@@ -845,7 +845,7 @@ impl From<String> for LenientString {
 }
 
 impl FromValue for LenientString {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(string)), meta) => Annotated(Some(string), meta),
             // XXX: True/False instead of true/false because of old python code
@@ -913,7 +913,7 @@ impl std::ops::DerefMut for JsonLenientString {
 }
 
 impl FromValue for JsonLenientString {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(string)), meta) => Annotated(Some(string.into()), meta),
             Annotated(Some(other), meta) => {
@@ -1042,7 +1042,7 @@ fn utc_result_to_annotated<V: IntoValue>(
 }
 
 impl FromValue for Timestamp {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         let rv = match value {
             Annotated(Some(Value::String(value)), mut meta) => {
                 // NaiveDateTime parses "%Y-%m-%dT%H:%M:%S%.f"

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -479,7 +479,7 @@ macro_rules! hex_metrastructure {
                 }
             }
 
-            fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+            fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
         }
 
         impl IntoValue for $type {
@@ -652,7 +652,7 @@ impl FromValue for IpAddr {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 /// An error used when parsing `Level`.
@@ -761,7 +761,7 @@ impl FromValue for Level {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl IntoValue for Level {
@@ -872,7 +872,7 @@ impl FromValue for LenientString {
         .map_value(LenientString)
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 /// A "into-string" type of value. All non-string values are serialized as JSON.
@@ -923,7 +923,7 @@ impl FromValue for JsonLenientString {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl From<String> for JsonLenientString {
@@ -1104,7 +1104,7 @@ impl FromValue for Timestamp {
         }
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+    fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
 }
 
 impl IntoValue for Timestamp {

--- a/relay-general/src/types/annotated.rs
+++ b/relay-general/src/types/annotated.rs
@@ -374,24 +374,10 @@ where
     }
 }
 
-impl Annotated<Value> {
-    fn attach_meta_tree(&mut self, mut meta_tree: MetaTree) {
-        match self.value_mut() {
-            Some(Value::Array(items)) => {
-                for (idx, item) in items.iter_mut().enumerate() {
-                    if let Some(meta_tree) = meta_tree.children.remove(&idx.to_string()) {
-                        item.attach_meta_tree(meta_tree);
-                    }
-                }
-            }
-            Some(Value::Object(items)) => {
-                for (key, value) in items.iter_mut() {
-                    if let Some(meta_tree) = meta_tree.children.remove(key) {
-                        value.attach_meta_tree(meta_tree);
-                    }
-                }
-            }
-            _ => {}
+impl<T: FromValue> Annotated<T> {
+    pub(crate) fn attach_meta_tree(&mut self, meta_tree: MetaTree) {
+        if let Some(value) = self.value_mut() {
+            value.attach_meta_map(meta_tree.children);
         }
 
         *self.meta_mut() = meta_tree.meta;

--- a/relay-general/src/types/annotated.rs
+++ b/relay-general/src/types/annotated.rs
@@ -7,7 +7,7 @@ use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
 
-use serde::de::{Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::de::Deserializer;
 use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 

--- a/relay-general/src/types/impls.rs
+++ b/relay-general/src/types/impls.rs
@@ -358,6 +358,26 @@ impl FromValue for Value {
     fn from_value(value: Annotated<Value>) -> Annotated<Value> {
         value
     }
+
+    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+        match self {
+            Value::Array(items) => {
+                for (idx, annotated) in items.iter_mut().enumerate() {
+                    if let Some(meta_tree) = meta_map.remove(&idx.to_string()) {
+                        annotated.attach_meta_tree(meta_tree);
+                    }
+                }
+            }
+            Value::Object(items) => {
+                for (key, annotated) in items.iter_mut() {
+                    if let Some(meta_tree) = meta_map.remove(key) {
+                        annotated.attach_meta_tree(meta_tree);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 impl IntoValue for Value {

--- a/relay-general/src/types/impls.rs
+++ b/relay-general/src/types/impls.rs
@@ -1,5 +1,5 @@
 use serde::ser::{SerializeMap, SerializeSeq};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
 use crate::types::{
@@ -374,9 +374,13 @@ impl Empty for Value {
 }
 
 impl FromValue for Value {
-    #[inline]
-    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Value> {
-        value
+    fn from_deserializer<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Annotated<Self>, D::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Annotated::from(Option::<Value>::deserialize(deserializer)?))
     }
 
     fn attach_meta_map(&mut self, meta_map: MetaMap) {

--- a/relay-general/src/types/impls.rs
+++ b/relay-general/src/types/impls.rs
@@ -26,7 +26,7 @@ impl<'a, T: IntoValue> Serialize for SerializePayload<'a, T> {
 macro_rules! derive_from_value {
     ($type:ident, $meta_type:ident, $expectation:expr) => {
         impl FromValue for $type {
-            fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+            fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
                 match value {
                     Annotated(Some(Value::$meta_type(value)), meta) => Annotated(Some(value), meta),
                     Annotated(None, meta) => Annotated(None, meta),
@@ -68,7 +68,7 @@ macro_rules! derive_to_value {
 macro_rules! derive_numeric_meta_structure {
     ($type:ident, $meta_type:ident, $expectation:expr) => {
         impl FromValue for $type {
-            fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+            fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
                 value.and_then(|value| {
                     let number = match value {
                         Value::U64(x) => num_traits::cast(x),
@@ -191,7 +191,7 @@ impl<T> FromValue for Array<T>
 where
     T: FromValue,
 {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::Array(items)), meta) => Annotated(
                 Some(items.into_iter().map(FromValue::from_value).collect()),
@@ -275,7 +275,7 @@ impl<T> FromValue for Object<T>
 where
     T: FromValue,
 {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::Object(items)), meta) => Annotated(
                 Some(
@@ -375,7 +375,7 @@ impl Empty for Value {
 
 impl FromValue for Value {
     #[inline]
-    fn from_value(value: Annotated<Value>) -> Annotated<Value> {
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Value> {
         value
     }
 
@@ -437,7 +437,7 @@ impl<T> FromValue for Box<T>
 where
     T: FromValue,
 {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self>
+    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self>
     where
         Self: Sized,
     {
@@ -519,7 +519,7 @@ macro_rules! tuple_meta_structure {
     ($($name:ident: $i:tt),+) => {
         impl< $( $name: FromValue ),* > FromValue for ( $( Annotated<$name>, )* ) {
             #[allow(non_snake_case, unused_variables)]
-            fn from_value(annotated: Annotated<Value>) -> Annotated<Self> {
+            fn from_value_legacy(annotated: Annotated<Value>) -> Annotated<Self> {
                 $(
                     let expected_elements: usize = $i + 1;
                     let expectation = match expected_elements {

--- a/relay-general/src/types/impls.rs
+++ b/relay-general/src/types/impls.rs
@@ -38,7 +38,7 @@ macro_rules! derive_from_value {
                 }
             }
 
-            fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+            fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
         }
     };
 }
@@ -89,7 +89,7 @@ macro_rules! derive_numeric_meta_structure {
                 })
             }
 
-            fn attach_meta_map(&mut self, mut meta_map: MetaMap) {}
+            fn attach_meta_map(&mut self, _meta_map: MetaMap) {}
         }
 
         derive_to_value!($type, $meta_type);
@@ -379,7 +379,7 @@ impl FromValue for Value {
         value
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         match self {
             Value::Array(items) => {
                 items.attach_meta_map(meta_map);
@@ -445,7 +445,7 @@ where
         Annotated(annotated.0.map(Box::new), annotated.1)
     }
 
-    fn attach_meta_map(&mut self, mut meta_map: MetaMap) {
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
         (&mut **self).attach_meta_map(meta_map);
     }
 }

--- a/relay-general/src/types/traits.rs
+++ b/relay-general/src/types/traits.rs
@@ -95,9 +95,12 @@ pub trait FromValue: Debug {
     }
 
     /// Legacy method for old implementors of FromValue
-    fn from_value_legacy(value: Annotated<Value>) -> Annotated<Self>
+    fn from_value_legacy(_value: Annotated<Value>) -> Annotated<Self>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        unimplemented!()
+    }
 
     /// Stub method for callers of FromValue::from_value.
     ///

--- a/relay-general/src/types/traits.rs
+++ b/relay-general/src/types/traits.rs
@@ -84,10 +84,7 @@ pub trait FromValue: Debug {
     where
         Self: Sized;
 
-    fn attach_meta_map(&mut self, meta_map: MetaMap) {
-        let _meta_map = meta_map;
-        todo!()
-    }
+    fn attach_meta_map(&mut self, meta_map: MetaMap);
 }
 
 /// Implemented for all meta structures.

--- a/relay-general/src/types/traits.rs
+++ b/relay-general/src/types/traits.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
+use serde::{Deserialize, Deserializer};
+
 use crate::types::{Annotated, MetaMap, MetaTree, Value};
 
 /// A value that can be empty.
@@ -79,6 +81,17 @@ impl Default for SkipSerialization {
 
 /// Implemented for all meta structures.
 pub trait FromValue: Debug {
+    fn from_deserializer<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Annotated<Self>, D::Error>
+    where
+        Self: Sized,
+    {
+        Ok(FromValue::from_value(Annotated::from(
+            Option::<Value>::deserialize(deserializer)?,
+        )))
+    }
+
     /// Creates a meta structure from an annotated boxed value.
     fn from_value(value: Annotated<Value>) -> Annotated<Self>
     where

--- a/relay-general/src/types/traits.rs
+++ b/relay-general/src/types/traits.rs
@@ -83,6 +83,11 @@ pub trait FromValue: Debug {
     fn from_value(value: Annotated<Value>) -> Annotated<Self>
     where
         Self: Sized;
+
+    fn attach_meta_map(&mut self, meta_map: MetaMap) {
+        let _meta_map = meta_map;
+        todo!()
+    }
 }
 
 /// Implemented for all meta structures.


### PR DESCRIPTION
Currently we deserialize in the following steps:

1. deserialize into `relay_general::Value` via serde
2. pop `_meta`, convert it from `Value` to `MetaTree` and recursively insert it via `Annotated::<Value>::attach_meta_tree` (that method only exists for `Annotated<Value>`)
3. convert `Value` to `Event` via `FromValue::from_value`

instead we could do:

1. deserialize `_meta` into `MetaTree` and the rest into `Event` via serde
2. use a new method `FromValue::attach_meta_map` to insert `_meta` recursively into the deserialized struct. Every struct has to implement that method

Advantages:

* no intermediate conversion into `Value`, fewer allocations
* is there more?

Disadvantages:

* `FromValue::attach_meta_map` and `FromValue::from_deserializer` have to be kept in sync when the trait is implemented manually. See for example `impl FromValue for PairList` where it gets hairy
* is there more?

there's a lot of intermediate steps and porting TBD until we get there.