### PR TITLE
ci: Update self-hosted e2e action to add sentry-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,8 +362,6 @@ jobs:
 
   self-hosted-end-to-end:
     runs-on: ubuntu-latest
-    # temporary, remove once we are confident the action is working
-    continue-on-error: true
     timeout-minutes: 30
 
     # Skip redundant checks for library releases
@@ -373,7 +371,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@711694d0081a834777ca9c77c3f4c322ce7b08c4
+        uses: getsentry/action-self-hosted-e2e-tests@20b5170d3b59d8b44ee5327d64b31d6b6b5aa34f
         with:
           project_name: relay
           image_url: us.gcr.io/sentryio/relay:${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
This bumps the action ref to getsentry/action-self-hosted-e2e-tests@20b5170, which introduces sentry-cli, a new dependency of our integration tests.

_#skip-changelog_