### PR TITLE
fix(txnames): Improve regex to properly parse the UUIDs

### DIFF
--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -7,17 +7,9 @@ use regex::Regex;
 /// <https://github.com/getsentry/sentry/blob/6ba59023a78bfe033e48ea4e035b64710a905c6b/src/sentry/grouping/strategies/message.py#L16-L97>
 pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"
-
-    (?x)
+        r#"(?x)
     (?P<uuid>[^/\\]*
-        \b
-            [0-9a-fA-F]{8}-
-            [0-9a-fA-F]{4}-
-            [0-9a-fA-F]{4}-
-            [0-9a-fA-F]{4}-
-            [0-9a-fA-F]{12}
-        \b
+        \b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b
     [^/\\]*) |
     (?P<sha1>[^/\\]*
         \b[0-9a-fA-F]{40}\b
@@ -53,8 +45,7 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     [^/\\]*) |
     (?P<int>[^/\\]*
         \b\d{2,}\b
-    [^/\\]*)
-"#,
+    [^/\\]*)"#,
     )
     .unwrap()
 });

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -402,6 +402,7 @@ mod tests {
 
     use chrono::offset::TimeZone;
     use chrono::{Duration, Utc};
+    use insta::assert_debug_snapshot;
     use similar_asserts::assert_eq;
 
     use relay_common::Glob;
@@ -1331,6 +1332,21 @@ mod tests {
         assert!(!event.meta().has_errors());
 
         assert!(is_high_cardinality_sdk(&event.0.unwrap()));
+    }
+
+    #[test]
+    fn test_normalize_transaction_names() {
+        let should_be_replaced = [
+            "/aaa11111-aa11-11a1-a11a-1aaa1111a111",
+            "/1aa111aa-11a1-11aa-a111-a1a11111aa11",
+            "/00a00000-0000-0000-0000-000000000001",
+        ];
+        let replaced = should_be_replaced.map(|s| {
+            let mut s = Annotated::new(s.to_owned());
+            let _ = normalize_transaction_name(&mut s).unwrap();
+            s.0.unwrap()
+        });
+        assert_debug_snapshot!(replaced);
     }
 
     #[test]

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1859,7 +1859,7 @@ mod tests {
     );
     transaction_name_test!(
         test_transaction_name_normalize_uuid,
-        "/u/7b25feeaq-ed2d-4132-bcbd-6232b7922add/edit",
+        "/u/7b25feea-ed2d-4132-bcbd-6232b7922add/edit",
         "/u/*/edit"
     );
     transaction_name_test!(

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1335,21 +1335,6 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_transaction_names() {
-        let should_be_replaced = [
-            "/aaa11111-aa11-11a1-a11a-1aaa1111a111",
-            "/1aa111aa-11a1-11aa-a111-a1a11111aa11",
-            "/00a00000-0000-0000-0000-000000000001",
-        ];
-        let replaced = should_be_replaced.map(|s| {
-            let mut s = Annotated::new(s.to_owned());
-            let _ = normalize_transaction_name(&mut s).unwrap();
-            s.0.unwrap()
-        });
-        assert_debug_snapshot!(replaced);
-    }
-
-    #[test]
     fn test_transaction_name_dont_normalize() {
         let json = r#"
         {
@@ -1799,6 +1784,22 @@ mod tests {
          "###);
     }
 
+    #[test]
+    fn test_normalize_transaction_names() {
+        let should_be_replaced = [
+            "/aaa11111-aa11-11a1-a11a-1aaa1111a111",
+            "/1aa111aa-11a1-11aa-a111-a1a11111aa11",
+            "/00a00000-0000-0000-0000-000000000001",
+            "/test/b25feeaa-ed2d-4132-bcbd-6232b7922add/url",
+        ];
+        let replaced = should_be_replaced.map(|s| {
+            let mut s = Annotated::new(s.to_owned());
+            normalize_transaction_name(&mut s).unwrap();
+            s.0.unwrap()
+        });
+        assert_debug_snapshot!(replaced);
+    }
+
     macro_rules! transaction_name_test {
         ($name:ident, $input:literal, $output:literal) => {
             #[test]
@@ -1858,7 +1859,7 @@ mod tests {
     );
     transaction_name_test!(
         test_transaction_name_normalize_uuid,
-        "/u/7b25feea-ed2d-4132-bcbd-6232b7922add/edit",
+        "/u/7b25feeaq-ed2d-4132-bcbd-6232b7922add/edit",
         "/u/*/edit"
     );
     transaction_name_test!(

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__normalize_transaction_names.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__normalize_transaction_names.snap
@@ -1,0 +1,10 @@
+---
+source: relay-general/src/store/transactions/processor.rs
+expression: replaced
+---
+[
+    "/*",
+    "/*",
+    "/*",
+    "/test/*/url",
+]


### PR DESCRIPTION
Basically regex contained whitespaces and new line in the beginning of the regex, which make the UUID fail to match any of the UUID-like strings.

#skip-changelog