### PR TITLE
fix(normalization): Make user agent normalization configurable

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -107,8 +107,11 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
 ) -> RelayStr {
     let processor = normalizer as *mut StoreProcessor;
     let mut event = Annotated::<Event>::from_json((*event).as_str())?;
-    let config = LightNormalizationConfig::default();
-    light_normalize_event(&mut event, &config)?;
+    let light_normalization_config = LightNormalizationConfig {
+        normalize_user_agent: (*processor).config().normalize_user_agent,
+        ..Default::default()
+    };
+    light_normalize_event(&mut event, &light_normalization_config)?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;
     RelayStr::from_string(event.to_json()?)
 }

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -508,6 +508,7 @@ pub struct LightNormalizationConfig<'a> {
     pub max_secs_in_past: Option<i64>,
     pub max_secs_in_future: Option<i64>,
     pub breakdowns_config: Option<&'a BreakdownsConfig>,
+    pub normalize_user_agent: Option<bool>,
 }
 
 pub fn light_normalize_event(
@@ -554,7 +555,7 @@ pub fn light_normalize_event(
         )?; // Timestamps are core in the metrics extraction
         normalize_event_tags(event)?; // Tags are added to every metric
         normalize_exceptions(event)?; // Browser extension filters look at the stacktrace
-        normalize_user_agent(event, Some(true)); // Legacy browsers filter
+        normalize_user_agent(event, config.normalize_user_agent); // Legacy browsers filter
         normalize_measurements(event); // Measurements are part of the metric extraction
         normalize_breakdowns(event, config.breakdowns_config); // Breakdowns are part of the metric extraction too
 

--- a/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -241,14 +241,6 @@ request:
     SERVER_SOFTWARE: Kestrel
   inferred_content_type: application/json
 contexts:
-  browser:
-    name: Chrome
-    version: 67.0.3396
-    type: browser
-  client_os:
-    name: Windows
-    version: "10"
-    type: os
   server-os:
     name: Windows
     version: "10"

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1754,6 +1754,7 @@ impl EnvelopeProcessor {
             max_secs_in_past: Some(self.config.max_secs_in_past()),
             max_secs_in_future: Some(self.config.max_secs_in_future()),
             breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
+            normalize_user_agent: Some(true),
         };
 
         metric!(timer(RelayTimers::EventProcessingLightNormalization), {


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/1366.

In https://github.com/getsentry/relay/pull/1366 light normalization runs unconditionally and there isn't a way to avoid that. Sometimes one is not interested in running user agent normalization, and before the PR it was disabled by default in the C ABI (what makes the PR a breaking change). This PR makes the user agent normalization optional, discarding the breaking change.

To verify the code is correct, besides adding the test in this PR, I also installed in sentry the python `py/` project in relay and run `test-relay-integration` and `test-python-ci` make targets.

Since no release was made with the bogus PR, the breaking change isn't visible to users and the PR neither should be in the changelog -- so not adding any entries to the changelog.
#skip-changelog

In `sentry`, [this](https://github.com/getsentry/sentry/blob/ef4edda386eb5d23560169dbff53f0747052a951/src/sentry/event_manager.py#L298) is one place where this is used.