### PR TITLE
fix(metrics): Fix name of PHP framework in SDK list [INGEST-1515]

### DIFF
--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -81,7 +81,7 @@ pub fn is_high_cardinality_sdk(event: &Event) -> bool {
         "sentry.javascript.vue",
         "sentry.javascript.nextjs",
         "sentry.php.laravel",
-        "sentry.php.symphony",
+        "sentry.php.symfony",
     ]
     .contains(&sdk_name)
     {


### PR DESCRIPTION
For reference, see https://github.com/getsentry/sentry-symfony/blob/4b5796901c526cadea57a82daa56059f93fbcfa5/src/SentryBundle.php#L14.

#skip-changelog