### PR TITLE
test(integration): Skip flaky test

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -653,6 +653,7 @@ def test_rate_limit_metrics_buckets(
     )
 
 
+@pytest.mark.skip(reason="Flaky test")
 def test_processing_quota_transaction_indexing(
     mini_sentry, relay_with_processing, metrics_consumer, transactions_consumer,
 ):


### PR DESCRIPTION
Skip the marked flaky test.

1. [This PR](https://github.com/getsentry/relay/pull/1544) passes CI and is merged.
2. CI on master fails [attempt 1](https://github.com/getsentry/relay/actions/runs/3338360468/jobs/5525929842#step:10:784).
3. CI on master passes [attempt 2](https://github.com/getsentry/relay/actions/runs/3338360468/jobs/5526346187).

I have not spent time figuring out how to fix it, or what is really failing. I'm disabling the test until we put in the time and figure it out.

#skip-changelog