### PR TITLE
fix(metrics): Get http method from event.request [INGEST-1515]

### DIFF
--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -93,9 +93,9 @@ pub fn is_high_cardinality_sdk(event: &Event) -> bool {
         return true;
     }
 
-    let is_http_method_options = event.get_tag_value("http.method") == Some("OPTIONS");
+    let http_method = event.request.value().and_then(|r| r.method.as_str());
     if sdk_name == "sentry.javascript.node"
-        && is_http_method_options
+        && http_method == Some("OPTIONS")
         && client_sdk.has_integration("Express")
     {
         return true;

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -93,9 +93,13 @@ pub fn is_high_cardinality_sdk(event: &Event) -> bool {
         return true;
     }
 
-    let http_method = event.request.value().and_then(|r| r.method.as_str());
+    let http_method = event
+        .request
+        .value()
+        .and_then(|r| r.method.as_str())
+        .unwrap_or_default();
     if sdk_name == "sentry.javascript.node"
-        && http_method == Some("OPTIONS")
+        && http_method.eq_ignore_ascii_case("options")
         && client_sdk.has_integration("Express")
     {
         return true;

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -1459,7 +1459,7 @@ mod tests {
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
             "sdk": {"name": "sentry.javascript.node", "integrations":["Express"]},
-            "tags": {"http.method": "OPTIONS"}
+            "request": {"method": "OPTIONS"}
         }
         "#;
 
@@ -1477,7 +1477,7 @@ mod tests {
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
             "sdk": {"name": "sentry.javascript.node", "integrations":["Express"]},
-            "tags": {"http.method": "OPTIONS"}
+            "request": {"method": "OPTIONS"}
         }
         "#;
 
@@ -1495,7 +1495,7 @@ mod tests {
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
             "sdk": {"name": "sentry.javascript.node", "integrations":["Express"]},
-            "tags": {"http.method": "GET"}
+            "request": {"method": "GET"}
         }
         "#;
 


### PR DESCRIPTION
For Express, we base the decision whether or not to drop a transaction name for metrics on the HTTP method. This should be extracted from `event.request`, not `event.tags["http.method"]`.

#skip-changelog