### PR TITLE
fix(metrics): Consistent transaction.status [INGEST-1416]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Parse custom units with length < 15 without crashing. ([#1312](https://github.com/getsentry/relay/pull/1312))
 - Split large metrics requests into smaller batches. This avoids failed metrics submission and lost Release Health data due to `413 Payload Too Large` errors on the upstream. ([#1326](https://github.com/getsentry/relay/pull/1326))
+- Metrics extraction: Map missing transaction status to "unknown". ([#1333](https://github.com/getsentry/relay/pull/1333))
 
 **Internal**:
 

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use {
     crate::metrics_extraction::conditional_tagging::run_conditional_tagging,
     crate::metrics_extraction::{utils, TaggingRule},
-    relay_common::UnixTimestamp,
+    relay_common::{SpanStatus, UnixTimestamp},
     relay_general::protocol::TraceContext,
     relay_general::protocol::{AsPair, Event, EventType, Timestamp},
     relay_general::protocol::{Context, ContextInner},
@@ -75,10 +75,11 @@ fn get_trace_context(event: &Event) -> Option<&TraceContext> {
     None
 }
 
+/// Extract transaction status, defaulting to Unknown.
+/// Needs to be consistent with `process_trace_context` in [`relay_general::store::normalize`].
 #[cfg(feature = "processing")]
-fn extract_transaction_status(trace_context: &TraceContext) -> Option<String> {
-    let span_status = trace_context.status.value()?;
-    Some(span_status.to_string())
+fn extract_transaction_status(trace_context: &TraceContext) -> SpanStatus {
+    trace_context.status.value().unwrap_or(SpanStatus::Unknown)
 }
 
 #[cfg(feature = "processing")]

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -75,11 +75,11 @@ fn get_trace_context(event: &Event) -> Option<&TraceContext> {
     None
 }
 
-/// Extract transaction status, defaulting to Unknown.
-/// Needs to be consistent with `process_trace_context` in [`relay_general::store::normalize`].
+/// Extract transaction status, defaulting to [`SpanStatus::Unknown`].
+/// Must be consistent with `process_trace_context` in [`relay_general::store::normalize`].
 #[cfg(feature = "processing")]
 fn extract_transaction_status(trace_context: &TraceContext) -> SpanStatus {
-    trace_context.status.value().unwrap_or(SpanStatus::Unknown)
+    *trace_context.status.value().unwrap_or(&SpanStatus::Unknown)
 }
 
 #[cfg(feature = "processing")]
@@ -198,9 +198,8 @@ fn extract_universal_tags(
     tags.insert("platform".to_owned(), platform.to_owned());
 
     if let Some(trace_context) = get_trace_context(event) {
-        if let Some(status) = extract_transaction_status(trace_context) {
-            tags.insert("transaction.status".to_owned(), status);
-        }
+        let status = extract_transaction_status(trace_context);
+        tags.insert("transaction.status".to_owned(), status.to_string());
 
         if let Some(op) = extract_transaction_op(trace_context) {
             tags.insert("transaction.op".to_owned(), op);
@@ -1126,6 +1125,80 @@ mod tests {
                     tags
                 }
             )]
+        );
+    }
+
+    #[test]
+    fn test_unknown_transaction_status_no_trace_context() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T07:59:01+0100"
+        }
+        "#;
+
+        let config: TransactionMetricsConfig = serde_json::from_str(
+            r#"
+        {
+            "extractMetrics": [
+                "d:transactions/duration@millisecond"
+            ]
+        }
+        "#,
+        )
+        .unwrap();
+
+        let event = Annotated::from_json(json).unwrap();
+
+        let mut metrics = vec![];
+        extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
+
+        assert_eq!(metrics.len(), 1, "{:?}", metrics);
+
+        assert_eq!(metrics[0].name, "d:transactions/duration@millisecond");
+        assert_eq!(
+            metrics[0].tags,
+            BTreeMap::from([("platform".to_string(), "other".to_string())])
+        );
+    }
+
+    #[test]
+    fn test_unknown_transaction_status() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T07:59:01+0100",
+            "contexts": {"trace": {}}
+        }
+        "#;
+
+        let config: TransactionMetricsConfig = serde_json::from_str(
+            r#"
+        {
+            "extractMetrics": [
+                "d:transactions/duration@millisecond"
+            ]
+        }
+        "#,
+        )
+        .unwrap();
+
+        let event = Annotated::from_json(json).unwrap();
+
+        let mut metrics = vec![];
+        extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
+
+        assert_eq!(metrics.len(), 1, "{:?}", metrics);
+
+        assert_eq!(metrics[0].name, "d:transactions/duration@millisecond");
+        assert_eq!(
+            metrics[0].tags,
+            BTreeMap::from([
+                ("transaction.status".to_string(), "unknown".to_string()),
+                ("platform".to_string(), "other".to_string())
+            ])
         );
     }
 }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -76,7 +76,7 @@ fn get_trace_context(event: &Event) -> Option<&TraceContext> {
 }
 
 /// Extract transaction status, defaulting to [`SpanStatus::Unknown`].
-/// Must be consistent with `process_trace_context` in [`relay_general::store::normalize`].
+/// Must be consistent with `process_trace_context` in [`relay_general::store`].
 #[cfg(feature = "processing")]
 fn extract_transaction_status(trace_context: &TraceContext) -> SpanStatus {
     *trace_context.status.value().unwrap_or(&SpanStatus::Unknown)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -536,6 +536,7 @@ def test_transaction_metrics(
         "name": "d:transactions/measurements.foo@none",
         "type": "d",
         "value": [1.2, 2.2],
+        "transaction.status": "unknown",
     }
 
     assert metrics["d:transactions/measurements.bar@none"] == {

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -528,6 +528,7 @@ def test_transaction_metrics(
         "tags": {
             "transaction": "/organizations/:orgId/performance/:eventSlug/",
             "platform": "other",
+            "transaction.status": "unknown",
         },
     }
 
@@ -536,7 +537,6 @@ def test_transaction_metrics(
         "name": "d:transactions/measurements.foo@none",
         "type": "d",
         "value": [1.2, 2.2],
-        "transaction.status": "unknown",
     }
 
     assert metrics["d:transactions/measurements.bar@none"] == {


### PR DESCRIPTION
In store normalization, we set `contexts.trace.status` to unknown in case it is missing from the trace context.
In metrics extraction, which runs before normalization, we simply ignored a missing status. Align.

* This does not increase dimensionality, since the bucket `..., status=none` will now move to bucket `..., status=unknown`.
* There is already a static string for `unknown` [in the indexer](https://github.com/getsentry/sentry/blob/a74e14fca258cdd7606f227b4a663994c9e0bb18/src/sentry/sentry_metrics/indexer/strings.py#L89), so this will not increase indexer storage.

## Future Work

To reduce code duplication, carve out the parts of store normalization that are needed for metrics extraction and put it something like a `PreMetricsProcessor` that runs before extraction.