### PR TITLE
ref(server): Remove overall envelope handling timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Remove timeout-based expiry of envelopes in Relay's internal buffers. The `cache.envelope_expiry` is now inactive. To control the size of the envelope buffer, use `cache.envelope_buffer_size` exclusively, instead. ([#1398](https://github.com/getsentry/relay/pull/1398))
 - Parse sample rates as JSON. ([#1353](https://github.com/getsentry/relay/pull/1353))
 - Filter events in external Relays, before extracting metrics. ([#1379](https://github.com/getsentry/relay/pull/1379))
 - Add `privatekey` and `private_key` as secret key name to datascrubbers. ([#1376](https://github.com/getsentry/relay/pull/1376))

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -727,7 +727,11 @@ struct Cache {
     project_grace_period: u32,
     /// The cache timeout for downstream relay info (public keys) in seconds.
     relay_expiry: u32,
-    /// The cache timeout for envelopes (store) before dropping them.
+    /// Unused cache timeout for envelopes.
+    ///
+    /// The envelope buffer is instead controlled by `envelope_buffer_size`, which controls the
+    /// maximum number of envelopes in the buffer. A time based configuration may be re-introduced
+    /// at a later point.
     #[serde(alias = "event_expiry")]
     envelope_expiry: u32,
     /// The maximum amount of envelopes to queue before dropping them.
@@ -1778,11 +1782,6 @@ impl Config {
     /// Returns the expiry timeout for cached relay infos (public keys).
     pub fn relay_cache_expiry(&self) -> Duration {
         Duration::from_secs(self.values.cache.relay_expiry.into())
-    }
-
-    /// Returns the timeout for buffered envelopes (due to upstream errors).
-    pub fn envelope_buffer_expiry(&self) -> Duration {
-        Duration::from_secs(self.values.cache.envelope_expiry.into())
     }
 
     /// Returns the maximum number of buffered envelopes

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -556,10 +556,10 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                 }
             }))
             .into_actor(self)
-            .and_then(clone!(envelope_context, |envelope, slf, _| {
+            .and_then(move |envelope, slf, _| {
                 let scoping = envelope_context.borrow().scoping();
                 slf.send_envelope(project_key, envelope, scoping, start_time)
-                    .then(clone!(envelope_context, |result| {
+                    .then(move |result| {
                         result.map_err(|error| {
                             let envelope_context = envelope_context.borrow();
                             let outcome = Outcome::Invalid(DiscardReason::Internal);
@@ -596,13 +596,9 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                                 }
                             }
                         })
-                    }))
+                    })
                     .into_actor(slf)
-            }))
-            .timeout(
-                self.config.envelope_buffer_expiry(),
-                ProcessingError::Timeout,
-            )
+            })
             .map(|_, _, _| metric!(counter(RelayCounters::EnvelopeAccepted) += 1))
             .map_err(move |error, slf, _| {
                 metric!(counter(RelayCounters::EnvelopeRejected) += 1);
@@ -633,13 +629,6 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                     );
                 } else {
                     relay_log::debug!("dropped envelope: {}", LogError(&error));
-                }
-
-                if let ProcessingError::Timeout = error {
-                    // handle the last failure (the timeout)
-                    if let Some(outcome) = outcome {
-                        envelope_context.borrow().send_outcomes(outcome);
-                    }
                 }
             })
             .then(move |x, slf, _| {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -136,9 +136,6 @@ pub enum ProcessingError {
     #[fail(display = "failed to apply quotas")]
     QuotasFailed(#[cause] RateLimitingError),
 
-    #[fail(display = "envelope exceeded its configured lifetime")]
-    Timeout,
-
     #[fail(display = "event dropped by sampling rule {}", _0)]
     Sampled(RuleId),
 }
@@ -169,7 +166,6 @@ impl ProcessingError {
             // Internal errors
             Self::SerializeFailed(_)
             | Self::ProjectFailed(_)
-            | Self::Timeout
             | Self::ProcessingFailed(_)
             | Self::MissingProjectId => Some(Outcome::Invalid(DiscardReason::Internal)),
             #[cfg(feature = "processing")]


### PR DESCRIPTION
Removes the overall timeout for Envelope buffering and handling,
controlled by the `cache.envelope_expiry` option. There is a range of
timeouts for project configs and upstream requests that individually
control these processes. The overall buffer is controlled by
`cache.envelope_buffer_size`.

A reasonable overall time limit is hard to set. In many cases, either
the limit is too short to bridge real downtimes, or it's too long for
the buffer size. In practice, we've been relying on the count-based
limit exclusively. With proper disk-based caching, the limit could be
set to a product-limit such as 30 days.

The option remains in the config and is now marked as unused. It is
likely that some form of time-based expiry is re-introduced once
disk-based caching is implemented.