### PR TITLE
chore(kafka): Set retention on MetricKafkaMessage

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -171,9 +171,12 @@ impl StoreService {
                         item,
                     )?;
                 }
-                ItemType::MetricBuckets => {
-                    self.produce_metrics(scoping.organization_id, scoping.project_id, item)?
-                }
+                ItemType::MetricBuckets => self.produce_metrics(
+                    scoping.organization_id,
+                    scoping.project_id,
+                    item,
+                    retention,
+                )?,
                 ItemType::Profile => self.produce_profile(
                     scoping.organization_id,
                     scoping.project_id,
@@ -498,6 +501,7 @@ impl StoreService {
         org_id: u64,
         project_id: ProjectId,
         item: &Item,
+        retention: u16,
     ) -> Result<(), StoreError> {
         let payload = item.payload();
 
@@ -511,6 +515,7 @@ impl StoreService {
                     value: bucket.value,
                     timestamp: bucket.timestamp,
                     tags: bucket.tags,
+                    retention_days: retention,
                 },
             )?;
         }
@@ -952,6 +957,7 @@ struct MetricKafkaMessage {
     timestamp: UnixTimestamp,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     tags: BTreeMap<String, String>,
+    retention_days: u16,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -161,6 +161,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     assert metrics["c:transactions/foo@none"] == {
         "org_id": 1,
         "project_id": project_id,
+        "retention_days": 90,
         "name": "c:transactions/foo@none",
         "value": 42.0,
         "type": "c",
@@ -170,6 +171,7 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     assert metrics["c:transactions/bar@second"] == {
         "org_id": 1,
         "project_id": project_id,
+        "retention_days": 90,
         "name": "c:transactions/bar@second",
         "value": 17.0,
         "type": "c",
@@ -226,6 +228,7 @@ def test_metrics_with_sharded_kafka(
     assert metrics2["c:transactions/foo@none"] == {
         "org_id": 5,
         "project_id": project_id,
+        "retention_days": 90,
         "name": "c:transactions/foo@none",
         "value": 42.0,
         "type": "c",
@@ -235,6 +238,7 @@ def test_metrics_with_sharded_kafka(
     assert metrics2["c:transactions/bar@second"] == {
         "org_id": 5,
         "project_id": project_id,
+        "retention_days": 90,
         "name": "c:transactions/bar@second",
         "value": 17.0,
         "type": "c",
@@ -272,6 +276,7 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
     assert metric == {
         "org_id": 1,
         "project_id": project_id,
+        "retention_days": 90,
         "name": "c:transactions/foo@none",
         "value": 15.0,
         "type": "c",
@@ -470,6 +475,7 @@ def test_session_metrics_processing(
     assert metrics["c:sessions/session@none"] == {
         "org_id": 1,
         "project_id": 42,
+        "retention_days": 90,
         "timestamp": expected_timestamp,
         "name": "c:sessions/session@none",
         "type": "c",
@@ -485,6 +491,7 @@ def test_session_metrics_processing(
     assert metrics["s:sessions/user@none"] == {
         "org_id": 1,
         "project_id": 42,
+        "retention_days": 90,
         "timestamp": expected_timestamp,
         "name": "s:sessions/user@none",
         "type": "s",
@@ -613,6 +620,7 @@ def test_transaction_metrics(
         "timestamp": int(timestamp.timestamp()),
         "org_id": 1,
         "project_id": 42,
+        "retention_days": 90,
         "tags": {
             "transaction": "/organizations/:orgId/performance/:eventSlug/",
             "platform": "other",

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -600,12 +600,14 @@ def test_rate_limit_metrics_buckets(
             "name": "d:sessions/duration@second",
             "org_id": 1,
             "project_id": 42,
+            "retention_days": 90,
             "type": "d",
             "value": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
         },
         {
             "name": "d:sessions/session@none",
             "org_id": 1,
+            "retention_days": 90,
             "project_id": 42,
             "type": "c",
             "value": 1.0,
@@ -613,6 +615,7 @@ def test_rate_limit_metrics_buckets(
         {
             "name": "d:sessions/session@user",
             "org_id": 1,
+            "retention_days": 90,
             "project_id": 42,
             "type": "s",
             "value": [1254],
@@ -620,6 +623,7 @@ def test_rate_limit_metrics_buckets(
         {
             "name": "d:transactions/duration@millisecond",
             "org_id": 1,
+            "retention_days": 90,
             "project_id": 42,
             "type": "d",
             "value": [1.0, 2.0, 3.0],
@@ -627,6 +631,7 @@ def test_rate_limit_metrics_buckets(
         {
             "name": "d:transactions/duration@millisecond",
             "org_id": 1,
+            "retention_days": 90,
             "project_id": 42,
             "type": "d",
             "value": violating_bucket,
@@ -634,6 +639,7 @@ def test_rate_limit_metrics_buckets(
         {
             "name": "d:transactions/measurements.lcp@millisecond",
             "org_id": 1,
+            "retention_days": 90,
             "project_id": 42,
             "type": "d",
             "value": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
@@ -641,6 +647,7 @@ def test_rate_limit_metrics_buckets(
         {
             "name": "d:transactions/measurements.lcp@millisecond",
             "org_id": 1,
+            "retention_days": 90,
             "project_id": 42,
             "type": "d",
             "value": [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0],


### PR DESCRIPTION
Use the event's retention and propagate it to metric kafka message. 

#skip-changelog

fix: #1779 