### PR TITLE
ref(system): Prefer biased select in service loops

### DIFF
--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -569,8 +569,10 @@ impl Service for HttpOutcomeProducer {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
-                    Some(message) = rx.recv() => self.handle_message(message),
+                    biased;
+
                     () = &mut self.pending_flush_handle => self.send_batch(),
+                    Some(message) = rx.recv() => self.handle_message(message),
                     else => break,
                 }
             }
@@ -657,8 +659,10 @@ impl Service for ClientReportOutcomeProducer {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
-                    Some(message) = rx.recv() => self.handle_message(message),
+                    biased;
+
                     () = &mut self.flush_handle => self.flush(),
+                    Some(message) = rx.recv() => self.handle_message(message),
                     else => break,
                 }
             }

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -187,8 +187,10 @@ impl Service for OutcomeAggregator {
 
             loop {
                 tokio::select! {
-                    Some(message) = rx.recv() => self.handle_track_outcome(message),
+                    biased;
+
                     () = &mut self.flush_handle => self.flush(),
+                    Some(message) = rx.recv() => self.handle_track_outcome(message),
                     _ = shutdown.changed() => self.handle_shutdown(&shutdown.borrow_and_update()),
                     else => break,
                 }

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -187,6 +187,8 @@ impl Service for OutcomeAggregator {
 
             loop {
                 tokio::select! {
+                    // Prioritize flush over receiving messages to prevent starving. Shutdown can be
+                    // last since it is not vital if there are still messages in the channel.
                     biased;
 
                     () = &mut self.flush_handle => self.flush(),

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -347,6 +347,7 @@ impl Service for RelayCacheService {
 
             loop {
                 tokio::select! {
+                    // Prioritize flush over receiving messages to prevent starving.
                     biased;
 
                     Some(result) = self.fetch_channel.1.recv() => self.handle_fetch_result(result),


### PR DESCRIPTION
Changes all services that select from multiple channels or futures in their main
loop to use `biased` select mode. This mode polls selected futures in their
declared order, which reduces runtime overheads and provides more deterministic
execution.

All of the changed services have a debounced flush cycle in common:
 1. Put a new entry into some internal queue.
 2. Defer a flush if not already scheduled.
 3. During flush, take all queued entries and handle them.

Since new entries and a flush can happen concurrently, the select statement
always needs to prioritize flush over new entries. Otherwise, a backlog on the
inbound message channel could starve flushes.

Note for future PRs: Given that this flush cycle occurs in at least 4 different
services (projects, relays, metrics, outcomes), it may be worth to build a
reusable component that handles this.

#skip-changelog

