### PR TITLE
fix(quotas): Correct reporting of rate limits for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Internal**:
 
 - Implement response context schema. ([#1529](https://github.com/getsentry/relay/pull/1529))
-- Support dedicated quotas for storing transaction payloads ("indexed transactions") via the `transaction_indexed` data category if metrics extraction is enabled. ([#1537](https://github.com/getsentry/relay/pull/1537))
+- Support dedicated quotas for storing transaction payloads ("indexed transactions") via the `transaction_indexed` data category if metrics extraction is enabled. ([#1537](https://github.com/getsentry/relay/pull/1537), [#1555](https://github.com/getsentry/relay/pull/1555))
 
 ## 22.10.0
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1760,10 +1760,6 @@ impl EnvelopeProcessorService {
                 .map_err(ProcessingError::QuotasFailed)?
         });
 
-        if enforcement.event_metrics_active() {
-            state.extracted_metrics.clear();
-        }
-
         if limits.is_limited() {
             ProjectCache::from_registry()
                 .do_send(UpdateRateLimits::new(scoping.project_key, limits));

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -266,18 +266,20 @@ impl Enforcement {
         self.event.is_active()
     }
 
-    /// Returns `true` if metrics extracted from the event should be rate limited.
-    #[cfg(feature = "processing")]
-    pub fn event_metrics_active(&self) -> bool {
-        self.event_metrics.is_active()
-    }
-
     /// Invokes [`TrackOutcome`] on all enforcements reported by the [`EnvelopeLimiter`].
     ///
     /// Relay generally does not emit outcomes for sessions, so those are skipped.
     pub fn track_outcomes(self, envelope: &Envelope, scoping: &Scoping) {
-        // Do not report outcomes for sessions.
-        for limit in [self.event, self.attachments, self.profiles, self.replays] {
+        let Self {
+            event,
+            attachments,
+            sessions: _, // Do not report outcomes for sessions.
+            profiles,
+            replays,
+            event_metrics,
+        } = self;
+
+        for limit in [event, attachments, profiles, replays, event_metrics] {
             if limit.is_active() {
                 let timestamp = relay_common::instant_to_date_time(envelope.meta().start_time());
                 TrackOutcome::from_registry().send(TrackOutcome {
@@ -433,7 +435,12 @@ where
                 // quota. Quota will be consumed by metrics in the metrics aggregator instead.
                 event_limits = (self.check)(scoping.item(category), 0)?;
                 longest = event_limits.longest();
-                enforcement.event_metrics = CategoryLimit::new(category, 1, longest);
+
+                // Only enforce and record an outcome if metrics haven't been extracted yet.
+                // Otherwise, the outcome is logged at a different place.
+                if !summary.event_metrics_extracted {
+                    enforcement.event_metrics = CategoryLimit::new(category, 1, longest);
+                }
 
                 // If the main category is rate limited, we drop both the event and metrics. If
                 // there's no rate limit, check for specific indexing quota and drop just the event.
@@ -970,7 +977,7 @@ mod tests {
         let (enforcement, limits) = limiter.enforce(&mut envelope, &scoping()).unwrap();
 
         assert!(limits.is_limited());
-        assert!(enforcement.event_metrics.is_active());
+        assert!(!enforcement.event_metrics.is_active());
         assert!(enforcement.event.is_active());
     }
 


### PR DESCRIPTION
With #1537 Relay started to under-report outcomes for rate limited transactions.
The root cause is that `Enforcement` was not updated to emit outcomes for
metrics.

This reveals that enforcements for metrics should be recorded only if metrics
have not been extracted from a transaction item yet. In this case, metrics can
still be considered part of the transaction item and as such an outcome is
needed. In contrast, once metrics have been extracted, responsibility for
recording outcomes is moved to the recipient of metrics.

