### PR TITLE
ref(server): Move all heavy actors into dedicated arbiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Parse sample rates as JSON. ([#1353](https://github.com/getsentry/relay/pull/1353))
 - Add `privatekey` and `private_key` as secret key name to datascrubbers. ([#1376](https://github.com/getsentry/relay/pull/1376))
 
+**Bug Fixes**:
+
+- Fix a bug where unreal crash reports were dropped when metrics extraction is enabled. ([#1355](https://github.com/getsentry/relay/pull/1355))
+- Extract user from metrics with EventUser's priority. ([#1363](https://github.com/getsentry/relay/pull/1363))
+
 **Internal**:
 
 - Support compressed project configs in redis cache. ([#1345](https://github.com/getsentry/relay/pull/1345))
@@ -16,12 +21,7 @@
 - Generate mobile measurements frames_frozen_rate, frames_slow_rate, stall_percentage. ([#1373](https://github.com/getsentry/relay/pull/1373))
 - Change to the internals of the healthcheck endpoint. ([#1374](https://github.com/getsentry/relay/pull/1374))
 - Re-encode the Typescript payload to normalize. ([#1372](https://github.com/getsentry/relay/pull/1372))
-
-
-**Bug Fixes**:
-
-- Fix a bug where unreal crash reports were dropped when metrics extraction is enabled. ([#1355](https://github.com/getsentry/relay/pull/1355))
-- Extract user from metrics with EventUser's priority. ([#1363](https://github.com/getsentry/relay/pull/1363))
+- Spawn more threads for CPU intensive work. ([#1378](https://github.com/getsentry/relay/pull/1378))
 
 ## 22.7.0
 


### PR DESCRIPTION
Each actix arbiter spawns a thread with its own single-threaded event loop. This
allows to create isolation between actors that may cause CPU spikes when
backlogged, and makes fair scheduling in actix easier.

While some of our actors, notably the `OutcomeProducer` and (metrics)
`Aggregator` had been spawned into a dedicated arbiter, most of the other actors
were still running on the main arbiter. The `EnvelopeManager` is known to cause
an increase in CPU consumption due to how it spawns futures internally. This
slows down the project cache and healthcheck, which in turn blocks incoming HTTP
requests.

Since there's a global slowdown of the main arbiter, it becomes hard to separate
cause from effect when investigating slow response times. It is not clear
whether the project cache causes increased queue sizes or whether increased
queue sizes delay project fetching.

To create clear separation, this PR introduces a dedicated arbiter for every
heavy actor.

