### PR TITLE
ref(actix): Port EnvelopeProcessor to tokio [INGEST-1566 INC-202]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Support profiles tagged for many transactions. ([#1444](https://github.com/getsentry/relay/pull/1444)), ([#1463](https://github.com/getsentry/relay/pull/1463)), ([#1464](https://github.com/getsentry/relay/pull/1464))
 - Track metrics for changes to the transaction name and DSC propagations. ([#1466](https://github.com/getsentry/relay/pull/1466))
 - Simplify the ingestion path to reduce endpoint response times. ([#1416](https://github.com/getsentry/relay/issues/1416), [#1429](https://github.com/getsentry/relay/issues/1429), [#1431](https://github.com/getsentry/relay/issues/1431))
-- Update the internal service architecture for the store and outcome services. ([#1405](https://github.com/getsentry/relay/pull/1405), [#1415](https://github.com/getsentry/relay/issues/1415), [#1421](https://github.com/getsentry/relay/issues/1421), [#1441](https://github.com/getsentry/relay/issues/1441), [#1457](https://github.com/getsentry/relay/issues/1457))
+- Update the internal service architecture for the store, outcome, and processor services. ([#1405](https://github.com/getsentry/relay/pull/1405), [#1415](https://github.com/getsentry/relay/issues/1415), [#1421](https://github.com/getsentry/relay/issues/1421), [#1441](https://github.com/getsentry/relay/issues/1441), [#1457](https://github.com/getsentry/relay/issues/1457), [#1470](https://github.com/getsentry/relay/pull/1470))
 
 ## 22.8.0
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -251,7 +251,7 @@ impl EnvelopeManager {
         if let HttpEncoding::Identity = request.http_encoding {
             UpstreamRelay::from_registry().do_send(SendRequest(request));
         } else {
-            EnvelopeProcessor::from_registry().do_send(EncodeEnvelope::new(request));
+            EnvelopeProcessor::from_registry().send(EncodeEnvelope::new(request));
         }
 
         Box::new(

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -711,7 +711,7 @@ impl Project {
                     ProjectCache::from_registry()
                         .do_send(AddSamplingState::new(sampling_key, process));
                 } else {
-                    EnvelopeProcessor::from_registry().do_send(process);
+                    EnvelopeProcessor::from_registry().send(process);
                 }
             }
         }
@@ -735,7 +735,7 @@ impl Project {
     fn flush_sampling(&self, mut message: ProcessEnvelope) {
         // Intentionally ignore all errors and leave the envelope unsampled.
         message.sampling_project_state = self.valid_state();
-        EnvelopeProcessor::from_registry().do_send(message);
+        EnvelopeProcessor::from_registry().send(message);
     }
 
     /// Enqueues an envelope for adding a dynamic sampling project state.

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -282,7 +282,7 @@ fn queue_envelope(
 
     if !metric_items.is_empty() {
         relay_log::trace!("sending metrics into processing queue");
-        EnvelopeProcessor::from_registry().do_send(ProcessMetrics {
+        EnvelopeProcessor::from_registry().send(ProcessMetrics {
             items: metric_items,
             project_key: envelope.meta().public_key(),
             start_time: envelope.meta().start_time(),

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -17,7 +17,7 @@ use crate::actors::envelopes::EnvelopeManager;
 use crate::actors::health_check::{HealthCheck, HealthCheckService};
 use crate::actors::outcome::{OutcomeProducer, OutcomeProducerService, TrackOutcome};
 use crate::actors::outcome_aggregator::OutcomeAggregator;
-use crate::actors::processor::EnvelopeProcessor;
+use crate::actors::processor::{EnvelopeProcessor, EnvelopeProcessorService};
 use crate::actors::project_cache::ProjectCache;
 use crate::actors::relays::RelayCache;
 use crate::actors::upstream::UpstreamRelay;
@@ -113,7 +113,7 @@ pub struct Registry {
     pub health_check: Addr<HealthCheck>,
     pub outcome_producer: Addr<OutcomeProducer>,
     pub outcome_aggregator: Addr<TrackOutcome>,
-    pub processor: actix::Addr<EnvelopeProcessor>,
+    pub processor: Addr<EnvelopeProcessor>,
 }
 
 impl fmt::Debug for Registry {
@@ -163,7 +163,7 @@ impl ServiceState {
         let _guard = main_runtime.enter();
 
         let buffer = Arc::new(BufferGuard::new(config.envelope_buffer_size()));
-        let processor = EnvelopeProcessor::start(config.clone(), redis_pool.clone())?;
+        let processor = EnvelopeProcessorService::foo(config.clone(), redis_pool.clone())?.start();
         let envelope_manager = EnvelopeManager::create(config.clone())?;
         registry.set(Arbiter::start(|_| envelope_manager));
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -163,7 +163,7 @@ impl ServiceState {
         let _guard = main_runtime.enter();
 
         let buffer = Arc::new(BufferGuard::new(config.envelope_buffer_size()));
-        let processor = EnvelopeProcessorService::foo(config.clone(), redis_pool.clone())?.start();
+        let processor = EnvelopeProcessorService::new(config.clone(), redis_pool.clone())?.start();
         let envelope_manager = EnvelopeManager::create(config.clone())?;
         registry.set(Arbiter::start(|_| envelope_manager));
 

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -284,7 +284,7 @@ pub fn process_unreal_envelope(
     }
 
     // If we have UE4 info, ensure an event is there to fill. DO NOT fill if there is no unreal
-    // information, or otherwise `EnvelopeProcessor::process` breaks.
+    // information, or otherwise `EnvelopeProcessorService::process` breaks.
     let event = event.get_or_insert_with(Event::default);
 
     if let Some(user_info) = user_header {


### PR DESCRIPTION
Removes the actix `SyncArbiter` in favor of a plain tokio service that
uses a semaphore around `spawn_blocking` to delegate CPU-intensive work.
The service is started in the main runtime since it does not exhibit a
large footprint. Tokio runtimes have a larger number of blocking threads
than required by the `EnvelopeProcessor`.

Tokio ensures that there are always threads to run blocking tasks. If
one of the tasks panics, drop handlers are still run, the panic handler
picks up the panic (reporting it to Sentry), and tokio starts a new
thread.

**Note**: The EnvelopeProcessor unit tests still do not require a tokio
runtime and cannot mock service dependencies. They will be ported in a
follow-up.