### PR TITLE
style(normalization): Implement default trait in `LightNormalizationConfig`

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -107,14 +107,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
 ) -> RelayStr {
     let processor = normalizer as *mut StoreProcessor;
     let mut event = Annotated::<Event>::from_json((*event).as_str())?;
-    let config = LightNormalizationConfig {
-        client_ip: None,
-        user_agent: None,
-        received_at: None,
-        max_secs_in_past: None,
-        max_secs_in_future: None,
-        breakdowns_config: None,
-    };
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config)?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;
     RelayStr::from_string(event.to_json()?)

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -1705,12 +1705,10 @@ fn test_future_timestamp() {
         None,
     );
     let config = LightNormalizationConfig {
-        client_ip: None,
-        user_agent: None,
         received_at,
         max_secs_in_past,
         max_secs_in_future,
-        breakdowns_config: None,
+        ..Default::default()
     };
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
@@ -1771,12 +1769,10 @@ fn test_past_timestamp() {
         None,
     );
     let config = LightNormalizationConfig {
-        client_ip: None,
-        user_agent: None,
         received_at,
         max_secs_in_past,
         max_secs_in_future,
-        breakdowns_config: None,
+        ..Default::default()
     };
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
@@ -1933,14 +1929,7 @@ fn test_light_normalization_is_idempotent() {
         ..Default::default()
     });
 
-    let config = LightNormalizationConfig {
-        client_ip: None,
-        user_agent: None,
-        received_at: None,
-        max_secs_in_past: None,
-        max_secs_in_future: None,
-        breakdowns_config: None,
-    };
+    let config = LightNormalizationConfig::default();
 
     fn remove_received_from_event(event: &mut Annotated<Event>) -> &mut Annotated<Event> {
         event

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -500,6 +500,7 @@ fn normalize_ip_addresses(event: &mut Event, client_ip: Option<&IpAddr>) {
     }
 }
 
+#[derive(Default)]
 pub struct LightNormalizationConfig<'a> {
     pub client_ip: Option<&'a IpAddr>,
     pub user_agent: Option<&'a str>,
@@ -830,18 +831,6 @@ impl Default for NormalizeProcessor<'_> {
     }
 }
 
-#[cfg(test)]
-fn get_empty_light_normalization_config<'a>() -> LightNormalizationConfig<'a> {
-    LightNormalizationConfig {
-        client_ip: None,
-        user_agent: None,
-        received_at: None,
-        max_secs_in_past: None,
-        max_secs_in_future: None,
-        breakdowns_config: None,
-    }
-}
-
 #[test]
 fn test_handles_type_in_value() {
     let mut processor = NormalizeProcessor::default();
@@ -958,7 +947,7 @@ fn test_user_ip_from_remote_addr() {
 
     let config = StoreConfig::default();
     let mut processor = NormalizeProcessor::new(Arc::new(config), None);
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -986,7 +975,7 @@ fn test_user_ip_from_invalid_remote_addr() {
 
     let config = StoreConfig::default();
     let mut processor = NormalizeProcessor::new(Arc::new(config), None);
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1007,8 +996,10 @@ fn test_user_ip_from_client_ip_without_auto() {
     };
 
     let mut processor = NormalizeProcessor::new(Arc::new(config), None);
-    let mut config = get_empty_light_normalization_config();
-    config.client_ip = Some(&ip_address);
+    let config = LightNormalizationConfig {
+        client_ip: Some(&ip_address),
+        ..Default::default()
+    };
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1034,8 +1025,10 @@ fn test_user_ip_from_client_ip_with_auto() {
 
     let geo = GeoIpLookup::open("tests/fixtures/GeoIP2-Enterprise-Test.mmdb").unwrap();
     let mut processor = NormalizeProcessor::new(Arc::new(config), Some(&geo));
-    let mut config = get_empty_light_normalization_config();
-    config.client_ip = Some(&ip_address);
+    let config = LightNormalizationConfig {
+        client_ip: Some(&ip_address),
+        ..Default::default()
+    };
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1058,8 +1051,10 @@ fn test_user_ip_from_client_ip_without_appropriate_platform() {
 
     let geo = GeoIpLookup::open("tests/fixtures/GeoIP2-Enterprise-Test.mmdb").unwrap();
     let mut processor = NormalizeProcessor::new(Arc::new(config), Some(&geo));
-    let mut config = get_empty_light_normalization_config();
-    config.client_ip = Some(&ip_address);
+    let config = LightNormalizationConfig {
+        client_ip: Some(&ip_address),
+        ..Default::default()
+    };
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1072,7 +1067,7 @@ fn test_user_ip_from_client_ip_without_appropriate_platform() {
 fn test_event_level_defaulted() {
     let processor = &mut NormalizeProcessor::default();
     let mut event = Annotated::new(Event::default());
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, processor, ProcessingState::root()).unwrap();
     assert_eq_dbg!(get_value!(event.level), Some(&Level::Error));
@@ -1103,7 +1098,7 @@ fn test_transaction_level_untouched() {
         })),
         ..Event::default()
     });
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, processor, ProcessingState::root()).unwrap();
     assert_eq_dbg!(get_value!(event.level), Some(&Level::Info));
@@ -1120,7 +1115,7 @@ fn test_environment_tag_is_moved() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1142,7 +1137,7 @@ fn test_empty_environment_is_removed_and_overwritten_with_tag() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1160,7 +1155,7 @@ fn test_empty_environment_is_removed() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
     assert_eq_dbg!(get_value!(event.environment), None);
@@ -1174,7 +1169,7 @@ fn test_none_environment_errors() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1202,7 +1197,7 @@ fn test_invalid_release_removed() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1236,7 +1231,7 @@ fn test_top_level_keys_moved_into_tags() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1291,7 +1286,7 @@ fn test_internal_tags_removed() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1319,7 +1314,7 @@ fn test_empty_tags_removed() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1371,7 +1366,7 @@ fn test_tags_deduplicated() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1435,7 +1430,7 @@ fn test_unknown_debug_image() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1525,7 +1520,7 @@ fn test_too_long_tags() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1571,7 +1566,7 @@ fn test_regression_backfills_abs_path_even_when_moving_stacktrace() {
     });
 
     let mut processor = NormalizeProcessor::default();
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1601,7 +1596,7 @@ fn test_parses_sdk_info_from_header() {
         None,
     );
 
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1625,7 +1620,7 @@ fn test_discards_received() {
 
     let mut processor = NormalizeProcessor::default();
 
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1657,7 +1652,7 @@ fn test_grouping_config() {
         None,
     );
 
-    let config = get_empty_light_normalization_config();
+    let config = LightNormalizationConfig::default();
     light_normalize(&mut event, &config).unwrap();
     process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 

--- a/relay-general/tests/test_fixtures.rs
+++ b/relay-general/tests/test_fixtures.rs
@@ -75,14 +75,7 @@ macro_rules! event_snapshot {
 
                 let config = StoreConfig::default();
                 let mut processor = StoreProcessor::new(config, None);
-                let config = LightNormalizationConfig {
-                  client_ip: None,
-                  user_agent: None,
-                  received_at: None,
-                  max_secs_in_past: None,
-                  max_secs_in_future: None,
-                  breakdowns_config: None,
-                };
+                let config = LightNormalizationConfig::default();
                 light_normalize(&mut event, &config).unwrap();
                 process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/1366#discussion_r937728054.

Implementing the default trait makes it easy to initialize a `LightNormalizationConfig` instance without the currently existing method `get_empty_light_normalization_config` (which returns an object full of `None`s). This has only impact on tests.

#skip-changelog