### PR TITLE
feat(scrubbing): Scrub `span.data.http.query` with default scrubbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Protocol validation for source map image type. ([#1869](https://github.com/getsentry/relay/pull/1869))
 - Strip quotes from client hint values. ([#1874](https://github.com/getsentry/relay/pull/1874))
 - Add Dotnet, Javascript and PHP support for profiling. ([#1871](https://github.com/getsentry/relay/pull/1871), [#1876](https://github.com/getsentry/relay/pull/1876), [#1885](https://github.com/getsentry/relay/pull/1885))
-- Scrub `span.data.http.query` with default scrubbers. ([#1899](https://github.com/getsentry/relay/pull/1889))
+- Scrub `span.data.http.query` with default scrubbers. ([#1889](https://github.com/getsentry/relay/pull/1889))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Protocol validation for source map image type. ([#1869](https://github.com/getsentry/relay/pull/1869))
 - Strip quotes from client hint values. ([#1874](https://github.com/getsentry/relay/pull/1874))
 - Add Dotnet, Javascript and PHP support for profiling. ([#1871](https://github.com/getsentry/relay/pull/1871), [#1876](https://github.com/getsentry/relay/pull/1876), [#1885](https://github.com/getsentry/relay/pull/1885))
+- Scrub `span.data.http.query` with default scrubbers. ([#1899](https://github.com/getsentry/relay/pull/1889))
 
 **Bug Fixes**:
 

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -364,6 +364,8 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
 #[cfg(test)]
 mod tests {
 
+    use std::collections::BTreeMap;
+
     use crate::pii::{DataScrubbingConfig, PiiConfig, ReplaceRedaction};
     use crate::processor::process_value;
     use crate::protocol::{
@@ -974,7 +976,7 @@ mod tests {
         let mut span = Annotated::new(Span {
             data: Annotated::new(DataElement {
                 http: Annotated::new(HttpElement {
-                    query: Annotated::new("dance=true".to_owned()),
+                    query: Annotated::new(Value::String("dance=true".to_owned())),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -999,7 +1001,45 @@ mod tests {
         let mut span = Annotated::new(Span {
             data: Annotated::new(DataElement {
                 http: Annotated::new(HttpElement {
-                    query: Annotated::new("ccnumber=5105105105105100&process_id=123".to_owned()),
+                    query: Annotated::new(Value::String(
+                        "ccnumber=5105105105105100&process_id=123".to_owned(),
+                    )),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(span);
+    }
+
+    #[test]
+    fn test_scrub_span_data_object_is_scrubbed() {
+        let mut span = Annotated::new(Span {
+            data: Annotated::new(DataElement {
+                http: Annotated::new(HttpElement {
+                    query: Annotated::new(Value::Object({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "ccnumber".to_owned(),
+                            Annotated::new(Value::String("5105105105105100".to_owned())),
+                        );
+                        map.insert(
+                            "process_id".to_owned(),
+                            Annotated::new(Value::String("123".to_owned())),
+                        );
+                        map
+                    })),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -999,7 +999,7 @@ mod tests {
         let mut span = Annotated::new(Span {
             data: Annotated::new(DataElement {
                 http: Annotated::new(HttpElement {
-                    query: Annotated::new("ccnumber=5105105105105100".to_owned()),
+                    query: Annotated::new("ccnumber=5105105105105100&process_id=123".to_owned()),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -363,11 +363,12 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
 
 #[cfg(test)]
 mod tests {
-    use crate::pii::{PiiConfig, ReplaceRedaction};
+
+    use crate::pii::{DataScrubbingConfig, PiiConfig, ReplaceRedaction};
     use crate::processor::process_value;
     use crate::protocol::{
-        Addr, DebugImage, DebugMeta, Event, ExtraValue, Headers, LogEntry, NativeDebugImage,
-        Request, TagEntry, Tags,
+        Addr, DataElement, DebugImage, DebugMeta, Event, ExtraValue, Headers, HttpElement,
+        LogEntry, NativeDebugImage, Request, Span, TagEntry, Tags,
     };
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::{Annotated, Object, Value};
@@ -966,5 +967,55 @@ mod tests {
             ReplaceBehavior::Value,
         );
         assert_eq!(chunks, res);
+    }
+
+    #[test]
+    fn test_scrub_span_data_not_scrubbed() {
+        let mut span = Annotated::new(Span {
+            data: Annotated::new(DataElement {
+                http: Annotated::new(HttpElement {
+                    query: Annotated::new("dance=true".to_owned()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(span);
+    }
+
+    #[test]
+    fn test_scrub_span_data_is_scrubbed() {
+        let mut span = Annotated::new(Span {
+            data: Annotated::new(DataElement {
+                http: Annotated::new(HttpElement {
+                    query: Annotated::new("ccnumber=5105105105105100".to_owned()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(span);
     }
 }

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_is_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_is_scrubbed.snap
@@ -5,7 +5,7 @@ expression: span
 {
   "data": {
     "http": {
-      "query": "ccnumber=[Filtered]"
+      "query": "ccnumber=[Filtered]&process_id=123"
     }
   },
   "_meta": {
@@ -21,7 +21,7 @@ expression: span
                 19
               ]
             ],
-            "len": 25
+            "len": 40
           }
         }
       }

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_is_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_is_scrubbed.snap
@@ -1,0 +1,30 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: span
+---
+{
+  "data": {
+    "http": {
+      "query": "ccnumber=[Filtered]"
+    }
+  },
+  "_meta": {
+    "data": {
+      "http": {
+        "query": {
+          "": {
+            "rem": [
+              [
+                "@creditcard:filter",
+                "s",
+                9,
+                19
+              ]
+            ],
+            "len": 25
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_not_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_not_scrubbed.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: span
+---
+{
+  "data": {
+    "http": {
+      "query": "dance=true"
+    }
+  }
+}

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_object_is_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_span_data_object_is_scrubbed.snap
@@ -1,0 +1,35 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: span
+---
+{
+  "data": {
+    "http": {
+      "query": {
+        "ccnumber": "[Filtered]",
+        "process_id": "123"
+      }
+    }
+  },
+  "_meta": {
+    "data": {
+      "http": {
+        "query": {
+          "ccnumber": {
+            "": {
+              "rem": [
+                [
+                  "@creditcard:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 16
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-general/src/protocol/span.rs
+++ b/relay-general/src/protocol/span.rs
@@ -95,7 +95,7 @@ mod tests {
             status: Annotated::new(SpanStatus::Ok),
             data: Annotated::new(DataElement {
                 http: Annotated::new(HttpElement {
-                    query: Annotated::new("is_sample_query=true".to_owned()),
+                    query: Annotated::new(Value::String("is_sample_query=true".to_owned())),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/relay-general/src/protocol/span.rs
+++ b/relay-general/src/protocol/span.rs
@@ -57,6 +57,8 @@ pub struct Span {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use chrono::{TimeZone, Utc};
     use similar_asserts::assert_eq;
 
@@ -77,7 +79,12 @@ mod tests {
   "status": "ok",
   "data": {
     "http": {
-      "query": "is_sample_query=true"
+      "query": "is_sample_query=true",
+      "not_query": "this is not the query"
+    },
+    "more_fields": {
+      "how_many": "yes",
+      "many": "a lot!"
     }
   }
 }"#;
@@ -96,9 +103,34 @@ mod tests {
             data: Annotated::new(DataElement {
                 http: Annotated::new(HttpElement {
                     query: Annotated::new(Value::String("is_sample_query=true".to_owned())),
-                    ..Default::default()
+                    other: {
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "not_query".to_owned(),
+                            Annotated::new(Value::String("this is not the query".to_owned())),
+                        );
+                        map
+                    },
                 }),
-                ..Default::default()
+                other: {
+                    let mut inner_map = BTreeMap::new();
+                    inner_map.insert(
+                        "how_many".to_owned(),
+                        Annotated::new(Value::String("yes".to_owned())),
+                    );
+                    inner_map.insert(
+                        "many".to_owned(),
+                        Annotated::new(Value::String("a lot!".to_owned())),
+                    );
+
+                    let mut outter_map = BTreeMap::new();
+                    outter_map.insert(
+                        "more_fields".to_owned(),
+                        Annotated::new(Value::Object(inner_map)),
+                    );
+
+                    outter_map
+                },
             }),
             ..Default::default()
         });

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -1131,7 +1131,7 @@ pub struct DataElement {
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct HttpElement {
     #[metastructure(pii = "true")]
-    pub query: Annotated<String>,
+    pub query: Annotated<Value>,
 
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
     pub other: Object<Value>,

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -1117,6 +1117,26 @@ impl schemars::JsonSchema for Timestamp {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
+pub struct DataElement {
+    #[metastructure(pii = "maybe")]
+    pub http: Annotated<HttpElement>,
+
+    #[metastructure(additional_properties, retain = "true", pii = "maybe")]
+    pub other: Object<Value>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
+pub struct HttpElement {
+    #[metastructure(pii = "true")]
+    pub query: Annotated<String>,
+
+    #[metastructure(additional_properties, retain = "true", pii = "maybe")]
+    pub other: Object<Value>,
+}
+
 #[cfg(test)]
 mod tests {
     use similar_asserts::assert_eq;


### PR DESCRIPTION
Ref: https://github.com/getsentry/relay/issues/1855

`span.data.http.query` may contain sensitive data, which is currently not scrubbed. This PR makes relay to scrub that field with default data scrubbers.