### PR TITLE
ref(server): Localize outcome emission in EnvelopeContext

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -12,7 +10,7 @@ use chrono::Utc;
 use failure::Fail;
 use futures01::{future, prelude::*, sync::oneshot};
 
-use relay_common::{clone, ProjectKey};
+use relay_common::ProjectKey;
 use relay_config::{Config, HttpEncoding, RelayMode};
 use relay_general::protocol::{ClientReport, EventId};
 use relay_log::LogError;
@@ -32,8 +30,8 @@ use crate::envelope::{self, ContentType, Envelope, EnvelopeError, Item, ItemType
 use crate::extractors::{PartialDsn, RequestMeta};
 use crate::http::{HttpError, Request, RequestBuilder, Response};
 use crate::service::ServerError;
-use crate::statsd::{RelayCounters, RelayHistograms, RelaySets, RelayTimers};
-use crate::utils::{self, EnvelopeContext, FutureExt as _, SendWithOutcome};
+use crate::statsd::{RelayHistograms, RelaySets};
+use crate::utils::{self, EnvelopeContext, FutureExt as _};
 
 #[cfg(feature = "processing")]
 use {
@@ -327,6 +325,7 @@ impl Default for EnvelopeManager {
 /// `Some(EventId)`.
 pub struct QueueEnvelope {
     pub envelope: Envelope,
+    pub envelope_context: EnvelopeContext,
     pub project_key: ProjectKey,
     pub start_time: Instant,
 }
@@ -351,6 +350,7 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
 
         let QueueEnvelope {
             mut envelope,
+            mut envelope_context,
             project_key,
             start_time,
         } = message;
@@ -384,21 +384,30 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
         //     since all items depend on this event.
         if let Some(event_envelope) = envelope.split_by(Item::requires_event) {
             relay_log::trace!("queueing separate envelope for non-event items");
+
+            // The envelope has been split, so we need to fork the context.
+            envelope_context.update(&envelope);
+            let event_context = EnvelopeContext::from_envelope(&event_envelope);
+
             self.active_envelopes += 1;
             context.notify(HandleEnvelope {
                 envelope: event_envelope,
+                envelope_context: event_context,
                 project_key,
-                start_time,
             });
         }
 
-        if !envelope.is_empty() {
+        if envelope.is_empty() {
+            // The envelope can be empty here if it contained only metrics items which were removed
+            // above. In this case, the envelope was accepted and needs no further queueing.
+            envelope_context.accept();
+        } else {
             relay_log::trace!("queueing envelope");
             self.active_envelopes += 1;
             context.notify(HandleEnvelope {
                 envelope,
+                envelope_context,
                 project_key,
-                start_time,
             });
         }
 
@@ -425,8 +434,8 @@ impl Handler<QueueEnvelope> for EnvelopeManager {
 /// metrics.
 struct HandleEnvelope {
     pub envelope: Envelope,
+    pub envelope_context: EnvelopeContext,
     pub project_key: ProjectKey,
-    pub start_time: Instant,
 }
 
 impl Message for HandleEnvelope {
@@ -458,111 +467,83 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
 
         let HandleEnvelope {
             envelope,
+            mut envelope_context,
             project_key,
-            start_time,
         } = message;
 
-        let sampling_project_key = utils::get_sampling_key(&envelope);
-
+        let start_time = envelope.meta().start_time();
         let event_id = envelope.event_id();
-        let envelope_context = Rc::new(RefCell::new(EnvelopeContext::from_envelope(&envelope)));
 
         let future = ProjectCache::from_registry()
-            .send_tracked(
-                CheckEnvelope::fetched(project_key, envelope),
-                *envelope_context.clone().borrow(),
-            )
+            .send(CheckEnvelope::fetched(project_key, envelope))
             .map_err(|_| ProcessingError::ScheduleFailed)
             .and_then(|result| result.map_err(ProcessingError::ProjectFailed))
-            .map_err(clone!(envelope_context, |err| {
-                if let Some(outcome) = err.to_outcome() {
-                    // TODO: Move this into CheckEnvelope
-                    envelope_context.borrow().send_outcomes(outcome);
-                }
-                err
-            }))
-            .and_then(clone!(envelope_context, |response| {
+            .and_then(move |response| {
                 // Use the project id from the loaded project state to account for redirects.
                 let project_id = response.scoping.project_id.value();
                 metric!(set(RelaySets::UniqueProjects) = project_id as i64);
 
-                let mut envelope_context = envelope_context.borrow_mut();
                 envelope_context.scope(response.scoping);
 
                 let checked = response.result.map_err(|reason| {
-                    envelope_context.send_outcomes(Outcome::Invalid(reason));
+                    envelope_context.reject(Outcome::Invalid(reason));
                     ProcessingError::Rejected(reason)
                 })?;
 
                 match checked.envelope {
                     Some(envelope) => {
                         envelope_context.update(&envelope);
-                        Ok(envelope)
+                        Ok((envelope, envelope_context))
                     }
                     // errors from rate limiting already produced outcomes nothing more to do
                     None => Err(ProcessingError::RateLimited),
                 }
-            }))
-            .and_then(clone!(envelope_context, |envelope| {
+            })
+            .and_then(move |(envelope, envelope_context)| {
                 // get the state for the current project. we can always fetch the cached version
                 // even if the no_cache flag was passed, as the cache was updated prior in
                 // `CheckEnvelope`.
                 ProjectCache::from_registry()
-                    .send_tracked(
-                        GetProjectState::new(project_key),
-                        *envelope_context.borrow(),
-                    )
+                    .send(GetProjectState::new(project_key))
                     .map_err(|_| ProcessingError::ScheduleFailed)
                     .and_then(|result| result.map_err(ProcessingError::ProjectFailed))
-                    .map_err(clone!(envelope_context, |err| {
-                        if let Some(outcome) = err.to_outcome() {
-                            envelope_context.borrow().send_outcomes(outcome);
-                        }
-                        err
-                    }))
-                    .map(|state| (envelope, state))
-            }))
-            .and_then(move |(envelope, project_state)| {
+                    .map(|state| (envelope, envelope_context, state))
+            })
+            .and_then(|(envelope, context, project_state)| {
                 // get the state for the sampling project.
                 // TODO: Could this run concurrently with main project cache fetch?
-                if let Some(sampling_project_key) = sampling_project_key {
+                if let Some(sampling_project_key) = utils::get_sampling_key(&envelope) {
                     let future = ProjectCache::from_registry()
                         .send(GetProjectState::new(sampling_project_key))
-                        .then(move |sampling_project_state| {
-                            match sampling_project_state {
-                                Ok(Ok(sampling_project_state)) => Box::new(future::ok((
-                                    envelope,
-                                    project_state,
-                                    Some(sampling_project_state),
-                                ))),
-                                // mailbox error or error getting the project, give up and leave envelope unsampled
-                                _ => Box::new(future::ok((envelope, project_state, None))),
-                            }
+                        .then(move |response| {
+                            // ignore all errors and leave envelope unsampled
+                            let sampling_state = response.ok().and_then(|r| r.ok());
+                            Ok((envelope, context, project_state, sampling_state))
                         });
+
                     Box::new(future) as ResponseFuture<_, _>
                 } else {
-                    Box::new(future::ok((envelope, project_state, None)))
+                    Box::new(future::ok((envelope, context, project_state, None)))
                 }
             })
-            .and_then(clone!(envelope_context, |(
-                envelope,
-                project_state,
-                sampling_project_state,
-            )| {
-                let message = ProcessEnvelope {
-                    envelope,
-                    project_state,
-                    sampling_project_state,
-                    start_time,
-                    scoping: envelope_context.borrow().scoping(),
-                };
+            .and_then(
+                move |(envelope, envelope_context, project_state, sampling_project_state)| {
+                    let message = ProcessEnvelope {
+                        envelope,
+                        project_state,
+                        sampling_project_state,
+                        start_time,
+                        scoping: envelope_context.scoping(),
+                    };
 
-                processor
-                    .send_tracked(message, *envelope_context.borrow())
-                    .map_err(|_err| ProcessingError::ScheduleFailed)
-                    .flatten()
-            }))
-            .and_then(clone!(envelope_context, |processed| {
+                    processor
+                        .send(message)
+                        .map_err(|_| ProcessingError::ScheduleFailed)
+                        .flatten()
+                        .map(|processed| (processed, envelope_context))
+                },
+            )
+            .and_then(move |(processed, mut envelope_context)| {
                 let project_cache = ProjectCache::from_registry();
                 let rate_limits = processed.rate_limits;
 
@@ -574,60 +555,62 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
 
                 match processed.envelope {
                     Some(envelope) => {
-                        envelope_context.borrow_mut().update(&envelope);
-                        Ok(envelope)
+                        envelope_context.update(&envelope);
+                        Ok((envelope, envelope_context))
                     }
                     None => Err(ProcessingError::RateLimited),
                 }
-            }))
+            })
             .into_actor(self)
-            .and_then(move |envelope, slf, _| {
-                let scoping = envelope_context.borrow().scoping();
+            .and_then(move |(envelope, mut envelope_context), slf, _| {
+                let scoping = envelope_context.scoping();
                 slf.send_envelope(project_key, envelope, scoping, start_time)
-                    .then(move |result| {
-                        result.map_err(|error| {
-                            let envelope_context = envelope_context.borrow();
+                    .then(move |result| match result {
+                        Ok(_) => {
+                            envelope_context.accept();
+                            Ok(())
+                        }
+                        Err(error) => {
                             let outcome = Outcome::Invalid(DiscardReason::Internal);
 
-                            match error {
+                            Err(match error {
                                 #[cfg(feature = "processing")]
                                 SendEnvelopeError::ScheduleFailed => {
-                                    envelope_context.send_outcomes(outcome);
+                                    envelope_context.reject(outcome);
                                     ProcessingError::ScheduleFailed
                                 }
 
                                 #[cfg(feature = "processing")]
                                 SendEnvelopeError::StoreFailed(e) => {
-                                    envelope_context.send_outcomes(outcome);
+                                    envelope_context.reject(outcome);
                                     ProcessingError::StoreFailed(e)
                                 }
 
                                 SendEnvelopeError::BodyEncodingFailed(e) => {
-                                    envelope_context.send_outcomes(outcome);
+                                    envelope_context.reject(outcome);
                                     ProcessingError::BodyEncodingFailed(e)
                                 }
 
                                 SendEnvelopeError::EnvelopeBuildFailed(e) => {
-                                    envelope_context.send_outcomes(outcome);
+                                    envelope_context.reject(outcome);
                                     ProcessingError::EnvelopeBuildFailed(e)
                                 }
 
                                 SendEnvelopeError::UpstreamRequestFailed(e) => {
-                                    if !e.is_received() {
-                                        envelope_context.send_outcomes(outcome);
+                                    if e.is_received() {
+                                        envelope_context.accept();
+                                    } else {
+                                        envelope_context.reject(outcome);
                                     }
 
                                     ProcessingError::UpstreamRequestFailed(e)
                                 }
-                            }
-                        })
+                            })
+                        }
                     })
                     .into_actor(slf)
             })
-            .map(|_, _, _| metric!(counter(RelayCounters::EnvelopeAccepted) += 1))
             .map_err(move |error, slf, _| {
-                metric!(counter(RelayCounters::EnvelopeRejected) += 1);
-
                 // if we are in capture mode, we stash away the event instead of forwarding it.
                 if capture {
                     // XXX: does not work with envelopes without event_id
@@ -639,25 +622,21 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                         relay_log::debug!("dropping failed envelope without event");
                     }
                 }
+
                 let outcome = error.to_outcome();
                 if let Some(Outcome::Invalid(DiscardReason::Internal)) = outcome {
                     // Errors are only logged for what we consider an internal discard reason. These
                     // indicate errors in the infrastructure or implementation bugs. In other cases,
                     // we "expect" errors and log them as debug level.
                     relay_log::with_scope(
-                        |scope| {
-                            scope.set_tag("project_key", project_key);
-                        },
-                        || {
-                            relay_log::error!("error processing envelope: {}", LogError(&error));
-                        },
+                        |scope| scope.set_tag("project_key", project_key),
+                        || relay_log::error!("error processing envelope: {}", LogError(&error)),
                     );
                 } else {
                     relay_log::debug!("dropped envelope: {}", LogError(&error));
                 }
             })
             .then(move |x, slf, _| {
-                metric!(timer(RelayTimers::EnvelopeTotalTime) = start_time.elapsed());
                 slf.active_envelopes -= 1;
                 fut::result(x)
             })

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -496,7 +496,11 @@ impl Handler<HandleEnvelope> for EnvelopeManager {
                         Ok((envelope, envelope_context))
                     }
                     // errors from rate limiting already produced outcomes nothing more to do
-                    None => Err(ProcessingError::RateLimited),
+                    None => {
+                        // TODO(ja): THIS IS WRONG, we miss an envelope_context.update().
+                        envelope_context.accept();
+                        Err(ProcessingError::RateLimited)
+                    }
                 }
             })
             .and_then(move |(envelope, envelope_context)| {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2273,16 +2273,18 @@ mod tests {
             item
         });
 
-        let envelope_response = processor
-            .process(ProcessEnvelope {
-                envelope_context: EnvelopeContext::from_envelope(&envelope),
-                envelope,
-                project_state: Arc::new(ProjectState::allowed()),
-                sampling_project_state: None,
-            })
-            .unwrap();
+        let new_envelope = relay_test::with_system(move || {
+            let envelope_response = processor
+                .process(ProcessEnvelope {
+                    envelope_context: EnvelopeContext::from_envelope(&envelope),
+                    envelope,
+                    project_state: Arc::new(ProjectState::allowed()),
+                    sampling_project_state: None,
+                })
+                .unwrap();
 
-        let (new_envelope, _) = envelope_response.envelope.unwrap();
+            envelope_response.envelope.unwrap().0
+        });
 
         assert_eq!(new_envelope.len(), 1);
         assert_eq!(new_envelope.items().next().unwrap().ty(), &ItemType::Event);

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -338,7 +338,11 @@ where
             let envelope = match checked.envelope {
                 Some(envelope) => envelope,
                 // rate limit outcome logged by CheckEnvelope already
-                None => return Err(BadStoreRequest::RateLimited(checked.rate_limits)),
+                None => {
+                    // TODO(ja): THIS IS WRONG, we miss an envelope_context.update().
+                    envelope_context.accept();
+                    return Err(BadStoreRequest::RateLimited(checked.rate_limits));
+                }
             };
 
             envelope_context.update(&envelope);

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -25,9 +25,7 @@ use crate::envelope::{AttachmentType, Envelope, EnvelopeError, ItemType, Items};
 use crate::extractors::RequestMeta;
 use crate::service::{ServiceApp, ServiceState};
 use crate::statsd::RelayCounters;
-use crate::utils::{
-    self, ApiErrorResponse, EnvelopeContext, FormDataIter, MultipartError, SendWithOutcome,
-};
+use crate::utils::{self, ApiErrorResponse, EnvelopeContext, FormDataIter, MultipartError};
 
 #[derive(Fail, Debug)]
 pub enum BadStoreRequest {
@@ -80,49 +78,6 @@ pub enum BadStoreRequest {
 
     #[fail(display = "event submission rejected with_reason: {:?}", _0)]
     EventRejected(DiscardReason),
-}
-
-impl BadStoreRequest {
-    fn to_outcome(&self) -> Option<Outcome> {
-        Some(match self {
-            BadStoreRequest::UnsupportedProtocolVersion(_) => {
-                Outcome::Invalid(DiscardReason::AuthVersion)
-            }
-
-            BadStoreRequest::EmptyBody => Outcome::Invalid(DiscardReason::NoData),
-            BadStoreRequest::EmptyEnvelope => Outcome::Invalid(DiscardReason::EmptyEnvelope),
-            BadStoreRequest::InvalidJson(_) => Outcome::Invalid(DiscardReason::InvalidJson),
-            BadStoreRequest::InvalidMsgpack(_) => Outcome::Invalid(DiscardReason::InvalidMsgpack),
-            BadStoreRequest::InvalidMultipart(_) => {
-                Outcome::Invalid(DiscardReason::InvalidMultipart)
-            }
-            BadStoreRequest::InvalidMinidump => Outcome::Invalid(DiscardReason::InvalidMinidump),
-            BadStoreRequest::MissingMinidump => {
-                Outcome::Invalid(DiscardReason::MissingMinidumpUpload)
-            }
-            BadStoreRequest::InvalidEnvelope(_) => Outcome::Invalid(DiscardReason::InvalidEnvelope),
-
-            BadStoreRequest::QueueFailed(event_error) => match event_error {
-                QueueEnvelopeError::TooManyEnvelopes => Outcome::Invalid(DiscardReason::Internal),
-            },
-            BadStoreRequest::ProjectFailed(project_error) => match project_error {
-                ProjectError::FetchFailed => Outcome::Invalid(DiscardReason::ProjectState),
-                _ => Outcome::Invalid(DiscardReason::Internal),
-            },
-            BadStoreRequest::PayloadError(payload_error) => match payload_error {
-                PayloadError::Overflow => Outcome::Invalid(DiscardReason::TooLarge),
-                _ => Outcome::Invalid(DiscardReason::Payload),
-            },
-
-            // should actually never create an outcome
-            BadStoreRequest::InvalidEventId => Outcome::Invalid(DiscardReason::Internal),
-
-            // Outcomes emitted at the source
-            BadStoreRequest::EventRejected(_) => return None,
-            BadStoreRequest::RateLimited(_) => return None,
-            BadStoreRequest::ScheduleFailed => return None,
-        })
-    }
 }
 
 impl ResponseError for BadStoreRequest {
@@ -344,47 +299,38 @@ where
     let project_key = meta.public_key();
     let start_time = meta.start_time();
     let config = request.state().config();
-
-    let envelope_context = Rc::new(RefCell::new(EnvelopeContext::from_request(&meta)));
+    let event_id = Rc::new(RefCell::new(None));
 
     let future = extract_envelope(&request, meta)
         .into_future()
-        .and_then(clone!(config, envelope_context, |mut envelope| {
-            envelope_context.borrow_mut().update(&envelope);
+        .and_then(clone!(config, event_id, |mut envelope| {
+            *event_id.borrow_mut() = envelope.event_id();
 
             // If configured, remove unknown items at the very beginning. If the envelope is
             // empty, we fail the request with a special control flow error to skip checks and
             // queueing, that still results in a `200 OK` response.
             utils::remove_unknown_items(&config, &mut envelope);
 
+            let mut envelope_context = EnvelopeContext::from_envelope(&envelope);
             if envelope.is_empty() {
-                // envelope is empty, cannot send outcomes
+                envelope_context.reject(Outcome::Invalid(DiscardReason::EmptyEnvelope));
                 Err(BadStoreRequest::EmptyEnvelope)
             } else {
-                Ok(envelope)
+                Ok((envelope, envelope_context))
             }
         }))
-        .and_then(clone!(envelope_context, |envelope| {
+        .and_then(move |(envelope, envelope_context)| {
             ProjectCache::from_registry()
-                .send_tracked(
-                    CheckEnvelope::cached(project_key, envelope),
-                    *envelope_context.clone().borrow(),
-                )
+                .send(CheckEnvelope::cached(project_key, envelope))
                 .map_err(|_| BadStoreRequest::ScheduleFailed)
                 .and_then(|result| result.map_err(BadStoreRequest::ProjectFailed))
-                .map_err(move |err| {
-                    if let Some(outcome) = err.to_outcome() {
-                        envelope_context.borrow().send_outcomes(outcome);
-                    }
-                    err
-                })
-        }))
-        .and_then(clone!(envelope_context, |response| {
-            let mut envelope_context = envelope_context.borrow_mut();
+                .map(|response| (response, envelope_context))
+        })
+        .and_then(move |(response, mut envelope_context)| {
             envelope_context.scope(response.scoping);
 
             let checked = response.result.map_err(|reason| {
-                envelope_context.send_outcomes(Outcome::Invalid(reason));
+                envelope_context.reject(Outcome::Invalid(reason));
                 BadStoreRequest::EventRejected(reason)
             })?;
 
@@ -397,32 +343,26 @@ where
 
             envelope_context.update(&envelope);
             if utils::check_envelope_size_limits(&config, &envelope) {
-                Ok((envelope, checked.rate_limits))
+                Ok((envelope, envelope_context, checked.rate_limits))
             } else {
-                envelope_context.send_outcomes(Outcome::Invalid(DiscardReason::TooLarge));
+                envelope_context.reject(Outcome::Invalid(DiscardReason::TooLarge));
                 Err(BadStoreRequest::PayloadError(PayloadError::Overflow))
             }
-        }))
-        .and_then(clone!(envelope_context, |(envelope, rate_limits)| {
+        })
+        .and_then(move |(envelope, envelope_context, rate_limits)| {
             let message = QueueEnvelope {
                 envelope,
+                envelope_context,
                 project_key,
                 start_time,
             };
 
             EnvelopeManager::from_registry()
-                .send_tracked(message, *envelope_context.clone().borrow())
+                .send(message)
                 .map_err(|_| BadStoreRequest::ScheduleFailed)
                 .and_then(|result| result.map_err(BadStoreRequest::QueueFailed))
-                .map_err(move |err| {
-                    if let Some(outcome) = err.to_outcome() {
-                        // TODO: Move this into Handler<QueueEnvelope>
-                        envelope_context.borrow().send_outcomes(outcome)
-                    }
-                    err
-                })
                 .map(move |event_id| (event_id, rate_limits))
-        }))
+        })
         .and_then(move |(event_id, rate_limits)| {
             if rate_limits.is_limited() {
                 Err(BadStoreRequest::RateLimited(rate_limits))
@@ -432,7 +372,7 @@ where
         })
         .or_else(move |error: BadStoreRequest| {
             metric!(counter(RelayCounters::EnvelopeRejected) += 1);
-            let event_id = envelope_context.borrow().event_id();
+            let event_id = *event_id.borrow();
 
             if !emit_rate_limit && matches!(error, BadStoreRequest::RateLimited(_)) {
                 return Ok(create_response(event_id));

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -1,11 +1,10 @@
 //! Envelope context type and helpers to ensure outcomes.
 
 use std::net;
+use std::time::Instant;
 
-use actix::prelude::dev::ToEnvelope;
-use actix::prelude::*;
+use actix::SystemService;
 use chrono::{DateTime, Utc};
-use futures01::prelude::*;
 
 use relay_common::DataCategory;
 use relay_general::protocol::EventId;
@@ -14,41 +13,36 @@ use relay_quotas::Scoping;
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::envelope::Envelope;
-use crate::extractors::RequestMeta;
+use crate::statsd::{RelayCounters, RelayTimers};
 use crate::utils::EnvelopeSummary;
 
 /// Contains the required envelope related information to create an outcome.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct EnvelopeContext {
     summary: EnvelopeSummary,
+    start_time: Instant,
     received_at: DateTime<Utc>,
     event_id: Option<EventId>,
     remote_addr: Option<net::IpAddr>,
     scoping: Scoping,
+    done: bool,
 }
 
 impl EnvelopeContext {
-    /// Creates an envelope context from the given request meta data.
-    ///
-    /// This context contains partial scoping and no envelope summary. There will be no outcomes
-    /// logged without updating this context.
-    pub fn from_request(meta: &RequestMeta) -> Self {
-        Self {
-            summary: EnvelopeSummary::empty(),
-            received_at: relay_common::instant_to_date_time(meta.start_time()),
-            event_id: None,
-            remote_addr: meta.client_addr(),
-            scoping: meta.get_partial_scoping(),
-        }
-    }
-
     /// Computes an envelope context from the given envelope.
     ///
     /// To provide additional scoping, use [`EnvelopeContext::scope`].
     pub fn from_envelope(envelope: &Envelope) -> Self {
-        let mut context = Self::from_request(envelope.meta());
-        context.update(envelope);
-        context
+        let meta = &envelope.meta();
+        Self {
+            summary: EnvelopeSummary::compute(envelope),
+            start_time: meta.start_time(),
+            received_at: relay_common::instant_to_date_time(meta.start_time()),
+            event_id: envelope.event_id(),
+            remote_addr: meta.client_addr(),
+            scoping: meta.get_partial_scoping(),
+            done: false,
+        }
     }
 
     /// Update the context with new envelope information.
@@ -66,10 +60,44 @@ impl EnvelopeContext {
         self
     }
 
-    /// Records outcomes for all items stored in this context.
+    /// Records an outcome scoped to this envelope's context.
+    ///
+    /// This envelope context should be updated using [`update`](Self::update) soon after this
+    /// operation to ensure that subsequent outcomes are consistent.
+    pub fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
+        let outcome_aggregator = OutcomeAggregator::from_registry();
+        outcome_aggregator.do_send(TrackOutcome {
+            timestamp: self.received_at,
+            scoping: self.scoping,
+            outcome,
+            event_id: self.event_id,
+            remote_addr: self.remote_addr,
+            category,
+            // Quantities are usually `usize` which lets us go all the way to 64-bit on our
+            // machines, but the protocol and data store can only do 32-bit.
+            quantity: quantity as u32,
+        });
+    }
+
+    /// Accepts the envelope and drops the context.
+    ///
+    /// This should be called if the envelope has been accepted by the upstream, which means that
+    /// the responsibility for logging outcomes has been moved. This function will not log any
+    /// outcomes.
+    pub fn accept(mut self) {
+        if !self.done {
+            self.finish(RelayCounters::EnvelopeAccepted);
+        }
+    }
+
+    /// Records rejection outcomes for all items stored in this context.
     ///
     /// This does not send outcomes for empty envelopes or request-only contexts.
-    pub fn send_outcomes(&self, outcome: Outcome) {
+    pub fn reject(&mut self, outcome: Outcome) {
+        if self.done {
+            return;
+        }
+
         if let Some(category) = self.summary.event_category {
             self.track_outcome(outcome.clone(), category, 1);
         }
@@ -89,22 +117,8 @@ impl EnvelopeContext {
                 self.summary.profile_quantity,
             );
         }
-    }
 
-    /// Records an outcome scoped to this envelope's context.
-    pub fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
-        let outcome_aggregator = OutcomeAggregator::from_registry();
-        outcome_aggregator.do_send(TrackOutcome {
-            timestamp: self.received_at,
-            scoping: self.scoping,
-            outcome,
-            event_id: self.event_id,
-            remote_addr: self.remote_addr,
-            category,
-            // Quantities are usually `usize` which lets us go all the way to 64-bit on our
-            // machines, but the protocol and data store can only do 32-bit.
-            quantity: quantity as u32,
-        });
+        self.finish(RelayCounters::EnvelopeRejected);
     }
 
     /// Returns scoping stored in this context.
@@ -112,59 +126,21 @@ impl EnvelopeContext {
         self.scoping
     }
 
-    /// Returns the event id of this context, if any.
-    pub fn event_id(&self) -> Option<EventId> {
-        self.event_id
-    }
-
     /// Returns the time at which the envelope was received at this Relay.
     pub fn received_at(&self) -> DateTime<Utc> {
         self.received_at
     }
+
+    /// Resets inner state to ensure there's no more logging.
+    fn finish(&mut self, counter: RelayCounters) {
+        relay_statsd::metric!(counter(counter) += 1);
+        relay_statsd::metric!(timer(RelayTimers::EnvelopeTotalTime) = self.start_time.elapsed());
+        self.done = true;
+    }
 }
 
-/// Extension trait for [`Addr`] to log [`Outcome`] for failed messages.
-pub trait SendWithOutcome<A> {
-    /// Sends an asynchronous message to the actor, tracking outcomes on failure.
-    ///
-    /// Communication channel to the actor is bounded. If the returned `Future` object get dropped,
-    /// the message cancels.
-    ///
-    /// If the actor rejects the message, an `Invalid` outcome with internal reason is logged. Any
-    /// error within the message result is not tracked by this function.
-    fn send_tracked<M>(
-        &self,
-        message: M,
-        envelope_context: EnvelopeContext,
-    ) -> ResponseFuture<M::Result, MailboxError>
-    where
-        M: Message,
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
-        M: Message + Send + 'static,
-        M::Result: Send;
-}
-
-impl<A> SendWithOutcome<A> for Addr<A>
-where
-    A: Actor,
-{
-    fn send_tracked<M>(
-        &self,
-        message: M,
-        envelope_context: EnvelopeContext,
-    ) -> ResponseFuture<M::Result, MailboxError>
-    where
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
-        M: Message + Send + 'static,
-        M::Result: Send,
-    {
-        let future = self.send(message).map_err(move |mailbox_error| {
-            envelope_context.send_outcomes(Outcome::Invalid(DiscardReason::Internal));
-            mailbox_error
-        });
-
-        Box::new(future)
+impl Drop for EnvelopeContext {
+    fn drop(&mut self) {
+        self.reject(Outcome::Invalid(DiscardReason::Internal));
     }
 }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -126,7 +126,16 @@ impl EnvelopeContext {
         self.scoping
     }
 
+    /// Returns the instant at which the envelope was received at this Relay.
+    ///
+    /// This is the monotonic time equivalent to [`received_at`](Self::received_at).
+    pub fn start_time(&self) -> Instant {
+        self.start_time
+    }
+
     /// Returns the time at which the envelope was received at this Relay.
+    ///
+    /// This is the date time equivalent to [`start_time`](Self::start_time).
     pub fn received_at(&self) -> DateTime<Utc> {
         self.received_at
     }


### PR DESCRIPTION
This change makes `EnvelopeContext` responsible for tracking the lifetime of an envelope and emitting outcomes. In a follow-up, the goal is to remove the long-running handler future in `EnvelopeManager`, and instead pass envelopes through separate queues the ingestion stages. Most importantly, this requires to have a central place that is bound to the envelope and emits outcomes and metrics when envelopes are dropped for any reason.

## EnvelopeContext

Before this change, `EnvelopeContext` was a data object containing all information to create outcomes. It is primarily used in three places:

  - The endpoint handler future, where it was shared across all future callbacks to emit outcomes when envelopes are dropped.
  - The envelope manager's handler future, in exactly the same way.
  - The envelope processor, where it was stored on the processing state and used to emit outcomes for inbound filtering and rate limiting.

The envelope context is now passed alongside the envelope through Relay and also moves through message handlers. This can ensure that outcomes are guaranteed when the envelope is dropped. It can be dropped in two ways:

  - Explicitly by calling `accept()` or `reject(outcome)`.
  - Implicitly by dropping, for instance if sending a message fails unexpectely. This represents a bug and will record an `"internal"` outcome.

Calling `accept()` consumes the envelope context. Temporarily, `reject()` does not yet consume, which will be changed in a follow-up.

## Control Flow

The flow of envelopes remains unchanged, with the envelope context now following the envelope through every step:

(in the endpoint)

  1. Load the request and construct an envelope. Drop empty envelopes.
  2. Send it to the project cache for the fast-path. This may drop the envelope for cached rate limits or disabled projects. Outcomes are emitted in the project cache. Updates the envelope context with project information if available.
  3. Send it to the envelope manager for queueing. If queueing fails, an outcome is emitted by the envelope manager.
  4. End the request.

(in envelope manager)

  1. Split envelopes into event-related items, metrics items, and everything else. This will create duplicate envelope contexts, since from here on there are multiple independent envelopes that get queued.
  2. Send the envelope through the project cache again, now ensuring an up-to-date project state. Same logic as in the endpoint.
  3. Send the envelope to the processor. All rate limits and invalid transactions are logged directly by the processor. An updated envelope and envelope context are sent back to the Envelope Manager.
  4. Submit the envelope to either Kafka, Upstream, or the internal capture map (only in capture mode). For simplicity, the envelope context remains in the waiting future outside.
  5. Explicitly drop the envelope context either by accepting or rejecting based on the result of the previous step.

## Follow-Ups

- Introduce a semaphore to limit the number of envelopes in Relay. The guard can be held by the envelope context. This is currently handled by a counter (`active_envelopes`) in the `EnvelopeManager`.
- Make capture mode explicit messages so they can be created from other services.
- Combine the envelope context and envelope in a single carrier type. Keeping the two separate required fewer code changes initially, however the context and the envelope always need to be passed and modified together.
- (optional) Introduce safer APIs to modify the envelope's contents and update the envelope context at the same time.

#skip-changelog
