### PR TITLE
instr(metrics): Track invalid timestamps [INGEST-1641]

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1032,6 +1032,10 @@ impl AggregatorConfig {
         let output_timestamp = UnixTimestamp::from_secs(ts);
 
         if output_timestamp < min_timestamp || output_timestamp > max_timestamp {
+            let delta = (ts as i64) - (now as i64);
+            relay_statsd::metric!(
+                histogram(MetricHistograms::InvalidBucketTimestamp) = delta as f64
+            );
             return Err(AggregateMetricsErrorKind::InvalidTimestamp.into());
         }
 

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -111,6 +111,11 @@ pub enum MetricHistograms {
     /// The distribution of buckets should be even.
     /// If it is not, this metric should expose it.
     PartitionKeys,
+
+    /// Distribution of invalid bucket timestamps observed, relative to the time of observation.
+    ///
+    /// This is a temporary metric to better understand why we see so many invalid timestamp errors.
+    InvalidBucketTimestamp,
 }
 
 impl HistogramMetric for MetricHistograms {
@@ -122,6 +127,7 @@ impl HistogramMetric for MetricHistograms {
             Self::BatchesPerPartition => "metrics.buckets.batches_per_partition",
             Self::BucketsPerBatch => "metrics.buckets.per_batch",
             Self::PartitionKeys => "metrics.buckets.partition_keys",
+            Self::InvalidBucketTimestamp => "metrics.buckets.invalid_timestamp",
         }
     }
 }


### PR DESCRIPTION
We record many more invalid bucket timestamps in processing relays than in pops. Maybe looking at their distribution helps us find out why.

#skip-changelog