### PR TITLE
ref: upgrade check-jsonschema so it does not reach network at runtime

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -43,15 +43,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - macos-version: "10.15"
+          - macos-version: "macos-10.15"
             target: x86_64-apple-darwin
             py-platform: macosx-10_15_x86_64
-          - macos-version: "11.0"
+          - macos-version: "macos-11.0"
             target: aarch64-apple-darwin
             py-platform: macosx-11_0_arm64
 
     name: Python macOS ${{ matrix.py-platform }}
-    runs-on: macos-${{ matrix.macos-version }}
+    runs-on: ${{ matrix.macos-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
--   repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.3.0
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.16.0
     hooks:
     - id: check-github-actions
     - id: check-github-workflows


### PR DESCRIPTION
the latest version of `check-jsonschema` vendors the github actions and workflows schemas rather than reaching out to the network to download them each time -- this should reduce flakiness of this check

Committed via https://github.com/asottile/all-repos

#skip-changelog