### PR TITLE
feat(replays): Log the event-id of a failed replay

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1025,6 +1025,7 @@ impl EnvelopeProcessorService {
         let meta = state.envelope.meta().clone();
         let client_addr = meta.client_addr();
         let user_agent = meta.user_agent();
+        let event_id = state.envelope.event_id();
 
         state.envelope.retain_items(|item| match item.ty() {
             ItemType::ReplayEvent => {
@@ -1112,7 +1113,8 @@ impl EnvelopeProcessorService {
                         }
                         Err(e) => {
                             relay_log::warn!(
-                                "replay-recording-event: failed to parse with message {}",
+                                "replay-recording-event: failed to parse {:?} with message {}",
+                                event_id,
                                 e
                             );
                             context.track_outcome(


### PR DESCRIPTION
This will allow us to look up failed recordings and fix future events.

#skip-changelog