### PR TITLE
ref(replays): Restrict data scrubbing to sentry payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 **Bug Fixes**:
 
-- Improve performance for replays, especially memory usage during data scrubbing.([#1800](https://github.com/getsentry/relay/pull/1800))
+- Improve performance for replays, especially memory usage during data scrubbing.([#1800](https://github.com/getsentry/relay/pull/1800), [#1825](https://github.com/getsentry/relay/pull/1825))
 
 **Internal**:
 

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -19,7 +19,7 @@ relay-filter = { path = "../relay-filter" }
 relay-general = { path = "../relay-general" }
 relay-log = { path = "../relay-log" }
 serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde_json = { version ="1.0.55", features = ["raw_value"] }
 serde-transcode = "1.1.1"
 unicase = "2.6.0"
 

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -8,25 +8,29 @@
 //! intact.
 
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::fmt;
-use std::io::{BufReader, Read};
+use std::io::Read;
+use std::rc::Rc;
 
 use flate2::{bufread::ZlibDecoder, write::ZlibEncoder, Compression};
 use once_cell::sync::Lazy;
+use serde::{de, ser, Deserializer};
+use serde_json::value::RawValue;
 
 use relay_general::pii::{PiiConfig, PiiProcessor};
 use relay_general::processor::{FieldAttrs, Pii, ProcessingState, Processor, ValueType};
 use relay_general::types::Meta;
 
-use crate::transform::{self, Transform};
+use crate::transform::Transform;
 
 /// Error returned from [`RecordingScrubber`].
 #[derive(Debug)]
 pub enum ParseRecordingError {
-    /// An error parsing the payload.
-    ///
-    /// This error can be caused by invalid compression or invalid JSON.
+    /// An error parsing the JSON payload.
     Parse(serde_json::Error),
+    /// Invalid or broken compression.
+    Compression(std::io::Error),
     /// Validation of the payload failed.
     ///
     /// The body is empty, is missing the headers, or the body.
@@ -37,6 +41,7 @@ impl fmt::Display for ParseRecordingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ParseRecordingError::Parse(serde_error) => write!(f, "{serde_error}"),
+            ParseRecordingError::Compression(error) => write!(f, "{error}"),
             ParseRecordingError::Message(message) => write!(f, "{message}"),
         }
     }
@@ -46,6 +51,7 @@ impl std::error::Error for ParseRecordingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ParseRecordingError::Parse(e) => Some(e),
+            ParseRecordingError::Compression(e) => Some(e),
             ParseRecordingError::Message(_) => None,
         }
     }
@@ -65,6 +71,121 @@ static STRING_STATE: Lazy<ProcessingState> = Lazy::new(|| {
     )
 });
 
