### PR TITLE
Add unknown log level for performance issues

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `transaction_info` to event payloads, including the transaction's source and internal original transaction name. ([#1330](https://github.com/getsentry/relay/pull/1330))
 - Add user-agent parsing to replays processor. ([#1420](https://github.com/getsentry/relay/pull/1420))
 - `convert_datascrubbing_config` will now return an error string when conversion fails on big regexes. ([#1474](https://github.com/getsentry/relay/pull/1474))
+- Add `unknown` log level to validator for use by performance issues. ([#1489](https://github.com/getsentry/relay/pull/1489))
 
 ## 0.8.13
 

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -642,6 +642,8 @@ pub enum Level {
     Error,
     /// Similar to error but indicates a critical event that usually causes a shutdown.
     Fatal,
+    /// Used for Performance Issues that don't correspond to a log level
+    Unknown,
 }
 
 impl Default for Level {
@@ -658,6 +660,7 @@ impl Level {
             30 => Level::Warning,
             40 => Level::Error,
             50 => Level::Fatal,
+            100 => Level::Unknown,
             _ => return None,
         })
     }
@@ -673,6 +676,7 @@ impl FromStr for Level {
             "warning" => Level::Warning,
             "error" => Level::Error,
             "fatal" | "critical" => Level::Fatal,
+            "unknown" => Level::Unknown,
             _ => return Err(ParseLevelError),
         })
     }
@@ -686,6 +690,7 @@ impl fmt::Display for Level {
             Level::Warning => write!(f, "warning"),
             Level::Error => write!(f, "error"),
             Level::Fatal => write!(f, "fatal"),
+            Level::Unknown => write!(f, "unknown"),
         }
     }
 }

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -604,7 +604,7 @@ expression: "relay_general::protocol::event_json_schema()"
               ]
             },
             "level": {
-              "description": " Severity level of the breadcrumb. _Optional._\n\n Allowed values are, from highest to lowest: `fatal`, `error`, `warning`, `info`, and\n `debug`. Levels are used in the UI to emphasize and deemphasize the crumb. Defaults to\n `info`.",
+              "description": " Severity level of the breadcrumb. _Optional._\n\n Allowed values are, from highest to lowest: `fatal`, `error`, `warning`, `info`, `debug`, and\n `unknown`. Levels are used in the UI to emphasize and deemphasize the crumb. Defaults to\n `info`.",
               "default": null,
               "anyOf": [
                 {
@@ -1904,7 +1904,8 @@ expression: "relay_general::protocol::event_json_schema()"
         "info",
         "warning",
         "error",
-        "fatal"
+        "fatal",
+        "unknown"
       ]
     },
     "LogEntry": {


### PR DESCRIPTION
Add unknown log level for performance issues, to be displayed in the UI as a more appropriate log level

https://github.com/getsentry/sentry/pull/39135 will follow with more testing added once this is merged

https://getsentry.atlassian.net/browse/WOR-2207