### PR TITLE
build: Upgrade sentry and related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
- "serde",
  "uuid 0.8.2",
 ]
 
@@ -2604,6 +2603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c424bc68d15e0778838ac013b5b3449544d8133633d8016319e7e05a820b8c0"
+dependencies = [
+ "log",
+ "serde",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,9 +3334,11 @@ dependencies = [
  "parking_lot 0.12.1",
  "regex",
  "schemars",
- "sentry-types 0.20.1",
+ "sentry-types",
  "serde",
  "serde_test",
+ "thiserror",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -3397,7 +3409,7 @@ dependencies = [
  "chrono",
  "cookie 0.16.2",
  "criterion",
- "debugid 0.7.3",
+ "debugid 0.8.0",
  "dynfmt",
  "enumset",
  "hmac",
@@ -3427,7 +3439,6 @@ dependencies = [
  "uaparser",
  "url 2.3.1",
  "utf16string",
- "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3622,7 +3633,6 @@ dependencies = [
  "tokio 1.25.0",
  "tokio-timer",
  "url 2.3.1",
- "uuid 0.8.2",
  "zstd",
 ]
 
@@ -3853,7 +3863,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "uuid 0.8.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -3961,11 +3971,12 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
+checksum = "c6f8ce69326daef9d845c3fd17149bd3dbd7caf5dc65dbbad9f5441a40ee407f"
 dependencies = [
  "httpdate",
+ "native-tls",
  "reqwest",
  "sentry-backtrace",
  "sentry-contexts",
@@ -3974,13 +3985,14 @@ dependencies = [
  "sentry-log",
  "sentry-panic",
  "tokio 1.25.0",
+ "ureq",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bafa55eefc6dbc04c7dac91e8c8ab9e89e9414f3193c105cabd991bbc75134"
+checksum = "3ed6c0254d4cce319800609aa0d41b486ee57326494802045ff27434fc9a2030"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -3990,12 +4002,13 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63317c4051889e73f0b00ce4024cae3e6a225f2e18a27d2c1522eb9ce2743da"
+checksum = "d3277dc5d2812562026f2095c7841f3d61bbe6789159b7da54f41d540787f818"
 dependencies = [
  "hostname",
  "libc",
+ "os_info",
  "rustc_version 0.4.0",
  "sentry-core",
  "uname",
@@ -4003,22 +4016,22 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
+checksum = "b5acbd3da4255938cf0384b6b140e6c07ff65919c26e4d7a989d8d90ee88fa91"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
- "sentry-types 0.27.0",
+ "sentry-types",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fcbb7efe38d7c213218445952096be246c1f914ef9591dc2cdae9cb4e316d8"
+checksum = "745358c78d3a64361de3659c101fa1ec6eb95bdabf7c88ce274c84338687f07c"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -4027,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a76b41861ebde9b0a689fa13080ad5508583e094c48acad461eec5acd7fc5f"
+checksum = "a4b922394014861334c24388a55825e4c715afb8ec7c1db900175aa9951f8241"
 dependencies = [
  "log",
  "sentry-core",
@@ -4037,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.27.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
+checksum = "beebc7aedbd3aa470cd19caad208a5efe6c48902595c0d111a193d8ce4f7bd15"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4058,24 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.20.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8124f0e9bc1113ecbcc8c3746e0e590943cf23e7d09c70a088c116869bb12e3"
-dependencies = [
- "chrono",
- "debugid 0.7.3",
- "serde",
- "serde_json",
- "thiserror",
- "url 2.3.1",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
+checksum = "10d8587b12c0b8211bb3066979ee57af6e8657e23cf439dc6c8581fd86de24e8"
 dependencies = [
  "debugid 0.8.0",
  "getrandom 0.2.8",
@@ -5126,6 +5124,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url 2.3.1",
+]
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5172,11 +5183,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.8",
- "serde",
- "sha1",
-]
 
 [[package]]
 name = "uuid"
@@ -5186,6 +5192,7 @@ checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 chrono = "0.4.11"
 ed25519-dalek = "0.9.1"
-thiserror = "1.0.24"
+thiserror = "1.0.38"
 hmac = "0.7.1"
 rand = "0.6.5"
 relay-common = { path = "../relay-common" }

--- a/relay-cabi/src/core.rs
+++ b/relay-cabi/src/core.rs
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn relay_uuid_is_nil(uuid: *const RelayUuid) -> bool {
 #[relay_ffi::catch_unwind]
 pub unsafe extern "C" fn relay_uuid_to_str(uuid: *const RelayUuid) -> RelayStr {
     let uuid = Uuid::from_slice(&(*uuid).data[..]).unwrap_or_else(|_| Uuid::nil());
-    RelayStr::from_string(uuid.to_hyphenated_ref().to_string())
+    RelayStr::from_string(uuid.as_hyphenated().to_string())
 }
 
 /// A binary buffer of known length.

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -17,9 +17,11 @@ lru = "0.7.6"
 once_cell = "1.13.1"
 parking_lot = "0.12.1"
 regex = "1.5.5"
-schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
-sentry-types = "0.20.0"
+schemars = { version = "0.8.1", features = ["uuid1", "chrono"], optional = true }
+sentry-types = "0.29.3"
 serde = { version = "1.0.114", features = ["derive"] }
+thiserror = "1.0.38"
+uuid = { version = "1.3.0", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
 serde_test = "1.0.125"

--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -22,4 +22,7 @@ pub use crate::retry::*;
 pub use crate::time::*;
 
 pub use sentry_types::protocol::LATEST as PROTOCOL_VERSION;
-pub use sentry_types::{Auth, Dsn, ParseAuthError, ParseDsnError, Scheme, Uuid};
+pub use sentry_types::{Auth, Dsn, ParseAuthError, ParseDsnError, Scheme};
+
+#[doc(inline)]
+pub use uuid::Uuid;

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -26,5 +26,5 @@ relay-redis = { path = "../relay-redis" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_yaml = "0.8.13"
-thiserror = "1.0.37"
+thiserror = "1.0.38"
 url = "2.1.1"

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 bytecount = "0.6.0"
 chrono = { version = "0.4.11", features = ["serde"] }
 cookie = { version = "0.16.0", features = ["percent-encode"] }
-debugid = { version = "0.7.2", features = ["serde"] }
+debugid = { version = "0.8.0", features = ["serde"] }
 dynfmt = { version = "0.1.4", features = ["python", "curly"] }
 enumset = "1.0.4"
 hmac = "0.7.1"
@@ -28,18 +28,17 @@ regex = "1.5.5"
 relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 relay-log = { path = "../relay-log" }
-schemars = { version = "0.8.1", features = ["uuid", "chrono"], optional = true }
+schemars = { version = "0.8.1", features = ["uuid1", "chrono"], optional = true }
 sentry-release-parser = { version = "1.3.1" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.5.5"
 sha-1 = "0.8.1"
 smallvec = { version = "1.4.0", features = ["serde"] }
-thiserror = "1.0.37"
+thiserror = "1.0.38"
 uaparser = { version = "0.5.1"  }
 url = "2.1.1"
 utf16string = "0.2.0"
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/relay-general/src/processor/impls.rs
+++ b/relay-general/src/processor/impls.rs
@@ -1,5 +1,6 @@
 use enumset::EnumSet;
-use uuid::Uuid;
+
+use relay_common::Uuid;
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
 use crate::types::{Annotated, Array, Meta, Object, ProcessingResult};

--- a/relay-general/src/protocol/contexts/profile.rs
+++ b/relay-general/src/protocol/contexts/profile.rs
@@ -32,7 +32,7 @@ mod tests {
 }"#;
         let context = Annotated::new(Context::Profile(Box::new(ProfileContext {
             profile_id: Annotated::new(EventId(
-                uuid::Uuid::parse_str("4c79f60c11214eb38604f4ae0781bfb2").unwrap(),
+                "4c79f60c11214eb38604f4ae0781bfb2".parse().unwrap(),
             )),
         })));
 
@@ -48,7 +48,7 @@ mod tests {
 }"#;
         let context = Annotated::new(Context::Profile(Box::new(ProfileContext {
             profile_id: Annotated::new(EventId(
-                uuid::Uuid::parse_str("4c79f60c11214eb38604f4ae0781bfb2").unwrap(),
+                "4c79f60c11214eb38604f4ae0781bfb2".parse().unwrap(),
             )),
         })));
 

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -9,7 +9,8 @@ use schemars::schema::Schema;
 
 use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+
+use relay_common::Uuid;
 
 use crate::processor::{ProcessValue, ProcessingState, Processor, ValueType};
 use crate::protocol::Addr;

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -8,6 +8,8 @@ use schemars::schema::Schema;
 
 use serde::{Serialize, Serializer};
 
+use relay_common::Uuid;
+
 use crate::macros::derive_string_meta_structure;
 use crate::processor::ProcessValue;
 use crate::protocol::{
@@ -23,13 +25,13 @@ use crate::types::{
 /// Wrapper around a UUID with slightly different formatting.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-pub struct EventId(pub uuid::Uuid);
+pub struct EventId(pub Uuid);
 
 impl EventId {
     /// Creates a new event id using a UUID v4.
     #[inline]
     pub fn new() -> Self {
-        Self(uuid::Uuid::new_v4())
+        Self(Uuid::new_v4())
     }
 
     /// Tests if the UUID is nil.
@@ -52,12 +54,12 @@ impl ProcessValue for EventId {}
 
 impl fmt::Display for EventId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.to_simple_ref())
+        write!(f, "{}", self.0.as_simple())
     }
 }
 
 impl FromStr for EventId {
-    type Err = uuid::Error;
+    type Err = <Uuid as FromStr>::Err;
 
     fn from_str(uuid_str: &str) -> Result<Self, Self::Err> {
         uuid_str.parse().map(EventId)

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -306,6 +306,10 @@ impl Replay {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use chrono::{TimeZone, Utc};
+
     use crate::pii::{DataScrubbingConfig, PiiProcessor};
     use crate::processor::process_value;
     use crate::processor::ProcessingState;
@@ -316,8 +320,6 @@ mod tests {
     use crate::testutils::get_value;
     use crate::types::Annotated;
     use crate::user_agent::RawUserAgentInfo;
-    use chrono::{TimeZone, Utc};
-    use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn test_event_roundtrip() {
@@ -347,12 +349,8 @@ mod tests {
 }"#;
 
         let replay = Annotated::new(Replay {
-            event_id: Annotated::new(EventId(
-                uuid::Uuid::parse_str("52df9022835246eeb317dbd739ccd059").unwrap(),
-            )),
-            replay_id: Annotated::new(EventId(
-                uuid::Uuid::parse_str("52df9022835246eeb317dbd739ccd059").unwrap(),
-            )),
+            event_id: Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap())),
+            replay_id: Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap())),
             replay_type: Annotated::new("session".to_string()),
             segment_id: Annotated::new(0),
             timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -3,7 +3,8 @@ use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+
+use relay_common::Uuid;
 
 use crate::macros::derive_fromstr_and_display;
 use crate::protocol::utils::null_to_default;

--- a/relay-general/src/types/impls.rs
+++ b/relay-general/src/types/impls.rs
@@ -1,6 +1,7 @@
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
-use uuid::Uuid;
+
+use relay_common::Uuid;
 
 use crate::macros::derive_string_meta_structure;
 use crate::types::{

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -17,7 +17,7 @@ relay-statsd = { path  = "../relay-statsd", optional = true }
 rmp-serde = { version = "0.14.3", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = { version = "1.0.55", optional = true }
-thiserror = "1.0.20"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 serde_yaml = "0.8.13"

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -16,8 +16,8 @@ console = { version = "0.15.5", optional = true }
 env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4.11", features = ["serde"] }
 relay-crash = { path = "../relay-crash", optional = true }
-sentry = { version = "0.27.0", features = ["debug-images", "log"], optional = true }
-sentry-core = { version = "0.27.0" }
+sentry = { version = "0.29.3", features = ["debug-images", "log"], optional = true }
+sentry-core = { version = "0.29.3" }
 serde = { version = "1.0.114", features = ["derive"], optional = true }
 serde_json = { version = "1.0.55", optional = true }
 

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -19,7 +19,7 @@ relay-statsd = { path = "../relay-statsd" }
 relay-system = { path = "../relay-system" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-thiserror = "1.0.20"
+thiserror = "1.0.38"
 tokio = { version = "1.0", features = ["macros", "time"] }
 
 [dev-dependencies]

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -16,7 +16,7 @@ data-encoding = "2.3.3"
 relay-general = { path = "../relay-general" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-thiserror = "1.0.20"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 serde_test = "1.0.125"

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -24,7 +24,7 @@ relay-log = { path = "../relay-log", optional = true }
 relay-redis = { path = "../relay-redis", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 smallvec = { version = "1.4.0", features = ["serde"] }
-thiserror = { version = "1.0.20", optional = true }
+thiserror = { version = "1.0.38", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.19.0", features = ["ron"] }

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 r2d2 = { version = "0.8.10", optional = true }
 redis = { version = "0.22.2", optional = true, features = ["cluster", "r2d2"] }
 serde = { version = "1.0.114", features = ["derive"] }
-thiserror = "1.0.20"
+thiserror = "1.0.38"
 
 [features]
 default = []

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -77,11 +77,10 @@ smallvec = { version = "1.4.0", features = ["serde"] }
 symbolic-common = { version = "10.1.2", optional = true, default-features=false }
 symbolic-unreal = { version = "10.1.2", optional = true, default-features=false, features=["serde"] }
 take_mut = "0.2.2"
-thiserror = "1.0.37"
+thiserror = "1.0.38"
 tokio = { version = "1.0", features = ["rt-multi-thread", "sync", "macros"] }
 tokio-timer = "0.2.13"
 url = { version = "2.1.1", features = ["serde"] }
-uuid = { version = "0.8.1", features = ["v5"] }
 zstd = { version = "0.11.2", optional = true }
 
 [target."cfg(not(windows))".dependencies]

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -442,7 +442,7 @@ pub fn create_text_event_id_response(id: Option<EventId>) -> HttpResponse {
     // i.e. xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     HttpResponse::Ok()
         .content_type("text/plain")
-        .body(format!("{}", id.0.to_hyphenated()))
+        .body(id.0.as_hyphenated().to_string())
 }
 
 /// A helper for creating Actix routes that are resilient against double-slashes

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -79,11 +79,11 @@ pub struct PartialDsn {
 impl PartialDsn {
     /// Ensures a valid public key and project ID in the DSN.
     fn from_dsn(dsn: Dsn) -> Result<Self, ParseDsnError> {
-        if dsn.project_id().value() == 0 {
-            return Err(ParseDsnError::InvalidProjectId(
-                ParseProjectIdError::InvalidValue,
-            ));
-        }
+        let project_id = dsn
+            .project_id()
+            .value()
+            .parse()
+            .map_err(|_| ParseDsnError::NoProjectId)?;
 
         let public_key = dsn
             .public_key()
@@ -96,7 +96,7 @@ impl PartialDsn {
             host: dsn.host().to_owned(),
             port: dsn.port(),
             path: dsn.path().to_owned(),
-            project_id: Some(dsn.project_id()),
+            project_id: Some(project_id),
         })
     }
 

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -41,7 +41,7 @@ pub fn project_state_with_config(sampling_config: SamplingConfig) -> ProjectStat
 
 pub fn create_sampling_context(sample_rate: Option<f64>) -> DynamicSamplingContext {
     DynamicSamplingContext {
-        trace_id: uuid::Uuid::new_v4(),
+        trace_id: relay_common::Uuid::new_v4(),
         public_key: "12345678901234567890123456789012".parse().unwrap(),
         release: None,
         environment: None,
@@ -62,7 +62,7 @@ pub fn new_envelope<T: Into<String>>(with_dsc: bool, transaction_name: T) -> Box
         format!(
             "{{\"transaction\": \"{}\", \"event_id\":\"{}\",\"dsn\":\"{}\", \"trace\": {}}}\n",
             transaction_name,
-            event_id.0.to_simple(),
+            event_id.0.as_simple(),
             dsn,
             serde_json::to_string(&create_sampling_context(None)).unwrap(),
         )
@@ -70,7 +70,7 @@ pub fn new_envelope<T: Into<String>>(with_dsc: bool, transaction_name: T) -> Box
         format!(
             "{{\"transaction\": \"{}\", \"event_id\":\"{}\",\"dsn\":\"{}\"}}\n",
             transaction_name,
-            event_id.0.to_simple(),
+            event_id.0.as_simple(),
             dsn,
         )
     };

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -157,7 +157,7 @@ mod tests {
     use similar_asserts::assert_eq;
 
     use chrono::Duration as DateDuration;
-    use uuid::Uuid;
+    use relay_common::Uuid;
 
     use relay_common::EventType;
     use relay_general::protocol::{EventId, LenientString};


### PR DESCRIPTION
Upgrades the Sentry SDK, which also required an upgrade of `uuid` to stable 1.0
and `sentry-types` to the latest version across all crates. The switch to stable
UUID caused some refactor due to changes in the public API.

Most notably, the `ProjectId` type is now vendored into Relay instead of being
imported from the SDK. The SDK represents it as a string internally, while Relay
continues to treat it as a numeric value.

#skip-changelog

