### PR TITLE
feat(normalization): Write default transaction source [INGEST-1511]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Support compressed project configs in redis cache. ([#1345](https://github.com/getsentry/relay/pull/1345))
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
-- Treat "unknown" transaction source as low cardinality, except for JS. ([#1352](https://github.com/getsentry/relay/pull/1352))
+- Treat "unknown" transaction source as low cardinality for safe SDKs. ([#1352](https://github.com/getsentry/relay/pull/1352), [#1356](https://github.com/getsentry/relay/pull/1356))
 - Conditionally write a default transaction source to the transaction payload. ([#1354](https://github.com/getsentry/relay/pull/1354))
 
 ## 22.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Support compressed project configs in redis cache. ([#1345](https://github.com/getsentry/relay/pull/1345))
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
 - Treat "unknown" transaction source as low cardinality, except for JS. ([#1352](https://github.com/getsentry/relay/pull/1352))
+- Conditionally write a default transaction source to the transaction payload. ([#1354](https://github.com/getsentry/relay/pull/1354))
+
 ## 22.7.0
 
 **Features**:

--- a/relay-general/src/protocol/clientsdk.rs
+++ b/relay-general/src/protocol/clientsdk.rs
@@ -64,6 +64,19 @@ pub struct ClientSdkInfo {
     pub other: Object<Value>,
 }
 
+impl ClientSdkInfo {
+    pub fn has_integration<T: AsRef<str>>(&self, integration: T) -> bool {
+        if let Some(integrations) = self.integrations.value() {
+            for x in integrations {
+                if x.as_str().unwrap_or_default() == integration.as_ref() {
+                    return true;
+                }
+            }
+        };
+        false
+    }
+}
+
 #[cfg(test)]
 use crate::testutils::{assert_eq_dbg, assert_eq_str};
 

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -545,6 +545,14 @@ impl Event {
             .and_then(|info| info.source.value())
             .unwrap_or(&TransactionSource::Unknown)
     }
+
+    pub fn get_tag_value(&self, tag_key: &str) -> Option<&str> {
+        if let Some(tags) = self.tags.value() {
+            tags.get(tag_key)
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -26,7 +26,9 @@ pub use normalize::breakdowns::{
     get_breakdown_measurements, BreakdownConfig, BreakdownsConfig, SpanOperationsConfig,
 };
 pub use normalize::{is_valid_platform, normalize_dist};
-pub use transactions::{get_measurement, get_transaction_op, validate_timestamps};
+pub use transactions::{
+    get_measurement, get_transaction_op, is_high_cardinality_sdk, validate_timestamps,
+};
 
 /// The config for store.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1,6 +1,6 @@
 use crate::processor::{ProcessValue, ProcessingState, Processor};
 use crate::protocol::{
-    ClientSdkInfo, Context, ContextInner, Event, EventType, Span, Timestamp, TransactionSource,
+    Context, ContextInner, Event, EventType, Span, Timestamp, TransactionSource,
 };
 use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult};
 /// Rejects transactions based on required fields.
@@ -57,14 +57,21 @@ pub fn validate_timestamps(
 /// "/user/123134/login".
 /// Newer SDK send the [`TransactionSource`] attribute, which we can rely on to determine cardinality,
 /// but for old SDKs, we fall back to this list.
-pub fn is_high_cardinality_sdk(client_sdk: &Annotated<ClientSdkInfo>) -> bool {
+pub fn is_high_cardinality_sdk(event: &Event) -> bool {
+    let client_sdk = match event.client_sdk.value() {
+        Some(info) => info,
+        None => {
+            return false;
+        }
+    };
+
     let sdk_name = client_sdk
+        .name
         .value()
-        .and_then(|sdk| sdk.name.value())
         .map(|s| s.as_str())
         .unwrap_or_default();
 
-    [
+    if [
         "sentry.javascript.angular",
         "sentry.javascript.browser",
         "sentry.javascript.ember",
@@ -72,8 +79,29 @@ pub fn is_high_cardinality_sdk(client_sdk: &Annotated<ClientSdkInfo>) -> bool {
         "sentry.javascript.react",
         "sentry.javascript.remix",
         "sentry.javascript.vue",
+        "sentry.javascript.nextjs",
+        "sentry.php.laravel",
+        "sentry.php.symphony",
     ]
     .contains(&sdk_name)
+    {
+        return true;
+    }
+
+    let is_http_status_404 = event.get_tag_value("http.status_code") == Some("404");
+    if sdk_name == "sentry.python" && is_http_status_404 && client_sdk.has_integration("django") {
+        return true;
+    }
+
+    let is_http_method_options = event.get_tag_value("http.method") == Some("OPTIONS");
+    if sdk_name == "sentry.javascript.node"
+        && is_http_method_options
+        && client_sdk.has_integration("Express")
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Set a default transaction source if it is missing, but only if the transaction name was
@@ -88,7 +116,7 @@ fn set_default_transaction_source(event: &mut Event) {
         .value()
         .and_then(|info| info.source.value());
 
-    if source.is_none() && !is_high_cardinality_sdk(&event.client_sdk) {
+    if source.is_none() && !is_high_cardinality_sdk(event) {
         let transaction_info = event.transaction_info.get_or_insert_with(Default::default);
         transaction_info
             .source

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -81,7 +81,7 @@ pub fn is_high_cardinality_sdk(client_sdk: &Annotated<ClientSdkInfo>) -> bool {
 /// This behavior makes it possible to identify transactions for which the transaction name was
 /// not extracted as a tag on the corresponding metrics, because
 ///     source == null <=> transaction name == null
-/// See [`relay_server::metrics_extraction::transactions::get_transaction_name`].
+/// See `relay_server::metrics_extraction::transactions::get_transaction_name`.
 fn set_default_transaction_source(event: &mut Event) {
     let source = event
         .transaction_info

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -215,26 +215,6 @@ fn is_low_cardinality(source: &TransactionSource, treat_unknown_as_low_cardinali
     }
 }
 
-fn is_browser_sdk(event: &Event) -> bool {
-    let sdk_name = event
-        .client_sdk
-        .value()
-        .and_then(|sdk| sdk.name.value())
-        .map(|s| s.as_str())
-        .unwrap_or_default();
-
-    [
-        "sentry.javascript.angular",
-        "sentry.javascript.browser",
-        "sentry.javascript.ember",
-        "sentry.javascript.gatsby",
-        "sentry.javascript.react",
-        "sentry.javascript.remix",
-        "sentry.javascript.vue",
-    ]
-    .contains(&sdk_name)
-}
-
 /// Decide whether we want to keep the transaction name.
 /// High-cardinality sources are excluded to protect our metrics infrastructure.
 /// Note that this will produce a discrepancy between metrics and raw transaction data.
@@ -254,7 +234,7 @@ fn get_transaction_name(
     let treat_unknown_as_low_cardinality = matches!(
         accept_transaction_names,
         AcceptTransactionNames::ClientBased
-    ) && !is_browser_sdk(event);
+    ) && !store::is_high_cardinality_sdk(&event.client_sdk);
 
     let source = event.get_transaction_source();
     let use_original_name = is_low_cardinality(source, treat_unknown_as_low_cardinality);

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -502,6 +502,8 @@ pub enum RelayCounters {
     EvictingStaleProjectCaches,
     /// Number of times that parsing a metrics bucket item from an envelope failed.
     MetricBucketsParsingFailed,
+    /// Count extraction of transaction names. Tag with the decision to drop / replace / use original.
+    MetricsTransactionNameExtracted,
 }
 
 impl CounterMetric for RelayCounters {
@@ -531,6 +533,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
+            RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
         }
     }
 }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -747,7 +747,7 @@ def test_graceful_shutdown(mini_sentry, relay):
     with pytest.raises(requests.ConnectionError):
         relay.send_metrics(project_id, metrics_payload, timestamp)
 
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.captured_events.get(timeout=5)
     assert len(envelope.items) == 1
     metrics_item = envelope.items[0]
     assert metrics_item.type == "metric_buckets"


### PR DESCRIPTION
For old SDK that do not yet send an `event.transaction_info.source` value, write the default "unknown" to the transaction payload.

For a specific group of SDKs that we expect to send many distinct transaction names (containing identifiers), omit the default, such that these transactions can be queried for explicitly in the product.