### PR TITLE
test(auth): Unflake re_auth_failure

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -891,7 +891,7 @@ def test_re_auth_failure(relay, mini_sentry):
     assert auth_count_1 < auth_count_2
 
     # Give Relay some time to process the auth response and mark itself as not ready
-    sleep(1)
+    sleep(0.1)
 
     # send a message, it should not come through while the authentication has failed
     relay.send_event(project_id, {"message": "123"})
@@ -910,7 +910,7 @@ def test_re_auth_failure(relay, mini_sentry):
     assert auth_count_2 < auth_count_3
 
     # Give Relay some time to process the auth response and mark itself as ready
-    sleep(1)
+    sleep(0.1)
 
     # now we should be re-authenticated and we should have the event
 

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -890,6 +890,9 @@ def test_re_auth_failure(relay, mini_sentry):
     auth_count_2 = counter[0]
     assert auth_count_1 < auth_count_2
 
+    # Give Relay some time to process the auth response and mark itself as not ready
+    sleep(1)
+
     # send a message, it should not come through while the authentication has failed
     relay.send_event(project_id, {"message": "123"})
     # sentry should have received nothing
@@ -905,6 +908,9 @@ def test_re_auth_failure(relay, mini_sentry):
     # check that we have had some auth that succeeded
     auth_count_3 = counter[0]
     assert auth_count_2 < auth_count_3
+
+    # Give Relay some time to process the auth response and mark itself as ready
+    sleep(1)
 
     # now we should be re-authenticated and we should have the event
 


### PR DESCRIPTION
It seems that in `test_re_auth_failure`, Relay was able to process a new event before it changed its `auth_state` from `Registered` to `Registering`. The integration test waits for the sentry side to handle the failing auth request, but not for the Relay side to handle the failing auth _response_.

#skip-changelog