### PR TITLE
ref(actix): Update service and associated traits

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -29,7 +29,7 @@ use crate::utils::{EnvelopeContext, FutureExt as _};
 
 #[cfg(feature = "processing")]
 use {
-    crate::actors::store::{StoreEnvelope, StoreError, StoreForwarder, StoreMessages},
+    crate::actors::store::{Store, StoreEnvelope, StoreError, StoreService},
     futures::{FutureExt, TryFutureExt},
     relay_system::{Addr as ServiceAddr, Service},
     tokio::runtime::Runtime,
@@ -152,7 +152,7 @@ pub struct EnvelopeManager {
     config: Arc<Config>,
     captures: BTreeMap<EventId, CapturedEnvelope>,
     #[cfg(feature = "processing")]
-    store_forwarder: Option<ServiceAddr<StoreMessages>>,
+    store_forwarder: Option<ServiceAddr<Store>>,
     #[cfg(feature = "processing")]
     _runtime: Runtime,
 }
@@ -168,7 +168,7 @@ impl EnvelopeManager {
 
         #[cfg(feature = "processing")]
         let store_forwarder = if config.processing_enabled() {
-            let actor = StoreForwarder::create(config.clone())?;
+            let actor = StoreService::create(config.clone())?;
             Some(actor.start())
         } else {
             None

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -29,9 +29,9 @@ use crate::utils::{EnvelopeContext, FutureExt as _};
 
 #[cfg(feature = "processing")]
 use {
-    crate::actors::store::{StoreEnvelope, StoreError, StoreForwarder},
+    crate::actors::store::{StoreEnvelope, StoreError, StoreForwarder, StoreMessages},
     futures::{FutureExt, TryFutureExt},
-    relay_system::Addr as ServiceAddr,
+    relay_system::{Addr as ServiceAddr, Service},
     tokio::runtime::Runtime,
 };
 
@@ -152,7 +152,7 @@ pub struct EnvelopeManager {
     config: Arc<Config>,
     captures: BTreeMap<EventId, CapturedEnvelope>,
     #[cfg(feature = "processing")]
-    store_forwarder: Option<ServiceAddr<StoreForwarder>>,
+    store_forwarder: Option<ServiceAddr<StoreMessages>>,
     #[cfg(feature = "processing")]
     _runtime: Runtime,
 }

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -111,7 +111,7 @@ impl HealthcheckService {
 impl Service for HealthcheckService {
     type Interface = Healthcheck;
 
-    fn run(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
         let service = Arc::new(self);
 
         let main_service = service.clone();

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -14,6 +14,7 @@ use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
 use crate::service::REGISTRY;
 use crate::statsd::RelayGauges;
 
+/// Checks whether Relay is alive and healthy based on its variant.
 #[derive(Clone, Copy, Debug)]
 pub enum IsHealthy {
     /// Check if the Relay is alive at all.
@@ -23,7 +24,7 @@ pub enum IsHealthy {
     Readiness,
 }
 
-/// Interface of the [`Healthcheck`] service.
+/// Service interface for the [`IsHealthy`] message.
 pub struct Healthcheck(IsHealthy, Sender<bool>);
 
 impl Interface for Healthcheck {}
@@ -36,6 +37,7 @@ impl FromMessage<IsHealthy> for Healthcheck {
     }
 }
 
+/// Service implementing the [`Healthcheck`] interface.
 #[derive(Debug)]
 pub struct HealthcheckService {
     is_shutting_down: AtomicBool,
@@ -45,11 +47,12 @@ pub struct HealthcheckService {
 impl HealthcheckService {
     /// Returns the [`Addr`] of the [`Healthcheck`] service.
     ///
-    /// Prior to using this, the service must be started using [`Healthcheck::start`].
+    /// Prior to using this, the service must be started using [`HealthcheckService::start`].
     ///
     /// # Panics
     ///
-    /// Panics if the service was not started using [`Healthcheck::start`] prior to this being used.
+    /// Panics if the service was not started using [`HealthcheckService::start`] prior to this
+    /// being used.
     pub fn from_registry() -> Addr<Healthcheck> {
         REGISTRY.get().unwrap().healthcheck.clone()
     }

--- a/relay-server/src/actors/healthcheck.rs
+++ b/relay-server/src/actors/healthcheck.rs
@@ -2,26 +2,44 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use actix::SystemService;
-use tokio::sync::{mpsc, oneshot};
 
 use relay_config::{Config, RelayMode};
 use relay_metrics::{AcceptsMetrics, Aggregator};
 use relay_statsd::metric;
-use relay_system::{compat, Controller};
+use relay_system::{
+    compat, Addr, AsyncResponse, Controller, FromMessage, Interface, Sender, Service,
+};
 
 use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
 use crate::service::REGISTRY;
 use crate::statsd::RelayGauges;
-use relay_system::{Addr, Service, ServiceMessage};
+
+#[derive(Clone, Copy, Debug)]
+pub enum IsHealthy {
+    /// Check if the Relay is alive at all.
+    Liveness,
+    /// Check if the Relay is in a state where the load balancer should route traffic to it (i.e.
+    /// it's both live/alive and not too busy).
+    Readiness,
+}
+
+/// Interface of the [`Healthcheck`] service.
+pub struct HealthcheckMessages(IsHealthy, Sender<bool>);
+
+impl Interface for HealthcheckMessages {}
+
+impl FromMessage<IsHealthy> for HealthcheckMessages {
+    type Response = AsyncResponse<bool>;
+
+    fn from_message(message: IsHealthy, sender: Sender<bool>) -> Self {
+        Self(message, sender)
+    }
+}
 
 #[derive(Debug)]
 pub struct Healthcheck {
     is_shutting_down: AtomicBool,
     config: Arc<Config>,
-}
-
-impl Service for Healthcheck {
-    type Messages = HealthcheckMessages;
 }
 
 impl Healthcheck {
@@ -32,7 +50,7 @@ impl Healthcheck {
     /// # Panics
     ///
     /// Panics if the service was not started using [`Healthcheck::start`] prior to this being used.
-    pub fn from_registry() -> Addr<Self> {
+    pub fn from_registry() -> Addr<HealthcheckMessages> {
         REGISTRY.get().unwrap().healthcheck.clone()
     }
 
@@ -80,18 +98,23 @@ impl Healthcheck {
         }
     }
 
-    /// Start this service, returning an [`Addr`] for communication.
-    pub fn start(self) -> Addr<Self> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<HealthcheckMessages>();
+    async fn handle_message(&self, message: HealthcheckMessages) {
+        let HealthcheckMessages(message, sender) = message;
+        let response = self.handle_is_healthy(message).await;
+        sender.send(response);
+    }
+}
 
-        let addr = Addr { tx };
+impl Service for Healthcheck {
+    type Interface = HealthcheckMessages;
 
+    fn run(self, mut rx: relay_system::Receiver<Self::Interface>) {
         let service = Arc::new(self);
+
         let main_service = service.clone();
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 let service = main_service.clone();
-
                 tokio::spawn(async move { service.handle_message(message).await });
             }
         });
@@ -106,40 +129,5 @@ impl Healthcheck {
                 }
             }
         });
-
-        addr
     }
-
-    async fn handle_message(&self, message: HealthcheckMessages) {
-        match message {
-            HealthcheckMessages::IsHealthy(msg, response_tx) => {
-                let response = self.handle_is_healthy(msg).await;
-                response_tx.send(response).ok()
-            }
-        };
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum IsHealthy {
-    /// Check if the Relay is alive at all.
-    Liveness,
-    /// Check if the Relay is in a state where the load balancer should route traffic to it (i.e.
-    /// it's both live/alive and not too busy).
-    Readiness,
-}
-
-impl ServiceMessage<Healthcheck> for IsHealthy {
-    type Response = bool;
-
-    fn into_messages(self) -> (HealthcheckMessages, oneshot::Receiver<Self::Response>) {
-        let (tx, rx) = oneshot::channel();
-        (HealthcheckMessages::IsHealthy(self, tx), rx)
-    }
-}
-
-/// All the message types which can be sent to the [`Healthcheck`] service.
-#[derive(Debug)]
-pub enum HealthcheckMessages {
-    IsHealthy(IsHealthy, oneshot::Sender<bool>),
 }

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -19,11 +19,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 #[cfg(feature = "processing")]
 use failure::{Fail, ResultExt};
 #[cfg(feature = "processing")]
-use rdkafka::producer::BaseRecord;
-#[cfg(feature = "processing")]
-use rdkafka::ClientConfig as KafkaClientConfig;
-use relay_system::Interface;
-use relay_system::NoResponse;
+use rdkafka::{producer::BaseRecord, ClientConfig as KafkaClientConfig};
+use relay_system::{Interface, NoResponse};
 use serde::{Deserialize, Serialize};
 
 use relay_common::{DataCategory, ProjectId, UnixTimestamp};

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -549,7 +549,7 @@ impl HttpOutcomeProducer {
 impl Service for HttpOutcomeProducer {
     type Interface = TrackRawOutcome;
 
-    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -637,7 +637,7 @@ impl ClientReportOutcomeProducer {
 impl Service for ClientReportOutcomeProducer {
     type Interface = TrackOutcome;
 
-    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -900,7 +900,7 @@ impl OutcomeProducerService {
 impl Service for OutcomeProducerService {
     type Interface = OutcomeProducer;
 
-    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             relay_log::info!("OutcomeProducer started.");
             while let Some(message) = rx.recv().await {

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -725,14 +725,14 @@ enum ProducerInner {
 }
 
 #[derive(Debug)]
-pub enum OutcomeProducerMessages {
+pub enum OutcomeProducer {
     TrackOutcome(TrackOutcome),
     TrackRawOutcome(TrackRawOutcome),
 }
 
-impl Interface for OutcomeProducerMessages {}
+impl Interface for OutcomeProducer {}
 
-impl FromMessage<TrackOutcome> for OutcomeProducerMessages {
+impl FromMessage<TrackOutcome> for OutcomeProducer {
     type Response = NoResponse;
 
     fn from_message(message: TrackOutcome, _: ()) -> Self {
@@ -740,7 +740,7 @@ impl FromMessage<TrackOutcome> for OutcomeProducerMessages {
     }
 }
 
-impl FromMessage<TrackRawOutcome> for OutcomeProducerMessages {
+impl FromMessage<TrackRawOutcome> for OutcomeProducer {
     type Response = NoResponse;
 
     fn from_message(message: TrackRawOutcome, _: ()) -> Self {
@@ -748,13 +748,13 @@ impl FromMessage<TrackRawOutcome> for OutcomeProducerMessages {
     }
 }
 
-pub struct OutcomeProducer {
+pub struct OutcomeProducerService {
     config: Arc<Config>,
     producer: ProducerInner,
 }
 
-impl OutcomeProducer {
-    pub fn from_registry() -> Addr<OutcomeProducerMessages> {
+impl OutcomeProducerService {
+    pub fn from_registry() -> Addr<OutcomeProducer> {
         REGISTRY.get().unwrap().outcome_producer.clone()
     }
 
@@ -793,10 +793,10 @@ impl OutcomeProducer {
         Ok(Self { config, producer })
     }
 
-    fn handle_message(&mut self, message: OutcomeProducerMessages) {
+    fn handle_message(&mut self, message: OutcomeProducer) {
         match message {
-            OutcomeProducerMessages::TrackOutcome(msg) => self.handle_track_outcome(msg),
-            OutcomeProducerMessages::TrackRawOutcome(msg) => self.handle_track_raw_outcome(msg),
+            OutcomeProducer::TrackOutcome(msg) => self.handle_track_outcome(msg),
+            OutcomeProducer::TrackRawOutcome(msg) => self.handle_track_raw_outcome(msg),
         }
     }
 
@@ -883,8 +883,8 @@ impl OutcomeProducer {
     }
 }
 
-impl Service for OutcomeProducer {
-    type Interface = OutcomeProducerMessages;
+impl Service for OutcomeProducerService {
+    type Interface = OutcomeProducer;
 
     fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -22,8 +22,9 @@ use failure::{Fail, ResultExt};
 use rdkafka::producer::BaseRecord;
 #[cfg(feature = "processing")]
 use rdkafka::ClientConfig as KafkaClientConfig;
+use relay_system::Interface;
+use relay_system::NoResponse;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, oneshot};
 
 use relay_common::{DataCategory, ProjectId, UnixTimestamp};
 use relay_config::{Config, EmitOutcomes};
@@ -35,7 +36,7 @@ use relay_log::LogError;
 use relay_quotas::{ReasonCode, Scoping};
 use relay_sampling::RuleId;
 use relay_statsd::metric;
-use relay_system::{compat, Addr, Service, ServiceMessage};
+use relay_system::{compat, Addr, FromMessage, Service};
 
 use crate::actors::envelopes::{EnvelopeManager, SendClientReports};
 use crate::actors::upstream::{SendQuery, UpstreamQuery, UpstreamRelay};
@@ -92,9 +93,13 @@ impl OutcomeId {
 }
 
 trait TrackOutcomeLike {
+    /// TODO: Doc
     fn reason(&self) -> Option<Cow<str>>;
+
+    /// TODO: Doc
     fn outcome_id(&self) -> OutcomeId;
 
+    /// TODO: Doc
     fn tag_name(&self) -> &'static str {
         match self.outcome_id() {
             OutcomeId::ACCEPTED => "accepted",
@@ -136,6 +141,16 @@ impl TrackOutcomeLike for TrackOutcome {
 
     fn outcome_id(&self) -> OutcomeId {
         self.outcome.to_outcome_id()
+    }
+}
+
+impl Interface for TrackOutcome {}
+
+impl FromMessage<Self> for TrackOutcome {
+    type Response = NoResponse;
+
+    fn from_message(message: Self, _: ()) -> Self {
+        message
     }
 }
 
@@ -455,6 +470,16 @@ impl TrackOutcomeLike for TrackRawOutcome {
     }
 }
 
+impl Interface for TrackRawOutcome {}
+
+impl FromMessage<Self> for TrackRawOutcome {
+    type Response = NoResponse;
+
+    fn from_message(message: Self, _: ()) -> Self {
+        message
+    }
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "processing", derive(Fail))]
 pub enum OutcomeError {
@@ -481,24 +506,6 @@ impl HttpOutcomeProducer {
         })
     }
 
-    pub fn start(mut self) -> Addr<Self> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<HttpOutcomeProducerMessages>();
-
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    Some(message) = rx.recv() => self.handle_message(message),
-                    () = &mut self.pending_flush_handle => self.send_batch(),
-                    else => break,
-                }
-            }
-        });
-
-        Addr { tx }
-    }
-}
-
-impl HttpOutcomeProducer {
     fn send_batch(&mut self) {
         self.pending_flush_handle.reset();
 
@@ -526,7 +533,7 @@ impl HttpOutcomeProducer {
         });
     }
 
-    fn send_http_message(&mut self, message: TrackRawOutcome) {
+    fn handle_message(&mut self, message: TrackRawOutcome) {
         relay_log::trace!("Batching outcome");
         self.unsent_outcomes.push(message);
 
@@ -537,36 +544,22 @@ impl HttpOutcomeProducer {
                 .set(self.config.outcome_batch_interval());
         }
     }
-
-    fn handle_message(&mut self, message: HttpOutcomeProducerMessages) {
-        match message {
-            HttpOutcomeProducerMessages::TrackRawOutcome(msg) => self.send_http_message(msg),
-        };
-    }
 }
 
 impl Service for HttpOutcomeProducer {
-    type Messages = HttpOutcomeProducerMessages;
-}
+    type Interface = TrackRawOutcome;
 
-impl ServiceMessage<HttpOutcomeProducer> for TrackRawOutcome {
-    type Response = ();
-
-    fn into_messages(
-        self,
-    ) -> (
-        HttpOutcomeProducerMessages,
-        oneshot::Receiver<Self::Response>,
-    ) {
-        let (tx, rx) = oneshot::channel();
-        tx.send(()).ok();
-        (HttpOutcomeProducerMessages::TrackRawOutcome(self), rx)
+    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(message) = rx.recv() => self.handle_message(message),
+                    () = &mut self.pending_flush_handle => self.send_batch(),
+                    else => break,
+                }
+            }
+        });
     }
-}
-
-#[derive(Debug)]
-enum HttpOutcomeProducerMessages {
-    TrackRawOutcome(TrackRawOutcome),
 }
 
 struct ClientReportOutcomeProducer {
@@ -575,35 +568,7 @@ struct ClientReportOutcomeProducer {
     flush_handle: SleepHandle,
 }
 
-impl Service for ClientReportOutcomeProducer {
-    type Messages = ClientReportOutcomeProducerMessages;
-}
-
 impl ClientReportOutcomeProducer {
-    pub fn start(mut self) -> Addr<Self> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<ClientReportOutcomeProducerMessages>();
-
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    Some(message) = rx.recv() => self.handle_message(message),
-                    () = &mut self.flush_handle => self.flush(),
-                    else => break,
-                }
-            }
-        });
-
-        Addr { tx }
-    }
-
-    fn handle_message(&mut self, message: ClientReportOutcomeProducerMessages) {
-        match message {
-            ClientReportOutcomeProducerMessages::TrackOutcome(msg) => {
-                self.handle_track_outcome(msg);
-            }
-        }
-    }
-
     fn create(config: &Config) -> Self {
         Self {
             // Use same batch interval as outcome aggregator
@@ -627,7 +592,7 @@ impl ClientReportOutcomeProducer {
         }
     }
 
-    fn handle_track_outcome(&mut self, msg: TrackOutcome) {
+    fn handle_message(&mut self, msg: TrackOutcome) {
         let mut client_report = ClientReport {
             timestamp: Some(UnixTimestamp::from_secs(
                 msg.timestamp.timestamp().try_into().unwrap_or(0),
@@ -668,24 +633,20 @@ impl ClientReportOutcomeProducer {
     }
 }
 
-impl ServiceMessage<ClientReportOutcomeProducer> for TrackOutcome {
-    type Response = ();
+impl Service for ClientReportOutcomeProducer {
+    type Interface = TrackOutcome;
 
-    fn into_messages(
-        self,
-    ) -> (
-        ClientReportOutcomeProducerMessages,
-        oneshot::Receiver<Self::Response>,
-    ) {
-        let (tx, rx) = oneshot::channel();
-        tx.send(()).ok();
-        (ClientReportOutcomeProducerMessages::TrackOutcome(self), rx)
+    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(message) = rx.recv() => self.handle_message(message),
+                    () = &mut self.flush_handle => self.flush(),
+                    else => break,
+                }
+            }
+        });
     }
-}
-
-#[derive(Debug)]
-enum ClientReportOutcomeProducerMessages {
-    TrackOutcome(TrackOutcome),
 }
 
 /// A wrapper around producers for the two Kafka topics.
@@ -756,11 +717,35 @@ impl KafkaOutcomesProducer {
 }
 
 enum ProducerInner {
-    AsClientReports(Addr<ClientReportOutcomeProducer>),
-    AsHttpOutcomes(Addr<HttpOutcomeProducer>),
+    AsClientReports(Addr<TrackOutcome>),
+    AsHttpOutcomes(Addr<TrackRawOutcome>),
     #[cfg(feature = "processing")]
     AsKafkaOutcomes(KafkaOutcomesProducer),
     Disabled,
+}
+
+#[derive(Debug)]
+pub enum OutcomeProducerMessages {
+    TrackOutcome(TrackOutcome),
+    TrackRawOutcome(TrackRawOutcome),
+}
+
+impl Interface for OutcomeProducerMessages {}
+
+impl FromMessage<TrackOutcome> for OutcomeProducerMessages {
+    type Response = NoResponse;
+
+    fn from_message(message: TrackOutcome, _: ()) -> Self {
+        Self::TrackOutcome(message)
+    }
+}
+
+impl FromMessage<TrackRawOutcome> for OutcomeProducerMessages {
+    type Response = NoResponse;
+
+    fn from_message(message: TrackRawOutcome, _: ()) -> Self {
+        Self::TrackRawOutcome(message)
+    }
 }
 
 pub struct OutcomeProducer {
@@ -769,7 +754,7 @@ pub struct OutcomeProducer {
 }
 
 impl OutcomeProducer {
-    pub fn from_registry() -> Addr<Self> {
+    pub fn from_registry() -> Addr<OutcomeProducerMessages> {
         REGISTRY.get().unwrap().outcome_producer.clone()
     }
 
@@ -806,19 +791,6 @@ impl OutcomeProducer {
         };
 
         Ok(Self { config, producer })
-    }
-
-    pub fn start(mut self) -> Addr<Self> {
-        relay_log::info!("OutcomeProducer started.");
-        let (tx, mut rx) = mpsc::unbounded_channel::<OutcomeProducerMessages>();
-
-        tokio::spawn(async move {
-            while let Some(message) = rx.recv().await {
-                self.handle_message(message);
-            }
-        });
-
-        Addr { tx }
     }
 
     fn handle_message(&mut self, message: OutcomeProducerMessages) {
@@ -882,13 +854,13 @@ impl OutcomeProducer {
             }
             ProducerInner::AsClientReports(ref producer) => {
                 Self::send_outcome_metric(&message, "client_report");
-                let _ = producer.send(message);
+                producer.send(message);
             }
             ProducerInner::AsHttpOutcomes(ref producer) => {
                 Self::send_outcome_metric(&message, "http");
-                let _ = producer.send(TrackRawOutcome::from_outcome(message, &self.config));
+                producer.send(TrackRawOutcome::from_outcome(message, &self.config));
             }
-            ProducerInner::Disabled => {}
+            ProducerInner::Disabled => (),
         }
     }
 
@@ -903,40 +875,24 @@ impl OutcomeProducer {
             }
             ProducerInner::AsHttpOutcomes(ref producer) => {
                 Self::send_outcome_metric(&message, "http");
-                let _ = producer.send(message);
+                producer.send(message);
             }
-            ProducerInner::AsClientReports(_) => {}
-            ProducerInner::Disabled => {}
+            ProducerInner::AsClientReports(_) => (),
+            ProducerInner::Disabled => (),
         }
     }
 }
 
 impl Service for OutcomeProducer {
-    type Messages = OutcomeProducerMessages;
-}
+    type Interface = OutcomeProducerMessages;
 
-impl ServiceMessage<OutcomeProducer> for TrackOutcome {
-    type Response = ();
-
-    fn into_messages(self) -> (OutcomeProducerMessages, oneshot::Receiver<Self::Response>) {
-        let (tx, rx) = oneshot::channel();
-        tx.send(()).ok();
-        (OutcomeProducerMessages::TrackOutcome(self), rx)
+    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            relay_log::info!("OutcomeProducer started.");
+            while let Some(message) = rx.recv().await {
+                self.handle_message(message);
+            }
+            relay_log::info!("OutcomeProducer stopped.");
+        });
     }
-}
-
-impl ServiceMessage<OutcomeProducer> for TrackRawOutcome {
-    type Response = ();
-
-    fn into_messages(self) -> (OutcomeProducerMessages, oneshot::Receiver<Self::Response>) {
-        let (tx, rx) = oneshot::channel();
-        tx.send(()).ok();
-        (OutcomeProducerMessages::TrackRawOutcome(self), rx)
-    }
-}
-
-#[derive(Debug)]
-pub enum OutcomeProducerMessages {
-    TrackOutcome(TrackOutcome),
-    TrackRawOutcome(TrackRawOutcome),
 }

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -41,8 +41,9 @@ enum AggregationMode {
     Lossy,
 }
 
-/// Aggregates outcomes into buckets, and flushes them periodically.
-/// Inspired by [`relay_metrics::Aggregator`].
+/// Aggregates [`Outcome`]s into buckets and flushes them periodically.
+///
+/// This service handles a single message [`TrackOutcome`].
 pub struct OutcomeAggregator {
     mode: AggregationMode,
     /// The width of each aggregated bucket in seconds

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -5,15 +5,13 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::time::Duration;
 
-use tokio::sync::{mpsc, oneshot};
-
 use relay_common::{DataCategory, UnixTimestamp};
 use relay_config::{Config, EmitOutcomes};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
-use relay_system::{Addr, Controller, Service, ServiceMessage, Shutdown};
+use relay_system::{Addr, Controller, Service, Shutdown};
 
-use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
+use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducerMessages, TrackOutcome};
 use crate::service::REGISTRY;
 use crate::statsd::RelayTimers;
 use crate::utils::SleepHandle;
@@ -54,17 +52,17 @@ pub struct OutcomeAggregator {
     /// Mapping from bucket key to quantity.
     buckets: HashMap<BucketKey, u32>,
     /// The recipient of the aggregated outcomes
-    outcome_producer: Addr<OutcomeProducer>,
+    outcome_producer: Addr<OutcomeProducerMessages>,
     /// An optional timeout to the next scheduled flush.
     flush_handle: SleepHandle,
 }
 
 impl OutcomeAggregator {
-    pub fn from_registry() -> Addr<Self> {
+    pub fn from_registry() -> Addr<TrackOutcome> {
         REGISTRY.get().unwrap().outcome_aggregator.clone()
     }
 
-    pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducer>) -> Self {
+    pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducerMessages>) -> Self {
         let mode = match config.emit_outcomes() {
             EmitOutcomes::AsOutcomes => AggregationMode::Lossless,
             EmitOutcomes::AsClientReports => AggregationMode::Lossy,
@@ -81,40 +79,12 @@ impl OutcomeAggregator {
         }
     }
 
-    pub fn start(mut self) -> Addr<Self> {
-        relay_log::info!("outcome aggregator started");
-        let (tx, mut rx) = mpsc::unbounded_channel::<OutcomeAggregatorMessages>();
-
-        tokio::spawn(async move {
-            let mut shutdown_rx = Controller::subscribe_v2().await;
-            loop {
-                tokio::select! {
-                    Some(message) = rx.recv() => self.handle_message(message),
-                    () = &mut self.flush_handle => self.flush(),
-                    _ = shutdown_rx.changed() => {
-                        self.handle_shutdown(&shutdown_rx.borrow_and_update())
-                    },
-                    else => break,
-                }
-            }
-            relay_log::info!("outcome aggregator stopped");
-        });
-
-        Addr { tx }
-    }
-
     fn handle_shutdown(&mut self, message: &Option<Shutdown>) {
         if let Some(message) = message {
             if message.timeout.is_some() {
                 self.flush();
                 relay_log::info!("outcome aggregator stopped");
             }
-        }
-    }
-
-    fn handle_message(&mut self, message: OutcomeAggregatorMessages) {
-        match message {
-            OutcomeAggregatorMessages::TrackOutcome(msg) => self.handle_track_outcome(msg),
         }
     }
 
@@ -134,7 +104,7 @@ impl OutcomeAggregator {
 
         if let Some(event_id) = event_id {
             relay_log::trace!("Forwarding outcome without aggregation: {}", event_id);
-            let _ = self.outcome_producer.send(msg);
+            self.outcome_producer.send(msg);
             return;
         }
 
@@ -187,7 +157,7 @@ impl OutcomeAggregator {
             };
 
             relay_log::trace!("Flushing outcome for timestamp {}", timestamp);
-            let _ = outcome_producer.send(outcome);
+            outcome_producer.send(outcome);
         }
     }
 
@@ -212,20 +182,23 @@ impl OutcomeAggregator {
 }
 
 impl Service for OutcomeAggregator {
-    type Messages = OutcomeAggregatorMessages;
-}
+    type Interface = TrackOutcome;
 
-impl ServiceMessage<OutcomeAggregator> for TrackOutcome {
-    type Response = ();
+    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            let mut shutdown = Controller::subscribe_v2().await;
+            relay_log::info!("outcome aggregator started");
 
-    fn into_messages(self) -> (OutcomeAggregatorMessages, oneshot::Receiver<Self::Response>) {
-        let (tx, rx) = oneshot::channel();
-        tx.send(()).ok();
-        (OutcomeAggregatorMessages::TrackOutcome(self), rx)
+            loop {
+                tokio::select! {
+                    Some(message) = rx.recv() => self.handle_track_outcome(message),
+                    () = &mut self.flush_handle => self.flush(),
+                    _ = shutdown.changed() => self.handle_shutdown(&shutdown.borrow_and_update()),
+                    else => break,
+                }
+            }
+
+            relay_log::info!("outcome aggregator stopped");
+        });
     }
-}
-
-#[derive(Debug)]
-pub enum OutcomeAggregatorMessages {
-    TrackOutcome(TrackOutcome),
 }

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -11,7 +11,7 @@ use relay_quotas::Scoping;
 use relay_statsd::metric;
 use relay_system::{Addr, Controller, Service, Shutdown};
 
-use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducerMessages, TrackOutcome};
+use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
 use crate::service::REGISTRY;
 use crate::statsd::RelayTimers;
 use crate::utils::SleepHandle;
@@ -52,7 +52,7 @@ pub struct OutcomeAggregator {
     /// Mapping from bucket key to quantity.
     buckets: HashMap<BucketKey, u32>,
     /// The recipient of the aggregated outcomes
-    outcome_producer: Addr<OutcomeProducerMessages>,
+    outcome_producer: Addr<OutcomeProducer>,
     /// An optional timeout to the next scheduled flush.
     flush_handle: SleepHandle,
 }
@@ -62,7 +62,7 @@ impl OutcomeAggregator {
         REGISTRY.get().unwrap().outcome_aggregator.clone()
     }
 
-    pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducerMessages>) -> Self {
+    pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducer>) -> Self {
         let mode = match config.emit_outcomes() {
             EmitOutcomes::AsOutcomes => AggregationMode::Lossless,
             EmitOutcomes::AsClientReports => AggregationMode::Lossy,

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -185,7 +185,7 @@ impl OutcomeAggregator {
 impl Service for OutcomeAggregator {
     type Interface = TrackOutcome;
 
-    fn run(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             let mut shutdown = Controller::subscribe_v2().await;
             relay_log::info!("outcome aggregator started");

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -836,7 +836,7 @@ impl EnvelopeProcessor {
                 }
             };
 
-            let _ = producer.send(TrackOutcome {
+            producer.send(TrackOutcome {
                 timestamp: timestamp.as_datetime(),
                 scoping: state.envelope_context.scoping(),
                 outcome,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -157,7 +157,7 @@ impl Producers {
     }
 }
 
-/// Message sent to the [`StoreForwarder`] containing an [`Envelope`].
+/// Publishes an [`Envelope`] to the Sentry core application through Kafka topics.
 #[derive(Clone, Debug)]
 pub struct StoreEnvelope {
     pub envelope: Envelope,
@@ -165,7 +165,7 @@ pub struct StoreEnvelope {
     pub scoping: Scoping,
 }
 
-/// Interface of the [`StoreForwarder`].
+/// Service interface for the [`StoreEnvelope`] message.
 #[derive(Debug)]
 pub struct Store(StoreEnvelope, Sender<Result<(), StoreError>>);
 
@@ -179,7 +179,7 @@ impl FromMessage<StoreEnvelope> for Store {
     }
 }
 
-/// Service for publishing events to Sentry through kafka topics.
+/// Service implementing the [`Store`] interface.
 pub struct StoreService {
     config: Arc<Config>,
     producers: Producers,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -8,9 +8,7 @@ use std::time::Instant;
 use bytes::Bytes;
 use failure::{Fail, ResultExt};
 use once_cell::sync::OnceCell;
-use rdkafka::error::KafkaError;
-use rdkafka::producer::BaseRecord;
-use rdkafka::ClientConfig;
+use rdkafka::{error::KafkaError, producer::BaseRecord, ClientConfig};
 use rmp_serde::encode::Error as RmpError;
 use serde::{ser::Error, Serialize};
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -13,7 +13,6 @@ use rdkafka::producer::BaseRecord;
 use rdkafka::ClientConfig;
 use rmp_serde::encode::Error as RmpError;
 use serde::{ser::Error, Serialize};
-use tokio::sync::{mpsc, oneshot};
 
 use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::{Config, KafkaTopic};
@@ -22,7 +21,7 @@ use relay_log::LogError;
 use relay_metrics::{Bucket, BucketValue, MetricNamespace, MetricResourceIdentifier};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
-use relay_system::{Addr, Service, ServiceMessage};
+use relay_system::{AsyncResponse, FromMessage, Interface, Sender, Service};
 
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::service::{ServerError, ServerErrorKind};
@@ -48,6 +47,47 @@ pub enum StoreError {
 }
 
 type Producer = Arc<ThreadedProducer>;
+
+/// Temporary map used to deduplicate kafka producers
+type ReusedProducersMap<'a> = BTreeMap<Option<&'a str>, Producer>;
+
+fn make_distinct_id(s: &str) -> Uuid {
+    static NAMESPACE: OnceCell<Uuid> = OnceCell::new();
+    let namespace =
+        NAMESPACE.get_or_init(|| Uuid::new_v5(&Uuid::NAMESPACE_URL, b"https://sentry.io/#did"));
+
+    s.parse()
+        .unwrap_or_else(|_| Uuid::new_v5(namespace, s.as_bytes()))
+}
+
+fn make_producer<'a>(
+    config: &'a Config,
+    reused_producers: &mut ReusedProducersMap<'a>,
+    kafka_topic: KafkaTopic,
+) -> Result<Producer, ServerError> {
+    let (config_name, kafka_config) = config
+        .kafka_config(kafka_topic)
+        .context(ServerErrorKind::KafkaError)?;
+
+    if let Some(producer) = reused_producers.get(&config_name) {
+        return Ok(Arc::clone(producer));
+    }
+
+    let mut client_config = ClientConfig::new();
+
+    for config_p in kafka_config {
+        client_config.set(config_p.name.as_str(), config_p.value.as_str());
+    }
+
+    let producer = Arc::new(
+        client_config
+            .create_with_context(CaptureErrorContext)
+            .context(ServerErrorKind::KafkaError)?,
+    );
+
+    reused_producers.insert(config_name, Arc::clone(&producer));
+    Ok(producer)
+}
 
 struct Producers {
     events: Producer,
@@ -119,87 +159,43 @@ impl Producers {
     }
 }
 
+/// Message sent to the [`StoreForwarder`] containing an [`Envelope`].
+#[derive(Clone, Debug)]
+pub struct StoreEnvelope {
+    pub envelope: Envelope,
+    pub start_time: Instant,
+    pub scoping: Scoping,
+}
+
+/// Interface of the [`StoreForwarder`].
+#[derive(Debug)]
+pub struct StoreMessages(StoreEnvelope, Sender<Result<(), StoreError>>);
+
+impl Interface for StoreMessages {}
+
+impl FromMessage<StoreEnvelope> for StoreMessages {
+    type Response = AsyncResponse<Result<(), StoreError>>;
+
+    fn from_message(message: StoreEnvelope, sender: Sender<Result<(), StoreError>>) -> Self {
+        Self(message, sender)
+    }
+}
+
 /// Service for publishing events to Sentry through kafka topics.
 pub struct StoreForwarder {
     config: Arc<Config>,
     producers: Producers,
 }
 
-impl Service for StoreForwarder {
-    type Messages = StoreMessages;
-}
-
-fn make_distinct_id(s: &str) -> Uuid {
-    static NAMESPACE: OnceCell<Uuid> = OnceCell::new();
-    let namespace =
-        NAMESPACE.get_or_init(|| Uuid::new_v5(&Uuid::NAMESPACE_URL, b"https://sentry.io/#did"));
-
-    s.parse()
-        .unwrap_or_else(|_| Uuid::new_v5(namespace, s.as_bytes()))
-}
-
-/// Temporary map used to deduplicate kafka producers
-type ReusedProducersMap<'a> = BTreeMap<Option<&'a str>, Producer>;
-
-fn make_producer<'a>(
-    config: &'a Config,
-    reused_producers: &mut ReusedProducersMap<'a>,
-    kafka_topic: KafkaTopic,
-) -> Result<Producer, ServerError> {
-    let (config_name, kafka_config) = config
-        .kafka_config(kafka_topic)
-        .context(ServerErrorKind::KafkaError)?;
-
-    if let Some(producer) = reused_producers.get(&config_name) {
-        return Ok(Arc::clone(producer));
-    }
-
-    let mut client_config = ClientConfig::new();
-
-    for config_p in kafka_config {
-        client_config.set(config_p.name.as_str(), config_p.value.as_str());
-    }
-
-    let producer = Arc::new(
-        client_config
-            .create_with_context(CaptureErrorContext)
-            .context(ServerErrorKind::KafkaError)?,
-    );
-
-    reused_producers.insert(config_name, Arc::clone(&producer));
-    Ok(producer)
-}
-
 impl StoreForwarder {
-    pub fn start(self) -> Addr<Self> {
-        relay_log::info!("store forwarder started");
-
-        let (tx, mut rx) = mpsc::unbounded_channel::<StoreMessages>();
-
-        tokio::spawn(async move {
-            while let Some(message) = rx.recv().await {
-                self.handle_message(message);
-            }
-
-            relay_log::info!("store forwarder stopped");
-        });
-
-        Addr { tx }
-    }
-
     pub fn create(config: Arc<Config>) -> Result<Self, ServerError> {
         let producers = Producers::create(&config)?;
-
         Ok(Self { config, producers })
     }
 
     fn handle_message(&self, message: StoreMessages) {
-        match message {
-            StoreMessages::StoreEnvelope(msg, responder_tx) => {
-                let response = self.handle_store_envelope(msg);
-                responder_tx.send(response).ok();
-            }
-        }
+        let StoreMessages(message, sender) = message;
+        sender.send(self.handle_store_envelope(message));
     }
 
     fn handle_store_envelope(&self, message: StoreEnvelope) -> Result<(), StoreError> {
@@ -723,6 +719,22 @@ impl StoreForwarder {
     }
 }
 
+impl Service for StoreForwarder {
+    type Interface = StoreMessages;
+
+    fn run(self, mut rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            relay_log::info!("store forwarder started");
+
+            while let Some(message) = rx.recv().await {
+                self.handle_message(message);
+            }
+
+            relay_log::info!("store forwarder stopped");
+        });
+    }
+}
+
 /// Common attributes for both standalone attachments and processing-relevant attachments.
 #[derive(Debug, Serialize)]
 struct ChunkedAttachment {
@@ -757,6 +769,7 @@ struct ChunkedAttachment {
     #[serde(skip_serializing_if = "Option::is_none")]
     rate_limited: Option<bool>,
 }
+
 /// attributes for Replay Recordings
 #[derive(Debug, Serialize)]
 struct ChunkedReplayRecording {
@@ -804,6 +817,7 @@ struct EventKafkaMessage {
     /// Attachments that are potentially relevant for processing.
     attachments: Vec<ChunkedAttachment>,
 }
+
 #[derive(Clone, Debug, Serialize)]
 struct ReplayEventKafkaMessage {
     /// Raw event payload.
@@ -863,6 +877,7 @@ struct ReplayRecordingChunkKafkaMessage {
     /// the tuple (id, chunk_index) is the unique identifier for a single chunk.
     chunk_index: usize,
 }
+
 #[derive(Debug, Serialize)]
 struct ReplayRecordingKafkaMessage {
     /// The replay id.
@@ -998,29 +1013,6 @@ impl KafkaMessage {
             }
             _ => rmp_serde::to_vec_named(&self).map_err(StoreError::InvalidMsgPack),
         }
-    }
-}
-
-/// Message sent to the [`StoreForwarder`] containing an [`Envelope`].
-#[derive(Clone, Debug)]
-pub struct StoreEnvelope {
-    pub envelope: Envelope,
-    pub start_time: Instant,
-    pub scoping: Scoping,
-}
-
-/// All the message types which can be sent to the [`StoreForwarder`].
-#[derive(Debug)]
-pub enum StoreMessages {
-    StoreEnvelope(StoreEnvelope, oneshot::Sender<Result<(), StoreError>>),
-}
-
-impl ServiceMessage<StoreForwarder> for StoreEnvelope {
-    type Response = Result<(), StoreError>;
-
-    fn into_messages(self) -> (StoreMessages, oneshot::Receiver<Self::Response>) {
-        let (tx, rx) = oneshot::channel();
-        (StoreMessages::StoreEnvelope(self, tx), rx)
     }
 }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -720,7 +720,7 @@ impl StoreService {
 impl Service for StoreService {
     type Interface = Store;
 
-    fn run(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             relay_log::info!("store forwarder started");
 

--- a/relay-server/src/endpoints/healthcheck.rs
+++ b/relay-server/src/endpoints/healthcheck.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use crate::service::ServiceApp;
 
-use crate::actors::healthcheck::{Healthcheck, IsHealthy};
+use crate::actors::healthcheck::{HealthcheckService, IsHealthy};
 
 #[derive(Serialize)]
 struct HealthcheckResponse {
@@ -34,7 +34,7 @@ impl HealthcheckResponse {
 
 fn healthcheck_impl(message: IsHealthy) -> ResponseFuture<HttpResponse, Error> {
     let fut = async move {
-        let addr = Healthcheck::from_registry();
+        let addr = HealthcheckService::from_registry();
         addr.send(message).await
     };
 

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -12,7 +12,7 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
 
     let producer = OutcomeProducer::from_registry();
     for outcome in body.inner.outcomes {
-        let _ = producer.send(outcome);
+        producer.send(outcome);
     }
 
     HttpResponse::Accepted().json(SendOutcomesResponse {})

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -1,7 +1,7 @@
 use actix_web::HttpResponse;
 use relay_config::EmitOutcomes;
 
-use crate::actors::outcome::{OutcomeProducer, SendOutcomes, SendOutcomesResponse};
+use crate::actors::outcome::{OutcomeProducerService, SendOutcomes, SendOutcomesResponse};
 use crate::extractors::{CurrentServiceState, SignedJson};
 use crate::service::ServiceApp;
 
@@ -10,7 +10,7 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
         return HttpResponse::Forbidden().finish();
     }
 
-    let producer = OutcomeProducer::from_registry();
+    let producer = OutcomeProducerService::from_registry();
     for outcome in body.inner.outcomes {
         producer.send(outcome);
     }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use actix::prelude::*;
 use actix_web::{server, App};
-use failure::ResultExt;
-use failure::{Backtrace, Context, Fail};
+use failure::{Backtrace, Context, Fail, ResultExt};
 use listenfd::ListenFd;
 use once_cell::race::OnceBox;
 
@@ -12,8 +11,7 @@ use relay_aws_extension::AwsExtension;
 use relay_config::Config;
 use relay_metrics::Aggregator;
 use relay_redis::RedisPool;
-use relay_system::{Addr, Service};
-use relay_system::{Configure, Controller};
+use relay_system::{Addr, Configure, Controller, Service};
 
 use crate::actors::envelopes::EnvelopeManager;
 use crate::actors::healthcheck::{Healthcheck, HealthcheckService};

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -12,12 +12,12 @@ use relay_aws_extension::AwsExtension;
 use relay_config::Config;
 use relay_metrics::Aggregator;
 use relay_redis::RedisPool;
-use relay_system::Addr;
+use relay_system::{Addr, Service};
 use relay_system::{Configure, Controller};
 
 use crate::actors::envelopes::EnvelopeManager;
-use crate::actors::healthcheck::Healthcheck;
-use crate::actors::outcome::OutcomeProducer;
+use crate::actors::healthcheck::{Healthcheck, HealthcheckMessages};
+use crate::actors::outcome::{OutcomeProducer, OutcomeProducerMessages, TrackOutcome};
 use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::actors::processor::EnvelopeProcessor;
 use crate::actors::project_cache::ProjectCache;
@@ -112,9 +112,9 @@ impl From<Context<ServerErrorKind>> for ServerError {
 
 #[derive(Clone)]
 pub struct Registry {
-    pub healthcheck: Addr<Healthcheck>,
-    pub outcome_producer: Addr<OutcomeProducer>,
-    pub outcome_aggregator: Addr<OutcomeAggregator>,
+    pub healthcheck: Addr<HealthcheckMessages>,
+    pub outcome_producer: Addr<OutcomeProducerMessages>,
+    pub outcome_aggregator: Addr<TrackOutcome>,
     pub processor: actix::Addr<EnvelopeProcessor>,
 }
 

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -97,7 +97,7 @@ impl EnvelopeContext {
     /// operation to ensure that subsequent outcomes are consistent.
     pub fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
         let outcome_aggregator = OutcomeAggregator::from_registry();
-        let _ = outcome_aggregator.send(TrackOutcome {
+        outcome_aggregator.send(TrackOutcome {
             timestamp: self.received_at,
             scoping: self.scoping,
             outcome,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -245,7 +245,7 @@ impl Enforcement {
         for limit in [self.event, self.attachments, self.profiles] {
             if limit.is_active() {
                 let timestamp = relay_common::instant_to_date_time(envelope.meta().start_time());
-                let _ = OutcomeAggregator::from_registry().send(TrackOutcome {
+                OutcomeAggregator::from_registry().send(TrackOutcome {
                     timestamp,
                     scoping: *scoping,
                     outcome: Outcome::RateLimited(limit.reason_code),

--- a/relay-server/src/utils/sleep_handle.rs
+++ b/relay-server/src/utils/sleep_handle.rs
@@ -34,8 +34,8 @@ impl SleepHandle {
 impl Future for SleepHandle {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        match unsafe { &mut self.get_unchecked_mut().0 } {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match &mut self.0 {
             Some(sleep) => Pin::new(sleep).poll(cx),
             None => Poll::Pending,
         }

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -118,9 +118,9 @@ impl std::error::Error for SendError {}
 
 /// Response behavior of an [`Interface`] message.
 ///
-/// The action type defines the response behavior of a service, such as asynchronous responses
-/// or fire-and-forget without responding. [`FromMessage`] implementations declare this behavior
-/// on the interface.
+/// It defines how a service handles and responds to interface messages, such as through
+/// asynchronous responses or fire-and-forget without responding. [`FromMessage`] implementations
+/// declare this behavior on the interface.
 ///
 /// See [`FromMessage`] for more information on how to use this trait.
 pub trait MessageResponse {
@@ -176,6 +176,8 @@ impl<T> fmt::Debug for Sender<T> {
 
 impl<T> Sender<T> {
     /// Sends the response value and closes the [`Request`].
+    ///
+    /// This silenly drops the value if the request has been dropped.
     pub fn send(self, value: T) {
         self.0.send(value).ok();
     }
@@ -349,7 +351,7 @@ impl<I: Interface> Addr<I> {
 /// created through [`channel`]. The channel closes when all associated [`Addr`]s are dropped.
 pub type Receiver<I> = mpsc::UnboundedReceiver<I>;
 
-/// Creates an unbounded channel for communicating with a [`Service`] without backpressure.
+/// Creates an unbounded channel for communicating with a [`Service`].
 ///
 /// The `Addr` as the sending part provides public access to the service, while the `Receiver`
 /// should remain internal to the service.
@@ -373,7 +375,7 @@ pub fn channel<I: Interface>() -> (Addr<I>, Receiver<I>) {
 ///
 /// The standard way to implement services is through the `run` function. It receives an inbound
 /// channel for all messages sent through the service's address. Note that this function is
-/// synchronous, so that this needs to spawn a task internally.
+/// synchronous, so that this needs to spawn at least one task internally:
 ///
 /// ```no_run
 /// use relay_system::{FromMessage, Interface, NoResponse, Receiver, Service};

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -152,10 +152,10 @@ impl<T> fmt::Debug for Request<T> {
 impl<T> Future for Request<T> {
     type Output = Result<T, SendError>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
-        // Pinning is structural for the wrapped oneshot receiver, it implements `Unpin`.
-        // See: https://doc.rust-lang.org/stable/std/pin/index.html#pinning-is-structural-for-field
-        unsafe { self.map_unchecked_mut(|r| &mut r.0).poll(cx) }.map(|r| r.map_err(|_| SendError))
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+        Pin::new(&mut self.0)
+            .poll(cx)
+            .map(|r| r.map_err(|_| SendError))
     }
 }
 

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -1,36 +1,108 @@
 use std::fmt;
 use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::Context;
 
 use tokio::sync::{mpsc, oneshot};
 
-/// Our definition of a service.
+/// A message interface for [services](Service).
 ///
-/// Services are much like actors: they receive messages from an inbox and handles them one
-/// by one.  Services are free to concurrently process these messages or not, most probably
-/// should.
+/// Most commonly, this interface is an enumeration of messages, but it can also be implemented on a
+/// single message. For each individual message, this type needs to implement the [`FromMessage`]
+/// trait.
 ///
-/// Messages always have a response which will be sent once the message is handled by the
-/// service.
-pub trait Service {
-    /// The messages is what is sent to the inbox of this service.
-    ///
-    /// It is an enum of all the message types that can be handled by this service together
-    /// with the response [sender](oneshot::Sender) for each message.
-    type Messages: Send + 'static;
-}
-
-/// A message which can be sent to a service.
+/// # Implementating Interfaces
 ///
-/// Messages have an associated `Response` type and can be unconditionally converted into
-/// the messages type of their [`Service`].
-pub trait ServiceMessage<S: Service> {
-    /// The type of the `Response`.
-    type Response: Send + 'static;
-
-    /// Creates and returns a wrapper containing the message and a Transmitter, also returns the
-    ///  corresponding Receiver.
-    fn into_messages(self) -> (S::Messages, oneshot::Receiver<Self::Response>);
-}
+/// There are three main ways to implement interfaces, which depends on the number of messages and
+/// their return values. The simplest way is an interface consisting of a **single message** with
+/// **no return value**. For this case, use the message directly as interface and choose
+/// `NoResponse` as response:
+///
+/// ```
+/// use relay_system::{FromMessage, Interface, NoResponse};
+///
+/// #[derive(Debug)]
+/// pub struct MyMessage;
+///
+/// impl Interface for MyMessage {}
+///
+/// impl FromMessage<Self> for MyMessage {
+///     type Response = NoResponse;
+///
+///     fn from_message(message: Self, _: ()) -> Self {
+///         message
+///     }
+/// }
+/// ```
+///
+/// If there is a **single message with a return value**, implement the interface as a wrapper for
+/// the message and the return [`Sender`]:
+///
+/// ```
+/// use relay_system::{AsyncResponse, FromMessage, Interface, Sender};
+///
+/// #[derive(Debug)]
+/// pub struct MyMessage;
+///
+/// #[derive(Debug)]
+/// pub struct MyInterface(MyMessage, Sender<bool>);
+///
+/// impl Interface for MyInterface {}
+///
+/// impl FromMessage<MyMessage> for MyInterface {
+///     type Response = AsyncResponse<bool>;
+///
+///     fn from_message(message: MyMessage, sender: Sender<bool>) -> Self {
+///         Self(message, sender)
+///     }
+/// }
+/// ```
+///
+/// Finally, interfaces with **multiple messages** of any kind can most commonly be implemented
+/// through an enumeration for every message. The variants of messages with return values need a
+/// `Sender` again:
+///
+/// ```
+/// use relay_system::{AsyncResponse, FromMessage, Interface, NoResponse, Sender};
+///
+/// #[derive(Debug)]
+/// pub struct GetFlag;
+///
+/// #[derive(Debug)]
+/// pub struct SetFlag(pub bool);
+///
+/// #[derive(Debug)]
+/// pub enum MyInterface {
+///     Get(GetFlag, Sender<bool>),
+///     Set(SetFlag),
+/// }
+///
+/// impl Interface for MyInterface {}
+///
+/// impl FromMessage<GetFlag> for MyInterface {
+///     type Response = AsyncResponse<bool>;
+///
+///     fn from_message(message: GetFlag, sender: Sender<bool>) -> Self {
+///         Self::Get(message, sender)
+///     }
+/// }
+///
+/// impl FromMessage<SetFlag> for MyInterface {
+///     type Response = NoResponse;
+///
+///     fn from_message(message: SetFlag, _: ()) -> Self {
+///         Self::Set(message)
+///     }
+/// }
+/// ```
+///
+/// # Requirements
+///
+/// Interfaces are meant to be sent to services via channels. As such, they need to be both `Send`
+/// and `'static`. It is highly encouraged to implement `Debug` on all interfaces and their
+/// messages.
+pub trait Interface: Send + 'static {}
 
 /// An error when [sending](Addr::send) a message to a service fails.
 #[derive(Clone, Copy, Debug)]
@@ -44,19 +116,203 @@ impl fmt::Display for SendError {
 
 impl std::error::Error for SendError {}
 
-/// The address for a [`Service`].
+/// Response behavior of an [`Interface`] message.
 ///
-/// The address of a [`Service`] allows you to [send](Addr::send) messages to the service as
-/// long as the service is running.  It can be freely cloned.
-#[derive(Debug)]
-pub struct Addr<S: Service> {
-    /// The transmitter of the channel used to communicate with the Service
-    pub tx: mpsc::UnboundedSender<S::Messages>,
+/// The action type defines the response behavior of a service, such as asynchronous responses
+/// or fire-and-forget without responding. [`FromMessage`] implementations declare this behavior
+/// on the interface.
+///
+/// See [`FromMessage`] for more information on how to use this trait.
+pub trait MessageResponse {
+    /// Sends responses from the service back to the waiting recipient.
+    type Sender;
+
+    /// The type returned from [`Addr::send`].
+    ///
+    /// This type can be either synchronous and asynchronous based on the responder.
+    type Output;
+
+    /// Returns the response channel for an interface message.
+    fn channel() -> (Self::Sender, Self::Output);
 }
 
-// Manually derive clone since we do not require `S: Clone` and the Clone derive adds this
+/// The request when sending an asynchronous message to a service.
+///
+/// This is returned from [`Addr::send`] when the message responds asynchronously through
+/// [`AsyncResponse`]. It is a future that should be awaited. The message still runs to
+/// completion if this future is dropped.
+pub struct Request<T>(oneshot::Receiver<T>);
+
+impl<T> fmt::Debug for Request<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Request").finish_non_exhaustive()
+    }
+}
+
+impl<T> Future for Request<T> {
+    type Output = Result<T, SendError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+        // Pinning is structural for the wrapped oneshot receiver, it implements `Unpin`.
+        // See: https://doc.rust-lang.org/stable/std/pin/index.html#pinning-is-structural-for-field
+        unsafe { self.map_unchecked_mut(|r| &mut r.0).poll(cx) }.map(|r| r.map_err(|_| SendError))
+    }
+}
+
+/// Sends a message response from a service back to the waiting [`Request`].
+///
+/// The sender is part of an [`AsyncResponse`] and should be moved into the service interface
+/// type. If this sender is dropped without calling [`send`](Self::send), the request fails with
+/// [`SendError`].
+pub struct Sender<T>(oneshot::Sender<T>);
+
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender")
+            .field("open", &!self.0.is_closed())
+            .finish()
+    }
+}
+
+impl<T> Sender<T> {
+    /// Sends the response value and closes the [`Request`].
+    pub fn send(self, value: T) {
+        self.0.send(value).ok();
+    }
+}
+
+/// Message response resulting in an asynchronous [`Request`].
+///
+/// The sender must be placed on the interface in [`FromMessage::from_message`].
+pub struct AsyncResponse<T>(PhantomData<T>);
+
+impl<T> fmt::Debug for AsyncResponse<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("AsyncResponse")
+    }
+}
+
+impl<T> MessageResponse for AsyncResponse<T> {
+    type Sender = Sender<T>;
+    type Output = Request<T>;
+
+    fn channel() -> (Self::Sender, Self::Output) {
+        let (tx, rx) = oneshot::channel();
+        (Sender(tx), Request(rx))
+    }
+}
+
+/// Message response for fire-and-forget messages with no output.
+///
+/// There is no sender associated to this response. When implementing [`FromMessage`], the sender
+/// can be ignored.
+pub struct NoResponse;
+
+impl fmt::Debug for NoResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("NoResponse")
+    }
+}
+
+impl MessageResponse for NoResponse {
+    type Sender = ();
+    type Output = ();
+
+    fn channel() -> (Self::Sender, Self::Output) {
+        ((), ())
+    }
+}
+
+/// Declares a message as part of an [`Interface`].
+///
+/// Messages have an associated `Response` type that determines the return value of sending the
+/// message. Within an interface, the responder can vary for each message. There are two provided
+/// responders.
+///
+/// # No Response
+///
+/// [`NoResponse`] is used for fire-and-forget messages that do not return any values. These
+/// messages do not spawn futures and cannot be awaited. It is neither possible to verify whether
+/// the message was delivered to the service.
+///
+/// When implementing `FromMessage` for such messages, the second argument can be ignored by
+/// convention:
+///
+/// ```
+/// use relay_system::{FromMessage, Interface, NoResponse};
+///
+/// struct MyMessage;
+///
+/// enum MyInterface {
+///     MyMessage(MyMessage),
+///     // ...
+/// }
+///
+/// impl Interface for MyInterface {}
+///
+/// impl FromMessage<MyMessage> for MyInterface {
+///     type Response = NoResponse;
+///
+///     fn from_message(message: MyMessage, _: ()) -> Self {
+///         Self::MyMessage(message)
+///     }
+/// }
+/// ```
+///
+/// # Asynchronous Responses
+///
+/// [`AsyncResponse`] is used for messages that resolve to some future value. This value is sent
+/// back by the service through a [`Sender`], which must be added into the interface:
+///
+/// ```
+/// use relay_system::{AsyncResponse, FromMessage, Interface, Sender};
+///
+/// struct MyMessage;
+///
+/// enum MyInterface {
+///     MyMessage(MyMessage, Sender<bool>),
+///     // ...
+/// }
+///
+/// impl Interface for MyInterface {}
+///
+/// impl FromMessage<MyMessage> for MyInterface {
+///     type Response = AsyncResponse<bool>;
+///
+///     fn from_message(message: MyMessage, sender: Sender<bool>) -> Self {
+///         Self::MyMessage(message, sender)
+///     }
+/// }
+/// ```
+///
+/// See [`Interface`] for more examples on how to build interfaces using this trait.
+pub trait FromMessage<M>: Interface {
+    /// The behavior declaring the return value when sending this message.
+    type Response: MessageResponse;
+
+    /// Converts the message into the service interface.
+    fn from_message(message: M, sender: <Self::Response as MessageResponse>::Sender) -> Self;
+}
+
+/// The address of a [`Service`].
+///
+/// The address of a [`Service`] allows you to [send](Self::send) messages to the service as
+/// long as the service is running. It can be freely cloned.
+pub struct Addr<I: Interface> {
+    tx: mpsc::UnboundedSender<I>,
+}
+
+impl<I: Interface> fmt::Debug for Addr<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Addr")
+            .field("open", &!self.tx.is_closed())
+            .finish()
+    }
+}
+
+// Manually derive `Clone` since we do not require `I: Clone` and the Clone derive adds this
 // constraint.
-impl<S: Service> Clone for Addr<S> {
+impl<I: Interface> Clone for Addr<I> {
     fn clone(&self) -> Self {
         Self {
             tx: self.tx.clone(),
@@ -64,25 +320,109 @@ impl<S: Service> Clone for Addr<S> {
     }
 }
 
-impl<S: Service> Addr<S> {
-    /// Sends an asynchronous message to the service and waits for the response.
+impl<I: Interface> Addr<I> {
+    /// Sends a message to the service and returns the response.
     ///
-    /// The result of the message does not have to be awaited. The message will be delivered and
-    /// handled regardless. The communication channel with the service is unbounded, so backlogs
-    /// could occur when sending too many messages.
+    /// Depending on the message's response behavior, this either returns a future resolving to the
+    /// return value, or does not return anything for fire-and-forget messages. The communication
+    /// channel with the service is unbounded, so backlogs could occur when sending too many
+    /// messages.
     ///
-    /// Sending the message can fail with `Err(SendError)` if the service has shut down.
-    // Note: this is written as returning `impl Future` instead of `async fn` in order not
-    // to capture the lifetime of `&self` in the returned future.
-    pub fn send<M>(&self, message: M) -> impl Future<Output = Result<M::Response, SendError>>
+    /// Sending asynchronous messages can fail with `Err(SendError)` if the service has shut down.
+    /// The result of asynchronous messages does not have to be awaited. The message will be
+    /// delivered and handled regardless:
+    pub fn send<M>(&self, message: M) -> <I::Response as MessageResponse>::Output
     where
-        M: ServiceMessage<S>,
+        I: FromMessage<M>,
     {
-        let (messages, response_rx) = message.into_messages();
-        let res = self.tx.send(messages);
-        async move {
-            res.map_err(|_| SendError)?;
-            response_rx.await.map_err(|_| SendError)
-        }
+        let (tx, rx) = I::Response::channel();
+        self.tx.send(I::from_message(message, tx)).ok(); // it's ok to drop, the response will fail
+        rx
+    }
+}
+
+/// Inbound channel for messages sent through an [`Addr`].
+///
+/// This channel is meant to be polled in a [`Service`].
+///
+/// Instances are created automatically when [running](Service::run) a service, or can be
+/// created through [`channel`]. The channel closes when all associated [`Addr`]s are dropped.
+pub type Receiver<I> = mpsc::UnboundedReceiver<I>;
+
+/// Creates an unbounded channel for communicating with a [`Service`] without backpressure.
+///
+/// The `Addr` as the sending part provides public access to the service, while the `Receiver`
+/// should remain internal to the service.
+pub fn channel<I: Interface>() -> (Addr<I>, Receiver<I>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (Addr { tx }, rx)
+}
+
+/// An asynchronous unit responding to messages.
+///
+/// Services receive messages conforming to some [`Interface`] through an [`Addr`] and handle them
+/// one by one. Internally, services are free to concurrently process these messages or not, most
+/// probably should.
+///
+/// Individual messages can have a response which will be sent once the message is handled by the
+/// service. The sender can asynchronously await the responses of such messages.
+///
+/// To start a service, create an instance of the service and use [`Service::start`].
+///
+/// # Implementing Services
+///
+/// The standard way to implement services is through the `run` function. It receives an inbound
+/// channel for all messages sent through the service's address. Note that this function is
+/// synchronous, so that this needs to spawn a task internally.
+///
+/// ```no_run
+/// use relay_system::{FromMessage, Interface, NoResponse, Receiver, Service};
+///
+/// struct MyMessage;
+///
+/// impl Interface for MyMessage {}
+///
+/// impl FromMessage<Self> for MyMessage {
+///     type Response = NoResponse;
+///
+///     fn from_message(message: Self, _: ()) -> Self {
+///         message
+///     }
+/// }
+///
+/// struct MyService;
+///
+/// impl Service for MyService {
+///     type Interface = MyMessage;
+///
+///     fn run(self, mut rx: Receiver<Self::Interface>) {
+///         tokio::spawn(async move {
+///             while let Some(message) = rx.recv().await {
+///                 // handle the message
+///             }
+///         });
+///     }
+/// }
+///
+/// let addr = MyService.start();
+/// ```
+pub trait Service: Sized {
+    /// The interface of messages this service implements.
+    ///
+    /// The interface can be a single message type or an enumeration of all the messages that
+    /// can be handled by this service.
+    type Interface: Interface;
+
+    /// Runs the service's accept loop.
+    ///
+    /// Receives an inbound channel for all messages sent through the service's address. Note
+    /// that this function is synchronous, so that this needs to spawn a task internally.
+    fn run(self, rx: Receiver<Self::Interface>);
+
+    /// Starts the service with its accept loop and returns an address to send messages in.
+    fn start(self) -> Addr<Self::Interface> {
+        let (addr, rx) = channel();
+        self.run(rx);
+        addr
     }
 }


### PR DESCRIPTION
Updates `Service` and associated traits with a new architecture that provides more implicit guidelines during implementation:

1. `Service` consumes messages corresponding to an interface and executes logic. It features a run loop internally that is spawned through a trait method. 
2. `Interface` declares one more multiple messages that a `Service` can handle. It's a data class that can be sent across threads.
3. `FromMessage` binds plain message objects (trait-less) to an interface. Per convention, the interface is or wraps the message object, although it's also possible to destruct the message object in the conversion. Additionally, this trait defines the response behavior: fire-and-forget or async.
4. `MessageResponse` is the trait defining response behaviors. There are two provided implementations: (1) `NoResponse` and (2) `AsyncResponse`.
5. `Addr` stays the channel for communicating with a `Service`. It is now created and returned automatically through provided methods on `Service`. 

#skip-changelog

