### PR TITLE
ref(server): Simplify CheckEnvelope

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -20,7 +20,7 @@ use relay_statsd::metric;
 
 use crate::actors::envelopes::{EnvelopeManager, QueueEnvelope, QueueEnvelopeError};
 use crate::actors::outcome::{DiscardReason, Outcome};
-use crate::actors::project_cache::{CheckEnvelope, ProjectCache, ProjectError};
+use crate::actors::project_cache::{CheckEnvelope, ProjectCache};
 use crate::envelope::{AttachmentType, Envelope, EnvelopeError, ItemType, Items};
 use crate::extractors::RequestMeta;
 use crate::service::{ServiceApp, ServiceState};
@@ -34,9 +34,6 @@ pub enum BadStoreRequest {
 
     #[fail(display = "could not schedule event processing")]
     ScheduleFailed,
-
-    #[fail(display = "failed to fetch project information")]
-    ProjectFailed(#[cause] ProjectError),
 
     #[fail(display = "empty request body")]
     EmptyBody,
@@ -101,15 +98,6 @@ impl ResponseError for BadStoreRequest {
                     .header(utils::RATE_LIMITS_HEADER, rate_limits_header)
                     .json(&body)
             }
-            BadStoreRequest::ProjectFailed(project_error) => match project_error {
-                ProjectError::FetchFailed => {
-                    // This particular project is somehow broken. We could treat this as 503 but it's
-                    // more likely that the error is local to this project.
-                    HttpResponse::InternalServerError().json(&body)
-                }
-                ProjectError::ScheduleFailed => HttpResponse::ServiceUnavailable().json(&body),
-            },
-
             BadStoreRequest::ScheduleFailed | BadStoreRequest::QueueFailed(_) => {
                 // These errors indicate that something's wrong with our actor system, most likely
                 // mailbox congestion or a faulty shutdown. Indicate an unavailable service to the
@@ -328,11 +316,10 @@ where
             ProjectCache::from_registry()
                 .send(CheckEnvelope::new(project_key, envelope, envelope_context))
                 .map_err(|_| BadStoreRequest::ScheduleFailed)
-                .and_then(|result| result.map_err(BadStoreRequest::ProjectFailed))
         })
         .and_then(clone!(config, |response| {
             // Skip over queuing and issue a rate limit right away
-            let checked = response.result.map_err(BadStoreRequest::EventRejected)?;
+            let checked = response.map_err(BadStoreRequest::EventRejected)?;
             let (envelope, mut envelope_context) = match checked.envelope {
                 Some(tuple) => tuple,
                 None => return Err(BadStoreRequest::RateLimited(checked.rate_limits)),


### PR DESCRIPTION
Since #1416 the CheckEnvelope message no longer needs to return scoping. This is
now passed through the EnvelopeContext. This PR removes dead fields and cleans
up code around it.

#skip-changelog

