### PR TITLE
feat(threads): Add state as an optional key in the threads interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Protocol validation for source map image type. ([#1869](https://github.com/getsentry/relay/pull/1869))
 - Strip quotes from client hint values. ([#1874](https://github.com/getsentry/relay/pull/1874))
 - Add Dotnet, Javascript and PHP support for profiling. ([#1871](https://github.com/getsentry/relay/pull/1871), [#1876](https://github.com/getsentry/relay/pull/1876), [#1885](https://github.com/getsentry/relay/pull/1885))
+- Add `thread.state` field to protocol. ([#1896](https://github.com/getsentry/relay/pull/1896))
 
 **Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `thread.state` field to protocol. ([#1896](https://github.com/getsentry/relay/pull/1896))
+
 ## 0.8.18
 
 - Add `instruction_addr_adjustment` field to `RawStacktrace`. ([#1716](https://github.com/getsentry/relay/pull/1716))

--- a/relay-general/src/protocol/thread.rs
+++ b/relay-general/src/protocol/thread.rs
@@ -125,6 +125,9 @@ pub struct Thread {
     /// A flag indicating whether the thread was responsible for rendering the user interface.
     pub main: Annotated<bool>,
 
+    #[metastructure(skip_serialization = "empty")]
+    pub state: Annotated<String>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,
@@ -169,6 +172,7 @@ mod tests {
   "crashed": true,
   "current": true,
   "main": true,
+  "state": "RUNNABLE",
   "other": "value"
 }"#;
         let thread = Annotated::new(Thread {
@@ -179,6 +183,7 @@ mod tests {
             crashed: Annotated::new(true),
             current: Annotated::new(true),
             main: Annotated::new(true),
+            state: Annotated::new("RUNNABLE".to_string()),
             other: {
                 let mut map = Map::new();
                 map.insert(

--- a/relay-general/src/protocol/thread.rs
+++ b/relay-general/src/protocol/thread.rs
@@ -125,6 +125,7 @@ pub struct Thread {
     /// A flag indicating whether the thread was responsible for rendering the user interface.
     pub main: Annotated<bool>,
 
+    /// Thread state at the time of the crash.
     #[metastructure(skip_serialization = "empty")]
     pub state: Annotated<String>,
 

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -3153,6 +3153,14 @@ expression: "relay_general::protocol::event_json_schema()"
                   "type": "null"
                 }
               ]
+            },
+            "state": {
+              "description": " Thread state at the time of the crash.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Thread state is an optional string currently sent by the Android SDK on the threads interface but isn't extracted. We want to extract and store it on the event json. Currently, we capture the JVM [states](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.State.html), but in the ANRv2 implementation, we expect to capture to states the Android VM [provides](https://cs.android.com/android/platform/superproject/+/master:art/runtime/thread_state.h). Note, these values are for Android only, other SDKs could send other values.

We only need to save thread state in nodestore, we don't anticipate running any queries against this field.

[Here](https://gist.github.com/shruthilayaj/2151eac05009466f4549c5f2ad48a11f) is an example event payload with thread states.

closes https://github.com/getsentry/sentry/issues/45196
