### PR TITLE
build: export LDFLAGS for librdkafka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ clean-target-dir:
 	@if [ "$$(uname -sm)" = "Darwin arm64" ]; then \
 		echo "Using 'librdkafka' from homebrew to build confluent-kafka"; \
 		export C_INCLUDE_PATH="$$(brew --prefix librdkafka)/include"; \
+		export LDFLAGS="-L$$(brew --prefix librdkafka)/lib"; \
 	fi; \
 	.venv/bin/pip install -U -r requirements-dev.txt
 	# Bump the mtime of an empty file.


### PR DESCRIPTION
Since I just set up a machine from scratch, apparently this is needed for a branch new machine to be able to build this on an M1 mac.

#skip-changelog