### PR TITLE
fix(normalization): Light normalize logentry [ISSUE-1574]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Do not apply rate limits or reject data based on expired project configs. ([#1404](https://github.com/getsentry/relay/pull/1404))
 - Process required stacktraces to fix filtering events originating from browser extensions. ([#1423](https://github.com/getsentry/relay/pull/1423))
+- Fix error message filtering when formatting the message of logentry. ([#1442](https://github.com/getsentry/relay/pull/1442))
 
 **Internal**:
 

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -529,6 +529,10 @@ fn normalize_ip_addresses(event: &mut Event, client_ip: Option<&IpAddr>) {
     }
 }
 
+fn normalize_logentry(logentry: &mut Annotated<LogEntry>, meta: &mut Meta) -> ProcessingResult {
+    logentry.apply(|le, _| logentry::normalize_logentry(le, meta))
+}
+
 #[derive(Default, Debug)]
 pub struct LightNormalizationConfig<'a> {
     pub client_ip: Option<&'a IpAddr>,
@@ -574,6 +578,7 @@ pub fn light_normalize_event(
         })?;
 
         // Default required attributes, even if they have errors
+        normalize_logentry(&mut event.logentry, meta)?;
         normalize_release_dist(event); // dist is a tag extracted along with other metrics from transactions
         normalize_timestamps(
             event,
@@ -720,14 +725,6 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         }
     }
 
-    fn process_logentry(
-        &mut self,
-        logentry: &mut LogEntry,
-        meta: &mut Meta,
-        _state: &ProcessingState<'_>,
-    ) -> ProcessingResult {
-        logentry::normalize_logentry(logentry, meta)
-    }
 
     fn process_exception(
         &mut self,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -725,7 +725,6 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         }
     }
 
-
     fn process_exception(
         &mut self,
         exception: &mut Exception,

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -1,4 +1,5 @@
 import datetime
+from time import sleep
 import pytest
 
 
@@ -99,6 +100,7 @@ def test_error_message_filters_are_applied(
     }
 
     relay.send_event(project_id, event)
+    sleep(1)
 
     if must_filter:
         events_consumer.assert_empty()


### PR DESCRIPTION
Error message filters look at the `formatted` and `message` entries of
an event, in that order. If `formatted` is not provided in the payload,
relay builds it from `message` and `params`, [see
docs](https://develop.sentry.dev/sdk/event-payloads/types/#typedef-LogEntry).
That build, aka logentry normalization, doesn't happen before filters
are applied. As a result, events with a `formatted` string that should
be filtered out are not, due to the string not being built yet.