### PR TITLE
chore(replays): Disable PII scrubbing for recording events

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1060,7 +1060,7 @@ impl EnvelopeProcessorService {
         let meta = state.envelope.meta().clone();
         let client_addr = meta.client_addr();
         let user_agent = meta.user_agent();
-        let event_id = state.envelope.event_id();
+        // let event_id = state.envelope.event_id();
 
         state.envelope.retain_items(|item| match item.ty() {
             ItemType::ReplayEvent => {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1129,31 +1129,31 @@ impl EnvelopeProcessorService {
                 }
             }
             ItemType::ReplayRecording => {
-                if replays_enabled {
-                    // Limit expansion of recordings to the max replay size. The payload is
-                    // decompressed temporarily and then immediately re-compressed. However, to
-                    // limit memory pressure, we use the replay limit as a good overall limit for
-                    // allocations.
-                    let limit = self.config.max_replay_size();
-                    let parsed_recording =
-                        metric!(timer(RelayTimers::ReplayRecordingProcessing), {
-                            relay_replays::recording::process_recording(&item.payload(), limit)
-                        });
+                // if replays_enabled {
+                //     // Limit expansion of recordings to the max replay size. The payload is
+                //     // decompressed temporarily and then immediately re-compressed. However, to
+                //     // limit memory pressure, we use the replay limit as a good overall limit for
+                //     // allocations.
+                //     let limit = self.config.max_replay_size();
+                //     let parsed_recording =
+                //         metric!(timer(RelayTimers::ReplayRecordingProcessing), {
+                //             relay_replays::recording::process_recording(&item.payload(), limit)
+                //         });
 
-                    match parsed_recording {
-                        Ok(recording) => {
-                            item.set_payload(ContentType::OctetStream, recording.as_slice());
-                        }
-                        Err(e) => {
-                            relay_log::warn!("replay-recording-event: {e} {event_id:?}");
-                            context.track_outcome(
-                                Outcome::Invalid(DiscardReason::InvalidReplayRecordingEvent),
-                                DataCategory::Replay,
-                                1,
-                            );
-                        }
-                    }
-                }
+                //     match parsed_recording {
+                //         Ok(recording) => {
+                //             item.set_payload(ContentType::OctetStream, recording.as_slice());
+                //         }
+                //         Err(e) => {
+                //             relay_log::warn!("replay-recording-event: {e} {event_id:?}");
+                //             context.track_outcome(
+                //                 Outcome::Invalid(DiscardReason::InvalidReplayRecordingEvent),
+                //                 DataCategory::Replay,
+                //                 1,
+                //             );
+                //         }
+                //     }
+                // }
 
                 // XXX: For now replays that could not be parsed are still accepted while we
                 // determine the impact of the recording parser.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -298,9 +298,8 @@ pub enum RelayTimers {
 
     /// Time in milliseconds spent on converting a transaction event into a metric.
     TransactionMetricsExtraction,
-
-    /// Time in milliseconds spent on parsing, normalizing and scrubbing replay recordings.
-    ReplayRecordingProcessing,
+    // Time in milliseconds spent on parsing, normalizing and scrubbing replay recordings.
+    // ReplayRecordingProcessing,
 }
 
 impl TimerMetric for RelayTimers {
@@ -331,7 +330,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::TimestampDelay => "requests.timestamp_delay",
             RelayTimers::OutcomeAggregatorFlushTime => "outcomes.aggregator.flush_time",
             RelayTimers::TransactionMetricsExtraction => "metrics.extraction.transactions",
-            RelayTimers::ReplayRecordingProcessing => "replay.recording.process",
+            // RelayTimers::ReplayRecordingProcessing => "replay.recording.process",
         }
     }
 }


### PR DESCRIPTION
Replays are currently broken right now so we want to disable the scrubber until we figure out how to fix it.  We can revert this once the implementation is updated.

#skip-changelog