### PR TITLE
ref(system): Add helper to start services in runtimes

### DIFF
--- a/relay-redis/src/noop.rs
+++ b/relay-redis/src/noop.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use crate::config::RedisConfig;
 
 /// This is an unconstructable type to make `Option<RedisPool>` zero-sized.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RedisPool;
 
 /// An error returned from `RedisPool`.

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -506,6 +506,7 @@ pub struct PublicKeyConfig {
     pub numeric_id: Option<u64>,
 }
 
+#[derive(Debug)]
 struct StateChannel {
     inner: BroadcastChannel<Arc<ProjectState>>,
     no_cache: bool,
@@ -534,6 +535,7 @@ enum GetOrFetch<'a> {
 ///
 /// This structure no longer uniquely identifies a project. Instead, it identifies a project key.
 /// Projects can define multiple keys, in which case this structure is duplicated for each instance.
+#[derive(Debug)]
 pub struct Project {
     backoff: RetryBackoff,
     next_fetch_attempt: Option<Instant>,

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -810,7 +810,7 @@ impl SharedClient {
 
             Some(upstream_limits)
         } else {
-            None // TODO(ja): Check if we still need to consume responses
+            None
         };
 
         // At this point, we consume the Response. This means we need to consume the response

--- a/relay-server/src/utils/garbage.rs
+++ b/relay-server/src/utils/garbage.rs
@@ -5,6 +5,7 @@ use std::thread::JoinHandle;
 /// Garbage disposal agent.
 ///
 /// Spawns a background thread which drops items sent to it via [`GarbageDisposal::dispose`].
+#[derive(Debug)]
 pub struct GarbageDisposal<T> {
     tx: mpsc::Sender<T>,
     queue_size: Arc<AtomicUsize>,

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use futures::future::Shared;
 use futures::FutureExt;
+use tokio::runtime::Runtime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::MissedTickBehavior;
 
@@ -978,6 +979,12 @@ pub trait Service: Sized {
         let (addr, rx) = channel(Self::name());
         self.spawn_handler(rx);
         addr
+    }
+
+    /// Starts the service in the given runtime and returns an address for it.
+    fn start_in(self, runtime: &Runtime) -> Addr<Self::Interface> {
+        let _guard = runtime.enter();
+        self.start()
     }
 
     /// Returns a unique name for this service implementation.


### PR DESCRIPTION
When creating Relay's services network, we commonly spawn groups of
services into dedicated runtimes. There is a repeated pattern of
creating a runtime, entering it, starting the service, dropping the
runtime guard.

Which runtime each service runs in depends on the runtime guard that was
last activated before. This is not as clear and safe in the code as it
could be. For that reason, this PR introduces a `spawn_in` that takes
care of all the above steps and returns the address.

Two services needed refactoring as a result: The `OutcomeProducer` and
`ProjectCache` implementations. Both spawned sub-services in their
constructors, which escaped the scope created by `spawn_in`. To ensure
that the sub-services run within the same runtime, all spawning of
services has moved into the `spawn_handler` function. Note that
`ProjectCache` now assumes a similar pattern to the `UpstreamRelay` with
an internal broker and message channel.

#skip-changelog

