### PR TITLE
chore(txnames): Replace identifiers in sanitized sources

### DIFF
--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -319,8 +319,13 @@ impl Processor for TransactionsProcessor<'_> {
             event.transaction_info.value_mut(),
         )?;
 
-        // Normalize transaction names for URLs transaction sources only.
-        if event.get_transaction_source() == &TransactionSource::Url && self.normalize_names {
+        // Normalize transaction names for URLs and Sanitized transaction sources.
+        // This in addition to renaming rules can catch some high cardinality parts.
+        if matches!(
+            event.get_transaction_source(),
+            &TransactionSource::Url | &TransactionSource::Sanitized
+        ) && self.normalize_names
+        {
             normalize_transaction_name(&mut event.transaction)?;
         }
 


### PR DESCRIPTION
This change adds `Sanitized` transaction source to transaction names normalization. 

This way, in addition to renaming rules, we can catch more high cardinality URL parts. 

#skip-changelog