### PR TITLE
feat(profiling): Fix logic reversal typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add InvalidReplayEvent outcome. ([#1455](https://github.com/getsentry/relay/pull/1455))
 - Add replay and replay-recording rate limiter. ([#1456](https://github.com/getsentry/relay/pull/1456))
 - Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444))
+- Fix logic reversal typo related to profiling. ([#1463](https://github.com/getsentry/relay/pull/1463))
 
 **Features**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -855,7 +855,7 @@ impl EnvelopeProcessor {
         let context = &state.envelope_context;
 
         if let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::Profile) {
-            if profiling_enabled {
+            if !profiling_enabled {
                 return;
             }
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -872,6 +872,7 @@ impl EnvelopeProcessor {
                     }
                 }
                 Err(err) => {
+                    println!("{:#?}", err);
                     context.track_outcome(
                         outcome_from_profile_error(err),
                         DataCategory::Profile,


### PR DESCRIPTION
I didn't realize a change wasn't pushed in the multi transactions branch until the branch was merged on master. Since I switched the loop from a `retain` to a `taken_item_by`, we need to return early if profiling is not enabled now.