### PR TITLE
fix(lint): Fix lint and  make sure that tests work for rust 1.64.0

### DIFF
--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -104,13 +104,13 @@ fn get_windows_version(description: &str) -> Option<(&str, &str)> {
 
     let version_name = match build_number {
         // Not considering versions below Windows XP
-        2600..=3790 => ("XP"),
-        6002 => ("Vista"),
-        7601 => ("7"),
-        9200 => ("8"),
-        9600 => ("8.1"),
-        10240..=19044 => ("10"),
-        22000..=22999 => ("11"),
+        2600..=3790 => "XP",
+        6002 => "Vista",
+        7601 => "7",
+        9200 => "8",
+        9600 => "8.1",
+        10240..=19044 => "10",
+        22000..=22999 => "11",
         // Fall back to raw version:
         _ => full_version,
     };

--- a/relay-replays/src/lib.rs
+++ b/relay-replays/src/lib.rs
@@ -49,9 +49,8 @@ pub fn normalize_replay_event(
     replay_input.set_user_agent_meta();
 
     // Set user ip-address if needed.
-    match detected_ip_address {
-        Some(ip_address) => replay_input.set_user_ip_address(ip_address),
-        None => (),
+    if let Some(ip_address) = detected_ip_address {
+        replay_input.set_user_ip_address(ip_address)
     }
 
     serde_json::to_vec(&replay_input)

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -641,13 +641,9 @@ impl SamplingConfig {
         sampling_context: &DynamicSamplingContext,
         ip_addr: Option<IpAddr>,
     ) -> Option<&'a SamplingRule> {
-        for rule in &self.rules {
-            if rule.ty == RuleType::Trace && rule.condition.matches(sampling_context, ip_addr) {
-                return Some(rule);
-            }
-        }
-
-        None
+        self.rules.iter().find(|&rule| {
+            rule.ty == RuleType::Trace && rule.condition.matches(sampling_context, ip_addr)
+        })
     }
 
     /// Get the first rule of type [`RuleType::Transaction`] or [`RuleType::Error`] whose conditions
@@ -665,13 +661,9 @@ impl SamplingConfig {
             RuleType::Error
         };
 
-        for rule in &self.rules {
-            if rule.ty == ty && rule.condition.matches(event, ip_addr) {
-                return Some(rule);
-            }
-        }
-
-        None
+        self.rules
+            .iter()
+            .find(|&rule| rule.ty == ty && rule.condition.matches(event, ip_addr))
     }
 }
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -641,7 +641,7 @@ impl SamplingConfig {
         sampling_context: &DynamicSamplingContext,
         ip_addr: Option<IpAddr>,
     ) -> Option<&'a SamplingRule> {
-        self.rules.iter().find(|&rule| {
+        self.rules.iter().find(|rule| {
             rule.ty == RuleType::Trace && rule.condition.matches(sampling_context, ip_addr)
         })
     }
@@ -663,7 +663,7 @@ impl SamplingConfig {
 
         self.rules
             .iter()
-            .find(|&rule| rule.ty == ty && rule.condition.matches(event, ip_addr))
+            .find(|rule| rule.ty == ty && rule.condition.matches(event, ip_addr))
     }
 }
 


### PR DESCRIPTION
It does what it says in the title 

#skip-changelog