### PR TITLE
chore(lint): remove unnecessary lint attributes

### DIFF
--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -481,14 +481,14 @@ fn normalize_event_tags(event: &mut Event) -> ProcessingResult {
 
     let server_name = std::mem::take(&mut event.server_name);
     if server_name.value().is_some() {
-        #[allow(clippy::unnecessary_to_owned)]
-        tags.insert("server_name".to_string(), server_name);
+        let tag_name = "server_name".to_string();
+        tags.insert(tag_name, server_name);
     }
 
     let site = std::mem::take(&mut event.site);
     if site.value().is_some() {
-        #[allow(clippy::unnecessary_to_owned)]
-        tags.insert("site".to_string(), site);
+        let tag_name = "site".to_string();
+        tags.insert(tag_name, site);
     }
 
     Ok(())


### PR DESCRIPTION
Moved the tag name def into separate variable, and remove unnecessary lint attributes `[allow(clippy::unnecessary_to_owned)]`

followup for #1566 

#skip-changelog