### PR TITLE
ci: Increase timeout for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           args: --workspace --all-targets --no-deps -- -D warnings
 
   test:
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It seems that these tests are flaking due to getting canceled as they exceed the 15 minute mark. Ideally tests would be sped up, but to avoid currently failing CI, I think this change makes the most sense.

_#skip-changelog_