### PR TITLE
feat(replays): Add looser type requirements for the user.id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update store service to use generic Addr and minor changes to generic Addr. ([#1415](https://github.com/getsentry/relay/pull/1415))
 - Added new Register for the Services that is initialized later than the current. ([#1421](https://github.com/getsentry/relay/pull/1421))
 - Batch metrics buckets into logical partitions before sending them as envelopes. ([#1440](https://github.com/getsentry/relay/pull/1440))
+- Add looser type requirements for the user.id field. ([#1443](https://github.com/getsentry/relay/pull/1443))
 
 **Features**:
 

--- a/relay-replays/src/lib.rs
+++ b/relay-replays/src/lib.rs
@@ -256,6 +256,7 @@ mod tests {
         let result = normalize_replay_event(payload, None);
         assert!(result.is_ok());
 
+        // Assert the user payload is just generally unaffected by parsing.
         let replay_output: ReplayInput = serde_json::from_slice(&result.unwrap()).unwrap();
         assert!(replay_output.user.ip_address.unwrap() == *"127.1.1.1");
         assert!(replay_output.user.username.is_none());

--- a/relay-replays/src/lib.rs
+++ b/relay-replays/src/lib.rs
@@ -255,5 +255,11 @@ mod tests {
         let payload = include_bytes!("../tests/fixtures/replay_failure_22_08_31.json");
         let result = normalize_replay_event(payload, None);
         assert!(result.is_ok());
+
+        let replay_output: ReplayInput = serde_json::from_slice(&result.unwrap()).unwrap();
+        assert!(replay_output.user.ip_address.unwrap() == *"127.1.1.1");
+        assert!(replay_output.user.username.is_none());
+        assert!(replay_output.user.email.unwrap() == *"email@sentry.io");
+        assert!(replay_output.user.id.unwrap().is_number());
     }
 }

--- a/relay-replays/src/lib.rs
+++ b/relay-replays/src/lib.rs
@@ -30,7 +30,7 @@ use std::fmt::Write;
 use std::net::IpAddr;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Error;
+use serde_json::{Error, Value};
 
 use relay_general::user_agent;
 
@@ -147,7 +147,7 @@ struct VersionedMeta {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct User {
-    id: Option<String>,
+    id: Option<Value>,
     username: Option<String>,
     email: Option<String>,
     ip_address: Option<String>,
@@ -171,7 +171,7 @@ struct Headers {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use crate::ReplayInput;
+    use crate::{normalize_replay_event, ReplayInput};
 
     #[test]
     fn test_set_ip_address() {
@@ -248,5 +248,12 @@ mod tests {
         assert!(device.family == *"Other");
         assert!(device.brand.is_none());
         assert!(device.model.is_none());
+    }
+
+    #[test]
+    fn test_loose_type_requirements() {
+        let payload = include_bytes!("../tests/fixtures/replay_failure_22_08_31.json");
+        let result = normalize_replay_event(payload, None);
+        assert!(result.is_ok());
     }
 }

--- a/relay-replays/tests/fixtures/replay_failure_22_08_31.json
+++ b/relay-replays/tests/fixtures/replay_failure_22_08_31.json
@@ -1,0 +1,76 @@
+{
+    "type": "replay_event",
+    "replay_start_timestamp": 1661961775.54,
+    "error_ids": [],
+    "trace_ids": [],
+    "urls": [],
+    "replay_id": "74c71922ae80410f9ad4563fa051c177",
+    "segment_id": 6,
+    "platform": "javascript",
+    "event_id": "d88bf2440b7f40f2854165bcb81db8f3",
+    "timestamp": 1661961780.614,
+    "environment": "prod",
+    "release": "frontend@76d8e21fb89c322a41bc3fd23972fab429b25dee",
+    "sdk": {
+        "integrations": [
+            "InboundFilters",
+            "FunctionToString",
+            "TryCatch",
+            "Breadcrumbs",
+            "GlobalHandlers",
+            "LinkedErrors",
+            "Dedupe",
+            "HttpContext",
+            "ExtraErrorData",
+            "BrowserTracing"
+        ],
+        "name": "sentry.javascript.react",
+        "version": "7.11.0",
+        "packages": [
+            {
+                "name": "npm:@sentry/react",
+                "version": "7.11.0"
+            }
+        ]
+    },
+    "tags": {
+        "transaction": "/organizations/:orgId/replays/",
+        "sentry_version": "22.9.0.dev0",
+        "organization": "1",
+        "organization.slug": "sentry",
+        "plan": "am1_business_ent_auf",
+        "plan.name": "Business",
+        "plan.max_members": "null",
+        "plan.total_members": "315",
+        "plan.tier": "am1",
+        "timeOrigin.mode": "timeOrigin"
+    },
+    "user": {
+        "ip_address": "73.241.205.8",
+        "email": "josh.ferge@sentry.io",
+        "id": 880461,
+        "isStaff": false,
+        "name": "Josh Ferge"
+    },
+    "contexts": {
+        "trace": {
+            "op": "pageload",
+            "span_id": "96656b785d9f493e",
+            "tags": {
+                "routing.instrumentation": "react-router-v3",
+                "ui.longTaskCount.grouped": "<=1"
+            },
+            "trace_id": "6af20ea8eb1741659686599dc75cc0e1"
+        },
+        "organization": {
+            "id": "1",
+            "slug": "sentry"
+        }
+    },
+    "request": {
+        "url": "https://sentry.io/organizations/sentry/replays/",
+        "headers": {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
+        }
+    }
+}

--- a/relay-replays/tests/fixtures/replay_failure_22_08_31.json
+++ b/relay-replays/tests/fixtures/replay_failure_22_08_31.json
@@ -46,11 +46,11 @@
         "timeOrigin.mode": "timeOrigin"
     },
     "user": {
-        "ip_address": "73.241.205.8",
-        "email": "josh.ferge@sentry.io",
-        "id": 880461,
+        "ip_address": "127.1.1.1",
+        "email": "email@sentry.io",
+        "id": 1,
         "isStaff": false,
-        "name": "Josh Ferge"
+        "name": "First Last"
     },
     "contexts": {
         "trace": {


### PR DESCRIPTION
Skip validation of the user.id field.  We will validate on the consumer side with the intent of adding stricter validation to relay in the future.