### PR TITLE
build(futures): Swap package names for futures 0.1 and 0.3

### DIFF
--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 actix = "0.7.9"
 failure = "0.1.8"
-futures = "0.1.28"
+futures01 = { version = "0.1.28", package = "futures" }
 relay-log = { path = "../relay-log" }
 relay-system = { path = "../relay-system" }
 reqwest = { version = "0.11.1", features = ["json", "blocking"] }

--- a/relay-aws-extension/src/aws_extension.rs
+++ b/relay-aws-extension/src/aws_extension.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use actix::{fut, prelude::*};
 use failure::Fail;
-use futures::{prelude::*, sync::oneshot};
+use futures01::{prelude::*, sync::oneshot};
 use reqwest::{Client, ClientBuilder, StatusCode, Url};
 use serde::Deserialize;
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};

--- a/relay-common/src/macros.rs
+++ b/relay-common/src/macros.rs
@@ -85,7 +85,7 @@ macro_rules! tryf {
     ($e:expr) => {
         match $e {
             Ok(value) => value,
-            Err(e) => return Box::new(::futures::future::err(::std::convert::From::from(e))),
+            Err(e) => return Box::new(::futures01::future::err(::std::convert::From::from(e))),
         }
     };
 }

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -24,7 +24,7 @@ crc32fast = "1.2.1"
 
 [dev-dependencies]
 criterion = "0.3"
