### PR TITLE
instr: Add distribution metric for partition keys [INGEST-1563]

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -3093,13 +3093,21 @@ mod tests {
     #[test]
     fn test_bucket_partitioning_128() {
         let output = run_test_bucket_partitioning(Some(128));
-        insta::assert_debug_snapshot!(output, @r###"
+        // Because buckets are stored in a HashMap, we do not know in what order the buckets will
+        // be processed, so we need to convert them to a set:
+        let (partition_keys, tail) = output.split_at(2);
+        insta::assert_debug_snapshot!(BTreeSet::from_iter(partition_keys), @r###"
+        {
+            "metrics.buckets.partition_keys:59|h",
+            "metrics.buckets.partition_keys:62|h",
+        }
+        "###);
+
+        insta::assert_debug_snapshot!(tail, @r###"
         [
             "metrics.buckets.per_batch:1|h",
-            "metrics.buckets.partition_keys:59|h",
             "metrics.buckets.batches_per_partition:1|h",
             "metrics.buckets.per_batch:1|h",
-            "metrics.buckets.partition_keys:62|h",
             "metrics.buckets.batches_per_partition:1|h",
         ]
         "###);

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -106,9 +106,9 @@ pub enum MetricHistograms {
     /// This corresponds to the number of buckets that will end up in an envelope.
     BucketsPerBatch,
 
-    /// Distribution of flush batches over partition keys.
+    /// Distribution of flush buckets over partition keys.
     ///
-    /// The distribution of buckets / bucket batches should be even.
+    /// The distribution of buckets should be even.
     /// If it is not, this metric should expose it.
     PartitionKeys,
 }

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -105,6 +105,12 @@ pub enum MetricHistograms {
     ///
     /// This corresponds to the number of buckets that will end up in an envelope.
     BucketsPerBatch,
+
+    /// Distribution of flush batches over partition keys.
+    ///
+    /// The distribution of buckets / bucket batches should be even.
+    /// If it is not, this metric should expose it.
+    PartitionKeys,
 }
 
 impl HistogramMetric for MetricHistograms {
@@ -115,6 +121,7 @@ impl HistogramMetric for MetricHistograms {
             Self::BucketsDelay => "metrics.buckets.delay",
             Self::BatchesPerPartition => "metrics.buckets.batches_per_partition",
             Self::BucketsPerBatch => "metrics.buckets.per_batch",
+            Self::PartitionKeys => "metrics.buckets.partition_keys",
         }
     }
 }


### PR DESCRIPTION
Add a distribution metric to detect imbalances in our assignment of buckets to partition keys. Note that this type of metric does not give us fine-grained histograms, so we might still miss subtle imbalances, but should be able to detect large outliers.

#skip-changelog