### PR TITLE
tmp: Log errors when the DSC is missing for project 1

### DIFF
--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -755,7 +755,7 @@ pub struct EnvelopeHeaders<M = RequestMeta> {
 
     /// Trace context associated with the request
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    trace: Option<ErrorBoundary<DynamicSamplingContext>>,
+    pub trace: Option<ErrorBoundary<DynamicSamplingContext>>,
 
     /// Other attributes for forward compatibility.
     #[serde(flatten)]
@@ -804,7 +804,7 @@ impl EnvelopeHeaders<PartialMeta> {
 
 #[derive(Clone, Debug)]
 pub struct Envelope {
-    headers: EnvelopeHeaders,
+    pub headers: EnvelopeHeaders,
     items: Items,
 }
 


### PR DESCRIPTION
DO NOT MERGE. Intended just for test deployment.

This will temporarily log errors when there's no DSC or an invalid DSC on project 1. Deserialization errors are logged. We would expect that this does not happen in practice, but have reasonable suspicion it does.

#skip-changelog

