### PR TITLE
docs(processor): Note certain events are only created in some Relays

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -289,8 +289,8 @@ impl ProcessEnvelopeState {
     /// Returns whether any item in the envelope creates an event in any relay.
     ///
     /// This is used to branch into the processing pipeline. If this function returns false, only
-    /// rate limits are executed. If this function returns true, an event is created in a relay
-    /// (it may be created in a managed relay, but not in any other type of relay).
+    /// rate limits are executed. If this function returns true, an event is created either in the
+    /// current relay or in an upstream processing relay.
     fn creates_event(&self) -> bool {
         self.envelope.items().any(Item::creates_event)
     }


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/1379#discussion_r937795229.

We had issues in production because it was assumed an event always existed in an envelope if `state.creates_event()` returns `true`. At the moment this isn't correct: it's possible a processing relay creates an event from an envelope but a PoP relay does not, while the code checking for that runs on these both relay types.

Although this is not a perfect mechanism to prevent this from happening in the future, it should give some visibility and hopefully avoids a similar situation.

#skip-changelog