### PR TITLE
ref(sampling): Switch default sampling mode to "received" [INGEST-1715]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Dynamic sampling is now based on the volume received by Relay by default and does not include the original volume dropped by client-side sampling in SDKs. This is required for the final dynamic sampling feature in the latest Sentry plans. ([#1591](https://github.com/getsentry/relay/pull/1591))
+
 **Internal**:
 
 - Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -659,15 +659,50 @@ impl FieldValueProvider for DynamicSamplingContext {
     }
 }
 
+/// Defines which population of items a dynamic sample rate applies to.
+///
+/// SDKs with client side sampling reduce the number of items sent to Relay, where dynamic sampling
+/// occurs. The sampling mode controlls whether the sample rate is relative to the original
+/// population of items before client-side sampling, or relative to the number received by Relay
+/// after client-side sampling.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SamplingMode {
+    /// The sample rate is based on the number of events received by Relay.
+    ///
+    /// Server-side dynamic sampling occurs on top of potential client-side sampling in the SDK. For
+    /// example, if the SDK samples at 50% and the server sampling rate is set at 10%, the resulting
+    /// effective sample rate is 5%.
+    Received,
+    /// The sample rate is based on the original number of events in the client.
+    ///
+    /// Server-side sampling compensates potential client-side sampling in the SDK. For example, if
+    /// the SDK samples at 50% and the server sampling rate is set at 10%, the resulting effective
+    /// sample rate is 10%.
+    ///
+    /// In this mode, the server sampling rate is capped by the client's sampling rate. Rules with a
+    /// higher sample rate than what the client is sending are effectively inactive.
+    Total,
+}
+
+impl Default for SamplingMode {
+    fn default() -> Self {
+        Self::Received
+    }
+}
+
 /// Represents the dynamic sampling configuration available to a project.
 ///
 /// Note: This comes from the organization data
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SamplingConfig {
-    /// The sampling rules for the project
+    /// The ordered sampling rules for the project from highest to lowest priority.
     pub rules: Vec<SamplingRule>,
-    /// The id of the next new Rule (used as a generator for unique rule ids)
+    /// Defines which population of items a dynamic sample rate applies to.
+    #[serde(default)]
+    pub mode: SamplingMode,
+    /// The unique identifier for the next new rule to be added.
     #[serde(default)]
     pub next_id: Option<u32>,
 }
@@ -1999,6 +2034,7 @@ mod tests {
                     time_range: Default::default(),
                 },
             ],
+            mode: SamplingMode::Received,
             next_id: None,
         };
 
@@ -2219,6 +2255,7 @@ mod tests {
                     time_range: Default::default(),
                 },
             ],
+            mode: SamplingMode::Received,
             next_id: None,
         }
     }
@@ -2291,6 +2328,7 @@ mod tests {
                     id: RuleId(1),
                     time_range: range,
                 }],
+                mode: SamplingMode::Received,
                 next_id: None,
             };
             assert_eq!(
@@ -2307,6 +2345,7 @@ mod tests {
                     id: RuleId(1),
                     time_range: range,
                 }],
