### PR TITLE
build: Upgrade sentry SDK to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,16 +1010,6 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "debugid"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
-dependencies = [
- "serde",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
@@ -2291,7 +2281,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e5cd2ca4f6b85c6c7fb41ae0aebe0b443a6c0558876f1d779c7236d42417cf"
 dependencies = [
- "debugid 0.8.0",
+ "debugid",
  "encoding",
  "memmap2",
  "minidump-common",
@@ -2311,7 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "694717103b2c15f8c16ddfaec1333fe15673bc22b10ffa6164427415701974ba"
 dependencies = [
  "bitflags",
- "debugid 0.8.0",
+ "debugid",
  "enum-primitive-derive",
  "num-traits",
  "range-map",
@@ -3279,7 +3269,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "regex",
  "schemars",
- "sentry-types 0.20.1",
+ "sentry-types",
  "serde",
  "serde_test",
  "thiserror",
@@ -3372,7 +3362,7 @@ dependencies = [
  "chrono",
  "cookie 0.17.0",
  "criterion",
- "debugid 0.8.0",
+ "debugid",
  "dynfmt",
  "enumset",
  "hmac 0.12.1",
@@ -3935,9 +3925,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f8ce69326daef9d845c3fd17149bd3dbd7caf5dc65dbbad9f5441a40ee407f"
+checksum = "b5ce6d3512e2617c209ec1e86b0ca2fea06454cd34653c91092bf0f3ec41f8e3"
 dependencies = [
  "httpdate",
  "native-tls",
@@ -3954,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed6c0254d4cce319800609aa0d41b486ee57326494802045ff27434fc9a2030"
+checksum = "0e7fe408d4d1f8de188a9309916e02e129cbe51ca19e55badea5a64899399b1a"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -3966,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3277dc5d2812562026f2095c7841f3d61bbe6789159b7da54f41d540787f818"
+checksum = "5695096a059a89973ec541062d331ff4c9aeef9c2951416c894f0fff76340e7d"
 dependencies = [
  "hostname",
  "libc",
@@ -3980,22 +3970,22 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5acbd3da4255938cf0384b6b140e6c07ff65919c26e4d7a989d8d90ee88fa91"
+checksum = "5b22828bfd118a7b660cf7a155002a494755c0424cebb7061e4743ecde9c7dbc"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
- "sentry-types 0.29.3",
+ "sentry-types",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745358c78d3a64361de3659c101fa1ec6eb95bdabf7c88ce274c84338687f07c"
+checksum = "0a9164d44a2929b1b7670afd7e87552514b70d3ae672ca52884639373d912a3d"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -4004,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b922394014861334c24388a55825e4c715afb8ec7c1db900175aa9951f8241"
+checksum = "bfa3a3f4477e77541c26eb84d0e355729dfa35c74c682eb8678f146db5126013"
 dependencies = [
  "log",
  "sentry-core",
@@ -4014,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beebc7aedbd3aa470cd19caad208a5efe6c48902595c0d111a193d8ce4f7bd15"
+checksum = "1f4ced2a7a8c14899d58eec402d946f69d5ed26a3fc363a7e8b1e5cb88473a01"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4035,26 +4025,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.20.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8124f0e9bc1113ecbcc8c3746e0e590943cf23e7d09c70a088c116869bb12e3"
+checksum = "360ee3270f7a4a1eee6c667f7d38360b995431598a73b740dfe420da548d9cc9"
 dependencies = [
- "chrono",
- "debugid 0.7.3",
- "serde",
- "serde_json",
- "thiserror",
- "url 2.3.1",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d8587b12c0b8211bb3066979ee57af6e8657e23cf439dc6c8581fd86de24e8"
-dependencies = [
- "debugid 0.8.0",
+ "debugid",
  "getrandom",
  "hex",
  "serde",
@@ -4382,7 +4357,7 @@ version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46939659856f0595dbbdbe0c8271d11c6788c780c859bf9afd834a723dd78fa3"
 dependencies = [
- "debugid 0.8.0",
+ "debugid",
  "memmap2",
  "stable_deref_trait",
  "uuid 1.3.0",
@@ -5170,10 +5145,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
- "serde",
-]
 
 [[package]]
 name = "uuid"

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.13.1"
 parking_lot = "0.12.1"
 regex = "1.5.5"
 schemars = { version = "0.8.1", features = ["uuid1", "chrono"], optional = true }
-sentry-types = "0.20.0"
+sentry-types = "0.30.0"
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.38"
 uuid = { version = "1.3.0", features = ["serde", "v4", "v5"] }

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -16,8 +16,8 @@ console = { version = "0.15.5", optional = true }
 env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4.11", features = ["serde"] }
 relay-crash = { path = "../relay-crash", optional = true }
-sentry = { version = "0.29.3", features = ["debug-images", "log"], optional = true }
-sentry-core = { version = "0.29.3" }
+sentry = { version = "0.30.0", features = ["debug-images", "log"], optional = true }
+sentry-core = { version = "0.30.0" }
 serde = { version = "1.0.114", features = ["derive"], optional = true }
 serde_json = { version = "1.0.55", optional = true }
 

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -85,7 +85,11 @@ pub struct PartialDsn {
 impl PartialDsn {
     /// Ensures a valid public key and project ID in the DSN.
     fn from_dsn(dsn: Dsn) -> Result<Self, ParseDsnError> {
-        let project_id = dsn.project_id().value();
+        let project_id = dsn
+            .project_id()
+            .value()
+            .parse()
+            .map_err(|_| ParseDsnError::NoProjectId)?;
 
         let public_key = dsn
             .public_key()
@@ -98,7 +102,7 @@ impl PartialDsn {
             host: dsn.host().to_owned(),
             port: dsn.port(),
             path: dsn.path().to_owned(),
-            project_id: Some(ProjectId::new(project_id)),
+            project_id: Some(project_id),
         })
     }
 


### PR DESCRIPTION
Move back to latest version of the Sentry SDK after it had to be reverted in
#1872 due to a regression.

#skip-changelog
Fixes #1875 
