### PR TITLE
feat(common): Add catch-all status code variant for SpanStatus

### DIFF
--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -305,6 +305,9 @@ pub enum SpanStatus {
     ///
     /// Prefer PermissionDenied if a user is logged in.
     Unauthenticated = 16,
+
+    /// Other code for forward compatibility
+    Other(u8),
 }
 
 /// Error parsing a `SpanStatus`.
@@ -368,6 +371,7 @@ impl fmt::Display for SpanStatus {
             SpanStatus::Aborted => write!(f, "aborted"),
             SpanStatus::OutOfRange => write!(f, "out_of_range"),
             SpanStatus::DataLoss => write!(f, "data_loss"),
+            SpanStatus::Other(code) => write!(f, "Unknown status code: {}", code),
         }
     }
 }

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2794,25 +2794,44 @@ expression: "relay_general::protocol::event_json_schema()"
     },
     "SpanStatus": {
       "description": "Trace status.\n\nValues from <https://github.com/open-telemetry/opentelemetry-specification/blob/8fb6c14e4709e75a9aaa64b0dbbdf02a6067682a/specification/api-tracing.md#status> Mapping to HTTP from <https://github.com/open-telemetry/opentelemetry-specification/blob/8fb6c14e4709e75a9aaa64b0dbbdf02a6067682a/specification/data-http.md#status>",
-      "type": "string",
-      "enum": [
-        "ok",
-        "cancelled",
-        "unknown",
-        "invalid_argument",
-        "deadline_exceeded",
-        "not_found",
-        "already_exists",
-        "permission_denied",
-        "resource_exhausted",
-        "failed_precondition",
-        "aborted",
-        "out_of_range",
-        "unimplemented",
-        "internal_error",
-        "unavailable",
-        "data_loss",
-        "unauthenticated"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "ok",
+            "cancelled",
+            "unknown",
+            "invalid_argument",
+            "deadline_exceeded",
+            "not_found",
+            "already_exists",
+            "permission_denied",
+            "resource_exhausted",
+            "failed_precondition",
+            "aborted",
+            "out_of_range",
+            "unimplemented",
+            "internal_error",
+            "unavailable",
+            "data_loss",
+            "unauthenticated"
+          ]
+        },
+        {
+          "description": "Other code for forward compatibility",
+          "type": "object",
+          "required": [
+            "other"
+          ],
+          "properties": {
+            "other": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "Stacktrace": {


### PR DESCRIPTION
#skip-changelog

Adds a status to SpanStatus that can hold an unknown status code. Useful for forward compatibility.

#1639 