### PR TITLE
ref(glob): Make the regex compilation for glob lazy

### DIFF
--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -13,7 +13,6 @@ mod glob;
 mod project;
 mod retry;
 mod time;
-mod utils;
 
 pub use crate::constants::*;
 pub use crate::glob::*;
@@ -21,7 +20,6 @@ pub use crate::macros::*;
 pub use crate::project::*;
 pub use crate::retry::*;
 pub use crate::time::*;
-pub use crate::utils::*;
 
 pub use sentry_types::protocol::LATEST as PROTOCOL_VERSION;
 pub use sentry_types::{Auth, Dsn, ParseAuthError, ParseDsnError, Scheme, Uuid};

--- a/relay-general/src/lib.rs
+++ b/relay-general/src/lib.rs
@@ -23,5 +23,6 @@ pub mod processor;
 pub mod protocol;
 pub mod store;
 pub mod types;
+pub mod utils;
 
 pub mod user_agent;

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -44,7 +44,7 @@ impl<'r> TransactionsProcessor<'r> {
             transaction.apply(|transaction, meta| {
                 let result = self.tx_name_rules.iter().find_map(|rule| {
                     rule.match_and_apply(Cow::Borrowed(transaction), info)
-                        .map(|applied_result| (rule.pattern.pattern(), applied_result))
+                        .map(|applied_result| (rule.pattern.compiled().pattern(), applied_result))
                 });
 
                 if let Some((rule, result)) = result {
@@ -412,9 +412,9 @@ mod tests {
 
     use crate::processor::process_value;
     use crate::protocol::{Contexts, SpanId, TraceContext, TraceId, TransactionSource};
+    use crate::store::LazyGlob;
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::Object;
-    use crate::utils::Glob;
 
     use super::*;
 
@@ -1501,29 +1501,20 @@ mod tests {
         "#;
 
         let rule1 = TransactionNameRule {
-            pattern: Glob::builder("/foo/*/user/*/**")
-                .capture_double_star(false)
-                .capture_question_mark(false)
-                .build(),
+            pattern: LazyGlob::new("/foo/*/user/*/**".to_string()),
             expiry: Utc::now() + Duration::hours(1),
             scope: Default::default(),
             redaction: Default::default(),
         };
         let rule2 = TransactionNameRule {
-            pattern: Glob::builder("/foo/*/**")
-                .capture_double_star(false)
-                .capture_question_mark(false)
-                .build(),
+            pattern: LazyGlob::new("/foo/*/**".to_string()),
             expiry: Utc::now() + Duration::hours(1),
             scope: Default::default(),
             redaction: Default::default(),
         };
         // This should not happend, such rules shouldn't be sent to relay at all.
         let rule3 = TransactionNameRule {
-            pattern: Glob::builder("/*/**")
-                .capture_double_star(false)
-                .capture_question_mark(false)
-                .build(),
+            pattern: LazyGlob::new("/*/**".to_string()),
             expiry: Utc::now() + Duration::hours(1),
             scope: Default::default(),
             redaction: Default::default(),
@@ -1657,14 +1648,14 @@ mod tests {
         "#;
         let mut event = Annotated::<Event>::from_json(json).unwrap();
         let rule1 = TransactionNameRule {
-            pattern: Glob::new("/foo/*/**"),
+            pattern: LazyGlob::new("/foo/*/**".to_string()),
             expiry: Utc::now() + Duration::hours(1),
             scope: Default::default(),
             redaction: Default::default(),
         };
         // This should not happend, such rules shouldn't be sent to relay at all.
         let rule2 = TransactionNameRule {
-            pattern: Glob::new("/*/**"),
+            pattern: LazyGlob::new("/*/**".to_string()),
             expiry: Utc::now() + Duration::hours(1),
             scope: Default::default(),
             redaction: Default::default(),
@@ -1728,10 +1719,7 @@ mod tests {
         "#;
 
         let rule = TransactionNameRule {
-            pattern: Glob::builder("/foo/*/**")
-                .capture_double_star(false)
-                .capture_question_mark(false)
-                .build(),
+            pattern: LazyGlob::new("/foo/*/**".to_string()),
             expiry: Utc::now() + Duration::hours(1),
             scope: Default::default(),
             redaction: Default::default(),

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -410,12 +410,11 @@ mod tests {
     use insta::assert_debug_snapshot;
     use similar_asserts::assert_eq;
 
-    use relay_common::Glob;
-
     use crate::processor::process_value;
     use crate::protocol::{Contexts, SpanId, TraceContext, TraceId, TransactionSource};
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::Object;
+    use crate::utils::Glob;
 
     use super::*;
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -25,7 +25,7 @@ impl LazyGlob {
         }
     }
 
-    /// Returns the compiled version of the glob
+    /// Returns the compiled version of the [`crate::utils::Glob`].
     pub fn compiled(&self) -> &Glob {
         self.glob.get_or_init(|| {
             Glob::builder(&self.raw)
@@ -51,8 +51,7 @@ fn deserialize_glob_pattern<'de, D>(deserializer: D) -> Result<LazyGlob, D::Erro
 where
     D: Deserializer<'de>,
 {
-    let pattern = String::deserialize(deserializer)?;
-    Ok(LazyGlob::new(pattern))
+    String::deserialize(deserializer).map(LazyGlob::new)
 }
 
 /// Contains transaction attribute the rule must only be applied to.

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
 use chrono::{DateTime, Utc};
-use relay_common::Glob;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::protocol::{TransactionInfo, TransactionSource};
+use crate::utils::Glob;
 
 /// Helper function to deserialize the string patter into the [`relay_common::Glob`].
 fn deserialize_glob_pattern<'de, D>(deserializer: D) -> Result<Glob, D::Error>

--- a/relay-general/src/utils.rs
+++ b/relay-general/src/utils.rs
@@ -4,7 +4,7 @@ use std::str;
 use once_cell::sync::OnceCell;
 use regex::Regex;
 
-use crate::macros::impl_str_serde;
+use relay_common::impl_str_serde;
 
 /// Glob options represent the underlying regex emulating the globs.
 #[derive(Debug)]

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -17,8 +17,8 @@ use bytes::Bytes;
 use futures01::{future, sync::oneshot, Future as _};
 use once_cell::sync::Lazy;
 
-use relay_common::GlobMatcher;
 use relay_config::Config;
+use relay_general::utils::GlobMatcher;
 use relay_log::LogError;
 
 use crate::actors::upstream::{


### PR DESCRIPTION
Currently we deserialize all the incoming glob patterns eagerly, converting the pattern to `Regex`.

This change make it so, that we only prepare the string pattern for the incoming globs, and compile the regex once we have to use it, consuming the prepared pattern.

This should reduce the deserialization time for the transaction name rules and also only the used rules will have compiled regexes in them and the rest will just wait it's turn. 

fix: https://github.com/getsentry/team-ingest/issues/33

#skip-changelog