### PR TITLE
feat(quotas): Optionally exceed quota once [INGEST-1654]

### DIFF
--- a/relay-quotas/src/is_rate_limited.lua
+++ b/relay-quotas/src/is_rate_limited.lua
@@ -5,7 +5,7 @@
 --  * [string] Key of the counter.
 --  * [string] Key of the refund counter.
 --
--- ``ARGV`` (3 per quota):
+-- ``ARGV`` (4 per quota):
 --  * [number]  Quota limit. Can be ``-1`` for unlimited quotas.
 --  * [number]  Absolute Expiration time as Unix timestamp (secs since 1.1.1970 ) for the key.
 --  * [number]  Quantity to increment the quota by, or ``0`` to check without incrementing.
@@ -34,9 +34,9 @@ assert(#KEYS / 2 == #ARGV / 4, "incorrect number of keys and arguments provided"
 
 -- parse the incoming string into boolean, returns `nil` if could not parse which is also considered `false`
 local function parse_boolean(v)
-    if v == '1' or v == 'true' or v == 'TRUE' then
+    if v == 'true' then
         return true
-    elseif v == '0' or v == 'false' or v == 'FALSE' then
+    elseif v == 'false' then
         return false
     else
         return nil

--- a/relay-quotas/src/is_rate_limited.lua
+++ b/relay-quotas/src/is_rate_limited.lua
@@ -32,17 +32,6 @@ assert(#KEYS % 2 == 0, "there must be 2 keys per quota")
 assert(#ARGV % 4 == 0, "there must be 4 args per quota")
 assert(#KEYS / 2 == #ARGV / 4, "incorrect number of keys and arguments provided")
 
--- parse the incoming string into boolean, returns `nil` if could not parse which is also considered `false`
-local function parse_boolean(v)
-    if v == 'true' then
-        return true
-    elseif v == 'false' then
-        return false
-    else
-        return nil
-    end
-end
-
 local results = {}
 local failed = false
 local num_quotas = #KEYS / 2
@@ -52,7 +41,7 @@ for i=0, num_quotas - 1 do
 
     local limit = tonumber(ARGV[v])
     local quantity = tonumber(ARGV[v+2])
-    local over_accept_once = parse_boolean(ARGV[v+3])
+    local over_accept_once = ARGV[v+3]
     local rejected = false
     -- limit=-1 means "no limit"
     if limit >= 0 then
@@ -61,7 +50,7 @@ for i=0, num_quotas - 1 do
         -- With over_accept_once, we only reject if the previous update already reached the limit. 
         -- This way, we ensure that we increment to or past the limit at some point,
         -- such that subsequent checks with quantity=0 are actually rejected.
-        if quantity == 0 or over_accept_once then
+        if quantity == 0 or over_accept_once == 'true' then
             rejected = consumed >= limit
         else
             rejected = consumed + quantity > limit

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -418,6 +418,59 @@ mod tests {
     }
 
     #[test]
+    fn test_quota_go_over() {
+        let quotas = &[Quota {
+            id: Some(format!("test_quota_go_over{:?}", SystemTime::now())),
+            categories: DataCategories::new(),
+            scope: QuotaScope::Organization,
+            scope_id: None,
+            limit: Some(2),
+            window: Some(60),
+            reason_code: Some(ReasonCode::new("get_lost")),
+        }];
+
+        let scoping = ItemScoping {
+            category: DataCategory::Error,
+            scoping: &Scoping {
+                organization_id: 42,
+                project_id: ProjectId::new(43),
+                project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+                key_id: Some(44),
+            },
+        };
+
+        let rate_limiter = build_rate_limiter();
+
+        // limit is 1, so first call not rate limited
+        let is_limited = rate_limiter
+            .is_rate_limited(quotas, scoping, 1)
+            .unwrap()
+            .is_limited();
+        assert!(!is_limited);
+
+        // go over limit, but first call is over-accepted
+        let is_limited = rate_limiter
+            .is_rate_limited(quotas, scoping, 2)
+            .unwrap()
+            .is_limited();
+        assert!(!is_limited);
+
+        // quota is exhausted, regardless of the quantity
+        let is_limited = rate_limiter
+            .is_rate_limited(quotas, scoping, 0)
+            .unwrap()
+            .is_limited();
+        assert!(is_limited);
+
+        // quota is exhausted, regardless of the quantity
+        let is_limited = rate_limiter
+            .is_rate_limited(quotas, scoping, 1)
+            .unwrap()
+            .is_limited();
+        assert!(is_limited);
+    }
+
+    #[test]
     fn test_bails_immediately_without_any_quota() {
         let scoping = ItemScoping {
             category: DataCategory::Error,

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -168,6 +168,10 @@ impl RedisRateLimiter {
     /// If no key is specified, then only organization-wide and project-wide quotas are checked. If
     /// a key is specified, then key-quotas are also checked.
     ///
+    /// If the current consumed quotas are still under the limit and the current quantity would put
+    /// it over the limit, which normaly would return the _rejection_, setting `over_accept_once`
+    /// to `true` will allow accept the incoming data even if the limit is exceeded once.
+    ///
     /// The passed `quantity` may be `0`. In this case, the rate limiter will check if the quota
     /// limit has been reached or exceeded without incrementing it in the success case. This can be
     /// useful to check for required quotas in a different data category.
@@ -176,6 +180,7 @@ impl RedisRateLimiter {
         quotas: &[Quota],
         item_scoping: ItemScoping<'_>,
         quantity: usize,
+        over_accept_once: bool,
     ) -> Result<RateLimits, RateLimitingError> {
         let timestamp = UnixTimestamp::now();
 
@@ -203,6 +208,7 @@ impl RedisRateLimiter {
                 invocation.arg(quota.limit());
                 invocation.arg(quota.expiry().as_secs() + GRACE);
                 invocation.arg(quantity);
+                invocation.arg(over_accept_once);
 
                 tracked_quotas.push(quota);
             } else {
@@ -305,7 +311,7 @@ mod tests {
         };
 
         let rate_limits: Vec<RateLimit> = build_rate_limiter()
-            .is_rate_limited(quotas, scoping, 1)
+            .is_rate_limited(quotas, scoping, 1, false)
             .expect("rate limiting failed")
             .into_iter()
             .collect();
@@ -347,7 +353,7 @@ mod tests {
 
         for i in 0..10 {
             let rate_limits: Vec<RateLimit> = rate_limiter
-                .is_rate_limited(quotas, scoping, 1)
+                .is_rate_limited(quotas, scoping, 1, false)
                 .expect("rate limiting failed")
                 .into_iter()
                 .collect();
@@ -394,25 +400,25 @@ mod tests {
 
         // limit is 1, so first call not rate limited
         assert!(!rate_limiter
-            .is_rate_limited(quotas, scoping, 1)
+            .is_rate_limited(quotas, scoping, 1, false)
             .unwrap()
             .is_limited());
 
         // quota is now exhausted
         assert!(rate_limiter
-            .is_rate_limited(quotas, scoping, 1)
+            .is_rate_limited(quotas, scoping, 1, false)
             .unwrap()
             .is_limited());
 
         // quota is exhausted, regardless of the quantity
         assert!(rate_limiter
-            .is_rate_limited(quotas, scoping, 0)
+            .is_rate_limited(quotas, scoping, 0, false)
             .unwrap()
             .is_limited());
 
         // quota is exhausted, regardless of the quantity
         assert!(rate_limiter
-            .is_rate_limited(quotas, scoping, 1)
+            .is_rate_limited(quotas, scoping, 1, false)
             .unwrap()
             .is_limited());
     }
@@ -443,28 +449,28 @@ mod tests {
 
         // limit is 1, so first call not rate limited
         let is_limited = rate_limiter
-            .is_rate_limited(quotas, scoping, 1)
+            .is_rate_limited(quotas, scoping, 1, true)
             .unwrap()
             .is_limited();
         assert!(!is_limited);
 
         // go over limit, but first call is over-accepted
         let is_limited = rate_limiter
-            .is_rate_limited(quotas, scoping, 2)
+            .is_rate_limited(quotas, scoping, 2, true)
             .unwrap()
             .is_limited();
         assert!(!is_limited);
 
         // quota is exhausted, regardless of the quantity
         let is_limited = rate_limiter
-            .is_rate_limited(quotas, scoping, 0)
+            .is_rate_limited(quotas, scoping, 0, true)
             .unwrap()
             .is_limited();
         assert!(is_limited);
 
         // quota is exhausted, regardless of the quantity
         let is_limited = rate_limiter
-            .is_rate_limited(quotas, scoping, 1)
+            .is_rate_limited(quotas, scoping, 1, true)
             .unwrap()
             .is_limited();
         assert!(is_limited);
@@ -483,7 +489,7 @@ mod tests {
         };
 
         let rate_limits: Vec<RateLimit> = build_rate_limiter()
-            .is_rate_limited(&[], scoping, 1)
+            .is_rate_limited(&[], scoping, 1, false)
             .expect("rate limiting failed")
             .into_iter()
             .collect();
@@ -528,7 +534,7 @@ mod tests {
 
         for i in 0..1 {
             let rate_limits: Vec<RateLimit> = rate_limiter
-                .is_rate_limited(quotas, scoping, 1)
+                .is_rate_limited(quotas, scoping, 1, false)
                 .expect("rate limiting failed")
                 .into_iter()
                 .collect();
@@ -575,7 +581,7 @@ mod tests {
 
         for i in 0..10 {
             let rate_limits: Vec<RateLimit> = rate_limiter
-                .is_rate_limited(quotas, scoping, 100)
+                .is_rate_limited(quotas, scoping, 100, false)
                 .expect("rate limiting failed")
                 .into_iter()
                 .collect();
@@ -682,9 +688,11 @@ mod tests {
             .arg(1) // limit
             .arg(now + 60) // expiry
             .arg(1) // quantity
+            .arg(false) // over accept once
             .arg(2) // limit
             .arg(now + 120) // expiry
-            .arg(1); // quantity
+            .arg(1) // quantity
+            .arg(false); // over accept once
 
         // The item should not be rate limited by either key.
         assert_eq!(
@@ -730,7 +738,8 @@ mod tests {
             .key(&baz) // refund key
             .arg(1) // limit
             .arg(now + 60) // expiry
-            .arg(1); // quantity
+            .arg(1) // quantity
+            .arg(false);
 
         // increment
         assert_eq!(
@@ -750,7 +759,8 @@ mod tests {
             .key(&apple) // refund key
             .arg(1) // limit
             .arg(now + 60) // expiry
-            .arg(1); // quantity
+            .arg(1) // quantity
+            .arg(false);
 
         // test that refund key is used
         assert_eq!(

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -447,7 +447,7 @@ mod tests {
 
         let rate_limiter = build_rate_limiter();
 
-        // limit is 1, so first call not rate limited
+        // limit is 2, so first call not rate limited
         let is_limited = rate_limiter
             .is_rate_limited(quotas, scoping, 1, true)
             .unwrap()

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1722,7 +1722,7 @@ impl EnvelopeProcessorService {
         // When invoking the rate limiter, capture if the event item has been rate limited to also
         // remove it from the processing state eventually.
         let mut envelope_limiter = EnvelopeLimiter::new(|item_scope, quantity| {
-            let limits = rate_limiter.is_rate_limited(quotas, item_scope, quantity)?;
+            let limits = rate_limiter.is_rate_limited(quotas, item_scope, quantity, false)?;
             remove_event |= Some(item_scope.category) == event_category && limits.is_limited();
             Ok(limits)
         });


### PR DESCRIPTION
For checks with `quantity=0`, we need the quota stored in redis to _exceed_ the rate limit to be executed. For this, it's necessary to _accept_ the first call of the rate limiter that exceeds the limit.

- [x] Test that describes desired behavior
- [x] Add an optional argument to lua script to over-accept.

```lua
 if quantity == 0 or over_accept_once then
      rejected = consumed >= limit
  else
      rejected = consumed + quantity > limit
  end
  ``` 

#skip-changelog