### PR TITLE
fix(gha): Skip Sentry integration tests on library release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release/**
+      - release-library/**
 
   pull_request:
 
@@ -298,6 +299,9 @@ jobs:
     name: Sentry-Relay Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+
+    # Skip redundant checks for library releases
+    if: "!startsWith(github.ref, 'refs/heads/release-library/')"
 
     steps:
       - name: Checkout Relay


### PR DESCRIPTION
Proper implementation of #1549

The "Sentry Relay Integration Tests" job should not run on library release
builds, since it only tests the Relay server binary against Sentry, but doesn't
test the library. The library release build is separate from binary release
builds, and as such this test can be skipped safely.

#skip-changelog
