### PR TITLE
ref(dynamic-sampling): Sample trace after metrics extraction [INGEST-837]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Parse custom units with length < 15 without crashing. ([#1312](https://github.com/getsentry/relay/pull/1312))
+- Extract metrics also from trace-sampled transactions. ([#1317](https://github.com/getsentry/relay/pull/1317))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+**Features**:
+
+- Extract metrics also from trace-sampled transactions. ([#1317](https://github.com/getsentry/relay/pull/1317))
+
 **Bug Fixes**:
 
 - Parse custom units with length < 15 without crashing. ([#1312](https://github.com/getsentry/relay/pull/1312))
-- Extract metrics also from trace-sampled transactions. ([#1317](https://github.com/getsentry/relay/pull/1317))
 
 **Internal**:
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -380,6 +380,7 @@ struct ProcessEnvelopeState {
     project_state: Arc<ProjectState>,
 
     /// The state of the project that initiated the current trace.
+    /// This is the config used for trace-based dynamic sampling.
     sampling_project_state: Option<Arc<ProjectState>>,
 
     /// The id of the project that this envelope is ingested into.

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1812,7 +1812,7 @@ impl EnvelopeProcessor {
     }
 
     /// Run dynamic sampling rules on trace header to see if we keep the event or remove it.
-    fn sample_trace(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+    fn sample_trace(&self, state: &ProcessEnvelopeState) -> Result<(), ProcessingError> {
         let sampling_project_state = match &state.sampling_project_state {
             // nothing to sample
             None => {
@@ -1822,7 +1822,7 @@ impl EnvelopeProcessor {
         };
 
         let result = utils::sample_trace(
-            &mut state.envelope,
+            &state.envelope,
             sampling_project_state,
             self.config.processing_enabled(),
         );

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -2650,7 +2650,6 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
             .and_then(move |(envelope, project_state)| {
                 // get the state for the sampling project.
                 // TODO: Could this run concurrently with main project cache fetch?
-                dbg!(sampling_project_key);
                 if let Some(sampling_project_key) = sampling_project_key {
                     let future = ProjectCache::from_registry()
                         .send(GetProjectState::new(sampling_project_key))

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -82,7 +82,9 @@ fn sample_transaction_internal(
     }
 }
 
-/// TODO: docs
+/// Returns the project key defined in the `trace` header of the envelope, if defined.
+/// If there are no transactions in the envelope, we return None here, because there is nothing
+/// to sample by trace.
 pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
     let transaction_item = envelope.get_item_by(|item| item.ty() == &ItemType::Transaction);
 
@@ -223,6 +225,15 @@ mod tests {
             SamplingResult::NoDecision,
             should_keep_event(&event, None, &proj_state, true)
         );
+    }
+
+    #[test]
+    fn test_basic_trace_sampling() {
+        //create an envelope with a event and a transaction
+        let envelope = new_envelope(true);
+        let state = get_project_state(Some(0.0), RuleType::Trace);
+        let result = sample_transaction_internal(&envelope, &state, true);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -64,10 +64,7 @@ fn sample_transaction_internal(
         return Ok(());
     }
 
-    let trace_context = envelope.trace_context();
-    // let transaction_item = envelope.get_item_by(|item| item.ty() == &ItemType::Transaction);
-
-    let trace_context = match trace_context {
+    let trace_context = match envelope.trace_context() {
         // we don't have what we need, can't sample the transactions in this envelope
         None => {
             return Ok(());
@@ -226,23 +223,6 @@ mod tests {
             SamplingResult::NoDecision,
             should_keep_event(&event, None, &proj_state, true)
         );
-    }
-
-    #[test]
-    /// Should remove transaction from envelope when a matching rule is detected
-    fn test_should_drop_transaction() {
-        //create an envelope with a event and a transaction
-        let mut envelope = new_envelope(true);
-        // add an item that is not dependent on the transaction (i.e. will not be dropped with it)
-        let session_item = Item::new(ItemType::Session);
-        envelope.add_item(session_item);
-
-        let state = get_project_state(Some(0.0), RuleType::Trace);
-
-        let result = sample_transaction_internal(&envelope, &state, true);
-        assert!(result.is_ok());
-        // the transaction item and dependent items should have been removed
-        assert_eq!(envelope.len(), 1);
     }
 
     #[test]

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_basic_trace_sampling() {
+    fn test_unsampled_envelope_with_sample_rate() {
         //create an envelope with a event and a transaction
         let envelope = new_envelope(true);
         let state = get_project_state(Some(0.0), RuleType::Trace);

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -148,6 +148,7 @@ def test_it_removes_transactions(mini_sentry, relay):
     envelope = Envelope()
     transaction, trace_id, event_id = _create_transaction_item()
     envelope.add_transaction(transaction)
+    print("ENVELOPE", envelope)
     _add_trace_info(envelope, trace_id=trace_id, public_key=public_key)
 
     # send the event, the transaction should be removed.

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -148,7 +148,6 @@ def test_it_removes_transactions(mini_sentry, relay):
     envelope = Envelope()
     transaction, trace_id, event_id = _create_transaction_item()
     envelope.add_transaction(transaction)
-    print("ENVELOPE", envelope)
     _add_trace_info(envelope, trace_id=trace_id, public_key=public_key)
 
     # send the event, the transaction should be removed.


### PR DESCRIPTION
The `sample_trace` logic needs to be called _after_ metrics are extracted from a transaction. For this,

* move the async code that fetches the project state for the `trace` project key out of `sample_trace` and into the envelope manager.
* pass the `sampling_project_key` to the `EnvelopeProcessor`,
* run `sample_trace()` right before `sample_event()`,
* make the sampling decision independent of envelope items, because these have already been cleared out by `extract_event()`.