### PR TITLE
fix(py): Respect the renormalize flag

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Restore correct behavior when `is_renormalize` is specified on `normalize_event`. ([#1548](https://github.com/getsentry/relay/pull/1548))
+
 ## 0.8.14
+
+**Warning:** This release contains a regression. Please update to a more recent version.
 
 - Add `transaction_info` to event payloads, including the transaction's source and internal original transaction name. ([#1330](https://github.com/getsentry/relay/pull/1330))
 - Add user-agent parsing to replays processor. ([#1420](https://github.com/getsentry/relay/pull/1420))

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -109,10 +109,17 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
 ) -> RelayStr {
     let processor = normalizer as *mut StoreProcessor;
     let mut event = Annotated::<Event>::from_json((*event).as_str())?;
+    let config = (*processor).config();
     let light_normalization_config = LightNormalizationConfig {
-        normalize_user_agent: (*processor).config().normalize_user_agent,
-        is_renormalize: (*processor).config().is_renormalize.unwrap_or(false),
-        ..Default::default()
+        client_ip: config.client_ip.as_ref(),
+        user_agent: config.user_agent.as_deref(),
+        received_at: config.received_at,
+        max_secs_in_past: config.max_secs_in_past,
+        max_secs_in_future: config.max_secs_in_future,
+        measurements_config: None, // only supported in relay
+        breakdowns_config: None,   // only supported in relay
+        normalize_user_agent: config.normalize_user_agent,
+        is_renormalize: config.is_renormalize.unwrap_or(false),
     };
     light_normalize_event(&mut event, &light_normalization_config)?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;


### PR DESCRIPTION
The `normalize` in the python package and C-ABI receives a structure with config arguments for the various normalizers. The `renormalize` flag is more central, as it is supposed to disable most of the normalizers. This is used in Sentry after the event has passed normalization to ensure that it is still structurally valid, but it may contain fields now that are prohibited during ingestion. 

In #1366 large parts of normalization were split into a dedicated `light_normalize` function which did not honor the renormalize flag. This PR restores correct behavior and disables the entire renormalize call.