### PR TITLE
instr(kafka): Log message type on send error [INGEST-1598]

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -184,7 +184,13 @@ impl Producer {
 
         producer
             .send(record)
-            .map_err(|(kafka_error, _message)| StoreError::SendFailed(kafka_error))
+            .map_err(|(kafka_error, _message)| {
+                relay_log::with_scope(
+                        |scope| scope.set_tag("variant", message.variant()),
+                        || relay_log::error!("error sending kafka message: {}", kafka_error),
+                    );
+                StoreError::SendFailed(kafka_error)
+            })
     }
 }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -182,15 +182,13 @@ impl Producer {
         };
         let record = BaseRecord::to(topic_name).key(&key).payload(&serialized);
 
-        producer
-            .send(record)
-            .map_err(|(kafka_error, _message)| {
-                relay_log::with_scope(
-                        |scope| scope.set_tag("variant", message.variant()),
-                        || relay_log::error!("error sending kafka message: {}", kafka_error),
-                    );
-                StoreError::SendFailed(kafka_error)
-            })
+        producer.send(record).map_err(|(kafka_error, _message)| {
+            relay_log::with_scope(
+                |scope| scope.set_tag("variant", message.variant()),
+                || relay_log::error!("error sending kafka message: {}", kafka_error),
+            );
+            StoreError::SendFailed(kafka_error)
+        })
     }
 }
 


### PR DESCRIPTION
From our statsd metrics it looks like it's not metrics that causes kafka messages that are too large. Let's verify this with a sentry error tagged by message type.

#skip-changelog