### PR TITLE
fix(server): Use compat::send for actix messages

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1950,9 +1950,7 @@ impl AggregatorService {
             Aggregator::InsertMetrics(msg) => self.handle_insert_metrics(msg),
             Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
             #[cfg(test)]
-            Aggregator::BucketCountInquiry(_, sender) => {
-                sender.send(self.buckets.len());
-            }
+            Aggregator::BucketCountInquiry(_, sender) => sender.send(self.buckets.len()),
         }
     }
 

--- a/relay-system/src/compat.rs
+++ b/relay-system/src/compat.rs
@@ -57,22 +57,3 @@ where
     EXECUTOR.get().unwrap().spawn(f);
     rx.await.map_err(|_| MailboxError::Closed)?
 }
-
-/// Sends a message to a recipient using `actix` 0.7 from a `tokio` 1.0 context.
-///
-/// The message is internally forwarded through a `tokio` 0.1 runtime in order to avoid panics when
-/// the channel queues fill up and tasks are getting parked.
-///
-/// # Panics
-///
-/// Panics if this is invoked outside of the [`Controller`](crate::Controller).
-///
-/// TODO(actix): required by ProjectCache and will be removed with ProjectCache migration.
-pub fn send_to_recipient<M>(addr: Recipient<M>, msg: M)
-where
-    M: Message + Send + 'static,
-    M::Result: Send,
-{
-    let f = futures01::future::lazy(move || addr.do_send(msg)).map_err(|_| ());
-    EXECUTOR.get().unwrap().spawn(f);
-}


### PR DESCRIPTION
Fix a panic in the newly converted project cache by using `compat::send` when dispatching messages from the tokio runtime to legacy actors.

Follow-up to #1635
Relates to #1602
Fixes [RELAY-CRM](https://sentry.my.sentry.io/organizations/sentry/issues/316000/)

#skip-changelog