### PR TITLE
ref(metrics): Stop logging relative bucket size [INGEST-1132]

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -148,13 +148,6 @@ impl DistributionValue {
         self.length
     }
 
-    /// Returns the size of the map used to store the distribution.
-    ///
-    /// This is only relevant for internal metrics.
-    fn internal_size(&self) -> usize {
-        self.values.len()
-    }
-
     /// Returns `true` if the map contains no elements.
     pub fn is_empty(&self) -> bool {
         self.length == 0

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -515,22 +515,9 @@ impl BucketValue {
         }
     }
 
-    /// Returns the number of values needed to encode the bucket (a measure of bucket
-    /// complexity).
-    pub fn relative_size(&self) -> usize {
-        match self {
-            Self::Counter(_) => 1,
-            Self::Set(s) => s.len(),
-            Self::Gauge(_) => 5,
-            Self::Distribution(m) => m.internal_size(),
-        }
-    }
-
     /// Estimates the number of bytes needed to encode the bucket value.
     /// Note that this does not necessarily match the exact memory footprint of the value,
     /// because datastructures might have a memory overhead.
-    ///
-    /// This is very similar to [`BucketValue::relative_size`], which can possibly be removed.
     pub fn cost(&self) -> usize {
         // Beside the size of [`BucketValue`], we also need to account for the cost of values
         // allocated dynamically.
@@ -1566,11 +1553,6 @@ impl Aggregator {
             );
             total_bucket_count += bucket_count;
 
-            let size_statsd_metrics: Vec<_> = project_buckets
-                .iter()
-                .map(|bucket| (bucket.value.ty(), bucket.value.relative_size()))
-                .collect();
-
             self.receiver
                 .send(FlushBuckets::new(project_key, project_buckets))
                 .into_actor(self)
@@ -1581,14 +1563,6 @@ impl Aggregator {
                             buckets.len()
                         );
                         slf.merge_all(project_key, buckets).ok();
-                    } else {
-                        for (bucket_type, bucket_relative_size) in size_statsd_metrics {
-                            relay_statsd::metric!(
-                                histogram(MetricHistograms::BucketRelativeSize) =
-                                    bucket_relative_size as u64,
-                                metric_type = bucket_type.as_str(),
-                            );
-                        }
                     }
                     fut::ok(())
                 })

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -86,12 +86,6 @@ pub enum MetricHistograms {
     /// equivalent to the number of projects being flushed.
     BucketsFlushedPerProject,
 
-    /// The number of metric elements in the bucket.
-    ///
-    /// BucketRelativeSize measures how many distinct values are in a bucket and therefore
-    /// BucketRelativeSize gives you a measurement of the bucket size and complexity.
-    BucketRelativeSize,
-
     /// The reporting delay at which a bucket arrives in Relay.
     ///
     /// A positive delay indicates the bucket arrives after its stated timestamp. Large delays
@@ -110,7 +104,6 @@ impl HistogramMetric for MetricHistograms {
         match *self {
             Self::BucketsFlushed => "metrics.buckets.flushed",
             Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
-            Self::BucketRelativeSize => "metrics.buckets.relative_bucket_size",
             Self::BucketsDelay => "metrics.buckets.delay",
         }
     }


### PR DESCRIPTION
In an ongoing effort to reduce the number of statsd metrics we emit (see also https://github.com/getsentry/relay/pull/1295), remove the `BucketRelativeSize`, which was emitted in a loop for every bucket flush.

Beside emitting a lot of statsd metrics, the `relative_size()` function was also a less precise approximation than the new `cost()` function, which IMO can be removed.

#skip-changelog