### PR TITLE
ref: Fewer metrics extracted for release health [INGEST-1350]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Internal**:
 
 - Fall back to version 2 project config if version 3 fails. ([#1314](https://github.com/getsentry/relay/pull/1314))
+- Reduce number of metrics extracted for release health. ([#1316](https://github.com/getsentry/relay/pull/1316))
 
 ## 22.6.0
 

--- a/relay-server/src/metrics_extraction/sessions.rs
+++ b/relay-server/src/metrics_extraction/sessions.rs
@@ -185,8 +185,7 @@ pub fn extract_session_metrics<T: SessionLike>(
         }
     }
 
-    // Count durations for all exited sessions. Note that right now, in the product we
-    // really only use durations from session.status=exited.
+    // Count durations only for exited sessions, since Sentry doesn't use durations for other types of sessions.
     if let Some((duration, status)) = session.final_duration() {
         if status == SessionStatus::Exited {
             target.push(Metric::new_mri(

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -277,7 +277,6 @@ def test_session_metrics_non_processing(
                     "sdk": "raven-node/2.6.3",
                     "environment": "production",
                     "release": "sentry-test@1.0.0",
-                    "session.status": "init",
                 },
                 "timestamp": ts,
                 "width": 1,
@@ -403,7 +402,6 @@ def test_session_metrics_processing(
             "sdk": "raven-node/2.6.3",
             "environment": "production",
             "release": "sentry-test@1.0.0",
-            "session.status": "init",
         },
     }
 


### PR DESCRIPTION
Since https://github.com/getsentry/relay/pull/1275, we extract user IDs into one or more of `init`, `ok`, `errored`, `crashed`, `abnormal` buckets. The latter three are used by the product, but init and ok can be consolidated into a single tag, because the product does not query them explicitily as of https://github.com/getsentry/sentry/pull/34858 and https://github.com/getsentry/sentry/pull/34957.

In order to reduce the number of buckets stored in clickhouse, consolidate these tags.

Also, stop collecting session.duration for non-healthy sessions.