### PR TITLE
feat(replays): Scrub PII from texts mutation nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix type errors in replay recording parsing. ([#1765](https://github.com/getsentry/relay/pull/1765))
 - Remove error and session sample rate fields from replay-event parser. ([#1791](https://github.com/getsentry/relay/pull/1791))
+- Scrub replay recording PII from mutation "texts" vector. ([#1796](https://github.com/getsentry/relay/pull/1796))
 
 ## 23.1.0
 

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -472,10 +472,10 @@ struct MutationAdditionIncrementalSourceData {
 
 #[cfg(test)]
 mod tests {
-    use crate::recording;
-    use crate::recording::{strip_pii, Event};
     use assert_json_diff::assert_json_eq;
     use serde_json::{Error, Value};
+
+    use crate::recording::{self, Event};
 
     fn loads(bytes: &[u8]) -> Result<Vec<Event>, Error> {
         serde_json::from_slice(bytes)
@@ -684,7 +684,7 @@ mod tests {
     fn test_scrub_pii_full_snapshot_event() {
         let payload = include_bytes!("../../tests/fixtures/rrweb-event-2.json");
         let mut events: Vec<recording::Event> = serde_json::from_slice(payload).unwrap();
-        strip_pii(&mut events).unwrap();
+        recording::strip_pii(&mut events).unwrap();
 
         let scrubbed_result = serde_json::to_string(&events).unwrap();
         assert!(scrubbed_result.contains("\"attributes\":{\"src\":\"#\"}"));
@@ -695,7 +695,7 @@ mod tests {
     fn test_scrub_pii_incremental_snapshot_event() {
         let payload = include_bytes!("../../tests/fixtures/rrweb-event-3.json");
         let mut events: Vec<recording::Event> = serde_json::from_slice(payload).unwrap();
-        strip_pii(&mut events).unwrap();
+        recording::strip_pii(&mut events).unwrap();
 
         let scrubbed_result = serde_json::to_string(&events).unwrap();
         assert!(scrubbed_result.contains("\"textContent\":\"[creditcard]\""));
@@ -706,7 +706,7 @@ mod tests {
     fn test_scrub_pii_custom_event() {
         let payload = include_bytes!("../../tests/fixtures/rrweb-event-5.json");
         let mut events: Vec<recording::Event> = serde_json::from_slice(payload).unwrap();
-        strip_pii(&mut events).unwrap();
+        recording::strip_pii(&mut events).unwrap();
 
         let scrubbed_result = serde_json::to_string(&events).unwrap();
         assert!(scrubbed_result.contains("\"description\":\"[creditcard]\""));

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -138,11 +138,11 @@ impl RecordingProcessor<'_> {
     ) -> Result<(), ProcessingAction> {
         match variant {
             IncrementalSourceDataVariant::Mutation(mutation) => {
+                for text in &mut mutation.texts {
+                    self.strip_pii(&mut text.value)?
+                }
                 for addition in &mut mutation.adds {
-                    match self.recurse_snapshot_node(&mut addition.node) {
-                        Ok(_) => {}
-                        Err(e) => return Err(e),
-                    }
+                    self.recurse_snapshot_node(&mut addition.node)?
                 }
             }
             IncrementalSourceDataVariant::Input(input) => self.strip_pii(&mut input.text)?,
@@ -442,12 +442,18 @@ struct InputIncrementalSourceData {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MutationIncrementalSourceData {
-    texts: Vec<Value>,
+    texts: Vec<Text>,
     attributes: Vec<Value>,
     removes: Vec<Value>,
     adds: Vec<MutationAdditionIncrementalSourceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_attach_iframe: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Text {
+    id: i32,
+    value: String,
 }
 
 #[derive(Debug)]
@@ -629,20 +635,9 @@ mod tests {
 
         recording::strip_pii(&mut events).unwrap();
 
-        let aa = events.pop().unwrap();
-        if let recording::Event::T3(bb) = aa {
-            if let recording::IncrementalSourceDataVariant::Mutation(mut cc) = bb.data {
-                let dd = cc.adds.pop().unwrap();
-                if let recording::NodeVariant::T2(mut ee) = dd.node.variant {
-                    let ff = ee.child_nodes.pop().unwrap();
-                    if let recording::NodeVariant::T3(gg) = ff.variant {
-                        assert_eq!(gg.text_content, "[ip]");
-                        return;
-                    }
-                }
-            }
-        }
-        unreachable!();
+        let parsed = serde_json::to_string(&events).unwrap();
+        assert!(parsed.contains("\"value\":\"[ip]\"")); // Assert texts were mutated.
+        assert!(parsed.contains("\"textContent\":\"[ip]\"")) // Assert text node was mutated.
     }
 
     #[test]

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -699,6 +699,7 @@ mod tests {
 
         let scrubbed_result = serde_json::to_string(&events).unwrap();
         assert!(scrubbed_result.contains("\"textContent\":\"[creditcard]\""));
+        assert!(scrubbed_result.contains("\"value\":\"***********\""));
     }
 
     #[test]

--- a/relay-replays/tests/fixtures/rrweb-event-2.json
+++ b/relay-replays/tests/fixtures/rrweb-event-2.json
@@ -1,0 +1,82 @@
+[
+    {
+        "type": 2,
+        "data": {
+            "node": {
+                "type": 0,
+                "childNodes": [
+                    {
+                        "type": 1,
+                        "name": "html",
+                        "publicId": "",
+                        "systemId": "",
+                        "id": 2
+                    },
+                    {
+                        "type": 2,
+                        "tagName": "html",
+                        "attributes": {
+                            "lang": "en"
+                        },
+                        "childNodes": [
+                            {
+                                "type": 2,
+                                "tagName": "head",
+                                "attributes": {},
+                                "childNodes": [],
+                                "id": 4
+                            },
+                            {
+                                "type": 2,
+                                "tagName": "body",
+                                "attributes": {},
+                                "childNodes": [
+                                    {
+                                        "type": 2,
+                                        "tagName": "a",
+                                        "attributes": {
+                                            "href": "https://github.com/getsentry/sourcemaps.io",
+                                            "class": "github-corner",
+                                            "aria-label": "View source on Github"
+                                        },
+                                        "childNodes": [
+                                            {
+                                                "type": 2,
+                                                "tagName": "div",
+                                                "attributes": {},
+                                                "childNodes": [
+                                                    {
+                                                        "type": 3,
+                                                        "textContent": "my ssn is 111-11-1111",
+                                                        "id": 244
+                                                    }
+                                                ],
+                                                "id": 18
+                                            },
+                                            {
+                                                "type": 2,
+                                                "tagName": "img",
+                                                "attributes": {"src": "https://www.sentry.io"},
+                                                "childNodes": [],
+                                                "id": 19
+                                            }
+                                        ],
+                                        "id": 17
+                                    }
+                                ],
+                                "id": 16
+                            }
+                        ],
+                        "id": 3
+                    }
+                ],
+                "id": 1
+            },
+            "initialOffset": {
+                "left": 0,
+                "top": 0
+            }
+        },
+        "timestamp": 1658770770472
+    }
+]

--- a/relay-replays/tests/fixtures/rrweb-event-3.json
+++ b/relay-replays/tests/fixtures/rrweb-event-3.json
@@ -1,33 +1,38 @@
-{
-    "type": 3,
-    "data": {
-        "source": 1,
-        "positions": [
-            {
-                "x": 2412,
-                "y": 131,
-                "id": 24,
-                "timeOffset": -402
-            },
-            {
-                "x": 2393,
-                "y": 133,
-                "id": 24,
-                "timeOffset": -232
-            },
-            {
-                "x": 2390,
-                "y": 125,
-                "id": 24,
-                "timeOffset": -64
-            },
-            {
-                "x": 2404,
-                "y": 62,
-                "id": 24,
-                "timeOffset": -10
-            }
-        ]
-    },
-    "timestamp": 1658770772443
-}
+[
+    {
+        "type": 3,
+        "data": {
+            "source": 0,
+            "texts": [
+                {
+                    "id": 44,
+                    "value": "111-11-1111"
+                }
+            ],
+            "attributes": [],
+            "removes": [],
+            "isAttachIframe": true,
+            "adds": [
+                {
+                    "parentId": 74,
+                    "previousId": null,
+                    "nextId": null,
+                    "node": {
+                        "type": 2,
+                        "tagName": "h1",
+                        "attributes": {},
+                        "childNodes": [
+                            {
+                                "type": 3,
+                                "textContent": "4111-1111-1111-1111",
+                                "id": 284
+                            }
+                        ],
+                        "id": 283
+                    }
+                }
+            ]
+        },
+        "timestamp": 1665063926945
+    }
+]

--- a/relay-replays/tests/fixtures/rrweb-event-5.json
+++ b/relay-replays/tests/fixtures/rrweb-event-5.json
@@ -6,7 +6,7 @@
             "tag": "performanceSpan",
             "payload": {
                 "op": "memory",
-                "description": "memory",
+                "description": "4111-1111-1111-1111",
                 "startTimestamp": 1658770772.902,
                 "endTimestamp": 1658770772.902,
                 "data": {
@@ -26,7 +26,7 @@
             "tag": "performanceSpan",
             "payload": {
                 "op": "navigation.navigate",
-                "description": "https://sentry.io",
+                "description": "https://sentry.io?ip-address=127.0.0.1",
                 "startTimestamp": 1665063926.125,
                 "endTimestamp": 1665063926.833,
                 "data": {
@@ -45,7 +45,7 @@
                 "timestamp": 1674135065.772,
                 "type": "default",
                 "category": "ui.input",
-                "message": "something happened",
+                "message": "user@email.com",
                 "data": {
                     "nodeId": 14235
                 }

--- a/relay-replays/tests/fixtures/rrweb-pii-ip-address.json
+++ b/relay-replays/tests/fixtures/rrweb-pii-ip-address.json
@@ -3,7 +3,12 @@
         "type": 3,
         "data": {
             "source": 0,
-            "texts": [],
+            "texts": [
+                {
+                    "id": 1,
+                    "value": "127.0.0.1"
+                }
+            ],
             "attributes": [],
             "removes": [],
             "adds": [


### PR DESCRIPTION
- Adds support for PII scrubbing the "texts" vector on the incremental mutation source struct.
- Adds coverage for this usecase.
- Improves coverage for existing cases.