### PR TITLE
Revert "feat(replays): Enable PII scrubbing for all organizations"

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1087,7 +1087,7 @@ impl EnvelopeProcessorService {
             ItemType::ReplayRecording => {
                 // XXX: Temporarily, only the Sentry org will be allowed to parse replays while
                 // we measure the impact of this change.
-                if replays_enabled {
+                if replays_enabled && state.project_state.organization_id == Some(1) {
                     // Limit expansion of recordings to the max replay size. The payload is
                     // decompressed temporarily and then immediately re-compressed. However, to
                     // limit memory pressure, we use the replay limit as a good overall limit for


### PR DESCRIPTION
Reverts getsentry/relay#1678

This is the suspected change increased the event's processing time. And maybe a mem leak. 

#skip-changelog