### PR TITLE
chore(redis): enable "tls" feature for redis crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add error and sample rate fields to the replay event parser. ([#1745](https://github.com/getsentry/relay/pull/1745))
+- Add SSL support to `relay-redis` crate. ([#1772](https://github.com/getsentry/relay/pull/1772))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Add error and sample rate fields to the replay event parser. ([#1745](https://github.com/getsentry/relay/pull/1745))
-- Add SSL support to `relay-redis` crate. ([#1772](https://github.com/getsentry/relay/pull/1772))
+- Add SSL support to `relay-redis` crate. It is possible to use `rediss` scheme to connnect to Redis cluster using TLS. ([#1772](https://github.com/getsentry/relay/pull/1772))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3091,13 +3091,14 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513b3649f1a111c17954296e4a3b9eecb108b766c803e2b99f179ebe27005985"
+checksum = "5c1aada340fba5deba625c84d109d0a83cc3565452d38083417992a702c2428d"
 dependencies = [
  "combine",
  "crc16",
  "itoa 1.0.2",
+ "native-tls",
  "percent-encoding 2.1.0",
  "r2d2",
  "rand 0.8.5",

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 [features]
 default = []
+tls = ["relay-redis/tls"]
 redis = [
     "thiserror",
     "relay-log",

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -11,12 +11,13 @@ publish = false
 
 [dependencies]
 r2d2 = { version = "0.8.10", optional = true }
-redis = { version = "0.22.1", optional = true, features = ["cluster", "r2d2"] }
+redis = { version = "0.22.2", optional = true, features = ["cluster", "r2d2"] }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.20"
 
 [features]
 default = []
+tls = ["redis/tls"]
 impl = ["r2d2", "redis"]
 
 [dev-dependencies]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [features]
 default = []
-ssl = ["native-tls", "actix-web/tls"]
+ssl = ["native-tls", "actix-web/tls", "relay-redis/tls", "relay-quotas/tls"]
 processing = ["minidump", "relay-config/processing", "relay-kafka/producer", "relay-quotas/redis", "relay-redis/impl", "symbolic-unreal", "symbolic-common"]
 
 [dependencies]


### PR DESCRIPTION
Added one more feature flag to `relay-redis` crate to be able to finetune what features are used and compiled into `relay`.
It is possible now to compile `relay-quotas` and `relay-server` with ssl support.  

This also bumps the crate version to `0.22.2` with some bug fixes in. 


fix: https://github.com/getsentry/relay/issues/995