### PR TITLE
(chore): Bump self hosted e2e tests action sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@627c9b50cb168c546ed6e2c461dae76d5d0c7cdb
+        uses: getsentry/action-self-hosted-e2e-tests@77805295ebff8a603def5970e18743ded72cb304
         with:
           project_name: relay
           image_url: ghcr.io/getsentry/relay:${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Bumps action commit sha to fail test suite properly from typo fix here:
https://github.com/getsentry/action-self-hosted-e2e-tests/pull/7

#skip-changelog