### PR TITLE
fix(pii): Revert regex limit for datascrubbing conversion [INGEST-1616]

### DIFF
--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use once_cell::sync::Lazy;
+use regex::RegexBuilder;
 
 use crate::pii::{
     DataScrubbingConfig, Pattern, PiiConfig, PiiConfigError, RedactPairRule, Redaction, RuleSpec,
@@ -72,7 +73,12 @@ pub fn to_pii_config(
                 "strip-fields".to_owned(),
                 RuleSpec {
                     ty: RuleType::RedactPair(RedactPairRule {
-                        key_pattern: Pattern::parse(&key_pattern, true)?,
+                        key_pattern: Pattern(
+                            RegexBuilder::new(&key_pattern)
+                                .case_insensitive(true)
+                                .build()
+                                .map_err(PiiConfigError::RegexError)?,
+                        ),
                     }),
                     redaction: Redaction::Replace("[Filtered]".to_owned().into()),
                 },
@@ -285,7 +291,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     fn test_convert_sensitive_fields_too_large() {
         let result = to_pii_config_impl(&DataScrubbingConfig {
             sensitive_fields: vec!["1"]
-                .repeat(4085) // lowest number that will fail
+                .repeat(9999999) // lowest number that will fail
                 .into_iter()
                 .map(|x| x.to_string())
                 .collect(),

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -291,7 +291,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     fn test_convert_sensitive_fields_too_large() {
         let result = to_pii_config_impl(&DataScrubbingConfig {
             sensitive_fields: vec!["1"]
-                .repeat(9999999) // lowest number that will fail
+                .repeat(999999) // lowest number that will fail
                 .into_iter()
                 .map(|x| x.to_string())
                 .collect(),

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -54,7 +54,7 @@ pub fn get_regex_for_rule_type(
     match ty {
         RuleType::RedactPair(ref redact_pair) => smallvec![(
             kv,
-            redact_pair.key_pattern.regex(),
+            &redact_pair.key_pattern.0,
             ReplaceBehavior::replace_value()
         )],
         RuleType::Password => {
@@ -69,7 +69,7 @@ pub fn get_regex_for_rule_type(
                 None => ReplaceBehavior::replace_match(),
             };
 
-            smallvec![(v, r.pattern.regex(), replace_behavior)]
+            smallvec![(v, &r.pattern.0, replace_behavior)]
         }
 
         RuleType::Imei => smallvec![(v, &*IMEI_REGEX, ReplaceBehavior::replace_match())],


### PR DESCRIPTION
This is a partial revert of #1474. Instead of applying a stricter size limit to regexes built from datascrubbing settings, which led to data loss for at least one project, only keep the part that prevents a panic on `CompiledSizeTooBig`.

#skip-changelog