### PR TITLE
fix(rate-limits): Rate limit profiles attached to transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 **Bug Fixes**:
 
 - Fix a bug where the replays ip-address normalization was not being applied when the user object was omitted. ([#1805](https://github.com/getsentry/relay/pull/1805))
-- Improve performance for replays, especially memory usage during data scrubbing.([#1800](https://github.com/getsentry/relay/pull/1800), [#1825](https://github.com/getsentry/relay/pull/1825))
+- Improve performance for replays, especially memory usage during data scrubbing. ([#1800](https://github.com/getsentry/relay/pull/1800), [#1825](https://github.com/getsentry/relay/pull/1825))
+- When a transaction is rate limited, also remove associated profiles. ([#1843](https://github.com/getsentry/relay/pull/1843))
 
 **Internal**:
 


### PR DESCRIPTION
We currently do not remove profiles from an envelope when its transaction is being rate limited. This has the unintended consequence that such an envelope, now containing only profiles, is no longer subject to dynamic sampling, because `get_sampling_key` only returns something when the envelope contains a transaction.

This PR fixes rate limiting & sampling behavior by enforcing event (i.e. transaction) rate limits also on the associated profiles, just like we do for attachments.

Fixes https://github.com/getsentry/relay/issues/1612.