### PR TITLE
test(replays): try replay recording processing without PII scrubbing

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1162,14 +1162,14 @@ impl EnvelopeProcessorService {
         });
         metric!(histogram(RelayHistograms::ReplayOriginalDecompressedSize) = buffer.len() as u64);
 
-        let mut events = metric!(timer(RelayTimers::ReplayRecordingDeserialize), {
+        let events = metric!(timer(RelayTimers::ReplayRecordingDeserialize), {
             recording::deserialize(buffer)?
         });
 
-        metric!(timer(RelayTimers::ReplayRecordingScrubPII), {
-            recording::strip_pii(&mut events)
-                .map_err(recording::RecordingParseError::ProcessingAction)?
-        });
+        // metric!(timer(RelayTimers::ReplayRecordingScrubPII), {
+        //     recording::strip_pii(&mut events)
+        //         .map_err(recording::RecordingParseError::ProcessingAction)?
+        // });
 
         let bytes = metric!(timer(RelayTimers::ReplayRecordingSerialize), {
             recording::serialize(events)?

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -313,7 +313,7 @@ pub enum RelayTimers {
     ReplayRecordingProcessing,
     ReplayRecordingDecompress,
     ReplayRecordingDeserialize,
-    ReplayRecordingScrubPII,
+    // ReplayRecordingScrubPII,
     ReplayRecordingCompress,
     ReplayRecordingSerialize,
 }
@@ -349,7 +349,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::ReplayRecordingProcessing => "replay.recording.process",
             RelayTimers::ReplayRecordingDecompress => "replay.recording.decompress",
             RelayTimers::ReplayRecordingDeserialize => "replay.recording.deserialize",
-            RelayTimers::ReplayRecordingScrubPII => "replay.recording.scrub_pii",
+            // RelayTimers::ReplayRecordingScrubPII => "replay.recording.scrub_pii",
             RelayTimers::ReplayRecordingCompress => "replay.recording.compress",
             RelayTimers::ReplayRecordingSerialize => "replay.recording.serialize",
         }


### PR DESCRIPTION
a version of replay recording processing without PII scrubbing to see if memory usage still increases. meant for canary deploy only.


#skip-changelog