### PR TITLE
fix(pii): Add private keys as secret key name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Parse sample rates as JSON. ([#1353](https://github.com/getsentry/relay/pull/1353))
+- Add `privatekey` and `private_key` as secret key name to datascrubbers. ([#1376](https://github.com/getsentry/relay/pull/1376))
 
 **Internal**:
 

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -229,6 +229,6 @@ lazy_static! {
         "#
     ).unwrap();
     static ref PASSWORD_KEY_REGEX: Regex = Regex::new(
-        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken|privatekey)"
+        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken|privatekey|private_key)"
     ).unwrap();
 }

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -229,6 +229,6 @@ lazy_static! {
         "#
     ).unwrap();
     static ref PASSWORD_KEY_REGEX: Regex = Regex::new(
-        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken)"
+        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken|privatekey)"
     ).unwrap();
 }


### PR DESCRIPTION


https://twitter.com/MoonRankNFT/status/1554911833617641472/photo/1


Its been reported that someone was - likely accidentally - sending a private key to their Sentry instance. There's not a great use case to allow storing that kind of value, so we are adding it to our default blocklists.

The hashes and "mnemonic" seem not very useful for pattern matching, but
we can at least filter out the string if it contains the word
"privatekey" (case-insensitive)

