### PR TITLE
docs(exception): Fix docs on adding metadata info to exceptions without type and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Do not apply rate limits or reject data based on expired project configs. ([#1404](https://github.com/getsentry/relay/pull/1404))
 - Process required stacktraces to fix filtering events originating from browser extensions. ([#1423](https://github.com/getsentry/relay/pull/1423))
 - Fix error message filtering when formatting the message of logentry. ([#1442](https://github.com/getsentry/relay/pull/1442))
+- Document that relay adds an error to the exception's metadata when neither `type` nor `value` are provided in the exception. ([#1452](https://github.com/getsentry/relay/pull/1452))
 
 **Internal**:
 

--- a/relay-general/src/protocol/exception.rs
+++ b/relay-general/src/protocol/exception.rs
@@ -30,14 +30,15 @@ use crate::types::{Annotated, Object, Value};
 pub struct Exception {
     /// Exception type, e.g. `ValueError`.
     ///
-    /// At least one of `type` or `value` is required, otherwise the exception is discarded.
-    // (note: requirement checked in checked in StoreNormalizeProcessor)
+    /// At least one of `type` or `value` is required. If neither is provided,
+    /// StoreNormalizeProcessor adds an error to the exception's metadata.
     #[metastructure(field = "type", max_chars = "symbol")]
     pub ty: Annotated<String>,
 
     /// Human readable display value.
     ///
-    /// At least one of `type` or `value` is required, otherwise the exception is discarded.
+    /// At least one of `type` or `value` is required. If neither is provided,
+    /// StoreNormalizeProcessor adds an error to the exception's metadata.
     #[metastructure(max_chars = "message", pii = "true")]
     pub value: Annotated<JsonLenientString>,
 


### PR DESCRIPTION
Relay doesn't discard exceptions without `type` and `value`. Instead, it adds an error to the exception's metadata indicating neither was provided. 

For the following event,

```
{"exception": {"values": [{"type": "", "value": ""}]}}
````

the `exception` in the event's `_meta` entry looks like this:

```
{
    "exception": {
        "values": {
            "0": {
                "": {
                    "err": [["missing_attribute", {"attribute": "type or value"}]],
                    "val": {
                        "mechanism": None,
                        "module": None,
                        "raw_stacktrace": None,
                        "stacktrace": None,
                        "thread_id": None,
                        "type": "",
                        "value": "",
                    },
                }
            }
        }
    }
}
```