### PR TITLE
fix: Properly escape generic type in docstring

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -788,7 +788,7 @@ impl Message for Authenticate {
 /// The `Authenticate` message is sent to the UpstreamRelay at Relay startup and coordinates the
 /// authentication of the current Relay with the upstream server.
 ///
-/// Any message the requires Relay authentication (i.e. SendQuery<T> messages) will be send only
+/// Any message the requires Relay authentication (i.e. `SendQuery<T>` messages) will be send only
 /// after Relay has successfully authenticated with the upstream server (i.e. an Authenticate
 /// message was successfully handled).
 ///
@@ -1223,7 +1223,7 @@ impl<T: UpstreamQuery> UpstreamRequest for UpstreamQueryRequest<T> {
     }
 }
 
-/// SendQuery<T> messages represent messages that need to be sent to the upstream server
+/// `SendQuery<T>` messages represent messages that need to be sent to the upstream server
 /// and use Relay authentication.
 ///
 /// The handler ensures that Relay is authenticated with the upstream server, adds the message


### PR DESCRIPTION
This fixes two errors in the documentation builds of `relay-server`, which fail due to a generic type not being escaped.

This is currently blocking the self-hosted release today.

_#skip-changelog_