### PR TITLE
fix(sampling): Forward compatibility for config

### DIFF
--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -33,6 +33,10 @@ pub enum RuleType {
     /// A non transaction rule applies to Errors, Security events...every type of event that
     /// is not a Transaction
     Error,
+
+    /// If the sampling config contains new rule types, do not sample at all.
+    #[serde(other)]
+    Unsupported,
 }
 
 /// A condition that checks the values using the equality operator.
@@ -372,7 +376,7 @@ pub struct SamplingRule {
 
 impl SamplingRule {
     fn supported(&self) -> bool {
-        self.condition.supported()
+        self.condition.supported() && self.ty != RuleType::Unsupported
     }
 
     /// Returns whether the sampling rule is active.
@@ -688,6 +692,10 @@ pub enum SamplingMode {
     /// In this mode, the server sampling rate is capped by the client's sampling rate. Rules with a
     /// higher sample rate than what the client is sending are effectively inactive.
     Total,
+
+    /// Catch-all variant for forward compatibility.
+    #[serde(other)]
+    Unsupported,
 }
 
 impl Default for SamplingMode {
@@ -2199,7 +2207,7 @@ mod tests {
             // supported in the code, so intentionally not implementing any logic for
             // that. This whole helper method should be revisited when the Error variant
             // is supported.
-            RuleType::Error => unimplemented!(),
+            RuleType::Error | RuleType::Unsupported => unimplemented!(),
         };
         let release_condition = format!("{}.release", rule_prefix);
         let env_condition = format!("{}.environment", rule_prefix);
@@ -2572,5 +2580,49 @@ mod tests {
 
         dsc.sample_rate = Some(-0.5);
         assert_eq!(dsc.adjusted_sample_rate(0.5), 0.5);
+    }
+
+    #[test]
+    fn test_supported() {
+        let rule: SamplingRule = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "type": "trace",
+            "sampleRate": 1,
+            "condition": {"op": "and", "inner": []}
+        }))
+        .unwrap();
+        assert!(rule.supported());
+    }
+
+    #[test]
+    fn test_unsupported_rule_type() {
+        let rule: SamplingRule = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "type": "new_rule_type_unknown_to_this_relay",
+            "sampleRate": 1,
+            "condition": {"op": "and", "inner": []}
+        }))
+        .unwrap();
+        assert!(!rule.supported());
+    }
+
+    #[test]
+    fn test_supported_sampling_mode() {
+        let config: SamplingConfig = serde_json::from_value(serde_json::json!({
+            "rules": [],
+            "mode": "total"
+        }))
+        .unwrap();
+        assert!(config.supported());
+    }
+
+    #[test]
+    fn test_unsupported_sampling_mode() {
+        let config: SamplingConfig = serde_json::from_value(serde_json::json!({
+            "rules": [],
+            "mode": "unknownSamplingMode"
+        }))
+        .unwrap();
+        assert!(!config.supported());
     }
 }

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -2605,24 +2605,4 @@ mod tests {
         .unwrap();
         assert!(!rule.supported());
     }
-
-    #[test]
-    fn test_supported_sampling_mode() {
-        let config: SamplingConfig = serde_json::from_value(serde_json::json!({
-            "rules": [],
-            "mode": "total"
-        }))
-        .unwrap();
-        assert!(config.supported());
-    }
-
-    #[test]
-    fn test_unsupported_sampling_mode() {
-        let config: SamplingConfig = serde_json::from_value(serde_json::json!({
-            "rules": [],
-            "mode": "unknownSamplingMode"
-        }))
-        .unwrap();
-        assert!(!config.supported());
-    }
 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -449,7 +449,7 @@ mod tests {
         let project_state = state_with_rule(Some(0.1), RuleType::Trace, SamplingMode::Unsupported);
         let sampling_context = create_sampling_context(Some(0.5));
         let spec = get_trace_sampling_rule(
-            true, // irrelevant, just skips unsupported rules
+            true,
             Some(&project_state),
             Some(&sampling_context),
             None,

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -448,12 +448,8 @@ mod tests {
     fn test_trace_rule_unsupported() {
         let project_state = state_with_rule(Some(0.1), RuleType::Trace, SamplingMode::Unsupported);
         let sampling_context = create_sampling_context(Some(0.5));
-        let spec = get_trace_sampling_rule(
-            true,
-            Some(&project_state),
-            Some(&sampling_context),
-            None,
-        );
+        let spec =
+            get_trace_sampling_rule(true, Some(&project_state), Some(&sampling_context), None);
 
         assert!(matches!(spec, Err(SamplingResult::Keep)));
     }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -445,6 +445,20 @@ mod tests {
     }
 
     #[test]
+    fn test_trace_rule_unsupported() {
+        let project_state = state_with_rule(Some(0.1), RuleType::Trace, SamplingMode::Unsupported);
+        let sampling_context = create_sampling_context(Some(0.5));
+        let spec = get_trace_sampling_rule(
+            true, // irrelevant, just skips unsupported rules
+            Some(&project_state),
+            Some(&sampling_context),
+            None,
+        );
+
+        assert!(matches!(spec, Err(SamplingResult::Keep)));
+    }
+
+    #[test]
     fn test_event_rule_received() {
         let project_state =
             state_with_rule(Some(0.1), RuleType::Transaction, SamplingMode::Received);

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -72,6 +72,12 @@ fn get_trace_sampling_rule(
     let sample_rate = match sampling_config.mode {
         SamplingMode::Received => rule.sample_rate,
         SamplingMode::Total => sampling_context.adjusted_sample_rate(rule.sample_rate),
+        SamplingMode::Unsupported => {
+            if processing_enabled {
+                relay_log::error!("Found unsupported sampling mode even as processing Relay, keep");
+            }
+            return Err(SamplingResult::Keep);
+        }
     };
 
     Ok(Some(SamplingSpec {


### PR DESCRIPTION
Add missing variants to enums in sampling config for forward compatibility.

#skip-changelog