### PR TITLE
feat(profiling): Allow to rate limit profiles on top of transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Track metrics for OpenTelemetry events. ([#1618](https://github.com/getsentry/relay/pull/1618))
 - Normalize transaction name for URLs transaction source, by replacing UUIDs, SHAs and numerical IDs in transaction names by placeholders. ([#1621](https://github.com/getsentry/relay/pull/1621))
 - Parse string as number to handle a release bug. ([#1637](https://github.com/getsentry/relay/pull/1637))
+- Allow to rate limit profiles on top of transactions. ([#1681](https://github.com/getsentry/relay/pull/1681))
 
 ## 22.11.0
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -539,6 +539,11 @@ where
             return false;
         }
 
+        // Remove profiles even if the transaction is not rate limited
+        if enforcement.profiles.is_active() && item.ty() == &ItemType::Profile {
+            return false;
+        }
+
         true
     }
 }


### PR DESCRIPTION
We'd like to rate limit profiles on top of transactions. If a transaction is not rate limited, we might still want to not accept the profile.