### PR TITLE
fix: Compilation warnings on nightly

### DIFF
--- a/relay-cabi/src/auth.rs
+++ b/relay-cabi/src/auth.rs
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn relay_publickey_parse(s: *const RelayStr) -> *mut Relay
 pub unsafe extern "C" fn relay_publickey_free(spk: *mut RelayPublicKey) {
     if !spk.is_null() {
         let pk = spk as *mut PublicKey;
-        Box::from_raw(pk);
+        let _dropped = Box::from_raw(pk);
     }
 }
 
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn relay_secretkey_parse(s: &RelayStr) -> *mut RelaySecret
 pub unsafe extern "C" fn relay_secretkey_free(spk: *mut RelaySecretKey) {
     if !spk.is_null() {
         let pk = spk as *mut SecretKey;
-        Box::from_raw(pk);
+        let _dropped = Box::from_raw(pk);
     }
 }
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn relay_geoip_lookup_new(path: *const c_char) -> *mut Rel
 pub unsafe extern "C" fn relay_geoip_lookup_free(lookup: *mut RelayGeoIpLookup) {
     if !lookup.is_null() {
         let lookup = lookup as *mut GeoIpLookup;
-        Box::from_raw(lookup);
+        let _dropped = Box::from_raw(lookup);
     }
 }
 
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn relay_store_normalizer_new(
 pub unsafe extern "C" fn relay_store_normalizer_free(normalizer: *mut RelayStoreNormalizer) {
     if !normalizer.is_null() {
         let normalizer = normalizer as *mut StoreProcessor;
-        Box::from_raw(normalizer);
+        let _dropped = Box::from_raw(normalizer);
     }
 }
 


### PR DESCRIPTION
`Box::from_raw` is now marked as `must_use`.

#skip-changelog
