### PR TITLE
feat(schema): Add app_memory to AppContext struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Improve performance of Redis accesses by not running `PING` everytime a connection is reused. ([#1394](https://github.com/getsentry/relay/pull/1394))
 - Distinguish between various discard reasons for profiles. ([#1395](https://github.com/getsentry/relay/pull/1395))
 - Add missing fields to GPUContext ([#1391](https://github.com/getsentry/relay/pull/1391))
+- Add app_memory to AppContext struct. ([#1403](https://github.com/getsentry/relay/pull/1403))
 
 ## 22.7.0
 

--- a/relay-general/src/protocol/contexts.rs
+++ b/relay-general/src/protocol/contexts.rs
@@ -292,6 +292,9 @@ pub struct AppContext {
     /// Internal build ID as it appears on the platform.
     pub app_build: Annotated<LenientString>,
 
+    /// Amount of memory used by the application in bytes.
+    pub app_memory: Annotated<u64>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
     pub other: Object<Value>,
@@ -982,6 +985,7 @@ fn test_app_context_roundtrip() {
   "app_name": "Baz App",
   "app_version": "1.0",
   "app_build": "100001",
+  "app_memory": 22883948,
   "other": "value",
   "type": "app"
 }"#;
@@ -993,6 +997,7 @@ fn test_app_context_roundtrip() {
         app_name: Annotated::new("Baz App".to_string()),
         app_version: Annotated::new("1.0".to_string()),
         app_build: Annotated::new("100001".to_string().into()),
+        app_memory: Annotated::new(22883948),
         other: {
             let mut map = Object::new();
             map.insert(

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -421,6 +421,16 @@ expression: event_json_schema()
                 "null"
               ]
             },
+            "app_memory": {
+              "description": " Amount of memory used by the application in bytes.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "app_name": {
               "description": " Application name as it appears on the platform.",
               "default": null,


### PR DESCRIPTION
Add new `app_memory` field to `AppContext` struct.

Spec PR: https://github.com/getsentry/develop/pull/658
Example of it being used: https://github.com/getsentry/sentry-cocoa/pull/2027