### PR TITLE
fix(server): Fallback to HTTP if Redis fails for project caches

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -226,8 +226,9 @@ impl Handler<UpdateProjectState> for ProjectCache {
         self.local_source
             .send(FetchOptionalProjectState { project_key })
             .map_err(|_| ())
-            .and_then(move |response| {
-                if let Some(state) = response {
+            .then(move |response| {
+                // Ignore errors from file system and fall through
+                if let Ok(Some(state)) = response {
                     return Box::new(future::ok(ProjectStateResponse::new(state)))
                         as ResponseFuture<_, _>;
                 }
@@ -268,8 +269,9 @@ impl Handler<UpdateProjectState> for ProjectCache {
                     Box::new(future::ok(None))
                 };
 
-                let fetch_redis = fetch_redis.and_then(move |response| {
-                    if let Some(state) = response {
+                let fetch_redis = fetch_redis.then(move |response| {
+                    // Ignore errors from Redis and fall through to upstream
+                    if let Ok(Some(state)) = response {
                         return Box::new(future::ok(ProjectStateResponse::new(state)))
                             as ResponseFuture<_, _>;
                     }


### PR DESCRIPTION
When Redis errors, Relay overwrites a stale but valid project state with an invalid one. To retain the capability of ingesting events, Relay should instead continue ingesting and try again later.

Since there's no graceful way to back off outer project config requests, this implementation makes it so that it falls through to the next source, the upstream. The HTTP endpoint might be down for the same reason, yet the retry behavior is better regulated.