### PR TITLE
feat(codeowners): Find codeowner path matches with rust

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add utility function for matching CODEOWNER paths against a stacktrace filepath ([#1746](https://github.com/getsentry/relay/pull/1746))
+
 ## 0.8.16
 
 - The minimum required Python version is now 3.8. This release does not contain known breaking changes for Python 3.7, but we no longer guarantee compatibility.

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -163,7 +163,10 @@ def is_glob_match(
 def is_codeowners_path_match(value, pattern):
     if isinstance(value, text_type):
         value = value.encode("utf-8")
-    return rustcall(lib.relay_is_codeowners_path_match, make_buf(value), encode_str(pattern))
+    return rustcall(
+        lib.relay_is_codeowners_path_match, make_buf(value), encode_str(pattern)
+    )
+
 
 def validate_pii_config(config):
     """

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -18,6 +18,7 @@ __all__ = [
     "StoreNormalizer",
     "GeoIpLookup",
     "is_glob_match",
+    "is_codeowners_path_match",
     "parse_release",
     "validate_pii_config",
     "convert_datascrubbing_config",
@@ -158,6 +159,11 @@ def is_glob_match(
         value = value.encode("utf-8")
     return rustcall(lib.relay_is_glob_match, make_buf(value), encode_str(pat), flags)
 
+
+def is_codeowners_path_match(value, pattern):
+    if isinstance(value, text_type):
+        value = value.encode("utf-8")
+    return rustcall(lib.relay_is_codeowners_path_match, make_buf(value), encode_str(pattern))
 
 def validate_pii_config(config):
     """

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -549,6 +549,14 @@ bool relay_is_glob_match(const struct RelayBuf *value,
                          GlobFlags flags);
 
 /**
+ * Converts a codeowners path into a regex and searches for match against the provided value.
+ *
+ * Returns `true` if the regex matches, `false` otherwise.
+ */
+bool relay_is_codeowners_path_match(const struct RelayBuf *value,
+                         const struct RelayStr *pat);
+
+/**
  * Parse a sentry release structure from a string.
  */
 struct RelayStr relay_parse_release(const struct RelayStr *value);

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -10,7 +10,7 @@ use std::slice;
 
 use once_cell::sync::OnceCell;
 
-use relay_common::{glob_match_bytes, translate_codeowners_pattern, GlobOptions};
+use relay_common::{codeowners_match_bytes, glob_match_bytes, GlobOptions};
 use relay_general::pii::{
     selector_suggestions_from_value, DataScrubbingConfig, PiiConfig, PiiProcessor,
 };
@@ -242,8 +242,7 @@ pub unsafe extern "C" fn relay_is_codeowners_path_match(
     value: *const RelayBuf,
     pattern: *const RelayStr,
 ) -> bool {
-    let regex = translate_codeowners_pattern((*pattern).as_str());
-    return Ok(regex.is_match((*value).as_bytes()));
+    codeowners_match_bytes((*value).as_bytes(), (*pattern).as_str())
 }
 
 /// Parse a sentry release structure from a string.

--- a/relay-common/src/glob.rs
+++ b/relay-common/src/glob.rs
@@ -33,6 +33,81 @@ fn translate_pattern(pat: &str, options: GlobOptions) -> Option<Regex> {
         .ok()
 }
 
+pub fn translate_codeowners_pattern(pattern: &str) -> Regex {
+    let mut regex = String::new();
+
+    // Special case backslash can match a backslash file or directory
+    if pattern.starts_with("\\") {
+        return Regex::new(r"\\(?:\z|/)").unwrap();
+    }
+
+    let anchored = pattern
+        .find("/")
+        .map_or(false, |pos| pos != pattern.len() - 1);
+
+    if anchored {
+        regex += r"\A";
+    } else {
+        regex += r"(?:\A|/)";
+    }
+
+    let matches_dir = pattern.ends_with("/");
+    let mut pattern = pattern;
+    if matches_dir {
+        pattern = pattern.trim_end_matches("/");
+    }
+
+    // patterns ending with "/*" are special. They only match items directly in the directory
+    // not deeper
+    let trailing_slash_star = pattern.len() > 1 && pattern.ends_with("/*");
+
+    let mut iterator = pattern.chars().enumerate();
+
+    // Anchored paths may or may not start with a slash
+    if anchored && pattern.starts_with("/") {
+        iterator.next();
+        regex += r"/?";
+    }
+
+    let mut num_to_skip = None;
+    for (i, ch) in iterator {
+        if let Some(skip_amount) = num_to_skip {
+            num_to_skip = Some(skip_amount - 1);
+            continue;
+        }
+        if ch == '*' {
+            // Handle double star (**) case properly
+            if i + 1 < pattern.len() && pattern.chars().nth(i + 1) == Some('*') {
+                let left_anchored = i == 0;
+                let leading_slash = i > 0 && pattern.chars().nth(i - 1) == Some('/');
+                let right_anchored = i + 2 == pattern.len();
+                let trailing_slash =
+                    i + 2 < pattern.len() && pattern.chars().nth(i + 2) == Some('/');
+
+                if (left_anchored || leading_slash) && (right_anchored || trailing_slash) {
+                    regex += ".*";
+                    num_to_skip = Some(2);
+                    continue;
+                }
+            }
+            regex += r"[^/]*";
+        } else if ch == '?' {
+            regex += r"[^/]";
+        } else {
+            regex += &regex::escape(ch.to_string().as_str());
+        }
+    }
+
+    if matches_dir {
+        regex += "/";
+    } else if trailing_slash_star {
+        regex += r"\z";
+    } else {
+        regex += r"(?:\z|/)";
+    }
+    Regex::new(&regex).unwrap()
+}
+
 /// Performs a glob operation on bytes.
 ///
 /// Returns `true` if the glob matches, `false` otherwise.
@@ -112,5 +187,39 @@ mod tests {
         long_string.push_str(".PY");
         test_glob!(&long_string, "*************************.py", true, {double_star: true, case_insensitive: true, path_normalize: true});
         test_glob!(&long_string, "*************************.js", false, {double_star: true, case_insensitive: true, path_normalize: true});
+    }
+
+    #[test]
+    fn test_translate_codeowners_pattern() {
+        let pattern = "*.txt";
+        let regex = translate_codeowners_pattern(pattern);
+        assert!(regex.is_match(b"file.txt"));
+        assert!(regex.is_match(b"file.txt/"));
+        assert!(regex.is_match(b"dir/file.txt"));
+
+        let pattern = "/dir/*.txt";
+        let regex = translate_codeowners_pattern(pattern);
+        assert!(regex.is_match(b"/dir/file.txt"));
+        assert!(regex.is_match(b"dir/file.txt"));
+        assert!(!regex.is_match(b"/dir/subdir/file.txt"));
+
+        let pattern = "apps/";
+        let regex = translate_codeowners_pattern(pattern);
+        assert!(regex.is_match(b"apps/file.txt"));
+        assert!(regex.is_match(b"/apps/file.txt"));
+        assert!(regex.is_match(b"/dir/apps/file.txt"));
+        assert!(regex.is_match(b"/dir/subdir/apps/file.txt"));
+
+        let pattern = "docs/*";
+        let regex = translate_codeowners_pattern(pattern);
+        assert!(regex.is_match(b"docs/getting-started.md"));
+        // should not match on nested files
+        assert!(!regex.is_match(b"docs/build-app/troubleshooting.md"));
+
+        let pattern = "/docs/";
+        let regex = translate_codeowners_pattern(pattern);
+        assert!(regex.is_match(b"/docs/file.txt"));
+        assert!(regex.is_match(b"/docs/subdir/file.txt"));
+        assert!(!regex.is_match(b"app/docs/file.txt"));
     }
 }


### PR DESCRIPTION
Proof of Concept PR

Benchmarked this solution agains the baseline python implementation https://github.com/getsentry/sentry/pull/43294

This code is benchmarking ~3 times faster than the baseline python implementation. So it is ready to be merged into Sentry.