### PR TITLE
fix(tests): Unflake v2 fallback test

### DIFF
--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -240,10 +240,9 @@ def test_fallback_to_v2(mini_sentry, relay):
     mini_sentry.test_failures.clear()
 
     # Relay attempted to query version 3, but then fell back to version 2:
-    assert "?version=3" in mini_sentry.request_log[-3]
-    assert "?version=2" in mini_sentry.request_log[-2]
-
-    assert "/envelope/" in mini_sentry.request_log[-1]  # The error that was logged
+    config_requests = [r for r in mini_sentry.request_log if "projectconfigs" in r]
+    assert "?version=3" in config_requests[-2], config_requests
+    assert "?version=2" in config_requests[-1], config_requests
 
     # Verify that valid config is now available:
     response = request_config()


### PR DESCRIPTION
The project config fallback to v2 test is flaky, see https://github.com/getsentry/relay/runs/7107098764?check_suite_focus=true#step:10:631.

Filter down list of requests to project config requests, in the hope that that stabilizes the array access.

#skip-changelog