### PR TITLE
fix(server): Forward-compatible AttachmentType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Dynamic sampling is now based on the volume received by Relay by default and does not include the original volume dropped by client-side sampling in SDKs. This is required for the final dynamic sampling feature in the latest Sentry plans. ([#1591](https://github.com/getsentry/relay/pull/1591))
 - Add OpenTelemetry Context ([#1617](https://github.com/getsentry/relay/pull/1617))
 - Add `app.in_foreground` and `thread.main` flag to protocol. ([#1578](https://github.com/getsentry/relay/pull/1578))
+
+**Bug Fixes**:
 - Make `attachment_type` on envelope items forward compatible by adding fallback variant. ([#1638](https://github.com/getsentry/relay/pull/1638))
 
 **Internal**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Dynamic sampling is now based on the volume received by Relay by default and does not include the original volume dropped by client-side sampling in SDKs. This is required for the final dynamic sampling feature in the latest Sentry plans. ([#1591](https://github.com/getsentry/relay/pull/1591))
 - Add OpenTelemetry Context ([#1617](https://github.com/getsentry/relay/pull/1617))
+- Make `attachment_type` on envelope items forward compatible by adding fallback variant. ([#1638](https://github.com/getsentry/relay/pull/1638))
 
 **Internal**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1471,11 +1471,11 @@ impl EnvelopeProcessorService {
         let raw_security_item = envelope.take_item_by(|item| item.ty() == &ItemType::RawSecurity);
         let form_item = envelope.take_item_by(|item| item.ty() == &ItemType::FormData);
         let attachment_item = envelope
-            .take_item_by(|item| item.attachment_type() == Some(AttachmentType::EventPayload));
+            .take_item_by(|item| item.attachment_type() == Some(&AttachmentType::EventPayload));
         let breadcrumbs1 = envelope
-            .take_item_by(|item| item.attachment_type() == Some(AttachmentType::Breadcrumbs));
+            .take_item_by(|item| item.attachment_type() == Some(&AttachmentType::Breadcrumbs));
         let breadcrumbs2 = envelope
-            .take_item_by(|item| item.attachment_type() == Some(AttachmentType::Breadcrumbs));
+            .take_item_by(|item| item.attachment_type() == Some(&AttachmentType::Breadcrumbs));
 
         // Event items can never occur twice in an envelope.
         if let Some(duplicate) = envelope.get_item_by(|item| self.is_duplicate(item)) {
@@ -1550,9 +1550,9 @@ impl EnvelopeProcessorService {
         let envelope = &mut state.envelope;
 
         let minidump_attachment =
-            envelope.get_item_by(|item| item.attachment_type() == Some(AttachmentType::Minidump));
+            envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
         let apple_crash_report_attachment = envelope
-            .get_item_by(|item| item.attachment_type() == Some(AttachmentType::AppleCrashReport));
+            .get_item_by(|item| item.attachment_type() == Some(&AttachmentType::AppleCrashReport));
 
         if let Some(item) = minidump_attachment {
             let event = state.event.get_or_insert_with(Event::default);
@@ -1608,7 +1608,7 @@ impl EnvelopeProcessorService {
 
             let attachment_size = envelope
                 .items()
-                .filter(|item| item.attachment_type() == Some(AttachmentType::Attachment))
+                .filter(|item| item.attachment_type() == Some(&AttachmentType::Attachment))
                 .map(|item| item.len() as u64)
                 .sum::<u64>();
 
@@ -1896,7 +1896,7 @@ impl EnvelopeProcessorService {
         let envelope = &mut state.envelope;
         if let Some(ref config) = state.project_state.config.pii_config {
             let minidump = envelope
-                .get_item_by_mut(|item| item.attachment_type() == Some(AttachmentType::Minidump));
+                .get_item_by_mut(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
 
             if let Some(item) = minidump {
                 let filename = item.filename().unwrap_or_default();

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -316,10 +316,7 @@ impl StoreService {
             content_type: item
                 .content_type()
                 .map(|content_type| content_type.as_str().to_owned()),
-            attachment_type: item
-                .attachment_type()
-                .unwrap_or(&AttachmentType::default())
-                .clone(),
+            attachment_type: item.attachment_type().cloned().unwrap_or_default(),
             chunks: chunk_index,
             size: Some(size),
             rate_limited: Some(item.rate_limited()),

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -316,7 +316,10 @@ impl StoreService {
             content_type: item
                 .content_type()
                 .map(|content_type| content_type.as_str().to_owned()),
-            attachment_type: item.attachment_type().unwrap_or_default(),
+            attachment_type: item
+                .attachment_type()
+                .unwrap_or(&AttachmentType::default())
+                .clone(),
             chunks: chunk_index,
             size: Some(size),
             rate_limited: Some(item.rate_limited()),

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -203,7 +203,7 @@ pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreReq
 
     if let Some(item) = items
         .iter()
-        .find(|item| item.attachment_type() == Some(AttachmentType::EventPayload))
+        .find(|item| item.attachment_type() == Some(&AttachmentType::EventPayload))
     {
         if let Some(event_id) = event_id_from_msgpack(&item.payload())? {
             return Ok(Some(event_id));

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -126,7 +126,7 @@ fn extract_envelope(
         .and_then(move |mut items| {
             let minidump_index = items
                 .iter()
-                .position(|item| item.attachment_type() == Some(AttachmentType::Minidump));
+                .position(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
 
             let mut minidump_item = match minidump_index {
                 Some(index) => items.swap_remove(index),

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -399,7 +399,7 @@ impl std::str::FromStr for AttachmentType {
             "event.breadcrumbs" => AttachmentType::Breadcrumbs,
             "unreal.context" => AttachmentType::UnrealContext,
             "unreal.logs" => AttachmentType::UnrealLogs,
-            other => AttachmentType::Unknown(other.to_owned()), // FIXME
+            other => AttachmentType::Unknown(other.to_owned()),
         })
     }
 }
@@ -643,17 +643,17 @@ impl Item {
             // event payloads. Plain attachments never create event payloads.
             ItemType::Attachment => {
                 match self.attachment_type().unwrap_or(&AttachmentType::default()) {
-                    &AttachmentType::AppleCrashReport
-                    | &AttachmentType::Minidump
-                    | &AttachmentType::EventPayload
-                    | &AttachmentType::Breadcrumbs => true,
-                    &AttachmentType::Attachment
-                    | &AttachmentType::UnrealContext
-                    | &AttachmentType::UnrealLogs => false,
+                    AttachmentType::AppleCrashReport
+                    | AttachmentType::Minidump
+                    | AttachmentType::EventPayload
+                    | AttachmentType::Breadcrumbs => true,
+                    AttachmentType::Attachment
+                    | AttachmentType::UnrealContext
+                    | AttachmentType::UnrealLogs => false,
                     // When an outdated Relay instance forwards an unknown attachment type for compatibility,
                     // we assume that the attachment does not create a new event. This will make it hard
                     // to introduce new attachment types which _do_ create a new event.
-                    &AttachmentType::Unknown(_) => false,
+                    AttachmentType::Unknown(_) => false,
                 }
             }
 

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -1,6 +1,6 @@
 use relay_config::Config;
 
-use crate::envelope::{Envelope, ItemType};
+use crate::envelope::{AttachmentType, Envelope, ItemType};
 
 /// Checks for size limits of items in this envelope.
 ///
@@ -67,7 +67,13 @@ pub fn remove_unknown_items(config: &Config, envelope: &mut Envelope) {
                 relay_log::debug!("dropping unknown item of type '{}'", ty);
                 false
             }
-            _ => true,
+            _ => match item.attachment_type() {
+                Some(AttachmentType::Unknown(ty)) => {
+                    relay_log::debug!("dropping unknown attachment of type '{}'", ty);
+                    false
+                }
+                _ => true,
+            },
         });
     }
 }

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -272,9 +272,9 @@ pub fn process_unreal_envelope(
         .get_header(UNREAL_USER_HEADER)
         .and_then(Value::as_str);
     let context_item =
-        envelope.get_item_by(|item| item.attachment_type() == Some(AttachmentType::UnrealContext));
+        envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::UnrealContext));
     let logs_item =
-        envelope.get_item_by(|item| item.attachment_type() == Some(AttachmentType::UnrealLogs));
+        envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::UnrealLogs));
 
     // Early exit if there is no information.
     if user_header.is_none() && context_item.is_none() && logs_item.is_none() {

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -56,11 +56,19 @@ def test_unknown_item(mini_sentry, relay):
     envelope.add_item(
         Item(payload=PayloadRef(bytes=b"something"), type="invalid_unknown")
     )
+    envelope.add_item(
+        Item(
+            payload=PayloadRef(bytes=b"something"),
+            type="attachment",
+            attachment_type="attachment_unknown",
+        )
+    )
     relay.send_envelope(PROJECT_ID, envelope)
 
     envelope = mini_sentry.captured_events.get(timeout=1)
-    assert len(envelope.items) == 1
+    assert len(envelope.items) == 2
     assert envelope.items[0].type == "invalid_unknown"
+    assert envelope.items[1].attachment_type == "attachment_unknown"
 
 
 def test_drop_unknown_item(mini_sentry, relay):
@@ -71,6 +79,13 @@ def test_drop_unknown_item(mini_sentry, relay):
     envelope = Envelope()
     envelope.add_item(
         Item(payload=PayloadRef(bytes=b"something"), type="invalid_unknown")
+    )
+    envelope.add_item(
+        Item(
+            payload=PayloadRef(bytes=b"something"),
+            type="attachment",
+            attachment_type="attachment_unknown",
+        )
     )
     relay.send_envelope(PROJECT_ID, envelope)
 

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -56,13 +56,9 @@ def test_unknown_item(mini_sentry, relay):
     envelope.add_item(
         Item(payload=PayloadRef(bytes=b"something"), type="invalid_unknown")
     )
-    envelope.add_item(
-        Item(
-            payload=PayloadRef(bytes=b"something"),
-            type="attachment",
-            attachment_type="attachment_unknown",
-        )
-    )
+    attachment = Item(payload=PayloadRef(bytes=b"something"), type="attachment")
+    attachment.headers["attachment_type"] = "attachment_unknown"
+    envelope.add_item(attachment)
     relay.send_envelope(PROJECT_ID, envelope)
 
     envelopes = [  # non-event items are split into separate envelopes, so fetch 2x here
@@ -71,7 +67,7 @@ def test_unknown_item(mini_sentry, relay):
     ]
 
     types = {
-        (item.type, item.attachment_type)
+        (item.type, item.headers.get("attachment_type"))
         for envelope in envelopes
         for item in envelope.items
     }
@@ -89,13 +85,9 @@ def test_drop_unknown_item(mini_sentry, relay):
     envelope.add_item(
         Item(payload=PayloadRef(bytes=b"something"), type="invalid_unknown")
     )
-    envelope.add_item(
-        Item(
-            payload=PayloadRef(bytes=b"something"),
-            type="attachment",
-            attachment_type="attachment_unknown",
-        )
-    )
+    attachment = Item(payload=PayloadRef(bytes=b"something"), type="attachment")
+    attachment.headers["attachment_type"] = "attachment_unknown"
+    envelope.add_item(attachment)
     relay.send_envelope(PROJECT_ID, envelope)
 
     envelope = mini_sentry.captured_events.get(timeout=1)


### PR DESCRIPTION
As we did in https://github.com/getsentry/relay/pull/1246 for `ItemType`, add an `Unknown(String)` variant to `AttachmentType`. When `accept_unknown_items` is set to false, items with this attachment type will be dropped.

This will allow outdated external Relays to forward new attachment types instead of dropping the entire envelope.

This defect was discovered in https://github.com/getsentry/rfcs/pull/33, which introduces a new attachment type.