### PR TITLE
ref(project): Skip serializing default fields

### DIFF
--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -12,6 +12,12 @@ use crate::processor::SelectorSpec;
 
 const COMPILED_PATTERN_MAX_SIZE: usize = 262_144;
 
+/// Helper method to check whether a flag is false.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn is_flag_default(flag: &bool) -> bool {
+    !*flag
+}
+
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum PiiConfigError {
     #[error("could not parse pattern")]
@@ -121,7 +127,7 @@ pub struct MultipleRule {
     /// A reference to other rules to apply
     pub rules: Vec<String>,
     /// When set to true, the outer rule is reported.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_flag_default")]
     pub hide_inner: bool,
 }
 
@@ -132,7 +138,7 @@ pub struct AliasRule {
     /// A reference to another rule to apply.
     pub rule: String,
     /// When set to true, the outer rule is reported.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_flag_default")]
     pub hide_inner: bool,
 }
 

--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -199,23 +199,29 @@ pub struct RuleSpec {
 #[serde(rename_all = "camelCase")]
 pub struct Vars {
     /// The default secret key for hashing operations.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hash_key: Option<String>,
+}
+
+impl Vars {
+    fn is_empty(&self) -> bool {
+        self.hash_key.is_none()
+    }
 }
 
 /// A set of named rule configurations.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct PiiConfig {
     /// A map of custom PII rules.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub rules: BTreeMap<String, RuleSpec>,
 
     /// Parameters for PII rules.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vars::is_empty")]
     pub vars: Vars,
 
     /// Mapping of selectors to rules.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub applications: BTreeMap<SelectorSpec, Vec<String>>,
 
     /// PII config derived from datascrubbing settings.

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -209,10 +209,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     fn test_convert_default_pii_config() {
         insta::assert_json_snapshot!(simple_enabled_pii_config(), @r###"
         {
-          "rules": {},
-          "vars": {
-            "hashKey": null
-          },
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
               "@common:filter",
@@ -235,10 +231,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         insta::assert_json_snapshot!(pii_config, @r###"
         {
-          "rules": {},
-          "vars": {
-            "hashKey": null
-          },
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
               "@common:filter",
@@ -270,9 +262,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
                 "text": "[Filtered]"
               }
             }
-          },
-          "vars": {
-            "hashKey": null
           },
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
@@ -327,10 +316,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         insta::assert_json_snapshot!(pii_config, @r###"
         {
-          "rules": {},
-          "vars": {
-            "hashKey": null
-          },
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !foobar": [
               "@common:filter",
@@ -355,10 +340,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
         insta::assert_json_snapshot!(pii_config, @r###"
         {
-          "rules": {},
-          "vars": {
-            "hashKey": null
-          },
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
               "@ip:replace"
@@ -1245,9 +1226,6 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
                 "text": "[Filtered]"
               }
             }
-          },
-          "vars": {
-            "hashKey": null
           },
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [

--- a/relay-general/src/pii/legacy.rs
+++ b/relay-general/src/pii/legacy.rs
@@ -6,15 +6,9 @@
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
-use crate::pii::{convert, PiiConfig};
+use crate::pii::{convert, is_flag_default, PiiConfig};
 
 use super::config::PiiConfigError;
-
-/// Helper method to check whether a flag is false.
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn is_flag_default(flag: &bool) -> bool {
-    !*flag
-}
 
 /// Configuration for Sentry's datascrubbing
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__convert__tests__regression_more_odd_keys.snap
@@ -1,12 +1,9 @@
 ---
 source: relay-general/src/pii/convert.rs
+assertion_line: 1391
 expression: pii_config
 ---
 {
-  "rules": {},
-  "vars": {
-    "hashKey": null
-  },
   "applications": {
     "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
       "@common:filter",

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -815,7 +815,7 @@ impl FieldValueProvider for DynamicSamplingContext {
 /// occurs. The sampling mode controlls whether the sample rate is relative to the original
 /// population of items before client-side sampling, or relative to the number received by Relay
 /// after client-side sampling.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum SamplingMode {
     /// The sample rate is based on the number of events received by Relay.
@@ -1031,7 +1031,7 @@ pub struct SamplingConfig {
     /// The ordered sampling rules v2 for the project.
     pub rules_v2: Vec<SamplingRule>,
     /// Defines which population of items a dynamic sample rate applies to.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub mode: SamplingMode,
 }
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -2181,9 +2181,6 @@ mod tests {
                   "UPPER",
                   "lower",
                 ],
-                options: EqCondOptions(
-                  ignoreCase: false,
-                ),
               ),
               GlobCondition(
                 op: "glob",
@@ -2258,7 +2255,6 @@ mod tests {
                 op: "custom",
                 name: "some_custom_op",
                 value: "some val",
-                options: {},
               ),
             ]"###);
     }
@@ -2451,13 +2447,9 @@ mod tests {
         "value": 2.0
       },
       "type": "transaction",
-      "id": 1,
-      "decayingFn": {
-        "type": "constant"
-      }
+      "id": 1
     }
-  ],
-  "mode": "received"
+  ]
 }"#;
 
         assert_eq!(serialized_config, expected_serialized_config)

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -43,7 +43,7 @@ pub enum RuleType {
 /// A condition that checks the values using the equality operator.
 ///
 /// For string values it supports case-insensitive comparison.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct EqCondOptions {
     #[serde(default)]
@@ -56,7 +56,7 @@ pub struct EqCondOptions {
 pub struct EqCondition {
     pub name: String,
     pub value: Value,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub options: EqCondOptions,
 }
 
@@ -175,7 +175,7 @@ pub struct CustomCondition {
     pub name: String,
     #[serde(default)]
     pub value: Value,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub options: HashMap<String, Value>,
 }
 
@@ -452,6 +452,11 @@ impl ActiveRule {
     }
 }
 
+/// Returns `true` if this value is equal to `Default::default()`.
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == T::default()
+}
+
 /// A sampling rule as it is deserialized from the project configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -467,7 +472,7 @@ pub struct SamplingRule {
     /// closed on at least one end, the rule is considered a decaying rule.
     #[serde(default, skip_serializing_if = "TimeRange::is_empty")]
     pub time_range: TimeRange,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub decaying_fn: DecayingFunction,
 }
 


### PR DESCRIPTION
Some fields that are not being sent by Sentry when they are empty are serialized by Relay. Align with Sentry and do not serialize these fields if they have default values.

**Why though?**

* The main reason is that https://github.com/getsentry/relay/pull/1860 introduced a validation function that can be used Sentry-side to check if Sentry accidentally produces any fields that Relay cannot use. This has already surfaced some inconsistencies (see https://github.com/getsentry/sentry/pull/45124), but it requires that Sentry and Relay produce the same fields.
* Reduced payload size when sending configs to downstream Relays.