### PR TITLE
feat(replays): emit org_id on recording kafka messages

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -380,6 +380,7 @@ impl StoreService {
                         KafkaMessage::ReplayRecording(ReplayRecordingKafkaMessage {
                             replay_id: event_id.ok_or(StoreError::NoEventId)?,
                             project_id: scoping.project_id,
+                            key_id: scoping.key_id,
                             org_id: scoping.organization_id,
                             retention_days: retention,
                             replay_recording,
@@ -1018,6 +1019,8 @@ struct ReplayRecordingKafkaMessage {
     replay_id: EventId,
     /// The project id for the current event.
     project_id: ProjectId,
+    /// The key_id for the current event.
+    key_id: Option<u64>,
     /// The org id for the current event.
     org_id: u64,
     /// The recording attachment.

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -382,6 +382,7 @@ impl StoreService {
                             project_id: scoping.project_id,
                             key_id: scoping.key_id,
                             org_id: scoping.organization_id,
+                            received: UnixTimestamp::from_instant(start_time).as_secs(),
                             retention_days: retention,
                             replay_recording,
                         });
@@ -1017,12 +1018,14 @@ struct ReplayRecordingChunkKafkaMessage {
 struct ReplayRecordingKafkaMessage {
     /// The replay id.
     replay_id: EventId,
-    /// The project id for the current event.
+    /// The project id for the current recording.
     project_id: ProjectId,
-    /// The key_id for the current event.
+    /// The key_id for the current recording.
     key_id: Option<u64>,
-    /// The org id for the current event.
+    /// The org id for the current recording.
     org_id: u64,
+    /// The timestamp of when the recording was Received by relay
+    received: u64,
     /// The recording attachment.
     replay_recording: ChunkedReplayRecording,
     retention_days: u16,

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -380,6 +380,7 @@ impl StoreService {
                         KafkaMessage::ReplayRecording(ReplayRecordingKafkaMessage {
                             replay_id: event_id.ok_or(StoreError::NoEventId)?,
                             project_id: scoping.project_id,
+                            org_id: scoping.organization_id,
                             retention_days: retention,
                             replay_recording,
                         });
@@ -1017,6 +1018,8 @@ struct ReplayRecordingKafkaMessage {
     replay_id: EventId,
     /// The project id for the current event.
     project_id: ProjectId,
+    /// The org id for the current event.
+    org_id: u64,
     /// The recording attachment.
     replay_recording: ChunkedReplayRecording,
     retention_days: u16,

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -83,6 +83,7 @@ def test_replay_recordings_processing(
         "replay_id": replay_id,
         "project_id": project_id,
         "org_id": org_id,
+        "key_id": 123,
         "retention_days": 90,
     }
 

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -1,5 +1,5 @@
+from datetime import datetime, timezone
 import pytest
-import time
 import uuid
 
 from requests.exceptions import HTTPError
@@ -37,7 +37,6 @@ def test_replay_recordings_processing(
     project_id = 42
     org_id = 0
     replay_id = "515539018c9b4260a6f999572f1661ee"
-
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(
         project_id, extra={"config": {"features": ["organizations:session-replay"]}}
@@ -73,18 +72,18 @@ def test_replay_recordings_processing(
 
     replay_recording = replay_recordings_consumer.get_individual_replay()
 
-    assert replay_recording == {
-        "type": "replay_recording",
-        "replay_recording": {
-            "chunks": replay_recording_num_chunks[id1],
-            "id": id1,
-            "size": len(replay_recording_contents[id1]),
-        },
-        "replay_id": replay_id,
-        "project_id": project_id,
-        "org_id": org_id,
-        "key_id": 123,
-        "retention_days": 90,
+    assert replay_recording["type"] == "replay_recording"
+    assert replay_recording["replay_recording"] == {
+        "chunks": replay_recording_num_chunks[id1],
+        "id": id1,
+        "size": len(replay_recording_contents[id1]),
     }
+    assert replay_recording["replay_id"] == replay_id
+    assert replay_recording["project_id"] == project_id
+    assert replay_recording["org_id"] == org_id
+    assert replay_recording["key_id"] == 123
+    assert replay_recording["retention_days"] == 90
+    assert replay_recording["received"]
+    assert type(replay_recording["received"]) == int
 
     outcomes_consumer.assert_empty()

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -35,6 +35,7 @@ def test_replay_recordings_processing(
     mini_sentry, relay_with_processing, replay_recordings_consumer, outcomes_consumer
 ):
     project_id = 42
+    org_id = 0
     replay_id = "515539018c9b4260a6f999572f1661ee"
 
     relay = relay_with_processing()
@@ -81,6 +82,7 @@ def test_replay_recordings_processing(
         },
         "replay_id": replay_id,
         "project_id": project_id,
+        "org_id": org_id,
         "retention_days": 90,
     }
 


### PR DESCRIPTION
we'd like to start emitting outcomes in our recordings consumer, and for that, we need the org id. since we already have it here in relay, let's just add that onto our kafka message, instead of having to grab it from the project_id downstream in the consumer.

this change is fine downstream as we ignore unused fields, and have tested locally.

#skip-changelog 