### PR TITLE
test(project_upstream): Test correct message handling

### DIFF
--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -76,3 +76,4 @@ libc = "0.2.71"
 [dev-dependencies]
 insta = { version = "1.19.0", features = ["json"] }
 relay-test = { path = "../relay-test" }
+tokio = { version = "1.0", features = ["test-util"] }


### PR DESCRIPTION
This change adds conditional compilation for `test` and not `test` targets, introducing the mocked `Upstream` service.

The tests check that the messages have proper flow, and project upstream manages inner queue the way it's supposed to:
* keeps internal queue
* merges same project key requests into one and broadcast the result

ref: #1758 


#skip-changelog