### PR TITLE
feat(protocol): Allow empty OS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Use client hint headers instead of User-Agent when available. ([#1752](https://github.com/getsentry/relay/pull/1752), [#1802](https://github.com/getsentry/relay/pull/1802))
+- Use client hint headers instead of User-Agent when available. ([#1752](https://github.com/getsentry/relay/pull/1752), [#1802](https://github.com/getsentry/relay/pull/1802), [#1838](https://github.com/getsentry/relay/pull/1838))
 - Apply all configured data scrubbing rules on Replays. ([#1731](https://github.com/getsentry/relay/pull/1731))
 - Add count transactions toward root project. ([#1734](https://github.com/getsentry/relay/pull/1734))
 - Add or remove the profile ID on the transaction's profiling context. ([#1801](https://github.com/getsentry/relay/pull/1801))

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -52,15 +52,15 @@ impl OsContext {
 impl FromUserAgentInfo for OsContext {
     fn from_client_hints(client_hints: &ClientHints<&str>) -> Option<Self> {
         let platform = client_hints.sec_ch_ua_platform?;
-        let version = client_hints.sec_ch_ua_platform_version?;
+        let version = client_hints.sec_ch_ua_platform_version.map(str::to_owned);
 
-        if platform.trim().is_empty() || version.trim().is_empty() {
+        if platform.trim().is_empty() {
             return None;
         }
 
         Some(Self {
             name: Annotated::new(platform.to_owned()),
-            version: Annotated::new(version.to_owned()),
+            version: Annotated::from(version),
             ..Default::default()
         })
     }

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -125,10 +125,25 @@ OsContext {
     #[test]
     fn test_ignore_empty_os() {
         let headers = Headers({
+            let headers = vec![Annotated::new((
+                Annotated::new("SEC-CH-UA-PLATFORM".to_string().into()),
+                Annotated::new(r#""#.to_string().into()),
+            ))];
+            PairList(headers)
+        });
+
+        let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
+        let from_hints = OsContext::from_client_hints(&client_hints);
+        assert!(from_hints.is_none())
+    }
+
+    #[test]
+    fn test_keep_empty_os_version() {
+        let headers = Headers({
             let headers = vec![
                 Annotated::new((
                     Annotated::new("SEC-CH-UA-PLATFORM".to_string().into()),
-                    Annotated::new(r#"macOS"#.to_string().into()),
+                    Annotated::new(r#"macOs"#.to_string().into()),
                 )),
                 Annotated::new((
                     Annotated::new("SEC-CH-UA-PLATFORM-VERSION".to_string().into()),
@@ -140,7 +155,7 @@ OsContext {
 
         let client_hints = RawUserAgentInfo::from_headers(&headers).client_hints;
         let from_hints = OsContext::from_client_hints(&client_hints);
-        assert!(from_hints.is_none())
+        assert!(from_hints.is_some())
     }
 
     #[test]


### PR DESCRIPTION
This will allow empty OS-versions, which means that the user may now see an empty string instead of the OS-version for events. This is so they can be notified to request OS-information as a client hint, as it is not enabled by default.