### PR TITLE
doc(metrics): Add bucket width to examples

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -669,6 +669,7 @@ pub struct ParseBucketError(#[cause] serde_json::Error);
 /// [
 ///   {
 ///     "timestamp": 1615889440,
+///     "width": 10,
 ///     "name": "endpoint.response_time",
 ///     "type": "d",
 ///     "unit": "millisecond",
@@ -679,6 +680,7 @@ pub struct ParseBucketError(#[cause] serde_json::Error);
 ///   },
 ///   {
 ///     "timestamp": 1615889440,
+///     "width": 10,
 ///     "name": "endpoint.hits",
 ///     "type": "c",
 ///     "value": 4,
@@ -688,6 +690,7 @@ pub struct ParseBucketError(#[cause] serde_json::Error);
 ///   },
 ///   {
 ///     "timestamp": 1615889440,
+///     "width": 10,
 ///     "name": "endpoint.parallel_requests",
 ///     "type": "g",
 ///     "value": {
@@ -700,6 +703,7 @@ pub struct ParseBucketError(#[cause] serde_json::Error);
 ///   },
 ///   {
 ///     "timestamp": 1615889440,
+///     "width": 10,
 ///     "name": "endpoint.users",
 ///     "type": "s",
 ///     "value": [

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -55,6 +55,7 @@
 //!     "value": [36, 49, 57, 68],
 //!     "type": "d",
 //!     "timestamp": 1615889440,
+//!     "width": 10,
 //!     "tags": {
 //!       "route": "user_index"
 //!     }
@@ -64,6 +65,7 @@
 //!     "value": 4,
 //!     "type": "c",
 //!     "timestamp": 1615889440,
+//!     "width": 10,
 //!     "tags": {
 //!       "route": "user_index"
 //!     }


### PR DESCRIPTION
Update the JSON examples for metrics buckets (envelope protocol) to contain the `width` attribute.

#skip-changelog