### PR TITLE
chore(kafka): switch to another error crate: thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,6 @@ dependencies = [
 name = "relay-kafka"
 version = "22.11.0"
 dependencies = [
- "failure",
  "rdkafka",
  "rdkafka-sys",
  "relay-log",
@@ -3347,6 +3346,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
 ]
 
 [[package]]

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -10,7 +10,6 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-failure = "0.1.8"
 rdkafka = { version = "0.24", optional = true }
 rdkafka-sys = { version = "2.1.0", optional = true }
 relay-log = { path  = "../relay-log" }
@@ -18,6 +17,7 @@ relay-statsd = { path  = "../relay-statsd", optional = true }
 rmp-serde = { version = "0.14.3", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = { version = "1.0.55", optional = true }
+thiserror = "1.0.20"
 
 [dev-dependencies]
 serde_yaml = "0.8.13"

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -1,16 +1,16 @@
 use std::collections::BTreeMap;
 
-use failure::Fail;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Kafka configuration errors.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum ConfigError {
     /// The user referenced a kafka config name that does not exist.
-    #[fail(display = "unknown kafka config name")]
+    #[error("unknown kafka config name")]
     UnknownKafkaConfigName,
     /// The user did not configure 0 shard
-    #[fail(display = "invalid kafka shard configuration: must have shard with index 0")]
+    #[error("invalid kafka shard configuration: must have shard with index 0")]
     InvalidShard,
 }
 

--- a/relay-kafka/src/lib.rs
+++ b/relay-kafka/src/lib.rs
@@ -16,7 +16,7 @@
 //!     builder = builder.add_kafka_topic_config(KafkaTopic::Events, &kafka_config_events).unwrap();
 //!
 //!     // And add potentially another topic config.
-//!     builder.add_kafka_topic_config(&kafka_config_metrics)?;
+//!     builder = builder.add_kafka_topic_config(KafkaTopic::Transactions, &kafka_config_metrics).unwrap();
 //!
 //!     // build the client
 //!     let kafka_client = builder.build();

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -2,9 +2,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::Arc;
 
-use failure::Fail;
 use rdkafka::producer::BaseRecord;
 use rdkafka::ClientConfig;
+use thiserror::Error;
 
 use relay_statsd::metric;
 
@@ -15,30 +15,30 @@ mod utils;
 use utils::{CaptureErrorContext, ThreadedProducer};
 
 /// Kafka producer errors.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum ClientError {
     /// Failed to send a kafka message.
-    #[fail(display = "failed to send kafka message")]
-    SendFailed(#[cause] rdkafka::error::KafkaError),
+    #[error("failed to send kafka message")]
+    SendFailed(#[source] rdkafka::error::KafkaError),
 
     /// Failed to find configured producer for the requested kafka topic.
-    #[fail(display = "failed to find producer for the requested kafka topic")]
+    #[error("failed to find producer for the requested kafka topic")]
     InvalidTopicName,
 
     /// Failed to create a kafka producer because of the invalid configuration.
-    #[fail(display = "failed to create kafka producer: invalid kafka config")]
-    InvalidConfig(#[cause] rdkafka::error::KafkaError),
+    #[error("failed to create kafka producer: invalid kafka config")]
+    InvalidConfig(#[source] rdkafka::error::KafkaError),
 
     /// Failed to serialize the message.
-    #[fail(display = "failed to serialize kafka message")]
-    InvalidMsgPack(#[cause] rmp_serde::encode::Error),
+    #[error("failed to serialize kafka message")]
+    InvalidMsgPack(#[source] rmp_serde::encode::Error),
 
     /// Failed to serialize the json message using serde.
-    #[fail(display = "failed to serialize json message")]
-    InvalidJson(#[cause] serde_json::Error),
+    #[error("failed to serialize json message")]
+    InvalidJson(#[source] serde_json::Error),
 
     /// Configuration is wrong and it cannot be used to identify the number of a shard.
-    #[fail(display = "invalid kafka shard")]
+    #[error("invalid kafka shard")]
     InvalidShard,
 }
 


### PR DESCRIPTION
The crate we use for error handling `failure` is deprecated and outdated. `thiserror` is a good, near drop-in replacement for `#[derive(Fail)]`.



#skip-changelog