### PR TITLE
fix(dynamic_sampling): Parse sample rates as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Parse sample rates as JSON. ([#1353](https://github.com/getsentry/relay/pull/1353))
+
 **Internal**:
 
 - Support compressed project configs in redis cache. ([#1345](https://github.com/getsentry/relay/pull/1345))


### PR DESCRIPTION
Some document somewhere says that this is JSON now, and the JS SDK wants
to make use of JSON.stringify because it reduces bundle size and
allegedly problems with older browsers.
