### PR TITLE
ref: Rename healthcheck to "health check"

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1167,7 +1167,7 @@ impl Message for FlushBuckets {
     type Result = Result<(), Vec<Bucket>>;
 }
 
-/// Check whether the aggregator has not (yet) exceeded its total limits. Used for healthchecks.
+/// Check whether the aggregator has not (yet) exceeded its total limits. Used for health checks.
 pub struct AcceptsMetrics;
 
 impl Message for AcceptsMetrics {

--- a/relay-server/src/actors/health_check.rs
+++ b/relay-server/src/actors/health_check.rs
@@ -25,11 +25,11 @@ pub enum IsHealthy {
 }
 
 /// Service interface for the [`IsHealthy`] message.
-pub struct Healthcheck(IsHealthy, Sender<bool>);
+pub struct HealthCheck(IsHealthy, Sender<bool>);
 
-impl Interface for Healthcheck {}
+impl Interface for HealthCheck {}
 
-impl FromMessage<IsHealthy> for Healthcheck {
+impl FromMessage<IsHealthy> for HealthCheck {
     type Response = AsyncResponse<bool>;
 
     fn from_message(message: IsHealthy, sender: Sender<bool>) -> Self {
@@ -37,31 +37,31 @@ impl FromMessage<IsHealthy> for Healthcheck {
     }
 }
 
-/// Service implementing the [`Healthcheck`] interface.
+/// Service implementing the [`HealthCheck`] interface.
 #[derive(Debug)]
-pub struct HealthcheckService {
+pub struct HealthCheckService {
     is_shutting_down: AtomicBool,
     config: Arc<Config>,
 }
 
-impl HealthcheckService {
-    /// Returns the [`Addr`] of the [`Healthcheck`] service.
+impl HealthCheckService {
+    /// Returns the [`Addr`] of the [`HealthCheck`] service.
     ///
-    /// Prior to using this, the service must be started using [`HealthcheckService::start`].
+    /// Prior to using this, the service must be started using [`HealthCheckService::start`].
     ///
     /// # Panics
     ///
-    /// Panics if the service was not started using [`HealthcheckService::start`] prior to this
+    /// Panics if the service was not started using [`HealthCheckService::start`] prior to this
     /// being used.
-    pub fn from_registry() -> Addr<Healthcheck> {
-        REGISTRY.get().unwrap().healthcheck.clone()
+    pub fn from_registry() -> Addr<HealthCheck> {
+        REGISTRY.get().unwrap().health_check.clone()
     }
 
-    /// Creates a new instance of the Healthcheck service.
+    /// Creates a new instance of the HealthCheck service.
     ///
     /// The service does not run. To run the service, use [`start`](Self::start).
     pub fn new(config: Arc<Config>) -> Self {
-        HealthcheckService {
+        HealthCheckService {
             is_shutting_down: AtomicBool::new(false),
             config,
         }
@@ -101,15 +101,15 @@ impl HealthcheckService {
         }
     }
 
-    async fn handle_message(&self, message: Healthcheck) {
-        let Healthcheck(message, sender) = message;
+    async fn handle_message(&self, message: HealthCheck) {
+        let HealthCheck(message, sender) = message;
         let response = self.handle_is_healthy(message).await;
         sender.send(response);
     }
 }
 
-impl Service for HealthcheckService {
-    type Interface = Healthcheck;
+impl Service for HealthCheckService {
+    type Interface = HealthCheck;
 
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
         let service = Arc::new(self);

--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -29,7 +29,7 @@
 //!     .expect("failed to start relay");
 //! ```
 pub mod envelopes;
-pub mod healthcheck;
+pub mod health_check;
 pub mod outcome;
 pub mod outcome_aggregator;
 pub mod processor;

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -506,7 +506,7 @@ impl UpstreamRelay {
         );
 
         ctx.run_later(next_backoff, |slf, ctx| {
-            let request = EnqueuedRequest::new(GetHealthcheck);
+            let request = EnqueuedRequest::new(GetHealthCheck);
             slf.enqueue(request, ctx, EnqueuePosition::Front);
         });
     }
@@ -964,9 +964,9 @@ impl Handler<ScheduleConnectionCheck> for UpstreamRelay {
 }
 
 /// Checks the status of the network connection with the upstream server
-struct GetHealthcheck;
+struct GetHealthCheck;
 
-impl UpstreamRequest for GetHealthcheck {
+impl UpstreamRequest for GetHealthCheck {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -10,7 +10,7 @@ mod common;
 mod envelope;
 mod events;
 mod forward;
-mod healthcheck;
+mod health_check;
 mod minidump;
 mod outcomes;
 mod project_configs;
@@ -23,7 +23,7 @@ mod unreal;
 pub fn configure_app(app: ServiceApp) -> ServiceApp {
     app
         // Internal routes pointing to /api/relay
-        .configure(healthcheck::configure_app)
+        .configure(health_check::configure_app)
         .configure(events::configure_app)
         .handler("/api/relay", statics::not_found)
         // Web API routes pointing to /api/0

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -8,7 +8,7 @@ session = requests.session()
 
 
 class SentryLike(object):
-    _healthcheck_passed = False
+    _health_check_passed = False
 
     default_dsn_public_key = "31a5a894b4524f74a9a8d0e27e21ba91"
 
@@ -95,12 +95,12 @@ class SentryLike(object):
                     raise
                 backoff *= 2
 
-    def wait_relay_healthcheck(self):
-        if self._healthcheck_passed:
+    def wait_relay_health_check(self):
+        if self._health_check_passed:
             return
 
         self._wait("/api/relay/healthcheck/ready/")
-        self._healthcheck_passed = True
+        self._health_check_passed = True
 
     def __repr__(self):
         return "<{}({})>".format(self.__class__.__name__, repr(self.upstream))

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -96,7 +96,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
         options=None,
         prepare=None,
         external=None,
-        wait_healthcheck=True,
+        wait_health_check=True,
         static_relays=None,
         version="latest",
     ):
@@ -172,8 +172,8 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             version,
         )
 
-        if wait_healthcheck:
-            relay.wait_relay_healthcheck()
+        if wait_health_check:
+            relay.wait_relay_health_check()
 
         return relay
 

--- a/tests/integration/test_aws_extension.py
+++ b/tests/integration/test_aws_extension.py
@@ -7,7 +7,7 @@ def test_register(aws_lambda_runtime, relay, mini_sentry):
 
     relay_options = {"aws": {"runtime_api": netloc}, "limits": {"shutdown_timeout": 2}}
 
-    relay(mini_sentry, options=relay_options, wait_healthcheck=False)
+    relay(mini_sentry, options=relay_options, wait_health_check=False)
     sleep(2)  # wait for clean shutdown, trigerred by 5th next_event request
 
     requests = aws_lambda_runtime.requests

--- a/tests/integration/test_ephemeral_config.py
+++ b/tests/integration/test_ephemeral_config.py
@@ -80,7 +80,7 @@ def test_store_via_ephemeral_relay(
         {},
         version,
     )
-    relay.wait_relay_healthcheck()
+    relay.wait_relay_health_check()
     print(mode)
     if mode == "managed":
         project_config["config"]["trustedRelays"] = list(relay.iter_public_keys())

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -42,13 +42,13 @@ def test_readiness(mini_sentry, relay):
     mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge
 
     try:
-        relay = relay(mini_sentry, wait_healthcheck=False)
+        relay = relay(mini_sentry, wait_health_check=False)
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         assert response.status_code == 503
 
         mini_sentry.app.view_functions["check_challenge"] = original_check_challenge
 
-        relay.wait_relay_healthcheck()
+        relay.wait_relay_health_check()
         response = relay.get("/api/relay/healthcheck/ready/")
         assert response.status_code == 200
     finally:
@@ -61,7 +61,7 @@ def test_readiness_flag(mini_sentry, relay):
 
     try:
         relay = relay(
-            mini_sentry, {"auth": {"ready": "always"}}, wait_healthcheck=False
+            mini_sentry, {"auth": {"ready": "always"}}, wait_health_check=False
         )
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         assert response.status_code == 200
@@ -74,7 +74,9 @@ def test_readiness_proxy(mini_sentry, relay):
     mini_sentry.app.view_functions["check_challenge"] = failing_check_challenge
 
     try:
-        relay = relay(mini_sentry, {"relay": {"mode": "proxy"}}, wait_healthcheck=False)
+        relay = relay(
+            mini_sentry, {"relay": {"mode": "proxy"}}, wait_health_check=False
+        )
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         assert response.status_code == 200
     finally:
@@ -87,7 +89,7 @@ def test_readiness_depends_on_aggregator_being_full(mini_sentry, relay):
         relay = relay(
             mini_sentry,
             {"aggregator": {"max_total_bucket_bytes": 0}},
-            wait_healthcheck=False,
+            wait_health_check=False,
         )
 
         response = wait_get(relay, "/api/relay/healthcheck/ready/")

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -34,9 +34,9 @@ def test_dynamic_relays(mini_sentry, relay, caller, projects):
         id2: {"public_key": str(pk2), "internal": False},
     }
 
-    relay1 = relay(mini_sentry, wait_healthcheck=True, static_relays=relays_conf)
+    relay1 = relay(mini_sentry, wait_health_check=True, static_relays=relays_conf)
     relay2 = relay(
-        mini_sentry, wait_healthcheck=True, external=True, static_relays=relays_conf,
+        mini_sentry, wait_health_check=True, external=True, static_relays=relays_conf,
     )
 
     # create info for our test parameters
@@ -98,7 +98,7 @@ def test_dynamic_relays(mini_sentry, relay, caller, projects):
 
 
 def test_invalid_json(mini_sentry, relay):
-    relay = relay(mini_sentry, wait_healthcheck=True)
+    relay = relay(mini_sentry, wait_health_check=True)
 
     body = {}  # missing the required `publicKeys` field
     packed, signature = SecretKey.parse(relay.secret_key).pack(body)
@@ -117,7 +117,7 @@ def test_invalid_json(mini_sentry, relay):
 
 
 def test_invalid_signature(mini_sentry, relay):
-    relay = relay(mini_sentry, wait_healthcheck=True)
+    relay = relay(mini_sentry, wait_health_check=True)
 
     response = relay.post(
         "/api/0/relays/projectconfigs/?version=2",
@@ -133,7 +133,7 @@ def test_invalid_signature(mini_sentry, relay):
 
 
 def test_broken_projectkey(mini_sentry, relay):
-    relay = relay(mini_sentry, wait_healthcheck=True)
+    relay = relay(mini_sentry, wait_health_check=True)
     mini_sentry.add_basic_project_config(42)
     public_key = mini_sentry.get_dsn_public_key(42)
 
@@ -164,7 +164,7 @@ def test_pending_projects(mini_sentry, relay):
     # V3 requests will never return a projectconfig on the first request, only some
     # subsequent request will contain the response.  However if the machine executing this
     # test is very slow this could still be a flaky test.
-    relay = relay(mini_sentry, wait_healthcheck=True)
+    relay = relay(mini_sentry, wait_health_check=True)
     project = mini_sentry.add_basic_project_config(42)
     public_key = mini_sentry.get_dsn_public_key(42)
 

--- a/tests/integration/test_publickeys.py
+++ b/tests/integration/test_publickeys.py
@@ -54,8 +54,8 @@ def test_public_keys(mini_sentry, relay, caller, relays_to_fetch):
     }
 
     # create 2 normal relays
-    relay1 = relay(mini_sentry, wait_healthcheck=True, static_relays=relays_conf)
-    relay2 = relay(mini_sentry, wait_healthcheck=True, static_relays=relays_conf)
+    relay1 = relay(mini_sentry, wait_health_check=True, static_relays=relays_conf)
+    relay2 = relay(mini_sentry, wait_health_check=True, static_relays=relays_conf)
 
     # create info for our test parameters
     r1 = RelayInfo(

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -20,7 +20,7 @@ def test_local_project_config(mini_sentry, relay):
     relay_config = {
         "cache": {"file_interval": 1, "project_expiry": 0, "project_grace_period": 0}
     }
-    relay = relay(mini_sentry, relay_config, wait_healthcheck=False)
+    relay = relay(mini_sentry, relay_config, wait_health_check=False)
     relay.config_dir.mkdir("projects").join("42.json").write(
         json.dumps(
             {
@@ -39,7 +39,7 @@ def test_local_project_config(mini_sentry, relay):
     # we don't look on the file system
     dsn_key = config["publicKeys"][0]["publicKey"]
 
-    relay.wait_relay_healthcheck()
+    relay.wait_relay_health_check()
     relay.send_event(project_id, dsn_key=dsn_key)
     event = mini_sentry.captured_events.get(timeout=1).get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -484,7 +484,7 @@ def test_events_buffered_before_auth(relay, mini_sentry):
 
     # keep max backoff as short as the configuration allows (1 sec)
     relay_options = {"http": {"max_retry_interval": 1}}
-    relay = relay(mini_sentry, relay_options, wait_healthcheck=False)
+    relay = relay(mini_sentry, relay_options, wait_health_check=False)
     assert evt.wait(1)  # wait for relay to start authenticating
 
     project_id = 42


### PR DESCRIPTION
The common spelling is "health check", so this PR changes all internal variable,
module, and type names to `health_check` and `HealthCheck`. The web endpoint is
not changed.

#skip-changelog
