### PR TITLE
feat(general): Scrub all fields with IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add max replay size configuration parameter. ([#1694](https://github.com/getsentry/relay/pull/1694))
 - Add nonchunked replay recording message type. ([#1653](https://github.com/getsentry/relay/pull/1653))
 - Add `abnormal_mechanism` field to SessionUpdate protocol. ([#1665](https://github.com/getsentry/relay/pull/1665))
+- Scrub all fields with IP addresses rather than only known IP address fields. (---)
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Add max replay size configuration parameter. ([#1694](https://github.com/getsentry/relay/pull/1694))
 - Add nonchunked replay recording message type. ([#1653](https://github.com/getsentry/relay/pull/1653))
 - Add `abnormal_mechanism` field to SessionUpdate protocol. ([#1665](https://github.com/getsentry/relay/pull/1665))
-- Scrub all fields with IP addresses rather than only known IP address fields. (---)
+- Scrub all fields with IP addresses rather than only known IP address fields. ([#1693](https://github.com/getsentry/relay/pull/1725))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Add max replay size configuration parameter. ([#1694](https://github.com/getsentry/relay/pull/1694))
 - Add nonchunked replay recording message type. ([#1653](https://github.com/getsentry/relay/pull/1653))
 - Add `abnormal_mechanism` field to SessionUpdate protocol. ([#1665](https://github.com/getsentry/relay/pull/1665))
-- Scrub all fields with IP addresses rather than only known IP address fields. ([#1693](https://github.com/getsentry/relay/pull/1725))
+- Scrub all fields with IP addresses rather than only known IP address fields. ([#1725](https://github.com/getsentry/relay/pull/1725))
 
 **Bug Fixes**:
 

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -449,7 +449,17 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
                     "username": "73.133.27.120",
                     "ip_address": "73.133.27.120",
                     "data": sensitive_vars()
-                }
+                },
+                "breadcrumbs": {
+                    "values": [
+                        {
+                            "message": "73.133.27.120"
+                        }
+                    ],
+                    "data": {
+                        "test_data": "73.133.27.120"
+                    },
+                },
             })
             .into(),
         );

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -42,8 +42,7 @@ pub fn to_pii_config(
         applications.insert(KNOWN_IP_FIELDS.clone(), vec!["@anything:remove".to_owned()]);
 
         // checks actual contents of all fields and scrubs where there is an IP address
-        let wildcard = SelectorSpec::Path(vec![SelectorPathItem::DeepWildcard]);
-        applications.insert(wildcard, vec!["@ip:replace".to_owned()]);
+        applied_rules.push("@ip:replace".to_owned());
     }
 
     if datascrubbing_config.scrub_data {
@@ -221,13 +220,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
-              "@common:filter"
+              "@common:filter",
+              "@ip:replace"
             ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
-            ],
-            "**": [
-              "@ip:replace"
             ]
           }
         }
@@ -249,13 +246,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
-              "@common:filter"
+              "@common:filter",
+              "@ip:replace"
             ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
-            ],
-            "**": [
-              "@ip:replace"
             ]
           }
         }
@@ -287,13 +282,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           "applications": {
             "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
               "@common:filter",
+              "@ip:replace",
               "strip-fields"
             ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
-            ],
-            "**": [
-              "@ip:replace"
             ]
           }
         }
@@ -328,13 +321,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           },
           "applications": {
             "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !foobar": [
-              "@common:filter"
+              "@common:filter",
+              "@ip:replace"
             ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
-            ],
-            "**": [
-              "@ip:replace"
             ]
           }
         }
@@ -357,11 +348,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "hashKey": null
           },
           "applications": {
+            "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
+              "@ip:replace"
+            ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
-            ],
-            "**": [
-              "@ip:replace"
             ]
           }
         }
@@ -1249,13 +1240,11 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
           "applications": {
             "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
               "@common:filter",
+              "@ip:replace",
               "strip-fields"
             ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
               "@anything:remove"
-            ],
-            "**": [
-              "@ip:replace"
             ]
           }
         }

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -19,8 +19,7 @@ static DATASCRUBBER_IGNORE: Lazy<SelectorSpec> = Lazy::new(|| {
         .unwrap()
 });
 
-// XXX: Move to @ip rule for better IP address scrubbing. Right now we just try to keep
-// compatibility with Python.
+/// Fields that are known to contain IPs. Used for legacy IP scrubbing.
 static KNOWN_IP_FIELDS: Lazy<SelectorSpec> = Lazy::new(|| {
     "($request.env.REMOTE_ADDR | $user.ip_address | $sdk.client_ip)"
         .parse()

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -436,12 +436,12 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
                 "breadcrumbs": {
                     "values": [
                         {
-                            "message": "73.133.27.120"
-                        }
+                            "message": "73.133.27.120",
+                            "data": {
+                                "test_data": "73.133.27.120"
+                                }
+                        },
                     ],
-                    "data": {
-                        "test_data": "73.133.27.120"
-                    },
                 },
                 "sdk": {
                     "client_ip": "127.0.0.1"

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -403,23 +403,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     }
 
     #[test]
-    fn test_sdk_client_ip_stripped() {
-        let mut data = Event::from_value(
-            serde_json::json!({
-                "sdk": {
-                    "client_ip": "127.0.0.1"
-                }
-            })
-            .into(),
-        );
-
-        let pii_config = simple_enabled_pii_config();
-        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
-        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
-        assert_annotated_snapshot!(data);
-    }
-
-    #[test]
     fn test_user() {
         let mut data = Event::from_value(
             serde_json::json!({
@@ -442,7 +425,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     /// Even if it doesn't make sense for there to be an IP-address
     /// such as in the username field.
     #[test]
-    fn test_user_ip_stripped() {
+    fn test_ip_stripped() {
         let mut data = Event::from_value(
             serde_json::json!({
                 "user": {
@@ -460,6 +443,9 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
                         "test_data": "73.133.27.120"
                     },
                 },
+                "sdk": {
+                    "client_ip": "127.0.0.1"
+                }
             })
             .into(),
         );

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__http_remote_addr_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__http_remote_addr_stripped.snap
@@ -15,10 +15,17 @@ expression: data
           "": {
             "rem": [
               [
+                "@ip:replace",
+                "s",
+                0,
+                4
+              ],
+              [
                 "@anything:remove",
                 "x"
               ]
-            ]
+            ],
+            "len": 9
           }
         }
       }

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__http_remote_addr_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__http_remote_addr_stripped.snap
@@ -5,7 +5,7 @@ expression: data
 {
   "request": {
     "env": {
-      "REMOTE_ADDR": "[ip]"
+      "REMOTE_ADDR": null
     }
   },
   "_meta": {
@@ -15,13 +15,10 @@ expression: data
           "": {
             "rem": [
               [
-                "@ip:replace",
-                "s",
-                0,
-                4
+                "@anything:remove",
+                "x"
               ]
-            ],
-            "len": 9
+            ]
           }
         }
       }

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__http_remote_addr_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__http_remote_addr_stripped.snap
@@ -5,7 +5,7 @@ expression: data
 {
   "request": {
     "env": {
-      "REMOTE_ADDR": null
+      "REMOTE_ADDR": "[ip]"
     }
   },
   "_meta": {
@@ -15,10 +15,13 @@ expression: data
           "": {
             "rem": [
               [
-                "@anything:remove",
-                "x"
+                "@ip:replace",
+                "s",
+                0,
+                4
               ]
-            ]
+            ],
+            "len": 9
           }
         }
       }

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__ip_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__ip_stripped.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "user": {
-    "ip_address": "[ip]",
+    "ip_address": null,
     "username": "[ip]",
     "data": {
       "a_password_here": "hello",
@@ -26,7 +26,7 @@ expression: data
     ]
   },
   "sdk": {
-    "client_ip": "[ip]"
+    "client_ip": null
   },
   "_meta": {
     "breadcrumbs": {
@@ -66,30 +66,30 @@ expression: data
     "sdk": {
       "client_ip": {
         "": {
-          "rem": [
+          "err": [
             [
-              "@ip:replace",
-              "s",
-              0,
-              4
+              "invalid_data",
+              {
+                "reason": "expected an ip address"
+              }
             ]
           ],
-          "len": 9
+          "val": "should also be stripped"
         }
       }
     },
     "user": {
       "ip_address": {
         "": {
-          "rem": [
+          "err": [
             [
-              "@ip:replace",
-              "s",
-              0,
-              4
+              "invalid_data",
+              {
+                "reason": "expected an ip address"
+              }
             ]
           ],
-          "len": 13
+          "val": "should be stripped despite lacking ip address"
         }
       },
       "username": {

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__ip_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__ip_stripped.snap
@@ -1,0 +1,95 @@
+---
+source: relay-general/src/pii/convert.rs
+expression: data
+---
+{
+  "user": {
+    "ip_address": "[ip]",
+    "username": "[ip]",
+    "data": {
+      "a_password_here": "hello",
+      "apiKey": "secret_key",
+      "api_key": "secret_key",
+      "foo": "bar",
+      "password": "hello",
+      "the_secret": "hello"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "message": "[ip]"
+      }
+    ],
+    "data": {
+      "test_data": "73.133.27.120"
+    }
+  },
+  "sdk": {
+    "client_ip": "[ip]"
+  },
+  "_meta": {
+    "breadcrumbs": {
+      "values": {
+        "0": {
+          "message": {
+            "": {
+              "rem": [
+                [
+                  "@ip:replace",
+                  "s",
+                  0,
+                  4
+                ]
+              ],
+              "len": 13
+            }
+          }
+        }
+      }
+    },
+    "sdk": {
+      "client_ip": {
+        "": {
+          "rem": [
+            [
+              "@ip:replace",
+              "s",
+              0,
+              4
+            ]
+          ],
+          "len": 9
+        }
+      }
+    },
+    "user": {
+      "ip_address": {
+        "": {
+          "rem": [
+            [
+              "@ip:replace",
+              "s",
+              0,
+              4
+            ]
+          ],
+          "len": 13
+        }
+      },
+      "username": {
+        "": {
+          "rem": [
+            [
+              "@ip:replace",
+              "s",
+              0,
+              4
+            ]
+          ],
+          "len": 13
+        }
+      }
+    }
+  }
+}

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__ip_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__ip_stripped.snap
@@ -18,12 +18,12 @@ expression: data
   "breadcrumbs": {
     "values": [
       {
-        "message": "[ip]"
+        "message": "[ip]",
+        "data": {
+          "test_data": "[ip]"
+        }
       }
-    ],
-    "data": {
-      "test_data": "73.133.27.120"
-    }
+    ]
   },
   "sdk": {
     "client_ip": "[ip]"
@@ -32,6 +32,21 @@ expression: data
     "breadcrumbs": {
       "values": {
         "0": {
+          "data": {
+            "test_data": {
+              "": {
+                "rem": [
+                  [
+                    "@ip:replace",
+                    "s",
+                    0,
+                    4
+                  ]
+                ],
+                "len": 13
+              }
+            }
+          },
           "message": {
             "": {
               "rem": [

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
@@ -11,6 +11,9 @@ expression: pii_config
     "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
       "@common:filter"
     ],
+    "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
+      "@anything:remove"
+    ],
     "**": [
       "@ip:replace"
     ]

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
@@ -9,13 +9,11 @@ expression: pii_config
   },
   "applications": {
     "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
-      "@common:filter"
+      "@common:filter",
+      "@ip:replace"
     ],
     "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
       "@anything:remove"
-    ],
-    "**": [
-      "@ip:replace"
     ]
   }
 }

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
@@ -11,8 +11,8 @@ expression: pii_config
     "($string || $number || $array) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
       "@common:filter"
     ],
-    "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
-      "@anything:remove"
+    "**": [
+      "@ip:replace"
     ]
   }
 }

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__sdk_client_ip_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__sdk_client_ip_stripped.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "sdk": {
-    "client_ip": null
+    "client_ip": "[ip]"
   },
   "_meta": {
     "sdk": {
@@ -12,10 +12,13 @@ expression: data
         "": {
           "rem": [
             [
-              "@anything:remove",
-              "x"
+              "@ip:replace",
+              "s",
+              0,
+              4
             ]
-          ]
+          ],
+          "len": 9
         }
       }
     }

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "user": {
-    "ip_address": null,
+    "ip_address": "[ip]",
     "username": "[Filtered]",
     "data": {
       "a_password_here": "[Filtered]",
@@ -88,10 +88,13 @@ expression: data
         "": {
           "rem": [
             [
-              "@anything:remove",
-              "x"
+              "@ip:replace",
+              "s",
+              0,
+              4
             ]
-          ]
+          ],
+          "len": 13
         }
       },
       "username": {

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
@@ -4,7 +4,7 @@ expression: data
 ---
 {
   "user": {
-    "ip_address": "[ip]",
+    "ip_address": null,
     "username": "[Filtered]",
     "data": {
       "a_password_here": "[Filtered]",
@@ -88,13 +88,10 @@ expression: data
         "": {
           "rem": [
             [
-              "@ip:replace",
-              "s",
-              0,
-              4
+              "@anything:remove",
+              "x"
             ]
-          ],
-          "len": 13
+          ]
         }
       },
       "username": {

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user.snap
@@ -88,10 +88,17 @@ expression: data
         "": {
           "rem": [
             [
+              "@ip:replace",
+              "s",
+              0,
+              4
+            ],
+            [
               "@anything:remove",
               "x"
             ]
-          ]
+          ],
+          "len": 13
         }
       },
       "username": {

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user_ip_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user_ip_stripped.snap
@@ -15,7 +15,36 @@ expression: data
       "the_secret": "hello"
     }
   },
+  "breadcrumbs": {
+    "values": [
+      {
+        "message": "[ip]"
+      }
+    ],
+    "data": {
+      "test_data": "73.133.27.120"
+    }
+  },
   "_meta": {
+    "breadcrumbs": {
+      "values": {
+        "0": {
+          "message": {
+            "": {
+              "rem": [
+                [
+                  "@ip:replace",
+                  "s",
+                  0,
+                  4
+                ]
+              ],
+              "len": 13
+            }
+          }
+        }
+      }
+    },
     "user": {
       "ip_address": {
         "": {

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user_ip_stripped.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__user_ip_stripped.snap
@@ -4,8 +4,8 @@ expression: data
 ---
 {
   "user": {
-    "ip_address": null,
-    "username": "secret",
+    "ip_address": "[ip]",
+    "username": "[ip]",
     "data": {
       "a_password_here": "hello",
       "apiKey": "secret_key",
@@ -21,10 +21,26 @@ expression: data
         "": {
           "rem": [
             [
-              "@anything:remove",
-              "x"
+              "@ip:replace",
+              "s",
+              0,
+              4
             ]
-          ]
+          ],
+          "len": 13
+        }
+      },
+      "username": {
+        "": {
+          "rem": [
+            [
+              "@ip:replace",
+              "s",
+              0,
+              4
+            ]
+          ],
+          "len": 13
         }
       }
     }


### PR DESCRIPTION
This change will scrub all fields containing an IP address, rather than scrubbing certain fields known to have them 

for the unit tests, testing ip scrubbing in sdk and user have been merged as it should scrub all fields.

referencing issue #1693 