### PR TITLE
ref(pii): Convert datascrubbing settings on deserialization [INC-202]

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -142,11 +142,9 @@ pub unsafe extern "C" fn relay_validate_pii_config(value: *const RelayStr) -> Re
 #[relay_ffi::catch_unwind]
 pub unsafe extern "C" fn relay_convert_datascrubbing_config(config: *const RelayStr) -> RelayStr {
     let config: DataScrubbingConfig = serde_json::from_str((*config).as_str())?;
-    match config.pii_config() {
-        Ok(Some(config)) => RelayStr::from_string(config.to_json()?),
-        Ok(None) => RelayStr::new("{}"),
-        // NOTE: Callers of this function must be able to handle this error.
-        Err(e) => RelayStr::from_string(e.to_string()),
+    match config.pii_config {
+        Some(config) => RelayStr::from_string(config.to_json()?),
+        None => RelayStr::new("{}"),
     }
 }
 

--- a/relay-general/benches/benchmarks.rs
+++ b/relay-general/benches/benchmarks.rs
@@ -127,7 +127,6 @@ fn datascrubbing_config() -> DataScrubbingConfigRepr {
         scrub_defaults: true,
         scrub_data: true,
         scrub_ip_addresses: true,
-        ..Default::default()
     }
 }
 

--- a/relay-general/src/pii/mod.rs
+++ b/relay-general/src/pii/mod.rs
@@ -20,7 +20,7 @@ pub use self::config::{
     RuleSpec, RuleType, Vars,
 };
 pub use self::generate_selectors::selector_suggestions_from_value;
-pub use self::legacy::DataScrubbingConfig;
+pub use self::legacy::{DataScrubbingConfig, DataScrubbingConfigRepr};
 pub use self::minidumps::ScrubMinidumpError;
 pub use self::processor::PiiProcessor;
 pub use self::redactions::{Redaction, ReplaceRedaction};

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2457,11 +2457,13 @@ mod tests {
         });
 
         let new_envelope = relay_test::with_system(move || {
-            let mut datascrubbing_settings = DataScrubbingConfigRepr::default();
-            // enable all the default scrubbing
-            datascrubbing_settings.scrub_data = true;
-            datascrubbing_settings.scrub_defaults = true;
-            datascrubbing_settings.scrub_ip_addresses = true;
+            let datascrubbing_settings = DataScrubbingConfigRepr {
+                // enable all the default scrubbing
+                scrub_data: true,
+                scrub_defaults: true,
+                scrub_ip_addresses: true,
+                ..Default::default()
+            };
 
             // Make sure to mask any IP-like looking data
             let pii_config = PiiConfig::from_json(


### PR DESCRIPTION
In #1474, we made the conversion from data scrubbing settings to pii config fallible. Because the conversion was performed lazily when the first event needed it, this meant that the erroneous project config was accepted, but events that tried to use it were dropped.

This PR replaces the lazy conversion with immediate conversion on deserialization, thereby making the entire project config invalid.