### PR TITLE
fix(metrics): Parse custom units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Parse custom units with length < 15 without crashing. ([#1311](https://github.com/getsentry/relay/pull/1311))
+
 ## 22.6.0
 
 **Compatibility:** This version of Relay requires Sentry server `22.6.0` or newer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**:
 
-- Parse custom units with length < 15 without crashing. ([#1311](https://github.com/getsentry/relay/pull/1311))
+- Parse custom units with length < 15 without crashing. ([#1312](https://github.com/getsentry/relay/pull/1312))
 
 ## 22.6.0
 

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -492,7 +492,7 @@ impl CustomUnit {
         }
 
         let mut unit = Self(Default::default());
-        unit.0[0..s.len()].copy_from_slice(s.as_bytes());
+        unit.0[..s.len()].copy_from_slice(s.as_bytes());
         unit.0[s.len()..].fill(0);
         unit.0.make_ascii_lowercase();
         Ok(unit)

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -501,8 +501,8 @@ impl CustomUnit {
     /// Returns the string representation of this unit.
     #[inline]
     pub fn as_str(&self) -> &str {
-        // Safety: The string is already validated to be of length 32 and valid ASCII when
-        // constructing `ProjectKey`.
+        // Safety: The string is already validated to be valid ASCII when
+        // parsing `CustomUnit`.
         unsafe { std::str::from_utf8_unchecked(&self.0).trim_end_matches('\0') }
     }
 }

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -487,12 +487,13 @@ pub struct CustomUnit([u8; CUSTOM_UNIT_MAX_SIZE]);
 impl CustomUnit {
     /// Parses a `CustomUnit` from a string.
     pub fn parse(s: &str) -> Result<Self, ParseMetricUnitError> {
-        if s.len() > CUSTOM_UNIT_MAX_SIZE || !s.is_ascii() {
+        if !s.is_ascii() {
             return Err(ParseMetricUnitError(()));
         }
 
         let mut unit = Self([0; CUSTOM_UNIT_MAX_SIZE]);
-        unit.0[..s.len()].copy_from_slice(s.as_bytes());
+        let slice = unit.0.get_mut(..s.len()).ok_or(ParseMetricUnitError(()))?;
+        slice.copy_from_slice(s.as_bytes());
         unit.0.make_ascii_lowercase();
         Ok(unit)
     }

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -482,18 +482,17 @@ const CUSTOM_UNIT_MAX_SIZE: usize = 15;
 
 /// Custom user-defined units without builtin conversion.
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-pub struct CustomUnit([u8; CUSTOM_UNIT_SIZE]);
+pub struct CustomUnit([u8; CUSTOM_UNIT_MAX_SIZE]);
 
 impl CustomUnit {
     /// Parses a `CustomUnit` from a string.
     pub fn parse(s: &str) -> Result<Self, ParseMetricUnitError> {
-        if s.len() > CUSTOM_UNIT_SIZE || !s.is_ascii() {
+        if s.len() > CUSTOM_UNIT_MAX_SIZE || !s.is_ascii() {
             return Err(ParseMetricUnitError(()));
         }
 
-        let mut unit = Self(Default::default());
+        let mut unit = Self([0; CUSTOM_UNIT_MAX_SIZE]);
         unit.0[..s.len()].copy_from_slice(s.as_bytes());
-        unit.0[s.len()..].fill(0);
         unit.0.make_ascii_lowercase();
         Ok(unit)
     }

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -478,7 +478,7 @@ impl fmt::Display for FractionUnit {
     }
 }
 
-const CUSTOM_UNIT_SIZE: usize = 15;
+const CUSTOM_UNIT_MAX_SIZE: usize = 15;
 
 /// Custom user-defined units without builtin conversion.
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]


### PR DESCRIPTION
The parser of `CustomUnit` only worked when the length of the custom unit was exactly 15.

Fixes [POP-RELAY-2GF](https://sentry.my.sentry.io/organizations/sentry/issues/311713/?project=9&project=5&project=4&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox&statsPeriod=14d).