### PR TITLE
fix(store): Apply the correct outcome for light normalization

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1866,7 +1866,7 @@ impl EnvelopeProcessor {
 
         metric!(timer(RelayTimers::EventProcessingLightNormalization), {
             light_normalize(&mut state.event, &config)
-                .map_err(ProcessingError::ProcessingFailed)?;
+                .map_err(|_| ProcessingError::InvalidTransaction)?;
         });
 
         Ok(())

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -34,7 +34,7 @@ def test_forced_shutdown(mini_sentry, relay):
 
     @mini_sentry.app.endpoint("get_project_config")
     def get_project_config():
-        sleep(1)  # Ensures the event is stuck in the queue when we send SIGINT
+        sleep(2)  # Ensures the event is stuck in the queue when we send SIGINT
         return get_project_config_original()
 
     relay = relay(mini_sentry)
@@ -43,6 +43,7 @@ def test_forced_shutdown(mini_sentry, relay):
 
     try:
         relay.send_event(project_id)
+        sleep(0.5)  # Give the event time to get stuck
 
         relay.shutdown(sig=signal.SIGINT)
         pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))


### PR DESCRIPTION
Follow-up to #1366. By applying `InvalidTransaction`, we do not report these
dropped envelopes to Sentry and apply a dedicated reason code.

The store normalizer returns an error for invalid transactions, which has to be
special cased. Other than that, the store normalizer is infallible.

#skip-changelog

