### PR TITLE
feat(transactions): Extract computed measurements [INGEST-1530]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
 - Treat "unknown" transaction source as low cardinality for safe SDKs. ([#1352](https://github.com/getsentry/relay/pull/1352), [#1356](https://github.com/getsentry/relay/pull/1356))
 - Conditionally write a default transaction source to the transaction payload. ([#1354](https://github.com/getsentry/relay/pull/1354))
+- Generate mobile measurements frames_frozen_rate, frames_slow_rate, stall_percentage. ([#1373](https://github.com/getsentry/relay/pull/1373))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 - Refactor profile processing into its own crate. ([#1340](https://github.com/getsentry/relay/pull/1340))
 - Treat "unknown" transaction source as low cardinality for safe SDKs. ([#1352](https://github.com/getsentry/relay/pull/1352), [#1356](https://github.com/getsentry/relay/pull/1356))
 - Conditionally write a default transaction source to the transaction payload. ([#1354](https://github.com/getsentry/relay/pull/1354))
-- Generate mobile measurements frames_frozen_rate, frames_slow_rate, stall_percentage. ([#1373](https://github.com/getsentry/- Change to the internals of the healthcheck endpoint. ([#1374](https://github.com/getsentry/relay/pull/1374))
+- Generate mobile measurements frames_frozen_rate, frames_slow_rate, stall_percentage. ([#1373](https://github.com/getsentry/relay/pull/1373))
+- Change to the internals of the healthcheck endpoint. ([#1374](https://github.com/getsentry/relay/pull/1374))
+
 
 **Bug Fixes**:
 

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -72,6 +72,14 @@ impl Measurements {
     pub fn into_inner(self) -> Object<Measurement> {
         self.0
     }
+
+    /// Return the value of the measurement with the given name, if it exists.
+    pub fn get_value(&self, key: &str) -> Option<f64> {
+        self.get(key)
+            .and_then(Annotated::value)
+            .and_then(|x| x.value.value())
+            .copied()
+    }
 }
 
 impl FromValue for Measurements {

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -25,7 +25,7 @@ pub use self::geo::{GeoIpError, GeoIpLookup};
 pub use normalize::breakdowns::{
     get_breakdown_measurements, BreakdownConfig, BreakdownsConfig, SpanOperationsConfig,
 };
-pub use normalize::{is_valid_platform, normalize_dist};
+pub use normalize::{compute_measurements, is_valid_platform, normalize_dist};
 pub use transactions::{
     get_measurement, get_transaction_op, is_high_cardinality_sdk, validate_timestamps,
 };

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -89,24 +89,18 @@ pub fn compute_measurements(transaction_duration_ms: f64, measurements: &mut Mea
     if let Some(frames_total) = measurements.get_value("frames_total") {
         if frames_total > 0.0 {
             if let Some(frames_frozen) = measurements.get_value("frames_frozen") {
-                measurements.insert(
-                    "frames_frozen_rate".to_owned(),
-                    Measurement {
-                        value: Annotated::new(frames_frozen / frames_total),
-                        unit: Annotated::new(MetricUnit::Fraction(FractionUnit::Ratio)),
-                    }
-                    .into(),
-                );
+                let frames_frozen_rate = Measurement {
+                    value: (frames_frozen / frames_total).into(),
+                    unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
+                };
+                measurements.insert("frames_frozen_rate".to_owned(), frames_frozen_rate.into());
             }
             if let Some(frames_slow) = measurements.get_value("frames_slow") {
-                measurements.insert(
-                    "frames_slow_rate".to_owned(),
-                    Measurement {
-                        value: Annotated::new(frames_slow / frames_total),
-                        unit: Annotated::new(MetricUnit::Fraction(FractionUnit::Ratio)),
-                    }
-                    .into(),
-                );
+                let frames_slow_rate = Measurement {
+                    value: (frames_slow / frames_total).into(),
+                    unit: MetricUnit::Fraction(FractionUnit::Ratio).into(),
+                };
+                measurements.insert("frames_slow_rate".to_owned(), frames_slow_rate.into());
             }
         }
     }
@@ -121,16 +115,11 @@ pub fn compute_measurements(transaction_duration_ms: f64, measurements: &mut Mea
                 == Some(&MetricUnit::Duration(DurationUnit::MilliSecond))
             {
                 if let Some(stall_total_time) = stall_total_time.value.0 {
-                    measurements.insert(
-                        "stall_percentage".to_owned(),
-                        Measurement {
-                            value: Annotated::new(
-                                100.0 * (stall_total_time / transaction_duration_ms),
-                            ),
-                            unit: Annotated::new(MetricUnit::Fraction(FractionUnit::Percent)),
-                        }
-                        .into(),
-                    );
+                    let stall_percentage = Measurement {
+                        value: (stall_total_time / transaction_duration_ms).into(),
+                        unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
+                    };
+                    measurements.insert("stall_percentage".to_owned(), stall_percentage.into());
                 }
             }
         }
@@ -1761,8 +1750,8 @@ fn test_computed_measurements() {
       "value": 4,
     },
     "stall_percentage": {
-      "value": 80,
-      "unit": "percent",
+      "value": 0.8,
+      "unit": "ratio",
     },
     "stall_total_time": {
       "value": 4000,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -7,13 +7,15 @@ use chrono::{Duration, Utc};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
+use relay_common::{DurationUnit, FractionUnit, MetricUnit};
 use smallvec::SmallVec;
 
 use crate::processor::{MaxChars, ProcessValue, ProcessingState, Processor};
 use crate::protocol::{
     self, AsPair, Breadcrumb, ClientSdkInfo, Context, Contexts, DebugImage, Event, EventId,
     EventType, Exception, Frame, HeaderName, HeaderValue, Headers, IpAddr, Level, LogEntry,
-    Request, SpanStatus, Stacktrace, Tags, TraceContext, User, VALID_PLATFORMS,
+    Measurement, Measurements, Request, SpanStatus, Stacktrace, Tags, TraceContext, User,
+    VALID_PLATFORMS,
 };
 use crate::store::{ClockDriftProcessor, GeoIpLookup, StoreConfig};
 use crate::types::{
@@ -82,6 +84,59 @@ pub fn normalize_dist(dist: &mut Option<String>) {
     }
 }
 
+/// Compute additional measurements derived from existing ones
+pub fn compute_measurements(transaction_duration_ms: f64, measurements: &mut Measurements) {
+    if let Some(frames_total) = measurements.get_value("frames_total") {
+        if frames_total > 0.0 {
+            if let Some(frames_frozen) = measurements.get_value("frames_frozen") {
+                measurements.insert(
+                    "frames_frozen_rate".to_owned(),
+                    Measurement {
+                        value: Annotated::new(frames_frozen / frames_total),
+                        unit: Annotated::new(MetricUnit::Fraction(FractionUnit::Ratio)),
+                    }
+                    .into(),
+                );
+            }
+            if let Some(frames_slow) = measurements.get_value("frames_slow") {
+                measurements.insert(
+                    "frames_slow_rate".to_owned(),
+                    Measurement {
+                        value: Annotated::new(frames_slow / frames_total),
+                        unit: Annotated::new(MetricUnit::Fraction(FractionUnit::Ratio)),
+                    }
+                    .into(),
+                );
+            }
+        }
+    }
+
+    // Get stall_percentage
+    if transaction_duration_ms > 0.0 {
+        if let Some(stall_total_time) = measurements
+            .get("stall_total_time")
+            .and_then(Annotated::value)
+        {
+            if stall_total_time.unit.value()
+                == Some(&MetricUnit::Duration(DurationUnit::MilliSecond))
+            {
+                if let Some(stall_total_time) = stall_total_time.value.0 {
+                    measurements.insert(
+                        "stall_percentage".to_owned(),
+                        Measurement {
+                            value: Annotated::new(
+                                100.0 * (stall_total_time / transaction_duration_ms),
+                            ),
+                            unit: Annotated::new(MetricUnit::Fraction(FractionUnit::Percent)),
+                        }
+                        .into(),
+                    );
+                }
+            }
+        }
+    }
+}
+
 /// The processor that normalizes events for store.
 pub struct NormalizeProcessor<'a> {
     config: Arc<StoreConfig>,
@@ -117,6 +172,13 @@ impl<'a> NormalizeProcessor<'a> {
         if event.ty.value() != Some(&EventType::Transaction) {
             // Only transaction events may have a measurements interface
             event.measurements = Annotated::empty();
+        } else if let Some(measurements) = event.measurements.value_mut() {
+            let duration_millis = match (event.start_timestamp.0, event.timestamp.0) {
+                (Some(start), Some(end)) => relay_common::chrono_to_positive_millis(end - start),
+                _ => 0.0,
+            };
+
+            compute_measurements(duration_millis, measurements);
         }
     }
 
@@ -1645,4 +1707,67 @@ fn test_normalize_dist_whitespace() {
     let mut dist = Some(" ".to_owned());
     normalize_dist(&mut dist);
     assert_eq!(dist.unwrap(), ""); // Not sure if this is what we want
+}
+
+#[test]
+fn test_computed_measurements() {
+    use crate::types::SerializableAnnotated;
+    use insta::assert_ron_snapshot;
+
+    let json = r#"
+        {
+            "type": "transaction",
+            "timestamp": "2021-04-26T08:00:05+0100",
+            "start_timestamp": "2021-04-26T08:00:00+0100",
+            "measurements": {
+                "frames_slow": {"value": 1},
+                "frames_frozen": {"value": 2},
+                "frames_total": {"value": 4},
+                "stall_total_time": {"value": 4000, "unit": "millisecond"}
+            }
+        }
+        "#;
+
+    let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
+
+    let processor = NormalizeProcessor::new(
+        Arc::new(StoreConfig {
+            ..Default::default()
+        }),
+        None,
+    );
+    processor.normalize_measurements(&mut event);
+
+    assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"{
+  "type": "transaction",
+  "timestamp": 1619420405,
+  "start_timestamp": 1619420400,
+  "measurements": {
+    "frames_frozen": {
+      "value": 2,
+    },
+    "frames_frozen_rate": {
+      "value": 0.5,
+      "unit": "ratio",
+    },
+    "frames_slow": {
+      "value": 1,
+    },
+    "frames_slow_rate": {
+      "value": 0.25,
+      "unit": "ratio",
+    },
+    "frames_total": {
+      "value": 4,
+    },
+    "stall_percentage": {
+      "value": 80,
+      "unit": "percent",
+    },
+    "stall_total_time": {
+      "value": 4000,
+      "unit": "millisecond",
+    },
+  },
+}"###);
 }

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -111,9 +111,11 @@ pub fn compute_measurements(transaction_duration_ms: f64, measurements: &mut Mea
             .get("stall_total_time")
             .and_then(Annotated::value)
         {
-            if stall_total_time.unit.value()
-                == Some(&MetricUnit::Duration(DurationUnit::MilliSecond))
-            {
+            if matches!(
+                stall_total_time.unit.value(),
+                // Accept milliseconds or None, but not other units
+                Some(&MetricUnit::Duration(DurationUnit::MilliSecond) | &MetricUnit::None) | None
+            ) {
                 if let Some(stall_total_time) = stall_total_time.value.0 {
                     let stall_percentage = Measurement {
                         value: (stall_total_time / transaction_duration_ms).into(),

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -366,7 +366,7 @@ fn get_metric_measurement_unit(metric: &str) -> Option<MetricUnit> {
         "stall_count" => Some(MetricUnit::None),
         "stall_total_time" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
         "stall_longest_time" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "stall_percentage" => Some(MetricUnit::Fraction(FractionUnit::Percent)),
+        "stall_percentage" => Some(MetricUnit::Fraction(FractionUnit::Ratio)),
 
         // Default
         _ => None,
@@ -1665,7 +1665,7 @@ mod tests {
             "extractMetrics": [
                 "d:transactions/measurements.frames_frozen_rate@ratio",
                 "d:transactions/measurements.frames_slow_rate@ratio",
-                "d:transactions/measurements.stall_percentage@percent"
+                "d:transactions/measurements.stall_percentage@ratio"
             ]
         }
         "#,
@@ -1692,7 +1692,7 @@ mod tests {
         );
 
         assert_eq!(
-            metrics[2].name, "d:transactions/measurements.stall_percentage@percent",
+            metrics[2].name, "d:transactions/measurements.stall_percentage@ratio",
             "{:?}",
             metrics[2]
         );

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -1653,8 +1653,7 @@ mod tests {
                     "value": 4
                 },
                 "stall_total_time": {
-                    "value": 4,
-                    "unit": "millisecond"
+                    "value": 4
                 }
             }
         }"#;

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import json
 import signal
-import time
 
 import pytest
 import requests
@@ -758,9 +757,6 @@ def test_graceful_shutdown(mini_sentry, relay):
     metrics_payload = f"transactions/bar:17|c"
     future_timestamp = timestamp + 60
     relay.send_metrics(project_id, metrics_payload, future_timestamp)
-
-    time.sleep(0.1)  # Give Relay time to process metric
-
     relay.shutdown(sig=signal.SIGTERM)
 
     # Try to send another metric (will be rejected)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 import json
 import signal
+import time
 
 import pytest
 import requests
@@ -757,6 +758,9 @@ def test_graceful_shutdown(mini_sentry, relay):
     metrics_payload = f"transactions/bar:17|c"
     future_timestamp = timestamp + 60
     relay.send_metrics(project_id, metrics_payload, future_timestamp)
+
+    time.sleep(0.1)  # Give Relay time to process metric
+
     relay.shutdown(sig=signal.SIGTERM)
 
     # Try to send another metric (will be rejected)


### PR DESCRIPTION
Extract the following derived mobile measurements, and write them back into the transaction:

```
frames_slow_rate := measurements.frames_slow / measurements.frames_total
frames_frozen_rate := measurements.frames_frozen / measurements.frames_total
stall_percentage := measurements.stall_total_time / transaction.duration
```

These new measurements will be available in both the metrics and the transactions dataset.

The addition to the measurement allowlist is done in https://github.com/getsentry/sentry/pull/37330.