### PR TITLE
fix(profiling): Forward the profile from a PoP to a processing node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@
 - Add looser type requirements for the user.id field. ([#1443](https://github.com/getsentry/relay/pull/1443))
 - Add InvalidReplayEvent outcome. ([#1455](https://github.com/getsentry/relay/pull/1455))
 - Add replay and replay-recording rate limiter. ([#1456](https://github.com/getsentry/relay/pull/1456))
-- Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444))
-- Fix logic reversal typo related to profiling. ([#1463](https://github.com/getsentry/relay/pull/1463))
-- Forward the profile from a PoP to a processing node. ([#1464](https://github.com/getsentry/relay/pull/1464))
+- Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444)), ([#1463](https://github.com/getsentry/relay/pull/1463)), ([#1464](https://github.com/getsentry/relay/pull/1464))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add replay and replay-recording rate limiter. ([#1456](https://github.com/getsentry/relay/pull/1456))
 - Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444))
 - Fix logic reversal typo related to profiling. ([#1463](https://github.com/getsentry/relay/pull/1463))
+- Forward the profile from a PoP to a processing node. ([#1464](https://github.com/getsentry/relay/pull/1464))
 
 **Features**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -850,16 +850,16 @@ impl EnvelopeProcessor {
 
     /// Remove profiles if the feature flag is not enabled
     fn process_profiles(&self, state: &mut ProcessEnvelopeState) {
+        if !self.config.processing_enabled() {
+            return;
+        }
+
         let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
         let envelope = &mut state.envelope;
         let context = &state.envelope_context;
 
         if let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::Profile) {
             if !profiling_enabled {
-                return;
-            }
-
-            if !self.config.processing_enabled() {
                 return;
             }
 
@@ -872,7 +872,6 @@ impl EnvelopeProcessor {
                     }
                 }
                 Err(err) => {
-                    println!("{:#?}", err);
                     context.track_outcome(
                         outcome_from_profile_error(err),
                         DataCategory::Profile,


### PR DESCRIPTION
This aims to fix another mistake where we'd end up removing the profiles if the `processing` feature is not enabled on the Relay node. With this PR, if processing is not enabled on the node, we don't touch the envelope.

#skip-changelog