### PR TITLE
fix(tests): Reduce rate limiting test flakyness [INGEST-1680]

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -680,7 +680,7 @@ def test_processing_quota_transaction_indexing(
             "scopeId": six.text_type(key_id),
             "categories": ["transaction_indexed"],
             "limit": 1,
-            "window": 300,
+            "window": 86400,
             "reasonCode": "get_lost",
         },
         {
@@ -689,7 +689,7 @@ def test_processing_quota_transaction_indexing(
             "scopeId": six.text_type(key_id),
             "categories": ["transaction"],
             "limit": 2,
-            "window": 300,
+            "window": 86400,
             "reasonCode": "get_lost",
         },
     ]


### PR DESCRIPTION
Rate limiting tests use real time. With small rate limiting windows, chances are
higher that the window changes between two event submissions. To counter this,
we've so far increased the window of the test quotas to one day, which makes it
extremely unlikely.

A proper solution for this problem would be to set explicit timestamps and move
such tests to unit-test level.

Closes https://github.com/getsentry/relay/pull/1554
#skip-changelog
