### PR TITLE
feat(protocol): Add `source` field to sdk interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add error and sample rate fields to the replay event parser. ([#1745](https://github.com/getsentry/relay/pull/1745))
+- Add `source` field to sdk interface in event payload. ([#1760](https://github.com/getsentry/relay/pull/1760))
 
 ## 23.1.0
 

--- a/relay-general/src/protocol/clientsdk.rs
+++ b/relay-general/src/protocol/clientsdk.rs
@@ -54,6 +54,13 @@ pub struct ClientSdkInfo {
     #[metastructure(skip_serialization = "empty_deep")]
     pub packages: Annotated<Array<ClientSdkPackage>>,
 
+    /// The installation mechanism for the SDK. _Optional._
+    ///
+    /// This can be a package manager like `npm` or `cocoapods` or a custom installation mechanism
+    /// like `cdn`.
+    #[metastructure(skip_serialization = "empty")]
+    pub source: Annotated<String>,
+
     /// IP Address of sender??? Seems unused. Do not send, this only leads to surprises wrt PII, as
     /// the value appears nowhere in the UI.
     #[metastructure(pii = "true", skip_serialization = "empty", omit_from_schema)]
@@ -120,6 +127,7 @@ mod tests {
                     version: Annotated::new("0.10.0".to_string()),
                 }),
             ]),
+            source: Annotated::new("cargo".to_string()),
             client_ip: Annotated::new(IpAddr("127.0.0.1".to_owned())),
             other: {
                 let mut map = Map::new();

--- a/relay-general/src/protocol/clientsdk.rs
+++ b/relay-general/src/protocol/clientsdk.rs
@@ -110,6 +110,7 @@ mod tests {
       "version": "0.10.0"
     }
   ],
+  "source": "cargo",
   "client_ip": "127.0.0.1",
   "other": "value"
 }"#;

--- a/relay-general/src/protocol/clientsdk.rs
+++ b/relay-general/src/protocol/clientsdk.rs
@@ -156,6 +156,7 @@ mod tests {
             integrations: Annotated::empty(),
             packages: Annotated::empty(),
             client_ip: Annotated::new(IpAddr("127.0.0.1".to_owned())),
+            source: Annotated::empty(),
             other: Default::default(),
         });
 

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -761,6 +761,14 @@ expression: "relay_general::protocol::event_json_schema()"
                 ]
               }
             },
+            "source": {
+              "description": " The installation mechanism for the SDK. _Optional._\n\n This can be a package manager like `npm` or `cocoapods` or a custom installation mechanism\n like `cdn`.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "version": {
               "description": " The version of the SDK. _Required._\n\n It should have the [Semantic Versioning](https://semver.org/) format `MAJOR.MINOR.PATCH`,\n without any prefix (no `v` or anything else in front of the major version number).\n\n Examples: `0.1.0`, `1.0.0`, `4.3.12`",
               "type": [


### PR DESCRIPTION
https://github.com/getsentry/sentry/issues/43427

We added the `source` field to the SDK event payload under the sdk interface so we can better track how users install our sdk: https://github.com/getsentry/develop/pull/815.

This PR updates the Relay schema to reflect the changed develop docs.