### PR TITLE
build(craft): Fix manylinux artifact name

### DIFF
--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -17,7 +17,7 @@ targets:
 requireNames:
   - /^sentry_relay-.*-py2\.py3-none-macosx_10_15_x86_64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-macosx_11_0_arm64.whl$/
-  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_i686.*\.whl$/
-  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2010_x86_64.*\.whl$/
+  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_i686.*\.whl$/
+  - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_x86_64.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_aarch64.*\.whl$/
   - /^sentry-relay-.*\.zip$/


### PR DESCRIPTION
In the process of https://github.com/getsentry/relay/pull/1438, we bumped everything to manylinux2014, but the craft file was not updated.

#skip-changelog