### PR TITLE
ci: Remove GCB tests and make GHA default for self-hosted e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@697a3ca95a72f93e3a1ebdb8f967be38d1f029f6
+        uses: getsentry/action-self-hosted-e2e-tests@4ff2dbfdd5c986a4670efaa16d82e460598359eb
         with:
           project_name: relay
           image_url: us.gcr.io/sentryio/relay:${{ github.event.pull_request.head.sha || github.sha }} 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -56,44 +56,6 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     args: ["push", "us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA"]
 
-  # Self-hosted Integration tests
-  - name: "gcr.io/$PROJECT_ID/docker-compose"
-    entrypoint: "bash"
-    env:
-      - "RELAY_IMAGE=us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA"
-      - "SENTRY_TEST_HOST=http://nginx"
-      - "CI=1"
-      - "REPORT_SELF_HOSTED_ISSUES=0"
-    args:
-      - "-e"
-      - "-c"
-      - |
-        mkdir self-hosted && cd self-hosted
-        curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
-        # The following trick is from https://stackoverflow.com/a/52400857/90297 with great gratuity
-        echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
-        ./install.sh
-        ./test.sh || docker-compose logs nginx web relay
-    timeout: 900s
-
-  - name: "gcr.io/cloud-builders/docker"
-    secretEnv: ["DOCKER_PASSWORD"]
-    entrypoint: "bash"
-    args:
-      - "-e"
-      - "-c"
-      - |
-        # Only push to Docker Hub from master
-        [ "$BRANCH_NAME" != "master" ] && exit 0
-        docker push us.gcr.io/$PROJECT_ID/relay:nightly
-        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-        docker tag us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA getsentry/relay:$SHORT_SHA
-        docker push getsentry/relay:$SHORT_SHA
-        docker tag us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA getsentry/relay:$COMMIT_SHA
-        docker push getsentry/relay:$COMMIT_SHA
-        docker tag us.gcr.io/$PROJECT_ID/relay:$COMMIT_SHA getsentry/relay:nightly
-        docker push getsentry/relay:nightly
-
 images:
   [
     "us.gcr.io/$PROJECT_ID/relay:deps",
@@ -103,12 +65,3 @@ timeout: 3600s
 options:
   # Run on bigger machines
   machineType: "E2_HIGHCPU_8"
-secrets:
-  - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
-    secretEnv:
-      # This is a personal access token for the sentrybuilder account, encrypted using the
-      # short guide at http://bit.ly/2Pg6uw9
-      DOCKER_PASSWORD: |
-        CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
-        TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
-        QcMK


### PR DESCRIPTION
This is the final step of [standardizing self-hosted e2e tests](https://github.com/getsentry/self-hosted/issues/1756). We remove tests from Google Cloud Build and replace it with the latest Github Action.



Note: this should not be merged until Tuesday