### PR TITLE
meta(vscode): Update name of rust-analyzer extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,7 @@
     // TOML language support
     "bungcip.better-toml",
     // Rust language server
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     // Python including Pylance
     "ms-python.python",
     // Crates.io dependency versions


### PR DESCRIPTION
See https://blog.rust-lang.org/2022/02/21/rust-analyzer-joins-rust-org.html.

#skip-changelog