### PR TITLE
feat: Allow to specify how many client sockets to use for statsd metrics

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -485,6 +485,10 @@ struct Metrics {
     /// For example, a value of `0.3` means that only 30% of the emitted metrics will be sent.
     /// Defaults to `1.0` (100%).
     sample_rate: f32,
+
+    // Number of UDP sockets we use for sending stuff
+    // TODO: make sure it can't be 0
+    client_sockets_num: u32,
 }
 
 impl Default for Metrics {
@@ -496,6 +500,7 @@ impl Default for Metrics {
             hostname_tag: None,
             buffering: true,
             sample_rate: 1.0,
+            client_sockets_num: 1,
         }
     }
 }
@@ -1758,6 +1763,10 @@ impl Config {
     /// Returns the global sample rate for all metrics.
     pub fn metrics_sample_rate(&self) -> f32 {
         self.values.metrics.sample_rate
+    }
+
+    pub fn metrics_client_sockets_num(&self) -> u32 {
+        self.values.metrics.client_sockets_num
     }
 
     /// Returns the default timeout for all upstream HTTP requests.

--- a/relay-statsd/src/buffered_multi_udp_sink.rs
+++ b/relay-statsd/src/buffered_multi_udp_sink.rs
@@ -1,0 +1,52 @@
+use std::io;
+use std::net::{ToSocketAddrs, UdpSocket};
+
+use cadence::{BufferedUdpMetricSink, MetricResult, MetricSink};
+use rand::distributions::{Distribution, Uniform};
+use rand::rngs::ThreadRng;
+
+#[derive(Debug)]
+pub struct BufferedMultiUdpMetricSink {
+    inner_sinks: Vec<BufferedUdpMetricSink>,
+    rng: ThreadRng,
+    distr: Uniform<usize>,
+}
+
+impl BufferedMultiUdpMetricSink {
+    pub fn from<A>(
+        sink_addr: A,
+        sockets: Vec<UdpSocket>,
+    ) -> MetricResult<BufferedMultiUdpMetricSink>
+    where
+        A: ToSocketAddrs,
+    {
+        let mut inner_sinks = Vec::new();
+
+        for socket in sockets {
+            let sink = BufferedUdpMetricSink::from(&sink_addr, socket)?;
+            inner_sinks.push(sink);
+        }
+
+        let rng = rand::thread_rng();
+        let distr = Uniform::from(0..inner_sinks.len());
+        Ok(BufferedMultiUdpMetricSink {
+            inner_sinks,
+            rng,
+            distr,
+        })
+    }
+}
+
+impl MetricSink for BufferedMultiUdpMetricSink {
+    fn emit(&self, metric: &str) -> io::Result<usize> {
+        let mut rng = self.rng;
+        self.inner_sinks[self.distr.sample(&mut rng)].emit(metric)
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        for sink in &self.inner_sinks {
+            sink.flush()?;
+        }
+        Ok(())
+    }
+}

--- a/relay-statsd/src/buffered_multi_udp_sink.rs
+++ b/relay-statsd/src/buffered_multi_udp_sink.rs
@@ -3,12 +3,10 @@ use std::net::{ToSocketAddrs, UdpSocket};
 
 use cadence::{BufferedUdpMetricSink, MetricResult, MetricSink};
 use rand::distributions::{Distribution, Uniform};
-use rand::rngs::ThreadRng;
 
 #[derive(Debug)]
 pub struct BufferedMultiUdpMetricSink {
     inner_sinks: Vec<BufferedUdpMetricSink>,
-    rng: ThreadRng,
     distr: Uniform<usize>,
 }
 
@@ -27,19 +25,14 @@ impl BufferedMultiUdpMetricSink {
             inner_sinks.push(sink);
         }
 
-        let rng = rand::thread_rng();
         let distr = Uniform::from(0..inner_sinks.len());
-        Ok(BufferedMultiUdpMetricSink {
-            inner_sinks,
-            rng,
-            distr,
-        })
+        Ok(BufferedMultiUdpMetricSink { inner_sinks, distr })
     }
 }
 
 impl MetricSink for BufferedMultiUdpMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
-        let mut rng = self.rng;
+        let mut rng = rand::thread_rng();
         self.inner_sinks[self.distr.sample(&mut rng)].emit(metric)
     }
 

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -56,6 +56,8 @@
 //! ```
 //!
 //! [Metric Types]: https://github.com/statsd/statsd/blob/master/docs/metric_types.md
+mod buffered_multi_udp_sink;
+
 use std::collections::BTreeMap;
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::ops::{Deref, DerefMut};
@@ -69,6 +71,8 @@ use parking_lot::RwLock;
 use rand::distributions::{Distribution, Uniform};
 
 use relay_log::LogError;
+
+use crate::buffered_multi_udp_sink::BufferedMultiUdpMetricSink;
 
 /// Maximum number of metric events that can be queued before we start dropping them
 const METRICS_MAX_QUEUE_SIZE: usize = 100_000;

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -67,6 +67,7 @@ pub fn init_metrics(config: &Config) -> Result<(), Error> {
         default_tags,
         config.metrics_buffering(),
         config.metrics_sample_rate(),
+        config.metrics_client_sockets_num(),
     );
 
     Ok(())


### PR DESCRIPTION
This allows to configure how many UDP sockets (sinks) relay uses when emitting statsd metrics. This might help with scaling the (internal) statsd metrics infra, because at the peak usage relay can produce quite a lot of data (more than some statsd servers can handle).

Just an experimental draft that'll probably be scrapped later.