### PR TITLE
chore(filters): Add filter for error about missing `Object.setPrototypeOf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+**Compatibility:** This version of Relay requires Sentry server `22.7.0` or newer.
+
+**Internal**:
+
+- Add filter for error about missing `Object.setPrototypeOf` to browser extension errors filter. ([#1308](https://github.com/getsentry/relay/pull/1308))
+
 ## 22.6.0
 
 **Compatibility:** This version of Relay requires Sentry server `22.6.0` or newer.

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -86,7 +86,9 @@ lazy_static! {
         # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
         plugin\.setSuspendState\sis\snot\sa\sfunction|
         # Chrome extension message passing failure
-        Extension\scontext\sinvalidated
+        Extension\scontext\sinvalidated|
+        # Ancient browsers without `Object.setPrototypeOf`
+        'Object\.setPrototypeOf'\sis\snot\sa\sfunction
     "#
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex");
@@ -226,6 +228,7 @@ mod tests {
             "null is not an object (evaluating 'elt.parentNode')",
             "plugin.setSuspendState is not a function",
             "Extension context invalidated",
+            "'Object.setPrototypeOf' is not a function",
         ];
 
         for exc_value in &exceptions {


### PR DESCRIPTION
Very old browsers don't have support for `Object.setPrototypeOf`, which we use in the JS SDK. (See the [MDN compatibility chart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf#browser_compatibility), which shows that the last browser to add support for it was Safari, in mid-2015.)

This adds an entry to the known browser extension errors filter so that said browsers don't spam users with useless errors. (Though I get that technically it isn't an extension throwing the error, the legacy browsers filter filters on browser name, not error message, and in the errors we're trying to block, no browser name is available, so it seemed like the best place to put it.)

Fixes https://github.com/getsentry/sentry-javascript/issues/5258.