### PR TITLE
fix(profiling): Warn on invalid JSON errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Track metrics for OpenTelemetry events. ([#1618](https://github.com/getsentry/relay/pull/1618))
 - Normalize transaction name for URLs transaction source, by replacing UUIDs, SHAs and numerical IDs in transaction names by placeholders. ([#1621](https://github.com/getsentry/relay/pull/1621))
 - Parse string as number to handle a release bug. ([#1637](https://github.com/getsentry/relay/pull/1637))
-- Expand Profiling's discard reasons. ([#1661](https://github.com/getsentry/relay/pull/1661))
+- Expand Profiling's discard reasons. ([#1661](https://github.com/getsentry/relay/pull/1661), [#1685](https://github.com/getsentry/relay/pull/1685))
 - Allow to rate limit profiles on top of transactions. ([#1681](https://github.com/getsentry/relay/pull/1681))
 
 ## 22.11.0

--- a/relay-profiling/src/outcomes.rs
+++ b/relay-profiling/src/outcomes.rs
@@ -3,6 +3,9 @@ use crate::ProfileError;
 pub fn discard_reason(err: ProfileError) -> &'static str {
     match err {
         ProfileError::CannotSerializePayload => "profiling_failed_serialization",
+        ProfileError::InvalidBase64Value => "profiling_invalid_base64_value",
+        ProfileError::InvalidJson(_) => "profiling_invalid_json",
+        ProfileError::InvalidSampledProfile => "profiling_invalid_sampled_profile",
         ProfileError::InvalidTransactionMetadata => "profiling_invalid_transaction_metadata",
         ProfileError::MalformedSamples => "profiling_malformed_samples",
         ProfileError::MalformedStacks => "profiling_malformed_stacks",
@@ -10,6 +13,5 @@ pub fn discard_reason(err: ProfileError) -> &'static str {
         ProfileError::NoTransactionAssociated => "profiling_no_transaction_associated",
         ProfileError::NotEnoughSamples => "profiling_not_enough_samples",
         ProfileError::PlatformNotSupported => "profiling_platform_not_supported",
-        _ => "profiling_unknown",
     }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -964,7 +964,7 @@ impl EnvelopeProcessorService {
                 Err(err) => {
                     match err {
                         relay_profiling::ProfileError::InvalidJson(_) => {
-                            relay_log::error!("invalid profile: {}", LogError(&err));
+                            relay_log::warn!("invalid profile: {}", LogError(&err));
                         }
                         _ => relay_log::debug!("invalid profile: {}", err),
                     };


### PR DESCRIPTION
We'd like the error to be logged but not sent to Sentry as it's high cardinality and not very useful in Sentry.

Changing it to a warn level log seems to log in Cloud Logging but not send anything to Sentry, which is the behavior we'd like to have.