### PR TITLE
feat: Switch from base64 to data-encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "debugid"
@@ -3166,8 +3166,8 @@ dependencies = [
 name = "relay-auth"
 version = "22.12.0"
 dependencies = [
- "base64 0.10.1",
  "chrono",
+ "data-encoding",
  "ed25519-dalek",
  "hmac",
  "rand 0.6.5",
@@ -3396,6 +3396,7 @@ dependencies = [
  "base64 0.10.1",
  "bytes 0.4.12",
  "chrono",
+ "data-encoding",
  "relay-general",
  "serde",
  "serde_json",
@@ -3470,11 +3471,11 @@ dependencies = [
  "actix",
  "actix-web",
  "anyhow",
- "base64 0.10.1",
  "brotli2",
  "bytes 0.4.12",
  "chrono",
  "clap",
+ "data-encoding",
  "failure",
  "flate2",
  "fragile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,7 +3393,6 @@ name = "relay-profiling"
 version = "22.12.0"
 dependencies = [
  "android_trace_log",
- "base64 0.10.1",
  "bytes 0.4.12",
  "chrono",
  "data-encoding",

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-base64 = "0.10.1"
 chrono = "0.4.11"
 ed25519-dalek = "0.9.1"
 thiserror = "1.0.24"
@@ -21,3 +20,4 @@ relay-common = { path = "../relay-common" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 sha2 = "0.8.1"
+data-encoding = "2.3.3"

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 
 [dependencies]
 android_trace_log = { version = "0.2.0", features = ["serde"] }
-base64 = "0.10.1"
 bytes = { version = "0.4.12", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+data-encoding = "2.3.3"
 relay-general = { path = "../relay-general" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use android_trace_log::chrono::{DateTime, Utc};
 use android_trace_log::{AndroidTraceLog, Clock, Time, Vm};
+use data_encoding::BASE64;
 use serde::{Deserialize, Serialize};
 
 use relay_general::protocol::EventId;
@@ -90,7 +91,7 @@ impl AndroidProfile {
     }
 
     fn parse(&mut self) -> Result<(), ProfileError> {
-        let profile_bytes = match base64::decode(&self.sampled_profile) {
+        let profile_bytes = match BASE64.decode(self.sampled_profile.as_bytes()) {
             Ok(profile) => profile,
             Err(_) => return Err(ProfileError::InvalidBase64Value),
         };

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -13,25 +13,17 @@ publish = false
 [features]
 default = []
 ssl = ["native-tls", "actix-web/tls"]
-processing = [
-    "minidump",
-    "relay-config/processing",
-    "relay-kafka/producer",
-    "relay-quotas/redis",
-    "relay-redis/impl",
-    "symbolic-unreal",
-    "symbolic-common",
-]
+processing = ["minidump", "relay-config/processing", "relay-kafka/producer", "relay-quotas/redis", "relay-redis/impl", "symbolic-unreal", "symbolic-common"]
 
 [dependencies]
 actix = "0.7.9"
 actix-web = { version = "0.7.19", default-features = false }
 anyhow = "1.0.66"
-base64 = "0.10.1"
 brotli2 = "0.3.2"
 bytes = { version = "0.4.12", features = ["serde"] }
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = "2.33.1"
+data-encoding = "2.3.3"
 failure = "0.1.8"
 flate2 = "1.0.19"
 fragile = { version = "2.0.0", features = ["slab"] } # used for vendoring sentry-actix

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -73,7 +73,7 @@ fn decode_bytes<B: Into<Bytes> + AsRef<[u8]>>(body: B) -> Result<Bytes, PayloadE
     // TODO: Switch to a streaming decoder
     // see https://github.com/alicemaz/rust-base64/pull/56
     let binary_body = BASE64
-        .decode(&body.as_ref())
+        .decode(body.as_ref())
         .map_err(|e| io::Error::new(ErrorKind::InvalidInput, e))?;
     if binary_body.starts_with(b"{") {
         return Ok(binary_body.into());

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -3,6 +3,7 @@ use std::io::{self, ErrorKind, Read};
 
 use actix_web::{error::PayloadError, HttpRequest};
 use bytes::Bytes;
+use data_encoding::BASE64;
 use flate2::read::ZlibDecoder;
 use futures01::prelude::*;
 use url::form_urlencoded;
@@ -71,8 +72,9 @@ fn decode_bytes<B: Into<Bytes> + AsRef<[u8]>>(body: B) -> Result<Bytes, PayloadE
 
     // TODO: Switch to a streaming decoder
     // see https://github.com/alicemaz/rust-base64/pull/56
-    let binary_body =
-        base64::decode(&body).map_err(|e| io::Error::new(ErrorKind::InvalidInput, e))?;
+    let binary_body = BASE64
+        .decode(&body.as_ref())
+        .map_err(|e| io::Error::new(ErrorKind::InvalidInput, e))?;
     if binary_body.starts_with(b"{") {
         return Ok(binary_body.into());
     }


### PR DESCRIPTION
Switches from an old version of base64 to data-encoding.

Refs https://github.com/marshallpierce/rust-base64/issues/213 and https://github.com/marshallpierce/rust-base64/issues/205

#skip-changelog