### PR TITLE
fix: Use a qualified release name for sentry and deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Make Redis connection pool configurable. ([#1418](https://github.com/getsentry/relay/pull/1418))
+
 **Bug Fixes**:
 
 - Do not apply rate limits or reject data based on expired project configs. ([#1404](https://github.com/getsentry/relay/pull/1404))
@@ -12,10 +16,7 @@
 - Defer dropping of projects to a background thread to speed up project cache eviction. ([#1410](https://github.com/getsentry/relay/pull/1410))
 - Update store service to use generic Addr and minor changes to generic Addr. ([#1415](https://github.com/getsentry/relay/pull/1415))
 - Added new Register for the Services that is initialized later than the current. ([#1421](https://github.com/getsentry/relay/pull/1421))
-
-**Features**:
-
-- Make Redis connection pool configurable. ([#1418](https://github.com/getsentry/relay/pull/1418))
+- Improve the release name used when reporting data to Sentry to include both the version and exact build. ([#1428](https://github.com/getsentry/relay/pull/1428))
 
 ## 22.8.0
 

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -8,6 +8,7 @@ version = "22.8.0"
 edition = "2018"
 license-file = "../LICENSE"
 publish = false
+build = "build.rs"
 
 [dependencies]
 chrono = { version = "0.4.19", optional = true }

--- a/relay-log/build.rs
+++ b/relay-log/build.rs
@@ -1,0 +1,26 @@
+use std::io;
+use std::process::{Command, Stdio};
+
+fn emit_release_var() -> Result<(), io::Error> {
+    let cmd = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .stderr(Stdio::inherit())
+        .output()?;
+
+    if !cmd.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("`git rev-parse' failed: {}", cmd.status),
+        ));
+    }
+
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    let revision = String::from_utf8_lossy(&cmd.stdout);
+    println!("cargo:rustc-env=RELAY_RELEASE=relay@{version}+{revision}");
+
+    Ok(())
+}
+
+fn main() {
+    emit_release_var().ok();
+}

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -10,11 +10,11 @@
 #   SENTRY_PROJECT: Project slug
 set -eu
 
-VERSION="${1:-}"
+REVISION="${1:-}"
 GITHUB_PROJECT="getsentry/relay"
-DOCKER_IMAGE="us.gcr.io/sentryio/relay:${VERSION}"
+DOCKER_IMAGE="us.gcr.io/sentryio/relay:${REVISION}"
 
-if [ -z "${VERSION}" ]; then
+if [ -z "${REVISION}" ]; then
   echo 'No version specified' && exit 1
 fi
 
@@ -40,9 +40,13 @@ sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
 echo 'Uploading system symbols...'
 sentry-cli upload-dif lib/x86_64-linux-gnu
 
-echo 'Creating a new deploy in Sentry...'
-sentry-cli releases new "${VERSION}"
-sentry-cli releases set-commits "${VERSION}" --commit "${GITHUB_PROJECT}@${VERSION}"
-sentry-cli releases deploys "${VERSION}" new -e release
-sentry-cli releases finalize "${VERSION}"
+echo 'Obtaining version information...'
+VERSION="$(docker run --rm "${DOCKER_IMAGE}" --version | cut -d' ' -f2)"
+RELEASE="relay@${VERSION}+${REVISION}"  # match RELEASE in relay_log::setup
+
+echo "Creating a new release and deploy for ${RELEASE} in Sentry..."
+sentry-cli releases new "${RELEASE}"
+sentry-cli releases set-commits "${RELEASE}" --commit "${GITHUB_PROJECT}@${REVISION}"
+sentry-cli releases deploys "${RELEASE}" new -e release
+sentry-cli releases finalize "${RELEASE}"
 echo 'Deploy created.'


### PR DESCRIPTION
The Sentry SDK used to report `relay-log@<version>` as release name, while the
deployment script used the commit SHA. To align the two, we now follow the
Sentry convention of `relay@<version>+<sha>` in both cases.

In Sentry, this renders as:

![image](https://user-images.githubusercontent.com/1433023/185604739-39636e82-d6dd-49fe-9be3-9c365b82ffbd.png)
