### PR TITLE
fix(changelog): use proper markdown links format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add OpenTelemetry Context ([#1617](https://github.com/getsentry/relay/pull/1617))
 - Add `app.in_foreground` and `thread.main` flag to protocol. ([#1578](https://github.com/getsentry/relay/pull/1578))
 - Add support for View Hierarchy attachment_type. ([#1642](https://github.com/getsentry/relay/pull/1642))
-- Add invalid replay recording outcome. ([#1684]https://github.com/getsentry/relay/pull/1684)
+- Add invalid replay recording outcome. ([#1684](https://github.com/getsentry/relay/pull/1684))
 - Add max replay size configuration parameter. ([#1694](https://github.com/getsentry/relay/pull/1694))
 
 **Bug Fixes**:
@@ -356,7 +356,7 @@
 **Features**:
 
 - Add sampling based on transaction name. ([#1058](https://github.com/getsentry/relay/pull/1058))
-- Support running Relay without config directory. The most important configuration, including Relay mode and credentials, can now be provided through commandline arguments or environment variables alone. ([#1055](https://github.com/getsentry/relay/pull/1055)
+- Support running Relay without config directory. The most important configuration, including Relay mode and credentials, can now be provided through commandline arguments or environment variables alone. ([#1055](https://github.com/getsentry/relay/pull/1055))
 - Protocol support for client reports. ([#1081](https://github.com/getsentry/relay/pull/1081))
 - Extract session metrics in non processing relays. ([#1073](https://github.com/getsentry/relay/pull/1073))
 


### PR DESCRIPTION
Fix few broken links in our `CHANGELOG`. 

#skip-changelog