### PR TITLE
feat(replays): Add replays scrubbing diagnostic script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "relay-scr"
+version = "23.1.1"
+dependencies = [
+ "num_cpus",
+ "relay-general",
+ "relay-replays",
+ "threadpool",
+]
+
+[[package]]
 name = "relay-server"
 version = "23.1.1"
 dependencies = [
@@ -4472,6 +4482,15 @@ dependencies = [
  "proc-macro2 1.0.39",
  "quote 1.0.18",
  "syn 1.0.96",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -79,7 +79,7 @@ impl<'a> ReplayScrubber<'a> {
         self.processor1.is_none() && self.processor2.is_none()
     }
 
-    fn scrub_replay<R, W>(&mut self, read: R, write: W) -> Result<(), ParseRecordingError>
+    pub fn scrub_replay<R, W>(&mut self, read: R, write: W) -> Result<(), ParseRecordingError>
     where
         R: std::io::Read,
         W: std::io::Write,

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -79,7 +79,7 @@ impl<'a> ReplayScrubber<'a> {
         self.processor1.is_none() && self.processor2.is_none()
     }
 
-    pub fn scrub_replay<R, W>(&mut self, read: R, write: W) -> Result<(), ParseRecordingError>
+    fn scrub_replay<R, W>(&mut self, read: R, write: W) -> Result<(), ParseRecordingError>
     where
         R: std::io::Read,
         W: std::io::Write,

--- a/tools/scrub-replays-diagnostic/.gitignore
+++ b/tools/scrub-replays-diagnostic/.gitignore
@@ -1,0 +1,4 @@
+input/*
+output/*
+diffs/*
+tmp/*

--- a/tools/scrub-replays-diagnostic/Cargo.toml
+++ b/tools/scrub-replays-diagnostic/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "relay-scr"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Replays functionality for Relay"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+version = "23.1.1"
+edition = "2021"
+license-file = "../LICENSE"
+publish = false
+
+[dependencies]
+relay-general = { path = "../../relay-general" }
+relay-replays = { path = "../../relay-replays" }
+threadpool= "1.8.1"
+num_cpus = "1.13.0"

--- a/tools/scrub-replays-diagnostic/Makefile
+++ b/tools/scrub-replays-diagnostic/Makefile
@@ -1,0 +1,16 @@
+SHELL=/bin/bash
+
+
+clean:
+	rm -rf ./output/*
+	rm -rf ./diffs/*
+	rm -rf ./tmp/*
+.PHONY: clean
+
+run: clean
+	./pretty-json.sh input
+	cargo run -q
+	./pretty-json.sh output
+	./diff.sh input output
+
+

--- a/tools/scrub-replays-diagnostic/Makefile
+++ b/tools/scrub-replays-diagnostic/Makefile
@@ -8,6 +8,7 @@ clean:
 .PHONY: clean
 
 run: clean
+	mkdir -p input output tmp diffs
 	./pretty-json.sh input
 	cargo run -q
 	./pretty-json.sh output

--- a/tools/scrub-replays-diagnostic/README.md
+++ b/tools/scrub-replays-diagnostic/README.md
@@ -1,0 +1,8 @@
+# Replay Scrubbing diagnostic script
+
+### Usage
+
+1. add your scrubbing function implementation to `scrubbing_function` in `src/main.rs`
+1. put replay input data you'd like to test in `./input`.
+1. run `make run`.
+1. look at diff in `./diffs`, and full output in `./output`.

--- a/tools/scrub-replays-diagnostic/diff.sh
+++ b/tools/scrub-replays-diagnostic/diff.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+for i in "$2"/*
+do
+    base_name=$(basename "${i}")
+    if test -f "$i"
+    then
+       diff "tmp/pretty-$1-$base_name" "tmp/pretty-$2-$base_name" > "diffs/${base_name}.diff"
+    fi
+done
+exit 0

--- a/tools/scrub-replays-diagnostic/pretty-json.sh
+++ b/tools/scrub-replays-diagnostic/pretty-json.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+for i in "$1"/*
+do
+    base_name=$(basename "${i}")
+    if test -f "$i"
+    then
+       jq --sort-keys . "$i" > "tmp/pretty-$1-$base_name"
+    fi
+done

--- a/tools/scrub-replays-diagnostic/src/main.rs
+++ b/tools/scrub-replays-diagnostic/src/main.rs
@@ -1,0 +1,98 @@
+use relay_general::pii::{DataScrubbingConfig, PiiConfig};
+use relay_replays::recording::ReplayScrubber;
+use std::fs;
+use std::sync::mpsc::channel;
+use threadpool::ThreadPool;
+
+enum ScrubbingResult {
+    Scrubbed,
+    NotScrubbed,
+    Skipped,
+}
+
+fn scrubbing_function<R, W>(input: R, output: W)
+where
+    R: std::io::Read,
+    W: std::io::Write,
+{
+    let binding = default_pii_config();
+    let mut scrubber = ReplayScrubber::new(usize::MAX, Some(&binding), None);
+
+    scrubber.scrub_replay(input, output).unwrap();
+
+    fn default_pii_config() -> PiiConfig {
+        let mut scrubbing_config = DataScrubbingConfig::default();
+        scrubbing_config.scrub_data = true;
+        scrubbing_config.scrub_defaults = true;
+        scrubbing_config.scrub_ip_addresses = true;
+        scrubbing_config.pii_config_uncached().unwrap().unwrap()
+    }
+}
+
+fn main() {
+    let paths = fs::read_dir("./input").unwrap();
+    let n_workers = num_cpus::get();
+    let pool = ThreadPool::new(n_workers);
+    let mut num_paths = 0;
+    let (tx, rx) = channel();
+
+    for path in paths {
+        num_paths += 1;
+        let tx = tx.clone();
+
+        pool.execute(move || {
+            let path = path.unwrap().path();
+            let file_name = path.file_name().unwrap().to_string_lossy().into_owned();
+            let path_name = path.to_string_lossy().into_owned();
+
+            if file_name == ".DS_Store" {
+                tx.send(ScrubbingResult::Skipped)
+                    .expect("channel will be there waiting for the pool");
+                return;
+            }
+
+            let file_contents =
+                fs::read_to_string(path_name).expect("Should have been able to read the file");
+
+            let replay_data_str = file_contents.as_str();
+
+            let mut transcoded = Vec::new();
+
+            scrubbing_function(replay_data_str.as_bytes(), &mut transcoded);
+
+            let parsed = std::str::from_utf8(&transcoded).unwrap();
+
+            if parsed != replay_data_str {
+                println!("scrubing-modified {file_name}");
+                writefile(&file_name, parsed).expect("file should have been written");
+                tx.send(ScrubbingResult::Scrubbed)
+                    .expect("channel will be there waiting for the pool");
+                // scrubbed += 1;
+            } else {
+                println!("scrubing did not modify {file_name}");
+                tx.send(ScrubbingResult::NotScrubbed)
+                    .expect("channel will be there waiting for the pool");
+            }
+        });
+    }
+
+    let mut scrubbed = 0;
+    let mut not_scrubbed = 0;
+    rx.iter().take(num_paths).for_each(|result| match result {
+        ScrubbingResult::Scrubbed => scrubbed += 1,
+        ScrubbingResult::NotScrubbed => not_scrubbed += 1,
+        ScrubbingResult::Skipped => (),
+    });
+
+    println!("Finished running scrubbing! Scrubbed: {scrubbed}, Not Scrubbed: {not_scrubbed}");
+}
+
+fn writefile(name: &str, s: &str) -> std::io::Result<()> {
+    use std::fs::File;
+    use std::io::prelude::*;
+    let mut path: String = "./output/".to_owned();
+    path.push_str(name);
+    let mut file = File::create(path)?;
+    file.write_all(s.as_bytes())?;
+    Ok(())
+}


### PR DESCRIPTION
Adds a tool to test scrubbing implementations. not intending to merge as is, but want to show an example of how to use it. see README.md for instructions.