### PR TITLE
chore(beta): address lint errors and suggestions

### DIFF
--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -22,7 +22,9 @@ use crate::macros::impl_str_serde;
 ///    violation. SDKs do not send such events.
 ///  - **Transaction events** (`transaction`): Contain operation spans and collected into traces for
 ///    performance monitoring.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize, Default,
+)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum EventType {
@@ -40,6 +42,7 @@ pub enum EventType {
     Transaction,
     /// All events that do not qualify as any other type.
     #[serde(other)]
+    #[default]
     Default,
 }
 
@@ -54,12 +57,6 @@ impl fmt::Display for ParseEventTypeError {
 }
 
 impl std::error::Error for ParseEventTypeError {}
-
-impl Default for EventType {
-    fn default() -> Self {
-        EventType::Default
-    }
-}
 
 impl FromStr for EventType {
     type Err = ParseEventTypeError;
@@ -575,7 +572,7 @@ impl std::ops::Deref for CustomUnit {
 /// measurements.
 ///
 /// Units and their precisions are uniquely represented by a string identifier.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default)]
 pub enum MetricUnit {
     /// A time duration, defaulting to `"millisecond"`.
     Duration(DurationUnit),
@@ -586,6 +583,7 @@ pub enum MetricUnit {
     /// user-defined units without builtin conversion or default.
     Custom(CustomUnit),
     /// Untyped value without a unit (`""`).
+    #[default]
     None,
 }
 
@@ -593,12 +591,6 @@ impl MetricUnit {
     /// Returns `true` if the metric_unit is [`None`].
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
-    }
-}
-
-impl Default for MetricUnit {
-    fn default() -> Self {
-        MetricUnit::None
     }
 }
 

--- a/relay-general/derive/src/lib.rs
+++ b/relay-general/derive/src/lib.rs
@@ -756,8 +756,9 @@ impl FieldAttrs {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 enum SkipSerialization {
+    #[default]
     Never,
     Null(bool),
     Empty(bool),
@@ -770,12 +771,6 @@ impl SkipSerialization {
             SkipSerialization::Null(deep) => quote!(crate::types::SkipSerialization::Null(#deep)),
             SkipSerialization::Empty(deep) => quote!(crate::types::SkipSerialization::Empty(#deep)),
         }
-    }
-}
-
-impl Default for SkipSerialization {
-    fn default() -> SkipSerialization {
-        SkipSerialization::Never
     }
 }
 

--- a/relay-general/src/pii/redactions.rs
+++ b/relay-general/src/pii/redactions.rs
@@ -29,7 +29,7 @@ impl Default for ReplaceRedaction {
 }
 
 /// Defines how replacements happen.
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum Redaction {
     /// The default redaction for this operation (normally equivalent to `Remove`).
@@ -37,6 +37,7 @@ pub enum Redaction {
     /// The main difference to `Remove` is that if the redaction is explicitly
     /// set to `Remove` it also applies in situations where a default
     /// redaction is therwise not passed down (for instance with `Multiple`).
+    #[default]
     Default,
     /// Removes the value and puts nothing in its place.
     Remove,
@@ -46,10 +47,4 @@ pub enum Redaction {
     Mask,
     /// Replaces the value with a hash
     Hash,
-}
-
-impl Default for Redaction {
-    fn default() -> Redaction {
-        Redaction::Default
-    }
 }

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -96,12 +96,13 @@ impl fmt::Display for ParseSessionStatusError {
 
 impl std::error::Error for ParseSessionStatusError {}
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AbnormalMechanism {
     AnrForeground,
     AnrBackground,
     #[serde(other)]
+    #[default]
     None,
 }
 
@@ -119,12 +120,6 @@ derive_fromstr_and_display!(AbnormalMechanism, ParseAbnormalMechanismError, {
     AbnormalMechanism::AnrBackground => "anr_background",
     AbnormalMechanism::None => "none",
 });
-
-impl Default for AbnormalMechanism {
-    fn default() -> Self {
-        AbnormalMechanism::None
-    }
-}
 
 impl AbnormalMechanism {
     fn is_none(&self) -> bool {

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -641,13 +641,14 @@ impl fmt::Display for ParseLevelError {
 impl std::error::Error for ParseLevelError {}
 
 /// Severity level of an event or breadcrumb.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "jsonschema", schemars(rename_all = "lowercase"))]
 pub enum Level {
     /// Indicates very spammy debug information.
     Debug,
     /// Informational messages.
+    #[default]
     Info,
     /// A warning.
     Warning,
@@ -655,12 +656,6 @@ pub enum Level {
     Error,
     /// Similar to error but indicates a critical event that usually causes a shutdown.
     Fatal,
-}
-
-impl Default for Level {
-    fn default() -> Self {
-        Level::Info
-    }
 }
 
 impl Level {

--- a/relay-server/src/utils/api.rs
+++ b/relay-server/src/utils/api.rs
@@ -4,23 +4,18 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 /// Represents an action requested by the Upstream sent in an error message.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum RelayErrorAction {
     Stop,
     #[serde(other)]
+    #[default]
     None,
 }
 
 impl RelayErrorAction {
     fn is_none(&self) -> bool {
         *self == Self::None
-    }
-}
-
-impl Default for RelayErrorAction {
-    fn default() -> Self {
-        RelayErrorAction::None
     }
 }
 


### PR DESCRIPTION
New lints added to beta on how to use `Default` derive macro. 

#skip-changelog