### PR TITLE
chore(transaction): Improve regex to group URL segments

### DIFF
--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -10,7 +10,7 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
         r#"
 
     (?x)
-    (?P<uuid>
+    (?P<uuid>[^/]*
         \b
             [0-9a-fA-F]{8}-
             [0-9a-fA-F]{4}-
@@ -18,14 +18,14 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
             [0-9a-fA-F]{4}-
             [0-9a-fA-F]{12}
         \b
-    ) |
-    (?P<sha1>
+    [^/]*) |
+    (?P<sha1>[^/]*
         \b[0-9a-fA-F]{40}\b
-    ) |
-    (?P<md5>
+    [^/]*) |
+    (?P<md5>[^/]*
         \b[0-9a-fA-F]{32}\b
-    ) |
-    (?P<date>
+    [^/]*) |
+    (?P<date>[^/]*
         (?:
             (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|
             (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|
@@ -47,13 +47,13 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
             (?::(60|[0-5][\d]))?\s+
             (?:[-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z]))
         )
-    ) |
-    (?P<hex>
+    [^/]*) |
+    (?P<hex>[^/]*
         \b0[xX][0-9a-fA-F]+\b
-    ) |
-    (?P<int>
+    [^/]*) |
+    (?P<int>[^/]*
         \b\d{2,}\b
-    )
+    [^/]*)
 "#,
     )
     .unwrap()

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -10,7 +10,7 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
         r#"
 
     (?x)
-    (?P<uuid>[^/]*
+    (?P<uuid>[^/\\]*
         \b
             [0-9a-fA-F]{8}-
             [0-9a-fA-F]{4}-
@@ -18,14 +18,14 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
             [0-9a-fA-F]{4}-
             [0-9a-fA-F]{12}
         \b
-    [^/]*) |
-    (?P<sha1>[^/]*
+    [^/\\]*) |
+    (?P<sha1>[^/\\]*
         \b[0-9a-fA-F]{40}\b
-    [^/]*) |
-    (?P<md5>[^/]*
+    [^/\\]*) |
+    (?P<md5>[^/\\]*
         \b[0-9a-fA-F]{32}\b
-    [^/]*) |
-    (?P<date>[^/]*
+    [^/\\]*) |
+    (?P<date>[^/\\]*
         (?:
             (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|
             (?:\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|
@@ -47,13 +47,13 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
             (?::(60|[0-5][\d]))?\s+
             (?:[-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z]))
         )
-    [^/]*) |
-    (?P<hex>[^/]*
+    [^/\\]*) |
+    (?P<hex>[^/\\]*
         \b0[xX][0-9a-fA-F]+\b
-    [^/]*) |
-    (?P<int>[^/]*
+    [^/\\]*) |
+    (?P<int>[^/\\]*
         \b\d{2,}\b
-    [^/]*)
+    [^/\\]*)
 "#,
     )
     .unwrap()

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1439,6 +1439,7 @@ mod tests {
                 "#,
                     $input
                 );
+
                 let mut event = Annotated::<Event>::from_json(&json).unwrap();
 
                 process_value(
@@ -1478,5 +1479,10 @@ mod tests {
         test_transaction_name_normalize_hex,
         "/u/0x3707344A4093822299F31D008/profile/123123213",
         "/u/*/profile/*"
+    );
+    transaction_name_test!(
+        test_transaction_name_normalize_windows_path,
+        r#"C:\\\\Program Files\\1234\\Files"#,
+        r#"C:\\Program Files\*\Files"#
     );
 }

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1488,5 +1488,9 @@ mod tests {
         r#"C:\\Program Files\*\Files"#
     );
     transaction_name_test!(test_transaction_name_skip_replace_all, "12345", "12345");
-    transaction_name_test!(test_transaction_name_skip_replace_all2, "open-12345-close", "open-12345-close");
+    transaction_name_test!(
+        test_transaction_name_skip_replace_all2,
+        "open-12345-close",
+        "open-12345-close"
+    );
 }

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -1488,4 +1488,5 @@ mod tests {
         r#"C:\\Program Files\*\Files"#
     );
     transaction_name_test!(test_transaction_name_skip_replace_all, "12345", "12345");
+    transaction_name_test!(test_transaction_name_skip_replace_all2, "open-12345-close", "open-12345-close");
 }

--- a/relay-general/src/store/transactions.rs
+++ b/relay-general/src/store/transactions.rs
@@ -238,9 +238,11 @@ fn normalize_transaction_name(transaction: &mut Annotated<String>) -> Processing
         let changed = TRANSACTION_NAME_NORMALIZER_REGEX
             .replace_all(trans, "*")
             .to_string();
-        if *trans != changed {
+        if *trans != changed && changed != "*" {
             meta.set_original_value(Some(trans.to_string()));
             *trans = changed
+        } else {
+            meta.clear_remarks();
         }
         Ok(())
     })
@@ -1485,4 +1487,5 @@ mod tests {
         r#"C:\\\\Program Files\\1234\\Files"#,
         r#"C:\\Program Files\*\Files"#
     );
+    transaction_name_test!(test_transaction_name_skip_replace_all, "12345", "12345");
 }


### PR DESCRIPTION
follow-up for #1597 

Group the entire segment in the pattern is found inside it. 
E.g. for url path which looks like `/user/public-19-profile/edit` we  want make sure to fold second segment and get the following result ~> `/user/*/edit`


#skip-changelog 