### PR TITLE
fix(server): Fix eviction metric

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -82,7 +82,6 @@ impl ProjectCache {
     /// a project that has expired recently and for which a fetch is already underway in
     /// [`super::project_upstream`].
     fn evict_stale_project_caches(&mut self) {
-        metric!(counter(RelayCounters::EvictingStaleProjectCaches) += 1);
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
@@ -91,9 +90,12 @@ impl ProjectCache {
             .drain_filter(|_, entry| entry.last_updated_at() + delta <= eviction_start);
 
         // Defer dropping the projects to a dedicated thread:
+        let mut count = 0;
         for (_, project) in expired {
             self.garbage_disposal.dispose(project);
+            count += 1;
         }
+        metric!(counter(RelayCounters::EvictingStaleProjectCaches) += count);
 
         // Log garbage queue size:
         let queue_size = self.garbage_disposal.queue_size() as f64;


### PR DESCRIPTION
According to the docs, this metric should emit the number of projects evicted:

https://github.com/getsentry/relay/blob/14b9dc845551e4dbd3672c7d474b69ffa19839d2/relay-server/src/statsd.rs#L498-L510

#skip-changelog