### PR TITLE
fix(http): Explain why we responded with 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Parse sample rates as JSON. ([#1353](https://github.com/getsentry/relay/pull/1353))
 - Filter events in external Relays, before extracting metrics. ([#1379](https://github.com/getsentry/relay/pull/1379))
 - Add `privatekey` and `private_key` as secret key name to datascrubbers. ([#1376](https://github.com/getsentry/relay/pull/1376))
+- Explain why we responded with 429. ([#1389](https://github.com/getsentry/relay/pull/1389))
 
 **Bug Fixes**:
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -73,7 +73,9 @@ pub enum BadStoreRequest {
     #[fail(display = "failed to read request body")]
     PayloadError(#[cause] PayloadError),
 
-    #[fail(display = "event rejected due to rate limit")]
+    #[fail(
+        display = "sentry dropped data due to a quota or internal rate limit being reached. this will not affect your application. see https://docs.sentry.io/product/accounts/quotas/ for more information."
+    )]
     RateLimited(RateLimits),
 
     #[fail(display = "event submission rejected with_reason: {:?}", _0)]

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -74,7 +74,7 @@ pub enum BadStoreRequest {
     PayloadError(#[cause] PayloadError),
 
     #[fail(
-        display = "sentry dropped data due to a quota or internal rate limit being reached. this will not affect your application. see https://docs.sentry.io/product/accounts/quotas/ for more information."
+        display = "Sentry dropped data due to a quota or internal rate limit being reached. This will not affect your application. See https://docs.sentry.io/product/accounts/quotas/ for more information."
     )]
     RateLimited(RateLimits),
 


### PR DESCRIPTION
fix https://github.com/getsentry/sentry/issues/37103

Oftentimes we are not in control of the HTTP response (load balancers and relay may reject the request for a variety of reasons, and it would probably be quite a bit of effort to add docs links to all of those return paths), but if we
are, we can provide a more helpful error message.

The context here is that a customer was confused about whether the
network errors in Chrome's dev console would have any impact on their
application. While we can't influence the color of what is shown in the
dev console, we can provide documentation links in request/response
details. This will still be quite hidden but better than nothing.

Other ideas were to stop emitting 429s, but we could only do that for
browser, mobile and other "client" SDKs. For server-side SDKs we _need_
them to see a 429 so they stop sending data. And even then that change
would come with high risk of multiplying inbound traffic by a large
factor.
