### PR TITLE
ref(ffi,cabi): Replace outdated failure with anyhow crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,9 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "anylog"
@@ -3191,8 +3194,8 @@ dependencies = [
 name = "relay-cabi"
 version = "0.8.15"
 dependencies = [
+ "anyhow",
  "chrono",
- "failure",
  "json-forensics",
  "once_cell",
  "relay-auth",
@@ -3255,7 +3258,7 @@ dependencies = [
 name = "relay-ffi"
 version = "22.11.0"
 dependencies = [
- "failure",
+ "anyhow",
  "relay-ffi-macros",
 ]
 

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = { version = "1.0.66", features = ["backtrace"] }
 chrono = "0.4.11"
-failure = "0.1.8"
 json-forensics = { version = "*", git = "https://github.com/getsentry/rust-json-forensics" }
 once_cell = "1.13.1"
 relay-auth = { path = "../relay-auth" }

--- a/relay-cabi/src/ffi.rs
+++ b/relay-cabi/src/ffi.rs
@@ -39,8 +39,8 @@ pub enum RelayErrorCode {
 
 impl RelayErrorCode {
     /// This maps all errors that can possibly happen.
-    pub fn from_error(error: &failure::Error) -> RelayErrorCode {
-        for cause in error.iter_chain() {
+    pub fn from_error(error: &anyhow::Error) -> RelayErrorCode {
+        for cause in error.chain() {
             if let Some(..) = cause.downcast_ref::<Panic>() {
                 return RelayErrorCode::Panic;
             }
@@ -111,7 +111,7 @@ pub extern "C" fn relay_err_get_last_message() -> RelayStr {
     use std::fmt::Write;
     relay_ffi::with_last_error(|err| {
         let mut msg = err.to_string();
-        for cause in err.iter_chain().skip(1) {
+        for cause in err.chain().skip(1) {
             write!(&mut msg, "\n  caused by: {}", cause).ok();
         }
         RelayStr::from_string(msg)

--- a/relay-ffi/Cargo.toml
+++ b/relay-ffi/Cargo.toml
@@ -10,5 +10,5 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-failure = "0.1.8"
+anyhow = "1.0.66"
 relay-ffi-macros = { path = "../relay-ffi-macros" }

--- a/relay-ffi/src/lib.rs
+++ b/relay-ffi/src/lib.rs
@@ -115,10 +115,10 @@ use std::thread;
 pub use relay_ffi_macros::catch_unwind;
 
 thread_local! {
-    static LAST_ERROR: RefCell<Option<failure::Error>> = RefCell::new(None);
+    static LAST_ERROR: RefCell<Option<anyhow::Error>> = RefCell::new(None);
 }
 
-fn set_last_error(err: failure::Error) {
+fn set_last_error(err: anyhow::Error) {
     LAST_ERROR.with(|e| {
         *e.borrow_mut() = Some(err);
     });
@@ -140,7 +140,7 @@ pub mod __internal {
     #[inline]
     pub unsafe fn catch_errors<F, T>(f: F) -> T
     where
-        F: FnOnce() -> Result<T, failure::Error> + panic::UnwindSafe,
+        F: FnOnce() -> Result<T, anyhow::Error> + panic::UnwindSafe,
     {
         match panic::catch_unwind(f) {
             Ok(Ok(result)) => result,
@@ -176,7 +176,7 @@ pub mod __internal {
 /// ```
 pub fn with_last_error<R, F>(f: F) -> Option<R>
 where
-    F: FnOnce(&failure::Error) -> R,
+    F: FnOnce(&anyhow::Error) -> R,
 {
     LAST_ERROR.with(|e| e.borrow().as_ref().map(f))
 }
@@ -201,7 +201,7 @@ where
 ///     None => println!("result: {}", parsed),
 /// }
 /// ```
-pub fn take_last_error() -> Option<failure::Error> {
+pub fn take_last_error() -> Option<anyhow::Error> {
     LAST_ERROR.with(|e| e.borrow_mut().take())
 }
 


### PR DESCRIPTION
Failure crate is outdated and not supported anymore. It's time to switch to modern alternative.
Instead of `failure::Error` switching to `anyhow::Error` which is a wrapper around a dynamic error type.

`Error` works a lot like `Box<dyn std::error::Error>`, but with these differences:

* Requires that the error is Send, Sync, and 'static.
* Guarantees that a backtrace is available, even if the underlying error type does not provide one.
* Is represented as a narrow pointer — exactly one word in size instead of two.

#skip-changelog