### PR TITLE
fix: Remove partition_key tag

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1757,7 +1757,6 @@ impl Aggregator {
     {
         let capped_batches =
             CappedBucketIter::new(buckets.into_iter(), self.config.max_flush_bytes);
-        let partition_tag = partition_key.to_string();
 
         let num_batches = capped_batches
             .map(|batch| {

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1747,12 +1747,8 @@ impl Aggregator {
     /// Split the provided buckets into batches and process each batch with the given function.
     ///
     /// For each batch, log a histogram metric.
-    fn process_batches<F>(
-        &self,
-        buckets: impl IntoIterator<Item = Bucket>,
-        partition_key: u64,
-        mut process: F,
-    ) where
+    fn process_batches<F>(&self, buckets: impl IntoIterator<Item = Bucket>, mut process: F)
+    where
         F: FnMut(Vec<Bucket>),
     {
         let capped_batches =
@@ -1796,7 +1792,7 @@ impl Aggregator {
             let num_partitions = self.config.flush_partitions.unwrap_or(1);
             let partitioned_buckets = self.partition_buckets(project_buckets, num_partitions);
             for (partition_key, buckets) in partitioned_buckets {
-                self.process_batches(buckets, partition_key, |batch| {
+                self.process_batches(buckets, |batch| {
                     let fut = self
                         .receiver
                         .send(FlushBuckets {
@@ -3071,8 +3067,8 @@ mod tests {
         let output = run_test_bucket_partitioning(None);
         insta::assert_debug_snapshot!(output, @r###"
         [
-            "metrics.buckets.per_batch:2|h|#partition_key:0",
-            "metrics.buckets.batches_per_partition:1|h|#partition_key:0",
+            "metrics.buckets.per_batch:2|h",
+            "metrics.buckets.batches_per_partition:1|h",
         ]
         "###);
     }
@@ -3082,10 +3078,10 @@ mod tests {
         let output = run_test_bucket_partitioning(Some(128));
         insta::assert_debug_snapshot!(output, @r###"
         [
-            "metrics.buckets.per_batch:1|h|#partition_key:59",
-            "metrics.buckets.batches_per_partition:1|h|#partition_key:59",
-            "metrics.buckets.per_batch:1|h|#partition_key:62",
-            "metrics.buckets.batches_per_partition:1|h|#partition_key:62",
+            "metrics.buckets.per_batch:1|h",
+            "metrics.buckets.batches_per_partition:1|h",
+            "metrics.buckets.per_batch:1|h",
+            "metrics.buckets.batches_per_partition:1|h",
         ]
         "###);
     }

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1763,7 +1763,6 @@ impl Aggregator {
             .map(|batch| {
                 relay_statsd::metric!(
                     histogram(MetricHistograms::BucketsPerBatch) = batch.len() as f64,
-                    partition_key = partition_tag.as_str(),
                 );
                 process(batch);
             })
@@ -1771,7 +1770,6 @@ impl Aggregator {
 
         relay_statsd::metric!(
             histogram(MetricHistograms::BatchesPerPartition) = num_batches as f64,
-            partition_key = partition_tag.as_str(),
         );
     }
 


### PR DESCRIPTION
Turns out we need to increase flush_partitions setting to 60k, so this
metric now has a risk of being high cardinality.

#skip-changelog