### PR TITLE
Stop using bundled wrapper of sentry-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,6 @@ jobs:
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions
           cp -r sentry/.github/actions/setup-sentry .github/actions/
-          cp -r sentry/.github/actions/setup-python .github/actions/
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry


### PR DESCRIPTION
Same fix as https://github.com/getsentry/symbolicator/pull/854 for https://github.com/getsentry/sentry/pull/36687.

Needed for https://github.com/getsentry/self-hosted/issues/1545.

#skip-changelog