### PR TITLE
Push docker images from self-hosted e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
       - name: Run Sentry self-hosted e2e CI
         uses: getsentry/action-self-hosted-e2e-tests@fa5b8240848f0e645ac2918c530e60ec8f50e4b8
         with:
+          docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
           project_name: relay
           local_image: ${{ steps.image_pull.outputs.relay-test-image-name }}
           docker_repo: docker.io/getsentry/relay


### PR DESCRIPTION
This enables the e2e test action to push Docker images to DockerHub on successful test runs. This is part of https://github.com/getsentry/self-hosted/issues/1756