### PR TITLE
fix(store): Do serialize default transaction source [INGEST-1511]

### DIFF
--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -258,7 +258,7 @@ pub struct Event {
     pub transaction: Annotated<String>,
 
     /// Additional information about the name of the transaction.
-    #[metastructure(skip_serialization = "empty")]
+    #[metastructure(skip_serialization = "null")]
     pub transaction_info: Annotated<TransactionInfo>,
 
     /// Time since the start of the transaction until the error occurred.

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -565,6 +565,9 @@ mod tests {
         {
           "type": "transaction",
           "transaction": "/",
+          "transaction_info": {
+            "source": "unknown"
+          },
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -669,6 +672,9 @@ mod tests {
         {
           "type": "transaction",
           "transaction": "/",
+          "transaction_info": {
+            "source": "unknown"
+          },
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -930,6 +936,9 @@ mod tests {
         {
           "type": "transaction",
           "transaction": "/",
+          "transaction_info": {
+            "source": "unknown"
+          },
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -1052,6 +1061,9 @@ mod tests {
         {
           "type": "transaction",
           "transaction": "/",
+          "transaction_info": {
+            "source": "unknown"
+          },
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -1097,6 +1109,9 @@ mod tests {
         {
           "type": "transaction",
           "transaction": "<unlabeled transaction>",
+          "transaction_info": {
+            "source": "unknown"
+          },
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {
@@ -1142,6 +1157,9 @@ mod tests {
         {
           "type": "transaction",
           "transaction": "<unlabeled transaction>",
+          "transaction_info": {
+            "source": "unknown"
+          },
           "timestamp": 946684810.0,
           "start_timestamp": 946684800.0,
           "contexts": {

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -385,6 +385,12 @@ def test_processing(
     assert event.get("project") is not None
     assert event.get("version") is not None
 
+    if event_type == "transaction":
+        assert event["transaction_info"]["source"] == "unknown"  # the default
+    else:
+        # Should not be serialized
+        assert "transaction_info" not in event
+
 
 # TODO: This parameterization should be unit-tested, instead
 @pytest.mark.parametrize(


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/1354, we introduced behavior that wrote back the default transaction source (`unknown`) into the event during normalization.

Unfortunately, since the default qualifies as `empty`, this value was still not serialized into the event payload:

https://github.com/getsentry/relay/blob/2d466f8908166fdd9c73da9da5a11b8f9bb4bcbb/relay-general/src/protocol/transaction.rs#L69-L74

#skip-changelog because the original impl is in the same version as the fix.