### PR TITLE
feat(schema): Add missing fields to DeviceContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Re-encode the Typescript payload to normalize. ([#1372](https://github.com/getsentry/relay/pull/1372))
 - Partially normalize events before extracting metrics. ([#1366](https://github.com/getsentry/relay/pull/1366))
 - Spawn more threads for CPU intensive work. ([#1378](https://github.com/getsentry/relay/pull/1378))
+- Add missing fields to DeviceContext ([#1383](https://github.com/getsentry/relay/pull/1383))
 
 ## 22.7.0
 

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -124,6 +124,7 @@ pub struct DeviceContext {
     /// CPU description.
     ///
     /// For example, Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz.
+    #[metastructure(pii = "maybe")]
     pub cpu_description: Annotated<String>,
 
     /// Processor frequency in MHz.
@@ -135,15 +136,17 @@ pub struct DeviceContext {
     /// Kind of device the application is running on.
     ///
     /// For example, `Unknown`, `Handheld`, `Console`, `Desktop`.
+    #[metastructure(pii = "maybe")]
     pub device_type: Annotated<String>,
 
     /// Status of the device's battery.
     ///
     /// For example, `Unknown`, `Charging`, `Discharging`, `NotCharging`, `Full`.
+    #[metastructure(pii = "maybe")]
     pub battery_status: Annotated<String>,
 
     /// Unique device identifier.
-    #[metastructure(pii = "maybe")]
+    #[metastructure(pii = "true")]
     pub device_unique_identifier: Annotated<String>,
 
     /// Whether vibration is available on the device.

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -116,7 +116,52 @@ pub struct DeviceContext {
     #[metastructure(pii = "maybe")]
     pub timezone: Annotated<String>,
 
-    /// Additional arbitrary fields for forwards compatibility.
+    /// Number of "logical processors".
+    ///
+    /// For example, 8.
+    pub processor_count: Annotated<u64>,
+
+    /// CPU description.
+    ///
+    /// For example, Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz.
+    pub cpu_description: Annotated<String>,
+
+    /// Processor frequency in MHz.
+    ///
+    /// Note that the actual CPU frequency might vary depending on current load and
+    /// power conditions, especially on low-powered devices like phones and laptops.
+    pub processor_frequency: Annotated<u64>,
+
+    /// Kind of device the application is running on.
+    ///
+    /// For example, `Unknown`, `Handheld`, `Console`, `Desktop`.
+    pub device_type: Annotated<String>,
+
+    /// Status of the device's battery.
+    ///
+    /// For example, `Unknown`, `Charging`, `Discharging`, `NotCharging`, `Full`.
+    pub battery_status: Annotated<String>,
+
+    /// Unique device identifier.
+    #[metastructure(pii = "maybe")]
+    pub device_unique_identifier: Annotated<String>,
+
+    /// Whether vibration is available on the device.
+    pub supports_vibration: Annotated<bool>,
+
+    /// Whether the accelerometer is available on the device.
+    pub supports_accelerometer: Annotated<bool>,
+
+    /// Whether the gyroscope is available on the device.
+    pub supports_gyroscope: Annotated<bool>,
+
+    /// Whether audio is available on the device.
+    pub supports_audio: Annotated<bool>,
+
+    /// Whether location support is available on the device.
+    pub supports_location_service: Annotated<bool>,
+
+    /// Additional arbitrary fields for forwards compatibility
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
     pub other: Object<Value>,
 }

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -820,6 +820,17 @@ fn test_device_context_roundtrip() {
   "external_free_storage": 2097152,
   "boot_time": "2018-02-08T12:52:12Z",
   "timezone": "Europe/Vienna",
+  "processor_count": 8,
+  "cpu_description": "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz",
+  "processor_frequency": 2400,
+  "device_type": "Handheld",
+  "battery_status": "Charging",
+  "device_unique_identifier": "1234567",
+  "supports_vibration": true,
+  "supports_accelerometer": true,
+  "supports_gyroscope": true,
+  "supports_audio": true,
+  "supports_location_service": true,
   "other": "value",
   "type": "device"
 }"#;
@@ -849,6 +860,17 @@ fn test_device_context_roundtrip() {
         external_free_storage: Annotated::new(2_097_152),
         boot_time: Annotated::new("2018-02-08T12:52:12Z".to_string()),
         timezone: Annotated::new("Europe/Vienna".to_string()),
+        processor_count: Annotated::new(8),
+        cpu_description: Annotated::new("Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz".to_string()),
+        processor_frequency: Annotated::new(2400),
+        device_type: Annotated::new("Handheld".to_string()),
+        battery_status: Annotated::new("Charging".to_string()),
+        device_unique_identifier: Annotated::new("1234567".to_string()),
+        supports_vibration: Annotated::new(true),
+        supports_accelerometer: Annotated::new(true),
+        supports_gyroscope: Annotated::new(true),
+        supports_audio: Annotated::new(true),
+        supports_location_service: Annotated::new(true),
         other: {
             let mut map = Object::new();
             map.insert(

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -982,6 +982,14 @@ expression: event_json_schema()
               ],
               "format": "double"
             },
+            "battery_status": {
+              "description": " Status of the device's battery.\n\n For example, `Unknown`, `Charging`, `Discharging`, `NotCharging`, `Full`.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "boot_time": {
               "description": " Indicator when the device was booted.",
               "default": null,
@@ -1003,6 +1011,30 @@ expression: event_json_schema()
               "default": null,
               "type": [
                 "boolean",
+                "null"
+              ]
+            },
+            "cpu_description": {
+              "description": " CPU description.\n\n For example, Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "device_type": {
+              "description": " Kind of device the application is running on.\n\n For example, `Unknown`, `Handheld`, `Console`, `Desktop`.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "device_unique_identifier": {
+              "description": " Unique device identifier.",
+              "default": null,
+              "type": [
+                "string",
                 "null"
               ]
             },
@@ -1120,6 +1152,26 @@ expression: event_json_schema()
                 "null"
               ]
             },
+            "processor_count": {
+              "description": " Number of \"logical processors\".\n\n For example, 8.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "processor_frequency": {
+              "description": " Processor frequency in MHz.\n\n Note that the actual CPU frequency might vary depending on current load and\n power conditions, especially on low-powered devices like phones and laptops.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "screen_density": {
               "description": " Device screen density.",
               "default": null,
@@ -1164,6 +1216,46 @@ expression: event_json_schema()
               ],
               "format": "uint64",
               "minimum": 0.0
+            },
+            "supports_accelerometer": {
+              "description": " Whether the accelerometer is available on the device.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "supports_audio": {
+              "description": " Whether audio is available on the device.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "supports_gyroscope": {
+              "description": " Whether the gyroscope is available on the device.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "supports_location_service": {
+              "description": " Whether location support is available on the device.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "supports_vibration": {
+              "description": " Whether vibration is available on the device.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "timezone": {
               "description": " Timezone of the device.",

--- a/relay-general/tests/snapshots/test_fixtures__unity_android__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_android__pii_stripping.snap
@@ -1,6 +1,5 @@
 ---
 source: relay-general/tests/test_fixtures.rs
-assertion_line: 112
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993

--- a/relay-general/tests/snapshots/test_fixtures__unity_android__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_android__pii_stripping.snap
@@ -1,5 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
+assertion_line: 112
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993
@@ -140,10 +141,10 @@ contexts:
     memory_size: ~
     boot_time: ~
     timezone: ~
-    battery_status: NotCharging
+    processor_count: 16
     cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
     device_type: Desktop
-    processor_count: 16
+    battery_status: NotCharging
     supports_vibration: false
     type: device
   gpu:
@@ -288,3 +289,4 @@ _meta:
                       - 7
                       - 13
                   len: 69
+

--- a/relay-general/tests/snapshots/test_fixtures__unity_ios__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_ios__pii_stripping.snap
@@ -1,6 +1,5 @@
 ---
 source: relay-general/tests/test_fixtures.rs
-assertion_line: 110
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993

--- a/relay-general/tests/snapshots/test_fixtures__unity_ios__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_ios__pii_stripping.snap
@@ -1,5 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
+assertion_line: 110
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993
@@ -140,10 +141,10 @@ contexts:
     memory_size: ~
     boot_time: ~
     timezone: ~
-    battery_status: NotCharging
+    processor_count: 16
     cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
     device_type: Desktop
-    processor_count: 16
+    battery_status: NotCharging
     supports_vibration: false
     type: device
   gpu:
@@ -288,3 +289,4 @@ _meta:
                       - 7
                       - 13
                   len: 69
+

--- a/relay-general/tests/snapshots/test_fixtures__unity_linux__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_linux__pii_stripping.snap
@@ -1,5 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
+assertion_line: 111
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993
@@ -140,10 +141,10 @@ contexts:
     memory_size: ~
     boot_time: ~
     timezone: ~
-    battery_status: NotCharging
+    processor_count: 16
     cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
     device_type: Desktop
-    processor_count: 16
+    battery_status: NotCharging
     supports_vibration: false
     type: device
   gpu:
@@ -288,3 +289,4 @@ _meta:
                       - 7
                       - 13
                   len: 69
+

--- a/relay-general/tests/snapshots/test_fixtures__unity_linux__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_linux__pii_stripping.snap
@@ -1,6 +1,5 @@
 ---
 source: relay-general/tests/test_fixtures.rs
-assertion_line: 111
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993

--- a/relay-general/tests/snapshots/test_fixtures__unity_macos__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_macos__pii_stripping.snap
@@ -1,5 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
+assertion_line: 108
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993
@@ -140,10 +141,10 @@ contexts:
     memory_size: ~
     boot_time: ~
     timezone: ~
-    battery_status: NotCharging
+    processor_count: 16
     cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
     device_type: Desktop
-    processor_count: 16
+    battery_status: NotCharging
     supports_vibration: false
     type: device
   gpu:
@@ -288,3 +289,4 @@ _meta:
                       - 7
                       - 13
                   len: 69
+

--- a/relay-general/tests/snapshots/test_fixtures__unity_macos__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_macos__pii_stripping.snap
@@ -1,6 +1,5 @@
 ---
 source: relay-general/tests/test_fixtures.rs
-assertion_line: 108
 expression: SerializableAnnotated(&event)
 ---
 event_id: 39c94eefab9447229d70df71c7d41993

--- a/relay-general/tests/snapshots/test_fixtures__unity_windows__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_windows__pii_stripping.snap
@@ -1,6 +1,5 @@
 ---
 source: relay-general/tests/test_fixtures.rs
-assertion_line: 109
 expression: SerializableAnnotated(&event)
 ---
 event_id: 6f6e2d3fa0754d14b37a2bec59619a98

--- a/relay-general/tests/snapshots/test_fixtures__unity_windows__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__unity_windows__pii_stripping.snap
@@ -1,5 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
+assertion_line: 109
 expression: SerializableAnnotated(&event)
 ---
 event_id: 6f6e2d3fa0754d14b37a2bec59619a98
@@ -137,10 +138,10 @@ contexts:
     memory_size: ~
     boot_time: ~
     timezone: ~
-    battery_status: Full
+    processor_count: 12
     cpu_description: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
     device_type: Desktop
-    processor_count: 12
+    battery_status: Full
     supports_vibration: false
     timezone_display_name: "(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius"
     type: device
@@ -256,3 +257,4 @@ _meta:
           rem:
             - - "@anything:remove"
               - x
+


### PR DESCRIPTION
While helping review https://github.com/getsentry/develop/pull/658, I realized the context spec in the develop docs is out of sync with the struct in Relay.

This PR syncs the DeviceContext with https://develop.sentry.dev/sdk/event-payloads/contexts/#device-context

Adds `processor_count`, `cpu_description`, `processor_frequency`, `device_type`, `battery_status`, `device_unique_identifier`, `supports_vibration`, `supports_accelerometer`, `supports_gyroscope`, `supports_audio`, and `supports_location_service`.

Another PR will be opened to update the other Contexts (and add `CultureContext`)
