### PR TITLE
feat: Add CrashType as a tag to allow filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Add Unreal crash type as an event tag ([#1744](https://github.com/getsentry/relay/pull/1744))
 - Add error and sample rate fields to the replay event parser. ([#1745](https://github.com/getsentry/relay/pull/1745))
 
 ## 23.1.0

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -234,6 +234,14 @@ fn merge_unreal_context(event: &mut Event, context: Unreal4Context) {
         event.level = Annotated::new(Level::Warning)
     }
 
+    if let Some(crash_type) = runtime_props.crash_type.take() {
+        let tags = event.tags.value_mut().get_or_insert_with(Tags::default);
+        tags.push(Annotated::new(TagEntry::from_pair((
+            Annotated::new("crash_type".to_string()),
+            Annotated::new(crash_type),
+        ))));
+    }
+
     // Modules are not used and later replaced with Modules from the Minidump or Apple Crash Report.
     runtime_props.modules.take();
 


### PR DESCRIPTION
Here's a small PR to fix [issue 38550](https://github.com/getsentry/sentry/issues/38550).

The unreal crash reporter gives some information about the type of crash that occured ( stall, crash, ...). We'd like to be able to filter crashes based on this information.

As discussed in the issue linked above, this PR adds the crash type to event tags.

I couldn't find much information about PR guidelines and it's my first commit in the Sentry codebase so, please, let me know if I can improve this PR in any way :)
