### PR TITLE
meta(make): Add help messages to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,18 @@ all: check test ## run all checks and tests
 check: style lint ## run the lints and check the code style for rust and python code
 .PHONY: check
 
-clean: ## remove python virtual environment and delete cached rust files together with .target folder
+clean: ## remove python virtual environment and delete cached rust files together with target folder
 	cargo clean
 	rm -rf .venv
 .PHONY: clean
 
 # Builds
 
-build: setup-git ## build relay with all features enabled with debug info
+build: setup-git ## build relay with all features enabled without debug info
 	cargo +stable build --all-features
 .PHONY: build
 
-release: setup-git ## build production release of the relay with
+release: setup-git ## build production binary of the relay with debug info
 	@cd relay && cargo +stable build --release --locked --features ${RELAY_FEATURES}
 .PHONY: release
 
@@ -30,15 +30,15 @@ build-linux-release: setup-git ## build linux release of the relay
 	objcopy --add-gnu-debuglink target/${TARGET}/release/relay{.debug,}
 .PHONY: build-linux-release
 
-sdist: setup-git setup-venv ## create a sdist of the Python code
+sdist: setup-git setup-venv ## create a sdist of the Python library
 	cd py && ../.venv/bin/python setup.py sdist --format=zip
 .PHONY: sdist
 
-wheel: setup-git setup-venv ## create a wheel of the Python code
+wheel: setup-git setup-venv ## build a wheel of the Python library
 	cd py && ../.venv/bin/python setup.py bdist_wheel
 .PHONY: wheel
 
-wheel-manylinux: setup-git ## create wheels for linux
+wheel-manylinux: setup-git ## build manylinux 2010 compatible wheels
 	@scripts/docker-manylinux.sh
 .PHONY: wheel-manylinux
 
@@ -66,7 +66,7 @@ test-integration: build setup-venv ## run integration tests
 
 # Documentation
 
-doc: doc-api ## generate API docs for Rust code
+doc: doc-api ## generate all API docs
 .PHONY: doc-api
 
 doc-api: setup-git ## generate API docs for Rust code

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ init-submodules:
 setup-git: .git/hooks/pre-commit init-submodules ## make sure all git configured and all the submodules are fetched
 .PHONY: setup-git
 
-setup-venv: .venv/bin/python .venv/python-requirements-stamp ## create a Python virtual environment
+setup-venv: .venv/bin/python .venv/python-requirements-stamp ## create a Python virtual environment with development requirements installed
 .PHONY: setup-venv
 
 devserver: ## run the development server

--- a/Makefile
+++ b/Makefile
@@ -2,135 +2,135 @@ SHELL=/bin/bash
 export RELAY_PYTHON_VERSION := python3
 export RELAY_FEATURES := ssl
 
-all: check test
+all: check test ## run all checks and tests
 .PHONY: all
 
-check: style lint
+check: style lint ## run the lints and check the code style for rust and python code
 .PHONY: check
 
-clean:
+clean: ## remove python virtual environment and delete cached rust files together with .target folder
 	cargo clean
 	rm -rf .venv
 .PHONY: clean
 
 # Builds
 
-build: setup-git
+build: setup-git ## build relay with all features enabled with debug info
 	cargo +stable build --all-features
 .PHONY: build
 
-release: setup-git
+release: setup-git ## build production release of the relay with
 	@cd relay && cargo +stable build --release --locked --features ${RELAY_FEATURES}
 .PHONY: release
 
-build-linux-release: setup-git
+build-linux-release: setup-git ## build linux release of the relay
 	cd relay && cargo build --release --locked --features ${RELAY_FEATURES} --target=${TARGET}
 	objcopy --only-keep-debug target/${TARGET}/release/relay{,.debug}
 	objcopy --strip-debug --strip-unneeded target/${TARGET}/release/relay
 	objcopy --add-gnu-debuglink target/${TARGET}/release/relay{.debug,}
 .PHONY: build-linux-release
 
-sdist: setup-git setup-venv
+sdist: setup-git setup-venv ## create a sdist of the Python code
 	cd py && ../.venv/bin/python setup.py sdist --format=zip
 .PHONY: sdist
 
-wheel: setup-git setup-venv
+wheel: setup-git setup-venv ## create a wheel of the Python code
 	cd py && ../.venv/bin/python setup.py bdist_wheel
 .PHONY: wheel
 
-wheel-manylinux: setup-git
+wheel-manylinux: setup-git ## create wheels for linux
 	@scripts/docker-manylinux.sh
 .PHONY: wheel-manylinux
 
 # Tests
 
-test: test-rust-all test-python test-integration
+test: test-rust-all test-python test-integration ## run all unit and integration tests
 .PHONY: test
 
