### PR TITLE
fix(replay): Limit allocations for replay decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Relay no longer accepts transaction events older than 5 days. Previously the event was accepted and stored, but since metrics for such old transactions are not supported it did not show up in parts of Sentry such as the Performance landing page. ([#1663](https://github.com/getsentry/relay/pull/1663))
 - Apply dynamic sampling to transactions from older SDKs and even in case Relay cannot load project information. This avoids accidentally storing 100% of transactions. ([#1667](https://github.com/getsentry/relay/pull/1667))
 - Replay recording parser now uses the entire body rather than a subset. ([#1682](https://github.com/getsentry/relay/pull/1682))
+- Fix a potential OOM in the Replay recording parser. ([#1691](https://github.com/getsentry/relay/pull/1691))
 
 **Internal**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1021,8 +1021,13 @@ impl EnvelopeProcessorService {
                 // XXX: Temporarily, only the Sentry org will be allowed to parse replays while
                 // we measure the impact of this change.
                 if replays_enabled && state.project_state.organization_id == Some(1) {
+                    // Limit expansion of recordings to the envelope size. The payload is
+                    // decompressed temporarily and then immediately re-compressed. However, to
+                    // limit memory pressure, we use the envelope limit as a good overall limit for
+                    // allocations.
+                    let limit = self.config.max_envelope_size();
                     let parsed_recording =
-                        relay_replays::recording::process_recording(&item.payload());
+                        relay_replays::recording::process_recording(&item.payload(), limit);
 
                     match parsed_recording {
                         Ok(recording) => {


### PR DESCRIPTION
The Replay recording processor reads a zlib compressed payload and decompresses
it in memory. This can lead to near unbounded allocations and exhaust Relay's
memory. This PR introduces an upper bound for these payloads.

For now, this limit is set to the overall envelope size limit. In practice, this
is configured to a rather large 100MB. We can consider to introduce a lower
limit once the feature matures and more information on reasonable file size is
available.

This PR also contains some changes to the error type and processing internals,
as well as the tests to align it with the usual coding style.