+/// The [`Transform`] implementation for data scrubbing.
+///
+/// This is used by [`EventStreamVisitor`] to scrub recording events.
+struct ScrubberTransform<'a> {
+    processor1: Option<PiiProcessor<'a>>,
+    processor2: Option<PiiProcessor<'a>>,
+}
+
+impl Transform for &'_ mut ScrubberTransform<'_> {
+    fn transform_str<'a>(&mut self, v: &'a str) -> Cow<'a, str> {
+        self.transform_string(v.to_owned())
+    }
+
+    fn transform_string(&mut self, mut value: String) -> Cow<'static, str> {
+        if let Some(ref mut processor) = self.processor1 {
+            if processor
+                .process_string(&mut value, &mut Meta::default(), &STRING_STATE)
+                .is_err()
+            {
+                return Cow::Borrowed("");
+            }
+        }
+
+        if let Some(ref mut processor) = self.processor2 {
+            if processor
+                .process_string(&mut value, &mut Meta::default(), &STRING_STATE)
+                .is_err()
+            {
+                return Cow::Borrowed("");
+            }
+        }
+
+        Cow::Owned(value)
+    }
+}
+
+/// Helper that runs data scrubbing on a raw JSON value during serialization.
+///
+/// This is used by [`EventStreamVisitor`] to serialize recording events on-the-fly from a stream.
+/// It uses a [`ScrubberTransform`] holding all state to perform the actual work.
+struct ScrubbedValue<'a, 'b>(&'a RawValue, Rc<RefCell<ScrubberTransform<'b>>>);
+
+impl serde::Serialize for ScrubbedValue<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut transform = self.1.borrow_mut();
+        let mut deserializer = serde_json::Deserializer::from_str(self.0.get());
+        let scrubber = crate::transform::Deserializer::new(&mut deserializer, &mut *transform);
+        serde_transcode::transcode(scrubber, serializer)
+    }
+}
+
+/// A visitor that deserializes, scrubs, and serializes a stream of recording events.
+struct EventStreamVisitor<'a, S> {
+    serializer: S,
+    scrubber: Rc<RefCell<ScrubberTransform<'a>>>,
+}
+
+impl<'a, S> EventStreamVisitor<'a, S> {
+    fn new(serializer: S, scrubber: Rc<RefCell<ScrubberTransform<'a>>>) -> Self {
+        Self {
+            serializer,
+            scrubber,
+        }
+    }
+}
+
+impl<'de, 'a, S> de::Visitor<'de> for EventStreamVisitor<'a, S>
+where
+    S: ser::Serializer,
+{
+    type Value = S::Ok;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "a replay recording event stream")
+    }
+
+    fn visit_seq<A>(self, mut v: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        #[derive(Clone, Copy, serde::Deserialize)]
+        struct TypeHelper {
+            #[serde(rename = "type")]
+            ty: u8,
+        }
+
+        use serde::ser::SerializeSeq;
+        let mut seq = self.serializer.serialize_seq(v.size_hint()).map_err(s2d)?;
+
+        while let Some(raw) = v.next_element::<&'de RawValue>()? {
+            // filter for sentry-specific events
+            let helper = serde_json::from_str::<TypeHelper>(raw.get()).unwrap();
+            if helper.ty == 5 {
+                seq.serialize_element(&ScrubbedValue(raw, self.scrubber.clone()))
+                    .map_err(s2d)?;
+            } else {
+                seq.serialize_element(raw).map_err(s2d)?;
+            }
+        }
+
+        seq.end().map_err(s2d)
+    }
+}
+
+fn s2d<S, D>(s: S) -> D
+where
+    S: ser::Error,
+    D: de::Error,
+{
+    D::custom(s.to_string())
+}
+
 /// A utility that performs data scrubbing on compressed Replay recording payloads.
 ///
 /// ### Example
