### PR TITLE
feat(system): Log service back pressure as metric [INGEST-1630]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p document-metrics -- -o relay_metrics.json relay-server/src/statsd.rs relay-metrics/src/statsd.rs relay-kafka/src/statsd.rs
+          args: -p document-metrics -- -o relay_metrics.json relay-*/src/statsd.rs
 
       - name: Deploy
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p document-metrics -- -o relay_metrics.json relay-*/src/statsd.rs
+          args: -p document-metrics -- -o relay_metrics.json
+            relay-kafka/src/statsd.rs
+            relay-metrics/src/statsd.rs
+            relay-server/src/statsd.rs
+            relay-system/src/statsd.rs
 
       - name: Deploy
         if: github.ref == 'refs/heads/master'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))
+
 ## 22.11.0
 
 **Features**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,6 +3543,7 @@ dependencies = [
  "futures 0.3.21",
  "once_cell",
  "relay-log",
+ "relay-statsd",
  "tokio 0.1.22",
  "tokio 1.19.2",
 ]

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.0", features = ["macros", "time"] }
 criterion = "0.3"
 futures01 = { version = "0.1.28", package = "futures" }
 insta = "1.19.0"
+relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }
 
 [[bench]]

--- a/relay-statsd/Cargo.toml
+++ b/relay-statsd/Cargo.toml
@@ -14,3 +14,7 @@ cadence = "0.26.0"
 parking_lot = "0.12.1"
 rand = "0.7.3"
 relay-log = { path = "../relay-log" }
+
+[features]
+default = []
+test = []

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -62,8 +62,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use cadence::{
-    BufferedUdpMetricSink, Metric, MetricBuilder, QueuingMetricSink, SpyMetricSink, StatsdClient,
-    UdpMetricSink,
+    BufferedUdpMetricSink, Metric, MetricBuilder, QueuingMetricSink, StatsdClient, UdpMetricSink,
 };
 use parking_lot::RwLock;
 use rand::distributions::{Distribution, Uniform};
@@ -164,8 +163,9 @@ pub fn set_client(client: MetricsClient) {
 }
 
 /// Set a test client for the period of the called function (only affects the current thread).
+#[cfg(feature = "test")]
 pub fn with_capturing_test_client(f: impl FnOnce()) -> Vec<String> {
-    let (rx, sink) = SpyMetricSink::new();
+    let (rx, sink) = cadence::SpyMetricSink::new();
     let test_client = MetricsClient {
         statsd_client: StatsdClient::from_sink("", sink),
         default_tags: Default::default(),
@@ -573,7 +573,6 @@ macro_rules! metric {
 
 #[cfg(test)]
 mod tests {
-
     use cadence::{NopMetricSink, StatsdClient};
 
     use crate::{set_client, with_capturing_test_client, with_client, GaugeMetric, MetricsClient};
@@ -608,7 +607,7 @@ mod tests {
         });
 
         assert_eq!(
-            captures.as_slice(),
+            captures,
             [
                 "foo:123|g|#server:server1,host:host1",
                 "bar:456|g|#server:server2,host:host2"

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -16,5 +16,6 @@ futures01 = { version = "0.1.28", package = "futures" }
 futures = { version = "0.3", package = "futures", features = ["compat"] }
 once_cell = "1.13.1"
 relay-log = { path = "../relay-log" }
+relay-statsd = { path = "../relay-statsd" }
 tokio = { version = "1.0", features = ["rt-multi-thread", "sync"] }
 tokio01 = { version = "0.1", package = "tokio" }

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -17,5 +17,9 @@ futures = { version = "0.3", package = "futures", features = ["compat"] }
 once_cell = "1.13.1"
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
-tokio = { version = "1.0", features = ["rt-multi-thread", "sync"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "sync", "macros"] }
 tokio01 = { version = "0.1", package = "tokio" }
+
+[dev-dependencies]
+relay-statsd = { path = "../relay-statsd", features = ["test"] }
+tokio = { version = "1.0", features = ["test-util"] }

--- a/relay-system/src/lib.rs
+++ b/relay-system/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod compat;
 mod controller;
 mod service;
+mod statsd;
 
 pub use self::controller::*;
 pub use self::service::*;

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -518,7 +518,6 @@ pub trait Service: Sized {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     struct MockMessage;
@@ -598,9 +597,9 @@ mod tests {
         assert_eq!(
             captures,
             [
-                "service.back_pressure:2|g|#service:mock", // 1 * INTERVAL
-                "service.back_pressure:1|g|#service:mock", // 2 * INTERVAL
-                "service.back_pressure:0|g|#service:mock", // 4 * INTERVAL
+                "service.back_pressure:2|g|#service:mock", // 2 * INTERVAL
+                "service.back_pressure:1|g|#service:mock", // 4 * INTERVAL
+                "service.back_pressure:0|g|#service:mock", // 6 * INTERVAL
             ]
         );
     }

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -378,7 +378,7 @@ impl<I: Interface> Receiver<I> {
     /// This method returns `None` if the channel has been closed and there are
     /// no remaining messages in the channel's buffer. This indicates that no
     /// further values can ever be received from this `Receiver`. The channel is
-    /// closed when all senders have been dropped, or when [`close`] is called.
+    /// closed when all senders have been dropped.
     ///
     /// If there are no messages in the channel's buffer, but the channel has
     /// not yet been closed, this method will sleep until a message is sent or

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -1,0 +1,22 @@
+use relay_statsd::GaugeMetric;
+
+/// Gauge metrics for Relay system components.
+pub enum SystemGauges {
+    /// A number of messages queued in a services inbound message channel.
+    ///
+    /// This metric is emitted once per second for every running service. Without backlogs, this
+    /// number should be close to `0`. If this number is monotonically increasing, the service is
+    /// not able to process the inbound message volume.
+    ///
+    /// This metric is tagged with:
+    ///  - `service`: The fully qualified type name of the service implementation.
+    ServiceBackPressure,
+}
+
+impl GaugeMetric for SystemGauges {
+    fn name(&self) -> &'static str {
+        match *self {
+            SystemGauges::ServiceBackPressure => "service.back_pressure",
+        }
+    }
+}


### PR DESCRIPTION
This adds central back pressure monitoring via statsd metrics to all
services that use the new tokio-based service framework. Channels track
the number of pending messages and emit a gauge metric with that number.

The metric is `service.back_pressure` and tagged with a `service` tag to
identify the specific service. The metric is debounced once per second.
Between these intervals, the back pressure number is not checked, so
this metric is not suitable to detect very short-lived spikes.
Additionally, the current implementation requires that the service makes
progress by polling `recv`.

The purpose of this metric is to detect lasting increases in backlogs
that indicate bottlenecks or degraded system behavior.