### PR TITLE
feat(project-config): Fall back to V2 after unsuccessful attempts [INGEST-1324 INGEST-1391]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Parse custom units with length < 15 without crashing. ([#1312](https://github.com/getsentry/relay/pull/1312))
 
+**Internal**:
+
+- Fall back to version 2 project config if version 3 fails. ([#1314](https://github.com/getsentry/relay/pull/1314))
+
 ## 22.6.0
 
 **Compatibility:** This version of Relay requires Sentry server `22.6.0` or newer.

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -129,6 +129,18 @@ pub struct UpstreamProjectSource {
     state_channels: HashMap<ProjectKey, ProjectStateChannel>,
 }
 
+type B = Vec<(ProjectKey, ProjectStateChannel)>;
+
+/// Separate regular channels from those with the `nocache` flag. The latter go in separate
+/// requests, since the upstream will block the response.
+fn partition_cache_no_cache<I>(channels: I) -> (B, B)
+where
+    I: Iterator<Item = (ProjectKey, ProjectStateChannel)>,
+{
+    let (nocache, cache) = channels.partition(|(_id, channel)| channel.no_cache);
+    (cache, nocache)
+}
+
 impl UpstreamProjectSource {
     pub fn new(config: Arc<Config>) -> Self {
         UpstreamProjectSource {
@@ -174,9 +186,7 @@ impl UpstreamProjectSource {
             .take(batch_size * num_batches)
             .collect();
 
-        // Separate regular channels from those with the `nocache` flag. The latter go in separate
-        // requests, since the upstream will block the response.
-        let (cache_channels, nocache_channels): (Vec<_>, Vec<_>) = (projects.iter())
+        let fresh_channels = (projects.iter())
             .filter_map(|id| Some((*id, self.state_channels.remove(id)?)))
             .filter(|(_id, channel)| {
                 if channel.expired() {
@@ -190,8 +200,10 @@ impl UpstreamProjectSource {
                     );
                 }
                 !channel.expired()
-            })
-            .partition(|(_id, channel)| channel.no_cache);
+            });
+
+        let (cache_channels, nocache_channels): (Vec<_>, Vec<_>) =
+            partition_cache_no_cache(fresh_channels);
         let total_count = cache_channels.len() + nocache_channels.len();
 
         metric!(histogram(RelayHistograms::ProjectStatePending) = self.state_channels.len() as u64);
@@ -394,5 +406,30 @@ impl Handler<FetchProjectState> for UpstreamProjectSource {
                 .map_err(|_| ())
                 .map(|x| ProjectStateResponse::new((*x).clone())),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_common::ProjectKey;
+
+    use super::{partition_cache_no_cache, ProjectStateChannel};
+
+    #[test]
+    fn test_partition_cache_no_cache() {
+        let project_key1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
+        let project_key2 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fef").unwrap();
+
+        let mut channel1 = ProjectStateChannel::new(Default::default());
+        channel1.no_cache();
+        let channel2 = ProjectStateChannel::new(Default::default());
+
+        let mixed = vec![(project_key1, channel1), (project_key2, channel2)];
+
+        let (cache, nocache) = partition_cache_no_cache(mixed.into_iter());
+        assert_eq!(cache.len(), 1);
+        assert!(!cache[0].1.no_cache);
+        assert_eq!(nocache.len(), 1);
+        assert!(nocache[0].1.no_cache);
     }
 }

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -176,7 +176,7 @@ impl UpstreamProjectSource {
 
         // Separate regular channels from those with the `nocache` flag. The latter go in separate
         // requests, since the upstream will block the response.
-        let (cache_channels, nocache_channels): (Vec<_>, Vec<_>) = (projects.iter())
+        let (nocache_channels, cache_channels): (Vec<_>, Vec<_>) = (projects.iter())
             .filter_map(|id| Some((*id, self.state_channels.remove(id)?)))
             .filter(|(_id, channel)| {
                 if channel.expired() {

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -24,8 +24,8 @@ use crate::utils::{self, ErrorBoundary};
 /// The version that will be used to query Upstream. The endpoint version is added as
 /// `version` query parameter to every outgoing request. See the `projectconfigs` endpoint for
 /// the versions that will be accepted by Relay.
-#[derive(Debug, Serialize)]
-enum GetProjectStatesVersion {
+#[derive(Debug)]
+pub enum GetProjectStatesVersion {
     /// Legacy version of the project states endpoint.
     V2,
     /// The current version of the project states endpoint.
@@ -38,7 +38,7 @@ enum GetProjectStatesVersion {
 /// invalid project keys instead of failing the entire batch.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct GetProjectStates {
+pub struct GetProjectStates {
     public_keys: Vec<ProjectKey>,
     full_config: bool,
     no_cache: bool,
@@ -234,8 +234,7 @@ impl UpstreamProjectSource {
                     no_cache: channels_batch.values().any(|c| c.no_cache),
                     version: if channels_batch.values().any(|c| c.almost_expired()) {
                         // For the time being, we assume that V2 is the more stable endpoint, so if
-                        // we fail to fetch the project config within half the timeout, fall back to V2.
-
+                        // we fail to fetch the project config within half the timeout period, fall back to V2.
                         relay_log::with_scope(
                             |scope| {
                                 let attempts_per_key: BTreeMap<String, u64> = channels_batch

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -234,9 +234,16 @@ def test_fallback_to_v2(mini_sentry, relay):
     # Give relay time to query sentry:
     time.sleep(1)
 
+    # Error was logged:
+    _, last_error = mini_sentry.test_failures[-1]
+    assert "Failed to fetch project config from V3 endpoint" in str(last_error)
+    mini_sentry.test_failures.clear()
+
     # Relay attempted to query version 3, but then fell back to version 2:
-    assert "?version=3" in mini_sentry.request_log[-2]
-    assert "?version=2" in mini_sentry.request_log[-1]
+    assert "?version=3" in mini_sentry.request_log[-3]
+    assert "?version=2" in mini_sentry.request_log[-2]
+
+    assert "/envelope/" in mini_sentry.request_log[-1]  # The error that was logged
 
     # Verify that valid config is now available:
     response = request_config()

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -159,7 +159,6 @@ def test_query_retry_maxed_out(
     This is not specific to processing or store, but here we have the outcomes
     consumer which we can use to assert that an event has been dropped.
     """
-
     request_count = 0
 
     outcomes_consumer = outcomes_consumer()
@@ -192,7 +191,11 @@ def test_query_retry_maxed_out(
 
         for (_, error) in mini_sentry.test_failures[:-1]:
             assert isinstance(error, AssertionError)
-            assert "error fetching project states" in str(error)
+            error_msg = str(error)
+            assert (
+                "Failed to fetch project config from V3 endpoint" in error_msg
+                or "error fetching project states" in error_msg
+            )
 
         _, last_error = mini_sentry.test_failures[-1]
         assert "failed to resolve project information" in str(last_error)


### PR DESCRIPTION
Until sentry's V3 project config endpoint is considered stable enough, fall back to the V2 endpoint when V3 fails to return a config within half the expiry timeout.