### PR TITLE
bug(replays): Allow null category field in breadcrumb payload

### DIFF
--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -297,7 +297,8 @@ struct BreadcrumbPayload {
     #[serde(rename = "type")]
     ty: String,
     timestamp: f64,
-    category: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     level: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -647,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_rrweb_snapshot_parsing() {
-        let payload = include_bytes!("../../tests/fixtures/rrweb.json");
+        let payload = include_bytes!("../../tests/fixtures/rrweb2.json");
 
         let input_parsed = loads(payload).unwrap();
         let input_raw: Value = serde_json::from_slice(payload).unwrap();

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -648,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_rrweb_snapshot_parsing() {
-        let payload = include_bytes!("../../tests/fixtures/rrweb2.json");
+        let payload = include_bytes!("../../tests/fixtures/rrweb.json");
 
         let input_parsed = loads(payload).unwrap();
         let input_raw: Value = serde_json::from_slice(payload).unwrap();

--- a/relay-replays/tests/fixtures/rrweb-event-5.json
+++ b/relay-replays/tests/fixtures/rrweb-event-5.json
@@ -51,5 +51,16 @@
                 }
             }
         }
+    },
+    {
+        "type": 5,
+        "timestamp": 1674135065772.32,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "timestamp": 1674135065.772,
+                "type": "default"
+            }
+        }
     }
 ]


### PR DESCRIPTION
The `category` field can sometimes be omitted.  Added behavior to reflect this usecase.

#skip-changelog