### PR TITLE
ref(metrics): Remove long running futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Generate a new profile ID when splitting a profile for multiple transactions. ([#1473](https://github.com/getsentry/relay/pull/1473))
 - Pin Rust version to 1.63.0 in Dockerfile. ([#1482](https://github.com/getsentry/relay/pull/1482))
 - Normalize measurement units in event payload. ([#1488](https://github.com/getsentry/relay/pull/1488))
-- Remove long-running futures from metrics flush ([#1492](https://github.com/getsentry/relay/pull/1492))
+- Remove long-running futures from metrics flush. ([#1492](https://github.com/getsentry/relay/pull/1492))
 
 ## 22.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-** Features **:
+**Features**:
 - Add INP web vital as a measurement. ([#1487](https://github.com/getsentry/relay/pull/1487))
 
 **Internal**:
 
 - Generate a new profile ID when splitting a profile for multiple transactions. ([#1473](https://github.com/getsentry/relay/pull/1473))
 - Pin Rust version to 1.63.0 in Dockerfile. ([#1482](https://github.com/getsentry/relay/pull/1482))
+- Remove long-running futures from metrics flush ([#1492](https://github.com/getsentry/relay/pull/1492))
 
 ## 22.9.0
 

--- a/relay-metrics/benches/aggregator.rs
+++ b/relay-metrics/benches/aggregator.rs
@@ -7,7 +7,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 
 use relay_common::{ProjectKey, UnixTimestamp};
 use relay_metrics::{Aggregator, AggregatorConfig};
-use relay_metrics::{Bucket, FlushBuckets, Metric, MetricValue};
+use relay_metrics::{FlushBuckets, Metric, MetricValue};
 
 #[derive(Clone, Default)]
 struct TestReceiver;
@@ -17,11 +17,9 @@ impl Actor for TestReceiver {
 }
 
 impl Handler<FlushBuckets> for TestReceiver {
-    type Result = Result<(), Vec<Bucket>>;
+    type Result = ();
 
-    fn handle(&mut self, _msg: FlushBuckets, _ctx: &mut Self::Context) -> Self::Result {
-        Ok(())
-    }
+    fn handle(&mut self, _msg: FlushBuckets, _ctx: &mut Self::Context) -> Self::Result {}
 }
 
 /// Struct representing a testcase for which insert + flush are timed.

--- a/relay-metrics/benches/aggregator.rs
+++ b/relay-metrics/benches/aggregator.rs
@@ -6,8 +6,7 @@ use actix::prelude::*;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 
 use relay_common::{ProjectKey, UnixTimestamp};
-use relay_metrics::{Aggregator, AggregatorConfig};
-use relay_metrics::{FlushBuckets, Metric, MetricValue};
+use relay_metrics::{Aggregator, AggregatorConfig, FlushBuckets, Metric, MetricValue};
 
 #[derive(Clone, Default)]
 struct TestReceiver;

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1762,7 +1762,7 @@ impl Aggregator {
         );
     }
 
-    /// Sends the [`FlushBuckets`] message to the receiver in the fire and forget fasion. It is up
+    /// Sends the [`FlushBuckets`] message to the receiver in the fire and forget fashion. It is up
     /// to the receiver to send the [`MergeBuckets`] message back if buckets could not be flushed
     /// and we require another re-try.
     ///
@@ -1892,6 +1892,17 @@ impl InsertMetrics {
             metrics: metrics.into_iter().collect(),
         }
     }
+
+    /// Returns the `ProjectKey` for the the current `InsertMetrics` message.
+    pub fn project_key(&self) -> ProjectKey {
+        self.project_key
+    }
+
+    /// Returns the list of the metrics in the current `InsertMetrics` message, consuming the
+    /// message itself.
+    pub fn metrics(self) -> Vec<Metric> {
+        self.metrics
+    }
 }
 
 impl Message for InsertMetrics {
@@ -1924,6 +1935,17 @@ impl MergeBuckets {
             project_key,
             buckets,
         }
+    }
+
+    /// Returns the `ProjectKey` for the the current `MergeBuckets` message.
+    pub fn project_key(&self) -> ProjectKey {
+        self.project_key
+    }
+
+    /// Returns the list of the buckets in the current `MergeBuckets` message, consuming the
+    /// message itself.
+    pub fn buckets(self) -> Vec<Bucket> {
+        self.buckets
     }
 }
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1785,15 +1785,14 @@ impl Aggregator {
             for (partition_key, buckets) in partitioned_buckets {
                 self.process_batches(buckets, |batch| {
                     let batch_size = batch.len();
-                    match self.receiver.do_send(FlushBuckets {
+                    if let Err(err) = self.receiver.do_send(FlushBuckets {
                         project_key,
                         partition_key,
                         buckets: batch,
                     }) {
-                        Ok(_) => {}
-                        Err(err) => {
-                            relay_log::error!("Failed to flush the buckets: {err}. Dropping current bucket batch of size: {batch_size}");
-                        }
+                            relay_log::error!(
+                                "Failed to flush the buckets: {err}. Dropping current {batch_size} buckets."
+                            );
                     }
                 });
             }

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1789,11 +1789,12 @@ impl Aggregator {
             for (partition_key, buckets) in partitioned_buckets {
                 self.process_batches(buckets, |batch| {
                     let batch_size = batch.len() as u64;
-                    if let Err(err) = self.receiver.do_send(FlushBuckets {
+                    let result = self.receiver.do_send(FlushBuckets {
                         project_key,
                         partition_key,
                         buckets: batch,
-                    }) {
+                    });
+                    if let Err(err) = result {
                         // remove the failed batch size from the total count, since it failed and
                         // will be dropped
                         total_bucket_count -= batch_size;

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1378,6 +1378,8 @@ impl<T: Iterator<Item = Bucket>> FusedIterator for CappedBucketIter<T> {}
 ///
 /// Internally, the aggregator maintains a continuous flush cycle every 100ms. It guarantees that
 /// all elapsed buckets belonging to the same [`ProjectKey`] are flushed together.
+///
+/// Receivers must implement a handler for the [`FlushBuckets`] message.
 pub struct Aggregator {
     config: AggregatorConfig,
     buckets: HashMap<BucketKey, QueuedBucket>,

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1772,7 +1772,6 @@ impl Aggregator {
 
         relay_log::trace!("flushing {} projects to receiver", flush_buckets.len());
 
-        let mut buckets_failed = vec![];
         let mut total_bucket_count = 0u64;
         for (project_key, project_buckets) in flush_buckets.into_iter() {
             let bucket_count = project_buckets.len() as u64;
@@ -1785,35 +1784,22 @@ impl Aggregator {
             let partitioned_buckets = self.partition_buckets(project_buckets, num_partitions);
             for (partition_key, buckets) in partitioned_buckets {
                 self.process_batches(buckets, |batch| {
-                    if let Err(err) = self.receiver.do_send(FlushBuckets {
+                    let batch_size = batch.len();
+                    match self.receiver.do_send(FlushBuckets {
                         project_key,
                         partition_key,
                         buckets: batch,
                     }) {
-                        let FlushBuckets {
-                            project_key,
-                            buckets,
-                            ..
-                        } = err.into_inner();
-
-                        // remove the number of buckets which were not flushed due to the `SendError`
-                        total_bucket_count -= buckets.len() as u64;
-                        buckets_failed.push((project_key, buckets));
+                        Ok(_) => {}
+                        Err(err) => {
+                            relay_log::error!("Failed to flush the buckets: {err}. Dropping current bucket batch of size: {batch_size}");
+                        }
                     }
                 });
             }
         }
-        relay_statsd::metric!(histogram(MetricHistograms::BucketsFlushed) = total_bucket_count);
 
-        relay_log::trace!(
-            "Merging back {} bucket batches which failed to flush.",
-            buckets_failed.len()
-        );
-        for (project_key, buckets) in buckets_failed {
-            if let Err(err) = self.merge_all(project_key, buckets) {
-                relay_log::error!("Failed to merge back not-flushed buckets: {}", err);
-            }
-        }
+        relay_statsd::metric!(histogram(MetricHistograms::BucketsFlushed) = total_bucket_count);
     }
 }
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -11,7 +11,7 @@ use relay_common::ProjectKey;
 use relay_config::{Config, HttpEncoding};
 use relay_general::protocol::ClientReport;
 use relay_log::LogError;
-use relay_metrics::{Aggregator, Bucket};
+use relay_metrics::{Aggregator, Bucket, MergeBuckets};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse};
@@ -367,10 +367,7 @@ impl EnvelopeManagerService {
                 "failed to submit the envelope, merging buckets back: {}",
                 err
             );
-            Aggregator::from_registry().do_send(relay_metrics::MergeBuckets::new(
-                scoping.project_key,
-                buckets,
-            ))
+            Aggregator::from_registry().do_send(MergeBuckets::new(scoping.project_key, buckets))
         }
     }
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -31,7 +31,7 @@ use relay_general::protocol::{
 use relay_general::store::{ClockDriftProcessor, LightNormalizationConfig};
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
 use relay_log::LogError;
-use relay_metrics::{Bucket, Metric};
+use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric};
 use relay_quotas::{DataCategory, RateLimits, ReasonCode};
 use relay_redis::RedisPool;
 use relay_sampling::{DynamicSamplingContext, RuleId};
@@ -41,7 +41,7 @@ use relay_system::{Addr, FromMessage, NoResponse, Service};
 use crate::actors::envelopes::{EnvelopeManager, SendEnvelope, SendEnvelopeError, SubmitEnvelope};
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::project::{Feature, ProjectState};
-use crate::actors::project_cache::{InsertMetrics, MergeBuckets, ProjectCache};
+use crate::actors::project_cache::ProjectCache;
 use crate::actors::upstream::{SendRequest, UpstreamRelay};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::metrics_extraction::sessions::{extract_session_metrics, SessionMetricsConfig};

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -17,7 +17,7 @@ use relay_filter::{matches_any_origin, FiltersConfig};
 use relay_general::pii::{DataScrubbingConfig, PiiConfig};
 use relay_general::store::{BreakdownsConfig, MeasurementsConfig};
 use relay_general::types::SpanAttribute;
-use relay_metrics::{self, Aggregator, Bucket, Metric};
+use relay_metrics::{self, Aggregator, Bucket, InsertMetrics, MergeBuckets, Metric};
 use relay_quotas::{Quota, RateLimits, Scoping};
 use relay_sampling::SamplingConfig;
 use relay_statsd::metric;
@@ -601,8 +601,7 @@ impl Project {
     /// The buckets will be keyed underneath this project key.
     pub fn merge_buckets(&mut self, buckets: Vec<Bucket>) {
         if self.metrics_allowed() {
-            Aggregator::from_registry()
-                .do_send(relay_metrics::MergeBuckets::new(self.project_key, buckets));
+            Aggregator::from_registry().do_send(MergeBuckets::new(self.project_key, buckets));
         }
     }
 
@@ -611,8 +610,7 @@ impl Project {
     /// The metrics will be keyed underneath this project key.
     pub fn insert_metrics(&mut self, metrics: Vec<Metric>) {
         if self.metrics_allowed() {
-            Aggregator::from_registry()
-                .do_send(relay_metrics::InsertMetrics::new(self.project_key, metrics));
+            Aggregator::from_registry().do_send(InsertMetrics::new(self.project_key, metrics));
         }
     }
 

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -670,7 +670,6 @@ impl Handler<FlushBuckets> for ProjectCache {
         }
 
         EnvelopeManager::from_registry().send(SendMetrics {
-            project_key,
             buckets,
             scoping,
             partition_key,


### PR DESCRIPTION
Instead of long running futures, which are waiting for the result from another actor, we just send the message fast and forget about it. It is the responsibility of the receiver to make sure to send the message back to aggregator for another re-try if the flushing fails.



