### PR TITLE
test(csp): Check origin with `*` on both ends

### DIFF
--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -285,6 +285,12 @@ mod tests {
             ),
             // this used to crash
             ("http://y:80", vec!["http://x"], false),
+            // starts on both ends
+            (
+                "https://abc.software.example.com",
+                vec!["*abc.software.example.com*"],
+                false,
+            ),
         ];
 
         for (url, origins, expected) in examples {


### PR DESCRIPTION
This came up as the customers issue and it would great to have an explicit test for this:

if `Allowed Domains` config contains domains with `*` on both ends, e.g. `*example.com*` - we won't match those if the incoming origin (or referer) is `https://example.com` as we currently support the `*` only at the beginning of the string.

That's also how it looks in the configuration page: 
<img width="555" alt="image" src="https://user-images.githubusercontent.com/1931331/219350912-54abbdec-0b2f-48d1-9d37-5542976f3ef0.png">


#skip-changelog
 