### PR TITLE
ci(gha): Modernize CI with updated actions

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -21,7 +21,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -42,4 +42,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets --all-features
+          args: --workspace --all-features

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -5,7 +5,7 @@ on:
     - cron: "11 7 * * 1,4"
 
 env:
-  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
 
 jobs:
   test-all:

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -32,13 +32,14 @@ jobs:
           override: true
           components: clippy
 
-      - name: Run clippy
+      - name: Run Clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --workspace --tests --examples -- -D clippy::all
+          args: --workspace --all-targets --all-features --no-deps -- -D warnings
 
-      - uses: actions-rs/cargo@v1
+      - name: Run Cargo Tests
+        uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features
+          args: --workspace --all-targets --all-features

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release/**
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -30,7 +30,7 @@ jobs:
           zip relay-Linux-x86_64-debug.zip relay.debug
           mv relay relay-Linux-x86_64
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: target/x86_64-unknown-linux-gnu/release/relay-Linux-x86_64*
@@ -64,7 +64,7 @@ jobs:
           mv relay relay-Darwin-x86_64
           zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: target/release/relay-Darwin-x86_64*
@@ -97,7 +97,7 @@ jobs:
           7z a relay-Windows-x86_64-pdb.zip relay.pdb
           mv relay.exe relay-Windows-x86_64.exe
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: target/release/relay-Windows-x86_64*

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -71,7 +71,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release-library/**
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           BUILD_ARCH: ${{ matrix.build-arch }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: py/dist/*
@@ -81,7 +81,7 @@ jobs:
           # consumed by cargo and setup.py to obtain the target dir
           CARGO_BUILD_TARGET: ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: py/dist/*
@@ -103,7 +103,7 @@ jobs:
         run: python setup.py sdist --format=zip
         working-directory: py
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: py/dist/*

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.macos-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -68,7 +68,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -95,7 +95,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           args: --workspace --all-targets --no-deps -- -D warnings
 
   test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +139,7 @@ jobs:
           args: --workspace
 
   test_all:
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: Test All Features (ubuntu-latest)
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -206,7 +206,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -283,7 +283,7 @@ jobs:
           command: build
           args: --all-features
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           RUSTFLAGS: -Dwarnings
         with:
           command: test
-          args: --workspace --all-targets
+          args: --workspace
 
   test_all:
     timeout-minutes: 10
@@ -181,7 +181,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets --all-features
+          args: --workspace --all-features
 
   test_py:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         with:
           command: doc
-          args: --workspace --all-targets --all-features --no-deps --document-private-items
+          args: --workspace --all-features --no-deps --document-private-items
 
   lint_default:
     name: Lint Rust Default Features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           components: clippy, rustfmt, rust-docs
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 
@@ -96,7 +96,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 
@@ -141,7 +141,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 
@@ -182,7 +182,7 @@ jobs:
       - name: Install Dependencies
         run: pip install -U pytest
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 
@@ -242,7 +242,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 25
 
     steps:
       - name: Install libcurl-dev
@@ -62,18 +61,49 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features --tests -- -D clippy::all
+          args: --workspace --all-targets --all-features --no-deps -- -D warnings
 
-      - name: Rust Doc Comments
+      - name: Check Docs
         uses: actions-rs/cargo@v1
         env:
           RUSTDOCFLAGS: -Dwarnings
         with:
           command: doc
-          args: --workspace --all-features --document-private-items --no-deps
+          args: --workspace --all-targets --all-features --no-deps --document-private-items
+
+  lint_default:
+    name: Lint Rust Default Features
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install libcurl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
+          override: true
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ github.job }}
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --all-targets --no-deps -- -D warnings
 
   test:
-    timeout-minutes: 25
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -102,12 +132,14 @@ jobs:
 
       - name: Run Cargo Tests
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -Dwarnings
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-targets
 
   test_all:
-    timeout-minutes: 25
+    timeout-minutes: 10
     name: Test All Features (ubuntu-latest)
     runs-on: ubuntu-latest
 
@@ -149,10 +181,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features
+          args: --workspace --all-targets --all-features
 
   test_py:
-    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -197,7 +228,7 @@ jobs:
   test_integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
 
     # Skip redundant checks for library releases
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y libcurl4-openssl-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -86,7 +86,7 @@ jobs:
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -131,7 +131,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y libcurl4-openssl-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -232,7 +232,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y libcurl4-openssl-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -271,13 +271,13 @@ jobs:
 
     steps:
       - name: Checkout Relay
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
       # Checkout Sentry and run integration tests against latest Relay
       - name: Checkout Sentry
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: getsentry/sentry
           path: sentry

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,7 +8,7 @@ jobs:
     name: Changelogs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
       - run: npx danger@10.5.3 ci
         env:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
       - run: npx danger@10.5.3 ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
   # Run actions on PRs, but only deploy on master
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   cargo_docs:
     name: Cargo Docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y libcurl4-openssl-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           components: rust-docs
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 
@@ -67,7 +67,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 
@@ -121,7 +121,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,6 @@ jobs:
     name: Cargo Docs
     runs-on: ubuntu-latest
 
-    env:
-      RUSTDOCFLAGS: -Dbroken_intra_doc_links
-
     steps:
       - name: Install libcurl-dev
         run: |
@@ -42,9 +39,11 @@ jobs:
 
       - name: Build Docs
         uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: -Dwarnings
         with:
           command: doc
-          args: --workspace --all-features --no-deps
+          args: --workspace --all-targets --all-features --no-deps
 
       - run: echo '<meta http-equiv="refresh" content="0; url=relay/" />Redirecting to <a href="relay/">relay</a>' > target/doc/index.html
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         with:
           command: doc
-          args: --workspace --all-targets --all-features --no-deps
+          args: --workspace --all-features --no-deps
 
       - run: echo '<meta http-equiv="refresh" content="0; url=relay/" />Redirecting to <a href="relay/">relay</a>' > target/doc/index.html
 

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -21,7 +21,7 @@ jobs:
     name: "Release a new Relay version"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -16,7 +16,7 @@ jobs:
     name: "Release a new librelay version"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ test: test-rust-all test-python test-integration ## run all unit and integration
 .PHONY: test
 
 test-rust: setup-git ## run tests for Rust code with default features enabled
-	cargo test --workspace
+	cargo test --workspace --all-targets
 .PHONY: test-rust
 
 test-rust-all: setup-git ## run tests for Rust code with all the features enabled
-	cargo test --workspace --all-features
+	cargo test --workspace --all-targets --all-features
 .PHONY: test-rust-all
 
 test-python: setup-git setup-venv ## run tests for Python code
@@ -66,12 +66,12 @@ test-integration: build setup-venv ## run integration tests
 
 # Documentation
 
-doc: doc-api ## generate all API docs
-.PHONY: doc-api
+doc: doc-rust ## generate all API docs
+.PHONY: doc
 
-doc-api: setup-git ## generate API docs for Rust code
+doc-rust: setup-git ## generate API docs for Rust code
 	cargo doc --workspace --all-features --no-deps
-.PHONY: doc-api
+.PHONY: doc-rust
 
 # Style checking
 
@@ -94,7 +94,7 @@ lint: lint-rust lint-python ## runt lint on Python and Rust code
 
 lint-rust: setup-git ## run lint on Rust code using clippy
 	@rustup component add clippy --toolchain stable 2> /dev/null
-	cargo +stable clippy --workspace --all-features --tests -- -D clippy::all
+	cargo +stable clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 .PHONY: lint-rust
 
 lint-python: setup-venv ## run lint on Python code using flake8
@@ -130,7 +130,7 @@ setup-git: .git/hooks/pre-commit init-submodules ## make sure all git configured
 setup-venv: .venv/bin/python .venv/python-requirements-stamp ## create a Python virtual environment with development requirements installed
 .PHONY: setup-venv
 
-devserver: ## run the development server
+devserver: ## run an auto-reloading development server
 	@systemfd --no-pid -s http::3000 -- cargo watch -x "run -- run"
 .PHONY: devserver
 

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ test: test-rust-all test-python test-integration ## run all unit and integration
 .PHONY: test
 
 test-rust: setup-git ## run tests for Rust code with default features enabled
-	cargo test --workspace --all-targets
+	cargo test --workspace
 .PHONY: test-rust
 
 test-rust-all: setup-git ## run tests for Rust code with all the features enabled
-	cargo test --workspace --all-targets --all-features
+	cargo test --workspace --all-features
 .PHONY: test-rust-all
 
 test-python: setup-git setup-venv ## run tests for Python code

--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -18,4 +18,4 @@ relay-system = { path = "../relay-system" }
 reqwest = { version = "0.11.1", features = ["json", "blocking"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
+tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "256"]
-#![allow(clippy::cognitive_complexity)]
 #![deny(unused_must_use)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",

--- a/relay-metrics/benches/aggregator.rs
+++ b/relay-metrics/benches/aggregator.rs
@@ -44,7 +44,7 @@ impl MetricInput {
 
         for i in 0..self.num_metrics {
             let key_id = i % self.num_project_keys;
-            let metric_name = format!("foo{}", i % self.num_metric_names);
+            let metric_name = format!("c:transactions/foo{}", i % self.num_metric_names);
             let mut metric = self.metric.clone();
             metric.name = metric_name;
             let key = ProjectKey::parse(&format!("{:0width$x}", key_id, width = 32)).unwrap();
@@ -79,7 +79,7 @@ fn bench_insert_and_flush(c: &mut Criterion) {
     let flush_receiver = TestReceiver.start().recipient();
 
     let counter = Metric {
-        name: "custom/foo@none".to_owned(),
+        name: "c:transactions/foo@none".to_owned(),
         value: MetricValue::Counter(42.),
         timestamp: UnixTimestamp::now(),
         tags: BTreeMap::new(),

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -72,7 +72,7 @@ smallvec = { version = "1.4.0", features = ["serde"] }
 symbolic-common = { version = "8.7.2", optional = true, default-features=false }
 symbolic-unreal = { version = "8.7.2", optional = true, default-features=false, features=["serde"] }
 take_mut = "0.2.2"
-tokio = { version = "1.0", features = ["rt-multi-thread"] } # in sync with reqwest
+tokio = { version = "1.0", features = ["rt-multi-thread", "sync"] }
 tokio-timer = "0.2.13"
 url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "0.8.1", features = ["v5"] }

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -16,5 +16,5 @@ futures01 = { version = "0.1.28", package = "futures" }
 futures = { version = "0.3", package = "futures", features = ["compat"] }
 once_cell = "1.13.1"
 relay-log = { path = "../relay-log" }
-tokio = { version = "1.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "sync"] }
 tokio01 = { version = "0.1", package = "tokio" }


### PR DESCRIPTION
Enables color output for all Rust builds, removes obsolete lints, localizes
warnings in lint jobs (tests no longer fail because of unused variables), and
upgrades the following GitHub actions:

- Upgrade to actions/checkout v3
- Upgrade swatinem/rust-cache to v2
- Upgrade actions/setup-python to v4
- Update actions/upload-artifact to v3
- Update actions/setup-node to v3

#skip-changelog
