### PR TITLE
fix(store): Catch invalid spans in light normalization [INGEST-1648]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Limit the number of custom measurements per event. ([#1483](https://github.com/getsentry/relay/pull/1483)))
 - Add INP web vital as a measurement. ([#1487](https://github.com/getsentry/relay/pull/1487))
 
+** Bug Fixes**:
+
+- Make sure that non-processing Relays drop all invalid transactions. ([#1513](https://github.com/getsentry/relay/pull/1513))
+
 **Internal**:
 
 - Introduce a new profile format called `sample`. ([#1462](https://github.com/getsentry/relay/pull/1462))

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -111,6 +111,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
     let mut event = Annotated::<Event>::from_json((*event).as_str())?;
     let light_normalization_config = LightNormalizationConfig {
         normalize_user_agent: (*processor).config().normalize_user_agent,
+        is_renormalize: (*processor).config().is_renormalize.unwrap_or(false),
         ..Default::default()
     };
     light_normalize_event(&mut event, &light_normalization_config)?;

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -109,13 +109,6 @@ impl<'a> Processor for StoreProcessor<'a> {
         legacy::LegacyProcessor.process_event(event, meta, state)?;
 
         if !is_renormalize {
-            // internally noops for non-transaction events
-            // TODO: Parts of this processor should probably be a filter once Relay is store so we
-            // can revert some changes to ProcessingAction
-            transactions::TransactionsProcessor.process_event(event, meta, state)?;
-        }
-
-        if !is_renormalize {
             // Normalize data in all interfaces
             self.normalize.process_event(event, meta, state)?;
         }

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -668,14 +668,25 @@ pub struct LightNormalizationConfig<'a> {
     pub measurements_config: Option<&'a MeasurementsConfig>,
     pub breakdowns_config: Option<&'a BreakdownsConfig>,
     pub normalize_user_agent: Option<bool>,
+    pub is_renormalize: bool,
 }
 
 pub fn light_normalize_event(
     event: &mut Annotated<Event>,
     config: &LightNormalizationConfig,
 ) -> ProcessingResult {
-    transactions::validate_annotated_transaction(event)?;
     event.apply(|event, meta| {
+        if !config.is_renormalize {
+            // Validate and normalize transaction
+            // internally noops for non-transaction events
+            // TODO: Parts of this processor should probably be a filter so we
+            // can revert some changes to ProcessingAction
+            transactions::TransactionsProcessor.process_event(
+                event,
+                meta,
+                ProcessingState::root(),
+            )?;
+        }
         // Check for required and non-empty values
         schema::SchemaProcessor.process_event(event, meta, ProcessingState::root())?;
 
@@ -2273,7 +2284,6 @@ mod tests {
 
             let res = light_normalize_event(&mut modified_event, &Default::default());
 
-            // TODO(jjbayer): Check all instantiations of ProcessingAction::InvalidTransaction
             assert!(res.is_err(), "{:?}", span);
         }
     }

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -678,7 +678,7 @@ pub fn light_normalize_event(
     event.apply(|event, meta| {
         if !config.is_renormalize {
             // Validate and normalize transaction
-            // internally noops for non-transaction events
+            // (internally noops for non-transaction events).
             // TODO: Parts of this processor should probably be a filter so we
             // can revert some changes to ProcessingAction
             transactions::TransactionsProcessor.process_event(

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -56,10 +56,6 @@ pub fn validate_timestamps(
     }
 }
 
-pub fn validate_annotated_transaction(event: &mut Annotated<Event>) -> ProcessingResult {
-    event.apply(|event, _meta| validate_transaction(event))
-}
-
 pub fn validate_transaction(event: &mut Event) -> ProcessingResult {
     if event.ty.value() != Some(&EventType::Transaction) {
         return Ok(());

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1957,6 +1957,7 @@ impl EnvelopeProcessorService {
             measurements_config: state.project_state.config.measurements.as_ref(),
             breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
             normalize_user_agent: Some(true),
+            is_renormalize: false,
         };
 
         metric!(timer(RelayTimers::EventProcessingLightNormalization), {


### PR DESCRIPTION
Make sure that all instances of `ProcessingAction::InvalidTransaction` are raised from light normalization. This was not the case for span validation until now.

This PR moves the call to `TransactionProcessor` to light normalization entirely. In a future PR, we might be able to remove the enum variant `ProcessingAction::InvalidTransaction` and make `Annotated::apply` infallible. That would make processors pure modifiers, instead of a mix of modifiers and filters:

https://github.com/getsentry/relay/blob/6e3f2054bbc5cbb2adf81779bd917bafa0277251/relay-general/src/store/mod.rs#L113-L114