### PR TITLE
ref(actix): Migrate the RelayCache actor

### DIFF
--- a/relay-common/src/retry.rs
+++ b/relay-common/src/retry.rs
@@ -11,6 +11,7 @@ const DEFAULT_RANDOMIZATION: f64 = 0.0;
 const INITIAL_INTERVAL: u64 = 1000;
 
 /// A retry interval generator that increases timeouts with exponential backoff.
+#[derive(Debug)]
 pub struct RetryBackoff {
     backoff: ExponentialBackoff,
     attempt: usize,

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -228,8 +228,6 @@ impl RelayCacheService {
     /// This assumes that currently no request is running. If the upstream request fails or new
     /// channels are pushed in the meanwhile, this will reschedule automatically.
     fn fetch_relays(&mut self) {
-        self.delay.reset();
-
         let channels = std::mem::take(&mut self.senders);
         relay_log::debug!(
             "updating public keys for {} relays (attempt {})",
@@ -281,6 +279,8 @@ impl RelayCacheService {
     fn handle_fetch_result(&mut self, result: FetchResult) {
         match result {
             Ok(response) => {
+                self.delay.reset();
+
                 for (id, info) in response.relays {
                     self.relays.insert(id, RelayState::from_option(info));
                 }

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -310,8 +310,8 @@ impl Service for RelayCacheService {
 
             loop {
                 tokio::select! {
-                    Some(message) = rx.recv() => self.get_or_fetch(message.0, message.1),
                     Some(result) = self.fetch_channel.1.recv() => self.handle_fetch_result(result),
+                    Some(message) = rx.recv() => self.get_or_fetch(message.0, message.1),
                     () = &mut self.delay => self.fetch_relays(),
                     else => break,
                 }

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use actix_web::{actix::*, Error, Json};
 use futures::{future, FutureExt, TryFutureExt};
 
-use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResult, RelayCache};
+use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse, RelayCache};
 use crate::extractors::SignedJson;
 use crate::service::ServiceApp;
 
-fn get_public_keys(body: SignedJson<GetRelays>) -> ResponseFuture<Json<GetRelaysResult>, Error> {
+fn get_public_keys(body: SignedJson<GetRelays>) -> ResponseFuture<Json<GetRelaysResponse>, Error> {
     let future = async move {
         let relay_cache = RelayCache::from_registry();
 
@@ -23,7 +23,7 @@ fn get_public_keys(body: SignedJson<GetRelays>) -> ResponseFuture<Json<GetRelays
             relays.insert(relay_id, relay_info);
         }
 
-        Ok(Json(GetRelaysResult { relays }))
+        Ok(Json(GetRelaysResponse { relays }))
     };
 
     Box::new(future.boxed().compat())

--- a/relay-server/src/utils/actix.rs
+++ b/relay-server/src/utils/actix.rs
@@ -15,28 +15,12 @@ impl<T, E> Response<T, E> {
         Response::Reply(Ok(value))
     }
 
-    pub fn reply(result: Result<T, E>) -> Self {
-        Response::Reply(result)
-    }
-
     pub fn future<F>(future: F) -> Self
     where
         F: IntoFuture<Item = T, Error = E>,
         F::Future: 'static,
     {
         Response::Future(Box::new(future.into_future()))
-    }
-}
-
-impl<T: 'static, E: 'static> Response<T, E> {
-    pub fn map<U, F: 'static>(self, f: F) -> Response<U, E>
-    where
-        F: FnOnce(T) -> U,
-    {
-        match self {
-            Response::Reply(result) => Response::reply(result.map(f)),
-            Response::Future(future) => Response::future(future.map(f)),
-        }
     }
 }
 

--- a/relay-server/src/utils/sleep_handle.rs
+++ b/relay-server/src/utils/sleep_handle.rs
@@ -36,9 +36,15 @@ impl Future for SleepHandle {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        match &mut self.0 {
+        let poll = match &mut self.0 {
             Some(sleep) => Pin::new(sleep).poll(cx),
             None => Poll::Pending,
+        };
+
+        if poll.is_ready() {
+            self.reset();
         }
+
+        poll
     }
 }

--- a/relay-server/src/utils/sleep_handle.rs
+++ b/relay-server/src/utils/sleep_handle.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 ///
 /// This has two internal states, either it is pending indefinite or it wakes up after a certain
 /// duration of time has elapsed.
+#[derive(Debug)]
 pub struct SleepHandle(Option<Pin<Box<tokio::time::Sleep>>>);
 
 impl SleepHandle {

--- a/relay-server/src/utils/sleep_handle.rs
+++ b/relay-server/src/utils/sleep_handle.rs
@@ -5,8 +5,10 @@ use std::time::Duration;
 
 /// A future wrapper around [`tokio::time::Sleep`].
 ///
-/// This has two internal states, either it is pending indefinite or it wakes up after a certain
-/// duration of time has elapsed.
+/// When initialized with [`SleepHandle::idle`], this future is pending indefinitely every time it
+/// is polled. To initiate a delay, use [`set`](Self::set). After the delay has passed, the future
+/// resolves with `()` **exactly once** and resets to idle. To reset the future while it is
+/// sleeping, use [`reset`](Self::reset).
 #[derive(Debug)]
 pub struct SleepHandle(Option<Pin<Box<tokio::time::Sleep>>>);
 


### PR DESCRIPTION
Updates the Relay cache to run as Tokio service. The upstream query is moved to a background task with its own `mpsc`. All other operations, such as updating the internal map and retrieving relay information, run sequentially in the service.

The service operates exactly as before, including an pre-existing race condition when a relay is queried while a fetch is running.

#skip-changelog
