### PR TITLE
feat(protocol): Add transaction_info to events [INGEST-1427]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Extract metrics also from trace-sampled transactions. ([#1317](https://github.com/getsentry/relay/pull/1317))
-
+- Support `transaction_info` on event payloads. ([#1330](https://github.com/getsentry/relay/pull/1330))
 
 **Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `transaction_info` to event payloads, including the transaction's source and internal original transaction name. ([#1330](https://github.com/getsentry/relay/pull/1330))
+
 ## 0.8.13
 
 - Add a data category constant for Replays. ([#1239](https://github.com/getsentry/relay/pull/1239))

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -12,7 +12,8 @@ use crate::processor::ProcessValue;
 use crate::protocol::{
     Breadcrumb, Breakdowns, ClientSdkInfo, Contexts, Csp, DebugMeta, Exception, ExpectCt,
     ExpectStaple, Fingerprint, Hpkp, LenientString, Level, LogEntry, Measurements, Metrics,
-    RelayInfo, Request, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, User, Values,
+    RelayInfo, Request, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, TransactionInfo,
+    User, Values,
 };
 use crate::types::{
     Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
@@ -254,6 +255,10 @@ pub struct Event {
     /// `UserView`), in a task queue it might be the function + module name.
     #[metastructure(max_chars = "culprit", trim_whitespace = "true")]
     pub transaction: Annotated<String>,
+
+    /// Additional information about the name of the transaction.
+    #[metastructure(skip_serialization = "empty")]
+    pub transaction_info: Annotated<TransactionInfo>,
 
     /// Time since the start of the transaction until the error occurred.
     pub time_spent: Annotated<u64>,

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -25,6 +25,7 @@ mod stacktrace;
 mod tags;
 mod templateinfo;
 mod thread;
+mod transaction;
 mod types;
 mod user;
 mod user_report;
@@ -68,6 +69,7 @@ pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrac
 pub use self::tags::{TagEntry, Tags};
 pub use self::templateinfo::TemplateInfo;
 pub use self::thread::{Thread, ThreadId};
+pub use self::transaction::TransactionInfo;
 pub use self::types::{
     datetime_to_timestamp, Addr, AsPair, InvalidRegVal, IpAddr, JsonLenientString, LenientString,
     Level, PairList, ParseLevelError, RegVal, Timestamp, Values,

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -69,7 +69,7 @@ pub use self::stacktrace::{Frame, FrameData, FrameVars, RawStacktrace, Stacktrac
 pub use self::tags::{TagEntry, Tags};
 pub use self::templateinfo::TemplateInfo;
 pub use self::thread::{Thread, ThreadId};
-pub use self::transaction::TransactionInfo;
+pub use self::transaction::{TransactionInfo, TransactionSource};
 pub use self::types::{
     datetime_to_timestamp, Addr, AsPair, InvalidRegVal, IpAddr, JsonLenientString, LenientString,
     Level, PairList, ParseLevelError, RegVal, Timestamp, Values,

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -27,6 +27,7 @@ pub enum TransactionSource {
     /// This is the default value set by Relay for legacy SDKs.
     Unknown,
     /// Any other unknown source that is not explicitly defined above.
+    #[schemars(skip)]
     Other(String),
 }
 

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -13,9 +13,6 @@ pub enum TransactionSource {
     Custom,
     /// Raw URL, potentially containing identifiers.
     Url,
-    /// The SDK is configured to send a [`route`](Self::Route), but has to fall back to a raw URL
-    /// for this particular transaction.
-    UrlFallback,
     /// Parametrized URL or route.
     Route,
     /// Name of the view handling the request.
@@ -38,7 +35,6 @@ impl FromStr for TransactionSource {
         match s {
             "custom" => Ok(Self::Custom),
             "url" => Ok(Self::Url),
-            "url-fallback" => Ok(Self::UrlFallback),
             "route" => Ok(Self::Route),
             "view" => Ok(Self::View),
             "component" => Ok(Self::Component),
@@ -54,7 +50,6 @@ impl fmt::Display for TransactionSource {
         match self {
             Self::Custom => write!(f, "custom"),
             Self::Url => write!(f, "url"),
-            Self::UrlFallback => write!(f, "url-fallback"),
             Self::Route => write!(f, "route"),
             Self::View => write!(f, "view"),
             Self::Component => write!(f, "component"),
@@ -133,15 +128,6 @@ pub struct TransactionInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_url_fallback_roundtrip() {
-        let json = r#""url-fallback""#;
-        let source = Annotated::new(TransactionSource::UrlFallback);
-
-        assert_eq_dbg!(source, Annotated::from_json(json).unwrap());
-        assert_eq_str!(json, source.payload_to_json_pretty().unwrap());
-    }
 
     #[test]
     fn test_other_source_roundtrip() {

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -1,0 +1,169 @@
+use std::fmt;
+use std::str::FromStr;
+
+use crate::processor::ProcessValue;
+use crate::types::{Annotated, Empty, ErrorKind, FromValue, IntoValue, SkipSerialization, Value};
+
+/// Describes how the name of the transaction was determined.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[schemars(rename_all = "kebab-case")]
+pub enum TransactionSource {
+    /// User-defined name set through `set_transaction_name`.
+    Custom,
+    /// Raw URL, potentially containing identifiers.
+    Url,
+    /// The SDK is configured to send a [`route`](Self::Route), but has to fall back to a raw URL
+    /// for this particular transaction.
+    UrlFallback,
+    /// Parametrized URL or route.
+    Route,
+    /// Name of the view handling the request.
+    View,
+    /// Named after a software component, such as a function or class name.
+    Component,
+    /// Name of a background task (e.g. a Celery task).
+    Task,
+    /// This is the default value set by Relay for legacy SDKs.
+    Unknown,
+    /// Any other unknown source that is not explicitly defined above.
+    Other(String),
+}
+
+impl FromStr for TransactionSource {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "custom" => Ok(Self::Custom),
+            "url" => Ok(Self::Url),
+            "url-fallback" => Ok(Self::UrlFallback),
+            "route" => Ok(Self::Route),
+            "view" => Ok(Self::View),
+            "component" => Ok(Self::Component),
+            "task" => Ok(Self::Task),
+            "unknown" => Ok(Self::Unknown),
+            s => Ok(Self::Other(s.to_owned())),
+        }
+    }
+}
+
+impl fmt::Display for TransactionSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Custom => write!(f, "custom"),
+            Self::Url => write!(f, "url"),
+            Self::UrlFallback => write!(f, "url-fallback"),
+            Self::Route => write!(f, "route"),
+            Self::View => write!(f, "view"),
+            Self::Component => write!(f, "component"),
+            Self::Task => write!(f, "task"),
+            Self::Unknown => write!(f, "unknown"),
+            Self::Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl Default for TransactionSource {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+impl Empty for TransactionSource {
+    #[inline]
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+}
+
+impl FromValue for TransactionSource {
+    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+        match String::from_value(value) {
+            Annotated(Some(value), mut meta) => match value.parse() {
+                Ok(source) => Annotated(Some(source), meta),
+                Err(_) => {
+                    meta.add_error(ErrorKind::InvalidData);
+                    meta.set_original_value(Some(value));
+                    Annotated(None, meta)
+                }
+            },
+            Annotated(None, meta) => Annotated(None, meta),
+        }
+    }
+}
+
+impl IntoValue for TransactionSource {
+    fn into_value(self) -> Value
+    where
+        Self: Sized,
+    {
+        Value::String(self.to_string())
+    }
+
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
+    where
+        Self: Sized,
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(&self.to_string(), s)
+    }
+}
+
+impl ProcessValue for TransactionSource {}
+
+/// Additional information about the name of the transaction.
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
+pub struct TransactionInfo {
+    /// Describes how the name of the transaction was determined.
+    ///
+    /// This will be used by the server to decide whether or not to scrub identifiers from the
+    /// transaction name, or replace the entire name with a placeholder.
+    pub source: Annotated<TransactionSource>,
+
+    /// The unmodified transaction name as obtained by the source.
+    ///
+    /// This value will only be set if the transaction name was modified during event processing.
+    #[metastructure(max_chars = "culprit", trim_whitespace = "true")]
+    pub original: Annotated<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_fallback_roundtrip() {
+        let json = r#""url-fallback""#;
+        let source = Annotated::new(TransactionSource::UrlFallback);
+
+        assert_eq_dbg!(source, Annotated::from_json(json).unwrap());
+        assert_eq_str!(json, source.payload_to_json_pretty().unwrap());
+    }
+
+    #[test]
+    fn test_other_source_roundtrip() {
+        let json = r#""something-new""#;
+        let source = Annotated::new(TransactionSource::Other("something-new".to_owned()));
+
+        assert_eq_dbg!(source, Annotated::from_json(json).unwrap());
+        assert_eq_str!(json, source.payload_to_json_pretty().unwrap());
+    }
+
+    #[test]
+    fn test_transaction_info_roundtrip() {
+        let json = r#"{
+  "source": "url",
+  "original": "/auth/login/john123/"
+}"#;
+
+        let info = Annotated::new(TransactionInfo {
+            source: Annotated::new(TransactionSource::Url),
+            original: Annotated::new("/auth/login/john123/".to_owned()),
+        });
+
+        assert_eq_dbg!(info, Annotated::from_json(json).unwrap());
+        assert_eq_str!(json, info.to_json_pretty().unwrap());
+    }
+}

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -7,7 +7,7 @@ use crate::types::{Annotated, Empty, ErrorKind, FromValue, IntoValue, SkipSerial
 /// Describes how the name of the transaction was determined.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[schemars(rename_all = "kebab-case")]
+#[cfg_attr(feature = "jsonschema", schemars(rename_all = "kebab-case"))]
 pub enum TransactionSource {
     /// User-defined name set through `set_transaction_name`.
     Custom,
@@ -24,7 +24,7 @@ pub enum TransactionSource {
     /// This is the default value set by Relay for legacy SDKs.
     Unknown,
     /// Any other unknown source that is not explicitly defined above.
-    #[schemars(skip)]
+    #[cfg_attr(feature = "jsonschema", schemars(skip))]
     Other(String),
 }
 

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1,5 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
+assertion_line: 106
 expression: event_json_schema()
 ---
 {
@@ -345,6 +346,18 @@ expression: event_json_schema()
           "type": [
             "string",
             "null"
+          ]
+        },
+        "transaction_info": {
+          "description": " Additional information about the name of the transaction.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TransactionInfo"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "type": {
@@ -2800,6 +2813,68 @@ expression: event_json_schema()
       "anyOf": [
         {
           "type": "string"
+        }
+      ]
+    },
+    "TransactionInfo": {
+      "description": " Additional information about the name of the transaction.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "original": {
+              "description": " The unmodified transaction name as obtained by the source.\n\n This value will only be set if the transaction name was modified during event processing.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "description": " Describes how the name of the transaction was determined.\n\n This will be used by the server to decide whether or not to scrub identifiers from the\n transaction name, or replace the entire name with a placeholder.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TransactionSource"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TransactionSource": {
+      "description": "Describes how the name of the transaction was determined.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "custom",
+            "url",
+            "url-fallback",
+            "route",
+            "view",
+            "component",
+            "task",
+            "unknown"
+          ]
+        },
+        {
+          "description": "Any other unknown source that is not explicitly defined above.",
+          "type": "object",
+          "required": [
+            "other"
+          ],
+          "properties": {
+            "other": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2853,7 +2853,6 @@ expression: event_json_schema()
       "enum": [
         "custom",
         "url",
-        "url-fallback",
         "route",
         "view",
         "component",

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2849,33 +2849,16 @@ expression: event_json_schema()
     },
     "TransactionSource": {
       "description": "Describes how the name of the transaction was determined.",
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "custom",
-            "url",
-            "url-fallback",
-            "route",
-            "view",
-            "component",
-            "task",
-            "unknown"
-          ]
-        },
-        {
-          "description": "Any other unknown source that is not explicitly defined above.",
-          "type": "object",
-          "required": [
-            "other"
-          ],
-          "properties": {
-            "other": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
+      "type": "string",
+      "enum": [
+        "custom",
+        "url",
+        "url-fallback",
+        "route",
+        "view",
+        "component",
+        "task",
+        "unknown"
       ]
     },
     "User": {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1530,7 +1530,9 @@ impl EnvelopeProcessor {
 
                 metric!(
                     counter(RelayCounters::EventTransactionSource) += 1,
-                    source = &source.to_string()
+                    source = &source.to_string(),
+                    sdk = envelope.meta().client_name().unwrap_or("proprietary"),
+                    platform = event.platform.as_str().unwrap_or("other"),
                 );
             }
         }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -29,7 +29,7 @@ use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp,
     IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionAggregates,
-    SessionAttributes, SessionUpdate, Timestamp, UserReport, Values,
+    SessionAttributes, SessionUpdate, Timestamp, TransactionSource, UserReport, Values,
 };
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
@@ -66,7 +66,6 @@ use {
     crate::service::ServerErrorKind,
     crate::utils::{EnvelopeLimiter, ErrorBoundary},
     failure::ResultExt,
-    relay_general::protocol::TransactionSource,
     relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
     relay_quotas::{RateLimitingError, RedisRateLimiter},
     symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -204,8 +204,19 @@ pub struct RequestMeta<D = PartialDsn> {
 
 impl<D> RequestMeta<D> {
     /// Returns the client that sent this event (Sentry SDK identifier).
+    ///
+    /// The client is formatted as `"sdk/version"`, for example `"raven-node/2.6.3"`.
     pub fn client(&self) -> Option<&str> {
         self.client.as_deref()
+    }
+
+    /// Returns the name of the client that sent the event without version.
+    ///
+    /// If the client is not sent in standard format, this method returns `None`.
+    pub fn client_name(&self) -> Option<&str> {
+        let client = self.client()?;
+        let (name, _version) = client.split_once('/')?;
+        Some(name)
     }
 
     /// Returns the protocol version of the event payload.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -453,7 +453,6 @@ pub enum RelayCounters {
     ///  - `source`: The source of the transaction name on the client. See the [transaction source
     ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
     ///    for all valid values.
-    #[cfg(feature = "processing")]
     EventTransactionSource,
     /// Number of HTTP requests reaching Relay.
     Requests,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -447,6 +447,14 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     ///  - `version`: The event protocol version number defaulting to `7`.
     EventProtocol,
+    /// The number of transaction events processed by the source of the transaction name.
+    ///
+    /// This metric is tagged with:
+    ///  - `source`: The source of the transaction name on the client. See the [transaction source
+    ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
+    ///    for all valid values.
+    #[cfg(feature = "processing")]
+    EventTransactionSource,
     /// Number of HTTP requests reaching Relay.
     Requests,
     /// Number of completed HTTP requests.
@@ -496,6 +504,7 @@ impl CounterMetric for RelayCounters {
             #[cfg(feature = "processing")]
             RelayCounters::ProcessingProduceError => "processing.produce.error",
             RelayCounters::EventProtocol => "event.protocol",
+            RelayCounters::EventTransactionSource => "event.transaction_source",
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -450,6 +450,9 @@ pub enum RelayCounters {
     /// The number of transaction events processed by the source of the transaction name.
     ///
     /// This metric is tagged with:
+    ///  - `platform`: The event's platform, such as `"javascript"`.
+    ///  - `sdk`: The name of the Sentry SDK sending the transaction. This tag is only set for
+    ///    Sentry's SDKs and defaults to "proprietary".
     ///  - `source`: The source of the transaction name on the client. See the [transaction source
     ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
     ///    for all valid values.


### PR DESCRIPTION
Implements `transaction_info` as documented in https://github.com/getsentry/develop/pull/624 and adds the `event.transaction_source` metric to measure how often each source occurs in practice. 

Requires #1329 