### PR TITLE
fix(server): Report indexing outcomes for dynamic sampling [INGEST-1681]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Implement response context schema. ([#1529](https://github.com/getsentry/relay/pull/1529))
 - Support dedicated quotas for storing transaction payloads ("indexed transactions") via the `transaction_indexed` data category if metrics extraction is enabled. ([#1537](https://github.com/getsentry/relay/pull/1537), [#1555](https://github.com/getsentry/relay/pull/1555))
+- Report outcomes for dynamic sampling with the correct indexed transaction data category to restore correct totals. ([#1561](https://github.com/getsentry/relay/pull/1561))
 
 ## 22.10.0
 

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -181,6 +181,16 @@ impl DataCategory {
         // outcomes (internally so!)
         (self as i8).try_into().ok()
     }
+
+    /// Returns a dedicated category for indexing if this data can be converted to metrics.
+    ///
+    /// This returns `None` for most data categories.
+    pub fn index_category(self) -> Option<Self> {
+        match self {
+            Self::Transaction => Some(Self::TransactionIndexed),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for DataCategory {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1816,6 +1816,7 @@ impl EnvelopeProcessorService {
                 }
             );
             state.transaction_metrics_extracted = true;
+            state.envelope_context.tmp_set_metrics_extracted();
 
             if let Some(context) = state.envelope.sampling_context() {
                 track_sampling_metrics(&state.project_state, context, event);

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1816,7 +1816,7 @@ impl EnvelopeProcessorService {
                 }
             );
             state.transaction_metrics_extracted = true;
-            state.envelope_context.tmp_set_metrics_extracted();
+            state.envelope_context.set_event_metrics_extracted();
 
             if let Some(context) = state.envelope.sampling_context() {
                 track_sampling_metrics(&state.project_state, context, event);

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -133,7 +133,7 @@ impl EnvelopeContext {
         let category = self.summary.event_category?;
 
         match category.index_category() {
-            Some(category) if self.summary.event_metrics_extracted => Some(category),
+            Some(index_category) if self.summary.event_metrics_extracted => Some(index_category),
             _ => Some(category),
         }
     }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -83,8 +83,12 @@ impl EnvelopeContext {
         self
     }
 
-    /// TODO(ja): What about this?
-    pub fn tmp_set_metrics_extracted(&mut self) -> &mut Self {
+    /// Record that event metrics have been extracted.
+    ///
+    /// This is usually done automatically as part of `EnvelopeContext::new` or `update`. However,
+    /// if the context needs to be updated in-flight without recomputing the entire summary, this
+    /// method can record that metric extraction for the event item has occurred.
+    pub fn set_event_metrics_extracted(&mut self) -> &mut Self {
         self.summary.event_metrics_extracted = true;
         self
     }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -83,6 +83,12 @@ impl EnvelopeContext {
         self
     }
 
+    /// TODO(ja): What about this?
+    pub fn tmp_set_metrics_extracted(&mut self) -> &mut Self {
+        self.summary.event_metrics_extracted = true;
+        self
+    }
+
     /// Re-scopes this context to the given scoping.
     pub fn scope(&mut self, scoping: Scoping) -> &mut Self {
         self.scoping = scoping;
@@ -119,6 +125,19 @@ impl EnvelopeContext {
         }
     }
 
+    /// Returns the data category of the event item in the envelope.
+    ///
+    /// If metrics have been extracted from the event item, this will return the indexing category.
+    /// Outcomes for metrics (the base data category) will be logged by the metrics aggregator.
+    fn event_category(&self) -> Option<DataCategory> {
+        let category = self.summary.event_category?;
+
+        match category.index_category() {
+            Some(category) if self.summary.event_metrics_extracted => Some(category),
+            _ => Some(category),
+        }
+    }
+
     /// Records rejection outcomes for all items stored in this context.
     ///
     /// This does not send outcomes for empty envelopes or request-only contexts.
@@ -131,7 +150,7 @@ impl EnvelopeContext {
         // TODO: This could be optimized with Capture::should_capture
         TestStore::from_registry().send(Capture::rejected(self.event_id, &outcome));
 
-        if let Some(category) = self.summary.event_category {
+        if let Some(category) = self.event_category() {
             self.track_outcome(outcome.clone(), category, 1);
         }
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -399,8 +399,9 @@ where
 
     /// Returns a dedicated data category for indexing if metrics are to be extracted.
     ///
-    /// This returns `None` for most data categories. Only if metrics extraction is enabled for
-    /// transactions, we treat them differently:
+    /// This is similar to [`DataCategory::index_category`], with an additional check if metrics
+    /// extraction is enabled for this category. At this point, this is only true for transactions:
+    ///
     ///  - `DataCategory::Transaction` counts the transaction metrics. If quotas with this category
     ///    are exhausted, both the event and metrics are dropped.
     ///  - `DataCategory::TransactionIndexed` counts ingested and stored events. If quotas with this
@@ -411,9 +412,7 @@ where
         }
 
         match self.config?.transaction_metrics {
-            Some(ErrorBoundary::Ok(ref c)) if c.is_enabled() => {
-                Some(DataCategory::TransactionIndexed)
-            }
+            Some(ErrorBoundary::Ok(ref c)) if c.is_enabled() => category.index_category(),
             _ => None,
         }
     }

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -167,6 +167,7 @@ def test_it_removes_transactions(mini_sentry, relay):
     # add a sampling rule to project config that removes all transactions (sample_rate=0)
     public_key = config["publicKeys"][0]["publicKey"]
     rules = _add_sampling_config(config, sample_rate=0, rule_type="trace")
+    config["config"]["transactionMetrics"] = {"version": 1}
 
     # create an envelope with a trace context that is initiated by this project (for simplicity)
     envelope = Envelope()
@@ -183,7 +184,8 @@ def test_it_removes_transactions(mini_sentry, relay):
     outcomes = mini_sentry.captured_outcomes.get(timeout=2)
     assert outcomes is not None
     outcome = outcomes["outcomes"][0]
-    assert outcome.get("outcome") == 1
+    assert outcome.get("outcome") == 1  # filtered
+    assert outcome.get("category") == 9  # transaction_indexed
     assert outcome.get("reason") == f"Sampled:{rules[0]['id']}"
 
 


### PR DESCRIPTION
Moves outcomes for transactions dropped through dynamic sampling to the
`transaction_indexed` data category. This ensures that within each data
category, every transaction is counted exactly once and totals sum up.

Example: Send 100 transactions to Sentry at a 50% sample rate. For 100
transactions, Relay extracts metrics and we report a `transaction:accepted`
outcome. For 50 transactions we report `transaction_indexed:filtered` and for 50
we report `transaction_indexed:accepted`.
