### PR TITLE
fix(build): Run check when PR is ready for review

### DIFF
--- a/.github/actions/changelog/index.js
+++ b/.github/actions/changelog/index.js
@@ -87,7 +87,7 @@ module.exports = async ({github, context, core}) => {
       pull_number: context.payload.pull_request.number,
     });
 
-    if (pr.merged) {
+    if (pr.merged || pr.draft) {
       return;
     }
 

--- a/.github/actions/changelog/index.js
+++ b/.github/actions/changelog/index.js
@@ -87,7 +87,8 @@ module.exports = async ({github, context, core}) => {
       pull_number: context.payload.pull_request.number,
     });
 
-    if (pr.merged || pr.draft) {
+   // While in draft mode, skip the check because changelogs often cause merge conflicts.
+   if (pr.merged || pr.draft) {
       return;
     }
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,7 @@
 name: "Changelog"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
Make sure to run the `Changelog` check when the PR converted from Draft to Ready for Review.

#skip-changelog