### PR TITLE
fix(outcomes): Use correct configuration for billing outcomes when specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Do not apply rate limits or reject data based on expired project configs. ([#1404](https://github.com/getsentry/relay/pull/1404))
 - Process required stacktraces to fix filtering events originating from browser extensions. ([#1423](https://github.com/getsentry/relay/pull/1423))
 - Fix error message filtering when formatting the message of logentry. ([#1442](https://github.com/getsentry/relay/pull/1442))
+- Use the different configuration for billing outcomes when specified. ([]())
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Do not apply rate limits or reject data based on expired project configs. ([#1404](https://github.com/getsentry/relay/pull/1404))
 - Process required stacktraces to fix filtering events originating from browser extensions. ([#1423](https://github.com/getsentry/relay/pull/1423))
 - Fix error message filtering when formatting the message of logentry. ([#1442](https://github.com/getsentry/relay/pull/1442))
-- Use the different configuration for billing outcomes when specified. ([]())
+- Use the different configuration for billing outcomes when specified. ([#1461](https://github.com/getsentry/relay/pull/1461))
 
 **Internal**:
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -681,7 +681,7 @@ impl KafkaOutcomesProducer {
             .context(ServerErrorKind::KafkaError)?;
 
         let (billing_name, billing_config) = config
-            .kafka_config(KafkaTopic::Outcomes)
+            .kafka_config(KafkaTopic::OutcomesBilling)
             .context(ServerErrorKind::KafkaError)?;
 
         let default = Self::create_producer(default_config)?;


### PR DESCRIPTION
Right now it does not matter if we use a different configuration for `OutcomesBilling` we always pick the default one. 

This fixes this behaviour and makes sure to use the dedicated configuration if specified.