### PR TITLE
build(py): Add sentry-pypi target

### DIFF
--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -1,11 +1,13 @@
 ---
-minVersion: 0.23.1
+minVersion: 0.34.1
 changelogPolicy: auto
 preReleaseCommand: ../scripts/bump-library.sh
 releaseBranchPrefix: release-library
 
 targets:
   - name: pypi
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi
   - name: gcs
     bucket: sentry-sdk-assets
     includeNames: /^(sentry-relay|sentry_relay).*(.whl|.zip)$/


### PR DESCRIPTION
As in https://github.com/getsentry/arroyo/pull/169, add a sentry-pypi target to the craft file to publish package to internal pypi.

#skip-changelog