### PR TITLE
ref(replays): emit JSON instead of msgpack

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -835,6 +835,9 @@ impl KafkaMessage {
             KafkaMessage::Metric(message) => {
                 serde_json::to_vec(message).map_err(StoreError::InvalidJson)
             }
+            KafkaMessage::ReplayEvent(message) => {
+                serde_json::to_vec(message).map_err(StoreError::InvalidJson)
+            }
             _ => rmp_serde::to_vec_named(&self).map_err(StoreError::InvalidMsgPack),
         }
     }

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -374,6 +374,8 @@ class ReplayEventsConsumer(ConsumerBase):
         assert message is not None
         assert message.error() is None
 
-        event = msgpack.unpackb(message.value(), raw=False, use_list=False)
-        assert event["type"] == "replay_event"
-        return json.loads(event["payload"].decode("utf8")), event
+        event = json.loads(message.value())
+        payload = json.loads(bytes(event["payload"]))
+
+        assert payload["type"] == "replay_event"
+        return payload, event


### PR DESCRIPTION
relay is now emitting `replay_event`s to be directly consumed by a snuba consumer, which do not have msgpack, so directly emit a kafka message in JSON.

See if you'd like an architecture overview update: https://www.notion.so/sentry/Replay-Backend-Architecture-Update-7-19-7c4ecc8af3fb4027992f3ee75dae9529

will change the topic name in an upcoming PR. for now, we are not receiving any events, so the downstream implications do not matter.

#skip-changelog 