### PR TITLE
feat(metrics): Actually batch by partition, set request header [INGEST-1562]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Defer dropping of projects to a background thread to speed up project cache eviction. ([#1410](https://github.com/getsentry/relay/pull/1410))
 - Update store service to use generic Addr and minor changes to generic Addr. ([#1415](https://github.com/getsentry/relay/pull/1415))
 - Added new Register for the Services that is initialized later than the current. ([#1421](https://github.com/getsentry/relay/pull/1421))
+- Batch metrics buckets into logical partitions before sending them as envelopes. ([#1440](https://github.com/getsentry/relay/pull/1440))
 
 **Features**:
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::fmt;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -345,6 +344,7 @@ impl Handler<SubmitEnvelope> for EnvelopeManager {
 ///
 /// Responds with `Err` if there was an error sending some or all of the buckets, containing the
 /// failed buckets.
+#[derive(Debug)]
 pub struct SendMetrics {
     /// The pre-aggregated metric buckets.
     pub buckets: Vec<Bucket>,
@@ -354,17 +354,6 @@ pub struct SendMetrics {
     pub project_key: ProjectKey,
     /// The key of the logical partition to send the metrics to.
     pub partition_key: u64,
-}
-
-impl fmt::Debug for SendMetrics {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct(std::any::type_name::<Self>())
-            .field("buckets", &self.buckets)
-            .field("scoping", &self.scoping)
-            .field("project", &format_args!("Addr<Project>"))
-            .field("partition", &format_args!("{}", self.partition_key))
-            .finish()
-    }
 }
 
 impl Message for SendMetrics {

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -554,6 +554,10 @@ impl UpstreamRelay {
             }
         }
 
+        if let Some(partition_key) = request.request.partition_key() {
+            builder.header("X-Sentry-Relay-Shard", partition_key);
+        }
+
         //try to build a ClientRequest
         let client_request = match request.request.build(builder) {
             Err(e) => {
@@ -1079,6 +1083,11 @@ pub trait UpstreamRequest: Send {
     /// This should be done (only) for calls to endpoints that use Relay authentication.
     fn set_relay_id(&self) -> bool {
         true
+    }
+
+    /// TODO: docs
+    fn partition_key(&self) -> Option<&String> {
+        None
     }
 
     /// Called whenever the request will be send over HTTP (possible multiple times)

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -1085,7 +1085,10 @@ pub trait UpstreamRequest: Send {
         true
     }
 
-    /// TODO: docs
+    /// Returns the value that will be used for the X-Sentry-Relay-Shard HTTP header.
+    ///
+    /// If set to None, the header will be omitted.
+    ///
     fn partition_key(&self) -> Option<&String> {
         None
     }

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -218,7 +218,7 @@ def mini_sentry(request):
         if flask_request.headers.get("transfer-encoding"):
             abort(400, "transfer encoding not supported")
 
-        sentry.request_log.append(flask_request.url)
+        sentry.request_log.append((flask_request.headers, flask_request.url))
 
     @app.route("/api/0/relays/register/challenge/", methods=["POST"])
     def get_challenge():

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -102,28 +102,42 @@ def test_metrics_backdated(mini_sentry, relay):
     ]
 
 
-def test_metrics_partition_key(mini_sentry, relay):
+@pytest.mark.parametrize(
+    "flush_partitions,expected_header", [(None, "0"), (0, "0"), (1, "0"), (128, "34")]
+)
+def test_metrics_partition_key(mini_sentry, relay, flush_partitions, expected_header):
+    forever = 100 * 365 * 24 * 60 * 60  # *almost forever
     relay_config = {
+        "processing": {"max_session_secs_in_past": forever,},
         "aggregator": {
             "bucket_interval": 1,
             "initial_delay": 0,
             "debounce_delay": 0,
-            "flush_partitions": 1,
-        }
+            "flush_partitions": flush_partitions,
+            "max_secs_in_past": forever,
+            "max_secs_in_future": forever,
+        },
     }
     relay = relay(mini_sentry, options=relay_config)
 
     project_id = 42
-    mini_sentry.add_basic_project_config(project_id)
+    mini_sentry.add_basic_project_config(
+        project_id,
+        dsn_public_key={  # Need explicit DSN to get a consistent partition key
+            "publicKey": "31a5a894b4524f74a9a8d0e27e21ba91",
+            "isEnabled": True,
+            "numericId": 42,
+        },
+    )
 
-    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"transactions/foo:42|c\ntransactions/bar:17|c"
+    timestamp = 999994711
+    metrics_payload = f"transactions/foo:42|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     mini_sentry.captured_events.get(timeout=3)
 
     headers, _ = mini_sentry.request_log[-1]
-    assert headers.get("X-Sentry-Relay-Shard") == "0", headers
+    assert headers.get("X-Sentry-Relay-Shard") == expected_header, headers
 
 
 def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_consumer):


### PR DESCRIPTION
Convert the dry run implemented in #1425 into an actual batching mechanism that splits metrics buckets into logical partitions.

The `partition_key` has to be passed through `ProjectCache`, `EnvelopeManager` and `UpstreamRelay` to be set as a header on the outgoing envelope request.