### PR TITLE
fix(server): Track session envelopes as accepted

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2056,23 +2056,27 @@ impl EnvelopeProcessorService {
             || {
                 match self.process_state(&mut state) {
                     Ok(()) => {
-                        if !state.extracted_metrics.is_empty() {
-                            let project_cache = ProjectCache::from_registry();
-                            project_cache
-                                .do_send(InsertMetrics::new(project_key, state.extracted_metrics));
-                        }
-
                         // The envelope could be modified or even emptied during processing, which
                         // requires recomputation of the context.
                         state.envelope_context.update(&state.envelope);
 
                         let envelope_response = if state.envelope.is_empty() {
-                            // Individual rate limits have already been issued
-                            state.envelope_context.reject(Outcome::RateLimited(None));
+                            if state.extracted_metrics.is_empty() {
+                                // Individual rate limits have already been issued
+                                state.envelope_context.reject(Outcome::RateLimited(None));
+                            } else {
+                                state.envelope_context.accept();
+                            }
                             None
                         } else {
                             Some((state.envelope, state.envelope_context))
                         };
+
+                        if !state.extracted_metrics.is_empty() {
+                            let project_cache = ProjectCache::from_registry();
+                            project_cache
+                                .do_send(InsertMetrics::new(project_key, state.extracted_metrics));
+                        }
 
                         Ok(ProcessEnvelopeResponse {
                             envelope: envelope_response,


### PR DESCRIPTION
Relay has a flag to disable ingestion of raw session payloads. When this flag is enabled, it converts sessions into metrics, passes them to the metrics aggregator, and removes the session item from the envelope.

This process may leave an empty envelope behind. Relay internally logs this as a rejection, since before an empty envelope was always the result of rate limiting. This PR changes this, so that an empty envelope counts as accepted if metrics were extracted for one of its items.

#skip-changelog
