### PR TITLE
ref(projectconfig): Metrics around redis compression [INGEST-1505 INGEST-1513]

### DIFF
--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -10,7 +10,7 @@ use relay_statsd::metric;
 
 use crate::actors::project::ProjectState;
 use crate::actors::project_cache::FetchOptionalProjectState;
-use crate::statsd::{RelayCounters, RelayTimers};
+use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 
 pub struct RedisProjectSource {
     config: Arc<Config>,
@@ -39,17 +39,27 @@ impl From<serde_json::Error> for RedisProjectError {
 }
 
 fn parse_redis_response(raw_response: &[u8]) -> Result<ProjectState, RedisProjectError> {
-    let decoded = metric!(timer(RelayTimers::ProjectStateDecompression), {
+    let decompression_result = metric!(timer(RelayTimers::ProjectStateDecompression), {
         zstd::decode_all(raw_response)
     });
 
-    let raw_response = match &decoded {
-        Ok(decoded) => decoded.as_slice(),
+    let decoded_response = match &decompression_result {
+        Ok(decoded) => {
+            metric!(
+                histogram(RelayHistograms::ProjectStateSizeBytesCompressed) =
+                    raw_response.len() as f64
+            );
+            metric!(
+                histogram(RelayHistograms::ProjectStateSizeBytesUncompressed) =
+                    decoded.len() as f64
+            );
+            decoded.as_slice()
+        }
         // If decoding fails, assume uncompressed payload and try again
         Err(_) => raw_response,
     };
 
-    Ok(serde_json::from_slice(raw_response)?)
+    Ok(serde_json::from_slice(decoded_response)?)
 }
 
 impl RedisProjectSource {

--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -50,7 +50,7 @@ fn parse_redis_response(raw_response: &[u8]) -> Result<ProjectState, RedisProjec
                     raw_response.len() as f64
             );
             metric!(
-                histogram(RelayHistograms::ProjectStateSizeBytesUncompressed) =
+                histogram(RelayHistograms::ProjectStateSizeBytesDecompressed) =
                     decoded.len() as f64
             );
             decoded.as_slice()

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -103,6 +103,12 @@ pub enum RelayHistograms {
     ///
     /// There is no limit to the number of cached projects.
     ProjectStateCacheSize,
+    /// The size of the compressed project config in the redis cache, in bytes.
+    #[cfg(feature = "processing")]
+    ProjectStateSizeBytesCompressed,
+    /// The size of the uncompressed project config in the redis cache, in bytes.
+    #[cfg(feature = "processing")]
+    ProjectStateSizeBytesUncompressed,
     /// The number of upstream requests queued up for sending.
     ///
     /// Relay employs connection keep-alive whenever possible. Connections are kept open for _15_
@@ -156,6 +162,14 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",
             RelayHistograms::ProjectStateReceived => "project_state.received",
             RelayHistograms::ProjectStateCacheSize => "project_cache.size",
+            #[cfg(feature = "processing")]
+            RelayHistograms::ProjectStateSizeBytesCompressed => {
+                "project_state.size_bytes.compressed"
+            }
+            #[cfg(feature = "processing")]
+            RelayHistograms::ProjectStateSizeBytesUncompressed => {
+                "project_state.size_bytes.uncompressed"
+            }
             RelayHistograms::UpstreamMessageQueueSize => "http_queue.size",
             RelayHistograms::UpstreamRetries => "upstream.retries",
             #[cfg(feature = "processing")]

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -108,7 +108,7 @@ pub enum RelayHistograms {
     ProjectStateSizeBytesCompressed,
     /// The size of the uncompressed project config in the redis cache, in bytes.
     #[cfg(feature = "processing")]
-    ProjectStateSizeBytesUncompressed,
+    ProjectStateSizeBytesDecompressed,
     /// The number of upstream requests queued up for sending.
     ///
     /// Relay employs connection keep-alive whenever possible. Connections are kept open for _15_
@@ -167,8 +167,8 @@ impl HistogramMetric for RelayHistograms {
                 "project_state.size_bytes.compressed"
             }
             #[cfg(feature = "processing")]
-            RelayHistograms::ProjectStateSizeBytesUncompressed => {
-                "project_state.size_bytes.uncompressed"
+            RelayHistograms::ProjectStateSizeBytesDecompressed => {
+                "project_state.size_bytes.decompressed"
             }
             RelayHistograms::UpstreamMessageQueueSize => "http_queue.size",
             RelayHistograms::UpstreamRetries => "upstream.retries",


### PR DESCRIPTION
Record more metrics for the decompression of project config entries in the redis cache (see #1345).

#skip-changelog