### PR TITLE
ref(replays): Control recording scrubbing through a feature flag

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -75,8 +75,12 @@ pub enum Feature {
     Profiling,
     /// Enables ingestion of Session Replays (Replay Recordings and Replay Events).
     #[serde(rename = "organizations:session-replay")]
-    Replays,
-    /// Enable transaction names normalization.
+    SessionReplay,
+    /// Enables data scrubbing of replay recording payloads.
+    #[serde(rename = "organizations:session-replay-recording-scrubbing")]
+    SessionReplayRecordingScrubbing,
+    /// Enables transaction names normalization.
+    ///
     /// Replacing UUIDs, SHAs and numerical IDs by placeholders.
     #[serde(rename = "organizations:transaction-name-normalize")]
     TransactionNameNormalize,


### PR DESCRIPTION
Revised data scrubbing on replays from #1800 can break recording payloads
because it scrubs strings that should be excluded from scrubbing. This breaks
the payloads and makes them unusable.

This introduces a feature flag to enable data scrubbing on recordings per
organization. By default, this flag is off.

Replaces #1813
See also getsentry/sentry#44093
#skip-changelog