### PR TITLE
fix(quotas): Make redis rate limiter work with quantity 0 [INGEST-1656]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Migrate to 2021 Rust edition. ([#1510](https://github.com/getsentry/relay/pull/1510))
 - Make the profiling frame object compatible with the stacktrace frame object from event. ([#1512](https://github.com/getsentry/relay/pull/1512))
 - Fix quota DataCategory::TransactionProcessed serialisation to match that of the CAPI. ([#1514](https://github.com/getsentry/relay/pull/1514))
+- Support checking quotas in the Redis rate limiter without incrementing them. ([#1519](https://github.com/getsentry/relay/pull/1519))
 
 ## 22.9.0
 

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -167,6 +167,10 @@ impl RedisRateLimiter {
     ///
     /// If no key is specified, then only organization-wide and project-wide quotas are checked. If
     /// a key is specified, then key-quotas are also checked.
+    ///
+    /// The passed `quantity` may be `0`. In this case, the rate limiter will check if the quota
+    /// limit has been reached or exceeded without incrementing it in the success case. This can be
+    /// useful to check for required quotas in a different data category.
     pub fn is_rate_limited(
         &self,
         quotas: &[Quota],


### PR DESCRIPTION
For #1515, it is required to check for a required quota of another data category without incrementing it. This PR updates the Redis LUA script to support a rate limiting quantity of `0`, which checks for existing rate limits without incrementing internal counters.

The rate limiter gains a new explicit branch to check whether the quantity is `0`. We could have indirectly achieved the same effect with `max(quantity, 1)`.
