### PR TITLE
fix: Update benchmark tests to compile

### DIFF
--- a/relay-general/benches/benchmarks.rs
+++ b/relay-general/benches/benchmarks.rs
@@ -91,6 +91,8 @@ fn bench_store_processor(c: &mut Criterion) {
         sent_at: None,
         received_at: None,
         breakdowns: None,
+        span_attributes: Default::default(),
+        client_sample_rate: None,
     };
 
     let mut processor = StoreProcessor::new(config, None);

--- a/relay-metrics/benches/aggregator.rs
+++ b/relay-metrics/benches/aggregator.rs
@@ -7,7 +7,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 
 use relay_common::{ProjectKey, UnixTimestamp};
 use relay_metrics::{Aggregator, AggregatorConfig};
-use relay_metrics::{Bucket, FlushBuckets, Metric, MetricUnit, MetricValue};
+use relay_metrics::{Bucket, FlushBuckets, Metric, MetricValue};
 
 #[derive(Clone, Default)]
 struct TestReceiver;
@@ -70,8 +70,7 @@ impl fmt::Display for MetricInput {
 
 lazy_static::lazy_static! {
     static ref COUNTER_METRIC: Metric = Metric {
-        name: "foo".to_owned(),
-        unit: MetricUnit::None,
+        name: "custom/foo@none".to_owned(),
         value: MetricValue::Counter(42.),
         timestamp: UnixTimestamp::now(),
         tags: BTreeMap::new(),


### PR DESCRIPTION
Benchmarks are not run in CI. Recent updates to metrics and the store processor
have added fields that were missed in the benchmark tests. This PR adds those
missing fields to get them compiling again.

In a follow-up, we will ensure to compile benchmark tests in CI at a minimum, or
even run them to some capacity.

#skip-changelog

