### PR TITLE
feat(profiling): Add thread metadata to tell which thread is the main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fall back to version 2 project config if version 3 fails. ([#1314](https://github.com/getsentry/relay/pull/1314))
 - Reduce number of metrics extracted for release health. ([#1316](https://github.com/getsentry/relay/pull/1316))
+- Indicate with thread is the main thread in thread metadata for profiles. ([#1320](https://github.com/getsentry/relay/pull/1320))
 
 ## 22.6.0
 

--- a/relay-server/src/utils/profile.rs
+++ b/relay-server/src/utils/profile.rs
@@ -159,6 +159,9 @@ struct Sample {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ThreadMetadata {
+    #[serde(default)]
+    is_main_thread: bool,
+
     #[serde(default, skip_serializing_if = "String::is_empty")]
     name: String,
     priority: u32,


### PR DESCRIPTION
We need to identify which thread is the main thread in Cocoa profiles. The client will now set a boolean in thread metadata to indicate the main thread. Here is the related change in the SDK https://github.com/getsentry/sentry-cocoa/pull/1918.

This should be an optional field.