### PR TITLE
feat(perf-vitals): Add INP measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+** Features **:
+- Add INP web vital as a measurement. ([#1487](https://github.com/getsentry/relay/pull/1487))
+
 **Internal**:
 
 - Generate a new profile ID when splitting a profile for multiple transactions. ([#1473](https://github.com/getsentry/relay/pull/1473))

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -158,6 +158,7 @@ mod tests {
         "LCP": {"value": 420.69, "unit": "millisecond"},
         "   lcp_final.element-Size123  ": {"value": 1},
         "fid": {"value": 2020},
+        "inp": {"value": 100.14},
         "cls": {"value": null},
         "fp": {"value": "im a first paint"},
         "Total Blocking Time": {"value": 3.14159},
@@ -176,6 +177,9 @@ mod tests {
     },
     "fp": {
       "value": null
+    },
+    "inp": {
+      "value": 100.14
     },
     "lcp": {
       "value": 420.69,
@@ -263,6 +267,13 @@ mod tests {
                 "fid".to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::new(2020f64),
+                    unit: Annotated::empty(),
+                }),
+            );
+            measurements.insert(
+                "inp".to_owned(),
+                Annotated::new(Measurement {
+                    value: Annotated::new(100.14),
                     unit: Annotated::empty(),
                 }),
             );

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -356,6 +356,7 @@ fn get_metric_measurement_unit(metric: &str) -> Option<MetricUnit> {
         "fcp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
         "lcp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
         "fid" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
+        "inp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
         "fp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
         "ttfb" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
         "ttfb.requesttime" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
@@ -619,6 +620,7 @@ fn get_measurement_rating(name: &str, value: f64) -> Option<String> {
         "lcp" => rate_range(2500.0, 4000.0),
         "fcp" => rate_range(1000.0, 3000.0),
         "fid" => rate_range(100.0, 300.0),
+        "inp" => rate_range(200.0, 500.0),
         "cls" => rate_range(0.1, 0.25),
         _ => None,
     }

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -123,6 +123,7 @@ def test_normalize_measurement_interface(
                 "LCP": {"value": 420.69},
                 "   lcp_final.element-Size123  ": {"value": 1},
                 "fid": {"value": 2020},
+                "inp": {"value": 100.14},
                 "cls": {"value": None},
                 "fp": {"value": "im a first paint"},
                 "Total Blocking Time": {"value": 3.14159},
@@ -143,6 +144,7 @@ def test_normalize_measurement_interface(
         "lcp": {"value": 420.69},
         "lcp_final.element-size123": {"value": 1},
         "fid": {"value": 2020},
+        "inp": {"value": 100.14},
         "cls": {"value": None},
         "fp": {"value": None},
         "missing_value": None,
@@ -182,6 +184,7 @@ def test_strip_measurement_interface(
             "measurements": {
                 "LCP": {"value": 420.69},
                 "fid": {"value": 2020},
+                "inp": {"value": 100.14},
                 "cls": {"value": None},
             },
         }


### PR DESCRIPTION
### Summary
Adds INP as an extracted metrics measurement, for the upcoming INP web vital.
