### PR TITLE
meta(vscode): Configure rust import preferences

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,11 @@
   "python.linting.enabled": true,
   "python.formatting.provider": "black",
 
+  // Rust Analyzer
+  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.imports.prefix": "crate",
+
   // Language-specific overrides
   "[markdown]": {
     "editor.rulers": [80],


### PR DESCRIPTION
Configures Rust Analyzer to follow the preferred import style when organizing
imports, mostly during auto-import:

 - Group imports by module path, emitting one line per module.
 - Prefix imports from the local crate with `crate::` instead of using `super`.

Note that Rust Analyzer is not configured to rewrite existing imports, and it
will try to match the import style of the files being edited.

This also enables clippy as check command so that clippy warnings show up 
while editing. This was likely already enabled in most local development
environments.

#skip-changelog

