### PR TITLE
fix(log): Align modules in development logs

### DIFF
--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -229,7 +229,7 @@ fn format_pretty(f: &mut env_logger::fmt::Formatter, record: &log::Record) -> io
 
     writeln!(
         f,
-        " {styled_level} {styled_target:width$} > {}",
+        " {styled_level:5} {styled_target:width$} > {}",
         record.args(),
         width = max_target_width(target),
     )


### PR DESCRIPTION
Fixes a minor regression in development logs. With this PR, the module of log
messages is aligned again.

#skip-changelog
