### PR TITLE
feat: Introduce tokio-metrics for task observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,6 +3567,7 @@ dependencies = [
  "symbolic-unreal",
  "take_mut",
  "tokio 1.19.2",
+ "tokio-metrics",
  "tokio-timer",
  "url 2.2.2",
  "uuid 0.8.2",
@@ -4656,6 +4657,17 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "log",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb585a0069b53171684e22d5255984ec30d1c7304fd0a4a9a603ffd8c765cdd"
+dependencies = [
+ "futures-util",
+ "pin-project-lite 0.2.9",
+ "tokio 1.19.2",
 ]
 
 [[package]]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -36,8 +36,8 @@ clap = "2.33.1"
 failure = "0.1.8"
 flate2 = "1.0.19"
 fragile = { version = "1.2.1", features = ["slab"] } # used for vendoring sentry-actix
-futures01 = { version = "0.1.28", package = "futures" }
 futures = { version = "0.3", package = "futures", features = ["compat"] }
+futures01 = { version = "0.1.28", package = "futures" }
 itertools = "0.8.2"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
 lazy_static = "1.4.0"
@@ -72,6 +72,7 @@ symbolic-common = { version = "8.7.2", optional = true, default-features=false }
 symbolic-unreal = { version = "8.7.2", optional = true, default-features=false, features=["serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
+tokio-metrics = "0.1.0"
 tokio-timer = "0.2.13"
 url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "0.8.1", features = ["v5"] }


### PR DESCRIPTION
This adds tokio-metrics and wraps the spawn methods in instrumented
futures, improving observability.  Metrics are emitted once every 5
seconds.

# Why is this useful?

Once we have all futures instrumented we will be able to see correlations between how the futures are working and other metrics degrading, e.g. upstream requests slowing down.  This will allow us to see which parts of which futures are slow and giving us very targeted information on which part of Relay's architecture needs to be improved to improve behaviour.

# Must it be manual?

Famously the `tokio-console` crate can instrument futures automatically, and so can `tokio-metrics` if used in a different mode.  However they require enabling the `tokio_unstable` compilation flag which is not suitable for production.  This approach is a bit more manual however much safer towards the future, it won't suddenly break.  With the architecture we have the number of spawn points should be limited so the overhead of doing this manually isn't so bad.

# This doubles the number of spawned futures!

It could be nicer to have only one extra future which loops and reports all the metrics instead of having one each for monitored future.  This is a bit more work because of what tokio-metrics exposes, plus it needs a centralised location for them.  But we can make this work if we like this thing in principle (which I hope we do 😉 ).