### PR TITLE
feat(protocol): Ignore empty client hints

### DIFF
--- a/relay-general/src/protocol/contexts/browser.rs
+++ b/relay-general/src/protocol/contexts/browser.rs
@@ -86,6 +86,10 @@ fn browser_from_client_hints(s: &str) -> Option<(String, String)> {
         let browser = captures.get(1)?.as_str().to_owned();
         let version = captures.get(2)?.as_str().to_owned();
 
+        if browser.is_empty() || version.is_empty() {
+            return None;
+        }
+
         return Some((browser, version));
     }
     None

--- a/relay-general/src/protocol/contexts/browser.rs
+++ b/relay-general/src/protocol/contexts/browser.rs
@@ -86,7 +86,7 @@ fn browser_from_client_hints(s: &str) -> Option<(String, String)> {
         let browser = captures.get(1)?.as_str().to_owned();
         let version = captures.get(2)?.as_str().to_owned();
 
-        if browser.is_empty() || version.is_empty() {
+        if browser.trim().is_empty() || version.trim().is_empty() {
             return None;
         }
 
@@ -163,7 +163,7 @@ mod tests {
                 Annotated::new("SEC-CH-UA".to_string().into()),
                 Annotated::new(
                     // browser field missing
-                    r#"Not_A Brand";v="99", "";v="109", "Chromium";v="109"#
+                    r#"Not_A Brand";v="99", " ";v="109", "Chromium";v="109"#
                         .to_string()
                         .into(),
                 ),
@@ -172,7 +172,6 @@ mod tests {
         });
 
         let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
-
         let from_hints = BrowserContext::from_client_hints(&client_hints);
         assert!(from_hints.is_none())
     }

--- a/relay-general/src/protocol/contexts/browser.rs
+++ b/relay-general/src/protocol/contexts/browser.rs
@@ -157,6 +157,27 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_empty_browser() {
+        let headers = Headers({
+            let headers = vec![Annotated::new((
+                Annotated::new("SEC-CH-UA".to_string().into()),
+                Annotated::new(
+                    // browser field missing
+                    r#"Not_A Brand";v="99", "";v="109", "Chromium";v="109"#
+                        .to_string()
+                        .into(),
+                ),
+            ))];
+            PairList(headers)
+        });
+
+        let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
+
+        let from_hints = BrowserContext::from_client_hints(&client_hints);
+        assert!(from_hints.is_none())
+    }
+
+    #[test]
     fn test_client_hints_with_unknown_browser() {
         let headers = Headers({
             let headers = vec![

--- a/relay-general/src/protocol/contexts/device.rs
+++ b/relay-general/src/protocol/contexts/device.rs
@@ -176,7 +176,7 @@ impl FromUserAgentInfo for DeviceContext {
     fn from_client_hints(client_hints: &ClientHints) -> Option<Self> {
         let device = client_hints.sec_ch_ua_model?.to_owned();
 
-        if device.is_empty() {
+        if device.trim().is_empty() {
             return None;
         }
 
@@ -259,7 +259,6 @@ mod tests {
         });
 
         let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
-
         let from_hints = DeviceContext::from_client_hints(&client_hints);
         assert!(from_hints.is_none())
     }

--- a/relay-general/src/protocol/contexts/device.rs
+++ b/relay-general/src/protocol/contexts/device.rs
@@ -175,6 +175,11 @@ impl DeviceContext {
 impl FromUserAgentInfo for DeviceContext {
     fn from_client_hints(client_hints: &ClientHints) -> Option<Self> {
         let device = client_hints.sec_ch_ua_model?.to_owned();
+
+        if device.is_empty() {
+            return None;
+        }
+
         Some(Self {
             model: Annotated::new(device),
             ..Default::default()

--- a/relay-general/src/protocol/contexts/device.rs
+++ b/relay-general/src/protocol/contexts/device.rs
@@ -249,6 +249,22 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_empty_device() {
+        let headers = Headers({
+            let headers = vec![Annotated::new((
+                Annotated::new("SEC-CH-UA-MODEL".to_string().into()),
+                Annotated::new("".to_string().into()),
+            ))];
+            PairList(headers)
+        });
+
+        let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
+
+        let from_hints = DeviceContext::from_client_hints(&client_hints);
+        assert!(from_hints.is_none())
+    }
+
+    #[test]
     fn test_device_context_roundtrip() {
         let json = r#"{
   "name": "iphone",

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -54,7 +54,7 @@ impl FromUserAgentInfo for OsContext {
         let platform = client_hints.sec_ch_ua_platform?;
         let version = client_hints.sec_ch_ua_platform_version?;
 
-        if platform.is_empty() || version.is_empty() {
+        if platform.trim().is_empty() || version.trim().is_empty() {
             return None;
         }
 
@@ -139,7 +139,6 @@ OsContext {
         });
 
         let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
-
         let from_hints = OsContext::from_client_hints(&client_hints);
         assert!(from_hints.is_none())
     }

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -123,6 +123,28 @@ OsContext {
     }
 
     #[test]
+    fn test_ignore_empty_os() {
+        let headers = Headers({
+            let headers = vec![
+                Annotated::new((
+                    Annotated::new("SEC-CH-UA-PLATFORM".to_string().into()),
+                    Annotated::new(r#"macOS"#.to_string().into()),
+                )),
+                Annotated::new((
+                    Annotated::new("SEC-CH-UA-PLATFORM-VERSION".to_string().into()),
+                    Annotated::new("".to_string().into()),
+                )),
+            ];
+            PairList(headers)
+        });
+
+        let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
+
+        let from_hints = OsContext::from_client_hints(&client_hints);
+        assert!(from_hints.is_none())
+    }
+
+    #[test]
     fn test_fallback_on_ua_string_for_os() {
         let headers = Headers({
             let headers = vec![

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -54,6 +54,10 @@ impl FromUserAgentInfo for OsContext {
         let platform = client_hints.sec_ch_ua_platform?;
         let version = client_hints.sec_ch_ua_platform_version?;
 
+        if platform.is_empty() || version.is_empty() {
+            return None;
+        }
+
         Some(Self {
             name: Annotated::new(platform.to_owned()),
             version: Annotated::new(version.to_owned()),


### PR DESCRIPTION
if a client hint has an empty string, it should be treated as missing. 

#skip-changelog
