### PR TITLE
fix(crash): Use main SDK to send crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Remove concurrent profiling. ([#1697](https://github.com/getsentry/relay/pull/1697))
+- Use the main Sentry SDK to submit crash reports instead of a custom curl-based backend. This removes a dependency on `libcurl` and ensures compliance with latest TLS standards for crash uploads. Note that this only affects Relay if the hidden `_crash_db` option is used. ([#1707](https://github.com/getsentry/relay/pull/1707))
 
 ## 22.12.0
 

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -9,8 +9,6 @@ fn main() {
         _ => return, // allow building with --all-features, fail during runtime
     }
 
-    println!("cargo:rustc-link-lib=curl");
-
     if !Path::new("sentry-native/.git").exists() {
         let _ = Command::new("git")
             .args(["submodule", "update", "--init", "--recursive"])
@@ -22,6 +20,8 @@ fn main() {
         .profile("RelWithDebInfo")
         // always build breakpad regardless of platform defaults
         .define("SENTRY_BACKEND", "breakpad")
+        // inject a custom transport instead of curl
+        .define("SENTRY_TRANSPORT", "none")
         // build a static library
         .define("BUILD_SHARED_LIBS", "OFF")
         // disable additional targets

--- a/relay-crash/src/lib.rs
+++ b/relay-crash/src/lib.rs
@@ -18,6 +18,7 @@ mod native {
 pub type Transport = fn(envelope: &[u8]);
 
 /// Serializes a sentry_native envelope and passes the buffer to the [`Transport`] function.
+#[cfg(unix)]
 unsafe extern "C" fn transport_proxy(
     envelope: *const native::sentry_envelope_s,
     tx_pointer: *mut std::ffi::c_void,

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use log::{Level, LevelFilter};
 use sentry::types::Dsn;
-use sentry::{Envelope, Hub};
 use serde::{Deserialize, Serialize};
 
 /// The full release name including the Relay version and SHA.
@@ -107,8 +106,8 @@ impl Default for SentryConfig {
 /// Captures an envelope from the native crash reporter using the main Sentry SDK.
 #[cfg(feature = "relay-crash")]
 fn capture_native_envelope(data: &[u8]) {
-    if let Some(client) = Hub::main().client() {
-        match Envelope::from_slice(data) {
+    if let Some(client) = sentry::Hub::main().client() {
+        match sentry::Envelope::from_slice(data) {
             Ok(envelope) => client.send_envelope(envelope),
             Err(error) => crate::error!("failed to capture crash: {}", crate::LogError(&error)),
         }

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -267,7 +267,7 @@ pub fn init(config: &LogConfig, sentry: &SentryConfig) {
         std::mem::forget(guard);
     }
 
-    // Initialize native crash reports after the Rust SDk, so that `capture_native_envelope` has
+    // Initialize native crash reporting after the Rust SDK, so that `capture_native_envelope` has
     // access to an initialized Hub to capture crashes from the previous run.
     #[cfg(feature = "relay-crash")]
     {


### PR DESCRIPTION
Relay captures crashes with the Sentry Native SDK and its breakpad backend. By
default, this uses `curl` as transport. In our Docker build, we dynamically link
with the installed development library. Since the build runs on CentOS 7, this
is an old library lacking many security features and patches. Even though the
production container has a more recent libcurl installed, the Native SDK
uploader fails the SSL handshake with sentry.io.

This PR removes the dependency on `curl` entirely and replaces it with a custom
transport function. We parse the envelope and send it using the main Sentry SDK.

