### PR TITLE
ref: Move envelope queueing directly into the endpoint handler

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -267,9 +267,7 @@ pub fn cors(app: ServiceApp) -> CorsBuilder<ServiceState> {
 ///   going straight into metrics aggregation. See [`ProcessMetrics`] for a full description.
 ///
 /// Queueing can fail if the queue exceeds [`Config::envelope_buffer_size`]. In this case, `Err` is
-/// returned and the envelope is not queued. Otherwise, this message responds with `Ok`. If it
-/// contained an event-related item, such as an event payload or an attachment, this contains
-/// `Some(EventId)`.
+/// returned and the envelope is not queued.
 fn queue_envelope(
     mut envelope: Envelope,
     mut envelope_context: EnvelopeContext,

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -266,7 +266,7 @@ pub fn cors(app: ServiceApp) -> CorsBuilder<ServiceState> {
 /// - Metrics are directly sent to the [`EnvelopeProcessor`], bypassing the manager's queue and
 ///   going straight into metrics aggregation. See [`ProcessMetrics`] for a full description.
 ///
-/// Queueing can fail if the queue exceeds [`Config::envelope_buffer_size`]. In this case, `Err` is
+/// Queueing can fail if the queue exceeds `envelope_buffer_size`. In this case, `Err` is
 /// returned and the envelope is not queued.
 fn queue_envelope(
     mut envelope: Envelope,

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -18,14 +18,16 @@ use relay_log::LogError;
 use relay_quotas::RateLimits;
 use relay_statsd::metric;
 
-use crate::actors::envelopes::{EnvelopeManager, QueueEnvelope, QueueEnvelopeError};
 use crate::actors::outcome::{DiscardReason, Outcome};
-use crate::actors::project_cache::{CheckEnvelope, ProjectCache};
-use crate::envelope::{AttachmentType, Envelope, EnvelopeError, ItemType, Items};
+use crate::actors::processor::{EnvelopeProcessor, ProcessMetrics};
+use crate::actors::project_cache::{CheckEnvelope, ProjectCache, ValidateEnvelope};
+use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
 use crate::extractors::RequestMeta;
 use crate::service::{ServiceApp, ServiceState};
 use crate::statsd::RelayCounters;
-use crate::utils::{self, ApiErrorResponse, FormDataIter, MultipartError};
+use crate::utils::{
+    self, ApiErrorResponse, BufferError, BufferGuard, EnvelopeContext, FormDataIter, MultipartError,
+};
 
 #[derive(Fail, Debug)]
 pub enum BadStoreRequest {
@@ -63,7 +65,7 @@ pub enum BadStoreRequest {
     InvalidEventId,
 
     #[fail(display = "failed to queue envelope")]
-    QueueFailed(#[cause] QueueEnvelopeError),
+    QueueFailed(#[cause] BufferError),
 
     #[fail(display = "failed to read request body")]
     PayloadError(#[cause] PayloadError),
@@ -252,6 +254,73 @@ pub fn cors(app: ServiceApp) -> CorsBuilder<ServiceState> {
     builder
 }
 
+/// Queues an envelope for processing.
+///
+/// Depending on the items in the envelope, there are multiple outcomes:
+///
+/// - Events and event related items, such as attachments, are always queued together. See the
+///   [crate-level documentation](crate) for a full description of how envelopes are
+///   queued and processed.
+/// - Sessions and Session batches are always queued separately. If they occur in the same envelope
+///   as an event, they are split off. Their path is the same as other Envelopes.
+/// - Metrics are directly sent to the [`EnvelopeProcessor`], bypassing the manager's queue and
+///   going straight into metrics aggregation. See [`ProcessMetrics`] for a full description.
+///
+/// Queueing can fail if the queue exceeds [`Config::envelope_buffer_size`]. In this case, `Err` is
+/// returned and the envelope is not queued. Otherwise, this message responds with `Ok`. If it
+/// contained an event-related item, such as an event payload or an attachment, this contains
+/// `Some(EventId)`.
+fn queue_envelope(
+    mut envelope: Envelope,
+    mut envelope_context: EnvelopeContext,
+    buffer_guard: &BufferGuard,
+) -> Result<(), BadStoreRequest> {
+    // Remove metrics from the envelope and queue them directly on the project's `Aggregator`.
+    let mut metric_items = Vec::new();
+    let is_metric = |i: &Item| matches!(i.ty(), ItemType::Metrics | ItemType::MetricBuckets);
+    while let Some(item) = envelope.take_item_by(is_metric) {
+        metric_items.push(item);
+    }
+
+    if !metric_items.is_empty() {
+        relay_log::trace!("sending metrics into processing queue");
+        EnvelopeProcessor::from_registry().do_send(ProcessMetrics {
+            items: metric_items,
+            project_key: envelope.meta().public_key(),
+            start_time: envelope.meta().start_time(),
+            sent_at: envelope.sent_at(),
+        });
+    }
+
+    // Split the envelope into event-related items and other items. This allows to fast-track:
+    //  1. Envelopes with only session items. They only require rate limiting.
+    //  2. Event envelope processing can bail out if the event is filtered or rate limited,
+    //     since all items depend on this event.
+    if let Some(event_envelope) = envelope.split_by(Item::requires_event) {
+        relay_log::trace!("queueing separate envelope for non-event items");
+
+        // The envelope has been split, so we need to fork the context.
+        let event_context = buffer_guard
+            .enter(&event_envelope)
+            .map_err(BadStoreRequest::QueueFailed)?;
+
+        // Update the old context after successful forking.
+        envelope_context.update(&envelope);
+        ProjectCache::from_registry().do_send(ValidateEnvelope::new(event_envelope, event_context));
+    }
+
+    if envelope.is_empty() {
+        // The envelope can be empty here if it contained only metrics items which were removed
+        // above. In this case, the envelope was accepted and needs no further queueing.
+        envelope_context.accept();
+    } else {
+        relay_log::trace!("queueing envelope");
+        ProjectCache::from_registry().do_send(ValidateEnvelope::new(envelope, envelope_context));
+    }
+
+    Ok(())
+}
+
 /// Handles Sentry events.
 ///
 /// Sentry events may come either directly from a http request ( the store endpoint calls this
@@ -284,8 +353,7 @@ where
         version = &format!("{}", version)
     );
 
-    let project_key = meta.public_key();
-    let start_time = meta.start_time();
+    let buffer_guard = request.state().buffer_guard();
     let config = request.state().config();
     let event_id = Rc::new(RefCell::new(None));
 
@@ -314,44 +382,27 @@ where
         }))
         .and_then(move |(envelope, envelope_context)| {
             ProjectCache::from_registry()
-                .send(CheckEnvelope::new(project_key, envelope, envelope_context))
+                .send(CheckEnvelope::new(envelope, envelope_context))
                 .map_err(|_| BadStoreRequest::ScheduleFailed)
         })
-        .and_then(clone!(config, |response| {
-            // Skip over queuing and issue a rate limit right away
+        .and_then(move |response| {
             let checked = response.map_err(BadStoreRequest::EventRejected)?;
-            let (envelope, mut envelope_context) = match checked.envelope {
-                Some(tuple) => tuple,
-                None => return Err(BadStoreRequest::RateLimited(checked.rate_limits)),
-            };
 
-            if utils::check_envelope_size_limits(&config, &envelope) {
-                Ok((envelope, envelope_context, checked.rate_limits))
-            } else {
-                envelope_context.reject(Outcome::Invalid(DiscardReason::TooLarge));
-                Err(BadStoreRequest::PayloadError(PayloadError::Overflow))
-            }
-        }))
-        .and_then(move |(envelope, envelope_context, rate_limits)| {
-            let message = QueueEnvelope {
-                envelope,
-                envelope_context,
-                project_key,
-                start_time,
-            };
+            if let Some((envelope, mut envelope_context)) = checked.envelope {
+                if !utils::check_envelope_size_limits(&config, &envelope) {
+                    envelope_context.reject(Outcome::Invalid(DiscardReason::TooLarge));
+                    return Err(BadStoreRequest::PayloadError(PayloadError::Overflow));
+                }
 
-            EnvelopeManager::from_registry()
-                .send(message)
-                .map_err(|_| BadStoreRequest::ScheduleFailed)
-                .and_then(|result| result.map_err(BadStoreRequest::QueueFailed))
-                .map(move |event_id| (event_id, rate_limits))
-        })
-        .and_then(move |(event_id, rate_limits)| {
-            if rate_limits.is_limited() {
-                Err(BadStoreRequest::RateLimited(rate_limits))
-            } else {
-                Ok(create_response(event_id))
+                let event_id = envelope.event_id();
+                queue_envelope(envelope, envelope_context, &buffer_guard)?;
+
+                if !checked.rate_limits.is_limited() {
+                    return Ok(create_response(event_id));
+                }
             }
+
+            Err(BadStoreRequest::RateLimited(checked.rate_limits))
         })
         .or_else(move |error: BadStoreRequest| {
             metric!(counter(RelayCounters::EnvelopeRejected) += 1);

--- a/relay-server/src/utils/buffer.rs
+++ b/relay-server/src/utils/buffer.rs
@@ -20,7 +20,7 @@ impl std::error::Error for BufferError {}
 /// Access control for envelope processing.
 ///
 /// The buffer guard is basically a semaphore that ensures the buffer does not outgrow the maximum
-/// number of envelopes configured through [`Config::envelope_buffer_size`]. To enter a new envelope
+/// number of envelopes configured through `envelope_buffer_size`. To enter a new envelope
 /// into the processing pipeline, use [`BufferGuard::enter`].
 #[derive(Debug)]
 pub struct BufferGuard {

--- a/relay-server/src/utils/buffer.rs
+++ b/relay-server/src/utils/buffer.rs
@@ -1,0 +1,69 @@
+use std::fmt;
+
+use crate::envelope::Envelope;
+use crate::statsd::RelayHistograms;
+use crate::utils::{EnvelopeContext, Semaphore};
+
+/// An error returned by [`BufferGuard::enter`] indicating that the buffer capacity has been
+/// exceeded.
+#[derive(Debug)]
+pub struct BufferError;
+
+impl fmt::Display for BufferError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "envelope buffer capacity exceeded")
+    }
+}
+
+impl std::error::Error for BufferError {}
+
+/// Access control for envelope processing.
+///
+/// The buffer guard is basically a semaphore that ensures the buffer does not outgrow the maximum
+/// number of envelopes configured through [`Config::envelope_buffer_size`]. To enter a new envelope
+/// into the processing pipeline, use [`BufferGuard::enter`].
+#[derive(Debug)]
+pub struct BufferGuard {
+    inner: Semaphore,
+    capacity: usize,
+}
+
+impl BufferGuard {
+    /// Creates a new `BufferGuard` based on config values.
+    pub fn new(capacity: usize) -> Self {
+        let inner = Semaphore::new(capacity);
+        Self { inner, capacity }
+    }
+
+    /// Returns the unused capacity of the pipeline.
+    pub fn available(&self) -> usize {
+        self.inner.available()
+    }
+
+    /// Returns the number of envelopes in the pipeline.
+    pub fn used(&self) -> usize {
+        self.capacity.saturating_sub(self.available())
+    }
+
+    /// Reserves resources for processing an envelope in Relay.
+    ///
+    /// Returns `Ok(EnvelopeContext)` on success, which internally holds a handle to the reserved
+    /// resources. When the envelope context is dropped, the slot is automatically reclaimed and can
+    /// be reused by a subsequent call to `enter`.
+    ///
+    /// If the buffer is full, this function returns `Err`.
+    pub fn enter(&self, envelope: &Envelope) -> Result<EnvelopeContext, BufferError> {
+        let permit = self.inner.try_acquire().ok_or(BufferError)?;
+
+        relay_statsd::metric!(histogram(RelayHistograms::EnvelopeQueueSize) = self.used() as u64);
+
+        relay_statsd::metric!(
+            histogram(RelayHistograms::EnvelopeQueueSizePct) = {
+                let queue_size_pct = self.used() as f64 * 100.0 / self.capacity as f64;
+                queue_size_pct.floor() as u64
+            }
+        );
+
+        Ok(EnvelopeContext::new(envelope, permit))
+    }
+}

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -1,5 +1,6 @@
 mod actix;
 mod api;
+mod buffer;
 mod dynamic_sampling;
 mod envelope_context;
 mod error_boundary;
@@ -23,6 +24,7 @@ mod unreal;
 
 pub use self::actix::*;
 pub use self::api::*;
+pub use self::buffer::*;
 pub use self::dynamic_sampling::*;
 pub use self::envelope_context::*;
 pub use self::error_boundary::*;

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -213,7 +213,7 @@ def test_store_buffer_size(mini_sentry, relay):
 
         for (_, error) in mini_sentry.test_failures:
             assert isinstance(error, AssertionError)
-            assert "Too many envelopes" in str(error)
+            assert "buffer capacity exceeded" in str(error)
     finally:
         mini_sentry.test_failures.clear()
 


### PR DESCRIPTION
The `QueueEnvelope` message no longer needs to reside on the `EnvelopeManager`
since #1416. Instead, it has become a simple dispatch function that calls
`ProcessMetrics` and `ValidateEnvelope` directly on the target actors.

To skip a redundant message, this PR removes this message entirely and moves its
code into the endpoint handler code. The BufferGuard has moved into utilities.

There is no expected change in behavior or performance, although there could be
a slight decrease in latency since the endpoint no longer has to wait for this
actor.

#skip-changelog

