### PR TITLE
ci(gha): Skip Sentry integration tests on library release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release/**
-      - release-library/**
 
   pull_request:
 


### PR DESCRIPTION
The "Sentry Relay Integration Tests" job should not run on library release
builds, since it only tests the Relay server binary against Sentry, but doesn't
test the library. The library release build is separate from binary release
builds, and as such this test can be skipped safely.

It is worth noting that there are currently no integration tests of the Relay
library with Sentry. Those should be added soon in a new PR, as the recently
failed release of 0.8.14 showed.

#skip-changelog

