### PR TITLE
feat(metrics): Use data category 'transactions' for metrics rate limiting [INGEST-1535]

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -57,7 +57,7 @@ use {
     crate::actors::envelopes::SendMetrics,
     crate::actors::project_cache::UpdateRateLimits,
     crate::service::ServerErrorKind,
-    crate::utils::{BucketLimiter, EnvelopeLimiter},
+    crate::utils::{BucketLimiter, EnvelopeLimiter, DATA_CATEGORY_FOR_METRICS},
     failure::ResultExt,
     relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
     relay_quotas::ItemScoping,
@@ -2197,7 +2197,7 @@ impl EnvelopeProcessorService {
 
         if let Some(rate_limiter) = self.rate_limiter.as_ref() {
             let item_scoping = ItemScoping {
-                category: DataCategory::TransactionProcessed,
+                category: DATA_CATEGORY_FOR_METRICS,
                 scoping: &scoping,
             };
             // We set over_accept_once such that the limit is actually reached, which allows subsequent

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -6,6 +6,9 @@ use relay_quotas::{ItemScoping, Quota, RateLimits, Scoping};
 
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 
+/// The data category used to apply rate limits to metrics buckets.
+pub const DATA_CATEGORY_FOR_METRICS: DataCategory = DataCategory::Transaction;
+
 /// Holds metrics buckets with some information about their contents.
 #[derive(Debug)]
 pub struct BucketLimiter {
@@ -120,7 +123,7 @@ impl BucketLimiter {
                 outcome,
                 event_id: None,
                 remote_addr: None,
-                category: DataCategory::TransactionProcessed,
+                category: DATA_CATEGORY_FOR_METRICS,
                 quantity: self.transaction_count as u32,
             });
         }
@@ -138,7 +141,7 @@ impl BucketLimiter {
         match rate_limits {
             Ok(rate_limits) => {
                 let item_scoping = ItemScoping {
-                    category: DataCategory::TransactionProcessed,
+                    category: DATA_CATEGORY_FOR_METRICS,
                     scoping: &self.scoping,
                 };
                 let applied_rate_limits = rate_limits.check_with_quotas(&self.quotas, item_scoping);

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -513,7 +513,7 @@ def test_rate_limit_metrics_buckets(
             "id": "test_rate_limiting_{}".format(uuid.uuid4().hex),
             "scope": "key",
             "scopeId": six.text_type(key_id),
-            "categories": ["transaction_processed"],
+            "categories": ["transaction"],
             "limit": 5,
             "window": 86400,
             "reasonCode": reason_code,
@@ -649,7 +649,7 @@ def test_rate_limit_metrics_buckets(
     ]
 
     outcomes_consumer.assert_rate_limited(
-        reason_code, key_id=key_id, categories=["transaction_processed"], quantity=3,
+        reason_code, key_id=key_id, categories=["transaction"], quantity=3,
     )
 
 


### PR DESCRIPTION
Change the data category for metrics bucket limiting.

This implements [Option 2](https://www.notion.so/sentry/Dynamic-Sampling-Packaging-v3-ec32aaeb6c054fe6930a8e6f519f634f#d69f3cea151c4c288917f45756708f3c) of the Dynamic Sampling Packaging V3 DACI:

The `transactions` category will now represent all transactions for which metrics have been extracted. Therefore, it should also be the category used to enforce rate limits on transaction-related metrics buckets.

**NOTES**

* This option has not been decided yet, which is why this PR is still a draft.
* This PR is based on #1535.