### PR TITLE
chore: Bump symbolic version to 10.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,12 +998,11 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elementtree"
-version = "0.7.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6319c9433cf1e95c60c8533978bccf0614f27f03bb4e514253468eeeaa7fe3"
+checksum = "83e91f812124e4fc7f82605feda4da357307185a4619baee415ae0b7f6d5e031"
 dependencies = [
  "string_cache",
- "xml-rs",
 ]
 
 [[package]]
@@ -4238,21 +4237,21 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic-common"
-version = "8.7.3"
+version = "10.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c276d5b296f30f0fb30d2128b6be6f9804be7669f1edef46c4d8c017de4c77c3"
+checksum = "492875918a6bcbae753a5fc6f39bc87566fc3c25182e76d7f128ef1c8a2375c6"
 dependencies = [
- "debugid 0.7.3",
+ "debugid 0.8.0",
  "memmap2",
  "stable_deref_trait",
- "uuid 0.8.2",
+ "uuid 1.1.2",
 ]
 
 [[package]]
 name = "symbolic-unreal"
-version = "8.7.3"
+version = "10.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa8d30ac2e896b1b0ce7e03f35de88a56caa307c5b8945b2a06e9b70c275343"
+checksum = "d1a3634df86c7be20a0ec8f61ee8eaa527fdcbda60ddd1619bd3eea80eba9d34"
 dependencies = [
  "anylog",
  "bytes 1.1.0",
@@ -5373,12 +5372,6 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yaml-rust"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -70,8 +70,8 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.0"
 smallvec = { version = "1.4.0", features = ["serde"] }
-symbolic-common = { version = "8.7.2", optional = true, default-features=false }
-symbolic-unreal = { version = "8.7.2", optional = true, default-features=false, features=["serde"] }
+symbolic-common = { version = "10.1.2", optional = true, default-features=false }
+symbolic-unreal = { version = "10.1.2", optional = true, default-features=false, features=["serde"] }
 take_mut = "0.2.2"
 tokio = { version = "1.0", features = ["rt-multi-thread", "sync", "macros"] }
 tokio-timer = "0.2.13"


### PR DESCRIPTION
Upgrade to the current latest version of the `symbolic-unreal` and `symbolic-common` crates. 

#skip-changelog