### PR TITLE
ref(actix): Migrate the AwsExtension to tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,9 +3176,6 @@ dependencies = [
 name = "relay-aws-extension"
 version = "22.9.0"
 dependencies = [
- "actix",
- "failure",
- "futures 0.1.31",
  "relay-log",
  "relay-system",
  "reqwest",

--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -10,12 +10,9 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-actix = "0.7.9"
-failure = "0.1.8"
-futures01 = { version = "0.1.28", package = "futures" }
 relay-log = { path = "../relay-log" }
 relay-system = { path = "../relay-system" }
 reqwest = { version = "0.11.1", features = ["json", "blocking"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-tokio = { version = "1.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.0" }

--- a/relay-aws-extension/src/lib.rs
+++ b/relay-aws-extension/src/lib.rs
@@ -6,10 +6,9 @@
 //! continues running across multiple function invocations.
 //!
 //! Sentry's extension is basically existing Relay running in proxy mode with an additional
-//! [`AwsExtension`] actor started in a separate [`Arbiter`](actix::Arbiter). The actor takes care
-//! of the extension lifecycle, namely registering the extension and continuously polling for next
-//! events. Note that the interval between two next event calls adds to the billing time of the
-//! lambda invocation.
+//! [`AwsExtension`] service. The service takes care of the extension lifecycle, namely registering
+//! the extension and continuously polling for next events. Note that the interval between two next
+//! event calls adds to the billing time of the lambda invocation.
 //!
 //! The main advantage we get currently from the extension is the lambda function not having to wait
 //! for the event being sent to Sentry by the SDK. The actual sending happens in a concurrent Relay

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -20,6 +20,7 @@ use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::actors::processor::{EnvelopeProcessor, EnvelopeProcessorService};
 use crate::actors::project_cache::ProjectCache;
 use crate::actors::relays::{RelayCache, RelayCacheService};
+use crate::actors::store::StoreService;
 use crate::actors::test_store::{TestStore, TestStoreService};
 use crate::actors::upstream::UpstreamRelay;
 use crate::middlewares::{
@@ -175,9 +176,9 @@ impl ServiceState {
 
         #[cfg(feature = "processing")]
         if config.processing_enabled() {
-            let rt = crate::utils::tokio_runtime_with_actix();
+            let rt = utils::tokio_runtime_with_actix();
             let _guard = rt.enter();
-            let store = crate::actors::store::StoreService::create(config.clone())?.start();
+            let store = StoreService::create(config.clone())?.start();
             envelope_manager.set_store_forwarder(store);
             _store_runtime = Some(rt);
         }
@@ -197,7 +198,7 @@ impl ServiceState {
 
         if let Some(aws_api) = config.aws_runtime_api() {
             if let Ok(aws_extension) = AwsExtension::new(aws_api) {
-                Arbiter::start(|_| aws_extension);
+                aws_extension.start();
             }
         }
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -20,6 +20,7 @@ use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::actors::processor::{EnvelopeProcessor, EnvelopeProcessorService};
 use crate::actors::project_cache::ProjectCache;
 use crate::actors::relays::{RelayCache, RelayCacheService};
+#[cfg(feature = "processing")]
 use crate::actors::store::StoreService;
 use crate::actors::test_store::{TestStore, TestStoreService};
 use crate::actors::upstream::UpstreamRelay;

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -71,6 +71,11 @@ pub struct Controller {
 }
 
 impl Controller {
+    /// Get actor's address from system registry.
+    pub fn from_registry() -> Addr<Self> {
+        SystemService::from_registry()
+    }
+
     /// Starts an actix system and runs the `factory` to start actors.
     ///
     /// The factory may be used to start actors in the actix system before it runs. If the factory

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -104,6 +104,9 @@ use tokio::sync::{mpsc, oneshot};
 /// messages.
 pub trait Interface: Send + 'static {}
 
+/// Services without messages can use `()` as their interface.
+impl Interface for () {}
+
 /// An error when [sending](Addr::send) a message to a service fails.
 #[derive(Clone, Copy, Debug)]
 pub struct SendError;


### PR DESCRIPTION
Plain migration of the AWS extension. On error and on shutdown, the extension
stops as before. Since the extension is fully asynchronous, it can run on the
main runtime.

#skip-changelog
