### PR TITLE
fix(server): Drop transactions outside of the metrics time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Bug Fixes**:
 
 - Make `attachment_type` on envelope items forward compatible by adding fallback variant. ([#1638](https://github.com/getsentry/relay/pull/1638))
+- Relay no longer accepts transaction events older than 5 days. Previously the event was accepted and stored, but since metrics for such old transactions are not supported it did not show up in parts of Sentry such as the Performance landing page. ([#1663](https://github.com/getsentry/relay/pull/1663))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1822,8 +1822,8 @@ impl Config {
     }
 
     /// Returns configuration for the metrics [aggregator](relay_metrics::Aggregator).
-    pub fn aggregator_config(&self) -> AggregatorConfig {
-        self.values.aggregator.clone()
+    pub fn aggregator_config(&self) -> &AggregatorConfig {
+        &self.values.aggregator
     }
 
     /// Return the statically configured Relays.

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -340,6 +340,10 @@ pub enum DiscardReason {
     /// (Relay) An event envelope was submitted but no payload could be extracted.
     NoEventPayload,
 
+    /// (Relay) The timestamp of an event was required for processing and either missing out of the
+    /// supported time range for ingestion.
+    Timestamp,
+
     /// (All) An error in Relay caused event ingestion to fail. This is the catch-all and usually
     /// indicates bugs in Relay, rather than an expected failure.
     Internal,
@@ -391,6 +395,7 @@ impl DiscardReason {
             DiscardReason::InvalidTransaction => "invalid_transaction",
             DiscardReason::InvalidEnvelope => "invalid_envelope",
             DiscardReason::InvalidCompression => "invalid_compression",
+            DiscardReason::Timestamp => "timestamp",
             DiscardReason::ProjectState => "project_state",
             DiscardReason::ProjectStatePii => "project_state_pii",
             DiscardReason::DuplicateItem => "duplicate_item",

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::io::Write;
@@ -2184,19 +2183,11 @@ impl EnvelopeProcessorService {
                 let mut timestamp = item.timestamp().unwrap_or(received_timestamp);
                 clock_drift_processor.process_timestamp(&mut timestamp);
 
-                let min_timestamp = max(
-                    0,
-                    received.timestamp() - self.config.max_session_secs_in_past(),
-                ) as u64;
-                let max_timestamp =
-                    (received.timestamp() + self.config.max_secs_in_future()) as u64;
-                if min_timestamp <= timestamp.as_secs() && timestamp.as_secs() <= max_timestamp {
-                    let metrics =
-                        Metric::parse_all(&payload, timestamp).filter_map(|result| result.ok());
+                let metrics =
+                    Metric::parse_all(&payload, timestamp).filter_map(|result| result.ok());
 
-                    relay_log::trace!("inserting metrics into project cache");
-                    project_cache.send(InsertMetrics::new(public_key, metrics));
-                }
+                relay_log::trace!("inserting metrics into project cache");
+                project_cache.send(InsertMetrics::new(public_key, metrics));
             } else if item.ty() == &ItemType::MetricBuckets {
                 match Bucket::parse_all(&payload) {
                     Ok(mut buckets) => {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1814,20 +1814,15 @@ impl EnvelopeProcessorService {
             return Ok(());
         }
 
-        let config = match state.project_state.config().transaction_metrics {
+        let project_config = state.project_state.config();
+        let extraction_config = match project_config.transaction_metrics {
             Some(ErrorBoundary::Ok(ref config)) => config,
             _ => return Ok(()),
         };
 
-        if !config.is_enabled() {
+        if !extraction_config.is_enabled() {
             return Ok(());
         }
-
-        let conditional_tagging_config = state
-            .project_state
-            .config
-            .metric_conditional_tagging
-            .as_slice();
 
         if let Some(event) = state.event.value() {
             let extracted_anything;
@@ -1837,8 +1832,9 @@ impl EnvelopeProcessorService {
                 {
                     // Actual logic outsourced for unit tests
                     extracted_anything = extract_transaction_metrics(
-                        config,
-                        conditional_tagging_config,
+                        self.config.aggregator_config(),
+                        extraction_config,
+                        &project_config.metric_conditional_tagging,
                         event,
                         &mut state.extracted_metrics,
                     );

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -26,7 +26,7 @@ pub enum ExtractMetricsError {
     /// The supported range is derived from the
     /// [`max_secs_in_past`](AggregatorConfig::max_secs_in_past) and
     /// [`max_secs_in_future`](AggregatorConfig::max_secs_in_future) configuration options.
-    #[error("timestamp too old or too much in the future")]
+    #[error("timestamp too old or too far in the future")]
     InvalidTimestamp,
 }
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -175,7 +175,7 @@ impl ServiceState {
 
         let guard = aggregator_runtime.enter();
         let aggregator = AggregatorService::new(
-            config.aggregator_config(),
+            config.aggregator_config().clone(),
             Some(project_cache.clone().recipient()),
         )
         .start();

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -108,7 +108,9 @@ def test_metrics_backdated(mini_sentry, relay):
 def test_metrics_partition_key(mini_sentry, relay, flush_partitions, expected_header):
     forever = 100 * 365 * 24 * 60 * 60  # *almost forever
     relay_config = {
-        "processing": {"max_session_secs_in_past": forever,},
+        "processing": {
+            "max_session_secs_in_past": forever,
+        },
         "aggregator": {
             "bucket_interval": 1,
             "initial_delay": 0,
@@ -191,8 +193,14 @@ def test_metrics_with_sharded_kafka(
                 "metrics": {
                     "shards": 3,
                     "mapping": {
-                        0: {"name": get_topic_name("metrics-1"), "config": "foo",},
-                        2: {"name": get_topic_name("metrics-2"), "config": "baz",},
+                        0: {
+                            "name": get_topic_name("metrics-1"),
+                            "config": "foo",
+                        },
+                        2: {
+                            "name": get_topic_name("metrics-2"),
+                            "config": "baz",
+                        },
                     },
                 }
             },
@@ -864,7 +872,7 @@ def test_graceful_shutdown(mini_sentry, relay):
 
     # Future timestamp will not be flushed regularly, only through force flush
     metrics_payload = f"transactions/bar:17|c"
-    future_timestamp = timestamp + 60
+    future_timestamp = timestamp + 30
     relay.send_metrics(project_id, metrics_payload, future_timestamp)
     relay.shutdown(sig=signal.SIGTERM)
 
@@ -900,7 +908,7 @@ def test_graceful_shutdown(mini_sentry, relay):
 def test_limit_custom_measurements(
     mini_sentry, relay, relay_with_processing, metrics_consumer, transactions_consumer
 ):
-    """ Custom measurement config is propagated to outer relay """
+    """Custom measurement config is propagated to outer relay"""
     metrics_consumer = metrics_consumer()
     transactions_consumer = transactions_consumer()
 


### PR DESCRIPTION
Relay used to accept transactions back-dated up to 30 days into the
past, but transaction metrics are restricted to 5 days, a restriction
which our storage relies on. With this PR, metric extraction now
validates the transaction timestamps and does not extract metrics if the
timestamp is outside the allowed range for metrics.

Additionally, Relay also needs to drop the transaction event for
consistency between metrics and events. Otherwise, a transaction may be
indexed that is not included in the "total" metrics dataset. This would
lead to inconsistency between the datasets and violate an invariant that
metrics contain a superset of indexed transactions.

Ref https://github.com/getsentry/relay/issues/1630

