### PR TITLE
ref(server): Log project key on event loss [INGEST-1324]

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -2727,7 +2727,14 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                     // Errors are only logged for what we consider an internal discard reason. These
                     // indicate errors in the infrastructure or implementation bugs. In other cases,
                     // we "expect" errors and log them as debug level.
-                    relay_log::error!("error processing envelope: {}", LogError(&error));
+                    relay_log::with_scope(
+                        |scope| {
+                            scope.set_tag("project_key", project_key);
+                        },
+                        || {
+                            relay_log::error!("error processing envelope: {}", LogError(&error));
+                        },
+                    );
                 } else {
                     relay_log::debug!("dropped envelope: {}", LogError(&error));
                 }


### PR DESCRIPTION
This might help us to see which projects fail to fetch their config, and estimate customer impact.

#skip-changelog