### PR TITLE
feat(normalization): Optionally mark scrubbed transactions as sanitized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Scrub `span.data.http.query` with default scrubbers. ([#1889](https://github.com/getsentry/relay/pull/1889))
 - Synthesize new class attribute in device context using specs found on the device, such as processor_count, memory_size, etc. ([#1895](https://github.com/getsentry/relay/pull/1895))
 - Add `thread.state` field to protocol. ([#1896](https://github.com/getsentry/relay/pull/1896))
+- Optionally mark scrubbed URL transactions as sanitized. ([#1917](https://github.com/getsentry/relay/pull/1917))
 
 **Bug Fixes**:
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -124,8 +124,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         measurements_config: None, // only supported in relay
         breakdowns_config: None,   // only supported in relay
         normalize_user_agent: config.normalize_user_agent,
-        normalize_transaction_name: false, // only supported in relay
-        tx_name_rules: &[],                // only supported in relay
+        transaction_name_config: Default::default(), // only supported in relay
         is_renormalize: config.is_renormalize.unwrap_or(false),
     };
     light_normalize_event(&mut event, &light_normalization_config)?;

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         transaction_name_config: Default::default(), // only supported in relay
         is_renormalize: config.is_renormalize.unwrap_or(false),
     };
-    light_normalize_event(&mut event, &light_normalization_config)?;
+    light_normalize_event(&mut event, light_normalization_config)?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;
     RelayStr::from_string(event.to_json()?)
 }

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -17,7 +17,11 @@ pub enum Feature {
     /// Replacing UUIDs, SHAs and numerical IDs by placeholders.
     #[serde(rename = "organizations:transaction-name-normalize")]
     TransactionNameNormalize,
-
+    /// True if transaction names scrubbed by regex patterns should be marked as "sanitized".
+    ///
+    /// Transaction names modified by clusterer rules are always marked as such.
+    #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]
+    TransactionNameMarkScrubbedAsSanitized,
     /// Unused.
     ///
     /// This used to control the initial experimental metrics extraction for sessions and has been

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -661,7 +661,7 @@ fn normalize_logentry(logentry: &mut Annotated<LogEntry>, _meta: &mut Meta) -> P
     logentry.apply(|le, meta| logentry::normalize_logentry(le, meta))
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct LightNormalizationConfig<'a> {
     pub client_ip: Option<&'a IpAddr>,
     pub user_agent: RawUserAgentInfo<&'a str>,
@@ -677,7 +677,7 @@ pub struct LightNormalizationConfig<'a> {
 
 pub fn light_normalize_event(
     event: &mut Annotated<Event>,
-    config: &LightNormalizationConfig,
+    config: LightNormalizationConfig,
 ) -> ProcessingResult {
     if config.is_renormalize {
         return Ok(());
@@ -689,7 +689,7 @@ pub fn light_normalize_event(
         // TODO: Parts of this processor should probably be a filter so we
         // can revert some changes to ProcessingAction)
         let mut transactions_processor =
-            transactions::TransactionsProcessor::new(&config.transaction_name_config);
+            transactions::TransactionsProcessor::new(config.transaction_name_config);
         transactions_processor.process_event(event, meta, ProcessingState::root())?;
 
         // Check for required and non-empty values
@@ -1130,7 +1130,7 @@ mod tests {
         let config = StoreConfig::default();
         let mut processor = NormalizeProcessor::new(Arc::new(config), None);
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let ip_addr = get_value!(event.user.ip_address!);
@@ -1158,7 +1158,7 @@ mod tests {
         let config = StoreConfig::default();
         let mut processor = NormalizeProcessor::new(Arc::new(config), None);
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(Annotated::empty(), event.value().unwrap().user);
@@ -1182,7 +1182,7 @@ mod tests {
             client_ip: Some(&ip_address),
             ..Default::default()
         };
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let ip_addr = get_value!(event.user.ip_address!);
@@ -1211,7 +1211,7 @@ mod tests {
             client_ip: Some(&ip_address),
             ..Default::default()
         };
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let user = get_value!(event.user!);
@@ -1237,7 +1237,7 @@ mod tests {
             client_ip: Some(&ip_address),
             ..Default::default()
         };
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let user = get_value!(event.user!);
@@ -1250,7 +1250,7 @@ mod tests {
         let processor = &mut NormalizeProcessor::default();
         let mut event = Annotated::new(Event::default());
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, processor, ProcessingState::root()).unwrap();
         assert_eq!(get_value!(event.level), Some(&Level::Error));
     }
@@ -1282,7 +1282,7 @@ mod tests {
             ..Event::default()
         });
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, processor, ProcessingState::root()).unwrap();
         assert_eq!(get_value!(event.level), Some(&Level::Info));
     }
@@ -1299,7 +1299,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let event = event.value().unwrap();
@@ -1321,7 +1321,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let event = event.value().unwrap();
@@ -1339,7 +1339,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
         assert_eq!(get_value!(event.environment), None);
     }
@@ -1353,7 +1353,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let environment = get_path!(event.environment!);
@@ -1379,7 +1379,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let release = get_path!(event.release!);
@@ -1413,7 +1413,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(get_value!(event.site), None);
@@ -1468,7 +1468,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(get_value!(event.tags!).len(), 1);
@@ -1496,7 +1496,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1548,7 +1548,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         // should keep the first occurrence of every tag
@@ -1610,7 +1610,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1709,7 +1709,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1742,7 +1742,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let dist = &event.value().unwrap().dist;
@@ -1778,7 +1778,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1808,7 +1808,7 @@ mod tests {
         );
 
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1831,7 +1831,7 @@ mod tests {
         let mut processor = NormalizeProcessor::default();
 
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(get_value!(event.received!), get_value!(event.timestamp!));
@@ -1858,7 +1858,7 @@ mod tests {
         );
 
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
@@ -1905,7 +1905,7 @@ mod tests {
 
         let mut processor = NormalizeProcessor::default();
         let config = LightNormalizationConfig::default();
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_json_snapshot!(SerializableAnnotated(&event), {".received" => "[received]"}, @r###"
@@ -1968,7 +1968,7 @@ mod tests {
             max_secs_in_future,
             ..Default::default()
         };
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
@@ -2027,7 +2027,7 @@ mod tests {
             max_secs_in_future,
             ..Default::default()
         };
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
@@ -2273,19 +2273,19 @@ mod tests {
             event
         }
 
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config.clone()).unwrap();
         let first = remove_received_from_event(&mut event.clone())
             .to_json()
             .unwrap();
         // Expected some fields (such as timestamps) exist after first light normalization.
 
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config.clone()).unwrap();
         let second = remove_received_from_event(&mut event.clone())
             .to_json()
             .unwrap();
         assert_eq!(&first, &second, "idempotency check failed");
 
-        light_normalize_event(&mut event, &config).unwrap();
+        light_normalize_event(&mut event, config).unwrap();
         let third = remove_received_from_event(&mut event.clone())
             .to_json()
             .unwrap();
@@ -2399,7 +2399,7 @@ mod tests {
                 .spans
                 .set_value(Some(vec![Annotated::<Span>::from_json(span).unwrap()]));
 
-            let res = light_normalize_event(&mut modified_event, &Default::default());
+            let res = light_normalize_event(&mut modified_event, Default::default());
 
             assert!(res.is_err(), "{span:?}");
         }
@@ -2419,7 +2419,7 @@ mod tests {
 
         let result = light_normalize_event(
             &mut event,
-            &LightNormalizationConfig {
+            LightNormalizationConfig {
                 is_renormalize: true,
                 ..Default::default()
             },

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -455,6 +455,7 @@ mod tests {
 
     use chrono::offset::TimeZone;
     use chrono::{Duration, Utc};
+    use insta::assert_debug_snapshot;
     use similar_asserts::assert_eq;
 
     use crate::processor::process_value;
@@ -2030,6 +2031,22 @@ mod tests {
            }
          }
          "###);
+    }
+
+    #[test]
+    fn test_normalize_transaction_names() {
+        let should_be_replaced = [
+            "/aaa11111-aa11-11a1-a11a-1aaa1111a111",
+            "/1aa111aa-11a1-11aa-a111-a1a11111aa11",
+            "/00a00000-0000-0000-0000-000000000001",
+            "/test/b25feeaa-ed2d-4132-bcbd-6232b7922add/url",
+        ];
+        let replaced = should_be_replaced.map(|s| {
+            let mut s = Annotated::new(s.to_owned());
+            scrub_identifiers(&mut s).unwrap();
+            s.0.unwrap()
+        });
+        assert_debug_snapshot!(replaced);
     }
 
     macro_rules! transaction_name_test {

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1593,7 +1593,10 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(true, &[]),
+            &mut TransactionsProcessor::new(&TransactionNameConfig {
+                scrub_identifiers: true,
+                ..Default::default()
+            }),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1678,46 +1681,6 @@ mod tests {
           }
         }
         "###);
-    }
-
-    /// When no identifiers are scrubbed, we should not set an original value in _meta.
-    #[test]
-    fn test_transaction_name_skip_original_value() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "/foo/static/page",
-            "transaction_info": {
-              "source": "url"
-            },
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {
-                "trace": {
-                    "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
-                    "span_id": "fa90fdead5f74053",
-                    "op": "rails.request",
-                    "status": "ok"
-                }
-            },
-            "sdk": {"name": "sentry.ruby"},
-            "modules": {"rack": "1.2.3"}
-
-        }
-        "#;
-        let mut event = Annotated::<Event>::from_json(json).unwrap();
-
-        process_value(
-            &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
-                scrub_identifiers: true,
-                ..Default::default()
-            }),
-            ProcessingState::root(),
-        )
-        .unwrap();
-
-        assert!(event.meta().is_empty());
     }
 
     #[test]

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -282,6 +282,11 @@ fn normalize_transaction_name(transaction: &mut Annotated<String>) -> Processing
             }
         }
 
+        if caps.is_empty() {
+            // Nothing to do for this transaction.
+            return Ok(());
+        }
+
         // Sort by the capture end position.
         caps.sort_by_key(|(capture, _)| capture.end());
         let mut changed = String::with_capacity(trans.len());
@@ -1524,7 +1529,7 @@ mod tests {
         "###);
     }
 
-    /// When no identifiers are scrubbed, we should not set an original value.
+    /// When no identifiers are scrubbed, we should not set an original value in _meta.
     #[test]
     fn test_transaction_name_skip_original_value() {
         let json = r#"
@@ -1558,33 +1563,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
-        {
-          "type": "transaction",
-          "transaction": "/foo/static/page",
-          "transaction_info": {
-            "source": "url"
-          },
-          "modules": {
-            "rack": "1.2.3"
-          },
-          "timestamp": 1619420400.0,
-          "start_timestamp": 1619420341.0,
-          "contexts": {
-            "trace": {
-              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
-              "span_id": "fa90fdead5f74053",
-              "op": "rails.request",
-              "status": "ok",
-              "type": "trace"
-            }
-          },
-          "sdk": {
-            "name": "sentry.ruby"
-          },
-          "spans": [],
-        }
-        "###);
+        assert!(event.meta().is_empty());
     }
 
     #[test]

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -12,7 +12,7 @@ use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Remark, 
 use super::TransactionNameRule;
 
 /// Configuration around removing high-cardinality parts of URL transactions.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TransactionNameConfig<'r> {
     /// True if regex patterns should be applied to erase identifiers from the transaction name.
     pub scrub_identifiers: bool,
@@ -25,12 +25,13 @@ pub struct TransactionNameConfig<'r> {
 }
 
 /// Rejects transactions based on required fields.
+#[derive(Default)]
 pub struct TransactionsProcessor<'r> {
-    name_config: &'r TransactionNameConfig<'r>,
+    name_config: TransactionNameConfig<'r>,
 }
 
 impl<'r> TransactionsProcessor<'r> {
-    pub fn new(name_config: &'r TransactionNameConfig<'r>) -> Self {
+    pub fn new(name_config: TransactionNameConfig<'r>) -> Self {
         Self { name_config }
     }
 
@@ -71,19 +72,6 @@ impl<'r> TransactionsProcessor<'r> {
             })?;
         }
         Ok(())
