### PR TITLE
feat(server): Add support for ViewHierarchy attachment_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - Dynamic sampling is now based on the volume received by Relay by default and does not include the original volume dropped by client-side sampling in SDKs. This is required for the final dynamic sampling feature in the latest Sentry plans. ([#1591](https://github.com/getsentry/relay/pull/1591))
 - Add OpenTelemetry Context ([#1617](https://github.com/getsentry/relay/pull/1617))
 - Add `app.in_foreground` and `thread.main` flag to protocol. ([#1578](https://github.com/getsentry/relay/pull/1578))
+- Add support for View Hierarchy attachment_type. ([#1642](https://github.com/getsentry/relay/pull/1642))
 
 **Bug Fixes**:
+
 - Make `attachment_type` on envelope items forward compatible by adding fallback variant. ([#1638](https://github.com/getsentry/relay/pull/1638))
 
 **Internal**:

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -385,7 +385,7 @@ impl fmt::Display for AttachmentType {
             AttachmentType::Breadcrumbs => write!(f, "event.breadcrumbs"),
             AttachmentType::UnrealContext => write!(f, "unreal.context"),
             AttachmentType::UnrealLogs => write!(f, "unreal.logs"),
-            AttachmentType::ViewHierarchy => write!(f, "event.viewhierarchy"),
+            AttachmentType::ViewHierarchy => write!(f, "event.view_hierarchy"),
             AttachmentType::Unknown(s) => s.fmt(f),
         }
     }
@@ -401,7 +401,7 @@ impl std::str::FromStr for AttachmentType {
             "event.applecrashreport" => AttachmentType::AppleCrashReport,
             "event.payload" => AttachmentType::EventPayload,
             "event.breadcrumbs" => AttachmentType::Breadcrumbs,
-            "event.viewhierarchy" => AttachmentType::ViewHierarchy,
+            "event.view_hierarchy" => AttachmentType::ViewHierarchy,
             "unreal.context" => AttachmentType::UnrealContext,
             "unreal.logs" => AttachmentType::UnrealLogs,
             other => AttachmentType::Unknown(other.to_owned()),
@@ -1445,7 +1445,7 @@ mod tests {
         let bytes = Bytes::from(
             "\
              {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n\
-             {\"type\":\"attachment\",\"length\":44,\"content_type\":\"application/json\",\"attachment_type\":\"event.viewhierarchy\"}\n\
+             {\"type\":\"attachment\",\"length\":44,\"content_type\":\"application/json\",\"attachment_type\":\"event.view_hierarchy\"}\n\
              {\"rendering_system\":\"compose\",\"windows\":[]}\n\
              ",
         );

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -361,7 +361,7 @@ pub enum AttachmentType {
     /// [`symbolic_unreal::Unreal4LogEntry`]: https://docs.rs/symbolic/*/symbolic/unreal/struct.Unreal4LogEntry.html
     UnrealLogs,
 
-    /// An application ui view hierarchy (json payload)
+    /// An application UI view hierarchy (json payload).
     ViewHierarchy,
 
     /// Unknown attachment type, forwarded for compatibility.


### PR DESCRIPTION
Add support for the upcoming [View Hierarchy](https://github.com/getsentry/rfcs/pull/33) feature.

If there's more work that needs to be done for relay, please let me know or kindly take over the PR 🙂 

I mapped the new attachment type to the String `"event.viewhierarchy"`, which matches with the existing `"event.applecrashreport"` - but I guess technically `"event.view_hierarchy"` would be more correct here.