### PR TITLE
ref(metrics): Partitioning cleanup [INGEST-1563]

### DIFF
--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -99,19 +99,11 @@ pub enum MetricHistograms {
     BucketsDelay,
 
     /// The number of batches emitted per partition by [`crate::aggregation::Aggregator`].
-    ///
-    /// This metric is only emitted if a partition key is set.
-    ///
-    /// Tags:
-    ///   - `partition_key`: The logical sharding key for the current batch.
     BatchesPerPartition,
 
     /// The number of buckets in a batch emitted by [`crate::aggregation::Aggregator`].
     ///
     /// This corresponds to the number of buckets that will end up in an envelope.
-    ///
-    /// Tags:
-    ///   - `partition_key`: The logical sharding key for the current batch.
     BucketsPerBatch,
 }
 

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -554,10 +554,6 @@ impl UpstreamRelay {
             }
         }
 
-        if let Some(partition_key) = request.request.partition_key() {
-            builder.header("X-Sentry-Relay-Shard", partition_key);
-        }
-
         //try to build a ClientRequest
         let client_request = match request.request.build(builder) {
             Err(e) => {
@@ -1083,14 +1079,6 @@ pub trait UpstreamRequest: Send {
     /// This should be done (only) for calls to endpoints that use Relay authentication.
     fn set_relay_id(&self) -> bool {
         true
-    }
-
-    /// Returns the value that will be used for the X-Sentry-Relay-Shard HTTP header.
-    ///
-    /// If set to None, the header will be omitted.
-    ///
-    fn partition_key(&self) -> Option<&String> {
-        None
     }
 
     /// Called whenever the request will be send over HTTP (possible multiple times)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -103,7 +103,7 @@ def test_metrics_backdated(mini_sentry, relay):
 
 
 @pytest.mark.parametrize(
-    "flush_partitions,expected_header", [(None, "0"), (0, "0"), (1, "0"), (128, "34")]
+    "flush_partitions,expected_header", [(None, None), (0, "0"), (1, "0"), (128, "34")]
 )
 def test_metrics_partition_key(mini_sentry, relay, flush_partitions, expected_header):
     forever = 100 * 365 * 24 * 60 * 60  # *almost forever
@@ -137,7 +137,10 @@ def test_metrics_partition_key(mini_sentry, relay, flush_partitions, expected_he
     mini_sentry.captured_events.get(timeout=3)
 
     headers, _ = mini_sentry.request_log[-1]
-    assert headers.get("X-Sentry-Relay-Shard") == expected_header, headers
+    if expected_header is None:
+        assert "X-Sentry-Relay-Shard" not in headers
+    else:
+        assert headers["X-Sentry-Relay-Shard"] == expected_header, headers
 
 
 def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_consumer):


### PR DESCRIPTION
Wrap up some loose ends from the partitioning story:

- If `flush_partitions` is configured to `None` (the default), do not set the `X-Sentry-Relay-Shard` header. This prevents us from sending all the load to a single processing relay by accident in case the load balancer uses the header, but it is not configured in Relay.
- Remove references to `partition_key` from the upstream actor. The `SendEnvelope` implementation can set the header directly on the builder.
- Update statsd docs.

#skip-changelog