### PR TITLE
ref(server): Migrate the project cache to Tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,12 +3370,9 @@ dependencies = [
 name = "relay-metrics"
 version = "22.11.0"
 dependencies = [
- "actix",
  "criterion",
- "failure",
  "float-ord",
  "fnv",
- "futures 0.1.31",
  "hash32",
  "insta",
  "relay-common",
@@ -3385,6 +3382,7 @@ dependencies = [
  "relay-test",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio 1.19.2",
 ]
 
@@ -3558,7 +3556,6 @@ dependencies = [
  "relay-log",
  "relay-system",
  "tokio 1.19.2",
- "tokio-timer",
 ]
 
 [[package]]

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -10,8 +10,6 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-actix = "0.7.9"
-failure = "0.1.8"
 float-ord = "0.3.1"
 fnv = "1.0.7"
 hash32 = "0.1.1"
@@ -21,14 +19,15 @@ relay-statsd = { path = "../relay-statsd" }
 relay-system = { path = "../relay-system" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
+thiserror = "1.0.20"
 tokio = { version = "1.0", features = ["macros", "time"] }
 
 [dev-dependencies]
 criterion = "0.3"
-futures01 = { version = "0.1.28", package = "futures" }
 insta = "1.19.0"
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }
+tokio = { version = "1.0", features = ["test-util"] }
 
 [[bench]]
 name = "aggregator"

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::collections::{btree_map, hash_map::Entry, BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::hash::Hasher;
@@ -1836,7 +1835,7 @@ impl AggregatorService {
             None => {
                 return BTreeMap::from([(None, buckets.into_iter().map(|x| x.bucket).collect())]);
             }
-            Some(x) => max(1, x), // handle 0,
+            Some(x) => x.max(1), // handle 0,
         };
         let mut partitions = BTreeMap::<_, Vec<Bucket>>::new();
         for bucket in buckets {

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -4,19 +4,18 @@ use std::fmt;
 use std::hash::Hasher;
 use std::iter::{FromIterator, FusedIterator};
 use std::mem;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use actix::{Message, Recipient};
-use failure::Fail;
 use float_ord::FloatOrd;
 use fnv::FnvHasher;
 use serde::{Deserialize, Serialize};
-use tokio::time;
+use thiserror::Error;
+use tokio::time::Instant;
 
 use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 use relay_log::LogError;
 use relay_system::{
-    compat, AsyncResponse, Controller, FromMessage, Interface, NoResponse, Sender, Service,
+    AsyncResponse, Controller, FromMessage, Interface, NoResponse, Recipient, Sender, Service,
     Shutdown,
 };
 
@@ -640,9 +639,9 @@ fn tags_cost(tags: &BTreeMap<String, String>) -> usize {
 }
 
 /// Error returned when parsing or serializing a [`Bucket`].
-#[derive(Debug, Fail)]
-#[fail(display = "failed to parse metric bucket")]
-pub struct ParseBucketError(#[cause] serde_json::Error);
+#[derive(Debug, Error)]
+#[error("failed to parse metric bucket")]
+pub struct ParseBucketError(#[source] serde_json::Error);
 
 /// An aggregation of metric values by the [`Aggregator`].
 ///
@@ -854,8 +853,8 @@ impl MetricsContainer for Bucket {
 }
 
 /// Any error that may occur during aggregation.
-#[derive(Debug, Fail, PartialEq)]
-#[fail(display = "failed to aggregate metrics: {}", kind)]
+#[derive(Debug, Error, PartialEq)]
+#[error("failed to aggregate metrics: {}", .kind)]
 pub struct AggregateMetricsError {
     kind: AggregateMetricsErrorKind,
 }
@@ -866,29 +865,29 @@ impl From<AggregateMetricsErrorKind> for AggregateMetricsError {
     }
 }
 
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 #[allow(clippy::enum_variant_names)]
 enum AggregateMetricsErrorKind {
     /// A metric bucket had invalid characters in the metric name.
-    #[fail(display = "found invalid characters")]
+    #[error("found invalid characters")]
     InvalidCharacters,
     /// A metric bucket had an unknown namespace in the metric name.
-    #[fail(display = "found unsupported namespace")]
+    #[error("found unsupported namespace")]
     UnsupportedNamespace,
     /// A metric bucket's timestamp was out of the configured acceptable range.
-    #[fail(display = "found invalid timestamp")]
+    #[error("found invalid timestamp")]
     InvalidTimestamp,
     /// Internal error: Attempted to merge two metric buckets of different types.
-    #[fail(display = "found incompatible metric types")]
+    #[error("found incompatible metric types")]
     InvalidTypes,
     /// A metric bucket had a too long string (metric name or a tag key/value).
-    #[fail(display = "found invalid string")]
+    #[error("found invalid string")]
     InvalidStringLength,
     /// A metric bucket is too large for the global bytes limit.
-    #[fail(display = "total metrics limit exceeded")]
+    #[error("total metrics limit exceeded")]
     TotalLimitExceeded,
     /// A metric bucket is too large for the per-project bytes limit.
-    #[fail(display = "project metrics limit exceeded")]
+    #[error("project metrics limit exceeded")]
     ProjectLimitExceeded,
 }
 
@@ -1064,6 +1063,7 @@ impl AggregatorConfig {
         let mut flush = None;
 
         if let MonotonicResult::Instant(instant) = bucket_timestamp.to_instant() {
+            let instant = Instant::from_std(instant);
             let bucket_end = instant + self.bucket_interval();
             let initial_flush = bucket_end + self.initial_delay();
             // If the initial flush is still pending, use that.
@@ -1361,21 +1361,11 @@ pub struct FlushBuckets {
     pub buckets: Vec<Bucket>,
 }
 
-// TODO(actix): required by ProjectCache and will be removed with ProjectCache migration.
-impl Message for FlushBuckets {
-    type Result = ();
-}
-
 /// A message containing a list of [`Metric`]s to be inserted into the aggregator.
 #[derive(Debug)]
 pub struct InsertMetrics {
     project_key: ProjectKey,
     metrics: Vec<Metric>,
-}
-
-// TODO(actix): required by ProjectCache and will be removed with ProjectCache migration.
-impl Message for InsertMetrics {
-    type Result = Result<(), AggregateMetricsError>;
 }
 
 impl InsertMetrics {
@@ -1407,11 +1397,6 @@ impl InsertMetrics {
 pub struct MergeBuckets {
     project_key: ProjectKey,
     buckets: Vec<Bucket>,
-}
-
-// TODO(actix): required by ProjectCache and will be removed with ProjectCache migration.
-impl Message for MergeBuckets {
-    type Result = Result<(), AggregateMetricsError>;
 }
 
 impl MergeBuckets {
@@ -1515,8 +1500,7 @@ impl FromMessage<MergeBuckets> for Aggregator {
 pub struct AggregatorService {
     config: AggregatorConfig,
     buckets: HashMap<BucketKey, QueuedBucket>,
-    // TODO(actix): required by ProjectCache and will be removed with ProjectCache migration.
-    receiver: Option<Recipient<FlushBuckets>>,
+    receiver: Option<Recipient<FlushBuckets, NoResponse>>,
     state: AggregatorState,
     cost_tracker: CostTracker,
 }
@@ -1526,7 +1510,10 @@ impl AggregatorService {
     ///
     /// The aggregator will flush a list of buckets to the receiver in regular intervals based on
     /// the given `config`.
-    pub fn new(config: AggregatorConfig, receiver: Option<Recipient<FlushBuckets>>) -> Self {
+    pub fn new(
+        config: AggregatorConfig,
+        receiver: Option<Recipient<FlushBuckets, NoResponse>>,
+    ) -> Self {
         Self {
             config,
             buckets: HashMap::new(),
@@ -1916,13 +1903,12 @@ impl AggregatorService {
             let partitioned_buckets = self.partition_buckets(project_buckets, num_partitions);
             for (partition_key, buckets) in partitioned_buckets {
                 self.process_batches(buckets, |batch| {
-                    if let Some(receiver) = self.receiver.clone() {
-                        let flush_buckets = FlushBuckets {
+                    if let Some(ref receiver) = self.receiver {
+                        receiver.send(FlushBuckets {
                             project_key,
                             partition_key,
                             buckets: batch,
-                        };
-                        compat::send_to_recipient(receiver, flush_buckets);
+                        });
                     }
                 });
             }
@@ -1962,12 +1948,12 @@ impl AggregatorService {
     fn handle_message(&mut self, msg: Aggregator) {
         match msg {
             Aggregator::AcceptsMetrics(_, sender) => self.handle_accepts_metrics(sender),
+            Aggregator::InsertMetrics(msg) => self.handle_insert_metrics(msg),
+            Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
             #[cfg(test)]
             Aggregator::BucketCountInquiry(_, sender) => {
                 sender.send(self.buckets.len());
             }
-            Aggregator::InsertMetrics(msg) => self.handle_insert_metrics(msg),
-            Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
         }
     }
 
@@ -1995,7 +1981,7 @@ impl Service for AggregatorService {
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
-            let mut ticker = time::interval(FLUSH_INTERVAL);
+            let mut ticker = tokio::time::interval(FLUSH_INTERVAL);
             let mut shutdown = Controller::subscribe_v2().await;
             relay_log::info!("aggregator started");
 
@@ -2031,7 +2017,6 @@ impl Drop for AggregatorService {
 
 #[cfg(test)]
 mod tests {
-    use actix::prelude::*;
     use std::sync::{Arc, RwLock};
 
     use super::*;
@@ -2041,8 +2026,18 @@ mod tests {
         buckets: Vec<Bucket>,
     }
 
-    // TODO(actix): this test receiver with its implementation will be removed onces the ProjectCache actor
-    // is migrated to the new tokio runtime.
+    struct TestInterface(FlushBuckets);
+
+    impl Interface for TestInterface {}
+
+    impl FromMessage<FlushBuckets> for TestInterface {
+        type Response = NoResponse;
+
+        fn from_message(message: FlushBuckets, _: ()) -> Self {
+            Self(message)
+        }
+    }
+
     #[derive(Clone, Default)]
     struct TestReceiver {
         // TODO: Better way to communicate with Actor after it's started?
@@ -2061,20 +2056,19 @@ mod tests {
         }
     }
 
-    impl Actor for TestReceiver {
-        type Context = Context<Self>;
-    }
+    impl Service for TestReceiver {
+        type Interface = TestInterface;
 
-    impl Handler<FlushBuckets> for TestReceiver {
-        type Result = ();
-
-        fn handle(&mut self, msg: FlushBuckets, _ctx: &mut Self::Context) -> Self::Result {
-            let buckets = msg.buckets;
-            relay_log::debug!("received buckets: {:#?}", buckets);
-            if self.reject_all {
-                return;
-            }
-            self.add_buckets(buckets);
+        fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+            tokio::spawn(async move {
+                while let Some(message) = rx.recv().await {
+                    let buckets = message.0.buckets;
+                    relay_log::debug!("received buckets: {:#?}", buckets);
+                    if !self.reject_all {
+                        self.add_buckets(buckets);
+                    }
+                }
+            });
         }
     }
 
@@ -2763,77 +2757,76 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_flush_bucket() {
+    #[tokio::test]
+    async fn test_flush_bucket() {
         relay_test::setup();
+        tokio::time::pause();
+
         let receiver = TestReceiver::default();
         let recipient = receiver.clone().start().recipient();
-        relay_test::block_with_actix(async move {
-            // Note that this is needed to initiate the compatibility layer so we can send the
-            // message from the new tokio runtime to the old system.
-            compat::init();
-            let config = AggregatorConfig {
-                bucket_interval: 1,
-                initial_delay: 0,
-                debounce_delay: 0,
-                ..Default::default()
-            };
-            let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
-            let aggregator = AggregatorService::new(config, Some(recipient)).start();
 
-            let mut metric = some_metric();
-            metric.timestamp = UnixTimestamp::now();
+        let config = AggregatorConfig {
+            bucket_interval: 1,
+            initial_delay: 0,
+            debounce_delay: 0,
+            ..Default::default()
+        };
+        let aggregator = AggregatorService::new(config, Some(recipient)).start();
 
-            aggregator.send(InsertMetrics {
-                project_key,
-                metrics: vec![metric],
-            });
+        let mut metric = some_metric();
+        metric.timestamp = UnixTimestamp::now();
 
-            let buckets_count = aggregator.send(BucketCountInquiry).await.unwrap();
-            // Let's check the number of buckets in the aggregator just after sending a
-            // message.
-            assert_eq!(buckets_count, 1);
-            // Wait until flush delay has passed. It is up to 2s: 1s for the current bucket
-            // and 1s for the flush shift. Adding 100ms buffer.
-            tokio::time::sleep(Duration::from_millis(2100)).await;
-            // receiver must have 1 bucket flushed
-            assert_eq!(receiver.bucket_count(), 1);
+        aggregator.send(InsertMetrics {
+            project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            metrics: vec![metric],
         });
+
+        let buckets_count = aggregator.send(BucketCountInquiry).await.unwrap();
+        // Let's check the number of buckets in the aggregator just after sending a
+        // message.
+        assert_eq!(buckets_count, 1);
+
+        // Wait until flush delay has passed. It is up to 2s: 1s for the current bucket
+        // and 1s for the flush shift. Adding 100ms buffer.
+        tokio::time::sleep(Duration::from_millis(2100)).await;
+        // receiver must have 1 bucket flushed
+        assert_eq!(receiver.bucket_count(), 1);
     }
 
-    #[test]
-    fn test_merge_back() {
+    #[tokio::test]
+    async fn test_merge_back() {
         relay_test::setup();
-        relay_test::block_with_actix(async move {
-            // Create a receiver which accepts nothing:
-            let receiver = TestReceiver {
-                reject_all: true,
-                ..TestReceiver::default()
-            };
-            let config = AggregatorConfig {
-                bucket_interval: 1,
-                initial_delay: 0,
-                debounce_delay: 0,
-                ..Default::default()
-            };
-            let recipient = receiver.clone().start().recipient();
+        tokio::time::pause();
 
-            let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
+        // Create a receiver which accepts nothing:
+        let receiver = TestReceiver {
+            reject_all: true,
+            ..TestReceiver::default()
+        };
+        let recipient = receiver.clone().start().recipient();
 
-            let aggregator = AggregatorService::new(config, Some(recipient)).start();
+        let config = AggregatorConfig {
+            bucket_interval: 1,
+            initial_delay: 0,
+            debounce_delay: 0,
+            ..Default::default()
+        };
+        let aggregator = AggregatorService::new(config, Some(recipient)).start();
 
-            let mut metric = some_metric();
-            metric.timestamp = UnixTimestamp::now();
-            aggregator.send(InsertMetrics {
-                project_key,
-                metrics: vec![metric],
-            });
-            assert_eq!(receiver.bucket_count(), 0);
-            tokio::time::sleep(Duration::from_millis(1100)).await;
-            let bucket_count = aggregator.send(BucketCountInquiry).await.unwrap();
-            assert_eq!(bucket_count, 1);
-            assert_eq!(receiver.bucket_count(), 0);
+        let mut metric = some_metric();
+        metric.timestamp = UnixTimestamp::now();
+
+        aggregator.send(InsertMetrics {
+            project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            metrics: vec![metric],
         });
+
+        assert_eq!(receiver.bucket_count(), 0);
+
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        let bucket_count = aggregator.send(BucketCountInquiry).await.unwrap();
+        assert_eq!(bucket_count, 1);
+        assert_eq!(receiver.bucket_count(), 0);
     }
 
     #[test]

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use failure::Fail;
 use r2d2::{Pool, PooledConnection};
 use redis::ConnectionLike;
@@ -98,6 +100,15 @@ enum RedisPoolInner {
     Single(Pool<redis::Client>),
 }
 
+impl fmt::Debug for RedisPoolInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cluster(_) => f.debug_tuple("Cluster").finish(),
+            Self::Single(_) => f.debug_tuple("Single").finish(),
+        }
+    }
+}
+
 /// Abstraction over cluster vs non-cluster mode.
 ///
 /// Even just writing a method that takes a command and executes it doesn't really work because
@@ -106,7 +117,7 @@ enum RedisPoolInner {
 ///
 /// Basically don't waste your time here, if you want to abstract over this, consider
 /// upstreaming to the redis crate.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RedisPool {
     inner: RedisPoolInner,
 }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -115,7 +115,7 @@ impl UpstreamRequest for SendEnvelope {
             Err(error) => {
                 match error {
                     UpstreamRequestError::RateLimited(upstream_limits) => {
-                        ProjectCache::from_registry().do_send(UpdateRateLimits::new(
+                        ProjectCache::from_registry().send(UpdateRateLimits::new(
                             self.project_key,
                             upstream_limits.clone().scope(&self.scoping),
                         ));

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1796,8 +1796,7 @@ impl EnvelopeProcessorService {
         });
 
         if limits.is_limited() {
-            ProjectCache::from_registry()
-                .do_send(UpdateRateLimits::new(scoping.project_key, limits));
+            ProjectCache::from_registry().send(UpdateRateLimits::new(scoping.project_key, limits));
         }
 
         if enforcement.event_active() {
@@ -2114,7 +2113,7 @@ impl EnvelopeProcessorService {
                         if !state.extracted_metrics.is_empty() {
                             let project_cache = ProjectCache::from_registry();
                             project_cache
-                                .do_send(InsertMetrics::new(project_key, state.extracted_metrics));
+                                .send(InsertMetrics::new(project_key, state.extracted_metrics));
                         }
 
                         Ok(ProcessEnvelopeResponse {
@@ -2129,7 +2128,7 @@ impl EnvelopeProcessorService {
                         if !state.extracted_metrics.is_empty() && err.should_keep_metrics() {
                             let project_cache = ProjectCache::from_registry();
                             project_cache
-                                .do_send(InsertMetrics::new(project_key, state.extracted_metrics));
+                                .send(InsertMetrics::new(project_key, state.extracted_metrics));
                         }
 
                         Err(err)
@@ -2202,7 +2201,7 @@ impl EnvelopeProcessorService {
                         Metric::parse_all(&payload, timestamp).filter_map(|result| result.ok());
 
                     relay_log::trace!("inserting metrics into project cache");
-                    project_cache.do_send(InsertMetrics::new(public_key, metrics));
+                    project_cache.send(InsertMetrics::new(public_key, metrics));
                 }
             } else if item.ty() == &ItemType::MetricBuckets {
                 match Bucket::parse_all(&payload) {
@@ -2212,7 +2211,7 @@ impl EnvelopeProcessorService {
                         }
 
                         relay_log::trace!("merging metric buckets into project cache");
-                        project_cache.do_send(MergeBuckets::new(public_key, buckets));
+                        project_cache.send(MergeBuckets::new(public_key, buckets));
                     }
                     Err(error) => {
                         relay_log::debug!("failed to parse metric bucket: {}", LogError(&error));
@@ -2260,7 +2259,7 @@ impl EnvelopeProcessorService {
                 if let Ok(limits) = rate_limits {
                     // Update the rate limits in the project cache.
                     ProjectCache::from_registry()
-                        .do_send(UpdateRateLimits::new(scoping.project_key, limits));
+                        .send(UpdateRateLimits::new(scoping.project_key, limits));
                 }
             }
         }

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -23,7 +23,7 @@ use relay_system::BroadcastChannel;
 
 use crate::actors::envelopes::{EnvelopeManager, SendMetrics};
 use crate::actors::outcome::{DiscardReason, Outcome};
-use crate::actors::processor::{EnvelopeProcessor, ProcessEnvelope, RateLimitFlushBuckets};
+use crate::actors::processor::{EnvelopeProcessor, ProcessEnvelope};
 use crate::actors::project_cache::{
     AddSamplingState, CheckedEnvelope, ProjectCache, RequestUpdate,
 };
@@ -35,6 +35,9 @@ use crate::metrics_extraction::TaggingRule;
 use crate::service::Registry;
 use crate::statsd::RelayCounters;
 use crate::utils::{self, EnvelopeContext, EnvelopeLimiter, ErrorBoundary, MetricsLimiter};
+
+#[cfg(feature = "processing")]
+use crate::actors::processor::RateLimitFlushBuckets;
 
 /// The expiry status of a project state. Return value of [`ProjectState::check_expiry`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -828,7 +831,7 @@ impl Project {
     /// Replaces the internal project state with a new one and triggers pending actions.
     ///
     /// This flushes pending envelopes from [`ValidateEnvelope`] and [`AddSamplingState`] and
-    /// notifies all pending receivers from [`get_or_fetch_state2`](Self::get_or_fetch_state2).
+    /// notifies all pending receivers from [`get_state`](Self::get_state).
     ///
     /// `no_cache` should be passed from the requesting call. Updates with `no_cache` will always
     /// take precedence.

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -512,14 +512,6 @@ impl StateChannel {
         self.no_cache = no_cache;
         self
     }
-
-    // pub fn receiver(&self) -> Shared<oneshot::Receiver<Arc<ProjectState>>> {
-    //     self.inner.clone()
-    // }
-
-    // pub fn send(self, state: Arc<ProjectState>) {
-    //     self.sender.send(state).ok();
-    // }
 }
 
 enum GetOrFetch<'a> {

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -584,7 +584,6 @@ impl ProjectCacheService {
     fn handle_flush_buckets(&mut self, message: FlushBuckets) {
         self.get_or_create_project(message.project_key)
             .flush_buckets(message.partition_key, message.buckets);
-        // TODO
     }
 
     async fn handle_message(&mut self, message: ProjectCache) {
@@ -640,6 +639,7 @@ pub struct FetchProjectState {
     pub no_cache: bool,
 }
 
+// TODO: Remove once `UpstreamProjectSource` was moved to tokio
 impl Message for FetchProjectState {
     type Result = Result<Arc<ProjectState>, ()>;
 }
@@ -655,6 +655,7 @@ impl FetchOptionalProjectState {
     }
 }
 
+// TODO: Remove once `RedisProjectSource` and `LocalProjectSource` were moved to tokio
 impl Message for FetchOptionalProjectState {
     type Result = Option<Arc<ProjectState>>;
 }

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -495,7 +495,7 @@ impl ProjectCacheService {
             .update_state(state, no_cache);
     }
 
-    async fn handle_update(&mut self, message: RequestUpdate) {
+    fn handle_request_update(&mut self, message: RequestUpdate) {
         let RequestUpdate {
             project_key,
             no_cache,
@@ -589,7 +589,7 @@ impl ProjectCacheService {
 
     async fn handle_message(&mut self, message: ProjectCache) {
         match message {
-            ProjectCache::RequestUpdate(message) => self.handle_update(message).await,
+            ProjectCache::RequestUpdate(message) => self.handle_request_update(message),
             ProjectCache::Get(message, sender) => self.handle_get(message, sender),
             ProjectCache::GetCached(message, sender) => {
                 sender.send(self.handle_get_cached(message))

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,37 +1,32 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use actix::prelude::*;
+use actix::prelude::{Actor, Message, SyncArbiter};
 use actix_web::ResponseError;
 use failure::Fail;
-use futures01::{future, Future};
+use futures::compat::Future01CompatExt;
 
 use relay_common::ProjectKey;
 use relay_config::{Config, RelayMode};
-use relay_metrics::{self, AggregateMetricsError, FlushBuckets, InsertMetrics, MergeBuckets};
-
+use relay_metrics::{self, FlushBuckets, InsertMetrics, MergeBuckets};
 use relay_quotas::RateLimits;
-
 use relay_redis::RedisPool;
 use relay_statsd::metric;
+use relay_system::{Addr, FromMessage, Interface, Sender, Service};
+use tokio::sync::mpsc;
 
-use crate::actors::envelopes::{EnvelopeManager, SendMetrics};
 use crate::actors::outcome::DiscardReason;
 use crate::actors::processor::ProcessEnvelope;
-use crate::actors::project::{ExpiryState, Project, ProjectState};
+use crate::actors::project::{Project, ProjectState};
 use crate::actors::project_local::LocalProjectSource;
 use crate::actors::project_upstream::UpstreamProjectSource;
 use crate::envelope::Envelope;
-use crate::service::Registry;
+use crate::service::REGISTRY;
 use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
-use crate::utils::{self, EnvelopeContext, GarbageDisposal, MetricsLimiter, Response};
+use crate::utils::{self, EnvelopeContext, GarbageDisposal};
 
 #[cfg(feature = "processing")]
-use {
-    crate::actors::processor::{EnvelopeProcessor, RateLimitFlushBuckets},
-    crate::actors::project_redis::RedisProjectSource,
-    relay_common::clone,
-};
+use {crate::actors::project_redis::RedisProjectSource, relay_common::clone};
 
 #[derive(Fail, Debug)]
 pub enum ProjectError {
@@ -44,17 +39,291 @@ pub enum ProjectError {
 
 impl ResponseError for ProjectError {}
 
-pub struct ProjectCache {
-    config: Arc<Config>,
-    projects: hashbrown::HashMap<ProjectKey, Project>, // need hashbrown because drain_filter is not stable in std yet
-    local_source: Addr<LocalProjectSource>,
-    upstream_source: Addr<UpstreamProjectSource>,
-    #[cfg(feature = "processing")]
-    redis_source: Option<Addr<RedisProjectSource>>,
-    garbage_disposal: GarbageDisposal<Project>,
+/// Fetches a project state from one of the available sources.
+///
+/// The project state is resolved in the following precedence:
+///
+///  1. Local file system
+///  2. Redis cache (processing mode only)
+///  3. Upstream (managed and processing mode only)
+///
+/// Requests to the upstream are performed via `UpstreamProjectSource`, which internally batches
+/// individual requests.
+#[derive(Clone)]
+pub struct UpdateProjectState {
+    /// The public key to fetch the project by.
+    project_key: ProjectKey,
+
+    /// If true, all caches should be skipped and a fresh state should be computed.
+    no_cache: bool,
+}
+
+impl UpdateProjectState {
+    pub fn new(project_key: ProjectKey, no_cache: bool) -> Self {
+        Self {
+            project_key,
+            no_cache,
+        }
+    }
+}
+
+/// Returns the project state.
+///
+/// The project state is fetched if it is missing or outdated. If `no_cache` is specified, then the
+/// state is always refreshed.
+#[derive(Debug)]
+pub struct GetProjectState {
+    project_key: ProjectKey,
+    no_cache: bool,
+}
+
+impl GetProjectState {
+    /// Fetches the project state and uses the cached version if up-to-date.
+    pub fn new(project_key: ProjectKey) -> Self {
+        Self {
+            project_key,
+            no_cache: false,
+        }
+    }
+
+    /// Fetches the project state and conditionally skips the cache.
+    pub fn no_cache(mut self, no_cache: bool) -> Self {
+        self.no_cache = no_cache;
+        self
+    }
+}
+
+/// Returns the project state if it is already cached.
+///
+/// This is used for cases when we only want to perform operations that do
+/// not require waiting for network requests.
+#[derive(Debug)]
+pub struct GetCachedProjectState {
+    project_key: ProjectKey,
+}
+
+impl GetCachedProjectState {
+    pub fn new(project_key: ProjectKey) -> Self {
+        Self { project_key }
+    }
+}
+
+/// A checked envelope and associated rate limits.
+///
+/// Items violating the rate limits have been removed from the envelope. If all items are removed
+/// from the envelope, `None` is returned in place of the envelope.
+#[derive(Debug)]
+pub struct CheckedEnvelope {
+    pub envelope: Option<(Envelope, EnvelopeContext)>,
+    pub rate_limits: RateLimits,
+}
+
+/// Checks the envelope against project configuration and rate limits.
+///
+/// When `fetched`, then the project state is ensured to be up to date. When `cached`, an outdated
+/// project state may be used, or otherwise the envelope is passed through unaltered.
+///
+/// To check the envelope, this runs:
+///  - Validate origins and public keys
+///  - Quotas with a limit of `0`
+///  - Cached rate limits
+#[derive(Debug)]
+pub struct CheckEnvelope {
+    envelope: Envelope,
+    context: EnvelopeContext,
+}
+
+impl CheckEnvelope {
+    /// Uses a cached project state and checks the envelope.
+    pub fn new(envelope: Envelope, context: EnvelopeContext) -> Self {
+        Self { envelope, context }
+    }
+}
+
+/// Validates the envelope against project configuration and rate limits.
+///
+/// This ensures internally that the project state is up to date and then runs the same checks as
+/// [`CheckEnvelope`]. Once the envelope has been validated, remaining items are forwarded to the
+/// next stage:
+///
+///  - If the envelope needs dynamic sampling, this sends [`AddSamplingState`] to the
+///    [`ProjectCache`] to add the required project state.
+///  - Otherwise, the envelope is directly submitted to the [`EnvelopeProcessor`].
+///
+/// [`EnvelopeProcessor`]: crate::actors::processor::EnvelopeProcessor
+pub struct ValidateEnvelope {
+    envelope: Envelope,
+    context: EnvelopeContext,
+}
+
+impl ValidateEnvelope {
+    pub fn new(envelope: Envelope, context: EnvelopeContext) -> Self {
+        Self { envelope, context }
+    }
+}
+
+/// Adds the project state for dynamic sampling and sends the envelope to processing.
+///
+/// If the project state is up to date, the envelope will be immediately submitted for processing.
+/// Otherwise, this queues the envelope and flushes it when the project has been updated.
+///
+/// This message will trigger an update of the project state internally if the state is stale or
+/// outdated.
+pub struct AddSamplingState {
+    project_key: ProjectKey,
+    message: ProcessEnvelope,
+}
+
+impl AddSamplingState {
+    pub fn new(project_key: ProjectKey, message: ProcessEnvelope) -> Self {
+        Self {
+            project_key,
+            message,
+        }
+    }
+}
+
+pub struct UpdateRateLimits {
+    project_key: ProjectKey,
+    rate_limits: RateLimits,
+}
+
+impl UpdateRateLimits {
+    pub fn new(project_key: ProjectKey, rate_limits: RateLimits) -> UpdateRateLimits {
+        Self {
+            project_key,
+            rate_limits,
+        }
+    }
+}
+
+pub enum ProjectCache {
+    // TODO(ja): Rename to RequestUpdate or FetchProjectState
+    Update(UpdateProjectState),
+    Get(
+        GetProjectState,
+        Sender<Result<Arc<ProjectState>, ProjectError>>,
+    ),
+    GetCached(GetCachedProjectState, Sender<Option<Arc<ProjectState>>>),
+    CheckEnvelope(
+        CheckEnvelope,
+        Sender<Result<CheckedEnvelope, DiscardReason>>,
+    ),
+    ValidateEnvelope(ValidateEnvelope),
+    AddSamplingState(AddSamplingState),
+    UpdateRateLimits(UpdateRateLimits),
+    InsertMetrics(InsertMetrics),
+    MergeBuckets(MergeBuckets),
+    FlushBuckets(FlushBuckets),
 }
 
 impl ProjectCache {
+    pub fn from_registry() -> Addr<Self> {
+        REGISTRY.get().unwrap().project_cache.clone()
+    }
+}
+
+impl Interface for ProjectCache {}
+
+impl FromMessage<UpdateProjectState> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: UpdateProjectState, _: ()) -> Self {
+        Self::Update(message)
+    }
+}
+
+impl FromMessage<GetProjectState> for ProjectCache {
+    type Response = relay_system::AsyncResponse<Result<Arc<ProjectState>, ProjectError>>;
+
+    fn from_message(
+        message: GetProjectState,
+        sender: Sender<Result<Arc<ProjectState>, ProjectError>>,
+    ) -> Self {
+        Self::Get(message, sender)
+    }
+}
+
+impl FromMessage<GetCachedProjectState> for ProjectCache {
+    type Response = relay_system::AsyncResponse<Option<Arc<ProjectState>>>;
+
+    fn from_message(
+        message: GetCachedProjectState,
+        sender: Sender<Option<Arc<ProjectState>>>,
+    ) -> Self {
+        Self::GetCached(message, sender)
+    }
+}
+
+impl FromMessage<CheckEnvelope> for ProjectCache {
+    type Response = relay_system::AsyncResponse<Result<CheckedEnvelope, DiscardReason>>;
+
+    fn from_message(
+        message: CheckEnvelope,
+        sender: Sender<Result<CheckedEnvelope, DiscardReason>>,
+    ) -> Self {
+        Self::CheckEnvelope(message, sender)
+    }
+}
+
+impl FromMessage<ValidateEnvelope> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: ValidateEnvelope, _: ()) -> Self {
+        Self::ValidateEnvelope(message)
+    }
+}
+
+impl FromMessage<AddSamplingState> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: AddSamplingState, _: ()) -> Self {
+        Self::AddSamplingState(message)
+    }
+}
+
+impl FromMessage<UpdateRateLimits> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: UpdateRateLimits, _: ()) -> Self {
+        Self::UpdateRateLimits(message)
+    }
+}
+
+impl FromMessage<InsertMetrics> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: InsertMetrics, _: ()) -> Self {
+        Self::InsertMetrics(message)
+    }
+}
+
+impl FromMessage<MergeBuckets> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: MergeBuckets, _: ()) -> Self {
+        Self::MergeBuckets(message)
+    }
+}
+
+impl FromMessage<FlushBuckets> for ProjectCache {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: FlushBuckets, _: ()) -> Self {
+        Self::FlushBuckets(message)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ProjectSource {
+    config: Arc<Config>,
+    local_source: actix::Addr<LocalProjectSource>,
+    upstream_source: actix::Addr<UpstreamProjectSource>,
+    #[cfg(feature = "processing")]
+    redis_source: Option<actix::Addr<RedisProjectSource>>,
+}
+
+impl ProjectSource {
     pub fn new(config: Arc<Config>, _redis: Option<RedisPool>) -> Self {
         let local_source = LocalProjectSource::new(config.clone()).start();
         let upstream_source = UpstreamProjectSource::new(config.clone()).start();
@@ -70,14 +339,108 @@ impl ProjectCache {
             )
         });
 
-        ProjectCache {
+        Self {
             config,
-            projects: hashbrown::HashMap::new(),
             local_source,
             upstream_source,
             #[cfg(feature = "processing")]
             redis_source,
+        }
+    }
+
+    async fn fetch(
+        &self,
+        project_key: ProjectKey,
+        no_cache: bool,
+    ) -> Result<ProjectStateResponse, ()> {
+        // TODO(ja): Remove ProjectStateResponse
+        let state_opt = self
+            .local_source
+            .send(FetchOptionalProjectState { project_key })
+            .compat()
+            .await
+            .map_err(|_| ())?;
+
+        if let Some(state) = state_opt {
+            return Ok(ProjectStateResponse::new(state));
+        }
+
+        match self.config.relay_mode() {
+            RelayMode::Proxy => {
+                return Ok(ProjectStateResponse::new(Arc::new(ProjectState::allowed())));
+            }
+            RelayMode::Static => {
+                return Ok(ProjectStateResponse::new(Arc::new(ProjectState::missing())));
+            }
+            RelayMode::Capture => {
+                return Ok(ProjectStateResponse::new(Arc::new(ProjectState::allowed())));
+            }
+            RelayMode::Managed => {
+                // Proceed with loading the config from redis or upstream
+            }
+        }
+
+        #[cfg(not(feature = "processing"))]
+        let state_opt = None;
+
+        #[cfg(feature = "processing")]
+        let state_opt = if let Some(ref redis_source) = self.redis_source {
+            redis_source
+                .send(FetchOptionalProjectState { project_key })
+                .compat()
+                .await
+                .map_err(|_| ())?
+        } else {
+            None
+        };
+
+        if let Some(state) = state_opt {
+            return Ok(ProjectStateResponse::new(state));
+        }
+
+        Ok(self
+            .upstream_source
+            .send(FetchProjectState {
+                project_key,
+                no_cache,
+            })
+            .compat()
+            .await
+            .map_err(|_| ())??)
+    }
+}
+
+/// TODO(ja): Doc
+struct UpdateProjectState2 {
+    /// The public key to fetch the project by.
+    project_key: ProjectKey,
+
+    /// TODO(ja): Doc
+    state: Arc<ProjectState>,
+
+    /// If true, all caches should be skipped and a fresh state should be computed.
+    no_cache: bool,
+}
+
+pub struct ProjectCacheService {
+    config: Arc<Config>,
+    projects: hashbrown::HashMap<ProjectKey, Project>, // need hashbrown because drain_filter is not stable in std yet
+    garbage_disposal: GarbageDisposal<Project>,
+    source: ProjectSource,
+    inner: (
+        mpsc::UnboundedSender<UpdateProjectState2>,
+        mpsc::UnboundedReceiver<UpdateProjectState2>,
+    ),
+}
+
+impl ProjectCacheService {
+    pub fn new(config: Arc<Config>, redis: Option<RedisPool>) -> Self {
+        Self {
+            config,
+            projects: hashbrown::HashMap::new(),
             garbage_disposal: GarbageDisposal::new(),
+            source: ProjectSource::new(config, redis),
+            inner: mpsc::unbounded_channel(),
         }
     }
 
@@ -125,37 +488,158 @@ impl ProjectCache {
                 Project::new(project_key, config)
             })
     }
-}
 
-impl Actor for ProjectCache {
-    type Context = Context<Self>;
+    fn merge_state(&mut self, message: UpdateProjectState2) {
+        let UpdateProjectState2 {
+            project_key,
+            state,
+            no_cache,
+        } = message;
 
-    fn started(&mut self, context: &mut Self::Context) {
-        // Set the mailbox size to the size of the envelope buffer. This is a rough estimate but
-        // should ensure that we're not dropping messages if the main arbiter running this actor
-        // gets hammered a bit.
-        let mailbox_size = self.config.envelope_buffer_size();
-        context.set_mailbox_capacity(mailbox_size);
+        self.get_or_create_project(project_key)
+            .update_state(state, no_cache);
+    }
 
-        context.run_interval(self.config.cache_eviction_interval(), |slf, _| {
-            slf.evict_stale_project_caches()
+    async fn handle_update(&mut self, message: UpdateProjectState) {
+        let UpdateProjectState {
+            project_key,
+            no_cache,
+        } = message;
+
+        // Bump the update time of the project in our hashmap to evade eviction.
+        self.get_or_create_project(project_key)
+            .refresh_updated_timestamp();
+
+        let source = self.source.clone();
+        let sender = self.inner.0.clone();
+
+        tokio::spawn(async move {
+            let state = match source.fetch(project_key, no_cache).await {
+                Ok(response) => response.state,
+                Err(()) => Arc::new(ProjectState::err()),
+            };
+
+            let message = UpdateProjectState2 {
+                project_key,
+                state,
+                no_cache,
+            };
+
+            sender.send(message).ok();
         });
-
-        relay_log::info!("project cache started");
     }
 
-    fn stopped(&mut self, _ctx: &mut Self::Context) {
-        relay_log::info!("project cache stopped");
+    async fn handle_get(
+        &mut self,
+        message: GetProjectState,
+    ) -> Result<Arc<ProjectState>, ProjectError> {
+        self.get_or_create_project(message.project_key)
+            .get_or_fetch_state(message.no_cache)
+            .await // TODO(ja): This is evil
+    }
+
+    fn handle_get_cached(&mut self, message: GetCachedProjectState) -> Option<Arc<ProjectState>> {
+        let project = self.get_or_create_project(message.project_key);
+        project.get_or_fetch_state(false);
+        project.valid_state()
+    }
+
+    fn handle_check_envelope(
+        &mut self,
+        message: CheckEnvelope,
+    ) -> Result<CheckedEnvelope, DiscardReason> {
+        let project = self.get_or_create_project(message.envelope.meta().public_key());
+
+        // Preload the project cache so that it arrives a little earlier in processing. However,
+        // do not pass `no_cache`. In case the project is rate limited, we do not want to force
+        // a full reload. Fetching must not block the store request.
+        project.get_or_fetch_state(false);
+
+        project.check_envelope(message.envelope, message.context)
+    }
+
+    fn handle_validate_envelope(&mut self, message: ValidateEnvelope) {
+        // Preload the project cache for dynamic sampling in parallel to the main one.
+        if let Some(sampling_key) = utils::get_sampling_key(&message.envelope) {
+            self.get_or_create_project(sampling_key)
+                .get_or_fetch_state(message.envelope.meta().no_cache());
+        }
+
+        self.get_or_create_project(message.envelope.meta().public_key())
+            .enqueue_validation(message.envelope, message.context);
+    }
+
+    fn handle_add_sampling_state(&mut self, message: AddSamplingState) {
+        self.get_or_create_project(message.project_key)
+            .enqueue_sampling(message.message);
+    }
+
+    fn handle_rate_limits(&mut self, message: UpdateRateLimits) {
+        self.get_or_create_project(message.project_key)
+            .merge_rate_limits(message.rate_limits);
+    }
+
+    fn handle_insert_metrics(&mut self, message: InsertMetrics) {
+        // Only keep if we have an aggregator, otherwise drop because we know that we were disabled.
+        self.get_or_create_project(message.project_key())
+            .insert_metrics(message.metrics());
+    }
+
+    fn handle_merge_buckets(&mut self, message: MergeBuckets) {
+        // Only keep if we have an aggregator, otherwise drop because we know that we were disabled.
+        self.get_or_create_project(message.project_key())
+            .merge_buckets(message.buckets());
+    }
+
+    fn handle_flush_buckets(&mut self, message: FlushBuckets) {
+        self.get_or_create_project(message.project_key)
+            .flush_buckets(message.partition_key, message.buckets);
+        // TODO
+    }
+
+    async fn handle_message(&mut self, message: ProjectCache) {
+        match message {
+            ProjectCache::Update(message) => self.handle_update(message).await,
+            // TODO(ja): This await is evil.
+            ProjectCache::Get(message, sender) => sender.send(self.handle_get(message).await),
+            ProjectCache::GetCached(message, sender) => {
+                sender.send(self.handle_get_cached(message))
+            }
+            ProjectCache::CheckEnvelope(message, sender) => {
+                sender.send(self.handle_check_envelope(message))
+            }
+            ProjectCache::ValidateEnvelope(message) => self.handle_validate_envelope(message),
+            ProjectCache::AddSamplingState(message) => self.handle_add_sampling_state(message),
+            ProjectCache::UpdateRateLimits(message) => self.handle_rate_limits(message),
+            ProjectCache::InsertMetrics(message) => self.handle_insert_metrics(message),
+            ProjectCache::MergeBuckets(message) => self.handle_merge_buckets(message),
+            ProjectCache::FlushBuckets(message) => self.handle_flush_buckets(message),
+        }
     }
 }
 
-impl Supervised for ProjectCache {}
+impl Service for ProjectCacheService {
+    type Interface = ProjectCache;
 
-impl SystemService for ProjectCache {}
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            relay_log::info!("project cache started");
 
-impl Default for ProjectCache {
-    fn default() -> Self {
-        unimplemented!("register with the SystemRegistry instead")
+            loop {
+                tokio::select! {
+                    biased;
+
+                    Some(message) = self.inner.1.recv() => self.merge_state(message),
+                    // context.run_interval(self.config.cache_eviction_interval(), |slf, _| {
+                    //     slf.evict_stale_project_caches()
+                    // });
+                    Some(message) = rx.recv() => self.handle_message(message).await,
+                    else => break,
+                }
+            }
+
+            relay_log::info!("project cache stopped");
+        });
     }
 }
 
@@ -196,467 +680,4 @@ impl FetchOptionalProjectState {
 
 impl Message for FetchOptionalProjectState {
     type Result = Option<Arc<ProjectState>>;
-}
-
-/// Fetches a project state from one of the available sources.
-///
-/// The project state is resolved in the following precedence:
-///
-///  1. Local file system
-///  2. Redis cache (processing mode only)
-///  3. Upstream (managed and processing mode only)
-///
-/// Requests to the upstream are performed via `UpstreamProjectSource`, which internally batches
-/// individual requests.
-#[derive(Clone)]
-pub struct UpdateProjectState {
-    /// The public key to fetch the project by.
-    project_key: ProjectKey,
-
-    /// If true, all caches should be skipped and a fresh state should be computed.
-    no_cache: bool,
-}
-
-impl UpdateProjectState {
-    pub fn new(project_key: ProjectKey, no_cache: bool) -> Self {
-        Self {
-            project_key,
-            no_cache,
-        }
-    }
-}
-
-impl Message for UpdateProjectState {
-    type Result = ();
-}
-
-impl Handler<UpdateProjectState> for ProjectCache {
-    type Result = ();
-
-    fn handle(&mut self, message: UpdateProjectState, context: &mut Self::Context) -> Self::Result {
-        let UpdateProjectState {
-            project_key,
-            no_cache,
-        } = message;
-
-        let project = self.get_or_create_project(project_key);
-
-        // Bump the update time of the project in our hashmap to evade eviction.
-        project.refresh_updated_timestamp();
-
-        let relay_mode = self.config.relay_mode();
-
-        let upstream_source = self.upstream_source.clone();
-        #[cfg(feature = "processing")]
-        let redis_source = self.redis_source.clone();
-
-        self.local_source
-            .send(FetchOptionalProjectState { project_key })
-            .map_err(|_| ())
-            .and_then(move |response| {
-                if let Some(state) = response {
-                    return Box::new(future::ok(ProjectStateResponse::new(state)))
-                        as ResponseFuture<_, _>;
-                }
-
-                match relay_mode {
-                    RelayMode::Proxy => {
-                        return Box::new(future::ok(ProjectStateResponse::new(Arc::new(
-                            ProjectState::allowed(),
-                        ))));
-                    }
-                    RelayMode::Static => {
-                        return Box::new(future::ok(ProjectStateResponse::new(Arc::new(
-                            ProjectState::missing(),
-                        ))));
-                    }
-                    RelayMode::Capture => {
-                        return Box::new(future::ok(ProjectStateResponse::new(Arc::new(
-                            ProjectState::allowed(),
-                        ))));
-                    }
-                    RelayMode::Managed => {
-                        // Proceed with loading the config from redis or upstream
-                    }
-                }
-
-                #[cfg(not(feature = "processing"))]
-                let fetch_redis = future::ok(None);
-
-                #[cfg(feature = "processing")]
-                let fetch_redis: ResponseFuture<_, _> = if let Some(ref redis_source) = redis_source
-                {
-                    Box::new(
-                        redis_source
-                            .send(FetchOptionalProjectState { project_key })
-                            .map_err(|_| ()),
-                    )
-                } else {
-                    Box::new(future::ok(None))
-                };
-
-                let fetch_redis = fetch_redis.and_then(move |response| {
-                    if let Some(state) = response {
-                        return Box::new(future::ok(ProjectStateResponse::new(state)))
-                            as ResponseFuture<_, _>;
-                    }
-
-                    let fetch_upstream = upstream_source
-                        .send(FetchProjectState {
-                            project_key,
-                            no_cache,
-                        })
-                        .map_err(|_| ())
-                        .and_then(move |result| result.map_err(|_| ()));
-
-                    Box::new(fetch_upstream)
-                });
-
-                Box::new(fetch_redis)
-            })
-            .into_actor(self)
-            .then(move |state_result, slf, _context| {
-                let state = match state_result {
-                    Ok(response) => response.state,
-                    Err(()) => Arc::new(ProjectState::err()),
-                };
-
-                slf.get_or_create_project(project_key)
-                    .update_state(state, no_cache);
-
-                fut::ok(())
-            })
-            .spawn(context);
-    }
-}
-
-/// Returns the project state.
-///
-/// The project state is fetched if it is missing or outdated. If `no_cache` is specified, then the
-/// state is always refreshed.
-#[derive(Debug)]
-pub struct GetProjectState {
-    project_key: ProjectKey,
-    no_cache: bool,
-}
-
-impl GetProjectState {
-    /// Fetches the project state and uses the cached version if up-to-date.
-    pub fn new(project_key: ProjectKey) -> Self {
-        Self {
-            project_key,
-            no_cache: false,
-        }
-    }
-
-    /// Fetches the project state and conditionally skips the cache.
-    pub fn no_cache(mut self, no_cache: bool) -> Self {
-        self.no_cache = no_cache;
-        self
-    }
-}
-
-impl Message for GetProjectState {
-    type Result = Result<Arc<ProjectState>, ProjectError>;
-}
-
-impl Handler<GetProjectState> for ProjectCache {
-    type Result = Response<Arc<ProjectState>, ProjectError>;
-
-    fn handle(&mut self, message: GetProjectState, _context: &mut Context<Self>) -> Self::Result {
-        let project = self.get_or_create_project(message.project_key);
-        project.get_or_fetch_state(message.no_cache)
-    }
-}
-
-/// Returns the project state if it is already cached.
-///
-/// This is used for cases when we only want to perform operations that do
-/// not require waiting for network requests.
-#[derive(Debug)]
-pub struct GetCachedProjectState {
-    project_key: ProjectKey,
-}
-
-impl GetCachedProjectState {
-    pub fn new(project_key: ProjectKey) -> Self {
-        Self { project_key }
-    }
-}
-
-impl Message for GetCachedProjectState {
-    type Result = Option<Arc<ProjectState>>;
-}
-
-impl Handler<GetCachedProjectState> for ProjectCache {
-    type Result = Option<Arc<ProjectState>>;
-
-    fn handle(
-        &mut self,
-        message: GetCachedProjectState,
-        _context: &mut Context<Self>,
-    ) -> Self::Result {
-        let project = self.get_or_create_project(message.project_key);
-        project.get_or_fetch_state(false);
-        project.valid_state()
-    }
-}
-
-/// Checks the envelope against project configuration and rate limits.
-///
-/// When `fetched`, then the project state is ensured to be up to date. When `cached`, an outdated
-/// project state may be used, or otherwise the envelope is passed through unaltered.
-///
-/// To check the envelope, this runs:
-///  - Validate origins and public keys
-///  - Quotas with a limit of `0`
-///  - Cached rate limits
-#[derive(Debug)]
-pub struct CheckEnvelope {
-    envelope: Envelope,
-    context: EnvelopeContext,
-}
-
-impl CheckEnvelope {
-    /// Uses a cached project state and checks the envelope.
-    pub fn new(envelope: Envelope, context: EnvelopeContext) -> Self {
-        Self { envelope, context }
-    }
-}
-
-/// A checked envelope and associated rate limits.
-///
-/// Items violating the rate limits have been removed from the envelope. If all items are removed
-/// from the envelope, `None` is returned in place of the envelope.
-#[derive(Debug)]
-pub struct CheckedEnvelope {
-    pub envelope: Option<(Envelope, EnvelopeContext)>,
-    pub rate_limits: RateLimits,
-}
-
-impl Message for CheckEnvelope {
-    type Result = Result<CheckedEnvelope, DiscardReason>;
-}
-
-impl Handler<CheckEnvelope> for ProjectCache {
-    type Result = Result<CheckedEnvelope, DiscardReason>;
-
-    fn handle(&mut self, message: CheckEnvelope, _: &mut Self::Context) -> Self::Result {
-        let project = self.get_or_create_project(message.envelope.meta().public_key());
-
-        // Preload the project cache so that it arrives a little earlier in processing. However,
-        // do not pass `no_cache`. In case the project is rate limited, we do not want to force
-        // a full reload. Fetching must not block the store request.
-        project.get_or_fetch_state(false);
-
-        project.check_envelope(message.envelope, message.context)
-    }
-}
-
-/// Validates the envelope against project configuration and rate limits.
-///
-/// This ensures internally that the project state is up to date and then runs the same checks as
-/// [`CheckEnvelope`]. Once the envelope has been validated, remaining items are forwarded to the
-/// next stage:
-///
-///  - If the envelope needs dynamic sampling, this sends [`AddSamplingState`] to the
-///    [`ProjectCache`] to add the required project state.
-///  - Otherwise, the envelope is directly submitted to the [`EnvelopeProcessor`].
-///
-/// [`EnvelopeProcessor`]: crate::actors::processor::EnvelopeProcessor
-pub struct ValidateEnvelope {
-    envelope: Envelope,
-    context: EnvelopeContext,
-}
-
-impl ValidateEnvelope {
-    pub fn new(envelope: Envelope, context: EnvelopeContext) -> Self {
-        Self { envelope, context }
-    }
-}
-
-impl Message for ValidateEnvelope {
-    type Result = ();
-}
-
-impl Handler<ValidateEnvelope> for ProjectCache {
-    type Result = ();
-
-    fn handle(&mut self, message: ValidateEnvelope, _: &mut Self::Context) -> Self::Result {
-        // Preload the project cache for dynamic sampling in parallel to the main one.
-        if let Some(sampling_key) = utils::get_sampling_key(&message.envelope) {
-            self.get_or_create_project(sampling_key)
-                .get_or_fetch_state(message.envelope.meta().no_cache());
-        }
-
-        self.get_or_create_project(message.envelope.meta().public_key())
-            .enqueue_validation(message.envelope, message.context);
-    }
-}
-
-/// Adds the project state for dynamic sampling and sends the envelope to processing.
-///
-/// If the project state is up to date, the envelope will be immediately submitted for processing.
-/// Otherwise, this queues the envelope and flushes it when the project has been updated.
-///
-/// This message will trigger an update of the project state internally if the state is stale or
-/// outdated.
-pub struct AddSamplingState {
-    project_key: ProjectKey,
-    message: ProcessEnvelope,
-}
-
-impl AddSamplingState {
-    pub fn new(project_key: ProjectKey, message: ProcessEnvelope) -> Self {
-        Self {
-            project_key,
-            message,
-        }
-    }
-}
-
-impl Message for AddSamplingState {
-    type Result = ();
-}
-
-impl Handler<AddSamplingState> for ProjectCache {
-    type Result = ();
-
-    fn handle(&mut self, message: AddSamplingState, _: &mut Self::Context) -> Self::Result {
-        self.get_or_create_project(message.project_key)
-            .enqueue_sampling(message.message);
-    }
-}
-
-pub struct UpdateRateLimits {
-    project_key: ProjectKey,
-    rate_limits: RateLimits,
-}
-
-impl UpdateRateLimits {
-    pub fn new(project_key: ProjectKey, rate_limits: RateLimits) -> UpdateRateLimits {
-        Self {
-            project_key,
-            rate_limits,
-        }
-    }
-}
-
-impl Message for UpdateRateLimits {
-    type Result = ();
-}
-
-impl Handler<UpdateRateLimits> for ProjectCache {
-    type Result = ();
-
-    fn handle(&mut self, message: UpdateRateLimits, _context: &mut Self::Context) -> Self::Result {
-        let UpdateRateLimits {
-            project_key,
-            rate_limits,
-        } = message;
-        let project = self.get_or_create_project(project_key);
-        project.merge_rate_limits(rate_limits);
-    }
-}
-
-impl Handler<InsertMetrics> for ProjectCache {
-    type Result = Result<(), AggregateMetricsError>;
-
-    fn handle(&mut self, message: InsertMetrics, _context: &mut Self::Context) -> Self::Result {
-        // Only keep if we have an aggregator, otherwise drop because we know that we were disabled.
-        let project = self.get_or_create_project(message.project_key());
-        project.insert_metrics(message.metrics());
-        Ok(())
-    }
-}
-
-impl Handler<MergeBuckets> for ProjectCache {
-    type Result = Result<(), AggregateMetricsError>;
-
-    fn handle(&mut self, message: MergeBuckets, _context: &mut Self::Context) -> Self::Result {
-        // Only keep if we have an aggregator, otherwise drop because we know that we were disabled.
-        let project = self.get_or_create_project(message.project_key());
-        project.merge_buckets(message.buckets());
-        Ok(())
-    }
-}
-
-impl Handler<FlushBuckets> for ProjectCache {
-    type Result = ();
-
-    fn handle(&mut self, message: FlushBuckets, _context: &mut Self::Context) -> Self::Result {
-        let FlushBuckets {
-            project_key,
-            partition_key,
-            buckets,
-        } = message;
-
-        let config = self.config.clone();
-        let project = self.get_or_create_project(project_key);
-        let expiry_state = project.expiry_state();
-
-        // Schedule an update to the project state if it is outdated, regardless of whether the
-        // metrics can be forwarded or not. We never wait for this update.
-        project.get_or_fetch_state(false);
-
-        let project_state = match expiry_state {
-            ExpiryState::Updated(state) | ExpiryState::Stale(state) => state,
-            ExpiryState::Expired => {
-                relay_log::trace!("project expired: merging back {} buckets", buckets.len());
-                // If the state is outdated, we need to wait for an updated state. Put them back into the
-                // aggregator.
-                Registry::aggregator().send(MergeBuckets::new(project_key, buckets));
-                return;
-            }
-        };
-
-        let scoping = match project.scoping() {
-            Some(scoping) => scoping,
-            _ => {
-                relay_log::trace!(
-                    "there is no scoping: merging back {} buckets",
-                    buckets.len()
-                );
-                Registry::aggregator().send(MergeBuckets::new(project_key, buckets));
-                return;
-            }
-        };
-
-        // Only send if the project state is valid, otherwise drop this bucket.
-        if project_state.check_disabled(config.as_ref()).is_err() {
-            return;
-        }
-
-        // Check rate limits if necessary:
-        let quotas = project_state.config.quotas.clone();
-        let buckets = match MetricsLimiter::create(buckets, quotas, scoping) {
-            Ok(mut bucket_limiter) => {
-                let cached_rate_limits = project.rate_limits().clone();
-                #[allow(unused_variables)]
-                let was_rate_limited = bucket_limiter.enforce_limits(Ok(&cached_rate_limits));
-
-                #[cfg(feature = "processing")]
-                if !was_rate_limited && config.processing_enabled() {
-                    // If there were no cached rate limits active, let the processor check redis:
-                    EnvelopeProcessor::from_registry().send(RateLimitFlushBuckets {
-                        bucket_limiter,
-                        partition_key,
-                    });
-
-                    return;
-                }
-
-                bucket_limiter.into_metrics()
-            }
-            Err(buckets) => buckets,
-        };
-
-        if !buckets.is_empty() {
-            EnvelopeManager::from_registry().send(SendMetrics {
-                buckets,
-                scoping,
-                partition_key,
-            });
-        }
-    }
 }

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use actix::prelude::{Actor, Message, SyncArbiter};
+use actix::{Actor, Message};
 use actix_web::ResponseError;
 use failure::Fail;
 use futures::compat::Future01CompatExt;
@@ -26,7 +26,7 @@ use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::{self, EnvelopeContext, GarbageDisposal};
 
 #[cfg(feature = "processing")]
-use {crate::actors::project_redis::RedisProjectSource, relay_common::clone};
+use {crate::actors::project_redis::RedisProjectSource, actix::SyncArbiter, relay_common::clone};
 
 #[derive(Fail, Debug, Clone)]
 pub enum ProjectError {

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -194,6 +194,21 @@ impl UpdateRateLimits {
     }
 }
 
+/// A cache for [`ProjectState`]s.
+///
+/// The project maintains information about organizations, projects, and project keys along with
+/// settings required to ingest traffic to Sentry. Internally, it tries to keep information
+/// up-to-date and automatically retires unused old data.
+///
+/// To retrieve information from the cache, use [`GetProjectState`] for guaranteed up-to-date
+/// information, or [`GetCachedProjectState`] for immediately available but potentially older
+/// information.
+///
+/// There are also higher-level operations, such as [`CheckEnvelope`] and [`ValidateEnvelope`] that
+/// inspect contents of envelopes for ingestion, as well as [`InsertMetrics`] and [`MergeBuckets`]
+/// to aggregate metrics associated with a project.
+///
+/// See the enumerated variants for a full list of available messages for this service.
 pub enum ProjectCache {
     RequestUpdate(RequestUpdate),
     Get(GetProjectState, ProjectSender),
@@ -304,6 +319,9 @@ impl FromMessage<FlushBuckets> for ProjectCache {
     }
 }
 
+/// Helper type that contains all configured sources for project cache fetching.
+///
+/// See [`RequestUpdate`] for a description on how project states are fetched.
 #[derive(Clone, Debug)]
 struct ProjectSource {
     config: Arc<Config>,
@@ -410,6 +428,7 @@ struct UpdateProjectState {
     no_cache: bool,
 }
 
+/// Service implementing the [`ProjectCache`] interface.
 pub struct ProjectCacheService {
     config: Arc<Config>,
     projects: hashbrown::HashMap<ProjectKey, Project>, // need hashbrown because drain_filter is not stable in std yet

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -16,6 +16,7 @@ use relay_log::LogError;
 use crate::actors::project::ProjectState;
 use crate::actors::project_cache::FetchOptionalProjectState;
 
+#[derive(Debug)]
 pub struct LocalProjectSource {
     config: Arc<Config>,
     local_states: HashMap<ProjectKey, Arc<ProjectState>>,

--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -12,6 +12,7 @@ use crate::actors::project::ProjectState;
 use crate::actors::project_cache::FetchOptionalProjectState;
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 
+#[derive(Debug)]
 pub struct RedisProjectSource {
     config: Arc<Config>,
     redis: RedisPool,

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -106,6 +106,7 @@ impl ProjectStateChannel {
     }
 }
 
+#[derive(Debug)]
 pub struct UpstreamProjectSource {
     backoff: RetryBackoff,
     config: Arc<Config>,

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -218,8 +218,11 @@ impl ServiceState {
         }
 
         let guard = aggregator_runtime.enter();
-        let aggregator =
-            AggregatorService::new(config.aggregator_config(), Some(project_cache.clone())).start();
+        let aggregator = AggregatorService::new(
+            config.aggregator_config(),
+            Some(project_cache.clone().recipient()),
+        )
+        .start();
         drop(guard);
 
         REGISTRY

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -18,7 +18,7 @@ use crate::actors::health_check::{HealthCheck, HealthCheckService};
 use crate::actors::outcome::{OutcomeProducer, OutcomeProducerService, TrackOutcome};
 use crate::actors::outcome_aggregator::OutcomeAggregator;
 use crate::actors::processor::{EnvelopeProcessor, EnvelopeProcessorService};
-use crate::actors::project_cache::ProjectCache;
+use crate::actors::project_cache::{ProjectCache, ProjectCacheService};
 use crate::actors::relays::{RelayCache, RelayCacheService};
 #[cfg(feature = "processing")]
 use crate::actors::store::StoreService;
@@ -121,6 +121,7 @@ pub struct Registry {
     pub envelope_manager: Addr<EnvelopeManager>,
     pub test_store: Addr<TestStore>,
     pub relay_cache: Addr<RelayCache>,
+    pub project_cache: Addr<ProjectCache>,
 }
 
 impl Registry {
@@ -153,6 +154,7 @@ pub struct ServiceState {
     _aggregator_runtime: Arc<tokio::runtime::Runtime>,
     _outcome_runtime: Arc<tokio::runtime::Runtime>,
     _main_runtime: Arc<tokio::runtime::Runtime>,
+    _project_runtime: Arc<tokio::runtime::Runtime>,
     _store_runtime: Option<Arc<tokio::runtime::Runtime>>,
 }
 
@@ -163,6 +165,7 @@ impl ServiceState {
         let registry = system.registry();
 
         let main_runtime = utils::create_runtime(config.cpu_concurrency());
+        let project_runtime = utils::create_runtime(1);
         let aggregator_runtime = utils::create_runtime(1);
         let outcome_runtime = utils::create_runtime(1);
         let mut _store_runtime = None;
@@ -201,9 +204,9 @@ impl ServiceState {
         let envelope_manager = envelope_manager.start();
         let test_store = TestStoreService::new(config.clone()).start();
 
-        let project_cache = ProjectCache::new(config.clone(), redis_pool);
-        let project_cache = Arbiter::start(|_| project_cache);
-        registry.set(project_cache.clone());
+        let guard = project_runtime.enter();
+        let project_cache = ProjectCacheService::new(config.clone(), redis_pool).start();
+        drop(guard);
 
         let health_check = HealthCheckService::new(config.clone()).start();
         let relay_cache = RelayCacheService::new(config.clone()).start();
@@ -216,8 +219,7 @@ impl ServiceState {
 
         let guard = aggregator_runtime.enter();
         let aggregator =
-            AggregatorService::new(config.aggregator_config(), Some(project_cache.recipient()))
-                .start();
+            AggregatorService::new(config.aggregator_config(), Some(project_cache.clone())).start();
         drop(guard);
 
         REGISTRY
@@ -230,6 +232,7 @@ impl ServiceState {
                 envelope_manager,
                 test_store,
                 relay_cache,
+                project_cache,
             }))
             .unwrap();
 
@@ -239,6 +242,7 @@ impl ServiceState {
             _aggregator_runtime: Arc::new(aggregator_runtime),
             _outcome_runtime: Arc::new(outcome_runtime),
             _main_runtime: Arc::new(main_runtime),
+            _project_runtime: Arc::new(project_runtime),
             _store_runtime: _store_runtime.map(Arc::new),
         })
     }

--- a/relay-server/src/utils/actix.rs
+++ b/relay-server/src/utils/actix.rs
@@ -16,7 +16,7 @@ pub fn create_runtime(threads: usize) -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(threads)
         .enable_all()
-        .on_thread_start(|| System::set_current(system.clone()))
+        .on_thread_start(move || System::set_current(system.clone()))
         .build()
         .unwrap()
 }

--- a/relay-server/src/utils/actix.rs
+++ b/relay-server/src/utils/actix.rs
@@ -1,53 +1,5 @@
-use ::actix::dev::{MessageResponse, ResponseChannel};
-use ::actix::prelude::*;
-use futures01::prelude::*;
+use actix::System;
 use tokio::runtime::Runtime;
-
-use relay_common::clone;
-
-pub enum Response<T, E> {
-    Reply(Result<T, E>),
-    Future(ResponseFuture<T, E>),
-}
-
-impl<T, E> Response<T, E> {
-    pub fn ok(value: T) -> Self {
-        Response::Reply(Ok(value))
-    }
-
-    pub fn future<F>(future: F) -> Self
-    where
-        F: IntoFuture<Item = T, Error = E>,
-        F::Future: 'static,
-    {
-        Response::Future(Box::new(future.into_future()))
-    }
-}
-
-impl<A, M, T: 'static, E: 'static> MessageResponse<A, M> for Response<T, E>
-where
-    A: Actor,
-    M: Message<Result = Result<T, E>>,
-    A::Context: AsyncContext<A>,
-{
-    fn handle<R: ResponseChannel<M>>(self, _context: &mut A::Context, tx: Option<R>) {
-        match self {
-            Response::Future(fut) => {
-                Arbiter::spawn(fut.then(move |res| {
-                    if let Some(tx) = tx {
-                        tx.send(res);
-                    }
-                    Ok(())
-                }));
-            }
-            Response::Reply(res) => {
-                if let Some(tx) = tx {
-                    tx.send(res);
-                }
-            }
-        }
-    }
-}
 
 /// Constructs a tokio [`Runtime`] configured for running [services](relay_system::Service).
 ///
@@ -64,7 +16,7 @@ pub fn create_runtime(threads: usize) -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(threads)
         .enable_all()
-        .on_thread_start(clone!(system, || System::set_current(system.clone())))
+        .on_thread_start(|| System::set_current(system.clone()))
         .build()
         .unwrap()
 }

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -654,7 +654,7 @@ pub trait FromMessage<M>: Interface {
 }
 
 /// Abstraction over address types for service channels.
-trait SendDispatch<M> {
+trait SendDispatch<M>: Send + Sync {
     /// The behavior declaring the return value when sending this message.
     ///
     /// When this is implemented for a type bound to an [`Interface`], this is the same behavior as

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -16,4 +16,3 @@ futures01 = { version = "0.1.28", package = "futures" }
 relay-log = { path = "../relay-log", features = ["test"] }
 relay-system = { path = "../relay-system" }
 tokio = "1.0"
-tokio-timer = "0.2.13"


### PR DESCRIPTION
Migrates the `ProjectCache` to a tokio-based Service. This includes changes to the inner workings of `Project` and `ProjectCache`:

- In addition to caching project states, the actor also dispatched requests for new states to the local-, Redis- and upstream sources. This message still exists, but the entire dispatch is now factored into the `ProjectSource` utility. Each lookup runs in its own task and does not hold (mutable) access of the cache. In a follow-up, the source utility can be further factored out of the project cache service.
- The `GetProjectState` created futures that resolves when the state has fetched. If projects cannot be resolved for longer periods of time, this accumulated many futures that slowed down the actor. The service now uses recently introduced `BroadcastChannels` and immediately end processing the incoming message. This means guaranteed responsiveness of the service independent of how many `GetProjectState` messages are sent in.
- Since the project fetch is now decoupled from the main service, there is a new internal channel to send resolved states back into the cache. The former message to trigger an update has been renamed to `RequestUpdate` for clarity.
- `FlushBuckets` was implemented directly in the project cache, while all other message handlers call through to a method on `Project`. The functionality is now moved to `Project`.
- The public `Project::get_or_fetch_state` function was used to probe for cached state, wait for loaded state, or trigger a prefetch for later access. These are now separate methods to make the intent more clear. Internally, they still rely on a common stub for simplicity.

Additionally, related utilities are updated:

- The metrics aggregator provided a hook to subscribe to flushed buckets. This was still implemented as `actix` recipient. Now that the project cache is migrated, it was possible and required to move the remaining bit of the aggregator to tokio as well. It works in the same way, just that this is now a `relay-system::Recipient`.
- To move metrics unit tests away from `actix`, the aggregator now uses `tokio::time::Instant`. This allows to [auto-advance](https://docs.rs/tokio/latest/tokio/time/fn.pause.html#auto-advance) time and use mocked time during tests.
- Similar to other services, the project cache subscribes to shutdown notifications before it accepts messages. This complicated tests, since the `Controller` internally still requires `actix`. For this reason, the subscribe mechanism was changed so that it always returns a `ShutdownHandle`, regardless of whether the controller runs or not.

Tracked by #1602 
Requires #1619 
Requires #1622 

#skip-changelog
