### PR TITLE
Assert array fields are capped to 100 items

### DIFF
--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -271,7 +271,6 @@ impl Replay {
         if let Some(items) = self.urls.value_mut() {
             items.truncate(100);
         }
-
     }
 
     fn normalize_ip_address(&mut self, ip_address: Option<RealIPAddr>) {

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -260,6 +260,8 @@ impl Replay {
     }
 
     fn normalize_array_fields(&mut self) {
+        // TODO: This should be replaced by the TrimmingProcessor.
+        // https://github.com/getsentry/relay/pull/1910#pullrequestreview-1337188206
         if let Some(items) = self.error_ids.value_mut() {
             items.truncate(100);
         }
@@ -581,6 +583,23 @@ mod tests {
         assert!(replay_value.error_ids.value().unwrap().len() == 100);
         assert!(replay_value.trace_ids.value().unwrap().len() == 100);
         assert!(replay_value.urls.value().unwrap().len() == 100);
+    }
+
+    #[test]
+    fn test_truncated_list_less_than_limit() {
+        let mut replay = Annotated::new(Replay {
+            urls: Annotated::new(Vec::new()),
+            error_ids: Annotated::new(Vec::new()),
+            trace_ids: Annotated::new(Vec::new()),
+            ..Default::default()
+        });
+
+        let replay_value = replay.value_mut().as_mut().unwrap();
+        replay_value.normalize_array_fields();
+
+        assert!(replay_value.error_ids.value().unwrap().is_empty());
+        assert!(replay_value.trace_ids.value().unwrap().is_empty());
+        assert!(replay_value.urls.value().unwrap().is_empty());
     }
 
     fn simple_enabled_config() -> DataScrubbingConfig {

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -260,23 +260,18 @@ impl Replay {
     }
 
     fn normalize_array_fields(&mut self) {
-        let new_error_ids = self.error_ids.value_mut().as_mut().map(|items| {
+        if let Some(items) = self.error_ids.value_mut() {
             items.truncate(100);
-            items.to_owned()
-        });
-        self.error_ids.set_value(new_error_ids);
+        }
 
-        let new_trace_ids = self.trace_ids.value_mut().as_mut().map(|items| {
+        if let Some(items) = self.trace_ids.value_mut() {
             items.truncate(100);
-            items.to_owned()
-        });
-        self.trace_ids.set_value(new_trace_ids);
+        }
 
-        let new_urls = self.urls.value_mut().as_mut().map(|items| {
+        if let Some(items) = self.urls.value_mut() {
             items.truncate(100);
-            items.to_owned()
-        });
-        self.urls.set_value(new_urls);
+        }
+
     }
 
     fn normalize_ip_address(&mut self, ip_address: Option<RealIPAddr>) {


### PR DESCRIPTION
Caps the size of the `error_ids`, `trace_ids`, and `urls` arrays to a maximum of 100 array items.  This will prevent very large messages from being produced to our Snuba consumer.  It will also reduce the number of "failed to produce message to Kafka ..." log messages in Relay.

#skip-changelog

closes: https://github.com/getsentry/replay-backend/issues/289