### PR TITLE
Add support for multi-extensions config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Limit the number of custom measurements per event. ([#1483](https://github.com/getsentry/relay/pull/1483)))
 - Add INP web vital as a measurement. ([#1487](https://github.com/getsentry/relay/pull/1487))
+- Add support for multi-extensions config. ([#1520](https://github.com/getsentry/relay/pull/1520))
 
 ** Bug Fixes**:
 
@@ -37,7 +38,6 @@
 - Fix error message filtering when formatting the message of logentry. ([#1442](https://github.com/getsentry/relay/pull/1442))
 - Loosen type requirements for the `user.id` field in Replays. ([#1443](https://github.com/getsentry/relay/pull/1443))
 - Fix panic in datascrubbing when number of sensitive fields was too large. ([#1474](https://github.com/getsentry/relay/pull/1474))
-
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,6 +3236,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "smallvec 1.8.0",
  "url 2.2.2",
 ]
 

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -26,3 +26,4 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_yaml = "0.8.13"
 url = "2.1.1"
+smallvec = "1.4.0"

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -154,7 +154,7 @@ enum ConfigFormat {
 impl ConfigFormat {
     pub fn extensions(&self) -> Vec<&'static str> {
         match self {
-            ConfigFormat::Yaml => vec!["yml", "yaml"],
+            ConfigFormat::Yaml => vec!["yaml", "yml"],
             ConfigFormat::Json => vec!["json"],
         }
     }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -168,8 +168,8 @@ trait ConfigObject: DeserializeOwned + Serialize {
     /// The basename of the config file.
     fn name() -> &'static str;
 
-    /// Check the full filename of the config file if it exists in the file storage. If none of
-    /// the defined files exist, it returns the last one even if it does not exist
+    /// The full filename of the config file, including the file extension.
+    /// The first matching file is returned, falling back to the last extension if none match.
     fn path(base: &Path) -> PathBuf {
         let extensions = Self::format().extensions();
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -152,10 +152,10 @@ enum ConfigFormat {
 }
 
 impl ConfigFormat {
-    pub fn extension(&self) -> &'static str {
+    pub fn extensions(&self) -> Vec<&'static str> {
         match self {
-            ConfigFormat::Yaml => "yml",
-            ConfigFormat::Json => "json",
+            ConfigFormat::Yaml => vec!["yml", "yaml"],
+            ConfigFormat::Json => vec!["json"],
         }
     }
 }
@@ -169,7 +169,18 @@ trait ConfigObject: DeserializeOwned + Serialize {
 
     /// The full filename of the config file, including the file extension.
     fn path(base: &Path) -> PathBuf {
-        base.join(format!("{}.{}", Self::name(), Self::format().extension()))
+        let extensions = Self::format().extensions();
+
+        for extension in &extensions[..extensions.len() - 1] {
+            let path = base.join(format!("{}.{}", Self::name(), extension));
+
+            if path.exists() {
+                return path;
+            }
+        }
+
+        // It must returns something, so returns the last extension even if it does not exist
+        base.join(format!("{}.{}", Self::name(), extensions.last().unwrap()))
     }
 
     /// Loads the config file from a file within the given directory location.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -168,7 +168,8 @@ trait ConfigObject: DeserializeOwned + Serialize {
     /// The basename of the config file.
     fn name() -> &'static str;
 
-    /// The full filename of the config file, including the file extension.
+    /// Check the full filename of the config file if it exists in the file storage. If none of
+    /// the defined files exist, it returns the last one even if it does not exist
     fn path(base: &Path) -> PathBuf {
         let extensions = Self::format().extensions();
 
@@ -180,7 +181,6 @@ trait ConfigObject: DeserializeOwned + Serialize {
             }
         }
 
-        // It must returns something, so returns the last extension even if it does not exist
         base.join(format!("{}.{}", Self::name(), extensions.last().unwrap()))
     }
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use failure::{Backtrace, Context, Fail};
 use serde::de::{Unexpected, Visitor};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+use smallvec::{smallvec, SmallVec};
 
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
 use relay_common::{Dsn, Uuid};
@@ -152,10 +153,10 @@ enum ConfigFormat {
 }
 
 impl ConfigFormat {
-    pub fn extensions(&self) -> Vec<&'static str> {
+    pub fn extensions(&self) -> SmallVec<[&'static str; 2]> {
         match self {
-            ConfigFormat::Yaml => vec!["yaml", "yml"],
-            ConfigFormat::Json => vec!["json"],
+            ConfigFormat::Yaml => smallvec!["yaml", "yml"],
+            ConfigFormat::Json => smallvec!["json"],
         }
     }
 }

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -99,6 +99,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
         external=None,
         wait_health_check=True,
         static_relays=None,
+        config_file="config.yml",
         version="latest",
     ):
         relay_bin = get_relay_binary(version)
@@ -134,7 +135,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
                 default_opts.setdefault(key, {}).update(options[key])
 
         dir = config_dir("relay")
-        dir.join("config.yml").write(yaml.dump(default_opts))
+        dir.join(config_file).write(yaml.dump(default_opts))
 
         output = subprocess.check_output(
             relay_bin + ["-c", str(dir), "credentials", "generate"]

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -6,6 +6,12 @@ import signal
 import zlib
 import subprocess
 
+def test_config_file(mini_sentry, relay):
+    config_file = "config.yaml"
+    relay = relay(mini_sentry, config_file=config_file)
+
+    assert os.path.exists(relay.config_dir.join(config_file))
+
 
 def test_graceful_shutdown(mini_sentry, relay):
     from time import sleep

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -6,6 +6,7 @@ import signal
 import zlib
 import subprocess
 
+
 def test_config_file(mini_sentry, relay):
     config_file = "config.yaml"
     relay = relay(mini_sentry, config_file=config_file)


### PR DESCRIPTION
Hi all :wave: 
with this PR config file with `.yaml` extension will be valid. If a `config.yaml` file exists, try to open that file. If not, try `config.yml`.

Why try `.yaml` instead of `.yml` first? Because if none exists and you run `credentials generate` the newly created credentials will be placed in `.yml`.

This resolves #1094 