### PR TITLE
ref(normalization): Add `Debug` trait to `LightNormalizationConfig`

### DIFF
--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -500,7 +500,7 @@ fn normalize_ip_addresses(event: &mut Event, client_ip: Option<&IpAddr>) {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct LightNormalizationConfig<'a> {
     pub client_ip: Option<&'a IpAddr>,
     pub user_agent: Option<&'a str>,


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/1366 and https://github.com/getsentry/relay/pull/1386.

A new struct `LightNormalizationConfig` was introduced, which got the `Default` trait added but not `Debug`. This PR adds the `Debug` trait.

#skip-changelog