### PR TITLE
feat(server): Track metrics for OpenTelemetry events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal**:
 
 - Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))
+- Track metrics for OpenTelemetry events ([#1618](https://github.com/getsentry/relay/pull/1618))
 
 ## 22.11.0
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1639,6 +1639,20 @@ impl EnvelopeProcessorService {
                     sdk = envelope.meta().client_name().unwrap_or("proprietary"),
                     platform = event.platform.as_str().unwrap_or("other"),
                 );
+
+                let otel_context = event
+                    .contexts
+                    .value()
+                    .and_then(|contexts| contexts.get("otel"))
+                    .and_then(Annotated::value);
+
+                if otel_context.is_some() {
+                    metric!(
+                        counter(RelayCounters::OpenTelemetryEvent) += 1,
+                        sdk = envelope.meta().client_name().unwrap_or("proprietary"),
+                        platform = event.platform.as_str().unwrap_or("other"),
+                    );
+                }
             }
         }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -564,6 +564,13 @@ pub enum RelayCounters {
     MetricBucketsParsingFailed,
     /// Count extraction of transaction names. Tag with the decision to drop / replace / use original.
     MetricsTransactionNameExtracted,
+    /// Number of Events with an OpenTelemetry Context
+    ///
+    /// This metric is tagged with:
+    ///  - `platform`: The event's platform, such as `"javascript"`.
+    ///  - `sdk`: The name of the Sentry SDK sending the transaction. This tag is only set for
+    ///    Sentry's SDKs and defaults to "proprietary".
+    OpenTelemetryEvent,
 }
 
 impl CounterMetric for RelayCounters {
@@ -592,6 +599,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
+            RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
         }
     }
 }


### PR DESCRIPTION
fixes https://github.com/getsentry/relay/issues/1615

This PR adds a statsd metric for OpenTelemetry events. It allows us to see at a high level the volume of OpenTelemetry and what SDKs they are being sent from.