### PR TITLE
build: Use cargo 1.60 optional dependencies

### DIFF
--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -25,5 +25,5 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_test = "1.0.125"
 
 [features]
-jsonschema = ["schemars"]
 default = []
+jsonschema = ["dep:schemars"]

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -48,9 +48,9 @@ pretty-hex = "0.2.0"
 similar-asserts = "1.4.2"
 
 [features]
-mmap = ["maxminddb/mmap", "memmap"]
-jsonschema = ["relay-common/jsonschema", "schemars"]
 default = ["mmap"]
+jsonschema = ["relay-common/jsonschema", "dep:schemars"]
+mmap = ["maxminddb/mmap", "dep:memmap"]
 
 [[bench]]
 name = "benchmarks"

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -26,11 +26,10 @@ serde_yaml = "0.8.13"
 [features]
 default = []
 producer = [
-  "rdkafka-sys",
+  "dep:rdkafka",
+  "dep:relay-log",
+  "dep:relay-statsd",
+  "dep:rmp-serde",
+  "dep:serde_json",
   "rdkafka-sys/cmake-build",
-  "rdkafka",
-  "relay-log",
-  "relay-statsd",
-  "rmp-serde",
-  "serde_json",
 ]

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -24,17 +24,19 @@ serde_json = { version = "1.0.55", optional = true }
 
 [features]
 default = []
-test = ["env_logger"]
+test = [
+    "dep:env_logger",
+]
 init = [
-    "chrono",
-    "console",
-    "env_logger",
-    "pretty_env_logger",
-    "sentry",
-    "serde",
-    "serde_json"
+    "dep:chrono",
+    "dep:console",
+    "dep:env_logger",
+    "dep:pretty_env_logger",
+    "dep:sentry",
+    "dep:serde",
+    "dep:serde_json",
 ]
 crash-handler = [
     "init",
-    "relay-crash"
+    "dep:relay-crash",
 ]

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -40,3 +40,6 @@ crash-handler = [
     "init",
     "dep:relay-crash",
 ]
+sentry = [
+    "dep:sentry",  # hidden export of the SDK
+]

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 default = []
 tls = ["relay-redis?/tls"]
 redis = [
-    "thiserror",
-    "relay-log",
+    "dep:thiserror",
+    "dep:relay-log",
     "relay-redis/impl",
 ]
 

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -10,17 +10,17 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
+chrono = "0.4.11"
+rand = "0.6.5"
+rand_pcg = "0.1.2"
 relay-common = { path = "../relay-common" }
+relay-filter = { path = "../relay-filter" }
 relay-general = { path = "../relay-general" }
 relay-log = { path = "../relay-log" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-relay-filter = { path = "../relay-filter" }
-rand = "0.6.5"
-rand_pcg = "0.1.2"
 unicase = "2.6.0"
-chrono = "0.4.11"
-similar-asserts = "1.4.2"
 
 [dev-dependencies]
 insta = { version = "1.19.0", features = ["ron"] }
+similar-asserts = "1.4.2"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -14,20 +14,20 @@ publish = false
 default = []
 ssl = [
     "actix-web/tls",
-    "native-tls",
+    "dep:native-tls",
     "relay-quotas/tls",
     "relay-redis/tls",
 ]
 processing = [
-    "minidump",
+    "dep:minidump",
+    "dep:relay-profiling",
+    "dep:symbolic-common",
+    "dep:symbolic-unreal",
+    "dep:zstd",
     "relay-config/processing",
     "relay-kafka/producer",
-    "relay-profiling",
     "relay-quotas/redis",
     "relay-redis/impl",
-    "symbolic-common",
-    "symbolic-unreal",
-    "zstd",
 ]
 
 [dependencies]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -59,7 +59,7 @@ relay-config = { path = "../relay-config" }
 relay-filter = { path = "../relay-filter" }
 relay-general = { path = "../relay-general" }
 relay-kafka = { path = "../relay-kafka", optional = true }
-relay-log = { path = "../relay-log" }
+relay-log = { path = "../relay-log", features = ["sentry"] }
 relay-metrics = { path = "../relay-metrics" }
 relay-profiling = { path = "../relay-profiling", optional = true }
 relay-quotas = { path = "../relay-quotas" }


### PR DESCRIPTION
Uses the syntax introduced in cargo 1.60.0 to enable [optional dependencies](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies) in all crates, for instance `dep:rdkafka`.

#skip-changelog
