### PR TITLE
test: Identify correct UA with enabled data scrubbing.

### DIFF
--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -83,5 +83,5 @@ zstd = { version = "0.11.2"}
 libc = "0.2.71"
 
 [dev-dependencies]
-insta = "1.19.0"
+insta = { version = "1.19.0", features = ["json"] }
 relay-test = { path = "../relay-test" }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2346,16 +2346,11 @@ mod tests {
         });
 
         let new_envelope = relay_test::with_system(move || {
-            let mut scrub_config = DataScrubbingConfig::default();
+            let mut datascrubbing_settings = DataScrubbingConfig::default();
             // enable all the default scrubbing
-            scrub_config.scrub_data = true;
-            scrub_config.scrub_defaults = true;
-            scrub_config.scrub_ip_addresses = true;
-
-            let mut config = ProjectConfig {
-                datascrubbing_settings: scrub_config,
-                ..Default::default()
-            };
+            datascrubbing_settings.scrub_data = true;
+            datascrubbing_settings.scrub_defaults = true;
+            datascrubbing_settings.scrub_ip_addresses = true;
 
             // Make sure to mask any IP-like looking data
             let pii_config = PiiConfig::from_json(
@@ -2368,7 +2363,12 @@ mod tests {
                 "##,
             )
             .unwrap();
-            config.pii_config = Some(pii_config);
+
+            let config = ProjectConfig {
+                datascrubbing_settings,
+                pii_config: Some(pii_config),
+                ..Default::default()
+            };
 
             let mut project_state = ProjectState::allowed();
             project_state.config = config;


### PR DESCRIPTION
With [UA reduction](https://www.chromium.org/updates/ua-reduction) Chromium user agent transformed to the form that looks like IPv4 address and it triggers PII scrubbing rules.

This test makes sure that even when the data must be scrubbed, we still can properly identify browser vendor and version.

The issue was basically fixed before, see https://github.com/getsentry/relay/issues/1375#issuecomment-1203676355 , and now we just want to make sure we have a test and won't have regressions in the future. 

fix: https://github.com/getsentry/relay/issues/1375

#skip-changelog