### PR TITLE
fix(build): Fetch with cli while updating the registry index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ ENV RELAY_FEATURES=${RELAY_FEATURES}
 COPY . .
 
 # Build with the modern compiler toolchain enabled
-RUN scl enable devtoolset-10 llvm-toolset-7.0 -- \
+RUN echo -e "[net]\ngit-fetch-with-cli = true" > $CARGO_HOME/config \
+    && scl enable devtoolset-10 llvm-toolset-7.0 -- \
     make build-linux-release \
     TARGET=${BUILD_TARGET} \
     RELAY_FEATURES=${RELAY_FEATURES}


### PR DESCRIPTION
It looks like docker build was killed because it used too much memory while updating the registry index, when forcing cargo to use cli, I could pass the step when the index is updated and successfully build the image.

Fixes #1559 
It seems related to https://github.com/rust-lang/cargo/issues/9167

 #skip-changelog