### PR TITLE
ci(danger): Fix draft and merged PR detection

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -62,10 +62,8 @@ async function checkChangelog() {
 }
 
 async function checkAll() {
-  // See: https://spectrum.chat/danger/javascript/support-for-github-draft-prs~82948576-ce84-40e7-a043-7675e5bf5690
-  const isDraft = danger.github.pr.mergeable_state === "draft";
-
-  if (isDraft) {
+  const pr = danger.github.pr;
+  if (pr.draft || pr.merged) {
     return;
   }
 


### PR DESCRIPTION
The changelog bot should not run on either draft PRs or merged PRs. There was
detection for draft PRs, but it seems the schema was changed. This fixes both
cases by checking for the flags documented at:

https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request

#skip-changelog
