### PR TITLE
fix(server): Avoid a panic in the Sentry middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,9 +1271,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d758e60b45e8d749c89c1b389ad8aee550f86aa12e2b9298b546dda7a82ab1"
+checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
+dependencies = [
+ "slab",
+]
 
 [[package]]
 name = "fuchsia-cprng"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { version = "0.4.11", features = ["serde"] }
 clap = "2.33.1"
 failure = "0.1.8"
 flate2 = "1.0.19"
-fragile = "1.0.0" # used for vendoring sentry-actix
+fragile = { version = "1.2.1", features = ["slab"] } # used for vendoring sentry-actix
 futures = "0.1.28"
 futures03 = { version = "0.3", package = "futures", features = ["compat"] }
 itertools = "0.8.2"


### PR DESCRIPTION
The `fragile` crate panics if multiple `Sticky`s are used in the same thread, unless the `slab` feature is enabled. Since we already have `slab` in our dependencies, this also gives us a slight speedup.

#skip-changelog