### PR TITLE
ref(store): Remove unit mismatch error [INGEST-1701]

### DIFF
--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -328,12 +328,6 @@ fn normalize_units(measurements: &mut Measurements) {
 
         let stated_unit = measurement.unit.value().copied();
         let default_unit = get_metric_measurement_unit(name);
-        if let (Some(default_), Some(stated)) = (default_unit, stated_unit) {
-            if default_ != stated {
-                relay_log::error!("unit mismatch on measurements.{}: {}", name, stated);
-            }
-        }
-
         measurement
             .unit
             .set_value(Some(stated_unit.or(default_unit).unwrap_or_default()))


### PR DESCRIPTION
Relay logged internal diagnostics when SDKs sent well-known transactions with an
unexpected unit. All these differences have been fixed in SDKs, so we can remove
this error now.

#skip-changelog

