### PR TITLE
feat(protocol): Add `debug_id` to stacktrace protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Make sure to scrub all the fields with PII. If the fields contain an object, the entire object will be removed. ([#1789](https://github.com/getsentry/relay/pull/1789))
 - Keep meta for removed custom measurements. ([#1815](https://github.com/getsentry/relay/pull/1815))
 - Drop replay recording payloads if they cannot be parsed or scrubbed. ([#1683](https://github.com/getsentry/relay/pull/1683))
+- Add `debug_id` to stacktrace protocol. ([#1832](https://github.com/getsentry/relay/pull/1832))
 
 ## 23.1.1
 

--- a/relay-general/src/protocol/stacktrace.rs
+++ b/relay-general/src/protocol/stacktrace.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::protocol::{Addr, NativeImagePath, RegVal};
+use crate::protocol::{Addr, DebugId, NativeImagePath, RegVal};
 use crate::types::{
     Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
 };
@@ -115,6 +115,10 @@ pub struct Frame {
     /// mostly ignored during issue grouping.
     #[metastructure(skip_serialization = "null")]
     pub in_app: Annotated<bool>,
+
+    /// Id that references a particular source map artifact
+    #[metastructure(skip_serialization = "null")]
+    pub debug_id: Annotated<DebugId>,
 
     /// Mapping of local variables and expression names that were available in this frame.
     // XXX: Probably want to trim per-var => new bag size?
@@ -531,6 +535,7 @@ mod tests {
     "}"
   ],
   "in_app": true,
+  "debug_id": "00000000-0000-0000-0000-000000000000",
   "vars": {
     "variable": "value"
   },
@@ -569,6 +574,7 @@ mod tests {
                 );
                 Annotated::new(vars.into())
             },
+            debug_id: Annotated::new("00000000-0000-0000-0000-000000000000".parse().unwrap()),
             data: Annotated::new(FrameData {
                 sourcemap: Annotated::new("http://example.com/invalid.map".to_string()),
                 ..Default::default()

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1496,6 +1496,18 @@ expression: "relay_general::protocol::event_json_schema()"
                 "null"
               ]
             },
+            "debug_id": {
+              "description": " Id that references a particular source map artifact",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DebugId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "filename": {
               "description": " The source file name (basename only).",
               "default": null,


### PR DESCRIPTION
Ref: https://github.com/getsentry/team-webplatform-meta/issues/17

Adds a `debug_id` field to the stacktrace protocol which is used to quickly reference a particular sourcemap artifact from a stack frame. It is typed as `DebugId` but will usually just contain a regular UUID.