### PR TITLE
feat(transaction): Normalize transaction name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Internal**:
 
 - Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))
+- Normalize transaction name for URLs transaction source, by replacing UUIDs, SHAs and numerical IDs in transaction names by placeholders. ([#1621](https://github.com/getsentry/relay/pull/1621))
 
 ## 22.11.0
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         measurements_config: None, // only supported in relay
         breakdowns_config: None,   // only supported in relay
         normalize_user_agent: config.normalize_user_agent,
-        normalize_transaction_name: None, // only supported in relay
+        normalize_transaction_name: false, // only supported in relay
         is_renormalize: config.is_renormalize.unwrap_or(false),
     };
     light_normalize_event(&mut event, &light_normalization_config)?;

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -119,6 +119,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         measurements_config: None, // only supported in relay
         breakdowns_config: None,   // only supported in relay
         normalize_user_agent: config.normalize_user_agent,
+        normalize_transaction_name: None, // only supported in relay
         is_renormalize: config.is_renormalize.unwrap_or(false),
     };
     light_normalize_event(&mut event, &light_normalization_config)?;

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -15,6 +15,7 @@ mod event_error;
 mod geo;
 mod legacy;
 mod normalize;
+mod regexes;
 mod remove_other;
 mod schema;
 mod transactions;

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -663,7 +663,7 @@ pub struct LightNormalizationConfig<'a> {
     pub measurements_config: Option<&'a MeasurementsConfig>,
     pub breakdowns_config: Option<&'a BreakdownsConfig>,
     pub normalize_user_agent: Option<bool>,
-    pub normalize_transaction_name: Option<bool>,
+    pub normalize_transaction_name: bool,
     pub is_renormalize: bool,
 }
 
@@ -680,9 +680,8 @@ pub fn light_normalize_event(
         // (internally noops for non-transaction events).
         // TODO: Parts of this processor should probably be a filter so we
         // can revert some changes to ProcessingAction
-        let mut transactions_processor = transactions::TransactionsProcessor::new(
-            config.normalize_transaction_name.unwrap_or_default(),
-        );
+        let mut transactions_processor =
+            transactions::TransactionsProcessor::new(config.normalize_transaction_name);
         transactions_processor.process_event(event, meta, ProcessingState::root())?;
 
         // Check for required and non-empty values

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -663,6 +663,7 @@ pub struct LightNormalizationConfig<'a> {
     pub measurements_config: Option<&'a MeasurementsConfig>,
     pub breakdowns_config: Option<&'a BreakdownsConfig>,
     pub normalize_user_agent: Option<bool>,
+    pub normalize_transaction_name: Option<bool>,
     pub is_renormalize: bool,
 }
 
@@ -679,7 +680,10 @@ pub fn light_normalize_event(
         // (internally noops for non-transaction events).
         // TODO: Parts of this processor should probably be a filter so we
         // can revert some changes to ProcessingAction
-        transactions::TransactionsProcessor.process_event(event, meta, ProcessingState::root())?;
+        let mut transactions_processor = transactions::TransactionsProcessor::new(
+            config.normalize_transaction_name.unwrap_or_default(),
+        );
+        transactions_processor.process_event(event, meta, ProcessingState::root())?;
 
         // Check for required and non-empty values
         schema::SchemaProcessor.process_event(event, meta, ProcessingState::root())?;

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -2,6 +2,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 /// Contains multiple capture groups which will be used as a replace placeholder.
+///
+/// This regex is inspired by one used for grouping:
+/// https://github.com/getsentry/sentry/blob/6ba59023a78bfe033e48ea4e035b64710a905c6b/src/sentry/grouping/strategies/message.py#L16-L97
 pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 /// Contains multiple capture groups which will be used as a replace placeholder.
 ///
 /// This regex is inspired by one used for grouping:
-/// https://github.com/getsentry/sentry/blob/6ba59023a78bfe033e48ea4e035b64710a905c6b/src/sentry/grouping/strategies/message.py#L16-L97
+/// <https://github.com/getsentry/sentry/blob/6ba59023a78bfe033e48ea4e035b64710a905c6b/src/sentry/grouping/strategies/message.py#L16-L97>
 pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -1,0 +1,57 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Contains multiple capture groups which will be used as a replace placeholder.
+pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"
+
+    (?x)
+    (?P<uuid>
+        \b
+            [0-9a-fA-F]{8}-
+            [0-9a-fA-F]{4}-
+            [0-9a-fA-F]{4}-
+            [0-9a-fA-F]{4}-
+            [0-9a-fA-F]{12}
+        \b
+    ) |
+    (?P<sha1>
+        \b[0-9a-fA-F]{40}\b
+    ) |
+    (?P<md5>
+        \b[0-9a-fA-F]{32}\b
+    ) |
+    (?P<date>
+        (?:
+            (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|
+            (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|
+            (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))
+        ) |
+        (?:
+            \b(?:(Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+)?
+            (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+
+            (?:[\d]{1,2})\s+
+            (?:[\d]{2}:[\d]{2}:[\d]{2})\s+
+            [\d]{4}
+        ) |
+        (?:
+            \b(?:(Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s+)?
+            (?:0[1-9]|[1-2]?[\d]|3[01])\s+
+            (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+
+            (?:19[\d]{2}|[2-9][\d]{3})\s+
+            (?:2[0-3]|[0-1][\d]):([0-5][\d])
+            (?::(60|[0-5][\d]))?\s+
+            (?:[-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z]))
+        )
+    ) |
+    (?P<hex>
+        \b0[xX][0-9a-fA-F]+\b
+    ) |
+    (?P<int>
+        \b\d{2,}\b
+    )
+"#,
+    )
+    .unwrap()
+});

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -4,10 +4,20 @@ use crate::processor::{ProcessValue, ProcessingState, Processor};
 use crate::protocol::{
     Context, ContextInner, Event, EventType, Span, Timestamp, TransactionSource,
 };
-use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult};
+use crate::store::regexes::TRANSACTION_NAME_NORMALIZER_REGEX;
+use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Remark, RemarkType};
 
 /// Rejects transactions based on required fields.
