### PR TITLE
feat(replays): Add handling for uncompressed payload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 **Internal**:
 
 - Fix type errors in replay recording parsing. ([#1765](https://github.com/getsentry/relay/pull/1765))
-- Add support for uncompressed recording payloads. ([#1793](https://github.com/getsentry/relay/pull/1793))
+- Add support for scrubbing uncompressed recording payloads. ([#1793](https://github.com/getsentry/relay/pull/1793))
 
 ## 23.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Internal**:
 
 - Fix type errors in replay recording parsing. ([#1765](https://github.com/getsentry/relay/pull/1765))
+- Add support for uncompressed recording payloads. ([#1793](https://github.com/getsentry/relay/pull/1793))
 
 ## 23.1.0
 

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -25,8 +25,7 @@ pub fn process_recording(bytes: &[u8], limit: usize) -> Result<Vec<u8>, Recordin
     // Walk recording scrubbing PII as we go.
     strip_pii(&mut body).map_err(RecordingParseError::ProcessingAction)?;
 
-    let out_bytes = serialize(headers, body)?;
-    Ok([headers.into(), vec![b'\n'], out_bytes].concat())
+    serialize(headers, body)
 }
 
 fn strip_pii(events: &mut Vec<Event>) -> Result<(), ProcessingAction> {

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -581,6 +581,18 @@ mod tests {
     }
 
     #[test]
+    fn test_process_recording_invalid_headers() {
+        // Invalid headers.  Validation should fail.
+        let payload: &[u8] = &[101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125];
+
+        let result = recording::process_recording(payload, 1000);
+        assert!(matches!(
+            result.unwrap_err(),
+            recording::RecordingParseError::InvalidHeaders(_),
+        ));
+    }
+
+    #[test]
     fn test_process_recording_no_headers() {
         // No header delimiter.  Entire payload is consumed as headers.  The empty body fails.
         let payload: &[u8] = &[

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -20,7 +20,7 @@ mod serialization;
 /// if decompressed contents exceed the limit.
 pub fn process_recording(bytes: &[u8], limit: usize) -> Result<Vec<u8>, RecordingParseError> {
     let (headers, body) =
-        protocol::deserialize(bytes, limit).map_err(RecordingParseError::ProtocolError)?;
+        protocol::load(bytes, limit).map_err(RecordingParseError::ProtocolError)?;
 
     let mut events: Vec<Event> =
         serde_json::from_slice(&body).map_err(RecordingParseError::InvalidBody)?;
@@ -29,7 +29,7 @@ pub fn process_recording(bytes: &[u8], limit: usize) -> Result<Vec<u8>, Recordin
     strip_pii(&mut events).map_err(RecordingParseError::ProcessingAction)?;
 
     let output_bytes = serde_json::to_vec(&events)?;
-    protocol::serialize(headers, output_bytes).map_err(RecordingParseError::ProtocolError)
+    protocol::dump(headers, output_bytes.as_slice()).map_err(RecordingParseError::ProtocolError)
 }
 
 fn strip_pii(events: &mut Vec<Event>) -> Result<(), ProcessingAction> {

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -56,16 +56,14 @@ fn deserialize(bytes: &[u8], limit: usize) -> Result<(&[u8], Vec<Event>), Record
     // We always attempt to decompress the body value. If decompression fails we try to JSON
     // deserialize the body bytes as is.
     match decompress(body, limit) {
-        Ok(buf) => {
-            let events: Vec<Event> =
-                serde_json::from_slice(&buf).map_err(RecordingParseError::InvalidBody)?;
-            Ok((headers, events))
-        }
-        Err(_) => {
-            let events: Vec<Event> =
-                serde_json::from_slice(body).map_err(RecordingParseError::InvalidBody)?;
-            Ok((headers, events))
-        }
+        Ok(buf) => Ok((
+            headers,
+            serde_json::from_slice(&buf).map_err(RecordingParseError::InvalidBody)?,
+        )),
+        Err(_) => Ok((
+            headers,
+            serde_json::from_slice(body).map_err(RecordingParseError::InvalidBody)?,
+        )),
     }
 }
 

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -46,14 +46,14 @@ fn strip_pii(events: &mut Vec<Event>) -> Result<(), ProcessingAction> {
 // its HTTP transport schema and serializing a recording to its Kafka transport schema.
 //
 // We expect recordings to come in the format of plaintext headers (JSON encoded), then a new
-// line character, then an optionally compressed RRWeb recording data.  Failure to inclue any
+// line character, then an optionally compressed RRWeb recording.  Failure to include any
 // component of this schema results in an error.
 
 fn deserialize(bytes: &[u8], limit: usize) -> Result<(&[u8], Vec<Event>), RecordingParseError> {
     let (headers, body) = read(bytes)?;
 
-    // We always attempt to decompress the body value. If decompression fails we try to JSON
-    // deserialize the body bytes as is.
+    // We always attempt to decompress the body value. If decompression fails we forward the raw
+    // payload to the next processing step for further validation.
     match decompress(body, limit) {
         Ok(buf) => Ok((
             headers,

--- a/relay-replays/src/recording/protocol.rs
+++ b/relay-replays/src/recording/protocol.rs
@@ -1,0 +1,164 @@
+/// Protocol.
+///
+/// The following section includes the behaviors responsible for deserializing a recording from
+/// its HTTP transport schema and serializing a recording to its Kafka transport schema.
+///
+/// We expect recordings to come in the format of plaintext headers (JSON encoded), then a new
+/// line character, then an optionally compressed RRWeb recording.  Failure to include any
+/// component of this schema results in an error.
+use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
+use serde_json::{Error as SError, Value};
+use std::fmt::Display;
+use std::io::{Error, Read, Write};
+
+/// Deserializes input bytes and returns a tuple of serialized (confirmed valid) JSON headers
+/// and the optionally decompressed body value.
+pub fn deserialize(bytes: &[u8], limit: usize) -> Result<(&[u8], Vec<u8>), ProtocolError> {
+    let (headers, body) = read(bytes)?;
+
+    // We always attempt to decompress the body value. If decompression fails we try to JSON
+    // deserialize the body bytes as is.
+    match decompress(body, limit) {
+        Ok(buf) => Ok((headers, buf)),
+        Err(_) => Ok((headers, body.into())),
+    }
+}
+
+/// Serializes the headers and body arguments into a single vec of bytes. The body value is
+/// compressed before being concatenated.  The final output is headers-bytes + "\n" (new-line
+/// character) + compressed-body-bytes.
+pub fn serialize(headers: &[u8], body: Vec<u8>) -> Result<Vec<u8>, ProtocolError> {
+    let output_bytes = compress(body)?;
+    Ok([headers.into(), vec![b'\n'], output_bytes].concat())
+}
+
+fn compress(output: Vec<u8>) -> Result<Vec<u8>, ProtocolError> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&output)
+        .map_err(ProtocolError::EncodingError)?;
+    encoder.finish().map_err(ProtocolError::EncodingError)
+}
+
+fn decompress(zipped_bytes: &[u8], limit: usize) -> Result<Vec<u8>, ProtocolError> {
+    let mut buffer = Vec::new();
+
+    let decoder = ZlibDecoder::new(zipped_bytes);
+    decoder
+        .take(limit as u64)
+        .read_to_end(&mut buffer)
+        .map_err(ProtocolError::EncodingError)?;
+
+    Ok(buffer)
+}
+
+fn read(bytes: &[u8]) -> Result<(&[u8], &[u8]), ProtocolError> {
+    match bytes.is_empty() {
+        true => Err(ProtocolError::MissingData),
+        false => {
+            let mut split = bytes.splitn(2, |b| b == &b'\n');
+            let header = split.next().ok_or(ProtocolError::MissingHeaders)?;
+
+            // Try to parse the headers to determine if they are valid JSON. This is a good sanity
+            // check to determine if our headers extraction is working properly.
+            serde_json::from_slice::<Value>(header).map_err(ProtocolError::InvalidHeaders)?;
+
+            let body = match split.next() {
+                Some(b"") | None => return Err(ProtocolError::MissingBody),
+                Some(body) => body,
+            };
+
+            Ok((header, body))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ProtocolError {
+    EncodingError(Error),
+    InvalidHeaders(SError),
+    MissingData,
+    MissingHeaders,
+    MissingBody,
+}
+
+impl Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProtocolError::InvalidHeaders(e) => {
+                write!(f, "recording headers could not be parsed {:?}", e)
+            }
+            ProtocolError::MissingData => write!(f, "no recording found"),
+            ProtocolError::MissingHeaders => write!(f, "no recording headers found"),
+            ProtocolError::MissingBody => write!(f, "not recording body found"),
+            ProtocolError::EncodingError(e) => write!(f, "{:?}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::recording::protocol::{deserialize, serialize, ProtocolError};
+    use serde_json::Value;
+
+    #[test]
+    fn test_deserialize_message() {
+        // Contains a 16 byte header followed by a new line character.
+        let payload: &[u8] = &[
+            123, 34, 115, 101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125, 10, 120,
+        ];
+
+        let result = deserialize(payload, 9999999999);
+        assert!(result.is_ok());
+
+        let (headers, _) = result.unwrap();
+        let head: Value = serde_json::from_slice(headers).unwrap();
+        let output = serde_json::to_string(&head).unwrap();
+        assert_eq!(output, "{\"segment_id\":3}");
+    }
+
+    #[test]
+    fn test_deserialize_no_contents() {
+        let payload: &[u8] = &[];
+        let result = deserialize(payload, 100);
+        assert!(matches!(result.unwrap_err(), ProtocolError::MissingData));
+    }
+
+    #[test]
+    fn test_deserialize_no_headers() {
+        // No header delimiter.  Entire payload is consumed as headers.  The empty body fails.
+        let payload: &[u8] = &[
+            123, 34, 115, 101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125,
+        ];
+        let result = deserialize(payload, 100);
+        assert!(matches!(result.unwrap_err(), ProtocolError::MissingBody));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_headers() {
+        let payload: &[u8] = &[123, 3, 10, 120];
+        let result = deserialize(payload, 100);
+        assert!(matches!(
+            result.unwrap_err(),
+            ProtocolError::InvalidHeaders(_)
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_no_body() {
+        // Empty bodies can not be decompressed and fail.
+        let payload: &[u8] = &[
+            123, 34, 115, 101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125, 10,
+        ];
+        let result = deserialize(payload, 100);
+        assert!(matches!(result.unwrap_err(), ProtocolError::MissingBody));
+    }
+
+    #[test]
+    fn test_serialization() {
+        assert_eq!(
+            serialize(&[11], vec![8]).unwrap().as_slice(),
+            &[11, 10, 120, 156, 227, 0, 0, 0, 9, 0, 9]
+        );
+    }
+}

--- a/relay-replays/src/recording/protocol.rs
+++ b/relay-replays/src/recording/protocol.rs
@@ -6,15 +6,16 @@
 /// We expect recordings to come in the format of plaintext headers (JSON encoded), then a new
 /// line character, then an optionally compressed RRWeb recording.  Failure to include any
 /// component of this schema results in an error.
-use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
-use serde::Deserialize;
-use serde_json::Error as SError;
 use std::fmt::Display;
 use std::io::{Error, Read, Write};
 
-/// Deserializes input bytes and returns a tuple of serialized (confirmed valid) JSON headers
-/// and the optionally decompressed body value.
-pub fn deserialize(bytes: &[u8], limit: usize) -> Result<(&[u8], Vec<u8>), ProtocolError> {
+use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
+use serde::Deserialize;
+use serde_json::Error as SError;
+
+/// Loads input bytes and returns a tuple of serialized (confirmed valid) JSON headers and the
+/// optionally decompressed body value.
+pub fn load(bytes: &[u8], limit: usize) -> Result<(&[u8], Vec<u8>), ProtocolError> {
     let (headers, body) = read(bytes)?;
 
     // We always attempt to decompress the body value. If decompression fails we try to JSON
@@ -25,15 +26,16 @@ pub fn deserialize(bytes: &[u8], limit: usize) -> Result<(&[u8], Vec<u8>), Proto
     }
 }
 
-/// Serializes the headers and body arguments into a single vec of bytes. The body value is
+/// Dumps the headers and body arguments into a single vec of bytes. The body value is
 /// compressed before being concatenated.  The final output is headers-bytes + "\n" (new-line
 /// character) + compressed-body-bytes.
-pub fn serialize(headers: &[u8], body: Vec<u8>) -> Result<Vec<u8>, ProtocolError> {
-    let output_bytes = compress(body)?;
-    Ok([headers.into(), vec![b'\n'], output_bytes].concat())
+pub fn dump(headers: &[u8], body: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+    let compressed_body = compress(body)?;
+    let output_bytes = [headers, b"\n", &compressed_body].concat();
+    Ok(output_bytes)
 }
 
-fn compress(output: Vec<u8>) -> Result<Vec<u8>, ProtocolError> {
+fn compress(output: &[u8]) -> Result<Vec<u8>, ProtocolError> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
     encoder
         .write_all(&output)
@@ -54,24 +56,23 @@ fn decompress(zipped_bytes: &[u8], limit: usize) -> Result<Vec<u8>, ProtocolErro
 }
 
 fn read(bytes: &[u8]) -> Result<(&[u8], &[u8]), ProtocolError> {
-    match bytes.is_empty() {
-        true => Err(ProtocolError::MissingData),
-        false => {
-            let mut split = bytes.splitn(2, |b| b == &b'\n');
-            let header = split.next().ok_or(ProtocolError::MissingHeaders)?;
-
-            // Try to parse the headers to determine if they are valid. This is a good sanity
-            // check to determine if our headers extraction is working properly.
-            serde_json::from_slice::<Headers>(header).map_err(ProtocolError::InvalidHeaders)?;
-
-            let body = match split.next() {
-                Some(b"") | None => return Err(ProtocolError::MissingBody),
-                Some(body) => body,
-            };
-
-            Ok((header, body))
-        }
+    if bytes.is_empty() {
+        return Err(ProtocolError::MissingData);
     }
+
+    let mut split = bytes.splitn(2, |b| b == &b'\n');
+    let header = split.next().ok_or(ProtocolError::MissingHeaders)?;
+
+    // Try to parse the headers to determine if they are valid. This is a good sanity
+    // check to determine if our headers extraction is working properly.
+    serde_json::from_slice::<Headers>(header).map_err(ProtocolError::InvalidHeaders)?;
+
+    let body = match split.next() {
+        Some(b"") | None => return Err(ProtocolError::MissingBody),
+        Some(body) => body,
+    };
+
+    Ok((header, body))
 }
 
 #[allow(dead_code)]
@@ -105,20 +106,15 @@ impl Display for ProtocolError {
 
 #[cfg(test)]
 mod tests {
-    use crate::recording::protocol::{deserialize, serialize, ProtocolError};
+    use crate::recording::protocol::{dump, load, ProtocolError};
     use serde_json::Value;
 
     #[test]
     fn test_deserialize_message() {
         // Contains a 16 byte header followed by a new line character.
-        let payload: &[u8] = &[
-            123, 34, 115, 101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125, 10, 120,
-        ];
+        let payload = b"{\"segment_id\":3}\nx".as_slice();
 
-        let result = deserialize(payload, 9999999999);
-        assert!(result.is_ok());
-
-        let (headers, _) = result.unwrap();
+        let (headers, _) = load(payload, 100).unwrap();
         let head: Value = serde_json::from_slice(headers).unwrap();
         let output = serde_json::to_string(&head).unwrap();
         assert_eq!(output, "{\"segment_id\":3}");
@@ -126,25 +122,15 @@ mod tests {
 
     #[test]
     fn test_deserialize_no_contents() {
-        let payload: &[u8] = &[];
-        let result = deserialize(payload, 100);
+        let payload = b"".as_slice();
+        let result = load(payload, 100);
         assert!(matches!(result.unwrap_err(), ProtocolError::MissingData));
     }
 
     #[test]
-    fn test_deserialize_no_headers() {
-        // No header delimiter.  Entire payload is consumed as headers.  The empty body fails.
-        let payload: &[u8] = &[
-            123, 34, 115, 101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125,
-        ];
-        let result = deserialize(payload, 100);
-        assert!(matches!(result.unwrap_err(), ProtocolError::MissingBody));
-    }
-
-    #[test]
     fn test_deserialize_invalid_headers() {
-        let payload: &[u8] = &[123, 3, 10, 120];
-        let result = deserialize(payload, 100);
+        let payload = b"{\"segment\":3}".as_slice();
+        let result = load(payload, 100);
         assert!(matches!(
             result.unwrap_err(),
             ProtocolError::InvalidHeaders(_)
@@ -154,17 +140,15 @@ mod tests {
     #[test]
     fn test_deserialize_no_body() {
         // Empty bodies can not be decompressed and fail.
-        let payload: &[u8] = &[
-            123, 34, 115, 101, 103, 109, 101, 110, 116, 95, 105, 100, 34, 58, 51, 125, 10,
-        ];
-        let result = deserialize(payload, 100);
+        let payload = b"{\"segment_id\":3}".as_slice();
+        let result = load(payload, 100);
         assert!(matches!(result.unwrap_err(), ProtocolError::MissingBody));
     }
 
     #[test]
     fn test_serialization() {
         assert_eq!(
-            serialize(&[11], vec![8]).unwrap().as_slice(),
+            dump(&[11], &[8]).unwrap().as_slice(),
             &[11, 10, 120, 156, 227, 0, 0, 0, 9, 0, 9]
         );
     }

--- a/relay-replays/src/recording/protocol.rs
+++ b/relay-replays/src/recording/protocol.rs
@@ -93,12 +93,12 @@ impl Display for ProtocolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProtocolError::InvalidHeaders(e) => {
-                write!(f, "recording headers could not be parsed {:?}", e)
+                write!(f, "recording headers could not be parsed {e:?}")
             }
             ProtocolError::MissingData => write!(f, "no recording found"),
             ProtocolError::MissingHeaders => write!(f, "no recording headers found"),
             ProtocolError::MissingBody => write!(f, "not recording body found"),
-            ProtocolError::EncodingError(e) => write!(f, "{:?}", e),
+            ProtocolError::EncodingError(e) => write!(f, "{e:?}"),
         }
     }
 }

--- a/relay-replays/src/recording/protocol.rs
+++ b/relay-replays/src/recording/protocol.rs
@@ -7,7 +7,8 @@
 /// line character, then an optionally compressed RRWeb recording.  Failure to include any
 /// component of this schema results in an error.
 use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
-use serde_json::{Error as SError, Value};
+use serde::Deserialize;
+use serde_json::Error as SError;
 use std::fmt::Display;
 use std::io::{Error, Read, Write};
 
@@ -59,9 +60,9 @@ fn read(bytes: &[u8]) -> Result<(&[u8], &[u8]), ProtocolError> {
             let mut split = bytes.splitn(2, |b| b == &b'\n');
             let header = split.next().ok_or(ProtocolError::MissingHeaders)?;
 
-            // Try to parse the headers to determine if they are valid JSON. This is a good sanity
+            // Try to parse the headers to determine if they are valid. This is a good sanity
             // check to determine if our headers extraction is working properly.
-            serde_json::from_slice::<Value>(header).map_err(ProtocolError::InvalidHeaders)?;
+            serde_json::from_slice::<Headers>(header).map_err(ProtocolError::InvalidHeaders)?;
 
             let body = match split.next() {
                 Some(b"") | None => return Err(ProtocolError::MissingBody),
@@ -71,6 +72,12 @@ fn read(bytes: &[u8]) -> Result<(&[u8], &[u8]), ProtocolError> {
             Ok((header, body))
         }
     }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct Headers {
+    segment_id: u16,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Couple of things happening here:

- Functional change allowing payloads *which could not be decompressed* to be move forward in the pipeline any way.  This allows us to accept non-compressed payloads which would have otherwise been rejected.
- The "protocol" related behavior.  Specifically compression, decompression, header parsing, and header validation have been moved to their own module.  This was done to separate the parser and the implementation details necessary to interact with the service.