### PR TITLE
ref(redis): Use a readonly client for project configs [INGEST-1557]

### DIFF
--- a/relay-redis/src/config.rs
+++ b/relay-redis/src/config.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+fn default_connections() -> u32 {
+    8
+}
+
 /// Configuration for connecting a redis client.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
@@ -10,6 +14,12 @@ pub enum RedisConfig {
         ///
         /// This can also be a single node which is configured in cluster mode.
         cluster_nodes: Vec<String>,
+
+        /// The maximum number of concurrent connections to the cluster.
+        ///
+        /// Defaults to 8.
+        #[serde(default = "default_connections")]
+        max_connections: u32,
     },
 
     /// Connect to a single Redis instance.

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -113,21 +113,26 @@ pub struct RedisPool {
 
 impl RedisPool {
     /// Creates a `RedisPool` from configuration.
-    pub fn new(config: &RedisConfig) -> Result<Self, RedisError> {
+    pub fn new(config: &RedisConfig, readonly: bool) -> Result<Self, RedisError> {
         match config {
             RedisConfig::Cluster { ref cluster_nodes } => {
                 let servers = cluster_nodes.iter().map(String::as_str).collect();
-                Self::cluster(servers)
+                Self::cluster(servers, readonly)
             }
             RedisConfig::Single(ref server) => Self::single(server),
         }
     }
 
     /// Creates a `RedisPool` in cluster configuration.
-    pub fn cluster(servers: Vec<&str>) -> Result<Self, RedisError> {
+    pub fn cluster(servers: Vec<&str>, readonly: bool) -> Result<Self, RedisError> {
+        let client = redis::cluster::ClusterClientBuilder::new(servers)
+            .readonly(readonly)
+            .open()
+            .map_err(RedisError::Redis)?;
+
         let pool = Pool::builder()
             .max_size(24)
-            .build(redis::cluster::ClusterClient::open(servers).map_err(RedisError::Redis)?)
+            .build(client)
             .map_err(RedisError::Pool)?;
 
         let inner = RedisPoolInner::Cluster(pool);


### PR DESCRIPTION
We use a single Redis client for both rate limiting and fetching project configs. Since the former needs to modify keys, the client cannot be set to readonly mode. Project config fetching only reads keys from redis, so setting the cluster client to readonly mode allows it to read from replicas, too.

Note - This PR is not yet merge ready:
- There should be a single Redis client in non-cluster mode
- Redis pool initialization should be moved and deduplicated
- Changes from master need to be merged in
- Cluster connections aren't configurable for single mode.

Based off of 1d91c35, which is currently deployed.

See INC-192