### PR TITLE
fix(protocol): Disallow `-` in measurement and breakdown names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Support decaying rules. Decaying rules are regular sampling rules, but they are only applicable in a specific time range. ([#1544](https://github.com/getsentry/relay/pull/1544))
+- Disallow `-` in measurement and breakdown names. These items are converted to metrics, which do not allow `-` in their name. ([#1571](https://github.com/getsentry/relay/pull/1571))
 
 **Bug Fixes**:
 

--- a/relay-general/src/protocol/breakdowns.rs
+++ b/relay-general/src/protocol/breakdowns.rs
@@ -16,7 +16,7 @@ impl Breakdowns {
             && name.starts_with(|c| matches!(c, 'a'..='z' | 'A'..='Z'))
             && name
                 .chars()
-                .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
+                .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '.'))
     }
 }
 
@@ -34,7 +34,7 @@ impl FromValue for Breakdowns {
                         return Some((name.into(), object));
                     } else {
                         processing_errors.push(Error::invalid(format!(
-                            "breakdown name '{}' can contain only characters a-z0-9.-_",
+                            "breakdown name '{}' can contain only characters a-z0-9._",
                             name
                         )));
                     }

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -101,7 +101,7 @@ impl FromValue for Measurements {
                         return Some((name.to_lowercase(), object));
                     } else {
                         processing_errors.push(Error::invalid(format!(
-                            "measurement name '{}' can contain only characters a-z0-9.-_",
+                            "measurement name '{}' can contain only characters a-z0-9._",
                             name
                         )));
                     }
@@ -139,7 +139,7 @@ fn is_valid_measurement_name(name: &str) -> bool {
     name.starts_with(|c| matches!(c, 'a'..='z' | 'A'..='Z'))
         && name
             .chars()
-            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.'))
+            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '.'))
 }
 
 #[cfg(test)]
@@ -185,9 +185,6 @@ mod tests {
       "value": 420.69,
       "unit": "millisecond"
     },
-    "lcp_final.element-size123": {
-      "value": 1.0
-    },
     "missing_value": null
   },
   "_meta": {
@@ -203,7 +200,13 @@ mod tests {
           [
             "invalid_data",
             {
-              "reason": "measurement name 'Total Blocking Time' can contain only characters a-z0-9.-_"
+              "reason": "measurement name 'lcp_final.element-Size123' can contain only characters a-z0-9._"
+            }
+          ],
+          [
+            "invalid_data",
+            {
+              "reason": "measurement name 'Total Blocking Time' can contain only characters a-z0-9._"
             }
           ]
         ]
@@ -257,13 +260,6 @@ mod tests {
                 }),
             );
             measurements.insert(
-                "lcp_final.element-size123".to_owned(),
-                Annotated::new(Measurement {
-                    value: Annotated::new(1f64),
-                    unit: Annotated::empty(),
-                }),
-            );
-            measurements.insert(
                 "fid".to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::new(2020f64),
@@ -301,7 +297,11 @@ mod tests {
         measurements_meta.add_error(Error::invalid("measurement name '' cannot be empty"));
 
         measurements_meta.add_error(Error::invalid(
-            "measurement name 'Total Blocking Time' can contain only characters a-z0-9.-_",
+            "measurement name 'lcp_final.element-Size123' can contain only characters a-z0-9._",
+        ));
+
+        measurements_meta.add_error(Error::invalid(
+            "measurement name 'Total Blocking Time' can contain only characters a-z0-9._",
         ));
 
         let event = Annotated::new(Event {

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -146,7 +146,6 @@ def test_normalize_measurement_interface(
         "inp": {"unit": "millisecond", "value": 100.14},
         "fp": {"unit": "millisecond", "value": None},
         "lcp": {"unit": "millisecond", "value": 420.69},
-        "lcp_final.element-size123": {"unit": "none", "value": 1.0},
         "missing_value": None,
     }
 


### PR DESCRIPTION
Names of custom measurements are converted into MRIs without any validation. This means that in metrics extraction, we are able to construct MRIs that are less strict than what the metrics protocol demands. Subsequent attempts to parse the MRI string into a `MetricsResourceIdentifier` object will fail.

This popped up in rate limiting, where we have to parse the MRI to know what namespace and name we are dealing with. Because of this bug, custom measurements with invalid names are currently not rate limited at all.

Fixes [POP-RELAY-2N8](https://sentry.my.sentry.io/organizations/sentry/issues/315035).