### PR TITLE
chore(project_local): Allow to follow symlinks for projects configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,6 +3583,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-unreal",
  "take_mut",
+ "tempfile",
  "thiserror",
  "tokio 1.25.0",
  "tokio-timer",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -92,3 +92,4 @@ libc = "0.2.71"
 insta = { version = "1.19.0", features = ["json"] }
 relay-test = { path = "../relay-test" }
 similar-asserts = "1.4.2"
+tempfile = "3"

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -196,6 +196,9 @@ mod tests {
     use super::load_local_states;
 
     /// Tests that we can follow the symlinks and read the project file properly.
+    ///
+    /// This works only on Unix systems.
+    #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn test_symlinked_projects() {
         let temp1 = tempfile::tempdir().unwrap();

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -184,3 +184,67 @@ impl Service for LocalProjectSourceService {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use relay_common::{ProjectId, ProjectKey};
+
+    use crate::actors::project::{ProjectState, PublicKeyConfig};
+
+    use super::load_local_states;
+
+    /// Tests that we can follow the symlinks and read the project file properly.
+    #[tokio::test]
+    async fn test_symlinked_projects() {
+        let temp1 = tempfile::tempdir().unwrap();
+        let temp2 = tempfile::tempdir().unwrap();
+
+        let tmp_project_file = "111111.json";
+        let project_key = ProjectKey::parse("55f6b2d962564e99832a39890ee4573e").unwrap();
+
+        let mut tmp_project_state = ProjectState::allowed();
+        tmp_project_state.public_keys.push(PublicKeyConfig {
+            public_key: project_key,
+            numeric_id: None,
+        });
+
+        // create the project file
+        let project_state = serde_json::to_string(&tmp_project_state).unwrap();
+        tokio::fs::write(
+            temp1.path().join(tmp_project_file),
+            project_state.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::symlink(
+            temp1.path().join(tmp_project_file),
+            temp2.path().join(tmp_project_file),
+        )
+        .await
+        .unwrap();
+
+        let extracted_project_state = load_local_states(temp2.path()).await.unwrap();
+
+        assert_eq!(
+            extracted_project_state
+                .get(&project_key)
+                .unwrap()
+                .project_id,
+            Some(ProjectId::from_str("111111").unwrap())
+        );
+
+        assert_eq!(
+            extracted_project_state
+                .get(&project_key)
+                .unwrap()
+                .public_keys
+                .first()
+                .unwrap()
+                .public_key,
+            project_key,
+        )
+    }
+}

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -84,7 +84,8 @@ async fn load_local_states(
     while let Some(entry) = directory.next_entry().await? {
         let path = entry.path();
 
-        if !entry.metadata().await?.is_file() {
+        let metadata = entry.metadata().await?;
+        if !(metadata.is_file() || metadata.is_symlink()) {
             relay_log::warn!("skipping {:?}, not a file", path);
             continue;
         }

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -185,6 +185,8 @@ impl Service for LocalProjectSourceService {
     }
 }
 
+/// This works only on Unix systems.
+#[cfg(not(target_os = "windows"))]
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -196,9 +198,6 @@ mod tests {
     use super::load_local_states;
 
     /// Tests that we can follow the symlinks and read the project file properly.
-    ///
-    /// This works only on Unix systems.
-    #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn test_symlinked_projects() {
         let temp1 = tempfile::tempdir().unwrap();


### PR DESCRIPTION

fix: https://github.com/getsentry/relay/issues/1102

#skip-changelog