### PR TITLE
fix(profiling): Parse string as number to handle a release bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Emit a `service.back_pressure` metric that measures internal back pressure by service. ([#1583](https://github.com/getsentry/relay/pull/1583))
 - Track metrics for OpenTelemetry events. ([#1618](https://github.com/getsentry/relay/pull/1618))
 - Normalize transaction name for URLs transaction source, by replacing UUIDs, SHAs and numerical IDs in transaction names by placeholders. ([#1621](https://github.com/getsentry/relay/pull/1621))
+- Parse string as number to handle a release bug. ([#1637](https://github.com/getsentry/relay/pull/1637))
 
 ## 22.11.0
 

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -25,3 +25,20 @@ pub enum MeasurementUnit {
     #[serde(alias = "hz")]
     Hertz,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_value_as_float() {
+        let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":1234.56789}"#;
+        assert!(serde_json::from_str::<MeasurementValue>(measurement_json).is_ok());
+    }
+
+    #[test]
+    fn test_value_as_string() {
+        let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"1234.56789"}"#;
+        assert!(serde_json::from_str::<MeasurementValue>(measurement_json).is_ok());
+    }
+}

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -13,6 +13,8 @@ pub struct MeasurementValue {
     // nanoseconds elapsed since the start of the profile
     #[serde(deserialize_with = "deserialize_number_from_string")]
     elapsed_since_start_ns: u64,
+
+    // Android 6.8.0 sends a string instead of a float64 so we need to accept both
     #[serde(deserialize_with = "deserialize_number_from_string")]
     value: f64,
 }

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -13,6 +13,7 @@ pub struct MeasurementValue {
     // nanoseconds elapsed since the start of the profile
     #[serde(deserialize_with = "deserialize_number_from_string")]
     elapsed_since_start_ns: u64,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
     value: f64,
 }
 


### PR DESCRIPTION
Android SDK 6.8.0 went out sending a string in the `value` field. This is technically a bug but since the release is out, we'd like to accommodate it instead of rejecting profiles.