### PR TITLE
instr(pii): Log error on failed config conversion [INC-202]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,6 +3308,7 @@ dependencies = [
  "regex",
  "relay-common",
  "relay-general-derive",
+ "relay-log",
  "schemars",
  "sentry-release-parser",
  "serde",

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -28,6 +28,7 @@ pest_derive = "2.1.0"
 regex = "1.5.5"
 relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
+relay-log = { path = "../relay-log" }
 schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
 sentry-release-parser = { version = "1.3.1" }
 serde = { version = "1.0.114", features = ["derive"] }

--- a/relay-general/src/pii/legacy.rs
+++ b/relay-general/src/pii/legacy.rs
@@ -76,6 +76,9 @@ impl DataScrubbingConfig {
     /// Like [`pii_config`](Self::pii_config) but without internal caching.
     #[inline]
     pub fn pii_config_uncached(&self) -> Result<Option<PiiConfig>, PiiConfigError> {
-        convert::to_pii_config(self)
+        convert::to_pii_config(self).map_err(|e| {
+            relay_log::error!("Failed to convert datascrubbing config");
+            e
+        })
     }
 }


### PR DESCRIPTION
#1474 introduced an explicit size limit on the regex used to convert legacy datascrubbing settings to PII config.

We are seeing new outcomes with reason `project_state_pii` in our statsd metrics now, so we should log an error to Sentry (tagged by project_id) to see which projects are affected.

#skip-changelog