### PR TITLE
ref: Make the pattern regex compilation lazy

### DIFF
--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -1,11 +1,10 @@
 use std::collections::BTreeMap;
 
 use once_cell::sync::Lazy;
-use regex::RegexBuilder;
 
 use crate::pii::{
-    DataScrubbingConfig, Pattern, PiiConfig, PiiConfigError, RedactPairRule, Redaction, RuleSpec,
-    RuleType, Vars,
+    DataScrubbingConfig, LazyPattern, PiiConfig, PiiConfigError, RedactPairRule, Redaction,
+    RuleSpec, RuleType, Vars,
 };
 use crate::processor::{SelectorPathItem, SelectorSpec, ValueType};
 
@@ -76,12 +75,7 @@ pub fn to_pii_config(
                 "strip-fields".to_owned(),
                 RuleSpec {
                     ty: RuleType::RedactPair(RedactPairRule {
-                        key_pattern: Pattern(
-                            RegexBuilder::new(&key_pattern)
-                                .case_insensitive(true)
-                                .build()
-                                .map_err(PiiConfigError::RegexError)?,
-                        ),
+                        key_pattern: LazyPattern::new(key_pattern, true),
                     }),
                     redaction: Redaction::Replace("[Filtered]".to_owned().into()),
                 },
@@ -296,15 +290,32 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
     #[test]
     fn test_convert_sensitive_fields_too_large() {
-        let result = to_pii_config_impl(&DataScrubbingConfig {
+        let mut data = Event::from_value(
+            serde_json::json!({
+                "user": {
+                    "data": {
+                        "1": "test"
+                    }
+                }
+            })
+            .into(),
+        );
+
+        let config = to_pii_config_impl(&DataScrubbingConfig {
             sensitive_fields: vec!["1"]
-                .repeat(999999) // lowest number that will fail
+                .repeat(99999) // lowest number that will fail
                 .into_iter()
                 .map(|x| x.to_string())
                 .collect(),
             ..simple_enabled_config()
-        });
-        assert!(result.is_err());
+        })
+        .unwrap()
+        .unwrap();
+
+        let mut pii_processor = PiiProcessor::new(config.compiled());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+        // The data won't be scrubbed here, since the regex cannot be compiled.
+        assert_annotated_snapshot!(data);
     }
 
     #[test]

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -75,7 +75,7 @@ pub fn to_pii_config(
                 "strip-fields".to_owned(),
                 RuleSpec {
                     ty: RuleType::RedactPair(RedactPairRule {
-                        key_pattern: LazyPattern::new(key_pattern, true),
+                        key_pattern: LazyPattern::new(key_pattern).case_insensitive(true),
                     }),
                     redaction: Redaction::Replace("[Filtered]".to_owned().into()),
                 },

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__convert_sensitive_fields_too_large.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__convert_sensitive_fields_too_large.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/pii/convert.rs
+expression: data
+---
+{
+  "user": {
+    "data": {
+      "1": "test"
+    }
+  }
+}


### PR DESCRIPTION
As a followup for #1819 (based on the comment https://github.com/getsentry/relay/pull/1819#discussion_r1097515998) this PR converts the `Pattern` to `LazyPattern` and delays the `Regex` compilation to the first usage. But we do keep the incoming raw string pattern around.

If the regex cannot be compiled, we avoid creating the redact rules, which keeps the similar behaviour, since before this change we just error out on the deserialization. 

#skip-changelog