### PR TITLE
feat(replays): Replace use of Value type with explicit types

### DIFF
--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -531,9 +531,9 @@ struct MouseInteractionIncrementalSourceData {
 struct ScrollIncrementalSourceData {
     id: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    x: Option<u64>,
+    x: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    y: Option<u64>,
+    y: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/relay-replays/src/recording/mod.rs
+++ b/relay-replays/src/recording/mod.rs
@@ -435,31 +435,31 @@ struct TextNode {
 /// -> MUTATION = 0
 ///     ... not documented
 /// -> MOUSEMOVE = 1
-///     {"source": 1, "positions": [{"id": 32258, "timeOffset": 0, "x": 243, "y": 597}]}
+///     `{"source": 1, "positions": [{"id": 32258, "timeOffset": 0, "x": 243, "y": 597}]}`
 /// -> MOUSEINTERACTION = 2
-///     {"source": 2, "id": 37960, "type": 9, "x": 286, "y": 491}
+///     `{"source": 2, "id": 37960, "type": 9, "x": 286, "y": 491}`
 /// -> SCROLL = 3
-///     {"source": 3, "id": 1, "x": 0, "y": 17}
+///     `{"source": 3, "id": 1, "x": 0, "y": 17}`
 /// -> VIEWPORTRESIZE = 4
-///     {"source": 4, "height": 667, "width": 390}
+///     `{"source": 4, "height": 667, "width": 390}`
 /// -> INPUT = 5
-///     {"source": 5, "id": 2331, "text": "*", "isChecked": false}
+///     `{"source": 5, "id": 2331, "text": "*", "isChecked": false}`
 /// -> TOUCHMOVE = 6
-///     {"source": 6, "positions": [{"id": 32258, "timeOffset": 0, "x": 243, "y": 597}]}
+///     `{"source": 6, "positions": [{"id": 32258, "timeOffset": 0, "x": 243, "y": 597}]}`
 /// -> MEDIAINTERACTION = 7
 ///     {"source" 7, "id": 2011, "currentTime": 12597196711, "volume": 100, "muted": false, "playbackRate": 1}
 /// -> STYLESHEETRULE = 8
-///     {"source": 8, "id": 40, "adds": [{"rule": "@-webkit-keyframes", "index": 117}]}
+///     `{"source": 8, "id": 40, "adds": [{"rule": "@-webkit-keyframes", "index": 117}]}`
 /// -> CANVASMUTATION = 9
 /// -> FONT = 10
 /// -> LOG = 11
 /// -> DRAG = 12
-///     {"source": 12, "positions": [{"id": 32258, "timeOffset": 0, "x": 243, "y": 597}]}
+///     `{"source": 12, "positions": [{"id": 32258, "timeOffset": 0, "x": 243, "y": 597}]}`
 /// -> STYLEDECLARATION = 13
 /// -> SELECTION = 14
-///     {"source": 14, "ranges": [{"start": 12, "startOffset": 11, "end": 15, "endOffset": 6}]}
+///     `{"source": 14, "ranges": [{"start": 12, "startOffset": 11, "end": 15, "endOffset": 6}]}`
 /// -> ADOPTEDSTYLESHEET = 15
-///     {"id": 1, "styleIds": [1], "styles": [{"rules": [{"rule": "t"}], "styleId": 1}]}
+///     `{"source": 15, "id": 1, "styleIds": [1], "styles": [{"rules": [{"rule": "t"}], "styleId": 1}]}`
 
 #[derive(Debug)]
 enum IncrementalSourceDataVariant {

--- a/relay-replays/src/recording/serialization.rs
+++ b/relay-replays/src/recording/serialization.rs
@@ -204,8 +204,14 @@ impl<'de> Deserialize<'de> for IncrementalSourceDataVariant {
                 .map(IncrementalSourceDataVariant::TouchMove),
             7 => Box::<MediaInteractionIncrementalSourceData>::deserialize(content_deserializer)
                 .map(IncrementalSourceDataVariant::MediaInteraction),
+            8 => Box::<StyleSheetRuleIncrementalSourceData>::deserialize(content_deserializer)
+                .map(IncrementalSourceDataVariant::StyleSheetRule),
             12 => Box::<DragIncrementalSourceData>::deserialize(content_deserializer)
                 .map(IncrementalSourceDataVariant::Drag),
+            14 => Box::<SelectionIncrementalSourceData>::deserialize(content_deserializer)
+                .map(IncrementalSourceDataVariant::Selection),
+            15 => Box::<AdoptedStyleSheetIncrementalSourceData>::deserialize(content_deserializer)
+                .map(IncrementalSourceDataVariant::AdoptedStyleSheet),
             source => Value::deserialize(content_deserializer).map(|value| {
                 IncrementalSourceDataVariant::Default(Box::new(DefaultIncrementalSourceData {
                     source,
@@ -228,7 +234,10 @@ enum InnerISDV<'a> {
     Input(&'a InputIncrementalSourceData),
     TouchMove(&'a TouchMoveIncrementalSourceData),
     MediaInteraction(&'a MediaInteractionIncrementalSourceData),
+    StyleSheetRule(&'a StyleSheetRuleIncrementalSourceData),
     Drag(&'a DragIncrementalSourceData),
+    Selection(&'a SelectionIncrementalSourceData),
+    AdoptedStyleSheet(&'a AdoptedStyleSheetIncrementalSourceData),
     Default(&'a Value),
 }
 
@@ -276,8 +285,17 @@ impl Serialize for IncrementalSourceDataVariant {
             IncrementalSourceDataVariant::MediaInteraction(i) => {
                 OuterISDV::new(7, InnerISDV::MediaInteraction(i.as_ref()))
             }
+            IncrementalSourceDataVariant::StyleSheetRule(i) => {
+                OuterISDV::new(7, InnerISDV::StyleSheetRule(i.as_ref()))
+            }
             IncrementalSourceDataVariant::Drag(i) => {
                 OuterISDV::new(12, InnerISDV::Drag(i.as_ref()))
+            }
+            IncrementalSourceDataVariant::Selection(i) => {
+                OuterISDV::new(14, InnerISDV::Selection(i.as_ref()))
+            }
+            IncrementalSourceDataVariant::AdoptedStyleSheet(i) => {
+                OuterISDV::new(14, InnerISDV::AdoptedStyleSheet(i.as_ref()))
             }
             IncrementalSourceDataVariant::Default(v) => {
                 OuterISDV::new(v.source, InnerISDV::Default(&v.value))


### PR DESCRIPTION
This should be an interesting canary test.  If we remove most of the usages of `Value` (which is memory intensive) can we achieve a sustainable, stable, long-term memory growth curve?

- Not all variants have been typed.
    - I focused on the most popular payload types first.
    - Will finish the remainder if the Canary test shows promising results (or I might just type them anyway as capacity allows).
- Not all fields have had their `Value` type replaced.  Those fields will require a custom deserializer which may be overkill for a canary test (should the test go poorly).
- Verified as working against >300 different RRWeb payloads.

cc: @jan-auer @jjbayer Thoughts on this as an aide to reducing resource usage?  I think the compounding effects of `Value` could be large.

#skip-changelog