### PR TITLE
chore(replays): Restructure scrubbing log output to be more readable in console

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1109,7 +1109,7 @@ impl EnvelopeProcessorService {
                             item.set_payload(ContentType::OctetStream, recording.as_slice());
                         }
                         Err(e) => {
-                            relay_log::warn!("replay-recording-event: {} {:?}", e, event_id);
+                            relay_log::warn!("replay-recording-event: {e} {event_id:?}");
                             context.track_outcome(
                                 Outcome::Invalid(DiscardReason::InvalidReplayRecordingEvent),
                                 DataCategory::Replay,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1109,11 +1109,7 @@ impl EnvelopeProcessorService {
                             item.set_payload(ContentType::OctetStream, recording.as_slice());
                         }
                         Err(e) => {
-                            relay_log::warn!(
-                                "replay-recording-event: failed to parse {:?} with message {}",
-                                event_id,
-                                e
-                            );
+                            relay_log::warn!("replay-recording-event: {} {:?}", e, event_id);
                             context.track_outcome(
                                 Outcome::Invalid(DiscardReason::InvalidReplayRecordingEvent),
                                 DataCategory::Replay,


### PR DESCRIPTION
Moving the event_id to the end makes it easier to identify what the error was at a glance.

#skip-changelog