### PR TITLE
fix(metrics): Fix broken extraction of ops breakdown and conditional tagging [INGEST-1529]

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -153,6 +153,12 @@ pub struct LimitedProjectConfig {
     pub session_metrics: SessionMetricsConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_metrics: Option<ErrorBoundary<TransactionMetricsConfig>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub metric_conditional_tagging: Vec<TaggingRule>,
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    pub span_attributes: BTreeSet<SpanAttribute>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breakdowns_v2: Option<BreakdownsConfig>,
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub features: BTreeSet<Feature>,
 }


### PR DESCRIPTION
When moving metric extraction out of processing mode, we missed adding the required project config fields to the `LimitedProjectConfig` structure that is sent to untrusted Relays. This caused invalid tagging for ops breakdowns and histograms.

Ref https://github.com/getsentry/relay/pull/1344

#skip-changelog