### PR TITLE
feat(statsd): Add a capturing client for use in tests [INGEST-1472]

### DIFF
--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -178,13 +178,7 @@ pub fn with_capturing_test_client(f: impl FnOnce()) -> Vec<String> {
 
     *METRICS_CLIENT.write() = old_client;
 
-    rx.iter()
-        .map(|x| {
-            let s = String::from_utf8(x).unwrap();
-            dbg!(&s);
-            s
-        })
-        .collect()
+    rx.iter().map(|x| String::from_utf8(x).unwrap()).collect()
 }
 
 /// Disable the client again.

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -56,11 +56,12 @@
 //! ```
 //!
 //! [Metric Types]: https://github.com/statsd/statsd/blob/master/docs/metric_types.md
-
 use std::collections::BTreeMap;
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
 
 use cadence::{
     BufferedUdpMetricSink, Metric, MetricBuilder, QueuingMetricSink, StatsdClient, UdpMetricSink,
@@ -82,6 +83,9 @@ pub struct MetricsClient {
     pub default_tags: BTreeMap<String, String>,
     /// Global sample rate.
     pub sample_rate: f32,
+    /// Capture mode. Only use in tests. Stores all the metric strings sent.
+    #[cfg(test)]
+    pub capture: Option<Arc<Mutex<Vec<String>>>>,
 }
 
 impl Deref for MetricsClient {
@@ -113,12 +117,24 @@ impl MetricsClient {
             metric = metric.with_tag(k, v);
         }
 
-        if let Err(error) = metric.try_send() {
-            relay_log::error!(
-                "Error sending a metric: {}, maximum capacity: {}",
-                LogError(&error),
-                METRICS_MAX_QUEUE_SIZE
-            );
+        match metric.try_send() {
+            Err(error) => {
+                relay_log::error!(
+                    "Error sending a metric: {}, maximum capacity: {}",
+                    LogError(&error),
+                    METRICS_MAX_QUEUE_SIZE
+                );
+            }
+            #[cfg(test)]
+            Ok(metric) => {
+                if let Some(capture) = self.capture.as_ref() {
+                    let mut guard = capture.lock().unwrap();
+                    let mutable_captures = guard.deref_mut();
+                    mutable_captures.push(metric.as_metric_str().to_owned());
+                }
+            }
+            #[cfg(not(test))]
+            _ => {}
         };
     }
 
@@ -160,6 +176,33 @@ pub mod prelude {
 /// Set a new statsd client.
 pub fn set_client(client: MetricsClient) {
     *METRICS_CLIENT.write() = Some(Arc::new(client));
+}
+
+/// Set a test client
+#[cfg(test)]
+pub fn with_capturing_test_client(f: impl FnOnce()) -> Vec<String> {
+    use cadence::NopMetricSink;
+
+    let old_client = METRICS_CLIENT.read().clone();
+
+    let test_client = MetricsClient {
+        statsd_client: StatsdClient::from_sink("", NopMetricSink),
+        default_tags: Default::default(),
+        sample_rate: 1.0,
+        capture: Some(Arc::new(Mutex::new(Vec::new()))),
+    };
+    set_client(test_client);
+
+    // TODO: This is a mess of clones.
+    let opt = METRICS_CLIENT.read().clone();
+    let member = opt.as_ref().and_then(|x| x.capture.as_ref());
+    let captured = member.unwrap().lock().unwrap().deref().clone();
+
+    f();
+
+    *METRICS_CLIENT.write() = old_client;
+
+    captured
 }
 
 /// Disable the client again.
@@ -212,6 +255,8 @@ pub fn init<A: ToSocketAddrs>(
         statsd_client,
         default_tags,
         sample_rate,
+        #[cfg(test)]
+        capture: None,
     });
 }
 
@@ -550,4 +595,41 @@ macro_rules! metric {
         });
         rv
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{with_capturing_test_client, GaugeMetric};
+
+    enum TestGauges {
+        Foo,
+        Bar,
+    }
+
+    impl GaugeMetric for TestGauges {
+        fn name(&self) -> &'static str {
+            match self {
+                Self::Foo => "foo",
+                Self::Bar => "bar",
+            }
+        }
+    }
+
+    #[test]
+    fn test_capturing_client() {
+        let captures = with_capturing_test_client(|| {
+            metric!(
+                gauge(TestGauges::Foo) = 123,
+                server = "server1",
+                host = "host1"
+            );
+            metric!(
+                gauge(TestGauges::Bar) = 456,
+                server = "server2",
+                host = "host2"
+            );
+        });
+
+        assert_eq!(captures.as_slice(), ["asdf", "asdf",])
+    }
 }


### PR DESCRIPTION
Add a utility function that lets you capture which statsd metrics were emitted.

For example:

```rust
let captures = with_capturing_test_client(|| {
    metric!(gauge(Foo) = 123, server = "server1");
    metric!(gauge(Bar) = 456, server = "server2");
});  

assert_eq!(captures.as_slice(), [
    "foo:123|g|#server:server1",
    "bar:456|g|#server:server2"
]);
```

#skip-changelog