### PR TITLE
fix: could not find `assert_json_snapshot` in `insta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Internal**:
 
+- Could not find `assert_json_snapshot` in `insta`. ([#1589](https://github.com/getsentry/relay/pull/1589))
 - Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))
 
 ## 22.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Internal**:
 
-- Could not find `assert_json_snapshot` in `insta`. ([#1589](https://github.com/getsentry/relay/pull/1589))
 - Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))
 
 ## 22.11.0

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -20,5 +20,5 @@ serde = { version = "1.0.114", features = ["derive"] }
 url = "2.1.1"
 
 [dev-dependencies]
-insta = "1.19.0"
+insta = { version = "1.19.0", features =  ["json"] }
 serde_json = "1.0.55"


### PR DESCRIPTION
Before this PR if you run:
```
cargo t --all-features -p relay-filter  test_should_filter_exception
   Compiling insta v1.19.0
   Compiling relay-filter v22.10.0 (/Users/andrii/work/relay/relay-filter)
error[E0433]: failed to resolve: could not find `assert_json_snapshot` in `insta`
   --> relay-filter/src/config.rs:271:16
    |
271 |         insta::assert_json_snapshot!(filters_config, @"{}");
    |                ^^^^^^^^^^^^^^^^^^^^ could not find `assert_json_snapshot` in `insta`

error[E0433]: failed to resolve: could not find `assert_json_snapshot` in `insta`
   --> relay-filter/src/config.rs:298:16
    |
298 |         insta::assert_json_snapshot!(filters_config, @r###"
    |                ^^^^^^^^^^^^^^^^^^^^ could not find `assert_json_snapshot` in `insta`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `relay-filter` due to 2 previous errors
```

after:
```
cargo t --all-features -p relay-filter  test_should_filter_exception
   Compiling insta v1.19.0
   Compiling relay-filter v22.10.0 (/Users/andrii/work/relay/relay-filter)
    Finished test [unoptimized] target(s) in 2.61s
     Running unittests src/lib.rs (target/debug/deps/relay_filter-1c424fc857c08b1d)

running 1 test
test error_messages::tests::test_should_filter_exception ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 47 filtered out; finished in 0.01s
```

#skip-changelog