### PR TITLE
feat(glob): Allow escaping wildcard characters in globs

### DIFF
--- a/relay-common/src/utils.rs
+++ b/relay-common/src/utils.rs
@@ -330,6 +330,21 @@ mod tests {
     }
 
     #[test]
+    fn test_do_not_replace() {
+        let g = Glob::builder(r"/foo/\*/*")
+            .capture_star(true)
+            .capture_double_star(false)
+            .capture_question_mark(false)
+            .build();
+
+        // A literal asterisk matches
+        assert_eq!(g.replace_captures("/foo/*/bar", "_"), "/foo/*/_");
+
+        // But only a literal asterisk
+        assert_eq!(g.replace_captures("/foo/nope/bar", "_"), "/foo/nope/bar");
+    }
+
+    #[test]
     fn test_glob_matcher() {
         #[derive(Clone, Copy, Debug, PartialEq)]
         enum Paths {


### PR DESCRIPTION
For transaction name replacement rules, we might encounter the case where there's a literal `*` in a transaction name. If this `*` makes it into a rule, it should not be interpret as a "replace" command, so we will escape it. This PR adds support for escaping `*` in globs. 

#skip-changelog

Relates to https://github.com/getsentry/team-ingest/issues/35.