### PR TITLE
replays: add warning log for parse errors

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1098,7 +1098,8 @@ impl EnvelopeProcessorService {
                         item.set_payload(ContentType::Json, &replay[..]);
                         true
                     }
-                    Err(_) => {
+                    Err(error) => {
+                        relay_log::warn!("failed to parse replay event: {}", LogError(&error));
                         context.track_outcome(
                             Outcome::Invalid(DiscardReason::InvalidReplayEvent),
                             DataCategory::Replay,


### PR DESCRIPTION
- we're seeing a decent amount of replay event parse failures in our outcomes table. We're not sure why exactly, so adding a warning here if we fail to parse the replay event.


#skip-changelog

closes https://github.com/getsentry/replay-backend/issues/168