### PR TITLE
feat(store): Limit custom measurements [INGEST-1621]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Limit the number of custom measurements per event. ([#1483](https://github.com/getsentry/relay/pull/1483)))
+
 **Internal**:
 
 - Generate a new profile ID when splitting a profile for multiple transactions. ([#1473](https://github.com/getsentry/relay/pull/1473))

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -27,7 +27,7 @@ pub use normalize::breakdowns::{
 };
 pub use normalize::{
     compute_measurements, is_valid_platform, light_normalize_event, normalize_dist,
-    LightNormalizationConfig,
+    LightNormalizationConfig, MeasurementsConfig,
 };
 pub use transactions::{
     get_measurement, get_transaction_op, is_high_cardinality_sdk, validate_timestamps,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -257,10 +257,12 @@ fn remove_invalid_measurements(
 ) {
     let mut custom_measurements_count = 0;
     measurements.retain(|name, value| {
-        let unit = match value.value().and_then(|m| m.unit.value()) {
-            Some(unit) => unit,
+        let measurement = match value.value() {
+            Some(m) => m,
             None => return false,
         };
+        // TODO(jjbayer): Should we actually normalize the unit into the event?
+        let unit = measurement.unit.value().unwrap_or(&MetricUnit::None);
 
         // Check if this is a builtin measurement:
         for builtin_measurement in &measurements_config.builtin_measurements {

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -43,7 +43,7 @@ mod user_agent;
 pub struct MeasurementsConfig {
     /// A list of measurements that are built-in and are not subject to custom measurement limits.
     #[serde(default, skip_serializing_if = "BTreeSet::<String>::is_empty")]
-    known_measurements: BTreeSet<String>,
+    builtin_measurements: BTreeSet<String>,
 
     /// The maximum number of measurements allowed per event that are not known measurements.
     max_custom_measurements: usize,
@@ -248,7 +248,7 @@ fn filter_custom_measurements(
     let mut custom_measurements_count = 0;
     measurements.retain(|name, _| {
         // Check if this is a builtin measurement:
-        if measurements_config.known_measurements.contains(name) {
+        if measurements_config.builtin_measurements.contains(name) {
             return true;
         }
         // For custom measurements, check the budget:
@@ -1972,7 +1972,7 @@ mod tests {
         let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
 
         let config: MeasurementsConfig = serde_json::from_value(json!({
-            "knownMeasurements": [
+            "builtinMeasurements": [
                 "frames_slow"
             ],
             "maxCustomMeasurements": 2,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -241,7 +241,6 @@ fn normalize_breakdowns(event: &mut Event, breakdowns_config: Option<&Breakdowns
 /// Note that [`Measurements`] is a BTreeMap, which means its keys are sorted.
 /// This ensures that for two events with the same measurement keys, the same set of custom
 /// measurements is retained.
-///
 fn filter_custom_measurements(
     measurements: &mut Measurements,
     measurements_config: &MeasurementsConfig,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -243,12 +243,15 @@ fn normalize_breakdowns(event: &mut Event, breakdowns_config: Option<&Breakdowns
     }
 }
 
-/// Enforce the limit on custom (user defined) measurements.
+/// Remove measurements that do not conform to the given config.
+///
+/// Built-in measurements are accepted if their unit is correct, dropped otherwise.
+/// Custom measurements are accepted up to a limit.
 ///
 /// Note that [`Measurements`] is a BTreeMap, which means its keys are sorted.
 /// This ensures that for two events with the same measurement keys, the same set of custom
 /// measurements is retained.
-fn filter_custom_measurements(
+fn remove_invalid_measurements(
     measurements: &mut Measurements,
     measurements_config: &MeasurementsConfig,
 ) {
@@ -286,7 +289,7 @@ fn normalize_measurements(event: &mut Event, measurements_config: Option<&Measur
         event.measurements = Annotated::empty();
     } else if let Some(measurements) = event.measurements.value_mut() {
         if let Some(measurements_config) = measurements_config {
-            filter_custom_measurements(measurements, measurements_config);
+            remove_invalid_measurements(measurements, measurements_config);
         }
 
         let duration_millis = match (event.start_timestamp.0, event.timestamp.0) {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1940,6 +1940,7 @@ impl EnvelopeProcessorService {
             received_at: Some(state.envelope_context.received_at()),
             max_secs_in_past: Some(self.config.max_secs_in_past()),
             max_secs_in_future: Some(self.config.max_secs_in_future()),
+            measurements_config: state.project_state.config.measurements.as_ref(),
             breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
             normalize_user_agent: Some(true),
         };

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -1,4 +1,6 @@
+use std::borrow::Cow;
 use std::collections::{BTreeSet, VecDeque};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -11,7 +13,7 @@ use smallvec::SmallVec;
 use url::Url;
 
 use relay_auth::PublicKey;
-use relay_common::{ProjectId, ProjectKey};
+use relay_common::{MetricUnit, ProjectId, ProjectKey};
 use relay_config::Config;
 use relay_filter::{matches_any_origin, FiltersConfig};
 use relay_general::pii::{DataScrubbingConfig, PiiConfig};
@@ -108,6 +110,9 @@ pub struct ProjectConfig {
     /// Configuration for sampling traces, if not present there will be no sampling.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_sampling: Option<SamplingConfig>,
+    /// Configuration for measurements.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measurements: Option<MeasurementsConfig>,
     /// Configuration for operation breakdown. Will be emitted only if present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub breakdowns_v2: Option<BreakdownsConfig>,

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
 use std::collections::{BTreeSet, VecDeque};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -13,11 +11,11 @@ use smallvec::SmallVec;
 use url::Url;
 
 use relay_auth::PublicKey;
-use relay_common::{MetricUnit, ProjectId, ProjectKey};
+use relay_common::{ProjectId, ProjectKey};
 use relay_config::Config;
 use relay_filter::{matches_any_origin, FiltersConfig};
 use relay_general::pii::{DataScrubbingConfig, PiiConfig};
-use relay_general::store::BreakdownsConfig;
+use relay_general::store::{BreakdownsConfig, MeasurementsConfig};
 use relay_general::types::SpanAttribute;
 use relay_metrics::{self, Aggregator, Bucket, Metric};
 use relay_quotas::{Quota, RateLimits, Scoping};
@@ -144,6 +142,7 @@ impl Default for ProjectConfig {
             event_retention: None,
             quotas: Vec::new(),
             dynamic_sampling: None,
+            measurements: None,
             breakdowns_v2: None,
             session_metrics: SessionMetricsConfig::default(),
             transaction_metrics: None,
@@ -176,6 +175,9 @@ pub struct LimitedProjectConfig {
     pub metric_conditional_tagging: Vec<TaggingRule>,
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub span_attributes: BTreeSet<SpanAttribute>,
+    /// Configuration for measurements.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measurements: Option<MeasurementsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub breakdowns_v2: Option<BreakdownsConfig>,
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]


### PR DESCRIPTION
If `measurementsConfig` is provided, limit the number of custom measurements that an event can contain. The distinction between built-in and custom measurements is made through an explicit allowlist in the project config.

Once we have a global relay config propagation mechanism, the allowlist should be moved there, but we should not hard-code it in Relay, because (light) normalization also happens in customer relays, which means that if we added a new built-in measurement, an outdated external relay would count it towards custom measurements.

To be done in follow-up PRs:

- Set this config in Sentry. See https://github.com/getsentry/sentry/pull/39001.
- Remove traces of old config (metrics allowlist, `customMeasurements` in `transactionMetrics`).
