### PR TITLE
fix(build): Pin ubuntu image to 20.04

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   test-all:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust: [beta]

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -20,7 +20,7 @@ jobs:
           - aarch64
 
     name: Python Linux ${{ matrix.build-arch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -89,7 +89,7 @@ jobs:
 
   sdist:
     name: Python sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Install libcurl-dev
@@ -73,7 +73,7 @@ jobs:
 
   lint_default:
     name: Lint Rust Default Features
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Install libcurl-dev
@@ -140,14 +140,14 @@ jobs:
 
   test_all:
     timeout-minutes: 15
-    name: Test All Features (ubuntu-latest)
-    runs-on: ubuntu-latest
+    name: Test All Features (ubuntu-20.04)
+    runs-on: ubuntu-20.04
 
     # Skip redundant checks for library releases
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"
 
     # Testing all features requires Docker container operations that are only available on
-    # `ubuntu-latest`. This `test-all` job is to be seen as complementary to the `test` job. If
+    # `ubuntu-20.04`. This `test-all` job is to be seen as complementary to the `test` job. If
     # services become available on other platforms, the jobs should be consolidated. See
     # https://docs.github.com/en/actions/guides/about-service-containers
 
@@ -193,7 +193,7 @@ jobs:
     if: "!startsWith(github.ref, 'refs/heads/release/')"
 
     name: Test Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -227,7 +227,7 @@ jobs:
 
   test_integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
 
     # Skip redundant checks for library releases
@@ -297,7 +297,7 @@ jobs:
 
   sentry-relay-integration-tests:
     name: Sentry-Relay Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
 
     # Skip redundant checks for library releases
@@ -363,7 +363,7 @@ jobs:
 
   self-hosted-end-to-end:
     needs: []
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # temporary, remove once we are confident the action is working
     continue-on-error: true
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Changelogs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   cargo_docs:
     name: Cargo Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Install libcurl-dev
@@ -56,7 +56,7 @@ jobs:
 
   event_schema:
     name: Event Schema
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
 
   metrics_docs:
     name: Metrics Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   enforce-license-compliance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: "Enforce License Compliance"
         uses: getsentry/action-enforce-license-compliance@main

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: "Release a new Relay version"
 
     steps:

--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: "Release a new librelay version"
 
     steps:


### PR DESCRIPTION
This pins the runner image to `ubuntu-20.04`.  Image tag taken from https://github.com/actions/runner-images

#skip-changelog