### PR TITLE
doc(replays): Add basic docs for Replays

### DIFF
--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relay-replays"
 authors = ["Sentry <oss@sentry.io>"]
-description = "Replays functionality for Relay"
+description = "Session replay functionality for Relay"
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"
 version = "23.1.1"

--- a/relay-replays/benches/benchmarks.rs
+++ b/relay-replays/benches/benchmarks.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use flate2::{bufread::ZlibEncoder, Compression};
 
 use relay_general::pii::DataScrubbingConfig;
-use relay_replays::recording::ReplayScrubber;
+use relay_replays::recording::RecordingScrubber;
 
 fn bench_recording(c: &mut Criterion) {
     let payload = include_bytes!("../tests/fixtures/rrweb.json");
@@ -21,7 +21,7 @@ fn bench_recording(c: &mut Criterion) {
     scrubbing_config.scrub_ip_addresses = true;
     let pii_config = scrubbing_config.pii_config_uncached().unwrap().unwrap();
 
-    let mut scrubber = ReplayScrubber::new(usize::MAX, Some(&pii_config), None);
+    let mut scrubber = RecordingScrubber::new(usize::MAX, Some(&pii_config), None);
 
     c.bench_with_input(BenchmarkId::new("rrweb", 1), &compressed, |b, &_| {
         b.iter(|| {

--- a/relay-replays/src/lib.rs
+++ b/relay-replays/src/lib.rs
@@ -1,2 +1,17 @@
+//! Session replay protocol and processing for Sentry.
+//!
+//! [Session Replay] provides a video-like reproduction of user interactions on a site or web app.
+//! All user interactions — including page visits, mouse movements, clicks, and scrolls — are
+//! captured, helping developers connect the dots between a known issue and how a user experienced
+//! it in the UI.
+//!
+//! [session replay]: https://docs.sentry.io/product/session-replay/
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
+    html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
+)]
+#![warn(missing_docs)]
+
 pub mod recording;
 mod transform;

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -145,7 +145,7 @@ impl<'a> RecordingScrubber<'a> {
         }
     }
 
-    /// Parses a replay recording payloads and applies data scrubbers.
+    /// Parses replay recording payloads and applies data scrubbers.
     ///
     /// # Compression
     ///

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use relay_replays::recording::ReplayScrubber;
+use relay_replays::recording::RecordingScrubber;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::io::Write;
@@ -1087,7 +1087,7 @@ impl EnvelopeProcessorService {
             .map_err(|e| ProcessingError::PiiConfigError(e.clone()))?
             .as_ref();
         let mut scrubber =
-            ReplayScrubber::new(limit, config.pii_config.as_ref(), datascrubbing_config);
+            RecordingScrubber::new(limit, config.pii_config.as_ref(), datascrubbing_config);
 
         state.envelope.retain_items(|item| match item.ty() {
             ItemType::ReplayEvent => {

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -43,8 +43,10 @@
 //!  - [`relay-kafka`]: Kafka-related functionality.
 //!  - [`relay-log`]: Error reporting and logging.
 //!  - [`relay-metrics`]: Metrics protocol and processing.
+//!  - [`relay-profiling`]: Profiling protocol and processing.
 //!  - [`relay-quotas`]: Sentry quotas and rate limiting.
 //!  - [`relay-redis`]: Pooled Redis and Redis cluster abstraction.
+//!  - [`relay-replays`]: Session replay protocol and processing.
 //!  - [`relay-sampling`]: Dynamic sampling functionality.
 //!  - [`relay-statsd`]: High-level StatsD metric client for internal measurements.
 //!  - [`relay-server`]: Endpoints and services.
@@ -75,8 +77,10 @@
 //! [`relay-kafka`]: ../relay_kafka/index.html
 //! [`relay-log`]: ../relay_log/index.html
 //! [`relay-metrics`]: ../relay_metrics/index.html
+//! [`relay-profiling`]: ../relay_profiling/index.html
 //! [`relay-quotas`]: ../relay_quotas/index.html
 //! [`relay-redis`]: ../relay_redis/index.html
+//! [`relay-replays`]: ../relay_replays/index.html
 //! [`relay-sampling`]: ../relay_sampling/index.html
 //! [`relay-statsd`]: ../relay_statsd/index.html
 //! [`relay-server`]: ../relay_server/index.html


### PR DESCRIPTION
Contains bare minimum documentation for the `relay-replays` module. More documentation on the payload and processing functionality, similar to `relay-metrics` and `relay-profiling` should be added in a followup.

#skip-changelog

