### PR TITLE
ref: Use simple modulo #shards to get the shard number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,6 @@ dependencies = [
  "clap",
  "failure",
  "flate2",
- "fnv",
  "fragile",
  "futures 0.1.31",
  "futures 0.3.21",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -35,7 +35,6 @@ chrono = { version = "0.4.11", features = ["serde"] }
 clap = "2.33.1"
 failure = "0.1.8"
 flate2 = "1.0.19"
-fnv = "1.0.7"
 fragile = { version = "1.2.1", features = ["slab"] } # used for vendoring sentry-actix
 futures = { version = "0.3", package = "futures", features = ["compat"] }
 futures01 = { version = "0.1.28", package = "futures" }


### PR DESCRIPTION
As a follow up for #1454 we decided that we do not have to hash the org id to get the shard number and simple modulo #shard will be sufficient.

As part of this small refactoring the `unwrap` was also removed and Result is returned instead, to propagate the error to the caller if it happens.

#skip-changelog