### PR TITLE
ref(pii): Consider all token as sensitive [INGEST-1550]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Limit the number of custom measurements per event. ([#1483](https://github.com/getsentry/relay/pull/1483)))
 - Add INP web vital as a measurement. ([#1487](https://github.com/getsentry/relay/pull/1487))
+- Consider all tokens as sensitive, filter out all `*token*` from the input. ([#1527](https://github.com/getsentry/relay/pull/1527))
 
 ** Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Limit the number of custom measurements per event. ([#1483](https://github.com/getsentry/relay/pull/1483)))
 - Add INP web vital as a measurement. ([#1487](https://github.com/getsentry/relay/pull/1487))
-- Consider all tokens as sensitive, filter out all `*token*` from the input. ([#1527](https://github.com/getsentry/relay/pull/1527))
+- PII scrubbing now treats any key containing `token` as a password. ([#1527](https://github.com/getsentry/relay/pull/1527))
 
 ** Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add `transaction_info` to event payloads, including the transaction's source and internal original transaction name. ([#1330](https://github.com/getsentry/relay/pull/1330))
 - Add user-agent parsing to replays processor. ([#1420](https://github.com/getsentry/relay/pull/1420))
 - `convert_datascrubbing_config` will now return an error string when conversion fails on big regexes. ([#1474](https://github.com/getsentry/relay/pull/1474))
-- Consider all tokens as sensitive, filter out all `*token*` from the input. ([#1527](https://github.com/getsentry/relay/pull/1527))
+- `relay_pii_strip_event` now treats any key containing `token` as a password. ([#1527](https://github.com/getsentry/relay/pull/1527))
 
 ## 0.8.13
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `transaction_info` to event payloads, including the transaction's source and internal original transaction name. ([#1330](https://github.com/getsentry/relay/pull/1330))
 - Add user-agent parsing to replays processor. ([#1420](https://github.com/getsentry/relay/pull/1420))
 - `convert_datascrubbing_config` will now return an error string when conversion fails on big regexes. ([#1474](https://github.com/getsentry/relay/pull/1474))
+- Consider all tokens as sensitive, filter out all `*token*` from the input. ([#1527](https://github.com/getsentry/relay/pull/1527))
 
 ## 0.8.13
 

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -1379,7 +1379,8 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
                     "access_token": "quz",
                     "stripetoken": "baz",
                     "my-token": "secret",
-                    "new_token": "hidden,"
+                    "new_token": "hidden",
+                    "secret-token-here": "ops"
                 }
             })
             .into(),

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -269,6 +269,6 @@ static US_SSN_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 static PASSWORD_KEY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|.*token)"
+        r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|.*token.*)"
     ).unwrap()
 });

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -269,6 +269,6 @@ static US_SSN_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 static PASSWORD_KEY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)(password|secret|passwd|api_key|apikey|access_token|auth|credentials|mysql_pwd|stripetoken|privatekey|private_key|github_token)"
+        r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|.*token)"
     ).unwrap()
 });

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__safe_fields_for_token.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__safe_fields_for_token.snap
@@ -9,6 +9,7 @@ expression: data
     "my-token": "[Filtered]",
     "new_token": "[Filtered]",
     "password": "[Filtered]",
+    "secret-token-here": "[Filtered]",
     "stripetoken": "baz"
   },
   "_meta": {
@@ -36,10 +37,23 @@ expression: data
               10
             ]
           ],
-          "len": 7
+          "len": 6
         }
       },
       "password": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 3
+        }
+      },
+      "secret-token-here": {
         "": {
           "rem": [
             [

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__safe_fields_for_token.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__safe_fields_for_token.snap
@@ -1,0 +1,57 @@
+---
+source: relay-general/src/pii/convert.rs
+expression: data
+---
+{
+  "extra": {
+    "access_token": "quz",
+    "github_token": "bar",
+    "my-token": "[Filtered]",
+    "new_token": "[Filtered]",
+    "password": "[Filtered]",
+    "stripetoken": "baz"
+  },
+  "_meta": {
+    "extra": {
+      "my-token": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 6
+        }
+      },
+      "new_token": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 7
+        }
+      },
+      "password": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 3
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Scrub all the fields where names end with `token` and make sure that `safe_fields` can be used to override the default scrubbing rule if needed. 

The question to the team: 
* do we want to scrub anything that contains `token` instead?  ~> **Yes**

#skip-changelog