### PR TITLE
ref(deps): Upgrade sentry SDK [INGEST-1560]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid 1.1.2",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,12 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "findshlibs"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37affc18a9c7cf90b6cf6a7700dab60439a8f138ac5ebc5f12b98281d8f687c9"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
 dependencies = [
+ "cc",
  "lazy_static",
  "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1568,6 +1580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,12 +1647,6 @@ checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
@@ -1674,7 +1686,7 @@ dependencies = [
  "http 0.2.8",
  "http-body",
  "httparse",
- "httpdate 1.0.2",
+ "httpdate",
  "itoa 1.0.2",
  "pin-project-lite 0.2.9",
  "socket2 0.4.4",
@@ -2113,7 +2125,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccb06643400b8a48ebcaf69d5c4b6adf50cacaf3b5d6aa27bfbaf0da21156cc"
 dependencies = [
- "debugid",
+ "debugid 0.7.3",
  "encoding",
  "log",
  "memmap2",
@@ -2133,7 +2145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190480ae87a21dc26a115c4ef5ce8c05c10074d55ea2042c472be7bf6dc6e592"
 dependencies = [
  "bitflags",
- "debugid",
+ "debugid 0.7.3",
  "enum-primitive-derive",
  "log",
  "num-traits 0.2.15",
@@ -3377,7 +3389,7 @@ dependencies = [
  "chrono",
  "cookie 0.16.0",
  "criterion",
- "debugid",
+ "debugid 0.7.3",
  "difference",
  "dynfmt",
  "enumset",
@@ -3733,15 +3745,6 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
@@ -3880,16 +3883,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -3905,21 +3899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "sentry"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27c425b07c7186018e2ef9ac3a25b01dae78b05a7ef604d07f216b9f59b42b4"
+checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
 dependencies = [
- "httpdate 0.3.2",
+ "httpdate",
  "reqwest",
  "sentry-backtrace",
  "sentry-contexts",
@@ -3927,64 +3912,63 @@ dependencies = [
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
+ "tokio 1.19.2",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a5b9d9be0a0e25b2aaa5f3e9815d7fc6b8904f800c41800e5583652b5ca733"
+checksum = "49bafa55eefc6dbc04c7dac91e8c8ab9e89e9414f3193c105cabd991bbc75134"
 dependencies = [
  "backtrace",
- "lazy_static",
+ "once_cell",
  "regex",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2410b212de9b2eb7427d2bf9a1f4f5cb2aa14359863d982066ead00d6de9bce0"
+checksum = "c63317c4051889e73f0b00ce4024cae3e6a225f2e18a27d2c1522eb9ce2743da"
 dependencies = [
  "hostname",
- "lazy_static",
  "libc",
- "regex",
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
  "sentry-core",
  "uname",
 ]
 
 [[package]]
 name = "sentry-core"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbe485e384cb5540940e65d729820ffcbedc0c902fcb27081e44dacfe6a0c34"
+checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "rand 0.8.5",
- "sentry-types 0.22.0",
+ "sentry-types 0.27.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329d5eca0591a2e042c0d6dda9705206922fda2e328e7cc7efd9015f47a32f56"
+checksum = "06fcbb7efe38d7c213218445952096be246c1f914ef9591dc2cdae9cb4e316d8"
 dependencies = [
  "findshlibs",
- "lazy_static",
+ "once_cell",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-log"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647143f672410ae5f242acd40f9f8f39729aff5ac7e856d91450fdfc30c2e960"
+checksum = "58a76b41861ebde9b0a689fa13080ad5508583e094c48acad461eec5acd7fc5f"
 dependencies = [
  "log",
  "sentry-core",
@@ -3992,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cf195cff04a50b90e6b9ac8b4874dc63b8e0a466f193702801ef98baa9bd90"
+checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4018,7 +4002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8124f0e9bc1113ecbcc8c3746e0e590943cf23e7d09c70a088c116869bb12e3"
 dependencies = [
  "chrono",
- "debugid",
+ "debugid 0.7.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -4028,17 +4012,19 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.22.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5e777cff85b44538ac766a9604676b7180d01d2566e76b2ac41426c734498c"
+checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
 dependencies = [
- "chrono",
- "debugid",
+ "debugid 0.8.0",
+ "getrandom 0.2.6",
+ "hex",
  "serde",
  "serde_json",
  "thiserror",
+ "time 0.3.9",
  "url 2.2.2",
- "uuid 0.8.2",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -4338,7 +4324,7 @@ version = "8.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c276d5b296f30f0fb30d2128b6be6f9804be7669f1edef46c4d8c017de4c77c3"
 dependencies = [
- "debugid",
+ "debugid 0.7.3",
  "memmap2",
  "stable_deref_trait",
  "uuid 0.8.2",
@@ -5164,6 +5150,16 @@ dependencies = [
  "getrandom 0.2.6",
  "serde",
  "sha1",
+]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom 0.2.6",
+ "serde",
 ]
 
 [[package]]

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -17,8 +17,8 @@ failure = "0.1.8"
 log = { version = "0.4.11", features = ["serde"] }
 pretty_env_logger = { version = "0.4.0", optional = true }
 relay-crash = { path = "../relay-crash", optional = true }
-sentry = { version = "0.22.0", features = ["debug-images", "log"], optional = true }
-sentry-core = { version = "0.22.0" }
+sentry = { version = "0.27.0", features = ["debug-images", "log"], optional = true }
+sentry-core = { version = "0.27.0" }
 serde = { version = "1.0.114", features = ["derive"], optional = true }
 serde_json = { version = "1.0.55", optional = true }
 

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -198,7 +198,7 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
 
         let root_scope = hub.push_scope();
         hub.configure_scope(move |scope| {
-            scope.add_event_processor(Box::new(move |mut event| {
+            scope.add_event_processor(move |mut event| {
                 let mut cached_data = cached_data.lock().unwrap();
                 if cached_data.is_none() && req.is_valid() {
                     let with_pii = client
@@ -226,7 +226,7 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
                 }
 
                 Some(event)
-            }));
+            });
         });
 
         outer_req.extensions_mut().insert(HubWrapper {
@@ -246,7 +246,7 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
                 Some(event_id) if self.emit_header => {
                     resp.headers_mut().insert(
                         "x-sentry-event",
-                        event_id.to_simple_ref().to_string().parse().unwrap(),
+                        event_id.as_simple().to_string().parse().unwrap(),
                     );
                 }
                 _ => {}


### PR DESCRIPTION
This allows us to eventually flush the client instead of close it, which may be a better option to capture more errors during shutdown

#skip-changelog