### PR TITLE
feat(metrics): Drop transaction tag for high-cardinality sources [INGEST-1437]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Features**:
 
-- Extract metrics also from trace-sampled transactions. ([#1317](https://github.com/getsentry/relay/pull/1317))
 - Adjust sample rate by envelope header's sample_rate. ([#1327](https://github.com/getsentry/relay/pull/1327))
 - Support `transaction_info` on event payloads. ([#1330](https://github.com/getsentry/relay/pull/1330))
 
@@ -21,7 +20,9 @@
 - Indicate with thread is the main thread in thread metadata for profiles. ([#1320](https://github.com/getsentry/relay/pull/1320))
 - Increase profile maximum size by an order of magnitude. ([#1321](https://github.com/getsentry/relay/pull/1321))
 - Add data category constant for processed transactions, encompassing all transactions that have been received and sent through dynamic sampling as well as metrics extraction. ([#1306](https://github.com/getsentry/relay/pull/1306))
+- Extract metrics also from trace-sampled transactions. ([#1317](https://github.com/getsentry/relay/pull/1317))
 - Extract metrics from a configurable amount of custom transaction measurements. ([#1324](https://github.com/getsentry/relay/pull/1324))
+- Metrics: Drop transaction tag for high-cardinality sources. ([#1339](https://github.com/getsentry/relay/pull/1339))
 
 ## 22.6.0
 

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -538,8 +538,19 @@ pub struct Event {
     pub other: Object<Value>,
 }
 
+impl Event {
+    pub fn get_transaction_source(&self) -> &TransactionSource {
+        self.transaction_info
+            .value()
+            .and_then(|info| info.source.value())
+            .unwrap_or(&TransactionSource::Unknown)
+    }
+}
+
 #[cfg(test)]
 use crate::testutils::{assert_eq_dbg, assert_eq_str};
+
+use super::TransactionSource;
 
 #[test]
 fn test_event_roundtrip() {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -29,7 +29,7 @@ use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventId, EventType, ExpectCt, ExpectStaple, Hpkp,
     IpAddr, LenientString, Metrics, RelayInfo, SecurityReportType, SessionAggregates,
-    SessionAttributes, SessionUpdate, Timestamp, TransactionSource, UserReport, Values,
+    SessionAttributes, SessionUpdate, Timestamp, UserReport, Values,
 };
 use relay_general::store::ClockDriftProcessor;
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
@@ -1518,11 +1518,7 @@ impl EnvelopeProcessor {
             event._metrics = Annotated::new(metrics);
 
             if event.ty.value() == Some(&EventType::Transaction) {
-                let source = event
-                    .transaction_info
-                    .value()
-                    .and_then(|info| info.source.value())
-                    .unwrap_or(&TransactionSource::Unknown);
+                let source = event.get_transaction_source();
 
                 metric!(
                     counter(RelayCounters::EventTransactionSource) += 1,

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -7,7 +7,7 @@ use {
     crate::metrics_extraction::{utils, TaggingRule},
     relay_common::{SpanStatus, UnixTimestamp},
     relay_general::protocol::TraceContext,
-    relay_general::protocol::{AsPair, Event, EventType, Timestamp},
+    relay_general::protocol::{AsPair, Event, EventType, Timestamp, TransactionSource},
     relay_general::protocol::{Context, ContextInner},
     relay_general::store,
     relay_general::types::Annotated,
@@ -169,6 +169,35 @@ fn extract_user_satisfaction(
     None
 }
 
+/// Decide whether we want to keep the transaction name.
+/// High-cardinality sources are excluded to protect our metrics infrastructure.
+/// Note that this will produce a discrepancy between metrics and raw transaction data.
+#[cfg(feature = "processing")]
+fn keep_transaction_name(source: &TransactionSource) -> bool {
+    match source {
+        // "custom" is like a box of chocolates, you never know what you're gonna get.
+        // For now, we hope that custom transaction names set by users are low-cardinality.
+        TransactionSource::Custom => true,
+        // "url" are raw URLs, potentially containing identifiers.
+        TransactionSource::Url => false,
+        TransactionSource::Route => true,
+        TransactionSource::View => true,
+        TransactionSource::Component => true,
+        TransactionSource::Task => true,
+
+        // "unknown" is the value for old SDKs that do not send a transaction source yet.
+        // Assume high-cardinality and drop.
+        TransactionSource::Unknown => false,
+
+        // Any other value would be an SDK bug, assume high-cardinality and drop.
+        TransactionSource::Other(source) => {
+            // EnvelopeProcessor sets project and SDK on the scope, so no need to add sentry tags here.
+            relay_log::error!("Invalid transaction source: '{}'", source);
+            false
+        }
+    }
+}
+
 /// These are the tags that are added to all extracted metrics.
 #[cfg(feature = "processing")]
 fn extract_universal_tags(
@@ -186,7 +215,9 @@ fn extract_universal_tags(
         tags.insert("environment".to_owned(), environment.to_owned());
     }
     if let Some(transaction) = event.transaction.as_str() {
-        tags.insert("transaction".to_owned(), transaction.to_owned());
+        if keep_transaction_name(event.get_transaction_source()) {
+            tags.insert("transaction".to_owned(), transaction.to_owned());
+        }
     }
 
     // The platform tag should not increase dimensionality in most cases, because most
@@ -461,10 +492,12 @@ fn get_measurement_rating(name: &str, value: f64) -> Option<String> {
 #[cfg(test)]
 #[cfg(feature = "processing")]
 mod tests {
+
     use super::*;
 
     use crate::metrics_extraction::TaggingRule;
     use insta::assert_debug_snapshot;
+    use relay_general::protocol::TransactionInfo;
     use relay_general::store::BreakdownsConfig;
     use relay_general::types::Annotated;
     use relay_metrics::DurationUnit;
@@ -481,6 +514,7 @@ mod tests {
             "dist": "foo ",
             "environment": "fake_environment",
             "transaction": "mytransaction",
+            "transaction_info": {"source": "custom"},
             "user": {
                 "id": "user123"
             },
@@ -741,11 +775,10 @@ mod tests {
             panic!(); // Duration must be set
         }
 
-        assert_eq!(duration_metric.tags.len(), 5);
+        assert_eq!(duration_metric.tags.len(), 4);
         assert_eq!(duration_metric.tags["release"], "1.2.3");
         assert_eq!(duration_metric.tags["transaction.status"], "ok");
         assert_eq!(duration_metric.tags["environment"], "fake_environment");
-        assert_eq!(duration_metric.tags["transaction"], "mytransaction");
         assert_eq!(duration_metric.tags["platform"], "other");
     }
 
@@ -793,12 +826,12 @@ mod tests {
         assert_eq!(metrics.len(), 2);
 
         let duration_metric = &metrics[0];
-        assert_eq!(duration_metric.tags.len(), 4);
+        assert_eq!(duration_metric.tags.len(), 3);
         assert_eq!(duration_metric.tags["satisfaction"], "tolerated");
         assert_eq!(duration_metric.tags["transaction.status"], "ok");
 
         let user_metric = &metrics[1];
-        assert_eq!(user_metric.tags.len(), 4);
+        assert_eq!(user_metric.tags.len(), 3);
         assert_eq!(user_metric.tags["satisfaction"], "tolerated");
     }
 
@@ -845,7 +878,7 @@ mod tests {
         assert_eq!(metrics.len(), 1);
 
         for metric in metrics {
-            assert_eq!(metric.tags.len(), 3);
+            assert_eq!(metric.tags.len(), 2);
             assert_eq!(metric.tags["satisfaction"], "satisfied");
         }
     }
@@ -887,7 +920,7 @@ mod tests {
         assert_eq!(metrics.len(), 1);
 
         for metric in metrics {
-            assert_eq!(metric.tags.len(), 2);
+            assert_eq!(metric.tags.len(), 1);
             assert!(!metric.tags.contains_key("satisfaction"));
         }
     }
@@ -937,7 +970,6 @@ mod tests {
                     timestamp: UnixTimestamp(1619420402),
                     tags: {
                         "platform": "other",
-                        "transaction": "foo",
                     },
                 },
                 Metric {
@@ -949,7 +981,6 @@ mod tests {
                     tags: {
                         "measurement_rating": "good",
                         "platform": "other",
-                        "transaction": "foo",
                     },
                 },
                 Metric {
@@ -960,7 +991,6 @@ mod tests {
                     timestamp: UnixTimestamp(1619420402),
                     tags: {
                         "platform": "other",
-                        "transaction": "foo",
                     },
                 },
             ]
@@ -1039,7 +1069,6 @@ mod tests {
                 {
                     let mut tags = BTreeMap::new();
                     tags.insert("satisfaction".to_owned(), "tolerated".to_owned());
-                    tags.insert("transaction".to_owned(), "foo".to_owned());
                     tags.insert("platform".to_owned(), "other".to_owned());
                     tags
                 }
@@ -1120,7 +1149,6 @@ mod tests {
                     let mut tags = BTreeMap::new();
                     tags.insert("satisfaction".to_owned(), "frustrated".to_owned());
                     tags.insert("measurement_rating".to_owned(), "good".to_owned());
-                    tags.insert("transaction".to_owned(), "foo".to_owned());
                     tags.insert("platform".to_owned(), "other".to_owned());
                     tags
                 }
@@ -1200,5 +1228,65 @@ mod tests {
                 ("platform".to_string(), "other".to_string())
             ])
         );
+    }
+
+    #[test]
+    fn test_has_transaction_tag() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "transaction": "foo",
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T07:59:01+0100",
+            "contexts": {"trace": {}}
+        }
+        "#;
+
+        let config: TransactionMetricsConfig = serde_json::from_str(
+            r#"
+        {
+            "extractMetrics": [
+                "d:transactions/duration@millisecond"
+            ]
+        }
+        "#,
+        )
+        .unwrap();
+
+        let event = Annotated::<Event>::from_json(json).unwrap();
+
+        for (source, expected_transaction_tag) in [
+            (TransactionSource::Custom, true),
+            (TransactionSource::Url, false),
+            (TransactionSource::Route, true),
+            (TransactionSource::View, true),
+            (TransactionSource::Component, true),
+            (TransactionSource::Task, true),
+            (TransactionSource::Unknown, false),
+            (
+                TransactionSource::Other("not-a-valid-source".to_owned()),
+                false,
+            ),
+        ] {
+            let mut event = event.clone();
+            event
+                .value_mut()
+                .as_mut()
+                .unwrap()
+                .transaction_info
+                .set_value(Some(TransactionInfo {
+                    source: Annotated::new(source.clone()),
+                    original: Annotated::empty(),
+                }));
+            let mut metrics = vec![];
+            extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
+
+            assert_eq!(
+                metrics[0].tags.get("transaction").is_some(),
+                expected_transaction_tag,
+                "{:?}",
+                source
+            );
+        }
     }
 }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -175,11 +175,13 @@ fn extract_user_satisfaction(
 #[cfg(feature = "processing")]
 fn keep_transaction_name(source: &TransactionSource) -> bool {
     match source {
-        // "custom" is like a box of chocolates, you never know what you're gonna get.
         // For now, we hope that custom transaction names set by users are low-cardinality.
         TransactionSource::Custom => true,
+
         // "url" are raw URLs, potentially containing identifiers.
         TransactionSource::Url => false,
+
+        // These four are names of software components, which we assume to be low-cardinality.
         TransactionSource::Route => true,
         TransactionSource::View => true,
         TransactionSource::Component => true,
@@ -191,7 +193,6 @@ fn keep_transaction_name(source: &TransactionSource) -> bool {
 
         // Any other value would be an SDK bug, assume high-cardinality and drop.
         TransactionSource::Other(source) => {
-            // EnvelopeProcessor sets project and SDK on the scope, so no need to add sentry tags here.
             relay_log::error!("Invalid transaction source: '{}'", source);
             false
         }

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -84,6 +84,7 @@ def generate_transaction_item():
         "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",
         "type": "transaction",
         "transaction": "/organizations/:orgId/performance/:eventSlug/",
+        "transaction_info": {"source": "route"},
         "start_timestamp": 1597976392.6542819,
         "timestamp": 1597976400.6189718,
         "contexts": {


### PR DESCRIPTION
Drop the `transaction` tag for metrics extracted from transaction payload if the transaction source is `url` or `unknown`, because these might contain identifiers that blow up the number of different metrics buckets.

Note that this leads to differences between the transactions dataset and the metrics dataset, which the product will have to handle.