### PR TITLE
fix(sessions): Deserialize abnormal_mechanism null as None

### DIFF
--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -29,6 +29,7 @@ mod transaction;
 mod types;
 mod user;
 mod user_report;
+mod utils;
 
 pub use sentry_release_parser::{validate_environment, validate_release};
 

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -1,6 +1,7 @@
+use crate::protocol::utils::null_to_default;
 use crate::protocol::EventId;
 
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// User feedback for an event as sent by the client to the userfeedback/userreport endpoint.
 ///
@@ -28,13 +29,4 @@ pub struct UserReport {
     /// Comments supplied by the user.
     #[serde(default, deserialize_with = "null_to_default")]
     pub comments: String,
-}
-
-fn null_to_default<'de, D, V>(deserializer: D) -> Result<V, D::Error>
-where
-    D: Deserializer<'de>,
-    V: Default + DeserializeOwned,
-{
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
 }

--- a/relay-general/src/protocol/utils.rs
+++ b/relay-general/src/protocol/utils.rs
@@ -1,0 +1,12 @@
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
+
+/// Returns the default value for a type if the provided value is `null`.
+pub fn null_to_default<'de, D, V>(deserializer: D) -> Result<V, D::Error>
+where
+    D: Deserializer<'de>,
+    V: Default + DeserializeOwned,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}


### PR DESCRIPTION
The `abnormal_mechanism` field on `Session` defaults to `AbnormalMechanism::None` when missing, but when SDKs supply an explicit `null` value, we would fail serialization.

Use the existing `null_to_default` helper function to map `null` to a valid value.