### PR TITLE
fix(time): Avoid panicking when provided timestamp is wrong

### DIFF
--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -129,8 +129,8 @@ impl UnixTimestamp {
     }
 
     /// Returns the timestamp as chrono datetime.
-    pub fn as_datetime(self) -> DateTime<Utc> {
-        DateTime::from_utc(NaiveDateTime::from_timestamp(self.0 as i64, 0), Utc)
+    pub fn as_datetime(self) -> Option<DateTime<Utc>> {
+        NaiveDateTime::from_timestamp_opt(self.0 as i64, 0).map(|n| DateTime::from_utc(n, Utc))
     }
 
     /// Converts the UNIX timestamp into an `Instant` based on the current system timestamp.

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -139,19 +139,22 @@ impl OutcomeAggregator {
                 category,
             } = bucket_key;
 
-            let timestamp = UnixTimestamp::from_secs(offset * bucket_interval);
-            let outcome = TrackOutcome {
-                timestamp: timestamp.as_datetime(),
-                scoping,
-                outcome,
-                event_id: None,
-                remote_addr,
-                category,
-                quantity,
-            };
+            if let Some(timestamp) =
+                UnixTimestamp::from_secs(offset * bucket_interval).as_datetime()
+            {
+                let outcome = TrackOutcome {
+                    timestamp,
+                    scoping,
+                    outcome,
+                    event_id: None,
+                    remote_addr,
+                    category,
+                    quantity,
+                };
 
-            relay_log::trace!("Flushing outcome for timestamp {}", timestamp);
-            outcome_producer.send(outcome);
+                relay_log::trace!("Flushing outcome for timestamp {}", timestamp);
+                outcome_producer.send(outcome);
+            }
         }
     }
 

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -110,15 +110,17 @@ impl<M: MetricsContainer, Q: AsRef<Vec<Quota>>> MetricsLimiter<M, Q> {
 
         // Track outcome for the transaction metrics we dropped here:
         if self.transaction_count > 0 {
-            TrackOutcome::from_registry().send(TrackOutcome {
-                timestamp: UnixTimestamp::now().as_datetime(), // as good as any timestamp
-                scoping: self.scoping,
-                outcome,
-                event_id: None,
-                remote_addr: None,
-                category: DataCategory::Transaction,
-                quantity: self.transaction_count as u32,
-            });
+            if let Some(timestamp) = UnixTimestamp::now().as_datetime() {
+                TrackOutcome::from_registry().send(TrackOutcome {
+                    timestamp,
+                    scoping: self.scoping,
+                    outcome,
+                    event_id: None,
+                    remote_addr: None,
+                    category: DataCategory::Transaction,
+                    quantity: self.transaction_count as u32,
+                });
+            }
         }
     }
 

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -1,4 +1,5 @@
 //! Quota and rate limiting helpers for metrics and metrics buckets.
+use chrono::Utc;
 
 use relay_common::{DataCategory, UnixTimestamp};
 use relay_metrics::{MetricNamespace, MetricResourceIdentifier, MetricsContainer};
@@ -110,17 +111,16 @@ impl<M: MetricsContainer, Q: AsRef<Vec<Quota>>> MetricsLimiter<M, Q> {
 
         // Track outcome for the transaction metrics we dropped here:
         if self.transaction_count > 0 {
-            if let Some(timestamp) = UnixTimestamp::now().as_datetime() {
-                TrackOutcome::from_registry().send(TrackOutcome {
-                    timestamp,
-                    scoping: self.scoping,
-                    outcome,
-                    event_id: None,
-                    remote_addr: None,
-                    category: DataCategory::Transaction,
-                    quantity: self.transaction_count as u32,
-                });
-            }
+            let timestamp = UnixTimestamp::now().as_datetime().unwrap_or_else(Utc::now);
+            TrackOutcome::from_registry().send(TrackOutcome {
+                timestamp,
+                scoping: self.scoping,
+                outcome,
+                event_id: None,
+                remote_addr: None,
+                category: DataCategory::Transaction,
+                quantity: self.transaction_count as u32,
+            });
         }
     }
 


### PR DESCRIPTION
Switch to `NaiveDateTime::from_timestamp_opt` to avoid panicking when the unix timestamp is somehow wrong and cannot be parsed to get the `NaiveDateTime` out of it. See [`chrono source code`](https://github.com/chronotope/chrono/blob/6684a470abcd037aeffcde7177128c40e9740f26/src/naive/datetime/mod.rs#L150)

fix: #1624 

#skip-changelog