### PR TITLE
feat: Add basic envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Our policy is that the .envrc is entirely optional, and a user
+# without direnv should not really have a worse dev experience in any way.
+
+# 'make' is in charge of creating and managing virtualenvs, and things like
+# pytest can still be directly invoked using .venv/bin/pytest
+
+if ! source .venv/bin/activate; then
+    echo "!!! you have no virtualenv, run 'make setup' to fix that."
+    # XXX: ideally, direnv is able to export PS1 as modified by sourcing venvs
+    #      but we'd have to patch direnv, and ".venv" isn't descriptive anyways
+    unset PS1
+fi


### PR DESCRIPTION
It seems like direnv is our go-to approach for enabling virtualenvs automatically: sentry, snuba, ops repos have an envrc that does basically that.

#skip-changelog