-pub struct TransactionsProcessor;
+#[derive(Default)]
+pub struct TransactionsProcessor {
+    normalize_names: bool,
+}
+
+impl TransactionsProcessor {
+    pub fn new(normalize_names: bool) -> Self {
+        Self { normalize_names }
+    }
+}
 
 /// Get the value for a measurement, e.g. lcp -> event.measurements.lcp
 pub fn get_measurement(transaction: &Event, name: &str) -> Option<f64> {
@@ -203,6 +213,54 @@ fn set_default_transaction_source(event: &mut Event) {
     }
 }
 
+/// Normalize the transaction name.
+///
+/// Replaces UUIDs, SHAs and numerical IDs in transaction names by placeholders.
+fn normalize_transaction_name(transaction: &mut Annotated<String>) -> ProcessingResult {
+    let capture_names = TRANSACTION_NAME_NORMALIZER_REGEX
+        .capture_names()
+        .flatten()
+        .collect::<Vec<_>>();
+
+    transaction.apply(|trans, meta| {
+        // Collect all the remarks first, since we will mutate the string afterwords and all the
+        // ranges will change.
+        for matches in TRANSACTION_NAME_NORMALIZER_REGEX.captures_iter(trans) {
+            // Skip first, since it's always the entire match and the following are groups.
+            // And if there is no matches, just cotinue to next iteration.
+            let mut matches_iter = matches.iter();
+            if matches_iter.next().is_none() {
+                continue;
+            }
+            for m in matches_iter.flatten() {
+                let remark = Remark::with_range(
+                    RemarkType::Substituted,
+                    "normalize_transaction_name",
+                    (m.start(), m.end()),
+                );
+                meta.add_remark(remark)
+            }
+        }
+        for name in capture_names {
+            if let Some(caps) = TRANSACTION_NAME_NORMALIZER_REGEX.captures(trans) {
+                if let Some(m) = caps.name(name) {
+                    if meta.original_value().is_none() {
+                        meta.set_original_value(Some(trans.to_string()))
+                    }
+                    let mut collector = String::new();
+                    collector.push_str(&trans[..m.start()]);
+                    collector.push('<');
+                    collector.push_str(name);
+                    collector.push('>');
+                    collector.push_str(&trans[m.end()..]);
+                    *trans = collector;
+                }
+            }
+        }
+        Ok(())
+    })
+}
+
 impl Processor for TransactionsProcessor {
     fn process_event(
         &mut self,
@@ -223,6 +281,11 @@ impl Processor for TransactionsProcessor {
             event
                 .transaction
                 .set_value(Some("<unlabeled transaction>".to_owned()))
+        }
+
+        // Normalize transaction names for URLs transaction sources only.
+        if event.get_transaction_source() == &TransactionSource::Url && self.normalize_names {
+            normalize_transaction_name(&mut event.transaction)?;
         }
 
         validate_transaction(event)?;
@@ -345,7 +408,7 @@ mod tests {
         let mut event = Annotated::new(Event::default());
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -362,7 +425,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -382,7 +445,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -403,7 +466,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -425,7 +488,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -451,7 +514,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -482,7 +545,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -516,7 +579,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -554,7 +617,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -607,7 +670,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -641,7 +704,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -661,7 +724,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -716,7 +779,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -755,7 +818,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -795,7 +858,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -836,7 +899,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -878,7 +941,7 @@ mod tests {
         assert_eq!(
             process_value(
                 &mut event,
-                &mut TransactionsProcessor,
+                &mut TransactionsProcessor::default(),
                 ProcessingState::root()
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -925,7 +988,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -988,7 +1051,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1032,7 +1095,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1048,7 +1111,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1096,7 +1159,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1144,7 +1207,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor,
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1226,5 +1289,141 @@ mod tests {
         assert!(!event.meta().has_errors());
 
         assert!(is_high_cardinality_sdk(&event.0.unwrap()));
+    }
+
+    #[test]
+    fn test_transaction_name_dont_normalize() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0",
+            "transaction_info": {
+              "source": "url"
+            },
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T07:59:01+0100",
+            "contexts": {
+                "trace": {
+                    "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+                    "span_id": "fa90fdead5f74053",
+                    "op": "rails.request",
+                    "status": "ok"
+                }
+            }
+        }
+        "#;
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+
+        // This must not normalize transaction name, since it's disabled.
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor::default(),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(event, @r###"
+        {
+          "type": "transaction",
+          "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0",
+          "transaction_info": {
+            "source": "url"
+          },
+          "timestamp": 1619420400.0,
+          "start_timestamp": 1619420341.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "rails.request",
+              "status": "ok",
+              "type": "trace"
+            }
+          },
+          "spans": []
+        }
+        "###);
+    }
+    #[test]
+    fn test_transaction_name_normalize() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0",
+            "transaction_info": {
+              "source": "url"
+            },
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T07:59:01+0100",
+            "contexts": {
+                "trace": {
+                    "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+                    "span_id": "fa90fdead5f74053",
+                    "op": "rails.request",
+                    "status": "ok"
+                }
+            },
+            "sdk": {"name": "sentry.ruby"},
+            "modules": {"rack": "1.2.3"}
+
+        }
+        "#;
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor::new(true),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(event, @r###"
+        {
+          "type": "transaction",
+          "transaction": "/foo/<sha1>/user/<int>/0",
+          "transaction_info": {
+            "source": "url"
+          },
+          "modules": {
+            "rack": "1.2.3"
+          },
+          "timestamp": 1619420400.0,
+          "start_timestamp": 1619420341.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "rails.request",
+              "status": "ok",
+              "type": "trace"
+            }
+          },
+          "sdk": {
+            "name": "sentry.ruby"
+          },
+          "spans": [],
+          "_meta": {
+            "transaction": {
+              "": {
+                "rem": [
+                  [
+                    "normalize_transaction_name",
+                    "s",
+                    5,
+                    45
+                  ],
+                  [
+                    "normalize_transaction_name",
+                    "s",
+                    51,
+                    54
+                  ]
+                ],
+                "val": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0"
+              }
+            }
+          }
+        }
+        "###);
     }
 }

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -227,11 +227,8 @@ fn normalize_transaction_name(transaction: &mut Annotated<String>) -> Processing
         for matches in TRANSACTION_NAME_NORMALIZER_REGEX.captures_iter(trans) {
             for name in &capture_names {
                 if let Some(m) = matches.name(name) {
-                    let remark = Remark::with_range(
-                        RemarkType::Substituted,
-                        format!("normalize_transaction_name:{}", name).as_str(),
-                        (m.start(), m.end()),
-                    );
+                    let remark =
+                        Remark::with_range(RemarkType::Substituted, *name, (m.start(), m.end()));
                     meta.add_remark(remark);
                     break;
                 }
@@ -1395,13 +1392,13 @@ mod tests {
               "": {
                 "rem": [
                   [
-                    "normalize_transaction_name:sha1",
+                    "sha1",
                     "s",
                     5,
                     45
                   ],
                   [
-                    "normalize_transaction_name:int",
+                    "int",
                     "s",
                     51,
                     54

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1985,6 +1985,11 @@ impl EnvelopeProcessorService {
             measurements_config: state.project_state.config.measurements.as_ref(),
             breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
             normalize_user_agent: Some(true),
+            normalize_transaction_name: Some(
+                state
+                    .project_state
+                    .has_feature(Feature::TransactionNameNormalize),
+            ),
             is_renormalize: false,
         };
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1986,11 +1986,10 @@ impl EnvelopeProcessorService {
             measurements_config: state.project_state.config.measurements.as_ref(),
             breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
             normalize_user_agent: Some(true),
-            normalize_transaction_name: Some(
-                state
-                    .project_state
-                    .has_feature(Feature::TransactionNameNormalize),
-            ),
+            normalize_transaction_name: state
+                .project_state
+                .has_feature(Feature::TransactionNameNormalize),
+
             is_renormalize: false,
         };
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -68,10 +68,11 @@ pub enum Feature {
     /// Enables ingestion and normalization of profiles.
     #[serde(rename = "organizations:profiling")]
     Profiling,
-    /// Enables ingestion of Session Replays (Replay Recordings and Replay Events)
+    /// Enables ingestion of Session Replays (Replay Recordings and Replay Events).
     #[serde(rename = "organizations:session-replay")]
     Replays,
-    /// docs
+    /// Enable transaction names normalization.
+    /// Replacing UUIDs, SHAs and numerical IDs by placeholders.
     #[serde(rename = "organizations:transaction-name-normalize")]
     TransactionNameNormalize,
 

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -71,6 +71,9 @@ pub enum Feature {
     /// Enables ingestion of Session Replays (Replay Recordings and Replay Events)
     #[serde(rename = "organizations:session-replay")]
     Replays,
+    /// docs
+    #[serde(rename = "organizations:transaction-name-normalize")]
+    TransactionNameNormalize,
 
     /// Unused.
     ///


### PR DESCRIPTION
Adding feature which, when enabled, supports transaction names normalization by replacing UUIDs, SHAs and numerical IDs in transaction names by placeholders.

This is the first step which should help to prevent high cardinality for transaction names.

ref: #1597 