### PR TITLE
feat(metrics): Treat ruby error responses as high-cardinality [INGEST-1536]

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -553,6 +553,13 @@ impl Event {
             None
         }
     }
+
+    pub fn has_module(&self, module_name: &str) -> bool {
+        self.modules
+            .value()
+            .map(|m| m.contains_key(module_name))
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -96,8 +96,8 @@ const METRIC_NAMESPACE: MetricNamespace = MetricNamespace::Transactions;
 
 fn get_trace_context(event: &Event) -> Option<&TraceContext> {
     let contexts = event.contexts.value()?;
-    let trace = contexts.get("trace").map(Annotated::value);
-    if let Some(Some(ContextInner(Context::Trace(trace_context)))) = trace {
+    let trace = contexts.get("trace").and_then(Annotated::value);
+    if let Some(ContextInner(Context::Trace(trace_context))) = trace {
         return Some(trace_context.as_ref());
     }
 


### PR DESCRIPTION
The Ruby SDK sometimes sends raw URLs as transaction name, apparently on certain error responses.

See https://github.com/getsentry/sentry-ruby/blob/c9b4eac913f0c6510178c451da57d91fc340fa20/sentry-ruby/lib/sentry/rack/capture_exceptions.rb#L21

Add heuristic to treat these cases as high-cardinality.

#skip-changelog