### PR TITLE
ref(store): Normalize units in event payload [INGEST-1638]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Generate a new profile ID when splitting a profile for multiple transactions. ([#1473](https://github.com/getsentry/relay/pull/1473))
 - Pin Rust version to 1.63.0 in Dockerfile. ([#1482](https://github.com/getsentry/relay/pull/1482))
+- Normalize units in event payload. ([#1488](https://github.com/getsentry/relay/pull/1488))
 
 ## 22.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - Generate a new profile ID when splitting a profile for multiple transactions. ([#1473](https://github.com/getsentry/relay/pull/1473))
 - Pin Rust version to 1.63.0 in Dockerfile. ([#1482](https://github.com/getsentry/relay/pull/1482))
-- Normalize units in event payload. ([#1488](https://github.com/getsentry/relay/pull/1488))
+- Normalize measurement units in event payload. ([#1488](https://github.com/getsentry/relay/pull/1488))
 
 ## 22.9.0
 

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -1937,6 +1937,7 @@ mod tests {
           "measurements": {
             "frames_frozen": {
               "value": 2.0,
+              "unit": "none",
             },
             "frames_frozen_rate": {
               "value": 0.5,
@@ -1944,6 +1945,7 @@ mod tests {
             },
             "frames_slow": {
               "value": 1.0,
+              "unit": "none",
             },
             "frames_slow_rate": {
               "value": 0.25,
@@ -1951,6 +1953,7 @@ mod tests {
             },
             "frames_total": {
               "value": 4.0,
+              "unit": "none",
             },
             "stall_percentage": {
               "value": 0.8,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -266,8 +266,8 @@ fn normalize_units(measurements: &mut Measurements) {
 
         let stated_unit = measurement.unit.value().copied();
         let default_unit = get_metric_measurement_unit(name);
-        if let (Some(default), Some(stated)) = (default_unit, stated_unit) {
-            if default != stated {
+        if let (Some(default_), Some(stated)) = (default_unit, stated_unit) {
+            if default_ != stated {
                 relay_log::error!("unit mismatch on measurements.{}: {}", name, stated);
             }
         }

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -8,7 +8,6 @@ use relay_general::protocol::{
     User,
 };
 use relay_general::store;
-use relay_general::store::LightNormalizationConfig;
 use relay_general::types::Annotated;
 use relay_metrics::{DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue};
 use serde::{Deserialize, Serialize};
@@ -589,6 +588,7 @@ mod tests {
 
     use relay_general::protocol::User;
     use relay_general::store::BreakdownsConfig;
+    use relay_general::store::LightNormalizationConfig;
     use relay_general::types::Annotated;
     use relay_metrics::DurationUnit;
 

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -2,13 +2,13 @@ use crate::metrics_extraction::conditional_tagging::run_conditional_tagging;
 use crate::metrics_extraction::utils;
 use crate::metrics_extraction::TaggingRule;
 use crate::statsd::RelayCounters;
-use relay_common::FractionUnit;
 use relay_common::{SpanStatus, UnixTimestamp};
 use relay_general::protocol::{
     AsPair, Context, ContextInner, Event, EventType, Timestamp, TraceContext, TransactionSource,
     User,
 };
 use relay_general::store;
+use relay_general::store::LightNormalizationConfig;
 use relay_general::types::Annotated;
 use relay_metrics::{DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue};
 use serde::{Deserialize, Serialize};
@@ -346,41 +346,6 @@ fn extract_universal_tags(
     tags
 }
 
-/// Returns the unit of the provided metric.
-///
-/// For known measurements, this returns `Some(MetricUnit)`, which can also include
-/// `Some(MetricUnit::None)`. For unknown measurement names, this returns `None`.
-fn get_metric_measurement_unit(metric: &str) -> Option<MetricUnit> {
-    match metric {
-        // Web
-        "fcp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "lcp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "fid" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "fp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "ttfb" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "ttfb.requesttime" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "cls" => Some(MetricUnit::None),
-
-        // Mobile
-        "app_start_cold" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "app_start_warm" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "frames_total" => Some(MetricUnit::None),
-        "frames_slow" => Some(MetricUnit::None),
-        "frames_slow_rate" => Some(MetricUnit::Fraction(FractionUnit::Ratio)),
-        "frames_frozen" => Some(MetricUnit::None),
-        "frames_frozen_rate" => Some(MetricUnit::Fraction(FractionUnit::Ratio)),
-
-        // React-Native
-        "stall_count" => Some(MetricUnit::None),
-        "stall_total_time" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "stall_longest_time" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "stall_percentage" => Some(MetricUnit::Fraction(FractionUnit::Ratio)),
-
-        // Default
-        _ => None,
-    }
-}
-
 pub fn extract_transaction_metrics(
     config: &TransactionMetricsConfig,
     breakdowns_config: Option<&store::BreakdownsConfig>,
@@ -465,18 +430,10 @@ fn extract_transaction_metrics_inner(
                 tags_for_measurement.insert("measurement_rating".to_owned(), rating);
             }
 
-            let stated_unit = measurement.unit.value().copied();
-            let default_unit = get_metric_measurement_unit(name);
-            if let (Some(default), Some(stated)) = (default_unit, stated_unit) {
-                if default != stated {
-                    relay_log::error!("unit mismatch on measurements.{}: {}", name, stated);
-                }
-            }
-
             push_metric(Metric::new_mri(
                 METRIC_NAMESPACE,
                 format!("measurements.{}", name),
-                stated_unit.or(default_unit).unwrap_or_default(),
+                measurement.unit.value().copied().unwrap_or_default(),
                 MetricValue::Distribution(value),
                 unix_timestamp,
                 tags_for_measurement,
@@ -659,7 +616,7 @@ mod tests {
             },
             "measurements": {
                 "foo": {"value": 420.69},
-                "lcp": {"value": 3000.0}
+                "lcp": {"value": 3000.0, "unit": "millisecond"}
             },
             "contexts": {
                 "trace": {
@@ -788,6 +745,12 @@ mod tests {
                 "fcp": {"value": 1.1},
                 "stall_count": {"value": 3.3},
                 "foo": {"value": 8.8}
+            },
+            "contexts": {
+                "trace": {
+                    "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+                    "span_id": "fa90fdead5f74053"
+                }
             }
         }
         "#;
@@ -805,7 +768,11 @@ mod tests {
         )
         .unwrap();
 
-        let event = Annotated::from_json(json).unwrap();
+        let mut event = Annotated::from_json(json).unwrap();
+
+        // Normalize first, to make sure the units are correct:
+        let res = store::light_normalize_event(&mut event, &LightNormalizationConfig::default());
+        assert!(res.is_ok(), "{:?}", res);
 
         let mut metrics = vec![];
         extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
@@ -840,6 +807,12 @@ mod tests {
             "measurements": {
                 "fcp": {"value": 1.1, "unit": "second"},
                 "lcp": {"value": 2.2, "unit": "none"}
+            },
+            "contexts": {
+                "trace": {
+                    "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+                    "span_id": "fa90fdead5f74053"
+                }
             }
         }"#;
 
@@ -853,7 +826,11 @@ mod tests {
         )
         .unwrap();
 
-        let event = Annotated::from_json(json).unwrap();
+        let mut event = Annotated::from_json(json).unwrap();
+
+        // Normalize first, to make sure the units are correct:
+        let res = store::light_normalize_event(&mut event, &LightNormalizationConfig::default());
+        assert!(res.is_ok(), "{:?}", res);
 
         let mut metrics = vec![];
         extract_transaction_metrics(&config, None, &[], event.value().unwrap(), &mut metrics);
@@ -1070,7 +1047,7 @@ mod tests {
             "timestamp": "2021-04-26T08:00:02+0100",
             "measurements": {
                 "a_custom1": {"value": 41},
-                "fcp": {"value": 0.123},
+                "fcp": {"value": 0.123, "unit": "millisecond"},
                 "g_custom2": {"value": 42, "unit": "second"},
                 "h_custom3": {"value": 43}
             }
@@ -1220,7 +1197,7 @@ mod tests {
             "start_timestamp": "2021-04-26T08:00:00+0100",
             "timestamp": "2021-04-26T08:00:02+0100",
             "measurements": {
-                "lcp": {"value": 41}
+                "lcp": {"value": 41, "unit": "millisecond"}
             }
         }
         "#;

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -140,11 +140,11 @@ def test_normalize_measurement_interface(
     assert "trace" in event["contexts"]
     assert "measurements" in event, event
     assert event["measurements"] == {
-        "lcp": {"value": 420.69},
-        "lcp_final.element-size123": {"value": 1},
-        "fid": {"value": 2020},
-        "cls": {"value": None},
-        "fp": {"value": None},
+        "cls": {"unit": "none", "value": None},
+        "fid": {"unit": "millisecond", "value": 2020.0},
+        "fp": {"unit": "millisecond", "value": None},
+        "lcp": {"unit": "millisecond", "value": 420.69},
+        "lcp_final.element-size123": {"unit": "none", "value": 1.0},
         "missing_value": None,
     }
 


### PR DESCRIPTION
The allowlist introduced in #1483 strictly checks the measurement unit. For that to work, we need to normalize the event unit first. Until now, unit normalization happened in metrics extraction. This PR moves it into (light) normalization.