+                mode: SamplingMode::Received,
                 next_id: None,
             };
             assert_eq!(

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -267,6 +267,11 @@ pub enum RuleCondition {
 }
 
 impl RuleCondition {
+    /// Returns a condition that matches everything.
+    pub fn all() -> Self {
+        Self::And(AndCondition { inner: Vec::new() })
+    }
+
     /// Checks if Relay supports this condition (in other words if the condition had any unknown configuration
     /// which was serialized as "Unsupported" (because the configuration is either faulty or was created for a
     /// newer relay that supports some other condition types)

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -5,7 +5,7 @@ use std::net::IpAddr;
 use relay_common::{ProjectKey, Uuid};
 use relay_general::protocol::Event;
 use relay_sampling::{
-    pseudo_random_from_uuid, DynamicSamplingContext, RuleId, SamplingConfig, SamplingRule,
+    pseudo_random_from_uuid, DynamicSamplingContext, RuleId, SamplingConfig, SamplingMode,
 };
 
 use crate::actors::project::ProjectState;
@@ -46,12 +46,19 @@ fn check_unsupported_rules(
     Ok(())
 }
 
-fn get_trace_sampling_rule<'a>(
+#[derive(Debug)]
+struct SamplingSpec {
+    sample_rate: f64,
+    rule_id: RuleId,
+    seed: Uuid,
+}
+
+fn get_trace_sampling_rule(
     processing_enabled: bool,
-    sampling_project_state: Option<&'a ProjectState>,
+    sampling_project_state: Option<&ProjectState>,
     sampling_context: Option<&DynamicSamplingContext>,
     ip_addr: Option<IpAddr>,
-) -> Result<Option<(&'a SamplingRule, Uuid)>, SamplingResult> {
+) -> Result<Option<SamplingSpec>, SamplingResult> {
     let sampling_context = or_ok_none!(sampling_context);
 
     if sampling_project_state.is_none() {
@@ -62,15 +69,25 @@ fn get_trace_sampling_rule<'a>(
     check_unsupported_rules(processing_enabled, sampling_config)?;
 
     let rule = or_ok_none!(sampling_config.get_matching_trace_rule(sampling_context, ip_addr));
-    Ok(Some((rule, sampling_context.trace_id)))
+    let sample_rate = match sampling_config.mode {
+        SamplingMode::Received => rule.sample_rate,
+        SamplingMode::Total => sampling_context.adjusted_sample_rate(rule.sample_rate),
+    };
+
+    Ok(Some(SamplingSpec {
+        sample_rate,
+        rule_id: rule.id,
+        seed: sampling_context.trace_id,
+    }))
 }
 
-fn get_event_sampling_rule<'a>(
+fn get_event_sampling_rule(
     processing_enabled: bool,
-    project_state: &'a ProjectState,
+    project_state: &ProjectState,
+    sampling_context: Option<&DynamicSamplingContext>,
     event: Option<&Event>,
     ip_addr: Option<IpAddr>,
-) -> Result<Option<(&'a SamplingRule, Uuid)>, SamplingResult> {
+) -> Result<Option<SamplingSpec>, SamplingResult> {
     let event = or_ok_none!(event);
     let event_id = or_ok_none!(event.id.value());
 
@@ -78,7 +95,16 @@ fn get_event_sampling_rule<'a>(
     check_unsupported_rules(processing_enabled, sampling_config)?;
 
     let rule = or_ok_none!(sampling_config.get_matching_event_rule(event, ip_addr));
-    Ok(Some((rule, event_id.0)))
+    let sample_rate = match (sampling_context, sampling_config.mode) {
+        (Some(ctx), SamplingMode::Total) => ctx.adjusted_sample_rate(rule.sample_rate),
+        _ => rule.sample_rate,
+    };
+
+    Ok(Some(SamplingSpec {
+        sample_rate,
+        rule_id: rule.id,
+        seed: event_id.0,
+    }))
 }
 
 /// Checks whether an event should be kept or removed by dynamic sampling.
@@ -98,32 +124,30 @@ pub fn should_keep_event(
         sampling_context,
         ip_addr,
     ) {
-        Ok(rule_and_uuid) => rule_and_uuid,
+        Ok(spec) => spec,
         Err(sampling_result) => return sampling_result,
     };
 
-    let matching_event_rule =
-        match get_event_sampling_rule(processing_enabled, project_state, event, ip_addr) {
-            Ok(rule_and_uuid) => rule_and_uuid,
-            Err(sampling_result) => return sampling_result,
-        };
+    let matching_event_rule = match get_event_sampling_rule(
+        processing_enabled,
+        project_state,
+        sampling_context,
+        event,
+        ip_addr,
+    ) {
+        Ok(spec) => spec,
+        Err(sampling_result) => return sampling_result,
+    };
 
     // NOTE: Event rules take precedence over trace rules. If the event rule has a lower sample rate
     // than the trace rule, this means that traces will be incomplete.
     // We could guarantee consistent traces if trace rules took precedence over event rules,
     // but we need the current behavior to allow health check rules
     // to take precedence over the overall base rate, which is set on the trace.
-    if let Some((rule, uuid)) = matching_event_rule.or(matching_trace_rule) {
-        let adjusted_sample_rate = if let Some(sampling_context) = sampling_context {
-            sampling_context.adjusted_sample_rate(rule.sample_rate)
-        } else {
-            rule.sample_rate
-        };
-
-        let random_number = pseudo_random_from_uuid(uuid);
-
-        if random_number >= adjusted_sample_rate {
-            return SamplingResult::Drop(rule.id);
+    if let Some(spec) = matching_event_rule.or(matching_trace_rule) {
+        let random_number = pseudo_random_from_uuid(spec.seed);
+        if random_number >= spec.sample_rate {
+            return SamplingResult::Drop(spec.rule_id);
         } else {
             return SamplingResult::Keep;
         }


### PR DESCRIPTION
SDKs with client side sampling reduce the number of items sent to Relay, where dynamic sampling
occurs. The sampling mode controlls whether the sample rate is relative to the original
population of items before client-side sampling, or relative to the number received by Relay
after client-side sampling.

There are two modes:
 - `received` (default): Server-side dynamic sampling occurs on top of potential client-side sampling in the SDK. For
    example, if the SDK samples at 50% and the server sampling rate is set at 10%, the resulting
    effective sample rate is 5%.
 - `total`: Server-side sampling compensates potential client-side sampling in the SDK. For example, if
   the SDK samples at 50% and the server sampling rate is set at 10%, the resulting effective
   sample rate is 10%.
   In this mode, the server sampling rate is capped by the client's sampling rate. Rules with a
   higher sample rate than what the client is sending are effectively inactive.

For beta customers of dynamic sampling that expect the former behavior, this
will be switched to `total` temporarily.
