### PR TITLE
ref(system): Make the main runtime multi-threaded

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -147,8 +147,8 @@ impl ServiceState {
         let system = System::current();
         let registry = system.registry();
 
-        let main_runtime = utils::tokio_runtime_with_actix();
-        let outcome_runtime = utils::tokio_runtime_with_actix();
+        let main_runtime = utils::create_runtime(config.cpu_concurrency());
+        let outcome_runtime = utils::create_runtime(1);
         let mut _store_runtime = None;
 
         let upstream_relay = UpstreamRelay::new(config.clone());
@@ -175,7 +175,7 @@ impl ServiceState {
 
         #[cfg(feature = "processing")]
         if config.processing_enabled() {
-            let rt = crate::utils::tokio_runtime_with_actix();
+            let rt = utils::create_runtime(1);
             let _guard = rt.enter();
             let store = crate::actors::store::StoreService::create(config.clone())?.start();
             envelope_manager.set_store_forwarder(store);

--- a/relay-server/src/utils/actix.rs
+++ b/relay-server/src/utils/actix.rs
@@ -49,19 +49,20 @@ where
     }
 }
 
-/// Constructs a single threaded tokio [`Runtime`] containing a clone of the actix [`System`].
+/// Constructs a tokio [`Runtime`] configured for running [services](relay_system::Service).
 ///
-/// This is required if you need to send messages from the tokio runtime to actix
-/// actors.
+/// For compatibility, this runtime also registers the actix [`System`]. This is required for
+/// interoperability with actors. To send messages to those actors, use
+/// [`compat::send`](relay_system::compat::send).
 ///
 /// # Panics
 ///
-/// The calling thread must have the actix system enabled, panics if this is invoked
-/// in a thread where actix is not enabled.
-pub fn tokio_runtime_with_actix() -> Runtime {
+/// The calling thread must have the actix system enabled, panics if this is invoked in a thread
+/// where actix is not enabled.
+pub fn create_runtime(threads: usize) -> Runtime {
     let system = System::current();
     tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1)
+        .worker_threads(threads)
         .enable_all()
         .on_thread_start(clone!(system, || System::set_current(system.clone())))
         .build()


### PR DESCRIPTION
The main runtime hosts most services and will potentially become the only
runtime in the long run. In that scenario, it should be multithreaded. However,
all expensive operations will likely also move to `spawn_blocking` or the
`EnvelopeProcessor`, so we may want to reduce the thread count of the runtime.

#skip-changelog

