### PR TITLE
ref(statsd): Add metric name as a tag for Sentry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Add metric name as tag on Sentry errors from relay dropping metrics. ([#1797](https://github.com/getsentry/relay/issues/1797))
+- Add metric name as tag on Sentry errors from relay dropping metrics. ([#1797](https://github.com/getsentry/relay/pull/1797))
 
 ## 23.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for client hints. ([#1752](https://github.com/getsentry/relay/pull/1752))
 
+**Internal**:
+
+- Add metric name as tag on Sentry errors from relay dropping metrics. ([#1680](https://github.com/getsentry/relay/issues/1680))
+
 ## 23.1.1
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Add metric name as tag on Sentry errors from relay dropping metrics. ([#1680](https://github.com/getsentry/relay/issues/1680))
+- Add metric name as tag on Sentry errors from relay dropping metrics. ([#1797](https://github.com/getsentry/relay/issues/1797))
 
 ## 23.1.1
 

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -492,67 +492,102 @@ pub trait GaugeMetric {
 macro_rules! metric {
     // counter increment
     (counter($id:expr) += $value:expr $(, $k:ident = $v:expr)* $(,)?) => {
-        $crate::with_client(|client| {
-            use $crate::_pred::*;
-            client.send_metric(
-                client.count_with_tags(&$crate::CounterMetric::name(&$id), $value)
-                $(.with_tag(stringify!($k), $v))*
-            )
-        })
+        relay_log::with_scope(
+            |scope| {
+                scope.set_tag("key", &$crate::CounterMetric::name(&$id));
+            }, || {
+                $crate::with_client(|client| {
+                    use $crate::_pred::*;
+                    client.send_metric(
+                        client.count_with_tags(&$crate::CounterMetric::name(&$id), $value)
+                        $(.with_tag(stringify!($k), $v))*
+                    )
+                })
+            }
+        )
     };
 
     // counter decrement
     (counter($id:expr) -= $value:expr $(, $k:ident = $v:expr)* $(,)?) => {
-        $crate::with_client(|client| {
-            use $crate::_pred::*;
-            client.send_metric(
-                client.count_with_tags(&$crate::CounterMetric::name(&$id), -$value)
-                    $(.with_tag(stringify!($k), $v))*
-            )
-        })
+        relay_log::with_scope(
+            |scope| {
+                scope.set_tag("key", &$crate::CounterMetric::name(&$id));
+            }, || {
+                $crate::with_client(|client| {
+                    use $crate::_pred::*;
+                    client.send_metric(
+                        client.count_with_tags(&$crate::CounterMetric::name(&$id), -$value)
+                            $(.with_tag(stringify!($k), $v))*
+                    )
+                })
+            }
+        )
     };
 
     // gauge set
     (gauge($id:expr) = $value:expr $(, $k:ident = $v:expr)* $(,)?) => {
         $crate::with_client(|client| {
             use $crate::_pred::*;
-            client.send_metric(
-                client.gauge_with_tags(&$crate::GaugeMetric::name(&$id), $value)
-                    $(.with_tag(stringify!($k), $v))*
+            relay_log::with_scope(
+                |scope| {
+                    scope.set_tag("key", &$crate::GaugeMetric::name(&$id));
+                }, || {
+                    client.send_metric(
+                        client.gauge_with_tags(&$crate::GaugeMetric::name(&$id), $value)
+                            $(.with_tag(stringify!($k), $v))*
+                    )
+                }
             )
         })
     };
 
     // histogram
     (histogram($id:expr) = $value:expr $(, $k:ident = $v:expr)* $(,)?) => {
-        $crate::with_client(|client| {
-            use $crate::_pred::*;
-            client.send_metric(
-                client.histogram_with_tags(&$crate::HistogramMetric::name(&$id), $value)
-                    $(.with_tag(stringify!($k), $v))*
-            )
-        })
+        use $crate::_pred::*;
+        relay_log::with_scope(
+            |scope| {
+                scope.set_tag("key", &$crate::HistogramMetric::name(&$id));
+            }, || {
+                $crate::with_client(|client| {
+                    client.send_metric(
+                        client.histogram_with_tags(&$crate::HistogramMetric::name(&$id), $value)
+                            $(.with_tag(stringify!($k), $v))*
+                    )
+                })
+            }
+        )
     };
 
     // sets (count unique occurrences of a value per time interval)
     (set($id:expr) = $value:expr $(, $k:ident = $v:expr)* $(,)?) => {
-        $crate::with_client(|client| {
-            use $crate::_pred::*;
-            client.send_metric(
-                client.set_with_tags(&$crate::SetMetric::name(&$id), $value)
-                    $(.with_tag(stringify!($k), $v))*
-            )
-        })
+        use $crate::_pred::*;
+        relay_log::with_scope(
+            |scope| {
+                scope.set_tag("key", &$crate::SetMetric::name(&$id));
+            }, || {
+                $crate::with_client(|client| {
+                    client.send_metric(
+                        client.set_with_tags(&$crate::SetMetric::name(&$id), $value)
+                            $(.with_tag(stringify!($k), $v))*
+                    )
+                })
+            }
+        )
     };
 
     // timer value (duration)
     (timer($id:expr) = $value:expr $(, $k:ident = $v:expr)* $(,)?) => {
         $crate::with_client(|client| {
-            use $crate::_pred::*;
-            client.send_metric(
-                client.time_with_tags(&$crate::TimerMetric::name(&$id), $value)
-                    $(.with_tag(stringify!($k), $v))*
-            )
+        relay_log::with_scope(
+            |scope| {
+                scope.set_tag("key", &$crate::TimerMetric::name(&$id));
+            }, || {
+                use $crate::_pred::*;
+                client.send_metric(
+                    client.time_with_tags(&$crate::TimerMetric::name(&$id), $value)
+                        $(.with_tag(stringify!($k), $v))*
+                )
+            })
         })
     };
 
@@ -560,13 +595,19 @@ macro_rules! metric {
     (timer($id:expr), $($k:ident = $v:expr,)* $block:block) => {{
         let now = std::time::Instant::now();
         let rv = {$block};
-        $crate::with_client(|client| {
-            use $crate::_pred::*;
-            client.send_metric(
-                client.time_with_tags(&$crate::TimerMetric::name(&$id), now.elapsed())
-                    $(.with_tag(stringify!($k), $v))*
-            )
-        });
+        relay_log::with_scope(
+            |scope| {
+                scope.set_tag("key", &$crate::TimerMetric::name(&$id));
+            }, || {
+                $crate::with_client(|client| {
+                    use $crate::_pred::*;
+                    client.send_metric(
+                        client.time_with_tags(&$crate::TimerMetric::name(&$id), now.elapsed())
+                            $(.with_tag(stringify!($k), $v))*
+                    )
+                });
+            }
+        );
         rv
     }};
 }


### PR DESCRIPTION
From time to time, we still get errors from relay dropping metrics due to the channel being full, see https://github.com/getsentry/relay/issues/1680. This PR attempts to add a tag to that Sentry issue, to identify more easily what metrics may be worsening the bottleneck. Next steps TBD, based on conclusions from the errors. This code is likely to be temporary and be removed after we figure out what and how to deal with the errors.

### The approach

The original idea was to extract the error and directly include it in the error here:
https://github.com/getsentry/relay/blob/2ec2a5e47a577fb6b7660624093df95c1db05d21/relay-statsd/src/lib.rs#L115-L116

There are two problems with that approach. Firstly, the error types come from statsd's source code and it's hard to consider every case. Secondly, the code is too generic and closed that it's hard to inject something nicely without a decent amount of workarounds. Lastly, I also tried replicating the issue locally generating a lot of metrics (lots of threads, queue size to 0 and 1, sample rate 1.0), but I have not been successful.

In the end, the simplest solution was to add the name as a tag to the scope where there's access to it, wrapping the call where the actual error is logged.