### PR TITLE
build: Upgrade parking_lot and use const initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,16 +2472,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
@@ -2526,20 +2516,6 @@ dependencies = [
  "redox_syscall 0.1.57",
  "rustc_version 0.2.3",
  "smallvec 0.6.14",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec 1.8.0",
  "winapi 0.3.9",
 ]
 
@@ -3314,7 +3290,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "lru",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.1",
  "regex",
  "relay-log",
  "schemars",
@@ -3550,7 +3526,7 @@ dependencies = [
  "listenfd",
  "minidump",
  "native-tls",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.1",
  "rdkafka",
  "rdkafka-sys",
  "regex",
@@ -3590,8 +3566,7 @@ name = "relay-statsd"
 version = "22.8.0"
 dependencies = [
  "cadence",
- "lazy_static",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.1",
  "rand 0.7.3",
  "relay-log",
 ]

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -17,7 +17,7 @@ globset = "0.4.5"
 lazy_static = "1.4.0"
 lazycell = "1.2.1"
 lru = "0.7.6"
-parking_lot = "0.10.0"
+parking_lot = "0.12.1"
 regex = "1.5.5"
 relay-log = { path = "../relay-log" }
 sentry-types = "0.20.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -44,7 +44,7 @@ lazy_static = "1.4.0"
 listenfd = "0.3.3"
 minidump = { version = "0.10.0", optional = true }
 native-tls = { version = "0.2.4", optional = true }
-parking_lot = "0.10.0"
+parking_lot = "0.12.1"
 rdkafka = { version = "0.24", optional = true }
 rdkafka-sys = { version = "2.1.0", optional = true }
 regex = "1.5.5"

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -15,10 +15,8 @@ use relay_system::{compat, Controller};
 use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
 use crate::statsd::RelayGauges;
 
-lazy_static::lazy_static! {
-    /// Singleton of the `Healthcheck` service.
-    static ref ADDRESS: RwLock<Option<Addr<HealthcheckMessage>>> = RwLock::new(None);
-}
+/// Singleton of the `Healthcheck` service.
+static ADDRESS: RwLock<Option<Addr<HealthcheckMessage>>> = RwLock::new(None);
 
 /// Internal wrapper of a message sent through an `Addr` with return channel.
 #[derive(Debug)]

--- a/relay-statsd/Cargo.toml
+++ b/relay-statsd/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [dependencies]
 cadence = "0.26.0"
-lazy_static = "1.4.0"
-parking_lot = "0.10.0"
+parking_lot = "0.12.1"
 rand = "0.7.3"
 relay-log = { path = "../relay-log" }

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -65,7 +65,6 @@ use std::sync::Arc;
 use cadence::{
     BufferedUdpMetricSink, Metric, MetricBuilder, QueuingMetricSink, StatsdClient, UdpMetricSink,
 };
-use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use rand::distributions::{Distribution, Uniform};
 
@@ -140,9 +139,7 @@ impl MetricsClient {
     }
 }
 
-lazy_static! {
-    static ref METRICS_CLIENT: RwLock<Option<Arc<MetricsClient>>> = RwLock::new(None);
-}
+static METRICS_CLIENT: RwLock<Option<Arc<MetricsClient>>> = RwLock::new(None);
 
 thread_local! {
     static CURRENT_CLIENT: Option<Arc<MetricsClient>> = METRICS_CLIENT.read().clone();


### PR DESCRIPTION
The latest version of `parking_lot` has `const` initializers for mutexes and
reader writer locks. This allows us remove `lazy_static` in a few places. This
version was already a dependency, so we could get rid of an old version.

With recent Rust versions, `Mutex` and `RwLock` have also improved. However, we
will need to evalate with more care which types to use in the future.

#skip-changelog

