### PR TITLE
style(filters): Fix typo `filter` -> `filtered`

### DIFF
--- a/relay-filter/src/lib.rs
+++ b/relay-filter/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::csp::matches_any_origin;
 
 /// Checks whether an event should be filtered for a particular configuration.
 ///
-/// If the event should be filter, the `Err` returned contains a filter reason.
+/// If the event should be filtered, the `Err` returned contains a filter reason.
 /// The reason is the message returned by the first filter that didn't pass.
 pub fn should_filter(
     event: &Event,


### PR DESCRIPTION
Fix minor typo.

#skip-changelog