-    }
-}
-
-impl<'r> Default for TransactionsProcessor<'r> {
-    fn default() -> Self {
-        const NAME_CONFIG: TransactionNameConfig = TransactionNameConfig {
-            scrub_identifiers: false,
-            mark_scrubbed_as_sanitized: false,
-            rules: &[],
-        };
-        Self {
-            name_config: &NAME_CONFIG,
-        }
     }
 }
 
@@ -1506,7 +1494,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 scrub_identifiers: true,
                 ..Default::default()
             }),
@@ -1593,7 +1581,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 scrub_identifiers: true,
                 ..Default::default()
             }),
@@ -1630,7 +1618,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: true,
                 ..Default::default()
@@ -1733,7 +1721,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 rules: rules.as_ref(),
                 ..Default::default()
             }),
@@ -1789,7 +1777,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 rules: rules.as_ref(),
                 ..Default::default()
             }),
@@ -1879,7 +1867,7 @@ mod tests {
         // This must not normalize transaction name, since it's disabled.
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 rules: rules.as_ref(),
                 ..Default::default()
             }),
@@ -1946,7 +1934,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(&TransactionNameConfig {
+            &mut TransactionsProcessor::new(TransactionNameConfig {
                 rules: &[rule],
                 ..Default::default()
             }),
@@ -2043,7 +2031,7 @@ mod tests {
 
                 process_value(
                     &mut event,
-                    &mut TransactionsProcessor::new(&TransactionNameConfig {
+                    &mut TransactionsProcessor::new(TransactionNameConfig {
                         scrub_identifiers: true,
                         ..Default::default()
                     }),

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -14,9 +14,7 @@ use super::TransactionNameRule;
 /// Configuration around removing high-cardinality parts of URL transactions.
 #[derive(Debug, Default)]
 pub struct TransactionNameConfig<'r> {
-    /// True if identifiers should be erased from the transaction name.
-    ///
-    /// Applies both pattern-based rules and rules discovered by the clusterer.
+    /// True if regex patterns should be applied to erase identifiers from the transaction name.
     pub scrub_identifiers: bool,
     /// True if transaction names scrubbed by regex patterns should be marked as [`TransactionSource::Sanitized`].
     ///
@@ -282,6 +280,7 @@ fn set_default_transaction_source(event: &mut Event) {
 /// Normalize the transaction name.
 ///
 /// Replaces UUIDs, SHAs and numerical IDs in transaction names by placeholders.
+/// Returns `Ok(true)` if the name was changed.
 fn scrub_identifiers(transaction: &mut Annotated<String>) -> Result<bool, ProcessingAction> {
     let capture_names = TRANSACTION_NAME_NORMALIZER_REGEX
         .capture_names()

--- a/relay-general/tests/test_fixtures.rs
+++ b/relay-general/tests/test_fixtures.rs
@@ -74,7 +74,7 @@ macro_rules! event_snapshot {
                 let config = StoreConfig::default();
                 let mut processor = StoreProcessor::new(config, None);
                 let config = LightNormalizationConfig::default();
-                light_normalize_event(&mut event, &config).unwrap();
+                light_normalize_event(&mut event, config).unwrap();
                 process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
                 let pii_config = pii_config();

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2209,7 +2209,7 @@ impl EnvelopeProcessorService {
         };
 
         metric!(timer(RelayTimers::EventProcessingLightNormalization), {
-            relay_general::store::light_normalize_event(&mut state.event, &config)
+            relay_general::store::light_normalize_event(&mut state.event, config)
                 .map_err(|_| ProcessingError::InvalidTransaction)?;
         });
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -30,7 +30,7 @@ use relay_general::protocol::{
     LenientString, Metrics, RelayInfo, Replay, ReplayError, SecurityReportType, SessionAggregates,
     SessionAttributes, SessionStatus, SessionUpdate, Timestamp, UserReport, Values,
 };
-use relay_general::store::{ClockDriftProcessor, LightNormalizationConfig};
+use relay_general::store::{ClockDriftProcessor, LightNormalizationConfig, TransactionNameConfig};
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
 use relay_log::LogError;
 use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric};
@@ -2195,10 +2195,15 @@ impl EnvelopeProcessorService {
             measurements_config: state.project_state.config.measurements.as_ref(),
             breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
             normalize_user_agent: Some(true),
-            normalize_transaction_name: state
-                .project_state
-                .has_feature(Feature::TransactionNameNormalize),
-            tx_name_rules: &state.project_state.config.tx_name_rules,
+            transaction_name_config: TransactionNameConfig {
+                scrub_identifiers: state
+                    .project_state
+                    .has_feature(Feature::TransactionNameNormalize),
+                mark_scrubbed_as_sanitized: state
+                    .project_state
+                    .has_feature(Feature::TransactionNameMarkScrubbedAsSanitized),
+                rules: &state.project_state.config.tx_name_rules,
+            },
 
             is_renormalize: false,
         };

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -564,7 +564,7 @@ mod tests {
         // Normalize first, to make sure that all things are correct as in the real pipeline:
         let res = store::light_normalize_event(
             &mut event,
-            &LightNormalizationConfig {
+            LightNormalizationConfig {
                 breakdowns_config: Some(&breakdowns_config),
                 ..Default::default()
             },
@@ -709,7 +709,7 @@ mod tests {
         let mut event = Annotated::from_json(json).unwrap();
 
         // Normalize first, to make sure the units are correct:
-        let res = store::light_normalize_event(&mut event, &LightNormalizationConfig::default());
+        let res = store::light_normalize_event(&mut event, LightNormalizationConfig::default());
         assert!(res.is_ok(), "{res:?}");
 
         let mut metrics = vec![];
@@ -801,7 +801,7 @@ mod tests {
         let mut event = Annotated::from_json(json).unwrap();
 
         // Normalize first, to make sure the units are correct:
-        let res = store::light_normalize_event(&mut event, &LightNormalizationConfig::default());
+        let res = store::light_normalize_event(&mut event, LightNormalizationConfig::default());
         assert!(res.is_ok(), "{res:?}");
 
         let mut metrics = vec![];
@@ -948,7 +948,7 @@ mod tests {
         .unwrap();
         let res = store::light_normalize_event(
             &mut event,
-            &LightNormalizationConfig {
+            LightNormalizationConfig {
                 measurements_config: Some(&measurements_config),
                 ..Default::default()
             },
@@ -1725,7 +1725,7 @@ mod tests {
 
         let mut event = Annotated::from_json(json).unwrap();
         // Normalize first, to make sure that the metrics were computed:
-        let _ = store::light_normalize_event(&mut event, &LightNormalizationConfig::default());
+        let _ = store::light_normalize_event(&mut event, LightNormalizationConfig::default());
 
         let mut metrics = vec![];
         let mut sampling_metrics = vec![];

--- a/tools/process-event/src/main.rs
+++ b/tools/process-event/src/main.rs
@@ -84,7 +84,7 @@ impl Cli {
         }
 
         if self.store {
-            light_normalize_event(&mut event, &LightNormalizationConfig::default())
+            light_normalize_event(&mut event, LightNormalizationConfig::default())
                 .map_err(|e| format_err!("{}", e))?;
             let mut processor = StoreProcessor::new(StoreConfig::default(), None);
             process_value(&mut event, &mut processor, ProcessingState::root())


### PR DESCRIPTION
If the corresponding feature flag is set, mark transactions that were scrubbed by regex patterns as `sanitized` instead of `url`.

### Motivation

If we discovered identifiers in a URL transaction by pattern matching, we previously did not risk marking it as `sanitized`, because it could theoretically still contain user names or other high-cardinality identifiers. But in practice this seems to conservative, and we'd rather assume that a URL scrubbed by pattern matching is low-cardinality enough.

### Risks

If there is a second identifier in the URL that neither the pattern-matching nor the clusterer discovered, we mark something high-cardinality as low-cardinality. This might add noise to the product and an increase in transaction metrics being rate-limited by the cardinality limiter.

https://github.com/getsentry/team-ingest/issues/69