### PR TITLE
fix(log): Honor `SentryConfig.enabled` and don't init SDK at all if it is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fix a bug where unreal crash reports were dropped when metrics extraction is enabled. ([#1355](https://github.com/getsentry/relay/pull/1355))
 - Extract user from metrics with EventUser's priority. ([#1363](https://github.com/getsentry/relay/pull/1363))
+- Honor `SentryConfig.enabled` and don't init SDK at all if it is false. ([#1380](https://github.com/getsentry/relay/pull/1380))
 
 **Internal**:
 

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -243,25 +243,27 @@ pub fn init(config: &LogConfig, sentry: &SentryConfig) {
         }
     }
 
-    let guard = sentry::init(sentry::ClientOptions {
-        dsn: sentry.enabled_dsn().cloned(),
-        in_app_include: vec![
-            "relay_auth::",
-            "relay_common::",
-            "relay_config::",
-            "relay_filter::",
-            "relay_general::",
-            "relay_quotas::",
-            "relay_redis::",
-            "relay_server::",
-            "relay::",
-        ],
-        integrations: vec![Arc::new(FailureIntegration::new())],
-        release,
-        attach_stacktrace: config.enable_backtraces,
-        ..Default::default()
-    });
+    if let Some(dsn) = sentry.enabled_dsn() {
+        let guard = sentry::init(sentry::ClientOptions {
+            dsn: Some(dsn).cloned(),
+            in_app_include: vec![
+                "relay_auth::",
+                "relay_common::",
+                "relay_config::",
+                "relay_filter::",
+                "relay_general::",
+                "relay_quotas::",
+                "relay_redis::",
+                "relay_server::",
+                "relay::",
+            ],
+            integrations: vec![Arc::new(FailureIntegration::new())],
+            release,
+            attach_stacktrace: config.enable_backtraces,
+            ..Default::default()
+        });
 
-    // Keep the client initialized. The client is flushed manually in `main`.
-    std::mem::forget(guard);
+        // Keep the client initialized. The client is flushed manually in `main`.
+        std::mem::forget(guard);
+    }
 }


### PR DESCRIPTION
Fixes edge case behavior where `enabled` is false but `SENTRY_DSN` is present on the machine and the SDK internally still picks it up.

This came up because relay in an AWS extension setting was reporting errors to the user's project and eating up their quota.
Note that in our AWS layer, we do have `SENTRY_DSN` set in the env to also be used by the language specific SDKs (node/python). 

#### Local testing
I tested that stuff like `relay_log::capture_error` no-ops successfully and does not break stuff even when the SDK is not initialized. And the fact that stuff compiles.

#### References

[Zendesk ticket](https://sentry.zendesk.com/agent/tickets/68841)