### PR TITLE
feat(replays): Filter recordings which could not be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add metric name as tag on Sentry errors from relay dropping metrics. ([#1797](https://github.com/getsentry/relay/pull/1797))
 - Make sure to scrub all the fields with PII. If the fields contain an object, the entire object will be removed. ([#1789](https://github.com/getsentry/relay/pull/1789))
 - Keep meta for removed custom measurements. ([#1815](https://github.com/getsentry/relay/pull/1815))
+- Drop replay recording payloads if they cannot be parsed or scrubbed. ([#1683](https://github.com/getsentry/relay/pull/1683))
 
 ## 23.1.1
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1157,6 +1157,7 @@ impl EnvelopeProcessorService {
                 match parsed_recording {
                     Ok(recording) => {
                         item.set_payload(ContentType::OctetStream, recording.as_slice());
+                        true
                     }
                     Err(e) => {
                         relay_log::warn!("replay-recording-event: {e} {event_id:?}");
@@ -1165,12 +1166,9 @@ impl EnvelopeProcessorService {
                             DataCategory::Replay,
                             1,
                         );
+                        false
                     }
                 }
-
-                // XXX: For now replays that could not be parsed are still accepted while we
-                // determine the impact of the recording parser.
-                true
             }
             _ => true,
         });


### PR DESCRIPTION
Drop replay recording payloads if they fail processing, which happens either when they contain invalid JSON or when data scrubbing fails. If replay processing is disabled, Relay does not inspect the payloads and unconditionally retains them.

Closes https://github.com/getsentry/replay-backend/issues/229