### PR TITLE
bug(replays): Fix error where some recordings can not be parsed due to type errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add error and sample rate fields to the replay event parser. ([#1745](https://github.com/getsentry/relay/pull/1745))
 
+**Internal**:
+
+- Fix type errors in replay recording parsing. ([#1765](https://github.com/getsentry/relay/pull/1765))
+
 ## 23.1.0
 
 **Features**:

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -313,7 +313,7 @@ struct MetaEvent {
 struct CustomEvent {
     #[serde(rename = "type")]
     ty: u8,
-    timestamp: f64,
+    timestamp: Value,
     data: CustomEventDataVariant,
 }
 
@@ -336,7 +336,7 @@ struct Breadcrumb {
 struct BreadcrumbPayload {
     #[serde(rename = "type")]
     ty: String,
-    timestamp: f64,
+    timestamp: Value,
     category: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     level: Option<String>,
@@ -357,8 +357,8 @@ struct PerformanceSpan {
 struct PerformanceSpanPayload {
     op: String,
     description: String,
-    start_timestamp: f64,
-    end_timestamp: f64,
+    start_timestamp: Value,
+    end_timestamp: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<Value>,
 }
@@ -796,7 +796,7 @@ mod tests {
     fn test_rrweb_event_5_parsing() {
         let payload = include_bytes!("../tests/fixtures/rrweb-event-5.json");
 
-        let input_parsed: recording::Event = serde_json::from_slice(payload).unwrap();
+        let input_parsed: Vec<recording::Event> = serde_json::from_slice(payload).unwrap();
         let input_raw: Value = serde_json::from_slice(payload).unwrap();
         assert_json_eq!(input_parsed, input_raw)
     }

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -380,7 +380,7 @@ struct PerformanceSpanPayload {
 #[serde(rename_all = "camelCase")]
 struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
-    root_id: Option<u32>,
+    root_id: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_shadow_host: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -434,7 +434,7 @@ impl<'de> serde::Deserialize<'de> for NodeVariant {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct DocumentNode {
-    id: u32,
+    id: i32,
     #[serde(rename = "type")]
     ty: u8,
     #[serde(rename = "childNodes")]
@@ -535,7 +535,7 @@ impl<'de> serde::Deserialize<'de> for IncrementalSourceDataVariant {
 #[serde(rename_all = "camelCase")]
 struct InputIncrementalSourceData {
     source: u8,
-    id: u32,
+    id: i32,
     text: String,
     is_checked: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -798,6 +798,6 @@ mod tests {
 
         let input_parsed: Vec<recording::Event> = serde_json::from_slice(payload).unwrap();
         let input_raw: Value = serde_json::from_slice(payload).unwrap();
-        assert_json_eq!(input_parsed, input_raw)
+        assert_json_eq!(input_parsed, input_raw);
     }
 }

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -313,7 +313,7 @@ struct MetaEvent {
 struct CustomEvent {
     #[serde(rename = "type")]
     ty: u8,
-    timestamp: Value,
+    timestamp: f64,
     data: CustomEventDataVariant,
 }
 
@@ -336,7 +336,7 @@ struct Breadcrumb {
 struct BreadcrumbPayload {
     #[serde(rename = "type")]
     ty: String,
-    timestamp: Value,
+    timestamp: f64,
     category: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     level: Option<String>,
@@ -357,8 +357,8 @@ struct PerformanceSpan {
 struct PerformanceSpanPayload {
     op: String,
     description: String,
-    start_timestamp: Value,
-    end_timestamp: Value,
+    start_timestamp: f64,
+    end_timestamp: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<Value>,
 }

--- a/relay-replays/tests/fixtures/rrweb-event-5.json
+++ b/relay-replays/tests/fixtures/rrweb-event-5.json
@@ -1,20 +1,108 @@
-{
-    "type": 5,
-    "timestamp": 1658770772.902,
-    "data": {
-        "tag": "performanceSpan",
-        "payload": {
-            "op": "memory",
-            "description": "memory",
-            "startTimestamp": 1658770772.902,
-            "endTimestamp": 1658770772.902,
-            "data": {
-                "memory": {
-                    "jsHeapSizeLimit": 4294705152,
-                    "totalJSHeapSize": 10204109,
-                    "usedJSHeapSize": 9131621
+[
+    {
+        "type": 5,
+        "timestamp": 1658770772.902,
+        "data": {
+            "tag": "performanceSpan",
+            "payload": {
+                "op": "memory",
+                "description": "memory",
+                "startTimestamp": 1658770772.902,
+                "endTimestamp": 1658770772.902,
+                "data": {
+                    "memory": {
+                        "jsHeapSizeLimit": 4294705152,
+                        "totalJSHeapSize": 10204109,
+                        "usedJSHeapSize": 9131621
+                    }
+                }
+            }
+        }
+    },
+    {
+        "type": 5,
+        "timestamp": 1658770772,
+        "data": {
+            "tag": "performanceSpan",
+            "payload": {
+                "op": "memory",
+                "description": "memory",
+                "startTimestamp": 1658770772,
+                "endTimestamp": 1658770772,
+                "data": {
+                    "memory": {
+                        "jsHeapSizeLimit": 4294705152,
+                        "totalJSHeapSize": 10204109,
+                        "usedJSHeapSize": 9131621
+                    }
+                }
+            }
+        }
+    },
+    {
+        "type": 5,
+        "timestamp": 1665063926.125,
+        "data": {
+            "tag": "performanceSpan",
+            "payload": {
+                "op": "navigation.navigate",
+                "description": "https://sentry.io",
+                "startTimestamp": 1665063926.125,
+                "endTimestamp": 1665063926.833,
+                "data": {
+                    "size": 9538,
+                    "duration": 710
+                }
+            }
+        }
+    },
+    {
+        "type": 5,
+        "timestamp": 1665063926,
+        "data": {
+            "tag": "performanceSpan",
+            "payload": {
+                "op": "navigation.navigate",
+                "description": "https://sentry.io",
+                "startTimestamp": 1665063926,
+                "endTimestamp": 1665063926,
+                "data": {
+                    "size": 9538,
+                    "duration": 710
+                }
+            }
+        }
+    },
+    {
+        "type": 5,
+        "timestamp": 1674135065772.32,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "timestamp": 1674135065.772,
+                "type": "default",
+                "category": "ui.input",
+                "message": "something happened",
+                "data": {
+                    "nodeId": 14235
+                }
+            }
+        }
+    },
+    {
+        "type": 5,
+        "timestamp": 1674135065772,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "timestamp": 1674135065,
+                "type": "default",
+                "category": "ui.input",
+                "message": "something happened",
+                "data": {
+                    "nodeId": 14235
                 }
             }
         }
     }
-}
+]

--- a/relay-replays/tests/fixtures/rrweb-event-5.json
+++ b/relay-replays/tests/fixtures/rrweb-event-5.json
@@ -21,26 +21,6 @@
     },
     {
         "type": 5,
-        "timestamp": 1658770772,
-        "data": {
-            "tag": "performanceSpan",
-            "payload": {
-                "op": "memory",
-                "description": "memory",
-                "startTimestamp": 1658770772,
-                "endTimestamp": 1658770772,
-                "data": {
-                    "memory": {
-                        "jsHeapSizeLimit": 4294705152,
-                        "totalJSHeapSize": 10204109,
-                        "usedJSHeapSize": 9131621
-                    }
-                }
-            }
-        }
-    },
-    {
-        "type": 5,
         "timestamp": 1665063926.125,
         "data": {
             "tag": "performanceSpan",
@@ -58,44 +38,11 @@
     },
     {
         "type": 5,
-        "timestamp": 1665063926,
-        "data": {
-            "tag": "performanceSpan",
-            "payload": {
-                "op": "navigation.navigate",
-                "description": "https://sentry.io",
-                "startTimestamp": 1665063926,
-                "endTimestamp": 1665063926,
-                "data": {
-                    "size": 9538,
-                    "duration": 710
-                }
-            }
-        }
-    },
-    {
-        "type": 5,
         "timestamp": 1674135065772.32,
         "data": {
             "tag": "breadcrumb",
             "payload": {
                 "timestamp": 1674135065.772,
-                "type": "default",
-                "category": "ui.input",
-                "message": "something happened",
-                "data": {
-                    "nodeId": 14235
-                }
-            }
-        }
-    },
-    {
-        "type": 5,
-        "timestamp": 1674135065772,
-        "data": {
-            "tag": "breadcrumb",
-            "payload": {
-                "timestamp": 1674135065,
                 "type": "default",
                 "category": "ui.input",
                 "message": "something happened",

--- a/relay-replays/tests/fixtures/rrweb-node-2.json
+++ b/relay-replays/tests/fixtures/rrweb-node-2.json
@@ -10,7 +10,7 @@
         {
             "type": 3,
             "textContent": "test",
-            "id": 284
+            "id": -1
         }
     ],
     "id": 283


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/258

Sentry event timestamps can be float or integer type.  Additionally id fields can be negative so we're using i32 now.