### PR TITLE
fix(logging): Log error for unexpected event drops

### DIFF
--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -208,6 +208,22 @@ impl Outcome {
             Outcome::Abuse => None,
         }
     }
+
+    /// Returns true if there is a bug or an infrastructure problem causing event loss.
+    ///
+    /// This can happen when we introduce bugs or during incidents.
+    ///
+    /// During healthy operation, this should always return false.
+    pub fn is_unexpected(&self) -> bool {
+        matches!(
+            self,
+            Outcome::Invalid(
+                DiscardReason::Internal
+                    | DiscardReason::ProjectState
+                    | DiscardReason::ProjectStatePii,
+            )
+        )
+    }
 }
 
 impl fmt::Display for Outcome {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -160,8 +160,9 @@ impl ProcessingError {
         }
     }
 
-    fn is_internal(&self) -> bool {
-        self.to_outcome() == Some(Outcome::Invalid(DiscardReason::Internal))
+    fn is_unexpected(&self) -> bool {
+        self.to_outcome()
+            .map_or(false, |outcome| outcome.is_unexpected())
     }
 
     fn should_keep_metrics(&self) -> bool {
@@ -2141,7 +2142,7 @@ impl EnvelopeProcessorService {
             Err(error) => {
                 // Errors are only logged for what we consider infrastructure or implementation
                 // bugs. In other cases, we "expect" errors and log them as debug level.
-                if error.is_internal() {
+                if error.is_unexpected() {
                     relay_log::with_scope(
                         |scope| scope.set_tag("project_key", project_key),
                         || relay_log::error!("error processing envelope: {}", LogError(&error)),

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -150,7 +150,14 @@ impl EnvelopeContext {
             return;
         }
 
-        relay_log::debug!("dropped envelope: {}", outcome);
+        // Errors are only logged for what we consider infrastructure or implementation
+        // bugs. In other cases, we "expect" errors and log them as debug level.
+        if outcome.is_unexpected() {
+            relay_log::error!("dropped envelope: {}", outcome);
+        } else {
+            relay_log::debug!("dropped envelope: {}", outcome);
+        }
+
         // TODO: This could be optimized with Capture::should_capture
         TestStore::from_registry().send(Capture::rejected(self.event_id, &outcome));
 


### PR DESCRIPTION
If we drop an envelope because we cannot load its project state, we should log an error.

After we extend the alert to include the new log message, we can close https://github.com/getsentry/relay/issues/1609. 