### PR TITLE
ref(utils): Add unit test for event and trace rules

### DIFF
--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -284,8 +284,7 @@ mod tests {
         })
     }
 
-    ///
-    ///
+    /// checks if
     #[test]
     fn test_trace_rules_applied_after_event_rules() {
         // a transaction rule that drops everything

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -303,37 +303,37 @@ mod tests {
         // a trace rule that keeps everything
         let trace_state = state_with_rule(Some(1.0), RuleType::Trace, SamplingMode::Received);
 
-        let matching_envelope = new_envelope(true, "healthcheck");
-        let non_matching_envelope = new_envelope(true, "test1");
+        let healthcheck_envelope = new_envelope(true, "healthcheck");
+        let other_envelope = new_envelope(true, "test1");
 
-        let matching_event = Event {
+        let healthcheck_event = Event {
             id: Annotated::new(EventId::new()),
             ty: Annotated::new(EventType::Transaction),
             transaction: Annotated::new("healthcheck".to_owned()),
             ..Event::default()
         };
 
-        let non_matching_event = Event {
+        let other_event = Event {
             id: Annotated::new(EventId::new()),
             ty: Annotated::new(EventType::Transaction),
             transaction: Annotated::new("test1".to_owned()),
             ..Event::default()
         };
 
-        // if it matches, the transaction should be dropped
+        // if it matches the transaction rule, the transaction should be dropped
         let should_drop = should_keep_event(
-            matching_envelope.dsc(),
-            Some(&matching_event),
+            healthcheck_envelope.dsc(),
+            Some(&healthcheck_event),
             None,
             &event_state,
             Some(&trace_state),
             false,
         );
 
-        // if it doesn't match, the transaction should be kept
+        // if it doesn't match the transaction rule, the transaction shouldn't be dropped
         let should_keep = should_keep_event(
-            non_matching_envelope.dsc(),
-            Some(&non_matching_event),
+            other_envelope.dsc(),
+            Some(&other_event),
             None,
             &event_state,
             Some(&trace_state),
@@ -344,8 +344,8 @@ mod tests {
         assert!(get_event_sampling_rule(
             false,
             &event_state,
-            matching_envelope.dsc(),
-            Some(&matching_event),
+            healthcheck_envelope.dsc(),
+            Some(&healthcheck_event),
             None,
         )
         .unwrap()
@@ -355,8 +355,8 @@ mod tests {
         assert!(get_event_sampling_rule(
             false,
             &event_state,
-            non_matching_envelope.dsc(),
-            Some(&non_matching_event),
+            other_envelope.dsc(),
+            Some(&other_event),
             None,
         )
         .unwrap()

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -165,12 +165,15 @@ pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
 
 #[cfg(test)]
 mod tests {
+
     use bytes::Bytes;
 
     use relay_common::EventType;
     use relay_general::protocol::EventId;
     use relay_general::types::Annotated;
-    use relay_sampling::{RuleCondition, RuleId, RuleType, SamplingConfig, SamplingRule};
+    use relay_sampling::{
+        EqCondition, RuleCondition, RuleId, RuleType, SamplingConfig, SamplingRule,
+    };
 
     use crate::envelope::Item;
 
@@ -219,20 +222,23 @@ mod tests {
     }
 
     /// ugly hack to build an envelope with an optional trace context
-    fn new_envelope(with_trace_context: bool) -> Box<Envelope> {
+    fn new_envelope<T: Into<String>>(with_dsc: bool, transaction_name: T) -> Box<Envelope> {
+        let transaction_name = transaction_name.into();
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42";
         let event_id = EventId::new();
 
-        let raw_event = if with_trace_context {
+        let raw_event = if with_dsc {
             format!(
-                "{{\"event_id\":\"{}\",\"dsn\":\"{}\", \"trace\": {}}}\n",
+                "{{\"transaction\": \"{}\", \"event_id\":\"{}\",\"dsn\":\"{}\", \"trace\": {}}}\n",
+                transaction_name,
                 event_id.0.to_simple(),
                 dsn,
                 serde_json::to_string(&create_sampling_context(None)).unwrap(),
             )
         } else {
             format!(
-                "{{\"event_id\":\"{}\",\"dsn\":\"{}\"}}\n",
+                "{{\"transaction\": \"{}\", \"event_id\":\"{}\",\"dsn\":\"{}\"}}\n",
+                transaction_name,
                 event_id.0.to_simple(),
                 dsn,
             )
@@ -252,6 +258,112 @@ mod tests {
         envelope.add_item(item3);
 
         envelope
+    }
+
+    fn state_with_rule_and_condition(
+        sample_rate: Option<f64>,
+        rule_type: RuleType,
+        mode: SamplingMode,
+        condition: RuleCondition,
+    ) -> ProjectState {
+        let rules = match sample_rate {
+            Some(sample_rate) => vec![SamplingRule {
+                condition,
+                sample_rate,
+                ty: rule_type,
+                id: RuleId(1),
+                time_range: Default::default(),
+            }],
+            None => Vec::new(),
+        };
+
+        state_with_config(SamplingConfig {
+            rules,
+            mode,
+            next_id: None,
+        })
+    }
+
+    ///
+    ///
+    #[test]
+    fn test_trace_rules_applied_after_event_rules() {
+        // a transaction rule that drops everything
+        let event_state = state_with_rule_and_condition(
+            Some(0.0),
+            RuleType::Transaction,
+            SamplingMode::Received,
+            RuleCondition::Eq(EqCondition {
+                name: "event.transaction".to_owned(),
+                value: "healthcheck".into(),
+                options: Default::default(),
+            }),
+        );
+
+        // a trace rule that keeps everything
+        let trace_state = state_with_rule(Some(1.0), RuleType::Trace, SamplingMode::Received);
+
+        let matching_envelope = new_envelope(true, "healthcheck");
+        let non_matching_envelope = new_envelope(true, "test1");
+
+        let matching_event = Event {
+            id: Annotated::new(EventId::new()),
+            ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("healthcheck".to_owned()),
+            ..Event::default()
+        };
+
+        let non_matching_event = Event {
+            id: Annotated::new(EventId::new()),
+            ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("test1".to_owned()),
+            ..Event::default()
+        };
+
+        // if it matches, the transaction should be dropped
+        let should_drop = should_keep_event(
+            matching_envelope.dsc(),
+            Some(&matching_event),
+            None,
+            &event_state,
+            Some(&trace_state),
+            false,
+        );
+
+        // if it doesn't match, the transaction should be kept
+        let should_keep = should_keep_event(
+            non_matching_envelope.dsc(),
+            Some(&non_matching_event),
+            None,
+            &event_state,
+            Some(&trace_state),
+            false,
+        );
+
+        // matching event should return an event rule
+        assert!(get_event_sampling_rule(
+            false,
+            &event_state,
+            matching_envelope.dsc(),
+            Some(&matching_event),
+            None,
+        )
+        .unwrap()
+        .is_some());
+
+        // non-matching event should not return an event rule
+        assert!(get_event_sampling_rule(
+            false,
+            &event_state,
+            non_matching_envelope.dsc(),
+            Some(&non_matching_event),
+            None,
+        )
+        .unwrap()
+        .is_none());
+
+        assert!(matches!(should_keep, SamplingResult::Keep));
+        assert!(matches!(should_drop, SamplingResult::Drop(_)));
     }
 
     #[test]
@@ -284,7 +396,7 @@ mod tests {
     #[test]
     fn test_unsampled_envelope_with_sample_rate() {
         //create an envelope with a event and a transaction
-        let envelope = new_envelope(true);
+        let envelope = new_envelope(true, "");
         let state = state_with_rule(Some(1.0), RuleType::Trace, SamplingMode::default());
         let sampling_state = state_with_rule(Some(0.0), RuleType::Trace, SamplingMode::default());
         let result = should_keep_event(
@@ -302,7 +414,7 @@ mod tests {
     /// Should keep transaction when no trace context is present
     fn test_should_keep_transaction_no_trace() {
         //create an envelope with a event and a transaction
-        let envelope = new_envelope(false);
+        let envelope = new_envelope(false, "");
         let state = state_with_rule(Some(1.0), RuleType::Trace, SamplingMode::default());
         let sampling_state = state_with_rule(Some(0.0), RuleType::Trace, SamplingMode::default());
 
@@ -324,7 +436,7 @@ mod tests {
     /// transaction
     fn test_should_signal_when_envelope_becomes_empty() {
         //create an envelope with a event and a transaction
-        let envelope = new_envelope(true);
+        let envelope = new_envelope(true, "");
         let state = state_with_rule(Some(1.0), RuleType::Trace, SamplingMode::default());
         let sampling_state = state_with_rule(Some(0.0), RuleType::Trace, SamplingMode::default());
 
@@ -384,7 +496,7 @@ mod tests {
         let sampling_config = serde_json::from_value(sampling_config).unwrap();
         let project_state = state_with_config(sampling_config);
 
-        let envelope = new_envelope(true);
+        let envelope = new_envelope(true, "");
 
         let event = Event {
             id: Annotated::new(EventId::new()),

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 import queue
+from .fixtures.mini_sentry import Sentry
+from .fixtures.relay import Relay
 
 
 def _create_transaction_item(trace_id=None, event_id=None, transaction=None):
@@ -679,48 +681,3 @@ def test_relay_chain(
         envelope.get_transaction_event()
 
 
-def test_event_rules_are_applied_after_trace_rules(
-    mini_sentry,
-    relay,
-):
-    """
-    Usecase: Some "baseline" trace sample rate is applied (100% because it's
-    easiest to test), but there's an additional transaction sample rule that
-    blocks all transaction events for the /healthcheck endpoint from coming
-    through.
-    """
-
-    project_id = 42
-    relay = relay(mini_sentry)
-    config = mini_sentry.add_basic_project_config(project_id)
-    public_key = config["publicKeys"][0]["publicKey"]
-    _add_sampling_config(config, sample_rate=1.0, rule_type="trace")
-    config["config"]["dynamicSampling"]["rules"].append(
-        {
-            "sampleRate": 0.0,
-            "type": "transaction",
-            "condition": {
-                "op": "eq",
-                "name": "event.transaction",
-                "value": "healthcheck",
-            },
-            "id": 99,
-        }
-    )
-
-    envelope, trace_id, event_id = _create_transaction_envelope(
-        public_key,
-        transaction="test1",
-    )
-
-    relay.send_envelope(project_id, envelope)
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    assert envelope.get_transaction_event()["transaction"] == "test1"
-
-    envelope, trace_id, event_id = _create_transaction_envelope(
-        public_key,
-        transaction="healthcheck",
-    )
-
-    with pytest.raises(queue.Empty):
-        envelope = mini_sentry.captured_events.get(timeout=1)

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -677,5 +677,3 @@ def test_relay_chain(
         envelope.get_event()
     else:
         envelope.get_transaction_event()
-
-

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -4,8 +4,6 @@ import json
 import pytest
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 import queue
-from .fixtures.mini_sentry import Sentry
-from .fixtures.relay import Relay
 
 
 def _create_transaction_item(trace_id=None, event_id=None, transaction=None):


### PR DESCRIPTION
Removes a python integration tests that checks if trace rules are applied after event rules, and replaces it with unit tests in rust that targets the specific functions more directly.

#skip-changelog