### PR TITLE
feat(replays): Leave non-critical fields as generic "Value" types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Apply dynamic sampling to transactions from older SDKs and even in case Relay cannot load project information. This avoids accidentally storing 100% of transactions. ([#1667](https://github.com/getsentry/relay/pull/1667))
 - Replay recording parser now uses the entire body rather than a subset. ([#1682](https://github.com/getsentry/relay/pull/1682))
 - Fix a potential OOM in the Replay recording parser. ([#1691](https://github.com/getsentry/relay/pull/1691))
+- Fix type error in replay recording parser. ([#1702](https://github.com/getsentry/relay/pull/1702))
 
 **Internal**:
 

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -656,7 +656,7 @@ mod tests {
 
     #[test]
     fn test_pii_credit_card_removal() {
-        let payload = include_bytes!("../tests/fixtures/big1.json");
+        let payload = include_bytes!("../tests/fixtures/rrweb-pii.json");
         let mut events: Vec<Event> = serde_json::from_slice(payload).unwrap();
 
         recording::strip_pii(&mut events).unwrap();

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -185,7 +185,7 @@ impl RecordingProcessor<'_> {
             "script" | "style" => {}
             "img" | "source" => {
                 let attrs = &mut element.attributes;
-                attrs.insert("src".to_string(), "#".to_string());
+                attrs.insert("src".to_string(), Value::String("#".to_string()));
                 self.recurse_element_children(element)?
             }
             _ => self.recurse_element_children(element)?,
@@ -444,36 +444,36 @@ struct DocumentNode {
 struct DocumentTypeNode {
     #[serde(rename = "type")]
     ty: u8,
-    id: u32,
-    public_id: String,
-    system_id: String,
-    name: String,
+    id: Value,
+    public_id: Value,
+    system_id: Value,
+    name: Value,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ElementNode {
-    id: u32,
+    id: Value,
     #[serde(rename = "type")]
     ty: u8,
-    attributes: HashMap<String, String>,
+    attributes: HashMap<String, Value>,
     tag_name: String,
     child_nodes: Vec<Node>,
     #[serde(rename = "isSVG", skip_serializing_if = "Option::is_none")]
-    is_svg: Option<bool>,
+    is_svg: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    need_block: Option<bool>,
+    need_block: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TextNode {
-    id: u32,
+    id: Value,
     #[serde(rename = "type")]
     ty: u8,
     text_content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    is_style: Option<bool>,
+    is_style: Option<Value>,
 }
 
 /// Incremental Source Parser
@@ -535,7 +535,10 @@ struct InputIncrementalSourceData {
     source: u8,
     id: u32,
     text: String,
-    is_checked: bool,
+    is_checked: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    user_triggered: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -547,14 +550,14 @@ struct MutationIncrementalSourceData {
     removes: Vec<Value>,
     adds: Vec<MutationAdditionIncrementalSourceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    is_attach_iframe: Option<bool>,
+    is_attach_iframe: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MutationAdditionIncrementalSourceData {
-    parent_id: u32,
-    next_id: Option<u32>,
+    parent_id: Value,
+    next_id: Value,
     node: Node,
 }
 
@@ -653,7 +656,7 @@ mod tests {
 
     #[test]
     fn test_pii_credit_card_removal() {
-        let payload = include_bytes!("../tests/fixtures/rrweb-pii.json");
+        let payload = include_bytes!("../tests/fixtures/big1.json");
         let mut events: Vec<Event> = serde_json::from_slice(payload).unwrap();
 
         recording::strip_pii(&mut events).unwrap();

--- a/relay-replays/tests/fixtures/rrweb-node-2.json
+++ b/relay-replays/tests/fixtures/rrweb-node-2.json
@@ -2,7 +2,9 @@
     "type": 2,
     "tagName": "h1",
     "attributes": {
-        "id": "react-tooltip"
+        "id": "react-tooltip",
+        "rr_scrollLeft": 1070,
+        "rr_scrollTop": 385
     },
     "childNodes": [
         {

--- a/relay-replays/tests/fixtures/rrweb-pii.json
+++ b/relay-replays/tests/fixtures/rrweb-pii.json
@@ -6,9 +6,11 @@
             "texts": [],
             "attributes": [],
             "removes": [],
+            "isAttachIframe": true,
             "adds": [
                 {
                     "parentId": 74,
+                    "previousId": null,
                     "nextId": null,
                     "node": {
                         "type": 2,


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/239

Leaves non-critical fields as generic `Value` types which can be re-serialized later without consequence to PII scrubbing.