### PR TITLE
instr(replays): Add timer metric to recording processing

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1094,7 +1094,9 @@ impl EnvelopeProcessorService {
                     // allocations.
                     let limit = self.config.max_replay_size();
                     let parsed_recording =
-                        relay_replays::recording::process_recording(&item.payload(), limit);
+                        metric!(timer(RelayTimers::ReplayRecordingProcessing), {
+                            relay_replays::recording::process_recording(&item.payload(), limit)
+                        });
 
                     match parsed_recording {
                         Ok(recording) => {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -298,6 +298,9 @@ pub enum RelayTimers {
 
     /// Time in milliseconds spent on converting a transaction event into a metric.
     TransactionMetricsExtraction,
+
+    /// Time in milliseconds spent on parsing, normalizing and scrubbing Relay recordings.
+    ReplayRecordingProcessing,
 }
 
 impl TimerMetric for RelayTimers {
@@ -328,6 +331,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::TimestampDelay => "requests.timestamp_delay",
             RelayTimers::OutcomeAggregatorFlushTime => "outcomes.aggregator.flush_time",
             RelayTimers::TransactionMetricsExtraction => "metrics.extraction.transactions",
+            RelayTimers::ReplayRecordingProcessing => "replay.recording.process",
         }
     }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -299,7 +299,7 @@ pub enum RelayTimers {
     /// Time in milliseconds spent on converting a transaction event into a metric.
     TransactionMetricsExtraction,
 
-    /// Time in milliseconds spent on parsing, normalizing and scrubbing Relay recordings.
+    /// Time in milliseconds spent on parsing, normalizing and scrubbing replay recordings.
     ReplayRecordingProcessing,
 }
 


### PR DESCRIPTION
We noticed an increase in total processing time which we suspect was caused by https://github.com/getsentry/relay/pull/1678.

Add a statsd metric to measure replay recording processing in isolation.

#skip-changelog