### PR TITLE
feat(metrics): Two modes for accepting transaction names [INGEST-1515]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support compressed project configs in redis cache. ([#1345](https://github.com/getsentry/relay/pull/1345))
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
-
+- Treat "unknown" transaction source as low cardinality, except for JS. ([#1352](https://github.com/getsentry/relay/pull/1352))
 ## 22.7.0
 
 **Features**:

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -54,12 +54,9 @@ pub struct CustomMeasurementConfig {
 /// The version is an integer scalar, incremented by one on each new version.
 const EXTRACT_MAX_VERSION: u16 = 1;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum AcceptTransactionNames {
-    /// Accept any transaction name
-    Disabled,
-
     /// For some SDKs, accept all transaction names, while for others, apply strict rules.
     ClientBased,
 
@@ -233,7 +230,6 @@ fn get_transaction_name(
     };
 
     let use_original_name = match accept_transaction_names {
-        AcceptTransactionNames::Disabled => true,
         AcceptTransactionNames::ClientBased => {
             let sdk_name = event
                 .client_sdk
@@ -242,7 +238,8 @@ fn get_transaction_name(
                 .map(|s| s.as_str())
                 .unwrap_or_default();
 
-            sdk_name != "FIXME" || is_low_cardinality(event.get_transaction_source())
+            (sdk_name != "sentry.javascript.react" && sdk_name != "sentry.javascript.browser")
+                || is_low_cardinality(event.get_transaction_source())
         }
         AcceptTransactionNames::Strict => is_low_cardinality(event.get_transaction_source()),
     };
@@ -299,7 +296,7 @@ fn extract_universal_tags(
     }
 
     let custom_tags = &config.extract_custom_tags;
-    if custom_tags.is_empty() {
+    if !custom_tags.is_empty() {
         // XXX(slow): event tags are a flat array
         if let Some(event_tags) = event.tags.value() {
             for tag_entry in &**event_tags {
@@ -551,7 +548,7 @@ mod tests {
 
     use crate::metrics_extraction::TaggingRule;
     use insta::assert_debug_snapshot;
-    use relay_general::protocol::TransactionInfo;
+    use relay_general::protocol::{ClientSdkInfo, TransactionInfo};
     use relay_general::store::BreakdownsConfig;
     use relay_general::types::Annotated;
     use relay_metrics::DurationUnit;
@@ -1309,41 +1306,72 @@ mod tests {
 
         let event = Annotated::<Event>::from_json(json).unwrap();
 
-        for (source, expected_transaction_tag) in [
-            (TransactionSource::Custom, None),
-            (
-                TransactionSource::Url,
-                Some("<< unparametrized >>".to_owned()),
-            ),
-            (TransactionSource::Route, Some("foo".to_owned())),
-            // (TransactionSource::View, true),
-            // (TransactionSource::Component, true),
-            // (TransactionSource::Task, true),
-            // (TransactionSource::Unknown, false),
-            // (
-            //     TransactionSource::Other("not-a-valid-source".to_owned()),
-            //     false,
-            // ),
+        for source in [
+            TransactionSource::Custom,
+            TransactionSource::Url,
+            TransactionSource::Route,
+            TransactionSource::View,
+            TransactionSource::Component,
+            TransactionSource::Task,
+            TransactionSource::Unknown,
+            TransactionSource::Other("XXX".to_owned()),
         ] {
-            let mut event = event.clone();
-            event
-                .value_mut()
-                .as_mut()
-                .unwrap()
-                .transaction_info
-                .set_value(Some(TransactionInfo {
-                    source: Annotated::new(source.clone()),
-                    original: Annotated::empty(),
-                }));
-            let mut metrics = vec![];
-            extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
+            for client_name in ["some_client", "sentry.javascript.react"] {
+                for strategy in [
+                    AcceptTransactionNames::Strict,
+                    AcceptTransactionNames::ClientBased,
+                ] {
+                    let mut event = event.clone();
+                    {
+                        let event = event.value_mut().as_mut().unwrap();
+                        event.transaction_info.set_value(Some(TransactionInfo {
+                            source: Annotated::new(source.clone()),
+                            original: Annotated::empty(),
+                        }));
 
-            assert_eq!(
-                metrics[0].tags.get("transaction"),
-                expected_transaction_tag.as_ref(),
-                "{:?}",
-                source
-            );
+                        event.client_sdk.set_value(Some(ClientSdkInfo {
+                            name: Annotated::new(client_name.to_owned()),
+                            ..Default::default()
+                        }));
+                    }
+
+                    let mut config = config.clone();
+                    config.accept_transaction_names = strategy;
+
+                    let mut metrics = vec![];
+                    extract_transaction_metrics(
+                        &config,
+                        None,
+                        &[],
+                        event.value().unwrap(),
+                        &mut metrics,
+                    );
+
+                    let expected_transaction_name =
+                        if matches!(strategy, AcceptTransactionNames::Strict)
+                            || client_name == "sentry.javascript.react"
+                        {
+                            match source {
+                                TransactionSource::Url => Some("<< unparametrized >>".to_owned()),
+                                TransactionSource::Unknown => None,
+                                TransactionSource::Other(_) => None,
+                                _ => Some("foo".to_owned()),
+                            }
+                        } else {
+                            // Any other case, accept anything
+                            Some("foo".to_owned())
+                        };
+
+                    assert_eq!(
+                        metrics[0].tags.get("transaction"),
+                        expected_transaction_name.as_ref(),
+                        "{:?} {:?} {:?}",
+                        strategy,
+                        client_name,
+                        source,
+                    );
+                }
+            }
         }
     }
 }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -54,7 +54,7 @@ pub struct CustomMeasurementConfig {
 /// The version is an integer scalar, incremented by one on each new version.
 const EXTRACT_MAX_VERSION: u16 = 1;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum AcceptTransactionNames {
     /// For some SDKs, accept all transaction names, while for others, apply strict rules.
@@ -1379,6 +1379,28 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_parse_transaction_name_strategy() {
+        for (config, expected_strategy) in [
+            (r#"{}"#, AcceptTransactionNames::Strict),
+            (
+                r#"{"acceptTransactionNames": "unknown-strategy"}"#,
+                AcceptTransactionNames::Strict,
+            ),
+            (
+                r#"{"acceptTransactionNames": "strict"}"#,
+                AcceptTransactionNames::Strict,
+            ),
+            (
+                r#"{"acceptTransactionNames": "clientBased"}"#,
+                AcceptTransactionNames::ClientBased,
+            ),
+        ] {
+            let config: TransactionMetricsConfig = serde_json::from_str(config).unwrap();
+            assert_eq!(config.accept_transaction_names, expected_strategy);
         }
     }
 }


### PR DESCRIPTION
Add a new project config flag `transactionMetrics.acceptTransactionNames` that can be either

* `strict` - Only accept transaction names from low-cardinality sources.
* `clientBased` - Accept all transaction names, except for `sentry.javascript.browser` and `sentry.javascript.react`, where `strict` rules apply.

In both cases, either omit the transaction name (when source is `unknown`), or replace by sentinel `<< unparametrized >>`.

By adding this to project configs, we can add an option in sentry to consistently sample a percentage of orgs into the new behavior.

Sentry-side implemented in https://github.com/getsentry/sentry/pull/37102