### PR TITLE
fix(profiling): Increase profile maximum size by an order of magnitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fall back to version 2 project config if version 3 fails. ([#1314](https://github.com/getsentry/relay/pull/1314))
 - Reduce number of metrics extracted for release health. ([#1316](https://github.com/getsentry/relay/pull/1316))
 - Indicate with thread is the main thread in thread metadata for profiles. ([#1320](https://github.com/getsentry/relay/pull/1320))
+- Increase profile maximum size by an order of magnitude. ([#1321](https://github.com/getsentry/relay/pull/1321))
 
 ## 22.6.0
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -565,7 +565,7 @@ impl Default for Limits {
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
-            max_profile_size: ByteSize::mebibytes(10),
+            max_profile_size: ByteSize::mebibytes(100),
             max_thread_count: num_cpus::get(),
             query_timeout: 30,
             max_connection_rate: 256,

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -565,7 +565,7 @@ impl Default for Limits {
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
-            max_profile_size: ByteSize::mebibytes(100),
+            max_profile_size: ByteSize::mebibytes(50),
             max_thread_count: num_cpus::get(),
             query_timeout: 30,
             max_connection_rate: 256,


### PR DESCRIPTION
With a few customers onboarded, we're seeing profiles lasting a few seconds that can end up being right above 10MiB after being expanded (so, they can be 1MiB coming from the client but then we expand them into a more useful format and the resulting JSON ends up being more than 10MiB to be sent to Kafka). This aims to allow such profiles to make it to the rest of the pipeline as they are not a problem.

There is a good discussion to have around the maximum size we want to allow (perhaps there's a limit to what Kafka can handle without too much trouble) and we'd be able to reduce the size of the payload (using a different format than JSON, compressing the payload before it's send to Kafka) but for now, I want to see those profiles through and assess if they are outliers or the norm before we put too much work into reducing the size.