### PR TITLE
Revert "ref(actix): Update Healthcheck Actor [INGEST-1481]"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
 - Treat "unknown" transaction source as low cardinality for safe SDKs. ([#1352](https://github.com/getsentry/relay/pull/1352), [#1356](https://github.com/getsentry/relay/pull/1356))
 - Conditionally write a default transaction source to the transaction payload. ([#1354](https://github.com/getsentry/relay/pull/1354))
-- Change to the internals of the healthcheck endpoint. ([#1349](https://github.com/getsentry/relay/pull/1349))
 
 **Bug Fixes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -3591,9 +3591,7 @@ dependencies = [
  "actix",
  "failure",
  "futures 0.1.31",
- "futures 0.3.21",
  "relay-log",
- "tokio 1.19.2",
 ]
 
 [[package]]

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use actix::SystemService;
-use futures03::compat::Future01CompatExt;
-use parking_lot::RwLock;
-use tokio::sync::{mpsc, oneshot};
+use actix::prelude::*;
+
+use futures::future;
+use futures::prelude::*;
 
 use relay_config::{Config, RelayMode};
 use relay_metrics::{AcceptsMetrics, Aggregator};
@@ -13,155 +13,47 @@ use relay_system::{Controller, Shutdown};
 use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
 use crate::statsd::RelayGauges;
 
-lazy_static::lazy_static! {
-    /// Singleton of the `Healthcheck` service.
-    static ref ADDRESS: RwLock<Option<Addr<HealthcheckMessage>>> = RwLock::new(None);
-}
-
-/// Internal wrapper of a message sent through an `Addr` with return channel.
-#[derive(Debug)]
-struct Message<T> {
-    data: T,
-    // TODO(tobias): This is hard-coded to return `bool`.
-    responder: oneshot::Sender<bool>,
-}
-
-/// An error when [sending](Addr::send) a message to a service fails.
-pub struct SendError;
-
-/// Channel for sending public messages into a service.
-///
-/// To send a message, use [`Addr::send`].
-#[derive(Clone, Debug)]
-pub struct Addr<T> {
-    tx: mpsc::UnboundedSender<Message<T>>,
-}
-
-impl<T> Addr<T> {
-    /// Sends an asynchronous message to the service and waits for the response.
-    ///
-    /// The result of the message does not have to be awaited. The message will be delivered and
-    /// handled regardless. The communication channel with the service is unbounded, so backlogs
-    /// could occur when sending too many messages.
-    ///
-    /// Sending the message can fail with `Err(SendError)` if the service has shut down.
-    pub async fn send(&self, data: T) -> Result<bool, SendError> {
-        let (responder, rx) = oneshot::channel();
-        let message = Message { data, responder };
-        self.tx.send(message).map_err(|_| SendError)?;
-        rx.await.map_err(|_| SendError)
-    }
-}
-
 pub struct Healthcheck {
     is_shutting_down: bool,
     config: Arc<Config>,
 }
 
 impl Healthcheck {
-    /// Returns the [`Addr`] of the [`Healthcheck`] actor.
-    ///
-    /// Prior to using this, the service must be started using [`Healthcheck::start`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the service was not started using [`Healthcheck::start`] prior to this being used.
-    pub fn from_registry() -> Addr<HealthcheckMessage> {
-        ADDRESS.read().as_ref().unwrap().clone()
-    }
-
-    /// Creates a new instance of the Healthcheck service.
-    ///
-    /// The service does not run. To run the service, use [`start`](Self::start).
     pub fn new(config: Arc<Config>) -> Self {
         Healthcheck {
             is_shutting_down: false,
             config,
         }
     }
+}
 
-    async fn handle_is_healthy(&mut self, message: IsHealthy) -> bool {
-        let upstream = UpstreamRelay::from_registry();
+impl Actor for Healthcheck {
+    type Context = Context<Self>;
 
-        if self.config.relay_mode() == RelayMode::Managed {
-            let fut = upstream.send(IsNetworkOutage).compat();
-            tokio::spawn(async move {
-                if let Ok(is_outage) = fut.await {
-                    metric!(gauge(RelayGauges::NetworkOutage) = if is_outage { 1 } else { 0 });
-                }
-            });
-        }
-
-        match message {
-            IsHealthy::Liveness => true, // Liveness always returns true
-            IsHealthy::Readiness => {
-                if self.is_shutting_down {
-                    return false;
-                }
-
-                if self.config.requires_auth()
-                    && !upstream
-                        .send(IsAuthenticated)
-                        .compat()
-                        .await
-                        .unwrap_or(false)
-                {
-                    return false;
-                }
-
-                Aggregator::from_registry()
-                    .send(AcceptsMetrics)
-                    .compat()
-                    .await
-                    .unwrap_or(false)
-            }
-        }
-    }
-
-    fn handle_shutdown(&mut self) -> bool {
-        self.is_shutting_down = true;
-        true // TODO(tobias): This should go away once messages are more generic
-    }
-
-    async fn handle(&mut self, message: HealthcheckMessage) -> bool {
-        match message {
-            HealthcheckMessage::Health(message) => self.handle_is_healthy(message).await,
-            HealthcheckMessage::Shutdown => self.handle_shutdown(),
-        }
-    }
-
-    /// Start this service, returning an [`Addr`] for communication.
-    pub fn start(mut self) -> Addr<HealthcheckMessage> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Message<_>>();
-
-        let addr = Addr { tx };
-        *ADDRESS.write() = Some(addr.clone());
-
-        tokio::spawn(async move {
-            while let Some(message) = rx.recv().await {
-                // TODO(tobias): This does not allow for concurrent execution.
-                let response = self.handle(message.data).await;
-                message.responder.send(response).ok();
-            }
-        });
-
-        // Forward shutdown signals to the main message channel
-        let shutdown_addr = addr.clone();
-        tokio::spawn(async move {
-            let mut shutdown_rx = Controller::subscribe_v2().await;
-
-            while shutdown_rx.changed().await.is_ok() {
-                if shutdown_rx.borrow_and_update().is_some() {
-                    let _ = shutdown_addr.send(HealthcheckMessage::Shutdown);
-                }
-            }
-        });
-
-        addr
+    fn started(&mut self, context: &mut Self::Context) {
+        Controller::subscribe(context.address());
     }
 }
 
-#[derive(Clone, Debug)]
+impl Supervised for Healthcheck {}
+
+impl SystemService for Healthcheck {}
+
+impl Default for Healthcheck {
+    fn default() -> Self {
+        unimplemented!("register with the SystemRegistry instead")
+    }
+}
+
+impl Handler<Shutdown> for Healthcheck {
+    type Result = Result<(), ()>;
+
+    fn handle(&mut self, _message: Shutdown, _context: &mut Self::Context) -> Self::Result {
+        self.is_shutting_down = true;
+        Ok(())
+    }
+}
+
 pub enum IsHealthy {
     /// Check if the Relay is alive at all.
     Liveness,
@@ -170,21 +62,51 @@ pub enum IsHealthy {
     Readiness,
 }
 
-/// All the message types which can be sent to the [`Healthcheck`] actor.
-#[derive(Clone, Debug)]
-pub enum HealthcheckMessage {
-    Health(IsHealthy),
-    Shutdown,
+impl Message for IsHealthy {
+    type Result = Result<bool, ()>;
 }
 
-impl From<Shutdown> for HealthcheckMessage {
-    fn from(_: Shutdown) -> Self {
-        HealthcheckMessage::Shutdown
-    }
-}
+impl Handler<IsHealthy> for Healthcheck {
+    type Result = ResponseFuture<bool, ()>;
 
-impl From<IsHealthy> for HealthcheckMessage {
-    fn from(is_healthy: IsHealthy) -> Self {
-        Self::Health(is_healthy)
+    fn handle(&mut self, message: IsHealthy, context: &mut Self::Context) -> Self::Result {
+        let upstream = UpstreamRelay::from_registry();
+
+        if self.config.relay_mode() == RelayMode::Managed {
+            upstream
+                .send(IsNetworkOutage)
+                .map_err(|_| ())
+                .map(|is_network_outage| {
+                    metric!(
+                        gauge(RelayGauges::NetworkOutage) = if is_network_outage { 1 } else { 0 }
+                    );
+                })
+                .into_actor(self)
+                .spawn(context);
+        }
+
+        match message {
+            IsHealthy::Liveness => Box::new(future::ok(true)),
+            IsHealthy::Readiness => {
+                if self.is_shutting_down {
+                    return Box::new(future::ok(false));
+                }
+
+                let is_aggregator_full = Aggregator::from_registry()
+                    .send(AcceptsMetrics)
+                    .map_err(|_| ());
+                let is_authenticated: Self::Result = if self.config.requires_auth() {
+                    Box::new(upstream.send(IsAuthenticated).map_err(|_| ()))
+                } else {
+                    Box::new(future::ok(true))
+                };
+
+                Box::new(
+                    is_aggregator_full
+                        .join(is_authenticated)
+                        .map(|(a, b)| a && b),
+                )
+            }
+        }
     }
 }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -8,7 +8,6 @@ use failure::{Backtrace, Context, Fail};
 use listenfd::ListenFd;
 
 use relay_aws_extension::AwsExtension;
-use relay_common::clone;
 use relay_config::Config;
 use relay_metrics::Aggregator;
 use relay_redis::RedisPool;
@@ -109,7 +108,6 @@ impl From<Context<ServerErrorKind>> for ServerError {
 #[derive(Clone)]
 pub struct ServiceState {
     config: Arc<Config>,
-    _runtime: Arc<tokio::runtime::Runtime>,
 }
 
 impl ServiceState {
@@ -117,16 +115,6 @@ impl ServiceState {
     pub fn start(config: Arc<Config>) -> Result<Self, ServerError> {
         let system = System::current();
         let registry = system.registry();
-
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .enable_all()
-            .on_thread_start(clone!(system, || System::set_current(system.clone())))
-            .build()
-            .unwrap();
-
-        // Enter the tokio runtime so we can start spawning tasks from the outside.
-        let _guard = runtime.enter();
 
         let upstream_relay = UpstreamRelay::new(config.clone());
         registry.set(Arbiter::start(|_| upstream_relay));
@@ -148,9 +136,7 @@ impl ServiceState {
 
         let project_cache = ProjectCache::new(config.clone(), redis_pool).start();
         registry.set(project_cache.clone());
-
-        Healthcheck::new(config.clone()).start(); // TODO(tobias): Registry is implicit
-
+        registry.set(Healthcheck::new(config.clone()).start());
         registry.set(RelayCache::new(config.clone()).start());
         registry
             .set(Aggregator::new(config.aggregator_config(), project_cache.recipient()).start());
@@ -164,10 +150,7 @@ impl ServiceState {
             }
         }
 
-        Ok(ServiceState {
-            config,
-            _runtime: Arc::new(runtime),
-        })
+        Ok(ServiceState { config })
     }
 
     /// Returns an atomically counted reference to the config.

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -13,6 +13,4 @@ publish = false
 actix = "0.7.9"
 failure = "0.1.8"
 futures = "0.1.28"
-futures03 = { version = "0.3", package = "futures", features = ["compat"] }
 relay-log = { path = "../relay-log" }
-tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -6,8 +6,6 @@ use actix::fut;
 use actix::prelude::*;
 use futures::future;
 use futures::prelude::*;
-use futures03::compat::Future01CompatExt;
-use tokio::sync::watch;
 
 #[doc(inline)]
 pub use actix::actors::signal::{Signal, SignalType};
@@ -62,10 +60,6 @@ pub struct Controller {
     timeout: Duration,
     /// Subscribed actors for the shutdown message.
     subscribers: Vec<Recipient<Shutdown>>,
-    /// Handed out to actors who wish to subscribe to the [`Shutdown`] message.
-    shutdown_receiver: watch::Receiver<Option<Shutdown>>,
-    /// The sender for the [`Shutdown`] message.
-    shutdown_sender: watch::Sender<Option<Shutdown>>,
 }
 
 impl Controller {
@@ -108,22 +102,6 @@ impl Controller {
         Controller::from_registry().do_send(Subscribe(addr.recipient()))
     }
 
-    /// Subscribes to the [`Shutdown`] message to handle graceful shutdown.
-    ///
-    /// Returns a receiver for the [`Shutdown`] message, to be used to gracefully
-    /// shutdown.  This sends a message to the [`Controller`] actor so will
-    /// block until this actor is running.
-    ///
-    /// TODO(tobias): The receiver of this message can not yet signal they have completed
-    /// shutdown.
-    pub async fn subscribe_v2() -> watch::Receiver<Option<Shutdown>> {
-        Controller::from_registry()
-            .send(SubscribeV2())
-            .compat()
-            .await
-            .unwrap() // FIXME: Remove this later
-    }
-
     /// Performs a graceful shutdown with the given timeout.
     ///
     /// This sends a `Shutdown` message to all subscribed actors and waits for them to finish. As
@@ -132,8 +110,6 @@ impl Controller {
         // Send a shutdown signal to all registered subscribers (including self). They will report
         // when the shutdown has completed. Note that we ignore all errors to make sure that we
         // don't cancel the shutdown of other actors if one actor fails.
-        self.shutdown_sender.send(Some(Shutdown { timeout })).ok();
-
         let futures: Vec<_> = self
             .subscribers
             .iter()
@@ -165,13 +141,9 @@ impl Controller {
 
 impl Default for Controller {
     fn default() -> Self {
-        let (shutdown_sender, shutdown_receiver) = watch::channel(None);
-
         Controller {
             timeout: Duration::from_secs(0),
             subscribers: Vec::new(),
-            shutdown_receiver,
-            shutdown_sender,
         }
     }
 }
@@ -258,22 +230,6 @@ impl Handler<Subscribe> for Controller {
 
     fn handle(&mut self, message: Subscribe, _context: &mut Self::Context) -> Self::Result {
         self.subscribers.push(message.0)
-    }
-}
-
-/// Internal message to handle subscribing to the [`Shutdown`] message.
-#[derive(Debug)]
-pub struct SubscribeV2();
-
-impl Message for SubscribeV2 {
-    type Result = watch::Receiver<Option<Shutdown>>;
-}
-
-impl Handler<SubscribeV2> for Controller {
-    type Result = MessageResult<SubscribeV2>;
-
-    fn handle(&mut self, _: SubscribeV2, _: &mut Self::Context) -> Self::Result {
-        MessageResult(self.shutdown_receiver.clone())
     }
 }
 


### PR DESCRIPTION
Causes a panic: `no Task is currently running`, this happens because the following code is executed eventually (in `actix::address::channel::AddressSender<T>::send`):
```rust
// If the channel has reached capacity, then the sender task needs to
// be parked. This will send the task handle on the parked task queue.
if park_self {
    self.park(true);
}
```
Which in turn executes `task::current()` which can panic as mentioned [here](https://docs.rs/tokio/0.1.22/tokio/prelude/task/fn.current.html)

Reverts getsentry/relay#1349
#skip-changelog