### PR TITLE
ref(ua): rename functions

### DIFF
--- a/relay-general/src/protocol/contexts/browser.rs
+++ b/relay-general/src/protocol/contexts/browser.rs
@@ -140,7 +140,8 @@ mod tests {
             PairList(headers)
         });
 
-        let browser = BrowserContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers)).unwrap();
+        let browser =
+            BrowserContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
         assert_debug_snapshot!(browser, @r###"
         BrowserContext {
@@ -171,7 +172,8 @@ mod tests {
             PairList(headers)
         });
 
-        let browser = BrowserContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers)).unwrap();
+        let browser =
+            BrowserContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
         assert_debug_snapshot!(browser, @r###"
         BrowserContext {
@@ -198,7 +200,8 @@ mod tests {
             PairList(headers)
         });
 
-        let browser = BrowserContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers)).unwrap();
+        let browser =
+            BrowserContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
         assert_eq!(
             browser.version.as_str().unwrap(),
             "109.0.0" // notice the version number is from UA string not from client hints

--- a/relay-general/src/protocol/contexts/device.rs
+++ b/relay-general/src/protocol/contexts/device.rs
@@ -220,7 +220,7 @@ mod tests {
             PairList(headers)
         });
 
-        let device = DeviceContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers));
+        let device = DeviceContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers));
         assert_eq!(device.unwrap().family.as_str().unwrap(), "foo g31(w)");
     }
     #[test]
@@ -239,7 +239,7 @@ mod tests {
             PairList(headers)
         });
 
-        let device = DeviceContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers));
+        let device = DeviceContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers));
         assert_eq!(device.unwrap().model.as_str().unwrap(), "moto g31(w)");
     }
 

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -103,7 +103,7 @@ mod tests {
             PairList(headers)
         });
 
-        let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers)).unwrap();
+        let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
         insta::assert_debug_snapshot!(os, @r###"
 OsContext {
@@ -138,7 +138,7 @@ OsContext {
             PairList(headers)
         });
 
-        let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::new(&headers)).unwrap();
+        let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
         insta::assert_debug_snapshot!(os, @r###"
 OsContext {

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -274,7 +274,7 @@ impl Replay {
             None => return,
         };
 
-        let mut user_agent_info = RawUserAgentInfo::new(headers);
+        let mut user_agent_info = RawUserAgentInfo::from_headers(headers);
 
         if user_agent_info.user_agent.is_none() {
             user_agent_info.user_agent = default_user_agent;

--- a/relay-general/src/store/normalize/user_agent.rs
+++ b/relay-general/src/store/normalize/user_agent.rs
@@ -22,7 +22,7 @@ pub fn normalize_user_agent(event: &mut Event) {
         None => return,
     };
 
-    let user_agent_info = RawUserAgentInfo::new(headers);
+    let user_agent_info = RawUserAgentInfo::from_headers(headers);
 
     let contexts = event.contexts.get_or_insert_with(|| Contexts::new());
     normalize_user_agent_info_generic(contexts, &event.platform, &user_agent_info);

--- a/relay-general/src/user_agent.rs
+++ b/relay-general/src/user_agent.rs
@@ -106,7 +106,7 @@ pub struct ClientHints<'a> {
 }
 
 impl<'a> RawUserAgentInfo<'a> {
-    pub fn new(headers: &'a Headers) -> Self {
+    pub fn from_headers(headers: &'a Headers) -> Self {
         let mut contexts = Self::default();
 
         for item in headers.iter() {

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -297,10 +297,10 @@ mod tests {
         }];
 
         // ensures the event is indeed dropped with and without processing enabled
-        let res = samplingresult_from_rules_and_proccessing_flag(rules.clone(), false);
+        let res = samplingresult_from_rules_and_processing_flag(rules.clone(), false);
         assert!(matches!(res, SamplingResult::Drop(_)));
 
-        let res = samplingresult_from_rules_and_proccessing_flag(rules.clone(), true);
+        let res = samplingresult_from_rules_and_processing_flag(rules.clone(), true);
         assert!(matches!(res, SamplingResult::Drop(_)));
 
         rules.push(SamplingRule {
@@ -313,10 +313,10 @@ mod tests {
         });
 
         // now that an unsupported rule has been pushed, it should keep the event if processing is disabled
-        let res = samplingresult_from_rules_and_proccessing_flag(rules.clone(), false);
+        let res = samplingresult_from_rules_and_processing_flag(rules.clone(), false);
         assert!(matches!(res, SamplingResult::Keep));
 
-        let res = samplingresult_from_rules_and_proccessing_flag(rules, true);
+        let res = samplingresult_from_rules_and_processing_flag(rules, true);
         assert!(matches!(res, SamplingResult::Drop(_))); // should also log an error
     }
 

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -253,7 +253,7 @@ mod tests {
         )
     }
 
-    fn samplingresult_from_rules_and_proccessing_flag(
+    fn samplingresult_from_rules_and_processing_flag(
         rules: Vec<SamplingRule>,
         processing_enabled: bool,
     ) -> SamplingResult {


### PR DESCRIPTION
This PR renames two functions:

* `RawUserAgentInfo::new()` -> `RawUserAgentInfo::from_headers()`
* Fix typo in `samplingresult_from_rules_and_proccessing_flag`.

This is a separate PR to avoid too many diffs in #1802.

#skip-changelog