### PR TITLE
chore(metrics): Remove satisfaction thresholds

### DIFF
--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Dynamic configuration for metrics extraction from sessions and transactions.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use relay_sampling::RuleCondition;
 use serde::{Deserialize, Serialize};
@@ -64,39 +64,6 @@ impl SessionMetricsConfig {
     }
 }
 
-/// The metric to which the user satisfaction threshold is applied.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SatisfactionMetric {
-    /// Apply to transaction duration.
-    Duration,
-    /// Apply to LCP.
-    Lcp,
-    /// Catch-all variant for forward compatibility.
-    #[serde(other)]
-    Unknown,
-}
-
-/// Configuration for a single threshold.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SatisfactionThreshold {
-    /// What metric to apply the threshold to.
-    pub metric: SatisfactionMetric,
-    /// Value of the threshold.
-    pub threshold: f64,
-}
-
-/// Configuration for applying the user satisfaction threshold.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SatisfactionConfig {
-    /// The project-wide threshold to apply.
-    pub project_threshold: SatisfactionThreshold,
-    /// Transaction-specific overrides of the project-wide threshold.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub transaction_thresholds: BTreeMap<String, SatisfactionThreshold>,
-}
-
 /// Configuration for extracting custom measurements from transaction payloads.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -139,8 +106,6 @@ pub struct TransactionMetricsConfig {
     pub extract_metrics: BTreeSet<String>,
     /// Custom event tags that are transferred from the transaction to metrics.
     pub extract_custom_tags: BTreeSet<String>,
-    /// Config for determining user satisfaction (satisfied / tolerated / frustrated)
-    pub satisfaction_thresholds: Option<SatisfactionConfig>,
     /// Deprecated in favor of top-level config field. Still here to be forwarded to external relays.
     pub custom_measurements: CustomMeasurementConfig,
     /// Defines whether URL transactions should be considered low cardinality.


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/33722, we do not send the `satisfactionThresholds` project config key anymore. See diff that removes the config [here](https://github.com/getsentry/sentry/pull/33722/files#diff-5e30755537fcfd5687d4399272065e49affcc12a4cf7a0bc377cff5234b8a08a).

Satisfaction thresholds are now applied using the more generic [conditional tagging](https://github.com/getsentry/relay/pull/1225) mechanism.

This PR removes all traces of the old configuration and business logic.

#skip-changelog