### PR TITLE
feat(profiling): Distinguish various discard reasons for profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Spawn more threads for CPU intensive work. ([#1378](https://github.com/getsentry/relay/pull/1378))
 - Add missing fields to DeviceContext ([#1383](https://github.com/getsentry/relay/pull/1383))
 - Improve performance of Redis accesses by not running `PING` everytime a connection is reused. ([#1394](https://github.com/getsentry/relay/pull/1394))
+- Distinguish between various discard reasons for profiles. ([#1395](https://github.com/getsentry/relay/pull/1395))
 
 ## 22.7.0
 

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -105,10 +105,11 @@ mod utils;
 
 use crate::android::parse_android_profile;
 use crate::cocoa::parse_cocoa_profile;
-use crate::error::ProfileError;
 use crate::python::parse_python_profile;
 use crate::rust::parse_rust_profile;
 use crate::typescript::parse_typescript_profile;
+
+pub use crate::error::ProfileError;
 
 #[derive(Debug, Deserialize)]
 struct MinimalProfile {

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -306,6 +306,10 @@ pub enum DiscardReason {
 
     /// (Relay) We failed to parse the profile so we discard the profile.
     ProcessProfile,
+
+    /// (Relay) The profile is parseable but semantically invalid. This could happen if
+    /// profiles lack sufficient samples.
+    InvalidProfile,
 }
 
 impl DiscardReason {
@@ -342,6 +346,7 @@ impl DiscardReason {
             DiscardReason::Internal => "internal",
             DiscardReason::TransactionSampled => "transaction_sampled",
             DiscardReason::EmptyEnvelope => "empty_envelope",
+            DiscardReason::InvalidProfile => "invalid_profile",
         }
     }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -366,7 +366,7 @@ fn outcome_from_parts(field: ClientReportField, reason: &str) -> Result<Outcome,
     }
 }
 
-pub fn outcome_from_profile_error(err: relay_profiling::ProfileError) -> Outcome {
+fn outcome_from_profile_error(err: relay_profiling::ProfileError) -> Outcome {
     let discard_reason = match err {
         relay_profiling::ProfileError::CannotSerializePayload => DiscardReason::Internal,
         relay_profiling::ProfileError::NotEnoughSamples => DiscardReason::InvalidProfile,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -370,6 +370,15 @@ fn outcome_from_parts(field: ClientReportField, reason: &str) -> Result<Outcome,
     }
 }
 
+pub fn outcome_from_profile_error(err: relay_profiling::ProfileError) -> Outcome {
+    let discard_reason = match err {
+        relay_profiling::ProfileError::CannotSerializePayload => DiscardReason::Internal,
+        relay_profiling::ProfileError::NotEnoughSamples => DiscardReason::InvalidProfile,
+        _ => DiscardReason::ProcessProfile,
+    };
+    Outcome::Invalid(discard_reason)
+}
+
 /// Synchronous service for processing envelopes.
 pub struct EnvelopeProcessor {
     config: Arc<Config>,
@@ -886,9 +895,9 @@ impl EnvelopeProcessor {
                                 item.set_payload(ContentType::Json, &payload[..]);
                                 return true;
                             }
-                            Err(_) => {
+                            Err(err) => {
                                 context.track_outcome(
-                                    Outcome::Invalid(DiscardReason::ProcessProfile),
+                                    outcome_from_profile_error(err),
                                     DataCategory::Profile,
                                     1,
                                 );


### PR DESCRIPTION
Profiles can be discarded for various reasons. Right now, all discarded profiles
produce an outcome with the same reason. This makes it difficult to track down
why a profile was discarded. This change breaks the invalid outcome into 3
separate reasons to help understand the behaviour better.

- `DiscardReason::ProcessProfile`
	- there are syntactic problems with the profile and cannot be parsed
- `DiscardReason::InvalidProfile`
	- there are semantic problems with the profile and should not be ingested
- `DiscardReason::Internal`
	- something else is going on, and we should look into it