### PR TITLE
fix(internal): Corrections for DSC metrics

### DIFF
--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -174,8 +174,8 @@ pub enum RelayHistograms {
     /// number of propagations.
     ///
     /// Tracks the same as `dynamic_sampling.propagations`, except that the value of this metric is
-    /// a percentage between `0.0` and `1.0`. A value of `0` means that no propagations occurred,
-    /// and `1` means that all propagations occurred with the wrong transaction name.
+    /// a percentage between `0.0` and `100.0`. A value of `0` means that no propagations occurred,
+    /// and `100` means that all propagations occurred with the wrong transaction name.
     ///
     /// This metric is tagged with:
     ///
@@ -200,7 +200,7 @@ pub enum RelayHistograms {
 
     /// Timing relative to the transaction duration until the final name is determined.
     ///
-    /// This is a percentage between `0.0` and `1.0`.
+    /// This is a percentage between `0.0` and `100.0`.
     ///
     /// This metric is tagged with:
     ///


### PR DESCRIPTION
Follow-up to #1466 that fixes some outlier conditions:

- Assume a 0% change vs propagations ratio when there were no changes
- Log timing metrics even if there was no change (using the start timestamp)
- Skip changes at the end of every transaction (i.e. event processors)

cc @ale-cota @AbhiPrasad 

#skip-changelog

