### PR TITLE
ref(pii): Make Redaction enum forward compatible

### DIFF
--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -171,6 +171,7 @@ trait StringMods: AsRef<[u8]> {
             Redaction::Replace(ref replace) => {
                 self.swap_content(replace.text.as_str(), PADDING);
             }
+            Redaction::Other => relay_log::warn!("Incoming redaction is not supported"),
         }
     }
 }

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -357,6 +357,7 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
                 text: Cow::Owned(replace.text.clone()),
             });
         }
+        Redaction::Other => relay_log::warn!("Incoming redaction is not supported"),
     }
 }
 

--- a/relay-general/src/pii/redactions.rs
+++ b/relay-general/src/pii/redactions.rs
@@ -48,7 +48,7 @@ pub enum Redaction {
     /// Replaces the value with a hash
     Hash,
     /// Added for forward compatibility as catch-all variant.
-    #[serde(other)]
+    #[serde(other, skip_serializing)]
     Other,
 }
 

--- a/relay-general/src/pii/redactions.rs
+++ b/relay-general/src/pii/redactions.rs
@@ -47,4 +47,32 @@ pub enum Redaction {
     Mask,
     /// Replaces the value with a hash
     Hash,
+    /// Added for forward compatibility as catch-all variant.
+    #[serde(other)]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_redaction_deser_method() {
+        let json = r#"{"method": "replace", "text": "[filter]"}"#;
+
+        let deser: Redaction = serde_json::from_str(json).unwrap();
+        let redaction = Redaction::Replace(ReplaceRedaction {
+            text: "[filter]".to_string(),
+        });
+        assert!(deser == redaction);
+    }
+
+    #[test]
+    fn test_redaction_deser_other() {
+        let json = r#"{"method": "foo", "text": "[filter]"}"#;
+
+        let deser: Redaction = serde_json::from_str(json).unwrap();
+        assert!(matches!(deser, Redaction::Other));
+    }
 }


### PR DESCRIPTION
This is part of https://github.com/getsentry/relay/issues/1751, which adds forward compatibility to the `Redaction` enum.

~In order to do that I had to split the `Redaction` into 2 separate variants:~
~* `Method` - which catches all the defined and proper redaction methods~
~* `Other` - for everything else, which also currently just being ignored and won't be propagated downstream~

Just added `Other` variant to `Redaction` enum as a catch all. 

To make sure it works, I've added 2 tests in `relay-general/src/pii/redactions.rs`. 

~There is still a question if if want to report an error or warning if we get something we currently do not expect or just ignoring the variant it good enough for now.~ 
Added warning to places when and if the added variant is used.

#skip-changelog