@@ -82,8 +203,7 @@ static STRING_STATE: Lazy<ProcessingState> = Lazy::new(|| {
 /// ```
 pub struct RecordingScrubber<'a> {
     limit: usize,
-    processor1: Option<PiiProcessor<'a>>,
-    processor2: Option<PiiProcessor<'a>>,
+    transform: Rc<RefCell<ScrubberTransform<'a>>>,
 }
 
 impl<'a> RecordingScrubber<'a> {
@@ -105,26 +225,30 @@ impl<'a> RecordingScrubber<'a> {
     ) -> Self {
         Self {
             limit,
-            processor1: config1.map(|c| PiiProcessor::new(c.compiled())),
-            processor2: config2.map(|c| PiiProcessor::new(c.compiled())),
+            transform: Rc::new(RefCell::new(ScrubberTransform {
+                processor1: config1.map(|c| PiiProcessor::new(c.compiled())),
+                processor2: config2.map(|c| PiiProcessor::new(c.compiled())),
+            })),
         }
     }
 
     /// Returns `true` if both configs are empty and no scrubbing would occur.
     pub fn is_empty(&self) -> bool {
-        self.processor1.is_none() && self.processor2.is_none()
+        let tmp = self.transform.borrow();
+        tmp.processor1.is_none() && tmp.processor2.is_none()
     }
 
-    fn scrub_replay<R, W>(&mut self, read: R, write: W) -> Result<(), ParseRecordingError>
+    fn scrub_replay<W>(&mut self, json: &[u8], write: W) -> Result<(), ParseRecordingError>
     where
-        R: std::io::Read,
         W: std::io::Write,
     {
-        let mut deserializer = serde_json::Deserializer::from_reader(read);
+        let mut deserializer = serde_json::Deserializer::from_slice(json);
         let mut serializer = serde_json::Serializer::new(write);
 
-        let transformer = transform::Deserializer::new(&mut deserializer, self);
-        serde_transcode::transcode(transformer, &mut serializer)?;
+        deserializer.deserialize_seq(EventStreamVisitor::new(
+            &mut serializer,
+            self.transform.clone(),
+        ))?;
 
         Ok(())
     }
@@ -140,12 +264,17 @@ impl<'a> RecordingScrubber<'a> {
         if body.first() == Some(&b'[') {
             self.scrub_replay(body, encoder)
         } else {
-            let decoder = ZlibDecoder::new(body).take(self.limit as u64);
-            self.scrub_replay(BufReader::new(decoder), encoder)
+            let mut decompressed = Vec::with_capacity(8 * 1024);
+            let mut decoder = ZlibDecoder::new(body).take(self.limit as u64);
+            decoder
+                .read_to_end(&mut decompressed)
+                .map_err(ParseRecordingError::Compression)?;
+
+            self.scrub_replay(&decompressed, encoder)
         }
     }
 
-    /// Parses replay recording payloads and applies data scrubbers.
+    /// Parses a replay recording payloads and applies data scrubbers.
     ///
     /// # Compression
     ///
@@ -188,34 +317,6 @@ impl<'a> RecordingScrubber<'a> {
         self.transcode_replay(body, &mut output)?;
 
         Ok(output)
-    }
-}
-
-impl Transform for &'_ mut RecordingScrubber<'_> {
-    fn transform_str<'a>(&mut self, v: &'a str) -> Cow<'a, str> {
-        self.transform_string(v.to_owned())
-    }
-
-    fn transform_string(&mut self, mut value: String) -> Cow<'static, str> {
-        if let Some(ref mut processor) = self.processor1 {
-            if processor
-                .process_string(&mut value, &mut Meta::default(), &STRING_STATE)
-                .is_err()
-            {
-                return Cow::Borrowed("");
-            }
-        }
-
-        if let Some(ref mut processor) = self.processor2 {
-            if processor
-                .process_string(&mut value, &mut Meta::default(), &STRING_STATE)
-                .is_err()
-            {
-                return Cow::Borrowed("");
-            }
-        }
-
-        Cow::Owned(value)
     }
 }
 
@@ -290,7 +391,7 @@ mod tests {
         let result = scrubber(&config).process_recording(payload);
         assert!(matches!(
             result.unwrap_err(),
-            super::ParseRecordingError::Parse(_),
+            super::ParseRecordingError::Compression(_),
         ));
     }
 
