### PR TITLE
fix(server): Retain valid cached project states on error

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -947,7 +947,7 @@ mod tests {
         let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
         let mut project_state = ProjectState::allowed();
         project_state.project_id = Some(ProjectId::new(123));
-        let mut project = Project::new(project_key, config.clone());
+        let mut project = Project::new(project_key, config);
         project.state_channel = Some(channel);
         project.state = Some(Arc::new(project_state));
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -952,19 +952,11 @@ mod tests {
         project.state = Some(Arc::new(project_state));
 
         // The project ID must be set.
-        assert_eq!(
-            project.state.as_ref().unwrap().project_id.unwrap().value(),
-            123
-        );
-
+        assert!(!project.state.as_ref().unwrap().invalid());
         // Try to update project with errored project state.
         project.update_state(Arc::new(ProjectState::err()), false);
-
         // Since we got invalid project state we still keep the old one meaning there
         // still must be the project id set.
-        assert_eq!(
-            project.state.as_ref().unwrap().project_id.unwrap().value(),
-            123
-        );
+        assert!(!project.state.as_ref().unwrap().invalid());
     }
 }


### PR DESCRIPTION
Fixes a case where valid project states are removed from the project cache after
the fetch deadline has succeeded. Relay should instead continue using caches
until the grace period has expired, and retry fetching in the background.

 - All errors are be mapped to `ProjectState::err`. The specific error (i.e.
   deserialization and network errors) can still be logged at the source.
 - `ProjectState::missing` always overwrites the existing state.
 - `ProjectState::err` only overwrites if the existing state is (hard) outdated.
    This error is cached and propagated.
 - Updated and stale states stay in the cache if the update is
   `ProjectState::err`. We have to figure out a backoff mechanism for this case
	 (probably a flag/Instant on the Project).

INGEST-1504
INGEST-1507

#skip-changelog