### PR TITLE
feat(protocol): Track transaction name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Features**:
 
 - Make Redis connection pool configurable. ([#1418](https://github.com/getsentry/relay/pull/1418))
+- Add user-agent parsing to replays processor. ([#1420](https://github.com/getsentry/relay/pull/1420))
+- Improve the release name used when reporting data to Sentry to include both the version and exact build. ([#1428](https://github.com/getsentry/relay/pull/1428))
 
 **Bug Fixes**:
 
@@ -25,12 +27,7 @@
 - Add InvalidReplayEvent outcome. ([#1455](https://github.com/getsentry/relay/pull/1455))
 - Add replay and replay-recording rate limiter. ([#1456](https://github.com/getsentry/relay/pull/1456))
 - Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444)), ([#1463](https://github.com/getsentry/relay/pull/1463)), ([#1464](https://github.com/getsentry/relay/pull/1464))
-
-**Features**:
-
-- Make Redis connection pool configurable. ([#1418](https://github.com/getsentry/relay/pull/1418))
-- Add user-agent parsing to replays processor. ([#1420](https://github.com/getsentry/relay/pull/1420))
-- Improve the release name used when reporting data to Sentry to include both the version and exact build. ([#1428](https://github.com/getsentry/relay/pull/1428))
+- Track metrics for changes to the transaction name and DSC propagations. ([#1466](https://github.com/getsentry/relay/pull/1466))
 
 ## 22.8.0
 

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -560,6 +560,26 @@ impl Event {
             .map(|m| m.contains_key(module_name))
             .unwrap_or(false)
     }
+
+    pub fn sdk_name(&self) -> &str {
+        if let Some(client_sdk) = self.client_sdk.value() {
+            if let Some(name) = client_sdk.name.as_str() {
+                return name;
+            }
+        }
+
+        "unknown"
+    }
+
+    pub fn sdk_version(&self) -> &str {
+        if let Some(client_sdk) = self.client_sdk.value() {
+            if let Some(version) = client_sdk.version.as_str() {
+                return version;
+            }
+        }
+
+        "unknown"
+    }
 }
 
 #[cfg(test)]

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -118,10 +118,10 @@ impl ProcessValue for TransactionSource {}
 #[derive(Clone, Debug, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct TransactionNameChange {
-    /// Describes how the name of the previous transaction was determined.
+    /// Describes how the previous transaction name was determined.
     pub source: Annotated<TransactionSource>,
 
-    /// The number of propagations from the start of the transactions to this change.
+    /// The number of propagations from the start of the transaction to this change.
     pub propagations: Annotated<u64>,
 
     /// Timestamp when the transaction name was changed.
@@ -147,6 +147,9 @@ pub struct TransactionInfo {
     pub original: Annotated<String>,
 
     /// A list of changes prior to the final transaction name.
+    ///
+    /// This list must be empty if the transaction name is set at the beginning of the transaction
+    /// and never changed. There is no placeholder entry for the initial transaction name.
     pub changes: Annotated<Vec<Annotated<TransactionNameChange>>>,
 
     /// The total number of propagations during the transaction.

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -158,6 +158,7 @@ pub struct TransactionInfo {
 
 #[cfg(test)]
 mod tests {
+    use chrono::{TimeZone, Utc};
     use similar_asserts::assert_eq;
 
     use super::*;
@@ -174,13 +175,27 @@ mod tests {
     #[test]
     fn test_transaction_info_roundtrip() {
         let json = r#"{
-  "source": "url",
-  "original": "/auth/login/john123/"
+  "source": "route",
+  "original": "/auth/login/john123/",
+  "changes": [
+    {
+      "source": "url",
+      "propagations": 1,
+      "timestamp": 946684800.0
+    }
+  ],
+  "propagations": 2
 }"#;
 
         let info = Annotated::new(TransactionInfo {
-            source: Annotated::new(TransactionSource::Url),
+            source: Annotated::new(TransactionSource::Route),
             original: Annotated::new("/auth/login/john123/".to_owned()),
+            changes: Annotated::new(vec![Annotated::new(TransactionNameChange {
+                source: Annotated::new(TransactionSource::Url),
+                propagations: Annotated::new(1),
+                timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0).into()),
+            })]),
+            propagations: Annotated::new(2),
         });
 
         assert_eq!(info, Annotated::from_json(json).unwrap());

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::processor::ProcessValue;
+use crate::protocol::Timestamp;
 use crate::types::{Annotated, Empty, ErrorKind, FromValue, IntoValue, SkipSerialization, Value};
 
 /// Describes how the name of the transaction was determined.
@@ -108,6 +109,21 @@ impl IntoValue for TransactionSource {
 
 impl ProcessValue for TransactionSource {}
 
+#[derive(Clone, Debug, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
+pub struct TransactionNameChange {
+    /// Describes how the name of the previous transaction was determined.
+    pub source: Annotated<TransactionSource>,
+
+    /// The number of propagations from the start of the transactions to this change.
+    pub propagations: Annotated<u64>,
+
+    /// Timestamp when the transaction name was changed.
+    ///
+    /// This adheres to the event timestamp specification.
+    pub timestamp: Annotated<Timestamp>,
+}
+
 /// Additional information about the name of the transaction.
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
@@ -123,6 +139,12 @@ pub struct TransactionInfo {
     /// This value will only be set if the transaction name was modified during event processing.
     #[metastructure(max_chars = "culprit", trim_whitespace = "true")]
     pub original: Annotated<String>,
+
+    /// A list of changes prior to the final transaction name.
+    pub changes: Annotated<Vec<Annotated<TransactionNameChange>>>,
+
+    /// The total number of propagations during the transaction.
+    pub propagations: Annotated<u64>,
 }
 
 #[cfg(test)]

--- a/relay-general/src/protocol/transaction.rs
+++ b/relay-general/src/protocol/transaction.rs
@@ -29,6 +29,21 @@ pub enum TransactionSource {
     Other(String),
 }
 
+impl TransactionSource {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Custom => "custom",
+            Self::Url => "url",
+            Self::Route => "route",
+            Self::View => "view",
+            Self::Component => "component",
+            Self::Task => "task",
+            Self::Unknown => "unknown",
+            Self::Other(ref s) => s,
+        }
+    }
+}
+
 impl FromStr for TransactionSource {
     type Err = std::convert::Infallible;
 
@@ -48,16 +63,7 @@ impl FromStr for TransactionSource {
 
 impl fmt::Display for TransactionSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Custom => write!(f, "custom"),
-            Self::Url => write!(f, "url"),
-            Self::Route => write!(f, "route"),
-            Self::View => write!(f, "view"),
-            Self::Component => write!(f, "component"),
-            Self::Task => write!(f, "task"),
-            Self::Unknown => write!(f, "unknown"),
-            Self::Other(s) => write!(f, "{}", s),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1,7 +1,6 @@
 ---
 source: relay-general/tests/test_fixtures.rs
-assertion_line: 110
-expression: event_json_schema()
+expression: "relay_general::protocol::event_json_schema()"
 ---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -2983,6 +2982,24 @@ expression: event_json_schema()
         {
           "type": "object",
           "properties": {
+            "changes": {
+              "description": " A list of changes prior to the final transaction name.\n\n This list must be empty if the transaction name is set at the beginning of the transaction\n and never changed. There is no placeholder entry for the initial transaction name.",
+              "default": null,
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/TransactionNameChange"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
             "original": {
               "description": " The unmodified transaction name as obtained by the source.\n\n This value will only be set if the transaction name was modified during event processing.",
               "default": null,
@@ -2991,12 +3008,66 @@ expression: event_json_schema()
                 "null"
               ]
             },
+            "propagations": {
+              "description": " The total number of propagations during the transaction.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "source": {
               "description": " Describes how the name of the transaction was determined.\n\n This will be used by the server to decide whether or not to scrub identifiers from the\n transaction name, or replace the entire name with a placeholder.",
               "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/TransactionSource"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TransactionNameChange": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "propagations": {
+              "description": " The number of propagations from the start of the transaction to this change.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "source": {
+              "description": " Describes how the previous transaction name was determined.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TransactionSource"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timestamp": {
+              "description": " Timestamp when the transaction name was changed.\n\n This adheres to the event timestamp specification.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
                 },
                 {
                   "type": "null"

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -32,7 +32,7 @@ use relay_log::LogError;
 use relay_metrics::{Bucket, Metric};
 use relay_quotas::{DataCategory, RateLimits, ReasonCode};
 use relay_redis::RedisPool;
-use relay_sampling::RuleId;
+use relay_sampling::{DynamicSamplingContext, RuleId};
 use relay_statsd::metric;
 
 use crate::actors::envelopes::{EnvelopeManager, SendEnvelope, SendEnvelopeError, SubmitEnvelope};
@@ -45,7 +45,7 @@ use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::metrics_extraction::sessions::{extract_session_metrics, SessionMetricsConfig};
 use crate::metrics_extraction::transactions::extract_transaction_metrics;
 use crate::service::{ServerError, REGISTRY};
-use crate::statsd::{RelayCounters, RelayTimers};
+use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 use crate::utils::{
     self, ChunkedFormDataAggregator, EnvelopeContext, ErrorBoundary, FormDataIter, SamplingResult,
 };
@@ -342,6 +342,94 @@ fn outcome_from_profile_error(err: relay_profiling::ProfileError) -> Outcome {
         _ => DiscardReason::ProcessProfile,
     };
     Outcome::Invalid(discard_reason)
+}
+
+fn track_sampling_metrics(
+    project_state: &ProjectState,
+    context: &DynamicSamplingContext,
+    event: &Event,
+) {
+    // We only collect this metric for the root transaction event, so ignore secondary projects.
+    if !project_state.is_matching_key(context.public_key) {
+        return;
+    }
+
+    let transaction_info = match event.transaction_info.value() {
+        Some(info) => info,
+        None => return,
+    };
+
+    let changes = match transaction_info.changes.value() {
+        Some(value) => value.as_slice(),
+        None => return,
+    };
+
+    let last_change = changes.last().and_then(|a| a.value());
+    let source = event.get_transaction_source().as_str();
+    let platform = event.platform.as_str().unwrap_or("other");
+    let sdk_name = event.sdk_name();
+    let sdk_version = event.sdk_version();
+
+    metric!(
+        histogram(RelayHistograms::DynamicSamplingChanges) = changes.len() as u64,
+        source = source,
+        platform = platform,
+        sdk_name = sdk_name,
+        sdk_version = sdk_version,
+    );
+
+    if let Some(&total) = transaction_info.propagations.value() {
+        // If there was no change, there were no propagations that happened with a wrong name.
+        let change = last_change
+            .and_then(|c| c.propagations.value())
+            .map_or(0, |v| *v);
+
+        metric!(
+            histogram(RelayHistograms::DynamicSamplingPropagationCount) = change,
+            source = source,
+            platform = platform,
+            sdk_name = sdk_name,
+            sdk_version = sdk_version,
+        );
+
+        let percentage = (change as f64) / (total as f64);
+        if percentage > 0.0 {
+            metric!(
+                histogram(RelayHistograms::DynamicSamplingPropagationPercentage) = percentage,
+                source = source,
+                platform = platform,
+                sdk_name = sdk_name,
+                sdk_version = sdk_version,
+            );
+        }
+    }
+
+    if let (Some(&start), Some(&change), Some(&end)) = (
+        event.start_timestamp.value(),
+        last_change.and_then(|c| c.timestamp.value()),
+        event.timestamp.value(),
+    ) {
+        let delay_ms = (change - start).num_milliseconds().unsigned_abs();
+        metric!(
+            histogram(RelayHistograms::DynamicSamplingChangeDuration) = delay_ms,
+            source = source,
+            platform = platform,
+            sdk_name = sdk_name,
+            sdk_version = sdk_version,
+        );
+
+        let duration_ms = (end - start).num_milliseconds() as f64;
+        let percentage = (delay_ms as f64) / duration_ms;
+        if percentage > 0.0 {
+            metric!(
+                histogram(RelayHistograms::DynamicSamplingChangePercentage) = percentage,
+                source = source,
+                platform = platform,
+                sdk_name = sdk_name,
+                sdk_version = sdk_version,
+            );
+        }
+    }
 }
 
 /// Synchronous service for processing envelopes.
@@ -1625,6 +1713,10 @@ impl EnvelopeProcessor {
                 }
             );
             state.transaction_metrics_extracted = true;
+
+            if let Some(context) = state.envelope.sampling_context() {
+                track_sampling_metrics(&state.project_state, context, event);
+            }
         }
         Ok(())
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -138,6 +138,77 @@ pub enum RelayHistograms {
     /// Size of queries (projectconfig queries, i.e. the request payload, not the response) sent by
     /// Relay over HTTP in bytes.
     UpstreamEnvelopeBodySize,
+
+    /// Counts how often a transaction name was changed before submitting the final transaction.
+    ///
+    /// A value of `0` indicates that the transaction was created with the final transaction name.
+    /// In this case, the DSC will have the correct transaction name guaranteed. However, to
+    /// determine how many traces had wrong transaction names propagated, check the
+    /// `dynamic_sampling.propagations`.
+    ///
+    /// This metric is tagged with:
+    ///
+    ///  - `source`: The transaction source value in the final event payload.
+    ///  - `platform`: The SDK platform value of the event payload.
+    ///  - `sdk_name`: The name of the client SDK as reported in the event payload.
+    ///  - `sdk_version`: The version of the client SDK as reported in the event payload.
+    DynamicSamplingChanges,
+
+    /// Counts the number of propagations before the final transaction name has been determined.
+    ///
+    /// A value of `0` indicates that the entire trace had identical transaction names in the
+    /// Dynamic Sampling Context (DSC). This means that the entire trace is sampled consistently.
+    ///
+    /// Note that this differs from `dynamic_sampling.changes`, which indicates changes even in the
+    /// absence of propagations.
+    ///
+    /// This metric is tagged with:
+    ///
+    ///  - `source`: The transaction source value in the final event payload.
+    ///  - `platform`: The SDK platform value of the event payload.
+    ///  - `sdk_name`: The name of the client SDK as reported in the event payload.
+    ///  - `sdk_version`: The version of the client SDK as reported in the event payload.
+    DynamicSamplingPropagationCount,
+
+    /// The number of propagations before the final transaction name change relative to the total
+    /// number of propagations.
+    ///
+    /// Tracks the same as `dynamic_sampling.propagations`, except that the value of this metric is
+    /// a percentage between `0.0` and `1.0`. A value of `0` means that no propagations occurred,
+    /// and `1` means that all propagations occurred with the wrong transaction name.
+    ///
+    /// This metric is tagged with:
+    ///
+    ///  - `source`: The transaction source value in the final event payload.
+    ///  - `platform`: The SDK platform value of the event payload.
+    ///  - `sdk_name`: The name of the client SDK as reported in the event payload.
+    ///  - `sdk_version`: The version of the client SDK as reported in the event payload.
+    DynamicSamplingPropagationPercentage,
+
+    /// Time in milliseconds from the start of transaction until the final name is determined.
+    ///
+    /// If the transaction name changes multiple times, this records only the last instance. This
+    /// metric is not logged if there were no changes to the transaction name.
+    ///
+    /// This metric is tagged with:
+    ///
+    ///  - `source`: The transaction source value in the final event payload.
+    ///  - `platform`: The SDK platform value of the event payload.
+    ///  - `sdk_name`: The name of the client SDK as reported in the event payload.
+    ///  - `sdk_version`: The version of the client SDK as reported in the event payload.
+    DynamicSamplingChangeDuration,
+
+    /// Timing relative to the transaction duration until the final name is determined.
+    ///
+    /// This is a percentage between `0.0` and `1.0`.
+    ///
+    /// This metric is tagged with:
+    ///
+    ///  - `source`: The transaction source value in the final event payload.
+    ///  - `platform`: The SDK platform value of the event payload.
+    ///  - `sdk_name`: The name of the client SDK as reported in the event payload.
+    ///  - `sdk_version`: The version of the client SDK as reported in the event payload.
+    DynamicSamplingChangePercentage,
 }
 
 impl HistogramMetric for RelayHistograms {
@@ -166,6 +237,13 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::KafkaMessageSize => "kafka.message_size",
             RelayHistograms::UpstreamQueryBodySize => "upstream.query.body_size",
             RelayHistograms::UpstreamEnvelopeBodySize => "upstream.envelope.body_size",
+            RelayHistograms::DynamicSamplingChanges => "dynamic_sampling.changes",
+            RelayHistograms::DynamicSamplingPropagationCount => "dynamic_sampling.propagations",
+            RelayHistograms::DynamicSamplingPropagationPercentage => {
+                "dynamic_sampling.propagation_pct"
+            }
+            RelayHistograms::DynamicSamplingChangeDuration => "dynamic_sampling.change_duration",
+            RelayHistograms::DynamicSamplingChangePercentage => "dynamic_sampling.change_pct",
         }
     }
 }


### PR DESCRIPTION
Introduces `propagations` and `changes` that provides more insight into how a
transaction name was changed during the lifetime of a transaction span. Since
the transaction name is propagated to downstream SDKs as part of the Dynamic
Sampling Context (DSC), this is a relevant quality metric for sampling traces by
transaction name.

All traces where propagations occur before the final transaction name is set
may not be sampled consistently if there are rules matching on the transaction
name.

Ref https://github.com/getsentry/sentry-javascript/issues/5679