@@ -324,19 +425,20 @@ mod tests {
 
     // RRWeb Payload Coverage
 
-    #[test]
-    fn test_pii_credit_card_removal() {
-        let payload = include_bytes!("../tests/fixtures/rrweb-pii.json");
+    // NOTE: Disabled because this tests for type 3 nodes.
+    // #[test]
+    // fn test_pii_credit_card_removal() {
+    //     let payload = include_bytes!("../tests/fixtures/rrweb-pii.json");
 
-        let mut transcoded = Vec::new();
-        let config = default_pii_config();
-        scrubber(&config)
-            .scrub_replay(payload.as_slice(), &mut transcoded)
-            .unwrap();
+    //     let mut transcoded = Vec::new();
+    //     let config = default_pii_config();
+    //     scrubber(&config)
+    //         .scrub_replay(payload.as_slice(), &mut transcoded)
+    //         .unwrap();
 
-        let parsed = std::str::from_utf8(&transcoded).unwrap();
-        assert!(parsed.contains(r#"{"type":3,"textContent":"[Filtered]","id":284}"#));
-    }
+    //     let parsed = std::str::from_utf8(&transcoded).unwrap();
+    //     assert!(parsed.contains(r#"{"type":3,"textContent":"[Filtered]","id":284}"#));
+    // }
 
     #[test]
     fn test_scrub_pii_navigation() {
@@ -366,53 +468,56 @@ mod tests {
         assert!(parsed.contains("https://sentry.io?credit-card=[Filtered]"));
     }
 
-    #[test]
-    fn test_pii_ip_address_removal() {
-        let payload = include_bytes!("../tests/fixtures/rrweb-pii-ip-address.json");
+    // NOTE: Disabled because this tests for type 3 nodes.
+    // #[test]
+    // fn test_pii_ip_address_removal() {
+    //     let payload = include_bytes!("../tests/fixtures/rrweb-pii-ip-address.json");
 
-        let mut transcoded = Vec::new();
-        let config = default_pii_config();
-        scrubber(&config)
-            .scrub_replay(payload.as_slice(), &mut transcoded)
-            .unwrap();
+    //     let mut transcoded = Vec::new();
+    //     let config = default_pii_config();
+    //     scrubber(&config)
+    //         .scrub_replay(payload.as_slice(), &mut transcoded)
+    //         .unwrap();
 
-        let parsed = std::str::from_utf8(&transcoded).unwrap();
-        assert!(parsed.contains("\"value\":\"[ip]\"")); // Assert texts were mutated.
-        assert!(parsed.contains("\"textContent\":\"[ip]\"")) // Assert text node was mutated.
-    }
+    //     let parsed = std::str::from_utf8(&transcoded).unwrap();
+    //     assert!(parsed.contains("\"value\":\"[ip]\"")); // Assert texts were mutated.
+    //     assert!(parsed.contains("\"textContent\":\"[ip]\"")) // Assert text node was mutated.
+    // }
 
     // Event Parsing and Scrubbing.
 
-    #[test]
-    fn test_scrub_pii_full_snapshot_event() {
-        let payload = include_bytes!("../tests/fixtures/rrweb-event-2.json");
+    // NOTE: Disabled because this tests for type 2 nodes.
+    // #[test]
+    // fn test_scrub_pii_full_snapshot_event() {
+    //     let payload = include_bytes!("../tests/fixtures/rrweb-event-2.json");
 
-        let mut transcoded = Vec::new();
-        let config = default_pii_config();
-        scrubber(&config)
-            .scrub_replay(payload.as_slice(), &mut transcoded)
-            .unwrap();
+    //     let mut transcoded = Vec::new();
+    //     let config = default_pii_config();
+    //     scrubber(&config)
+    //         .scrub_replay(payload.as_slice(), &mut transcoded)
+    //         .unwrap();
 
-        let scrubbed_result = std::str::from_utf8(&transcoded).unwrap();
-        // NOTE: The normalization below was removed
-        // assert!(scrubbed_result.contains("\"attributes\":{\"src\":\"#\"}"));
-        assert!(scrubbed_result.contains("\"textContent\":\"my ssn is [Filtered]\""));
-    }
+    //     let scrubbed_result = std::str::from_utf8(&transcoded).unwrap();
+    //     // NOTE: The normalization below was removed
+    //     // assert!(scrubbed_result.contains("\"attributes\":{\"src\":\"#\"}"));
+    //     assert!(scrubbed_result.contains("\"textContent\":\"my ssn is [Filtered]\""));
+    // }
 
-    #[test]
-    fn test_scrub_pii_incremental_snapshot_event() {
-        let payload = include_bytes!("../tests/fixtures/rrweb-event-3.json");
+    // NOTE: Disabled because this tests for type 3 nodes.
+    // #[test]
+    // fn test_scrub_pii_incremental_snapshot_event() {
+    //     let payload = include_bytes!("../tests/fixtures/rrweb-event-3.json");
 
-        let mut transcoded = Vec::new();
-        let config = default_pii_config();
-        scrubber(&config)
-            .scrub_replay(payload.as_slice(), &mut transcoded)
-            .unwrap();
+    //     let mut transcoded = Vec::new();
+    //     let config = default_pii_config();
+    //     scrubber(&config)
+    //         .scrub_replay(payload.as_slice(), &mut transcoded)
+    //         .unwrap();
 
-        let scrubbed_result = std::str::from_utf8(&transcoded).unwrap();
-        assert!(scrubbed_result.contains("\"textContent\":\"[Filtered]\""));
-        assert!(scrubbed_result.contains("\"value\":\"[Filtered]\""));
-    }
+    //     let scrubbed_result = std::str::from_utf8(&transcoded).unwrap();
+    //     assert!(scrubbed_result.contains("\"textContent\":\"[Filtered]\""));
+    //     assert!(scrubbed_result.contains("\"value\":\"[Filtered]\""));
+    // }
 
     #[test]
     fn test_scrub_pii_custom_event() {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1071,7 +1071,8 @@ impl EnvelopeProcessorService {
     fn process_replays(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
         let project_state = &mut state.project_state;
         let replays_enabled = project_state.has_feature(Feature::SessionReplay);
-        let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
+        // let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
+        let scrubbing_enabled = true; // TODO(ja): Revert this after test
 
         let context = &state.envelope_context;
         let meta = state.envelope.meta().clone();

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1071,8 +1071,7 @@ impl EnvelopeProcessorService {
     fn process_replays(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
         let project_state = &mut state.project_state;
         let replays_enabled = project_state.has_feature(Feature::SessionReplay);
-        // let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
-        let scrubbing_enabled = true; // TODO(ja): Revert this after test
+        let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
 
         let context = &state.envelope_context;
         let meta = state.envelope.meta().clone();


### PR DESCRIPTION
Unconditional data scrubbing can can break recording payloads because it scrubs strings that should be excluded from scrubbing. Eventually, the data scrubber will have to recurse through rrweb's DOM nodes and skip safe sub-trees or fields from scrubbing.

However, the client's default is to redact all strings from the DOM, which greatly reduces the chance of sensitive data ending up in the recording payloads. This leaves just Sentry's own payloads to be scrubbed, which are always top-level events marked with `type: 5`.

This PR updates the scrubber and introduces a visitor that streams through the top-level event list. When it encounters an item with type `5`, it uses the existing transforming deserializer to scrub all strings in the event, otherwise skipping it. This solution allows us to continue scrubbing without a strict schema.

# Alternatives

During implementation, there were two main alternatives considered:

1. Implement a struct for the top-level events that contains the `type`, `timestamp`, and opaque `data`. Inspect the type, conditionally map it to another struct that wraps `data` in `ScrubbedValue`, and then serialize that struct.
2. (implemented) Deserialize the top-level events into `RawValue`, parse it once with a helper struct to obtain the type. If the type matches, send the entire value through the transformer.

The second approach ultimately ended up in less code with equal to better performance, even though it requires to parse the raw value twice.

# Safety

The `raw_value` feature in the `serde_json` deserializer is now enabled for all of Relay, since it is not possible to load the same crate another time with a separate set of features. There are no documented caveats on the `raw_value` feature in `serde_json`. The implementation uses a special token (`"$serde_json::private::RawValue"`) in a way that makes it is safe for both serialize and deserialize:

- **Serialization**: Goes through `serialize_struct` with the token as name. Triggering this behavior requires a manual implementation of `Serialize` using this token, which our code does not contain.
- **Deserialization**: Goes through `deserialize_newtype_struct` with the token as name. Again, this requires a manual implementation of `Deserialize` to trigger accidentally. 

Closes #1806