### PR TITLE
chore(build): Update rust toolchain to 1.68.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM centos:7 AS relay-deps
 
 # Pin the Rust version for now
-ARG RUST_TOOLCHAIN_VERSION=1.67.1
+ARG RUST_TOOLCHAIN_VERSION=1.68.0
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM centos:7 AS relay-deps
 
 # Pin the Rust version for now
-ARG RUST_TOOLCHAIN_VERSION=1.67.1
+ARG RUST_TOOLCHAIN_VERSION=1.68.0
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \


### PR DESCRIPTION
Update Rust to the current latest `1.68.0`

#skip-changelog