### PR TITLE
ref(project_upstream): shorted soft-deadline

### DIFF
--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -103,7 +103,7 @@ impl ProjectStateChannel {
             sender,
             receiver: receiver.shared(),
             deadline: now + timeout,
-            // after 1/3 of the time, fall back to v2 project config requests
+            // after 1/5 of the time, fall back to v2 project config requests
             soft_deadline: now + timeout / 5,
             no_cache: false,
             attempts: 0,

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -104,7 +104,7 @@ impl ProjectStateChannel {
             receiver: receiver.shared(),
             deadline: now + timeout,
             // after 1/3 of the time, fall back to v2 project config requests
-            soft_deadline: now + timeout / 3,
+            soft_deadline: now + timeout / 5,
             no_cache: false,
             attempts: 0,
         }


### PR DESCRIPTION
We still see some timeouts on pop relays when v3 is enabled.  This
shortens the fallback to 6s in practice, which is still plenty to
compute a projectconfig and should help pop relays from seeing the
results faster.

#skip-changelog