### PR TITLE
chore(kafka): Add more information into the error

### DIFF
--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -1,5 +1,5 @@
 use rdkafka::producer::{DeliveryResult, ProducerContext};
-use rdkafka::ClientContext;
+use rdkafka::{ClientContext, Message};
 
 use relay_log::LogError;
 use relay_statsd::metric;
@@ -18,10 +18,18 @@ impl ProducerContext for CaptureErrorContext {
     /// This method is called after attempting to send a message to Kafka.
     /// It's called asynchronously for every message, so we want to handle errors explicitly here.
     fn delivery(&self, result: &DeliveryResult, _delivery_opaque: Self::DeliveryOpaque) {
-        if let Err((error, _message)) = result {
-            relay_log::error!(
-                "failed to produce message to Kafka (delivery callback): {}",
-                LogError(error)
+        if let Err((error, message)) = result {
+            relay_log::with_scope(
+                |scope| {
+                    scope.set_tag("topic", message.topic());
+                    scope.set_tag("payload_len", message.payload_len())
+                },
+                || {
+                    relay_log::error!(
+                        "failed to produce message to Kafka (delivery callback): {}",
+                        LogError(error)
+                    )
+                },
             );
 
             metric!(counter(KafkaCounters::ProcessingProduceError) += 1);


### PR DESCRIPTION
Adding more information into the error to check what topic exactly is failing and what message size we have at this point. 

This also related to: #1477 

#skip-changelog