### PR TITLE
ref(actix): Migrate RedisProjectSource from actor to utility class

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -7,7 +7,6 @@ use tokio::time::Instant;
 
 use relay_common::ProjectKey;
 use relay_config::{Config, RelayMode};
-use relay_log::LogError;
 use relay_metrics::{self, FlushBuckets, InsertMetrics, MergeBuckets};
 use relay_quotas::RateLimits;
 use relay_redis::RedisPool;
@@ -373,7 +372,10 @@ impl ProjectSource {
             let state_opt = match state_fetch_result {
                 Ok(x) => x.map(ProjectState::sanitize).map(Arc::new),
                 Err(e) => {
-                    relay_log::error!("Failed to fetch project from Redis: {}", LogError(&e));
+                    relay_log::error!(
+                        "Failed to fetch project from Redis: {}",
+                        relay_log::LogError(&e)
+                    );
                     None
                 }
             };

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -7,6 +7,7 @@ use tokio::time::Instant;
 
 use relay_common::ProjectKey;
 use relay_config::{Config, RelayMode};
+use relay_log::LogError;
 use relay_metrics::{self, FlushBuckets, InsertMetrics, MergeBuckets};
 use relay_quotas::RateLimits;
 use relay_redis::RedisPool;
@@ -24,7 +25,7 @@ use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::{self, EnvelopeContext, GarbageDisposal};
 
 #[cfg(feature = "processing")]
-use {crate::actors::project_redis::RedisProjectSource, actix::SyncArbiter, relay_common::clone};
+use crate::actors::project_redis::RedisProjectSource;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum ProjectError {
@@ -326,7 +327,7 @@ struct ProjectSource {
     local_source: actix::Addr<LocalProjectSource>,
     upstream_source: actix::Addr<UpstreamProjectSource>,
     #[cfg(feature = "processing")]
-    redis_source: Option<actix::Addr<RedisProjectSource>>,
+    redis_source: Option<RedisProjectSource>,
 }
 
 impl ProjectSource {
@@ -335,15 +336,7 @@ impl ProjectSource {
         let upstream_source = UpstreamProjectSource::new(config.clone()).start();
 
         #[cfg(feature = "processing")]
-        let redis_source = _redis.map(|pool| {
-            SyncArbiter::start(
-                config.cpu_concurrency(),
-                clone!(config, || RedisProjectSource::new(
-                    config.clone(),
-                    pool.clone()
-                )),
-            )
-        });
+        let redis_source = _redis.map(|pool| RedisProjectSource::new(config.clone(), pool));
 
         Self {
             config,
@@ -372,9 +365,18 @@ impl ProjectSource {
 
         #[cfg(feature = "processing")]
         if let Some(redis_source) = self.redis_source {
-            let state_opt = compat::send(redis_source, FetchOptionalProjectState { project_key })
-                .await
-                .map_err(|_| ())?;
+            let state_fetch_result =
+                tokio::task::spawn_blocking(move || redis_source.get_config(project_key))
+                    .await
+                    .map_err(|_| ())?;
+
+            let state_opt = match state_fetch_result {
+                Ok(x) => x.map(ProjectState::sanitize).map(Arc::new),
+                Err(e) => {
+                    relay_log::error!("Failed to fetch project from Redis: {}", LogError(&e));
+                    None
+                }
+            };
 
             if let Some(state) = state_opt {
                 return Ok(state);

--- a/relay-server/src/actors/project_redis.rs
+++ b/relay-server/src/actors/project_redis.rs
@@ -1,24 +1,21 @@
 use std::sync::Arc;
 
-use actix::prelude::*;
 use relay_common::ProjectKey;
 use relay_config::Config;
-use relay_log::LogError;
 use relay_redis::{RedisError, RedisPool};
 use relay_statsd::metric;
 
 use crate::actors::project::ProjectState;
-use crate::actors::project_cache::FetchOptionalProjectState;
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RedisProjectSource {
     config: Arc<Config>,
     redis: RedisPool,
 }
 
 #[derive(Debug, thiserror::Error)]
-enum RedisProjectError {
+pub enum RedisProjectError {
     #[error("failed to parse projectconfig from redis")]
     Parsing(#[from] serde_json::Error),
 
@@ -55,7 +52,7 @@ impl RedisProjectSource {
         RedisProjectSource { config, redis }
     }
 
-    fn get_config(&self, key: ProjectKey) -> Result<Option<ProjectState>, RedisProjectError> {
+    pub fn get_config(&self, key: ProjectKey) -> Result<Option<ProjectState>, RedisProjectError> {
         let mut command = relay_redis::redis::cmd("GET");
 
         let prefix = self.config.projectconfig_cache_prefix();
@@ -80,36 +77,6 @@ impl RedisProjectSource {
         };
 
         Ok(response)
-    }
-}
-
-impl Actor for RedisProjectSource {
-    type Context = SyncContext<Self>;
-
-    fn started(&mut self, _ctx: &mut Self::Context) {
-        relay_log::info!("redis project cache started");
-    }
-
-    fn stopped(&mut self, _ctx: &mut Self::Context) {
-        relay_log::info!("redis project cache stopped");
-    }
-}
-
-impl Handler<FetchOptionalProjectState> for RedisProjectSource {
-    type Result = Option<Arc<ProjectState>>;
-
-    fn handle(
-        &mut self,
-        message: FetchOptionalProjectState,
-        _ctx: &mut Self::Context,
-    ) -> Self::Result {
-        match self.get_config(message.project_key()) {
-            Ok(x) => x.map(ProjectState::sanitize).map(Arc::new),
-            Err(e) => {
-                relay_log::error!("Failed to fetch project from Redis: {}", LogError(&e));
-                None
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Instead of using the `actix::Actor` and instead of migrating this to our new `Service` this change introduces the simple utility class `RedisProjectSource` which just provides only one helper method to fetch project config. 

The call to this method is wrapped into `tokio::task::spawn_blocking` which should be executed on the separated thread pool.  And the rest of the functionality stays practically the same. 

fix: #1604 

#skip-changelog