### PR TITLE
test(project): Check the relay behavior for invalid states

### DIFF
--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -2,10 +2,11 @@
 Tests the project_configs endpoint (/api/0/relays/projectconfigs/)
 """
 
-import json
 import uuid
 import pytest
 import time
+from requests.exceptions import HTTPError
+import queue
 from collections import namedtuple
 
 from sentry_relay import PublicKey, SecretKey, generate_key_pair
@@ -208,3 +209,124 @@ def test_pending_projects(mini_sentry, relay):
     print(data)
     assert public_key in data["configs"]
     assert data.get("pending") is None
+
+
+def request_config(relay, packed, signature):
+    return relay.post(
+        "/api/0/relays/projectconfigs/?version=3",
+        data=packed,
+        headers={
+            "X-Sentry-Relay-Id": relay.relay_id,
+            "X-Sentry-Relay-Signature": signature,
+        },
+    )
+
+
+def get_response(relay, packed, signature):
+    data = None
+    deadline = time.monotonic() + 15
+    while time.monotonic() <= deadline:
+        # send 1 r/s
+        time.sleep(1)
+        response = request_config(relay, packed, signature)
+        assert response.ok
+        data = response.json()
+        if data["configs"]:
+            break
+    else:
+        print("Relay did still not receive a project config from minisentry")
+    return data
+
+
+def test_unparsable_project_config(mini_sentry, relay):
+    project_key = 42
+    relay_config = {
+        "cache": {"project_expiry": 2, "project_grace_period": 2, "miss_expiry": 2}
+    }
+    relay = relay(mini_sentry, relay_config, wait_health_check=True)
+    mini_sentry.add_full_project_config(project_key)
+    public_key = mini_sentry.get_dsn_public_key(project_key)
+
+    # Config is broken and will produce the invalid project state.
+    config = mini_sentry.project_configs[project_key]["config"]
+    config.setdefault("dynamicSampling", {}).setdefault("rules", []).append(
+        {
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {"op": "glob", "name": "releases", "value": ["1.1.1", "1.1.2"]}
+                ],
+            },
+            "sampleRate": 0.7,
+            "type": "trace",
+            "id": 1,
+            "timeRange": {
+                "start": "2022-10-10T00:00:00.000000Z",
+                "end": "2022-10-20T00:00:00.000000Z",
+            },
+            "decayingFn": {"function": "linear", "decayedSampleRate": 0.9},
+        }
+    )
+
+    body = {"publicKeys": [public_key]}
+    packed, signature = SecretKey.parse(relay.secret_key).pack(body)
+
+    # This request should return invalid project state and also send the error to Sentry.
+    data = get_response(relay, packed, signature)
+    assert {
+        "configs": {
+            public_key: {
+                "projectId": None,
+                "lastChange": None,
+                "disabled": True,
+                "publicKeys": [],
+                "slug": None,
+                "config": {
+                    "allowedDomains": ["*"],
+                    "trustedRelays": [],
+                    "piiConfig": None,
+                },
+                "organizationId": None,
+            }
+        }
+    } == data
+
+    try:
+        # This event will be dropped since the project state is invalid.
+        pytest.raises(HTTPError, lambda: relay.send_event(project_key))
+        time.sleep(0.5)
+        assert {str(e) for _, e in mini_sentry.test_failures} == {
+            f"Relay sent us event: error fetching project state {public_key}: missing field `type`",
+            "Relay sent us event: dropped envelope: invalid data (project_state)",
+        }
+    finally:
+        mini_sentry.test_failures.clear()
+
+    # Fix the config.
+    config = mini_sentry.project_configs[project_key]["config"]
+    config["dynamicSampling"]["rules"] = [
+        {
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {"op": "glob", "name": "releases", "value": ["1.1.1", "1.1.2"]}
+                ],
+            },
+            "sampleRate": 0.7,
+            "type": "trace",
+            "id": 1,
+            "timeRange": {
+                "start": "2022-10-10T00:00:00.000000Z",
+                "end": "2022-10-20T00:00:00.000000Z",
+            },
+            "decayingFn": {"type": "linear", "decayedSampleRate": 0.9},
+        }
+    ]
+
+    # Wait for caches to expire.
+    time.sleep(3)
+
+    # This must succeed, since we will re-request the project state update at this point.
+    relay.send_event(42)
+    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    assert event["logentry"] == {"formatted": "Hello, World!"}


### PR DESCRIPTION
Add integration test for project config:
* to check the behavior of the relay when we get the invalid project from upstream
  - the invalid state is saved in the ProjectCache and will be using till it expires
  - the incoming events are dropped because of the invalid state
* to make sure we recover when the project expires and the new one we get is valid one
  - once the old state expired the new one is saved in the ProjectCache
  - the events can be sent again and they are properly processed

And the second test makes sure to check that relay uses internal cache and re-uses stale state if the new one is invalid. 

ref: #1758 

#skip-changelog

