### PR TITLE
ref(service): Move from_registry to interface types

### DIFF
--- a/relay-server/src/actors/health_check.rs
+++ b/relay-server/src/actors/health_check.rs
@@ -27,6 +27,20 @@ pub enum IsHealthy {
 /// Service interface for the [`IsHealthy`] message.
 pub struct HealthCheck(IsHealthy, Sender<bool>);
 
+impl HealthCheck {
+    /// Returns the [`Addr`] of the [`HealthCheck`] service.
+    ///
+    /// Prior to using this, the service must be started using [`HealthCheckService::start`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the service was not started using [`HealthCheckService::start`] prior to this
+    /// being used.
+    pub fn from_registry() -> Addr<Self> {
+        REGISTRY.get().unwrap().health_check.clone()
+    }
+}
+
 impl Interface for HealthCheck {}
 
 impl FromMessage<IsHealthy> for HealthCheck {
@@ -45,18 +59,6 @@ pub struct HealthCheckService {
 }
 
 impl HealthCheckService {
-    /// Returns the [`Addr`] of the [`HealthCheck`] service.
-    ///
-    /// Prior to using this, the service must be started using [`HealthCheckService::start`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the service was not started using [`HealthCheckService::start`] prior to this
-    /// being used.
-    pub fn from_registry() -> Addr<HealthCheck> {
-        REGISTRY.get().unwrap().health_check.clone()
-    }
-
     /// Creates a new instance of the HealthCheck service.
     ///
     /// The service does not run. To run the service, use [`start`](Self::start).

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -129,6 +129,12 @@ pub struct TrackOutcome {
     pub quantity: u32,
 }
 
+impl TrackOutcome {
+    pub fn from_registry() -> Addr<Self> {
+        REGISTRY.get().unwrap().outcome_aggregator.clone()
+    }
+}
+
 impl TrackOutcomeLike for TrackOutcome {
     fn reason(&self) -> Option<Cow<str>> {
         self.outcome.to_reason()
@@ -727,6 +733,12 @@ pub enum OutcomeProducer {
     TrackRawOutcome(TrackRawOutcome),
 }
 
+impl OutcomeProducer {
+    pub fn from_registry() -> Addr<Self> {
+        REGISTRY.get().unwrap().outcome_producer.clone()
+    }
+}
+
 impl Interface for OutcomeProducer {}
 
 impl FromMessage<TrackOutcome> for OutcomeProducer {
@@ -752,10 +764,6 @@ pub struct OutcomeProducerService {
 }
 
 impl OutcomeProducerService {
-    pub fn from_registry() -> Addr<OutcomeProducer> {
-        REGISTRY.get().unwrap().outcome_producer.clone()
-    }
-
     pub fn create(config: Arc<Config>) -> Result<Self, ServerError> {
         let producer = match config.emit_outcomes() {
             EmitOutcomes::AsOutcomes => {

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -12,7 +12,6 @@ use relay_statsd::metric;
 use relay_system::{Addr, Controller, Service, Shutdown};
 
 use crate::actors::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
-use crate::service::REGISTRY;
 use crate::statsd::RelayTimers;
 use crate::utils::SleepHandle;
 
@@ -59,10 +58,6 @@ pub struct OutcomeAggregator {
 }
 
 impl OutcomeAggregator {
-    pub fn from_registry() -> Addr<TrackOutcome> {
-        REGISTRY.get().unwrap().outcome_aggregator.clone()
-    }
-
     pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducer>) -> Self {
         let mode = match config.emit_outcomes() {
             EmitOutcomes::AsOutcomes => AggregationMode::Lossless,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -37,7 +37,6 @@ use relay_statsd::metric;
 
 use crate::actors::envelopes::{EnvelopeManager, SendEnvelope, SendEnvelopeError, SubmitEnvelope};
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
-use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::actors::project::{Feature, ProjectState};
 use crate::actors::project_cache::{InsertMetrics, MergeBuckets, ProjectCache};
 use crate::actors::upstream::{SendRequest, UpstreamRelay};
@@ -911,7 +910,7 @@ impl EnvelopeProcessor {
             return;
         }
 
-        let producer = OutcomeAggregator::from_registry();
+        let producer = TrackOutcome::from_registry();
         for ((outcome_type, reason, category), quantity) in output_events.into_iter() {
             let outcome = match outcome_from_parts(outcome_type, &reason) {
                 Ok(outcome) => outcome,

--- a/relay-server/src/endpoints/health_check.rs
+++ b/relay-server/src/endpoints/health_check.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::service::ServiceApp;
 
-use crate::actors::health_check::{HealthCheckService, IsHealthy};
+use crate::actors::health_check::{HealthCheck, IsHealthy};
 
 #[derive(Serialize)]
 struct HealthCheckResponse {
@@ -35,7 +35,7 @@ impl HealthCheckResponse {
 
 fn health_check_impl(message: IsHealthy) -> ResponseFuture<HttpResponse, Error> {
     let fut = async move {
-        let addr = HealthCheckService::from_registry();
+        let addr = HealthCheck::from_registry();
         addr.send(message).await
     };
 

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -1,7 +1,7 @@
 use actix_web::HttpResponse;
 use relay_config::EmitOutcomes;
 
-use crate::actors::outcome::{OutcomeProducerService, SendOutcomes, SendOutcomesResponse};
+use crate::actors::outcome::{OutcomeProducer, SendOutcomes, SendOutcomesResponse};
 use crate::extractors::{CurrentServiceState, SignedJson};
 use crate::service::ServiceApp;
 
@@ -10,7 +10,7 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
         return HttpResponse::Forbidden().finish();
     }
 
-    let producer = OutcomeProducerService::from_registry();
+    let producer = OutcomeProducer::from_registry();
     for outcome in body.inner.outcomes {
         producer.send(outcome);
     }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -12,7 +12,6 @@ use relay_quotas::Scoping;
 
 use crate::actors::envelopes::{Capture, EnvelopeManager};
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
-use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::envelope::Envelope;
 use crate::statsd::{RelayCounters, RelayTimers};
 use crate::utils::{EnvelopeSummary, SemaphorePermit};
@@ -96,7 +95,7 @@ impl EnvelopeContext {
     /// This envelope context should be updated using [`update`](Self::update) soon after this
     /// operation to ensure that subsequent outcomes are consistent.
     pub fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
-        let outcome_aggregator = OutcomeAggregator::from_registry();
+        let outcome_aggregator = TrackOutcome::from_registry();
         outcome_aggregator.send(TrackOutcome {
             timestamp: self.received_at,
             scoping: self.scoping,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -6,7 +6,6 @@ use relay_quotas::{
 };
 
 use crate::actors::outcome::{Outcome, TrackOutcome};
-use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::envelope::{Envelope, Item, ItemType};
 
 /// Name of the rate limits header.
@@ -252,7 +251,7 @@ impl Enforcement {
         for limit in [self.event, self.attachments, self.profiles, self.replays] {
             if limit.is_active() {
                 let timestamp = relay_common::instant_to_date_time(envelope.meta().start_time());
-                OutcomeAggregator::from_registry().send(TrackOutcome {
+                TrackOutcome::from_registry().send(TrackOutcome {
                     timestamp,
                     scoping: *scoping,
                     outcome: Outcome::RateLimited(limit.reason_code),


### PR DESCRIPTION
When actors implemented `SystemService` directly, we used to obtain instances
via `<Actor>::from_registry`. Since new addresses bind to an interface rather
than service implementations, the registry getters should also be on the
interface class instead. This has the positive effect that there are no
references to the service classes in the code base outside of regular startup.

Even with this refactor, it can still make sense to remove the registry if this
helps with unit testing.

#skip-changelog

