### PR TITLE
ref(profiling): Enforce and standardize profile measurement units

### DIFF
--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -1,11 +1,10 @@
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::utils::deserialize_number_from_string;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Measurement {
-    #[serde(deserialize_with = "deserialize_measurement_unit")]
-    unit: String,
+    unit: MeasurementUnit,
     values: Vec<MeasurementValue>,
 }
 
@@ -17,18 +16,11 @@ pub struct MeasurementValue {
     value: f64,
 }
 
-fn deserialize_measurement_unit<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: de::Deserializer<'de>,
-{
-    let s: &str = de::Deserialize::deserialize(deserializer)?;
-
-    match s {
-        "nanosecond" | "ns" => Ok("nanosecond".to_string()),
-        "hertz" | "hz" => Ok("hertz".to_string()),
-        _ => Err(de::Error::custom(format!(
-            "invalid measurement unit: {}",
-            s
-        ))),
-    }
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MeasurementUnit {
+    #[serde(alias = "ns")]
+    Nanosecond,
+    #[serde(alias = "hz")]
+    Hertz,
 }

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -1,17 +1,34 @@
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Serialize};
 
 use crate::utils::deserialize_number_from_string;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Measurement {
+    #[serde(deserialize_with = "deserialize_measurement_unit")]
     unit: String,
     values: Vec<MeasurementValue>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MeasurementValue {
-    // nanoseconds elapsed since the start of the profile (wall clock)
+    // nanoseconds elapsed since the start of the profile
     #[serde(deserialize_with = "deserialize_number_from_string")]
     elapsed_since_start_ns: u64,
     value: f64,
+}
+
+fn deserialize_measurement_unit<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let s: &str = de::Deserialize::deserialize(deserializer)?;
+
+    match s {
+        "nanosecond" | "ns" => Ok("nanosecond".to_string()),
+        "hertz" | "hz" => Ok("hertz".to_string()),
+        _ => Err(de::Error::custom(format!(
+            "invalid measurement unit: {}",
+            s
+        ))),
+    }
 }


### PR DESCRIPTION
This PR, as the title suggests, aims at enforcing the unit type checking.

New units will be added as needed when we'll start to support new kind of measurements.



#skip-changelog