### PR TITLE
fix(profiling): Expand all Profile items in an envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add InvalidReplayEvent outcome. ([#1455](https://github.com/getsentry/relay/pull/1455))
 - Add replay and replay-recording rate limiter. ([#1456](https://github.com/getsentry/relay/pull/1456))
 - Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444)), ([#1463](https://github.com/getsentry/relay/pull/1463)), ([#1464](https://github.com/getsentry/relay/pull/1464))
+- Expand all Profile items in an envelope. ([#1465](https://github.com/getsentry/relay/pull/1465))
 
 **Features**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -863,11 +863,11 @@ impl EnvelopeProcessor {
         }
 
         let context = &state.envelope_context;
-        let new_profiles: &mut Vec<Vec<u8>> = &mut Vec::new();
+        let mut new_profiles = Vec::new();
 
         while let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::Profile) {
             match relay_profiling::expand_profile(&item.payload()[..]) {
-                Ok(mut payloads) => new_profiles.append(&mut payloads),
+                Ok(payloads) => new_profiles.extend(payloads),
                 Err(err) => {
                     context.track_outcome(
                         outcome_from_profile_error(err),
@@ -878,7 +878,7 @@ impl EnvelopeProcessor {
             }
         }
 
-        for payload in new_profiles.iter() {
+        for payload in new_profiles {
             let mut item = Item::new(ItemType::Profile);
             item.set_payload(ContentType::Json, &payload[..]);
             envelope.add_item(item);

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -867,7 +867,7 @@ impl EnvelopeProcessor {
 
         while let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::Profile) {
             match relay_profiling::expand_profile(&item.payload()[..]) {
-                Ok(payloads) => new_profiles.extend(payloads),
+                Ok(mut payloads) => new_profiles.append(&mut payloads),
                 Err(err) => {
                     context.track_outcome(
                         outcome_from_profile_error(err),


### PR DESCRIPTION
This fixes the last 2 remaing issues introduced by my recent PRs:
- remove `Profile` items if the organization doesn't have profiling enabled
- expand all `Profile` items in an envelope as opposed to jus the first one