-futures = "0.1.28"
+futures01 = { version = "0.1.28", package = "futures" }
 insta = "1.1.0"
 lazy_static = "1.4.0"
 relay-test = { path = "../relay-test" }

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1904,7 +1904,7 @@ impl Handler<MergeBuckets> for Aggregator {
 
 #[cfg(test)]
 mod tests {
-    use futures::future::Future;
+    use futures01::future::Future;
     use std::sync::{Arc, RwLock};
 
     use super::*;

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -36,8 +36,8 @@ clap = "2.33.1"
 failure = "0.1.8"
 flate2 = "1.0.19"
 fragile = { version = "1.2.1", features = ["slab"] } # used for vendoring sentry-actix
-futures = "0.1.28"
-futures03 = { version = "0.3", package = "futures", features = ["compat"] }
+futures01 = { version = "0.1.28", package = "futures" }
+futures = { version = "0.3", package = "futures", features = ["compat"] }
 itertools = "0.8.2"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
 lazy_static = "1.4.0"

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Duration as SignedDuration, Utc};
 use failure::Fail;
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
-use futures::{future, prelude::*, sync::oneshot};
+use futures01::{future, prelude::*, sync::oneshot};
 use lazy_static::lazy_static;
 use serde_json::Value as SerdeValue;
 

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use actix::SystemService;
-use futures03::compat::Future01CompatExt;
+use futures::compat::Future01CompatExt;
 use parking_lot::RwLock;
 use tokio::sync::{mpsc, oneshot};
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -17,7 +17,7 @@ use actix_web::http::Method;
 use chrono::{DateTime, SecondsFormat, Utc};
 #[cfg(feature = "processing")]
 use failure::{Fail, ResultExt};
-use futures::future::Future;
+use futures01::future::Future;
 #[cfg(feature = "processing")]
 use rdkafka::producer::BaseRecord;
 #[cfg(feature = "processing")]

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use actix::prelude::*;
 use chrono::{DateTime, Utc};
-use futures::{future::Shared, sync::oneshot, Future};
+use futures01::{future::Shared, sync::oneshot, Future};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use smallvec::SmallVec;

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use actix::prelude::*;
 use actix_web::ResponseError;
 use failure::Fail;
-use futures::{future, Future};
+use futures01::{future, Future};
 
 use relay_common::ProjectKey;
 use relay_config::{Config, RelayMode};

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::thread;
 
 use actix::prelude::*;
-use futures::{sync::oneshot, Future};
+use futures01::{sync::oneshot, Future};
 
 use relay_common::{ProjectId, ProjectKey};
 use relay_config::Config;

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use actix::fut;
 use actix::prelude::*;
 use actix_web::http::Method;
-use futures::{future, future::Shared, sync::oneshot, Future};
+use futures01::{future, future::Shared, sync::oneshot, Future};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -9,7 +9,7 @@ use ::actix::fut;
 use ::actix::prelude::*;
 use actix_web::{http::Method, HttpResponse, ResponseError};
 use failure::Fail;
-use futures::{future, future::Shared, sync::oneshot, Future};
+use futures01::{future, future::Shared, sync::oneshot, Future};
 use serde::{Deserialize, Serialize};
 
 use relay_auth::{PublicKey, RelayId};

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -1,6 +1,6 @@
 use ::actix::prelude::*;
 use actix_web::server::StopServer;
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use relay_config::Config;
 use relay_statsd::metric;

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -28,7 +28,7 @@ use ::actix::fut;
 use ::actix::prelude::*;
 use actix_web::http::{header, Method};
 use failure::Fail;
-use futures::{future, prelude::*, sync::oneshot};
+use futures01::{future, prelude::*, sync::oneshot};
 use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;

--- a/relay-server/src/body/peek_line.rs
+++ b/relay-server/src/body/peek_line.rs
@@ -1,6 +1,6 @@
 use actix_web::HttpRequest;
 use bytes::Bytes;
-use futures::{Async, Future, Poll, Stream};
+use futures01::{Async, Future, Poll, Stream};
 use smallvec::SmallVec;
 
 use crate::extractors::{Decoder, SharedPayload};

--- a/relay-server/src/body/request_body.rs
+++ b/relay-server/src/body/request_body.rs
@@ -1,6 +1,6 @@
 use actix_web::{error::PayloadError, HttpRequest};
 use bytes::Bytes;
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use crate::extractors::{Decoder, SharedPayload};
 use crate::utils;

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -4,7 +4,7 @@ use std::io::{self, ErrorKind, Read};
 use actix_web::{error::PayloadError, HttpRequest};
 use bytes::Bytes;
 use flate2::read::ZlibDecoder;
-use futures::prelude::*;
+use futures01::prelude::*;
 use url::form_urlencoded;
 
 use relay_statsd::metric;

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -1,5 +1,5 @@
 use actix_web::{actix::ResponseFuture, http::Method, HttpRequest, HttpResponse};
-use futures::Future;
+use futures01::Future;
 
 use relay_common::tryf;
 use relay_general::protocol::EventId;

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -9,7 +9,7 @@ use actix_web::http::{header, StatusCode};
 use actix_web::middleware::cors::{Cors, CorsBuilder};
 use actix_web::{error::PayloadError, HttpRequest, HttpResponse, ResponseError};
 use failure::Fail;
-use futures::prelude::*;
+use futures01::prelude::*;
 use serde::Deserialize;
 
 use relay_common::{clone, tryf};

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -2,7 +2,7 @@
 
 use actix::prelude::*;
 use actix_web::{HttpRequest, HttpResponse};
-use futures::Future;
+use futures01::Future;
 use serde::Serialize;
 
 use relay_general::protocol::EventId;

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -2,7 +2,7 @@
 
 use actix_web::actix::*;
 use actix_web::{http::Method, HttpResponse, Path};
-use futures::future::Future;
+use futures01::future::Future;
 
 use crate::actors::envelopes::{EnvelopeManager, GetCapturedEnvelope};
 use crate::envelope;

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -14,7 +14,7 @@ use actix_web::http::{HeaderMap, Method};
 use actix_web::{AsyncResponder, Error, HttpMessage, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use failure::Fail;
-use futures::{future, prelude::*, sync::oneshot};
+use futures01::{future, prelude::*, sync::oneshot};
 
 use lazy_static::lazy_static;
 

--- a/relay-server/src/endpoints/healthcheck.rs
+++ b/relay-server/src/endpoints/healthcheck.rs
@@ -1,8 +1,8 @@
 //! A simple healthcheck endpoint for the relay.
 use ::actix::prelude::*;
 use actix_web::{Error, HttpResponse};
-use futures::prelude::*;
-use futures03::{FutureExt, TryFutureExt};
+use futures::{FutureExt, TryFutureExt};
+use futures01::prelude::*;
 use serde::Serialize;
 
 use crate::service::ServiceApp;

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -1,7 +1,7 @@
 use actix_web::multipart::{Multipart, MultipartItem};
 use actix_web::{actix::ResponseFuture, HttpMessage, HttpRequest, HttpResponse};
 use bytes::Bytes;
-use futures::{future, Future, Stream};
+use futures01::{future, Future, Stream};
 
 use relay_general::protocol::EventId;
 
@@ -59,22 +59,25 @@ fn get_embedded_minidump(
         None => return Box::new(future::ok(None)),
     };
 
-    let f = Multipart::new(Ok(boundary.to_string()), futures::stream::once(Ok(payload)))
-        .map_err(MultipartError::InvalidMultipart)
-        .filter_map(|item| {
-            if let MultipartItem::Field(field) = item {
-                if let Some(content_disposition) = field.content_disposition() {
-                    if content_disposition.get_name() == Some(MINIDUMP_FIELD_NAME) {
-                        return Some(field);
-                    }
+    let f = Multipart::new(
+        Ok(boundary.to_string()),
+        futures01::stream::once(Ok(payload)),
+    )
+    .map_err(MultipartError::InvalidMultipart)
+    .filter_map(|item| {
+        if let MultipartItem::Field(field) = item {
+            if let Some(content_disposition) = field.content_disposition() {
+                if content_disposition.get_name() == Some(MINIDUMP_FIELD_NAME) {
+                    return Some(field);
                 }
             }
-            None
-        })
-        .and_then(move |field| consume_field(field, max_size))
-        .into_future()
-        .map_err(|(err, _)| BadStoreRequest::InvalidMultipart(err))
-        .map(|(data, _)| data.map(Bytes::from));
+        }
+        None
+    })
+    .and_then(move |field| consume_field(field, max_size))
+    .into_future()
+    .map_err(|(err, _)| BadStoreRequest::InvalidMultipart(err))
+    .map(|(data, _)| data.map(Bytes::from));
 
     Box::new(f)
 }

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use actix::prelude::*;
 use actix_web::{Error, FromRequest, Json};
-use futures::{future, Future};
+use futures01::{future, Future};
 use serde::{Deserialize, Serialize};
 
 use relay_common::ProjectKey;

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -1,5 +1,5 @@
 use actix_web::{actix::*, Error, Json};
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use crate::actors::relays::{GetRelays, GetRelaysResult, RelayCache};
 use crate::extractors::SignedJson;

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -2,7 +2,7 @@
 
 use actix_web::actix::ResponseFuture;
 use actix_web::{pred, HttpMessage, HttpRequest, HttpResponse, Query, Request};
-use futures::Future;
+use futures01::Future;
 use serde::Deserialize;
 
 use relay_general::protocol::EventId;

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -3,7 +3,7 @@
 use actix::prelude::*;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use bytes::{Bytes, BytesMut};
-use futures::Future;
+use futures01::Future;
 use serde::Serialize;
 
 use relay_general::protocol::EventId;

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -1,5 +1,5 @@
 use actix_web::{actix::ResponseFuture, HttpRequest, HttpResponse};
-use futures::Future;
+use futures01::Future;
 
 use relay_general::protocol::EventId;
 

--- a/relay-server/src/extractors/decoder.rs
+++ b/relay-server/src/extractors/decoder.rs
@@ -7,7 +7,7 @@ use actix_web::{HttpMessage, HttpRequest};
 use brotli2::write::BrotliDecoder;
 use bytes::Bytes;
 use flate2::write::{GzDecoder, ZlibDecoder};
-use futures::{Async, Poll, Stream};
+use futures01::{Async, Poll, Stream};
 use relay_config::HttpEncoding;
 
 use crate::extractors::SharedPayload;

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -7,7 +7,7 @@ use actix::ResponseFuture;
 use actix_web::http::header;
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use failure::Fail;
-use futures::{future, Future};
+use futures01::{future, Future};
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/relay-server/src/extractors/shared_payload.rs
+++ b/relay-server/src/extractors/shared_payload.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use actix_web::dev::Payload;
 use actix_web::{FromRequest, HttpMessage, HttpRequest};
 use bytes::Bytes;
-use futures::{Async, Poll, Stream};
+use futures01::{Async, Poll, Stream};
 
 /// A shared reference to an actix request payload.
 ///

--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -2,7 +2,7 @@ use actix_web::actix::*;
 use actix_web::http::StatusCode;
 use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use failure::Fail;
-use futures::prelude::*;
+use futures01::prelude::*;
 use serde::de::DeserializeOwned;
 
 use relay_auth::{RelayId, UnpackError};

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -11,8 +11,8 @@
 use std::io;
 
 use failure::Fail;
-use futures::prelude::*;
-use futures03::{FutureExt, TryFutureExt, TryStreamExt};
+use futures::{FutureExt, TryFutureExt, TryStreamExt};
+use futures01::prelude::*;
 use serde::de::DeserializeOwned;
 
 use relay_config::HttpEncoding;

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -9,7 +9,7 @@ use actix_web::error::Error;
 use actix_web::middleware::{Finished, Middleware, Response, Started};
 use actix_web::{http::header, Body, HttpMessage, HttpRequest, HttpResponse};
 use failure::Fail;
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use relay_log::_sentry::{types::Uuid, Hub, Level, ScopeGuard};
 use relay_log::protocol::{ClientSdkPackage, Event, Request};

--- a/relay-server/src/utils/actix.rs
+++ b/relay-server/src/utils/actix.rs
@@ -1,7 +1,7 @@
 use ::actix::dev::{MessageResponse, ResponseChannel};
 use ::actix::fut::IntoActorFuture;
 use ::actix::prelude::*;
-use futures::prelude::*;
+use futures01::prelude::*;
 
 pub enum Response<T, E> {
     Reply(Result<T, E>),

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -5,7 +5,7 @@ use actix::prelude::*;
 use actix_web::{error::PayloadError, multipart, HttpMessage, HttpRequest};
 use bytes::Bytes;
 use failure::Fail;
-use futures::{future, Async, Future, Poll, Stream};
+use futures01::{future, Async, Future, Poll, Stream};
 use serde::{Deserialize, Serialize};
 
 use crate::envelope::{AttachmentType, ContentType, Item, ItemType, Items};

--- a/relay-server/src/utils/shutdown.rs
+++ b/relay-server/src/utils/shutdown.rs
@@ -1,5 +1,5 @@
 use actix::prelude::*;
-use futures::prelude::*;
+use futures01::prelude::*;
 
 pub struct DropGuardedFuture<F: Sized> {
     name: &'static str,

--- a/relay-server/src/utils/tracked_future.rs
+++ b/relay-server/src/utils/tracked_future.rs
@@ -1,5 +1,5 @@
 use actix::{Message, Recipient};
-use futures::{Async, Future, Poll};
+use futures01::{Async, Future, Poll};
 
 /// Message send on the notification channel when the tracked future finishes or is disposed.
 pub struct TrackedFutureFinished;
@@ -83,7 +83,7 @@ mod test {
 
     use actix::{Actor, Context, Handler};
     use failure::_core::time::Duration;
-    use futures::sync::oneshot::{channel, Sender};
+    use futures01::sync::oneshot::{channel, Sender};
     use tokio_timer::Timeout;
 
     struct TestActor {
@@ -127,8 +127,8 @@ mod test {
     fn test_tracked_future_termination() {
         relay_test::setup();
         let mut futures = [
-            Some(futures::future::ok::<bool, ()>(true)),
-            Some(futures::future::err::<bool, ()>(())),
+            Some(futures01::future::ok::<bool, ()>(true)),
+            Some(futures01::future::err::<bool, ()>(())),
         ];
         for future in &mut futures {
             relay_test::block_fn(|| {

--- a/relay-server/src/utils/with_outcome.rs
+++ b/relay-server/src/utils/with_outcome.rs
@@ -1,6 +1,6 @@
 use actix::prelude::dev::ToEnvelope;
 use actix::prelude::*;
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use crate::actors::envelopes::EnvelopeContext;
 use crate::actors::outcome::{DiscardReason, Outcome};

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 actix = "0.7.9"
 failure = "0.1.8"
-futures = "0.1.28"
-futures03 = { version = "0.3", package = "futures", features = ["compat"] }
+futures01 = { version = "0.1.28", package = "futures" }
+futures = { version = "0.3", package = "futures", features = ["compat"] }
 relay-log = { path = "../relay-log" }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 use actix::actors::signal;
 use actix::fut;
 use actix::prelude::*;
-use futures::future;
-use futures::prelude::*;
-use futures03::compat::Future01CompatExt;
+use futures::compat::Future01CompatExt;
+use futures01::future;
+use futures01::prelude::*;
 use tokio::sync::watch;
 
 #[doc(inline)]

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 [dependencies]
 actix = "0.7.9"
 actix-web = { version = "0.7.19", default-features = false}
-futures = "0.1.28"
+futures01 = { version = "0.1.28", package = "futures" }
 relay-log = { path = "../relay-log", features = ["test"] }
 tokio-timer = "0.2.13"

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use actix::{System, SystemRunner};
-use futures::{future, IntoFuture};
+use futures01::{future, IntoFuture};
 
 pub use actix_web::test::*;
 use tokio_timer::Delay;

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -125,7 +125,7 @@ where
 /// Returns a future which completes after the requested delay.
 /// ```
 /// use std::time::Duration;
-/// use futures::future::Future;
+/// use futures01::future::Future;
 ///
 /// relay_test::setup();
 /// relay_test::block_fn(|| {

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "2.33.0", default-features = false, features = ["wrap_help"] 
 console = "0.10.0"
 dialoguer = "0.5.0"
 failure = "0.1.8"
-futures = "0.1.28"
+futures01 = { version = "0.1.28", package = "futures" }
 hostname = "0.3.1"
 lazy_static = "1.4.0"
 relay-common = { path = "../relay-common" }


### PR DESCRIPTION
As part of the effort to future-proof Relay as outlined here #1374 the goal is to use the standard [Futures](https://doc.rust-lang.org/stable/std/future/trait.Future.html) instead of the older version of the crate. With this effort currently under way this PR refactors the system by changing `futures` to `futures01` and `futures03` to `futures`. As such it builds further on the changes made here #1374.

#skip-changelog