### PR TITLE
feat(replays): Remove error and session sample rate fields and replace with context fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Internal**:
 
 - Fix type errors in replay recording parsing. ([#1765](https://github.com/getsentry/relay/pull/1765))
+- Remove error and session sample rate fields from replay-event parser. ([#1791](https://github.com/getsentry/relay/pull/1791))
 
 ## 23.1.0
 

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -109,28 +109,6 @@ pub struct Replay {
     /// ```
     pub replay_type: Annotated<String>,
 
-    /// The sample rate used to make a recording decision when an error has been detected.
-    ///
-    /// Example:
-    ///
-    /// ```json
-    /// {
-    ///     "error_sample_rate": 0.75
-    /// }
-    /// ```
-    pub error_sample_rate: Annotated<f64>,
-
-    /// The sample rate used to make a recording decision
-    ///
-    /// Example:
-    ///
-    /// ```json
-    /// {
-    ///     "session_sample_rate": 0.125
-    /// }
-    /// ```
-    pub session_sample_rate: Annotated<f64>,
-
     /// Segment identifier.
     ///
     /// A number representing a unique segment identifier in the chain of replay segments.
@@ -396,8 +374,6 @@ mod tests {
                 uuid::Uuid::parse_str("52df9022835246eeb317dbd739ccd059").unwrap(),
             )),
             replay_type: Annotated::new("session".to_string()),
-            error_sample_rate: Annotated::new(0.5),
-            session_sample_rate: Annotated::new(0.5),
             segment_id: Annotated::new(0),
             timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0).into()),
             replay_start_timestamp: Annotated::new(Utc.ymd(2000, 1, 1).and_hms(0, 0, 0).into()),

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -6,8 +6,6 @@ def generate_replay_sdk_event():
         "type": "replay_event",
         "replay_id": "d2132d31b39445f1938d7e21b6bf0ec4",
         "replay_type": "session",
-        "error_sample_rate": 0.125,
-        "session_sample_rate": 0.5,
         "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",
         "segment_id": 0,
         "timestamp": 1597977777.6189718,
@@ -38,7 +36,11 @@ def generate_replay_sdk_event():
                 "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
                 "span_id": "FA90FDEAD5F74052",
                 "type": "trace",
-            }
+            },
+            "replay": {
+                "error_sample_rate": 0.125,
+                "session_sample_rate": 0.5,
+            },
         },
     }
 
@@ -65,8 +67,6 @@ def test_replay_event_with_processing(
     # Assert required fields were returned.
     assert parsed_replay["replay_id"] == replay["replay_id"]
     assert parsed_replay["replay_type"] == replay["replay_type"]
-    assert parsed_replay["error_sample_rate"] == replay["error_sample_rate"]
-    assert parsed_replay["session_sample_rate"] == replay["session_sample_rate"]
     assert parsed_replay["event_id"] == replay["event_id"]
     assert parsed_replay["type"] == replay["type"]
     assert parsed_replay["segment_id"] == replay["segment_id"]
@@ -104,6 +104,11 @@ def test_replay_event_with_processing(
         "browser": {"name": "Safari", "version": "15.5", "type": "browser"},
         "device": {"brand": "Apple", "family": "Mac", "model": "Mac", "type": "device"},
         "os": {"name": "Mac OS X", "version": "10.15.7", "type": "os"},
+        "replay": {
+            "type": "replay",
+            "error_sample_rate": replay["contexts"]["replay"]["error_sample_rate"],
+            "session_sample_rate": replay["contexts"]["replay"]["session_sample_rate"],
+        },
         "trace": {
             "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
             "span_id": "fa90fdead5f74052",


### PR DESCRIPTION
The SDK team has determined that the `contexts` object is the more appropriate place for these fields to live.  Therefore, we can remove these unnecessary fields and allow them to be parsed as a member of the contexts object.