### PR TITLE
style(envelope-docs): Fix wording

### DIFF
--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -429,7 +429,7 @@ pub struct ItemHeaders {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     timestamp: Option<UnixTimestamp>,
 
-    /// Flag indicating if metrics have already been extracted from the item
+    /// Flag indicating if metrics have already been extracted from the item.
     ///
     /// In order to only extract metrics once from an item while through a
     /// chain of Relays, a Relay that extracts metrics from an item (typically

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -433,7 +433,7 @@ pub struct ItemHeaders {
     ///
     /// In order to only extract metrics once from an item while through a
     /// chain of Relays, a Relay that extracts metrics from an item (typically
-    /// the first Relay) MUST set this flat to true so that downstream Relays do
+    /// the first Relay) MUST set this flat to true so that upstream Relays do
     /// not extract the metric again causing double counting of the metric.
     #[serde(default, skip_serializing_if = "is_false")]
     metrics_extracted: bool,


### PR DESCRIPTION
- Add a missing dot at the end of a sentence.
- Fix wording: `downstream` -> `upstream`.

Events go from clients to Sentry, which means they are forwarded
upstream. Metric extraction happens in the first relay configured to
extract metrics, and the following relays in chain (upstream relays)
must not extract metrics again. The word used in the comment is
"downstream", which according to the flow, it's not correct.

#skip-changelog