### PR TITLE
build(dockerfile): Pin Rust version to 1.63.0 in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Pin Rust version to 1.63.0 in Dockerfile. ([#1482](https://github.com/getsentry/relay/pull/1482))
+
 ## 22.9.0
 
 **Features**:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --profile minimal --default-toolchain=1.63
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,12 @@ FROM $DOCKER_ARCH/centos:7 AS relay-deps
 
 ARG DOCKER_ARCH
 ARG BUILD_ARCH=x86_64
+# Pin the Rust version for now
+ARG RUST_TOOLCHAIN_VERSION=1.63.0
 
 ENV DOCKER_ARCH=${DOCKER_ARCH}
 ENV BUILD_ARCH=${BUILD_ARCH}
+ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
 
@@ -30,7 +33,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --profile minimal --default-toolchain=1.63
+    | sh -s -- -y --profile minimal --default-toolchain=${RUST_TOOLCHAIN_VERSION}
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 


### PR DESCRIPTION
At the moment the toolchain container layer is cached, so we're implicitly using an older Rust version.


