### PR TITLE
[DO NOT MERGE] Add metric on envelope process errors

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2139,6 +2139,10 @@ impl EnvelopeProcessorService {
                 };
             }
             Err(error) => {
+                relay_statsd::metric!(
+                    counter(RelayCounters::HandleProcessEnvelopeError) += 1,
+                    internal_error = error.is_internal()
+                );
                 // Errors are only logged for what we consider infrastructure or implementation
                 // bugs. In other cases, we "expect" errors and log them as debug level.
                 if error.is_internal() {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2141,7 +2141,7 @@ impl EnvelopeProcessorService {
             Err(error) => {
                 relay_statsd::metric!(
                     counter(RelayCounters::HandleProcessEnvelopeError) += 1,
-                    internal_error = error.is_internal()
+                    internal_error = if error.is_internal() { "true" } else { "false" }
                 );
                 // Errors are only logged for what we consider infrastructure or implementation
                 // bugs. In other cases, we "expect" errors and log them as debug level.

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2141,7 +2141,7 @@ impl EnvelopeProcessorService {
             Err(error) => {
                 relay_statsd::metric!(
                     counter(RelayCounters::HandleProcessEnvelopeError) += 1,
-                    internal_error = if error.is_internal() { "true" } else { "false" }
+                    internal_error = &error.is_internal().to_string()
                 );
                 // Errors are only logged for what we consider infrastructure or implementation
                 // bugs. In other cases, we "expect" errors and log them as debug level.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -564,6 +564,8 @@ pub enum RelayCounters {
     MetricBucketsParsingFailed,
     /// Count extraction of transaction names. Tag with the decision to drop / replace / use original.
     MetricsTransactionNameExtracted,
+    /// Count of errors resulting from processing an envelope.
+    HandleProcessEnvelopeError,
 }
 
 impl CounterMetric for RelayCounters {
@@ -592,6 +594,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
+            RelayCounters::HandleProcessEnvelopeError => "processing.handle_process_envelope_error",
         }
     }
 }


### PR DESCRIPTION
**DO NOT MERGE**

The error logged in `relay-server/src/actors/processor.rs` has not reached Sentry in a long time, and it would have been critical to identifying an incident earlier. We don't know what the cause of the error not popping in Sentry is, so I'm adding a metric to see if this code path is ever reached in the first place.

The goal is to deploy this in a canary and let it run for some time until we collect data to determine if that piece of code was actually reached.