### PR TITLE
build(log): Upgrade log dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "terminal_size 0.2.3",
+ "terminal_size",
 ]
 
 [[package]]
@@ -658,18 +658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clicolors-control"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-dependencies = [
- "atty",
- "lazy_static",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,23 +693,6 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes 1.4.0",
  "memchr",
-]
-
-[[package]]
-name = "console"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586208b33573b7f76ccfbe5adb076394c88deaf81b84d7213969805b0a952a7"
-dependencies = [
- "clicolors-control",
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size 0.1.17",
- "termios",
- "unicode-width",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1106,7 +1077,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
 dependencies = [
- "console 0.15.5",
+ "console",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -1322,12 +1293,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -1335,12 +1306,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
- "humantime 2.1.0",
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1864,15 +1835,6 @@ checksum = "62eef4964b4e1c2d66981a5646d893768fd15d96957aae5e0e85c632503e9724"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1992,7 +1954,7 @@ version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f0f08b46e4379744de2ab67aa8f7de3ffd1da3e275adc41fcc82053ede46ff"
 dependencies = [
- "console 0.15.5",
+ "console",
  "lazy_static",
  "linked-hash-map",
  "pest",
@@ -2914,16 +2876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger 0.7.1",
- "log",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,10 +3498,9 @@ name = "relay-log"
 version = "23.1.1"
 dependencies = [
  "chrono",
- "console 0.10.3",
- "env_logger 0.7.1",
+ "console",
+ "env_logger 0.10.0",
  "log",
- "pretty_env_logger",
  "relay-crash",
  "sentry",
  "sentry-core",
@@ -4358,7 +4309,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
 dependencies = [
- "console 0.15.5",
+ "console",
  "similar",
 ]
 
@@ -4576,31 +4527,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,15 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,15 +312,13 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 2.34.0",
- "env_logger 0.9.3",
  "lazy_static",
  "lazycell",
  "log",
@@ -339,6 +328,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 1.0.107",
  "which",
 ]
 
@@ -567,21 +557,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -589,7 +564,7 @@ dependencies = [
  "bitflags",
  "clap_lex 0.2.4",
  "indexmap",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -603,7 +578,7 @@ dependencies = [
  "clap_lex 0.3.1",
  "is-terminal",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "terminal_size",
 ]
@@ -1289,19 +1264,6 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -3499,7 +3461,7 @@ version = "23.1.1"
 dependencies = [
  "chrono",
  "console",
- "env_logger 0.10.0",
+ "env_logger",
  "log",
  "relay-crash",
  "sentry",
@@ -4409,12 +4371,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -4533,15 +4489,6 @@ checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -5277,12 +5224,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/relay-crash/Cargo.toml
+++ b/relay-crash/Cargo.toml
@@ -13,5 +13,5 @@ publish = false
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = "0.64.0"
 cmake = { version = "0.1.46" }

--- a/relay-crash/src/lib.rs
+++ b/relay-crash/src/lib.rs
@@ -32,7 +32,7 @@ unsafe extern "C" fn transport_proxy(
 
     if !buf.is_null() && len > 0 {
         let transport: Transport = std::mem::transmute(tx_pointer);
-        transport(std::slice::from_raw_parts(buf as *const u8, len as usize));
+        transport(std::slice::from_raw_parts(buf as *const u8, len));
     }
 
     native::sentry_free(buf as _);

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -12,10 +12,9 @@ build = "build.rs"
 
 [dependencies]
 chrono = { version = "0.4.19", optional = true, features = ["serde"] }
-console = { version = "0.10.0", optional = true }
-env_logger = { version = "0.7.1", optional = true }
+console = { version = "0.15.5", optional = true }
+env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4.11", features = ["serde"] }
-pretty_env_logger = { version = "0.4.0", optional = true }
 relay-crash = { path = "../relay-crash", optional = true }
 sentry = { version = "0.27.0", features = ["debug-images", "log"], optional = true }
 sentry-core = { version = "0.27.0" }
@@ -31,7 +30,6 @@ init = [
     "dep:chrono",
     "dep:console",
     "dep:env_logger",
-    "dep:pretty_env_logger",
     "dep:sentry",
     "dep:serde",
     "dep:serde_json",

--- a/relay-log/build.rs
+++ b/relay-log/build.rs
@@ -1,4 +1,7 @@
-use std::io;
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 fn emit_release_var() -> Result<(), io::Error> {
@@ -21,6 +24,43 @@ fn emit_release_var() -> Result<(), io::Error> {
     Ok(())
 }
 
+fn list_crates() -> Vec<String> {
+    let mut crates = Vec::new();
+
+    for result in fs::read_dir("../").unwrap() {
+        let entry = result.unwrap();
+
+        if !entry.file_type().unwrap().is_dir() {
+            continue;
+        }
+
+        if let Some(s) = entry.file_name().to_str() {
+            if s.starts_with("relay") {
+                crates.push(s.to_owned());
+            }
+        }
+    }
+
+    crates
+}
+
+fn emit_crate_list() -> Result<(), io::Error> {
+    let crates = list_crates();
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("constants.gen.rs");
+    let mut f = File::create(dest_path).unwrap();
+
+    write!(f, "const CRATE_NAMES: &[&str] = &[")?;
+    for name in &crates {
+        write!(f, "\"{name}\",")?;
+    }
+    writeln!(f, "];")?;
+
+    Ok(())
+}
+
 fn main() {
     emit_release_var().ok();
+    emit_crate_list().unwrap();
 }


### PR DESCRIPTION
Updates `env_logger`. For human readable output we have used
`pretty_env_logger`, which is no longer compatible with the latest `env_logger`
version. This PR vendors the relevant bits of the implementation.

Previously, the `relay-log` crate hard-coded a list of all workspace members to
set log levels based on the configuration. This has been refactored:

 - The list of workspace members is now created in a build script.
 - The default level filter sets every workspace member to TRACE.
 - There is a global `max_level` filter based on the overall log level config.

NOTE: Eventually, we will want to move to `tracing` like Symbolicator did. This
PR is merely an effort to keep dependencies up-to-date. The current refactors
should help with moving to `tracing`.

#skip-changelog

