### PR TITLE
ref(server): Simplify HTTP server and service startup

### DIFF
--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -3,7 +3,7 @@
 //! Services require a tokio to run, see [`relay_system`] and particularly
 //! [`Controller`](relay_system::Controller) for more information.
 //!
-//! The web server is wrapped by [`ServerService`](server::ServerService). It starts the actix HTTP
+//! The web server is wrapped by [`HttpServer`](server::HttpServer). It starts the actix HTTP
 //! web server and dispatches the graceful shutdown signal. Internally, it creates several other
 //! services comprising the service state:
 //!

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -35,7 +35,7 @@ use relay_system::{Addr, FromMessage, Service};
 use crate::actors::envelopes::{EnvelopeManager, SendClientReports};
 use crate::actors::upstream::{Method, SendQuery, UpstreamQuery, UpstreamRelay};
 #[cfg(feature = "processing")]
-use crate::service::ServerError;
+use crate::service::ServiceError;
 use crate::service::REGISTRY;
 use crate::statsd::RelayCounters;
 use crate::utils::SleepHandle;
@@ -720,12 +720,10 @@ impl KafkaOutcomesProducer {
         let mut client_builder = KafkaClient::builder();
 
         for topic in &[KafkaTopic::Outcomes, KafkaTopic::OutcomesBilling] {
-            let kafka_config = &config
-                .kafka_config(*topic)
-                .context(ServerError::KafkaError)?;
+            let kafka_config = &config.kafka_config(*topic).context(ServiceError::Kafka)?;
             client_builder = client_builder
                 .add_kafka_topic_config(*topic, kafka_config)
-                .context(ServerError::KafkaError)?;
+                .context(ServiceError::Kafka)?;
         }
 
         Ok(Self {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -59,7 +59,7 @@ use crate::utils::{
 use {
     crate::actors::envelopes::SendMetrics,
     crate::actors::project_cache::UpdateRateLimits,
-    crate::service::ServerError,
+    crate::service::ServiceError,
     crate::utils::{EnvelopeLimiter, MetricsLimiter},
     anyhow::Context,
     relay_general::protocol::{Context as SentryContext, Contexts, ProfileContext},
@@ -541,7 +541,7 @@ impl EnvelopeProcessorService {
         #[cfg(feature = "processing")]
         {
             let geoip_lookup = match config.geoip_path() {
-                Some(p) => Some(GeoIpLookup::open(p).context(ServerError::GeoIpError)?),
+                Some(p) => Some(GeoIpLookup::open(p).context(ServiceError::GeoIp)?),
                 None => None,
             };
 

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -1,20 +1,148 @@
+use actix::Recipient;
+use actix_web::server::{self, StopServer};
+use actix_web::App;
+use anyhow::{Context, Result};
+use futures01::Future;
+use listenfd::ListenFd;
+
 use relay_config::Config;
 use relay_statsd::metric;
-use relay_system::{Controller, Service, Shutdown};
+use relay_system::{Addr, Controller, Service, Shutdown};
 
-use crate::service::HttpServer;
+use crate::middlewares::{
+    AddCommonHeaders, ErrorHandlers, Metrics, ReadRequestMiddleware, SentryMiddleware,
+};
+use crate::service::ServiceState;
 use crate::statsd::RelayCounters;
 
+// TODO(ja): Split this into Server and Service error.
+use crate::service::ServerError;
+
+/// The actix app type for the relay web service.
+pub type ServiceApp = App<ServiceState>;
+
+fn make_app(state: ServiceState) -> ServiceApp {
+    App::with_state(state)
+        .middleware(SentryMiddleware::new())
+        .middleware(Metrics)
+        .middleware(AddCommonHeaders)
+        .middleware(ErrorHandlers)
+        .middleware(ReadRequestMiddleware)
+        .configure(crate::endpoints::configure_app)
+}
+
+fn dump_listen_infos<H, F>(server: &server::HttpServer<H, F>)
+where
+    H: server::IntoHttpHandler + 'static,
+    F: Fn() -> H + Send + Clone + 'static,
+{
+    relay_log::info!("spawning http server");
+    for (addr, scheme) in server.addrs_with_scheme() {
+        relay_log::info!("  listening on: {}://{}/", scheme, addr);
+    }
+}
+
+fn listen<H, F>(
+    server: server::HttpServer<H, F>,
+    config: &Config,
+) -> Result<server::HttpServer<H, F>>
+where
+    H: server::IntoHttpHandler + 'static,
+    F: Fn() -> H + Send + Clone + 'static,
+{
+    Ok(
+        match ListenFd::from_env()
+            .take_tcp_listener(0)
+            .context(ServerError::ListenFailed)?
+        {
+            Some(listener) => server.listen(listener),
+            None => server
+                .bind(config.listen_addr())
+                .context(ServerError::BindFailed)?,
+        },
+    )
+}
+
+#[cfg(feature = "ssl")]
+fn listen_ssl<H, F>(
+    mut server: server::HttpServer<H, F>,
+    config: &Config,
+) -> Result<server::HttpServer<H, F>>
+where
+    H: server::IntoHttpHandler + 'static,
+    F: Fn() -> H + Send + Clone + 'static,
+{
+    if let (Some(addr), Some(path), Some(password)) = (
+        config.tls_listen_addr(),
+        config.tls_identity_path(),
+        config.tls_identity_password(),
+    ) {
+        use native_tls::{Identity, TlsAcceptor};
+        use std::fs::File;
+        use std::io::Read;
+
+        let mut file = File::open(path).unwrap();
+        let mut data = vec![];
+        file.read_to_end(&mut data).unwrap();
+        let identity =
+            Identity::from_pkcs12(&data, password).context(ServerError::TlsInitFailed)?;
+
+        let acceptor = TlsAcceptor::builder(identity)
+            .build()
+            .context(ServerError::TlsInitFailed)?;
+
+        server = server
+            .bind_tls(addr, acceptor)
+            .context(ServerError::BindFailed)?;
+    }
+
+    Ok(server)
+}
+
+#[cfg(not(feature = "ssl"))]
+fn listen_ssl<H, F>(
+    server: server::HttpServer<H, F>,
+    config: &Config,
+) -> Result<server::HttpServer<H, F>, ServerError>
+where
+    H: server::IntoHttpHandler + 'static,
+    F: Fn() -> H + Send + Clone + 'static,
+{
+    if config.tls_listen_addr().is_some()
+        || config.tls_identity_path().is_some()
+        || config.tls_identity_password().is_some()
+    {
+        Err(ServerError::TlsNotSupported.into())
+    } else {
+        Ok(server)
+    }
+}
+
+// TODO(ja): Document
 pub struct ServerService {
-    http_server: HttpServer,
+    http_server: Recipient<StopServer>,
 }
 
 impl ServerService {
-    pub fn start(config: Config) -> anyhow::Result<()> {
+    pub fn start(config: &Config, service: ServiceState) -> anyhow::Result<Addr<()>> {
         metric!(counter(RelayCounters::ServerStarting) += 1);
-        let http_server = HttpServer::start(config)?;
-        Self { http_server }.start();
-        Ok(())
+
+        let mut server = server::new(move || make_app(service.clone()));
+        server = server
+            .workers(config.cpu_concurrency())
+            .shutdown_timeout(config.shutdown_timeout().as_secs() as u16)
+            .keep_alive(config.keepalive_timeout().as_secs() as usize)
+            .maxconn(config.max_connections())
+            .maxconnrate(config.max_connection_rate())
+            .backlog(config.max_pending_connections())
+            .disable_signals();
+
+        server = listen(server, config)?;
+        server = listen_ssl(server, config)?;
+        dump_listen_infos(&server);
+
+        let http_server = server.start().recipient();
+        Ok(Self { http_server }.start())
     }
 }
 
@@ -24,13 +152,17 @@ impl Service for ServerService {
     fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             let mut shutdown = Controller::shutdown_handle();
+
             loop {
-                tokio::select! {
-                    Shutdown { timeout } = shutdown.notified() => {
-                       self.http_server.shutdown(timeout.is_some());
-                    },
-                    else => break,
-                }
+                let Shutdown { timeout } = shutdown.notified().await;
+                let graceful = timeout.is_some();
+
+                // We assume graceful shutdown if we're given a timeout. The actix-web http server is
+                // configured with the same timeout, so it will match. Unfortunately, we have to drop any
+                // errors  and replace them with the generic `TimeoutError`.
+                relay_log::info!("Shutting down HTTP server"); // TODO(ja): Where was this coming from?
+                self.http_server.send(StopServer { graceful }).wait().ok();
+                // TODO(ja): harmful. wait() blocks the main runtime.
             }
         });
     }

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -20,7 +20,7 @@ use relay_statsd::metric;
 use relay_system::{AsyncResponse, FromMessage, Interface, Sender, Service};
 
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
-use crate::service::ServerError;
+use crate::service::ServiceError;
 use crate::statsd::RelayCounters;
 
 /// The maximum number of individual session updates generated for each aggregate item.
@@ -59,10 +59,10 @@ impl Producer {
         {
             let kafka_config = &config
                 .kafka_config(*topic)
-                .map_err(|_| ServerError::KafkaError)?;
+                .map_err(|_| ServiceError::Kafka)?;
             client_builder = client_builder
                 .add_kafka_topic_config(*topic, kafka_config)
-                .map_err(|_| ServerError::KafkaError)?
+                .map_err(|_| ServiceError::Kafka)?
         }
 
         Ok(Self {

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -1,11 +1,11 @@
-use actix_web::{http::Method, HttpRequest, HttpResponse};
+use actix_web::{http::Method, App, HttpRequest, HttpResponse};
 
 use relay_general::protocol::EventId;
 
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::Envelope;
 use crate::extractors::RequestMeta;
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 use crate::utils::MultipartItems;
 
 async fn extract_envelope(
@@ -41,7 +41,7 @@ async fn store_attachment(
     Ok(HttpResponse::Created().finish())
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     let url_pattern = common::normpath(r"/api/{project:\d+}/events/{event_id:[\w-]+}/attachments/");
 
     common::cors(app)

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 
 use actix_web::http::{header, StatusCode};
 use actix_web::middleware::cors::{Cors, CorsBuilder};
-use actix_web::{error::PayloadError, HttpResponse};
+use actix_web::{error::PayloadError, App, HttpResponse};
 use serde::Deserialize;
 
 use relay_general::protocol::{EventId, EventType};
@@ -17,7 +17,7 @@ use crate::actors::outcome::{DiscardReason, Outcome};
 use crate::actors::processor::{EnvelopeProcessor, ProcessMetrics};
 use crate::actors::project_cache::{CheckEnvelope, ProjectCache, ValidateEnvelope};
 use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 use crate::statsd::RelayCounters;
 use crate::utils::{
     self, ApiErrorResponse, BufferError, BufferGuard, EnvelopeContext, FormDataIter, MultipartError,
@@ -230,7 +230,7 @@ pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreReq
 /// To configure CORS, register endpoints using `resource()` and finalize by calling `register()`, which
 /// returns an App. This configures POST as allowed method, allows default sentry headers, and
 /// exposes the return headers.
-pub fn cors(app: ServiceApp) -> CorsBuilder<ServiceState> {
+pub fn cors(app: App<ServiceState>) -> CorsBuilder<ServiceState> {
     let mut builder = Cors::for_app(app);
 
     builder

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -1,6 +1,6 @@
 //! Handles envelope store requests.
 
-use actix_web::{HttpRequest, HttpResponse};
+use actix_web::{App, HttpRequest, HttpResponse};
 use serde::Serialize;
 
 use relay_general::protocol::EventId;
@@ -9,7 +9,7 @@ use crate::body;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::Envelope;
 use crate::extractors::{EnvelopeMeta, RequestMeta};
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 
 async fn extract_envelope(
     request: &HttpRequest<ServiceState>,
@@ -41,7 +41,7 @@ async fn store_envelope(
     Ok(HttpResponse::Ok().json(StoreResponse { id }))
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     common::cors(app)
         .resource(&common::normpath(r"/api/{project:\d+}/envelope/"), |r| {
             r.name("store-envelope");

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -1,14 +1,13 @@
 //! Returns captured events.
 
-use actix_web::actix::MailboxError;
-use actix_web::{http::Method, HttpResponse, Path};
+use actix_web::{actix::MailboxError, http::Method, App, HttpResponse, Path};
 use futures::TryFutureExt;
 
 use relay_general::protocol::EventId;
 
 use crate::actors::test_store::{GetCapturedEnvelope, TestStore};
 use crate::envelope;
-use crate::service::ServiceApp;
+use crate::service::ServiceState;
 
 async fn get_captured_event(event_id: Path<EventId>) -> Result<HttpResponse, MailboxError> {
     let request = GetCapturedEnvelope {
@@ -33,7 +32,7 @@ async fn get_captured_event(event_id: Path<EventId>) -> Result<HttpResponse, Mai
     Ok(response)
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     app.resource("/api/relay/events/{event_id}/", |r| {
         r.name("internal-events");
         r.method(Method::GET)

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -12,7 +12,7 @@ use actix::ResponseFuture;
 use actix_web::error::{ParseError, ResponseError};
 use actix_web::http::header::{self, HeaderName, HeaderValue};
 use actix_web::http::{uri::PathAndQuery, HeaderMap, StatusCode};
-use actix_web::{Error, HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{App, Error, HttpMessage, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use futures::TryFutureExt;
 use once_cell::sync::Lazy;
@@ -29,7 +29,7 @@ use crate::body;
 use crate::endpoints::statics;
 use crate::extractors::ForwardedFor;
 use crate::http::{HttpError, RequestBuilder, Response};
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 
 /// Headers that this endpoint must handle and cannot forward.
 static HOP_BY_HOP_HEADERS: &[HeaderName] = &[
@@ -293,7 +293,7 @@ pub fn forward_compat(request: &HttpRequest<ServiceState>) -> ResponseFuture<Htt
 ///
 /// NOTE: This endpoint registers a catch-all handler on `/api`. Register this endpoint last, since
 /// no routes can be registered afterwards!
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     // We only forward API requests so that relays cannot be used to surf sentry's frontend. The
     // "/api/" path is special as it is actually a web UI endpoint.
     app.resource("/api/", |r| {

--- a/relay-server/src/endpoints/health_check.rs
+++ b/relay-server/src/endpoints/health_check.rs
@@ -1,11 +1,11 @@
 //! A simple health check endpoint for the relay.
 
-use actix_web::{Error, HttpResponse};
+use actix_web::{App, Error, HttpResponse};
 use futures::TryFutureExt;
 use serde::Serialize;
 
 use crate::actors::health_check::{HealthCheck, IsHealthy};
-use crate::service::ServiceApp;
+use crate::service::ServiceState;
 
 #[derive(Serialize)]
 struct Status {
@@ -19,7 +19,7 @@ async fn health_check(message: IsHealthy) -> Result<HttpResponse, Error> {
     })
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     app.resource("/api/relay/healthcheck/ready/", |r| {
         r.name("internal-healthcheck-ready");
         r.get()

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -1,5 +1,5 @@
 use actix_web::multipart::{Multipart, MultipartItem};
-use actix_web::{HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{App, HttpMessage, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
 use futures01::{stream, Stream};
@@ -11,7 +11,7 @@ use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 use crate::utils::{consume_field, get_multipart_boundary, MultipartError, MultipartItems};
 
 /// The field name of a minidump in the multipart form-data upload.
@@ -189,7 +189,7 @@ async fn store_minidump(
     Ok(common::create_text_event_id_response(id))
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     common::cors(app)
         // No mandatory trailing slash here because people already use it like this.
         .resource(&common::normpath(r"/api/{project:\d+}/minidump"), |r| {

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -3,8 +3,6 @@
 //! This module contains implementations for all supported relay endpoints, as well as a generic
 //! `forward` endpoint that sends unknown requests to the upstream.
 
-use crate::service::ServiceApp;
-
 mod attachments;
 mod common;
 mod envelope;
@@ -20,7 +18,11 @@ mod statics;
 mod store;
 mod unreal;
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+use actix_web::App;
+
+use crate::service::ServiceState;
+
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     app
         // Internal routes pointing to /api/relay
         .configure(health_check::configure_app)

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -1,9 +1,9 @@
-use actix_web::HttpResponse;
+use actix_web::{App, HttpResponse};
 use relay_config::EmitOutcomes;
 
 use crate::actors::outcome::{OutcomeProducer, SendOutcomes, SendOutcomesResponse};
 use crate::extractors::{CurrentServiceState, SignedJson};
-use crate::service::ServiceApp;
+use crate::service::ServiceState;
 
 fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> HttpResponse {
     if !body.relay.internal || state.config().emit_outcomes() != EmitOutcomes::AsOutcomes {
@@ -18,7 +18,7 @@ fn send_outcomes(state: CurrentServiceState, body: SignedJson<SendOutcomes>) -> 
     HttpResponse::Accepted().json(SendOutcomesResponse {})
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     app.resource("/api/0/relays/outcomes/", |r| {
         r.name("relay-outcomes");
         r.post().with(send_outcomes);

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use actix::prelude::*;
-use actix_web::{Error, FromRequest, Json};
+use actix::MailboxError;
+use actix_web::{App, Error, FromRequest, Json};
 use futures::{future, TryFutureExt};
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ use relay_dynamic_config::ErrorBoundary;
 use crate::actors::project::{LimitedProjectState, ProjectState};
 use crate::actors::project_cache::{GetCachedProjectState, GetProjectState, ProjectCache};
 use crate::extractors::SignedJson;
-use crate::service::ServiceApp;
+use crate::service::ServiceState;
 
 /// V2 version of this endpoint.
 ///
@@ -173,7 +173,7 @@ async fn get_project_configs(
     Ok(Json(GetProjectStatesResponseWrapper { configs, pending }))
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     app.resource("/api/0/relays/projectconfigs/", |r| {
         r.name("relay-projectconfigs");
         r.post()

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use actix_web::{actix::*, Error, Json};
+use actix_web::{actix::MailboxError, App, Error, Json};
 use futures::{future, TryFutureExt};
 
 use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse, RelayCache};
 use crate::extractors::SignedJson;
-use crate::service::ServiceApp;
+use crate::service::ServiceState;
 
 async fn get_public_keys(body: SignedJson<GetRelays>) -> Result<Json<GetRelaysResponse>, Error> {
     let relay_cache = RelayCache::from_registry();
@@ -30,7 +30,7 @@ async fn get_public_keys(body: SignedJson<GetRelays>) -> Result<Json<GetRelaysRe
 /// Note that this has nothing to do with Sentry public keys, which refer to the public key portion
 /// of a DSN used for authenticating event submission. This endpoint is for Relay's public keys,
 /// which authenticate entire Relays.
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     app.resource("/api/0/relays/publickeys/", |r| {
         r.name("relay-publickeys");
         r.post()

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -1,6 +1,6 @@
 //! Endpoints for security reports.
 
-use actix_web::{pred, HttpMessage, HttpRequest, HttpResponse, Query, Request};
+use actix_web::{pred, App, HttpMessage, HttpRequest, HttpResponse, Query, Request};
 use serde::Deserialize;
 
 use relay_general::protocol::EventId;
@@ -9,7 +9,7 @@ use crate::body;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 
 #[derive(Debug, Deserialize)]
 struct SecurityReportParams {
@@ -84,7 +84,7 @@ impl pred::Predicate<ServiceState> for SecurityReportFilter {
     }
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     common::cors(app)
         // Default security endpoint
         .resource(&common::normpath(r"/api/{project:\d+}/security/"), |r| {

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -1,6 +1,6 @@
 //! Handles event store requests.
 
-use actix_web::{http::Method, HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{http::Method, App, HttpMessage, HttpRequest, HttpResponse};
 use bytes::{Bytes, BytesMut};
 use serde::Serialize;
 
@@ -10,7 +10,7 @@ use crate::body;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 
 // Transparent 1x1 gif
 // See http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
@@ -113,7 +113,7 @@ async fn store_event(
     })
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     common::cors(app)
         // Standard store endpoint. Some SDKs send multiple leading or trailing slashes due to bugs
         // in their URL handling. Since actix does not normalize such paths, allow any number of

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -1,4 +1,4 @@
-use actix_web::{HttpRequest, HttpResponse};
+use actix_web::{App, HttpRequest, HttpResponse};
 
 use relay_general::protocol::EventId;
 
@@ -7,7 +7,7 @@ use crate::constants::UNREAL_USER_HEADER;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
-use crate::service::{ServiceApp, ServiceState};
+use crate::service::ServiceState;
 
 async fn extract_envelope(
     request: &HttpRequest<ServiceState>,
@@ -52,7 +52,7 @@ async fn store_unreal(
     Ok(common::create_text_event_id_response(id))
 }
 
-pub fn configure_app(app: ServiceApp) -> ServiceApp {
+pub fn configure_app(app: App<ServiceState>) -> App<ServiceState> {
     common::cors(app)
         .resource(
             &common::normpath(r"/api/{project:\d+}/unreal/{sentry_key:\w+}/"),

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -269,10 +269,13 @@ mod utils;
 #[cfg(test)]
 mod testutils;
 
+use std::sync::Arc;
+
 use relay_config::Config;
-use relay_system::Controller;
+use relay_system::{Configure, Controller};
 
 use crate::actors::server::ServerService;
+use crate::service::ServiceState;
 
 /// Runs a relay web server and spawns all internal worker threads.
 ///
@@ -280,19 +283,27 @@ use crate::actors::server::ServerService;
 /// shutdown signal is received or a fatal error happens. Behavior of the server is determined by
 /// the `config` passed into this funciton.
 pub fn run(config: Config) -> anyhow::Result<()> {
-    // Run the controller and block until a shutdown signal is sent to this process. This will
-    // create an actix system, start a web server and run all relevant actors inside. See the
-    // `actors` module documentation for more information on all actors.
+    let config = Arc::new(config);
 
     // Spawn the main tokio runtime here since the controller cannot access the config.
     let main_runtime = crate::service::create_runtime("main-rt", config.cpu_concurrency());
     let _guard = main_runtime.enter();
 
-    let shutdown_timeout = config.shutdown_timeout();
-    Controller::run(|| ServerService::start(config))?;
+    // TODO(ja): Where to put this? This could be part of Controller::run now.
+    Controller::from_registry().do_send(Configure {
+        shutdown_timeout: config.shutdown_timeout(),
+    });
+
+    // Run the controller and block until a shutdown signal is sent to this process. This will
+    // create an actix system, start a web server and run all relevant actors inside. See the
+    // `actors` module documentation for more information on all actors.
+    Controller::run(|| {
+        let service = ServiceState::start(config.clone())?;
+        ServerService::start(&config, service)
+    })?;
 
     // Properly shutdown the new tokio runtime.
-    main_runtime.shutdown_timeout(shutdown_timeout);
+    main_runtime.shutdown_timeout(config.shutdown_timeout());
     relay_log::info!("relay shutdown complete");
 
     Ok(())

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -26,9 +26,6 @@ use crate::utils::BufferGuard;
 
 pub static REGISTRY: OnceBox<Registry> = OnceBox::new();
 
-// TODO(ja): Remove this?
-pub use crate::actors::server::ServiceApp;
-
 /// Indicates the type of failure of the server.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, thiserror::Error)]
 pub enum ServerError {

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -28,37 +28,20 @@ pub static REGISTRY: OnceBox<Registry> = OnceBox::new();
 
 /// Indicates the type of failure of the server.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, thiserror::Error)]
-pub enum ServerError {
-    /// Binding failed.
-    #[error("bind to interface failed")]
-    BindFailed,
-
-    /// Listening on the HTTP socket failed.
-    #[error("listening failed")]
-    ListenFailed,
-
-    /// A TLS error ocurred.
-    #[error("could not initialize the TLS server")]
-    TlsInitFailed,
-
-    /// TLS support was not compiled in.
-    #[cfg(not(feature = "ssl"))]
-    #[error("compile with the `ssl` feature to enable SSL support")]
-    TlsNotSupported,
-
+pub enum ServiceError {
     /// GeoIp construction failed.
     #[cfg(feature = "processing")]
     #[error("could not load the Geoip Db")]
-    GeoIpError,
+    GeoIp,
 
     /// Initializing the Kafka producer failed.
     #[cfg(feature = "processing")]
     #[error("could not initialize kafka producer")]
-    KafkaError,
+    Kafka,
 
     /// Initializing the Redis cluster client failed.
     #[error("could not initialize redis cluster client")]
-    RedisError,
+    Redis,
 }
 
 #[derive(Clone)]
@@ -137,7 +120,7 @@ impl ServiceState {
 
         let redis_pool = match config.redis() {
             Some(redis_config) if config.processing_enabled() => {
-                Some(RedisPool::new(redis_config).context(ServerError::RedisError)?)
+                Some(RedisPool::new(redis_config).context(ServiceError::Redis)?)
             }
             _ => None,
         };

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -1,12 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use actix::Recipient;
-use actix_web::server::StopServer;
-use actix_web::{server, App};
 use anyhow::{Context, Result};
-use futures01::Future;
-use listenfd::ListenFd;
 use once_cell::race::OnceBox;
 use tokio::runtime::Runtime;
 
@@ -14,7 +9,7 @@ use relay_aws_extension::AwsExtension;
 use relay_config::Config;
 use relay_metrics::{Aggregator, AggregatorService};
 use relay_redis::RedisPool;
-use relay_system::{Addr, Configure, Controller, Service};
+use relay_system::{Addr, Service};
 
 use crate::actors::envelopes::{EnvelopeManager, EnvelopeManagerService};
 use crate::actors::health_check::{HealthCheck, HealthCheckService};
@@ -27,12 +22,12 @@ use crate::actors::relays::{RelayCache, RelayCacheService};
 use crate::actors::store::StoreService;
 use crate::actors::test_store::{TestStore, TestStoreService};
 use crate::actors::upstream::{UpstreamRelay, UpstreamRelayService};
-use crate::middlewares::{
-    AddCommonHeaders, ErrorHandlers, Metrics, ReadRequestMiddleware, SentryMiddleware,
-};
 use crate::utils::BufferGuard;
 
 pub static REGISTRY: OnceBox<Registry> = OnceBox::new();
+
+// TODO(ja): Remove this?
+pub use crate::actors::server::ServiceApp;
 
 /// Indicates the type of failure of the server.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, thiserror::Error)]
@@ -221,154 +216,5 @@ impl ServiceState {
     /// buffer. See [`BufferGuard`] for more information.
     pub fn buffer_guard(&self) -> &BufferGuard {
         &self.buffer_guard
-    }
-}
-
-/// The actix app type for the relay web service.
-pub type ServiceApp = App<ServiceState>;
-
-fn make_app(state: ServiceState) -> ServiceApp {
-    App::with_state(state)
-        .middleware(SentryMiddleware::new())
-        .middleware(Metrics)
-        .middleware(AddCommonHeaders)
-        .middleware(ErrorHandlers)
-        .middleware(ReadRequestMiddleware)
-        .configure(crate::endpoints::configure_app)
-}
-
-fn dump_listen_infos<H, F>(server: &server::HttpServer<H, F>)
-where
-    H: server::IntoHttpHandler + 'static,
-    F: Fn() -> H + Send + Clone + 'static,
-{
-    relay_log::info!("spawning http server");
-    for (addr, scheme) in server.addrs_with_scheme() {
-        relay_log::info!("  listening on: {}://{}/", scheme, addr);
-    }
-}
-
-fn listen<H, F>(
-    server: server::HttpServer<H, F>,
-    config: &Config,
-) -> Result<server::HttpServer<H, F>>
-where
-    H: server::IntoHttpHandler + 'static,
-    F: Fn() -> H + Send + Clone + 'static,
-{
-    Ok(
-        match ListenFd::from_env()
-            .take_tcp_listener(0)
-            .context(ServerError::ListenFailed)?
-        {
-            Some(listener) => server.listen(listener),
-            None => server
-                .bind(config.listen_addr())
-                .context(ServerError::BindFailed)?,
-        },
-    )
-}
-
-#[cfg(feature = "ssl")]
-fn listen_ssl<H, F>(
-    mut server: server::HttpServer<H, F>,
-    config: &Config,
-) -> Result<server::HttpServer<H, F>>
-where
-    H: server::IntoHttpHandler + 'static,
-    F: Fn() -> H + Send + Clone + 'static,
-{
-    if let (Some(addr), Some(path), Some(password)) = (
-        config.tls_listen_addr(),
-        config.tls_identity_path(),
-        config.tls_identity_password(),
-    ) {
-        use native_tls::{Identity, TlsAcceptor};
-        use std::fs::File;
-        use std::io::Read;
-
-        let mut file = File::open(path).unwrap();
-        let mut data = vec![];
-        file.read_to_end(&mut data).unwrap();
-        let identity =
-            Identity::from_pkcs12(&data, password).context(ServerError::TlsInitFailed)?;
-
-        let acceptor = TlsAcceptor::builder(identity)
-            .build()
-            .context(ServerError::TlsInitFailed)?;
-
-        server = server
-            .bind_tls(addr, acceptor)
-            .context(ServerError::BindFailed)?;
-    }
-
-    Ok(server)
-}
-
-#[cfg(not(feature = "ssl"))]
-fn listen_ssl<H, F>(
-    server: server::HttpServer<H, F>,
-    config: &Config,
-) -> Result<server::HttpServer<H, F>, ServerError>
-where
-    H: server::IntoHttpHandler + 'static,
-    F: Fn() -> H + Send + Clone + 'static,
-{
-    if config.tls_listen_addr().is_some()
-        || config.tls_identity_path().is_some()
-        || config.tls_identity_password().is_some()
-    {
-        Err(ServerError::TlsNotSupported.into())
-    } else {
-        Ok(server)
-    }
-}
-
-/// Keeps the address to the running http servers and helps with start/stop handling.
-pub struct HttpServer(Recipient<StopServer>);
-
-impl HttpServer {
-    /// Given a relay config spawns the server together with all actors and lets them run forever.
-    ///
-    /// Effectively this boots the server.
-    pub fn start(config: Config) -> Result<Self> {
-        let config = Arc::new(config);
-
-        Controller::from_registry().do_send(Configure {
-            shutdown_timeout: config.shutdown_timeout(),
-        });
-
-        let state = ServiceState::start(config.clone())?;
-        let mut server = server::new(move || make_app(state.clone()));
-        server = server
-            .workers(config.cpu_concurrency())
-            .shutdown_timeout(config.shutdown_timeout().as_secs() as u16)
-            .keep_alive(config.keepalive_timeout().as_secs() as usize)
-            .maxconn(config.max_connections())
-            .maxconnrate(config.max_connection_rate())
-            .backlog(config.max_pending_connections())
-            .disable_signals();
-
-        server = listen(server, &config)?;
-        server = listen_ssl(server, &config)?;
-
-        dump_listen_infos(&server);
-        let recipient = server.start().recipient();
-        Ok(Self(recipient))
-    }
-
-    /// Triggers the shutdown process by sending [`actix_web::server::StopServer`] to the running http server.
-    pub fn shutdown(&self, graceful: bool) {
-        let Self(recipient) = self;
-        relay_log::info!("Shutting down HTTP server");
-        recipient.send(StopServer { graceful }).wait().ok();
-    }
-}
-
-impl fmt::Debug for HttpServer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("HttpServer")
-            .field(&"actix::Recipient<actix_web::server::StopServer>")
-            .finish()
     }
 }

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -122,8 +122,7 @@ impl Controller {
     /// actors have completed a graceful shutdown.
     pub fn run<F, R, E>(factory: F) -> Result<(), E>
     where
-        F: FnOnce() -> Result<R, E> + 'static,
-        F: Sync + Send,
+        F: FnOnce() -> Result<R, E>,
     {
         // Spawn a legacy actix system for the controller's signals.
         let sys = actix::System::new("relay");
@@ -139,6 +138,7 @@ impl Controller {
 
         // All actors have started successfully. Run the system, which blocks the current thread
         // until a signal arrives or `Controller::stop` is called.
+        // TODO(ja): The log should move where the shutdown log is too (server or main lib?)
         relay_log::info!("relay server starting");
         sys.run();
 

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -46,9 +46,6 @@ impl ShutdownHandle {
 /// This service contains a static `run` method which will run a tokio system and block the current
 /// thread until the system shuts down again.
 ///
-/// It starts with default configuration. To change this configuration, send the [`Configure`]
-/// message.
-///
 /// To shut down more gracefully, other actors can register with [`Controller::shutdown_handle`].
 /// When a shutdown signal is sent to the process, they will receive a [`Shutdown`] message with an
 /// optional timeout. They can respond with a future, after which they will be stopped. Once all
@@ -95,10 +92,8 @@ impl Controller {
     /// Private function to create a new controller.
     ///
     /// Use `from_registry` for public access.
-    fn new() -> Self {
-        Self {
-            timeout: Duration::from_secs(0),
-        }
+    fn new(timeout: Duration) -> Self {
+        Self { timeout }
     }
 
     /// Get actor's address from system registry.
@@ -107,7 +102,7 @@ impl Controller {
     ///
     /// This method panics when it is invoked outside of a controller context (`Controller::run`).
     pub fn from_registry() -> Addr<Self> {
-        CONTROLLER.get_or_init(|| Controller::new().start()).clone()
+        CONTROLLER.get().expect("No Controller running").clone()
     }
 
     /// Runs the `factory` to start actors.
@@ -120,17 +115,19 @@ impl Controller {
     /// returns an error, the actix system is not started and instead an error returned. Otherwise,
     /// the system blocks the current thread until a shutdown signal is sent to the server and all
     /// actors have completed a graceful shutdown.
-    pub fn run<F, R, E>(factory: F) -> Result<(), E>
+    pub fn run<F, R, E>(shutdown_timeout: Duration, factory: F) -> Result<(), E>
     where
         F: FnOnce() -> Result<R, E>,
     {
         // Spawn a legacy actix system for the controller's signals.
         let sys = actix::System::new("relay");
 
-        // Ensure that the controller starts if no service has started it yet. It will register with
+        // Ensure that the controller starts if no service has starts it. It will register with
         // `ProcessSignals` shut down even if no actors have subscribed. If we remove this line, the
         // controller will not be instantiated and our system will not listen for signals.
-        Controller::from_registry();
+        CONTROLLER
+            .set(Controller::new(shutdown_timeout).start())
+            .ok();
 
         // Run the factory and exit early if an error happens. The return value of the factory is
         // discarded for convenience, to allow shorthand notations.
@@ -208,25 +205,6 @@ impl Handler<signal::Signal> for Controller {
             }
             _ => (),
         }
-    }
-}
-
-/// Configures the [`Controller`] with new parameters.
-#[derive(Debug)]
-pub struct Configure {
-    /// The maximum shutdown timeout before killing actors.
-    pub shutdown_timeout: Duration,
-}
-
-impl Message for Configure {
-    type Result = ();
-}
-
-impl Handler<Configure> for Controller {
-    type Result = ();
-
-    fn handle(&mut self, message: Configure, _context: &mut Self::Context) -> Self::Result {
-        self.timeout = message.shutdown_timeout;
     }
 }
 

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -107,7 +107,7 @@ impl Controller {
     ///
     /// This method panics when it is invoked outside of a controller context (`Controller::run`).
     pub fn from_registry() -> Addr<Self> {
-        CONTROLLER.get().expect("No Controller running").clone()
+        CONTROLLER.get_or_init(|| Controller::new().start()).clone()
     }
 
     /// Runs the `factory` to start actors.
@@ -130,7 +130,7 @@ impl Controller {
         // Ensure that the controller starts if no service has started it yet. It will register with
         // `ProcessSignals` shut down even if no actors have subscribed. If we remove this line, the
         // controller will not be instantiated and our system will not listen for signals.
-        CONTROLLER.set(Controller::new().start()).ok();
+        Controller::from_registry();
 
         // Run the factory and exit early if an error happens. The return value of the factory is
         // discarded for convenience, to allow shorthand notations.

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -138,8 +138,6 @@ impl Controller {
 
         // All actors have started successfully. Run the system, which blocks the current thread
         // until a signal arrives or `Controller::stop` is called.
-        // TODO(ja): The log should move where the shutdown log is too (server or main lib?)
-        relay_log::info!("relay server starting");
         sys.run();
 
         Ok(())


### PR DESCRIPTION
The HTTP server and `ServiceState` comprising all services are tightly coupled. This PR separates them in such a way that the service state can be started by itself and is then passed to the HttpServer during startup. Additionally, bootstrapping is streamlined in the top-level `run` method.

This change will allow to refactor the `Controller`, which is required to remove actix from our dependencies.

Follows https://github.com/getsentry/relay/pull/1723
#skip-changelog
