### PR TITLE
test: Add a test for negative glob matches

### DIFF
--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -251,4 +251,11 @@ mod tests {
         assert!(globs.is_match("1.18.4.2153-2aa83397b"));
         assert!(!globs.is_match("1.18.5.2153-2aa83397b"));
     }
+
+    #[test]
+    fn test_match_range_neg() {
+        let globs = globs!("1.18.[!0-4].*");
+        assert!(!globs.is_match("1.18.4.2153-2aa83397b"));
+        assert!(globs.is_match("1.18.5.2153-2aa83397b"));
+    }
 }

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -258,4 +258,13 @@ mod tests {
         assert!(!globs.is_match("1.18.4.2153-2aa83397b"));
         assert!(globs.is_match("1.18.5.2153-2aa83397b"));
     }
+
+    #[test]
+    fn test_match_neg_unsupported() {
+        // this is not necessarily desirable behavior, but it is our current one: negation (!)
+        // outside of [] doesn't work
+        let globs = globs!("!1.18.4.*");
+        assert!(!globs.is_match("1.18.4.2153-2aa83397b"));
+        assert!(!globs.is_match("1.18.5.2153-2aa83397b"));
+    }
 }


### PR DESCRIPTION
see also https://github.com/getsentry/sentry-docs/pull/5336

#skip-changelog