-test-rust: setup-git
+test-rust: setup-git ## run tests for Rust code with default features enabled
 	cargo test --workspace
 .PHONY: test-rust
 
-test-rust-all: setup-git
+test-rust-all: setup-git ## run tests for Rust code with all the features enabled
 	cargo test --workspace --all-features
 .PHONY: test-rust-all
 
-test-python: setup-git setup-venv
+test-python: setup-git setup-venv ## run tests for Python code
 	RELAY_DEBUG=1 .venv/bin/pip install -v --editable py
 	.venv/bin/pytest -v py
 .PHONY: test-python
 
-test-integration: build setup-venv
+test-integration: build setup-venv ## run integration tests
 	.venv/bin/pytest tests -n auto -v
 .PHONY: test-integration
 
 # Documentation
 
-doc: doc-api
+doc: doc-api ## generate API docs for Rust code
 .PHONY: doc-api
 
-doc-api: setup-git
+doc-api: setup-git ## generate API docs for Rust code
 	cargo doc --workspace --all-features --no-deps
 .PHONY: doc-api
 
 # Style checking
 
-style: style-rust style-python
+style: style-rust style-python ## check code style
 .PHONY: style
 
-style-rust:
+style-rust: ## check Rust code style
 	@rustup component add rustfmt --toolchain stable 2> /dev/null
 	cargo +stable fmt --all -- --check
 .PHONY: style-rust
 
-style-python: setup-venv
+style-python: setup-venv ## check Python code style
 	.venv/bin/black --check py tests --exclude '\.eggs|sentry_relay/_lowlevel.*'
 .PHONY: style-python
 
 # Linting
 
-lint: lint-rust lint-python
+lint: lint-rust lint-python ## runt lint on Python and Rust code
 .PHONY: lint
 
-lint-rust: setup-git
+lint-rust: setup-git ## run lint on Rust code using clippy
 	@rustup component add clippy --toolchain stable 2> /dev/null
 	cargo +stable clippy --workspace --all-features --tests -- -D clippy::all
 .PHONY: lint-rust
 
-lint-python: setup-venv
+lint-python: setup-venv ## run lint on Python code using flake8
 	.venv/bin/flake8 py
 .PHONY: lint-python
 
 # Formatting
 
-format: format-rust format-python
+format: format-rust format-python ## format all the Rust and Python code
 .PHONY: format
 
-format-rust:
+format-rust: ## format the Rust code
 	@rustup component add rustfmt --toolchain stable 2> /dev/null
 	cargo +stable fmt --all
 .PHONY: format-rust
 
-format-python: setup-venv
+format-python: setup-venv ## format the Python code
 	.venv/bin/black py tests scripts --exclude '\.eggs|sentry_relay/_lowlevel.*'
 .PHONY: format-python
 
 # Development
 
-setup: setup-git setup-venv
+setup: setup-git setup-venv ## run setup tasks to create and configure development environment
 .PHONY: setup
 
 init-submodules:
 	@git submodule update --init --recursive
 .PHONY: init-submodules
 
-setup-git: .git/hooks/pre-commit init-submodules
+setup-git: .git/hooks/pre-commit init-submodules ## make sure all git configured and all the submodules are fetched
 .PHONY: setup-git
 
-setup-venv: .venv/bin/python .venv/python-requirements-stamp
+setup-venv: .venv/bin/python .venv/python-requirements-stamp ## create a Python virtual environment
 .PHONY: setup-venv
 
-devserver:
+devserver: ## run the development server
 	@systemfd --no-pid -s http::3000 -- cargo watch -x "run -- run"
 .PHONY: devserver
 
@@ -164,3 +164,7 @@ clean-target-dir:
 
 .git/hooks/pre-commit:
 	@cd .git/hooks && ln -sf ../../scripts/git-precommit-hook pre-commit
+
+help: ## this help
+	@ awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m\t%s\n", $$1, $$2 }' $(MAKEFILE_LIST) | column -s$$'\t' -t
+.PHONY: help

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ development:
   also performed in CI.
 - `make clean`: Removes all build artifacts, the virtualenv and cached files.
 
+For more avalibale make targets, please, run `make help`.
+
 Integration tests require Redis and Kafka running in their default
 configuration. The most convenient way to get all required services is via
 [`sentry devservices`](https://develop.sentry.dev/services/devservices/), which


### PR DESCRIPTION
Adding useful documentation or help messages to the Makefile will help
contributors to quickly check all the available targets and what exactly
they do without opening the file itself.

Now one can just run `make help` to get the beautiful help message, like :

```
❯ make help
Usage: make <target>
Targets:
  all                   run all checks and tests
  check                 run the lints and check the code style for rust and python code
  clean                 remove python virtual environment and delete cached rust files together with .target folder
  build                 build relay with all features enabled with debug info
  release               build production release of the relay with

...

```
#skip-changelog


