### PR TITLE
feat(system): Add broadcast behavior for debounced services

### DIFF
--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -12,7 +12,9 @@ use relay_auth::{PublicKey, RelayId};
 use relay_common::RetryBackoff;
 use relay_config::{Config, RelayInfo};
 use relay_log::LogError;
-use relay_system::{compat, Addr, FromMessage, Interface, Service};
+use relay_system::{
+    compat, Addr, FromMessage, Interface, Service, SharedChannel, SharedResponse, SharedSender,
+};
 
 use crate::actors::upstream::{RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay};
 use crate::service::REGISTRY;
@@ -181,8 +183,6 @@ impl RelayState {
 ///  - `Ok`: The task succeeded and information from the response should be inserted into the cache.
 ///  - `Err`: The task failed and the senders should be placed back for the next fetch.
 type FetchResult = Result<GetRelaysResponse, HashMap<RelayId, SharedChannel<GetRelayResult>>>;
-
-use relay_system::{SharedChannel, SharedResponse, SharedSender};
 
 /// Service implementing the [`RelayCache`] interface.
 #[derive(Debug)]

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -182,7 +182,7 @@ impl RelayState {
 /// Result type of the background fetch task.
 ///
 ///  - `Ok`: The task succeeded and information from the response should be inserted into the cache.
-///  - `Err`: The task failed and the senders should be placed back for the next fetch.
+///  - `Err`: The task failed and the channels should be placed back for the next fetch.
 type FetchResult = Result<GetRelaysResponse, HashMap<RelayId, BroadcastChannel<GetRelayResult>>>;
 
 /// Service implementing the [`RelayCache`] interface.
@@ -190,7 +190,7 @@ type FetchResult = Result<GetRelaysResponse, HashMap<RelayId, BroadcastChannel<G
 pub struct RelayCacheService {
     static_relays: HashMap<RelayId, RelayInfo>,
     relays: HashMap<RelayId, RelayState>,
-    senders: HashMap<RelayId, BroadcastChannel<GetRelayResult>>,
+    channels: HashMap<RelayId, BroadcastChannel<GetRelayResult>>,
     fetch_channel: (mpsc::Sender<FetchResult>, mpsc::Receiver<FetchResult>),
     backoff: RetryBackoff,
     delay: SleepHandle,
@@ -203,7 +203,7 @@ impl RelayCacheService {
         Self {
             static_relays: config.static_relays().clone(),
             relays: HashMap::new(),
-            senders: HashMap::new(),
+            channels: HashMap::new(),
             fetch_channel: mpsc::channel(1),
             backoff: RetryBackoff::new(config.http_max_retry_interval()),
             delay: SleepHandle::idle(),
@@ -236,7 +236,7 @@ impl RelayCacheService {
     /// This assumes that currently no request is running. If the upstream request fails or new
     /// channels are pushed in the meanwhile, this will reschedule automatically.
     fn fetch_relays(&mut self) {
-        let channels = std::mem::take(&mut self.senders);
+        let channels = std::mem::take(&mut self.channels);
         relay_log::debug!(
             "updating public keys for {} relays (attempt {})",
             channels.len(),
@@ -252,7 +252,7 @@ impl RelayCacheService {
             let upstream = UpstreamRelay::from_registry();
             let query_result = match compat::send(upstream, SendQuery(request)).await {
                 Ok(inner) => inner,
-                // Drop the senders to propagate the SendError up.
+                // Drop the channels to propagate the `SendError` up.
                 Err(_send_error) => return,
             };
 
@@ -289,11 +289,11 @@ impl RelayCacheService {
                 }
             }
             Err(channels) => {
-                self.senders.extend(channels);
+                self.channels.extend(channels);
             }
         }
 
-        if !self.senders.is_empty() {
+        if !self.channels.is_empty() {
             self.schedule_fetch();
         }
     }
@@ -301,7 +301,7 @@ impl RelayCacheService {
     /// Resolves information for a Relay and passes it to the sender.
     ///
     /// Sends information immediately if it is available in the cache. Otherwise, this schedules a
-    /// delayed background fetch and queues the sender.
+    /// delayed background fetch and attaches the sender to a broadcast channel.
     fn get_or_fetch(&mut self, message: GetRelay, sender: BroadcastSender<GetRelayResult>) {
         let relay_id = message.relay_id;
 
@@ -328,7 +328,7 @@ impl RelayCacheService {
         }
 
         relay_log::debug!("relay {} public key requested", relay_id);
-        self.senders
+        self.channels
             .entry(relay_id)
             .or_insert_with(BroadcastChannel::new)
             .attach(sender);

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -373,7 +373,7 @@ impl<T: Clone> BroadcastChannel<T> {
         sender.0.send(InitialResponse::Poll(self.rx.clone())).ok();
     }
 
-    /// Send a value to all attached senders and close the channel.
+    /// Sends a value to all attached senders and closes the channel.
     ///
     /// This method succeeds even if no senders are attached to this channel anymore. To check if
     /// this channel is still active with senders attached, use [`is_attached`](Self::is_attached).

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -258,7 +258,9 @@ enum SharedRequestState<T> {
 /// This is returned from [`Addr::send`] when the message responds asynchronously through
 /// [`SharedResponse`]. It is a future that should be awaited. The message still runs to
 /// completion if this future is dropped.
-pub struct SharedRequest<T>(SharedRequestState<T>);
+pub struct SharedRequest<T>(SharedRequestState<T>)
+where
+    T: Clone;
 
 impl<T: Clone> Future for SharedRequest<T> {
     type Output = Result<T, SendError>;
@@ -287,7 +289,10 @@ impl<T: Clone> Future for SharedRequest<T> {
 /// TODO(ja): Doc
 // TODO(ja): Debug?
 #[derive(Debug)]
-pub struct SharedChannel<T> {
+pub struct SharedChannel<T>
+where
+    T: Clone,
+{
     tx: oneshot::Sender<T>,
     rx: Shared<oneshot::Receiver<T>>,
 }
@@ -322,7 +327,9 @@ impl<T: Clone> Default for SharedChannel<T> {
 /// TODO(ja): Doc
 // TODO(ja): Debug
 #[derive(Debug)]
-pub struct SharedSender<T>(oneshot::Sender<Foo<T>>);
+pub struct SharedSender<T>(oneshot::Sender<Foo<T>>)
+where
+    T: Clone;
 
 impl<T: Clone> SharedSender<T> {
     /// TODO(ja): Doc
@@ -339,15 +346,17 @@ impl<T: Clone> SharedSender<T> {
 }
 
 /// TODO(ja): Doc
-pub struct SharedResponse<T>(PhantomData<T>);
+pub struct SharedResponse<T>(PhantomData<T>)
+where
+    T: Clone;
 
-impl<T> fmt::Debug for SharedResponse<T> {
+impl<T: Clone> fmt::Debug for SharedResponse<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("SharedResponse")
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> MessageResponse for SharedResponse<T> {
+impl<T: Clone> MessageResponse for SharedResponse<T> {
     type Sender = SharedSender<T>;
     type Output = SharedRequest<T>;
 


### PR DESCRIPTION
The `ProjectCache` and `RelayCache` actors both follow a common pattern: They
maintain a map of cached objects that they populate asynchronously. There is a
message in their public interface to retrieve data from this cache.

Since the `RelayCache` was ported in #1485, it keeps a list of senders for each
waiting caller of that message. Once the cache entry has been resolved, it loops
through all senders and passed a clone of the value on. This has the downside
that it doesn't only require resources on the requesting side, but also in the
cache actor itself.

A better approach is to break this into a two-step process:
 1. The service creates a shared channel that will be populated once
 2. Recipients attach to the shared channel and wait for the response

The recipient therefore first has to await the receive end of the shared
channel, and then await the value from that channel. Of course, if the value is
already in the cache, this can be skipped, and the value can be sent directly
to the recipient.

# Implementation Details

This PR implements this with two nested `oneshot` channels. The outer channel
resolves an enum, which is either the result value, or a shared inner channel
that resolves the value.

We implement this as service response behavior, so that the building blocks for
this (senders, channels, ...) can be reused between multiple services. This can
be used for some of the messages, while other messages have regular async
behavior. The response future type is opaque, so users of such a service do not
notice the two-step behavior; they simply resolve the final value.

This PR updates the `RelayCacheService` to use this new response behavior.
Internally, the service still needs to hold two maps:
 - A map for the actual raw data that it pulls responses from. This data can be
   different or more elaborate than what's exposed via public messages.
 - A map for open channels. Entries in this map can be removed as soon as the
   cache value is resolved, because after that the service can short-circuit and
	 respond with the value directly.

# Alternatives

Tokio provides [`watch`](https://docs.rs/tokio/latest/tokio/sync/watch/index.html)
channels that would be a suitable building block for this. However, since the
service currently controls when it considers cached values valid and when to
expose them, we cannot expose watch channels directly.

# References

Tracked by getsentry/relay#1602
Requires getsentry/relay#1622
#skip-changelog
