### PR TITLE
fix(unreal): Don't drop event in PoP relays [INC-181] [ISSUE-1558]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Support compressed project configs in redis cache. ([#1345](https://github.com/getsentry/relay/pull/1345))
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
 - Treat "unknown" transaction source as low cardinality, except for JS. ([#1352](https://github.com/getsentry/relay/pull/1352))
+
+**Bug Fixes**:
+
+- Fix a bug where unreal crash reports were dropped when metrics extraction is enabled. ([#1355](https://github.com/getsentry/relay/pull/1355))
+
 ## 22.7.0
 
 **Features**:

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1722,10 +1722,8 @@ impl EnvelopeProcessor {
                 }
             );
             state.transaction_metrics_extracted = true;
-            Ok(())
-        } else {
-            Err(ProcessingError::NoEventPayload)
         }
+        Ok(())
     }
 
     /// Apply data privacy rules to the event payload.


### PR DESCRIPTION
metrics extraction errors in pops if there is no event in the envelope.
This at least impacts Unreal events, but potentially more event types
where `creates_event` is True without there actually being an event in
the envelope.
