### PR TITLE
feat(replays): Add max replay size configuration parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add `app.in_foreground` and `thread.main` flag to protocol. ([#1578](https://github.com/getsentry/relay/pull/1578))
 - Add support for View Hierarchy attachment_type. ([#1642](https://github.com/getsentry/relay/pull/1642))
 - Add invalid replay recording outcome. ([#1684]https://github.com/getsentry/relay/pull/1684)
-- Add max replay size configuration parameter. ([#1694]https://github.com/getsentry/relay/pull/1694)
+- Add max replay size configuration parameter. ([#1694](https://github.com/getsentry/relay/pull/1694))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add `app.in_foreground` and `thread.main` flag to protocol. ([#1578](https://github.com/getsentry/relay/pull/1578))
 - Add support for View Hierarchy attachment_type. ([#1642](https://github.com/getsentry/relay/pull/1642))
 - Add invalid replay recording outcome. ([#1684]https://github.com/getsentry/relay/pull/1684)
-- Add max replay size configuration parameter ([#1694]https://github.com/getsentry/relay/pull/1694)
+- Add max replay size configuration parameter. ([#1694]https://github.com/getsentry/relay/pull/1694)
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `app.in_foreground` and `thread.main` flag to protocol. ([#1578](https://github.com/getsentry/relay/pull/1578))
 - Add support for View Hierarchy attachment_type. ([#1642](https://github.com/getsentry/relay/pull/1642))
 - Add invalid replay recording outcome. ([#1684]https://github.com/getsentry/relay/pull/1684)
+- Add max replay size configuration parameter ([#1694]https://github.com/getsentry/relay/pull/1694)
 
 **Bug Fixes**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -536,6 +536,8 @@ struct Limits {
     max_api_chunk_upload_size: ByteSize,
     /// The maximum payload size for a profile
     max_profile_size: ByteSize,
+    /// The maximum payload size for a replay
+    max_replay_size: ByteSize,
     /// The maximum number of threads to spawn for CPU and web work, each.
     ///
     /// The total number of threads spawned will roughly be `2 * max_thread_count + 1`. Defaults to
@@ -571,6 +573,7 @@ impl Default for Limits {
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
             max_profile_size: ByteSize::mebibytes(50),
+            max_replay_size: ByteSize::mebibytes(100),
             max_thread_count: num_cpus::get(),
             query_timeout: 30,
             max_connection_rate: 256,
@@ -1712,6 +1715,11 @@ impl Config {
     /// Returns the maximum payload size for a profile
     pub fn max_profile_size(&self) -> usize {
         self.values.limits.max_profile_size.as_bytes()
+    }
+
+    /// Returns the maximum payload size for a replay
+    pub fn max_replay_size(&self) -> usize {
+        self.values.limits.max_replay_size.as_bytes()
     }
 
     /// Returns the maximum number of active requests

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1717,7 +1717,7 @@ impl Config {
         self.values.limits.max_profile_size.as_bytes()
     }
 
-    /// Returns the maximum payload size for a replay
+    /// Returns the maximum payload size for a replay.
     pub fn max_replay_size(&self) -> usize {
         self.values.limits.max_replay_size.as_bytes()
     }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -536,7 +536,7 @@ struct Limits {
     max_api_chunk_upload_size: ByteSize,
     /// The maximum payload size for a profile
     max_profile_size: ByteSize,
-    /// The maximum payload size for a replay
+    /// The maximum payload size for a replay.
     max_replay_size: ByteSize,
     /// The maximum number of threads to spawn for CPU and web work, each.
     ///

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1025,7 +1025,7 @@ impl EnvelopeProcessorService {
                     // decompressed temporarily and then immediately re-compressed. However, to
                     // limit memory pressure, we use the envelope limit as a good overall limit for
                     // allocations.
-                    let limit = self.config.max_envelope_size();
+                    let limit = self.config.max_replay_size();
                     let parsed_recording =
                         relay_replays::recording::process_recording(&item.payload(), limit);
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1021,9 +1021,9 @@ impl EnvelopeProcessorService {
                 // XXX: Temporarily, only the Sentry org will be allowed to parse replays while
                 // we measure the impact of this change.
                 if replays_enabled && state.project_state.organization_id == Some(1) {
-                    // Limit expansion of recordings to the envelope size. The payload is
+                    // Limit expansion of recordings to the max replay size. The payload is
                     // decompressed temporarily and then immediately re-compressed. However, to
-                    // limit memory pressure, we use the envelope limit as a good overall limit for
+                    // limit memory pressure, we use the replay limit as a good overall limit for
                     // allocations.
                     let limit = self.config.max_replay_size();
                     let parsed_recording =


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/234

Defaulting to 100 mebibytes for now.  We'll look into lowering it and can update the value later.

100 concurrent request limit * 100 mebibytes per replay = 10.5 GB memory requirements.  Do we have resources to satisfy this?  I assume so since other sizes are 100 MiB.