### PR TITLE
chore: Apply import grouping from coding style

### DIFF
--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -9,11 +9,12 @@ use std::str::FromStr;
 use chrono::{DateTime, Duration, Utc};
 use data_encoding::BASE64URL_NOPAD;
 use hmac::{Hmac, Mac};
-use rand::{rngs::OsRng, thread_rng, RngCore};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sha2::Sha512;
-
+use rand::rngs::OsRng;
+use rand::{thread_rng, RngCore};
 use relay_common::{UnixTimestamp, Uuid};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use sha2::Sha512;
 
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
 

--- a/relay-aws-extension/src/aws_extension.rs
+++ b/relay-aws-extension/src/aws_extension.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 use std::fmt;
 use std::ops::ControlFlow;
 
+use relay_system::{Controller, Service, Signal, SignalType};
 use reqwest::{Client, ClientBuilder, StatusCode, Url};
 use serde::Deserialize;
-
-use relay_system::{Controller, Service, Signal, SignalType};
 
 const EXTENSION_NAME: &str = "sentry-lambda-extension";
 const EXTENSION_NAME_HEADER: &str = "Lambda-Extension-Name";

--- a/relay-cabi/src/auth.rs
+++ b/relay-cabi/src/auth.rs
@@ -1,10 +1,9 @@
 use chrono::Duration;
-use serde::Serialize;
-
 use relay_auth::{
     generate_key_pair, generate_relay_id, PublicKey, RegisterRequest, RegisterResponse, RelayId,
     RelayVersion, SecretKey,
 };
+use serde::Serialize;
 
 use crate::core::{RelayBuf, RelayStr, RelayUuid};
 

--- a/relay-cabi/src/constants.rs
+++ b/relay-cabi/src/constants.rs
@@ -1,6 +1,6 @@
-use crate::core::RelayStr;
-
 pub use relay_common::{DataCategory, EventType, SpanStatus};
+
+use crate::core::RelayStr;
 
 /// Returns the API name of the given `DataCategory`.
 #[no_mangle]

--- a/relay-cabi/src/core.rs
+++ b/relay-cabi/src/core.rs
@@ -1,9 +1,6 @@
 use std::ffi::CStr;
-use std::mem;
 use std::os::raw::c_char;
-use std::ptr;
-use std::slice;
-use std::str;
+use std::{mem, ptr, slice, str};
 
 use relay_common::Uuid;
 

--- a/relay-cabi/src/ffi.rs
+++ b/relay-cabi/src/ffi.rs
@@ -1,9 +1,8 @@
-use sentry_release_parser::InvalidRelease;
-
 use relay_auth::{KeyParseError, UnpackError};
 use relay_ffi::Panic;
 use relay_general::store::GeoIpError;
 use relay_general::types::ProcessingAction;
+use sentry_release_parser::InvalidRelease;
 
 use crate::core::RelayStr;
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -9,7 +9,6 @@ use std::os::raw::c_char;
 use std::slice;
 
 use once_cell::sync::OnceCell;
-
 use relay_common::{codeowners_match_bytes, glob_match_bytes, GlobOptions};
 use relay_dynamic_config::{validate_json, ProjectConfig};
 use relay_general::pii::{

--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -13,14 +13,13 @@ mod glob;
 mod project;
 mod time;
 
+pub use sentry_types::protocol::LATEST as PROTOCOL_VERSION;
+pub use sentry_types::{Auth, Dsn, ParseAuthError, ParseDsnError, Scheme};
+#[doc(inline)]
+pub use uuid::Uuid;
+
 pub use crate::constants::*;
 pub use crate::glob::*;
 pub use crate::macros::*;
 pub use crate::project::*;
 pub use crate::time::*;
-
-pub use sentry_types::protocol::LATEST as PROTOCOL_VERSION;
-pub use sentry_types::{Auth, Dsn, ParseAuthError, ParseDsnError, Scheme};
-
-#[doc(inline)]
-pub use uuid::Uuid;

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -270,8 +270,9 @@ impl<'de> Deserialize<'de> for UnixTimestamp {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+
+    use super::*;
 
     #[test]
     fn test_parse_timestamp_int() {

--- a/relay-config/src/byte_size.rs
+++ b/relay-config/src/byte_size.rs
@@ -2,10 +2,10 @@ use std::convert::TryInto;
 use std::fmt;
 use std::str::FromStr;
 
-use serde::{de, ser::Serializer, Serialize};
-
 pub use human_size::ParsingError as ByteSizeParseError;
 use human_size::{Any, Size, SpecificSize};
+use serde::ser::Serializer;
+use serde::{de, Serialize};
 
 /// Represents a size in bytes.
 ///

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1,20 +1,14 @@
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryInto;
-use std::env;
 use std::error::Error;
-use std::fmt;
-use std::fs;
-use std::io;
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
+use std::{env, fmt, fs, io};
 
 use anyhow::Context;
-use serde::de::{Unexpected, Visitor};
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
-
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
 use relay_common::{Dsn, Uuid};
 use relay_kafka::{
@@ -22,6 +16,8 @@ use relay_kafka::{
 };
 use relay_metrics::AggregatorConfig;
 use relay_redis::RedisConfig;
+use serde::de::{DeserializeOwned, Unexpected, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::byte_size::ByteSize;
 use crate::upstream::UpstreamDescriptor;
@@ -1047,9 +1043,9 @@ impl ConfigObject for MinimalConfig {
 
 /// Alternative serialization of RelayInfo for config file using snake case.
 mod config_relay_info {
-    use super::*;
-
     use serde::ser::SerializeMap;
+
+    use super::*;
 
     // Uses snake_case as opposed to camelCase.
     #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/relay-config/src/upstream.rs
+++ b/relay-config/src/upstream.rs
@@ -1,12 +1,10 @@
 use std::borrow::Cow;
-use std::fmt;
-use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
-
-use url::Url;
+use std::{fmt, io};
 
 use relay_common::{Dsn, Scheme};
+use url::Url;
 
 /// Indicates failures in the upstream error api.
 #[derive(Debug, thiserror::Error)]

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -1,8 +1,5 @@
 use std::collections::BTreeSet;
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
 use relay_auth::PublicKey;
 use relay_filter::FiltersConfig;
 use relay_general::pii::{DataScrubbingConfig, PiiConfig};
@@ -10,6 +7,8 @@ use relay_general::store::{BreakdownsConfig, MeasurementsConfig, TransactionName
 use relay_general::types::SpanAttribute;
 use relay_quotas::Quota;
 use relay_sampling::SamplingConfig;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::feature::Feature;
 use crate::{ErrorBoundary, SessionMetricsConfig, TaggingRule, TransactionMetricsConfig};

--- a/relay-ffi/src/lib.rs
+++ b/relay-ffi/src/lib.rs
@@ -108,9 +108,7 @@
 
 use std::cell::RefCell;
 use std::error::Error;
-use std::fmt;
-use std::panic;
-use std::thread;
+use std::{fmt, panic, thread};
 
 pub use relay_ffi_macros::catch_unwind;
 

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -2,7 +2,6 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-
 use relay_general::protocol::{Event, Exception};
 
 use crate::{FilterConfig, FilterStatKey};
@@ -126,10 +125,10 @@ fn get_exception_source(event: &Event) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_general::protocol::{Frame, JsonLenientString, RawStacktrace, Stacktrace, Values};
     use relay_general::types::Annotated;
+
+    use super::*;
 
     /// Returns an event with the specified exception on the last position in the stack.
     fn get_event_with_exception(e: Exception) -> Event {

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -1,4 +1,5 @@
-use std::{convert::TryFrom, fmt};
+use std::convert::TryFrom;
+use std::fmt;
 
 use globset::GlobBuilder;
 use once_cell::sync::OnceCell;

--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -156,10 +156,10 @@ pub fn matches_any_origin(url: Option<&str>, origins: &[SchemeDomainPort]) -> bo
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_general::protocol::Csp;
     use relay_general::types::Annotated;
+
+    use super::*;
 
     fn get_csp_event(blocked_uri: Option<&str>, source_file: Option<&str>) -> Event {
         fn annotated_string_or_none(val: Option<&str>) -> Annotated<String> {

--- a/relay-filter/src/error_messages.rs
+++ b/relay-filter/src/error_messages.rs
@@ -58,11 +58,10 @@ pub fn should_filter(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_general::protocol::{Exception, LogEntry, Values};
     use relay_general::types::Annotated;
 
+    use super::*;
     use crate::GlobPatterns;
 
     #[test]

--- a/relay-filter/src/legacy_browsers.rs
+++ b/relay-filter/src/legacy_browsers.rs
@@ -150,10 +150,9 @@ mod tests {
     const SAFARI_6_UA: &str =
         "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.17.4; en-GB) AppleWebKit/605.1.5 (KHTML, like Gecko) Version/6.0 Safari/605.1.5";
 
-    use super::*;
-
     use std::collections::BTreeSet;
 
+    use super::*;
     use crate::testutils;
 
     fn get_legacy_browsers_config(

--- a/relay-filter/src/localhost.rs
+++ b/relay-filter/src/localhost.rs
@@ -1,7 +1,6 @@
 //! Implements filtering for events originating from the localhost
-use url::Url;
-
 use relay_general::protocol::Event;
+use url::Url;
 
 use crate::{FilterConfig, FilterStatKey};
 
@@ -54,10 +53,10 @@ fn get_url(event: &Event) -> Option<Url> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_general::protocol::{IpAddr, Request, User};
     use relay_general::types::Annotated;
+
+    use super::*;
 
     fn get_event_with_ip_addr(val: &str) -> Event {
         Event {

--- a/relay-filter/src/releases.rs
+++ b/relay-filter/src/releases.rs
@@ -21,11 +21,10 @@ pub fn should_filter(event: &Event, config: &ReleasesFilterConfig) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_general::protocol::{Event, LenientString};
     use relay_general::types::Annotated;
 
+    use super::*;
     use crate::GlobPatterns;
 
     fn get_event_for_release(release: &str) -> Event {

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -2,7 +2,6 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-
 use relay_general::protocol::Event;
 use relay_general::user_agent;
 
@@ -71,7 +70,6 @@ pub fn should_filter(event: &Event, config: &FilterConfig) -> Result<(), FilterS
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::testutils;
 
     #[test]

--- a/relay-general/benches/benchmarks.rs
+++ b/relay-general/benches/benchmarks.rs
@@ -1,8 +1,6 @@
-use std::fmt;
-use std::fs;
+use std::{fmt, fs};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-
 use relay_general::pii::{DataScrubbingConfig, PiiProcessor};
 use relay_general::processor::{process_value, SelectorSpec};
 use relay_general::protocol::{Event, IpAddr};

--- a/relay-general/src/pii/attachments.rs
+++ b/relay-general/src/pii/attachments.rs
@@ -507,9 +507,8 @@ impl<'a> PiiAttachmentsProcessor<'a> {
 mod tests {
     use itertools::Itertools;
 
-    use crate::pii::PiiConfig;
-
     use super::*;
+    use crate::pii::PiiConfig;
 
     enum AttachmentBytesTestCase<'a> {
         Builtin {

--- a/relay-general/src/pii/builtin.rs
+++ b/relay-general/src/pii/builtin.rs
@@ -353,15 +353,15 @@ declare_builtin_rules! {
 // TODO: Move these tests to /tests
 #[cfg(test)]
 mod tests {
-    use similar_asserts::assert_eq;
     use std::collections::BTreeMap;
 
+    use similar_asserts::assert_eq;
+
+    use super::*;
     use crate::pii::config::PiiConfig;
     use crate::pii::processor::PiiProcessor;
     use crate::processor::{process_value, ProcessingState, ValueType};
     use crate::types::{Annotated, Remark, RemarkType};
-
-    use super::*;
 
     #[derive(Clone, Debug, PartialEq, Empty, FromValue, ProcessValue, IntoValue)]
     struct FreeformRoot {

--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -3,9 +3,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use once_cell::sync::OnceCell;
 use regex::{Regex, RegexBuilder};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use relay_log::LogError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::pii::{CompiledPiiConfig, Redaction};
 use crate::processor::SelectorSpec;

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -129,6 +129,7 @@ pub fn to_pii_config(
 mod tests {
     use similar_asserts::assert_eq;
 
+    use super::to_pii_config as to_pii_config_impl;
     /// These tests are ported from Sentry's Python testsuite (test_data_scrubber). Each testcase
     /// has an equivalent testcase in Python.
     use crate::pii::{DataScrubbingConfig, PiiConfig, PiiProcessor};
@@ -137,8 +138,6 @@ mod tests {
     use crate::store::{StoreConfig, StoreProcessor};
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::FromValue;
-
-    use super::to_pii_config as to_pii_config_impl;
 
     fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiConfig> {
         let rv = to_pii_config_impl(datascrubbing_config).unwrap();

--- a/relay-general/src/pii/generate_selectors.rs
+++ b/relay-general/src/pii/generate_selectors.rs
@@ -147,9 +147,8 @@ pub fn selector_suggestions_from_value<T: ProcessValue>(
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::Event;
-
     use super::*;
+    use crate::protocol::Event;
 
     #[test]
     fn test_empty() {

--- a/relay-general/src/pii/legacy.rs
+++ b/relay-general/src/pii/legacy.rs
@@ -6,9 +6,8 @@
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
-use crate::pii::{convert, is_flag_default, PiiConfig};
-
 use super::config::PiiConfigError;
+use crate::pii::{convert, is_flag_default, PiiConfig};
 
 /// Configuration for Sentry's datascrubbing
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/relay-general/src/pii/minidumps.rs
+++ b/relay-general/src/pii/minidumps.rs
@@ -322,11 +322,11 @@ impl PiiAttachmentsProcessor<'_> {
 
 #[cfg(test)]
 mod tests {
-    use minidump::{format::RVA, MinidumpModule, Module};
-
-    use crate::pii::PiiConfig;
+    use minidump::format::RVA;
+    use minidump::{MinidumpModule, Module};
 
     use super::*;
+    use crate::pii::PiiConfig;
 
     struct TestScrubber {
         orig_dump: Minidump<'static, &'static [u8]>,

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -366,6 +366,7 @@ mod tests {
 
     use std::collections::BTreeMap;
 
+    use super::*;
     use crate::pii::{DataScrubbingConfig, PiiConfig, ReplaceRedaction};
     use crate::processor::process_value;
     use crate::protocol::{
@@ -374,8 +375,6 @@ mod tests {
     };
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::{Annotated, Object, Value};
-
-    use super::*;
 
     #[test]
     fn test_basic_stripping() {

--- a/relay-general/src/processor/impls.rs
+++ b/relay-general/src/processor/impls.rs
@@ -1,5 +1,4 @@
 use enumset::EnumSet;
-
 use relay_common::Uuid;
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};

--- a/relay-general/src/processor/size.rs
+++ b/relay-general/src/processor/size.rs
@@ -436,9 +436,8 @@ impl<'a> ser::SerializeStructVariant for &'a mut SizeEstimatingSerializer {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{Annotated, Object, Value};
-
     use super::*;
+    use crate::types::{Annotated, Object, Value};
 
     #[test]
     fn test_estimate_size() {

--- a/relay-general/src/protocol/breadcrumb.rs
+++ b/relay-general/src/protocol/breadcrumb.rs
@@ -125,9 +125,8 @@ pub struct Breadcrumb {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_breadcrumb_roundtrip() {

--- a/relay-general/src/protocol/clientsdk.rs
+++ b/relay-general/src/protocol/clientsdk.rs
@@ -81,9 +81,8 @@ impl ClientSdkInfo {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_client_sdk_roundtrip() {

--- a/relay-general/src/protocol/contexts/browser.rs
+++ b/relay-general/src/protocol/contexts/browser.rs
@@ -2,9 +2,8 @@ use once_cell::sync::OnceCell;
 use regex::Regex;
 
 use crate::protocol::FromUserAgentInfo;
-use crate::store;
 use crate::types::{Annotated, Object, Value};
-use crate::user_agent;
+use crate::{store, user_agent};
 
 /// Web browser information.
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]

--- a/relay-general/src/protocol/contexts/cloud_resource.rs
+++ b/relay-general/src/protocol/contexts/cloud_resource.rs
@@ -65,9 +65,8 @@ impl CloudResourceContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::Context;
-
     use super::*;
+    use crate::protocol::Context;
 
     #[test]
     pub(crate) fn test_cloud_resource_context_roundtrip() {

--- a/relay-general/src/protocol/contexts/device.rs
+++ b/relay-general/src/protocol/contexts/device.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::protocol::FromUserAgentInfo;
 use crate::store::user_agent::is_known;
 use crate::types::{Annotated, Object, Value};
 use crate::user_agent::{parse_device, ClientHints};
-use serde::{Deserialize, Serialize};
 
 #[derive(
     Clone,
@@ -232,8 +233,7 @@ impl FromUserAgentInfo for DeviceContext {
 #[cfg(test)]
 mod tests {
     use crate::protocol::contexts::device::DeviceClass;
-    use crate::protocol::{DeviceContext, FromUserAgentInfo};
-    use crate::protocol::{Headers, PairList};
+    use crate::protocol::{DeviceContext, FromUserAgentInfo, Headers, PairList};
     use crate::types::{Annotated, Object, Value};
     use crate::user_agent::RawUserAgentInfo;
 

--- a/relay-general/src/protocol/contexts/mod.rs
+++ b/relay-general/src/protocol/contexts/mod.rs
@@ -215,11 +215,10 @@ impl FromValue for Contexts {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::processor::{ProcessingState, Processor};
     use crate::protocol::Event;
     use crate::types::{Map, Meta, ProcessingResult};
-
-    use super::*;
 
     #[test]
     fn test_other_context_roundtrip() {

--- a/relay-general/src/protocol/contexts/otel.rs
+++ b/relay-general/src/protocol/contexts/otel.rs
@@ -32,9 +32,8 @@ impl OtelContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::Context;
-
     use super::*;
+    use crate::protocol::Context;
 
     #[test]
     pub(crate) fn test_otel_context_roundtrip() {

--- a/relay-general/src/protocol/contexts/profile.rs
+++ b/relay-general/src/protocol/contexts/profile.rs
@@ -1,6 +1,5 @@
-use crate::types::Annotated;
-
 use crate::protocol::EventId;
+use crate::types::Annotated;
 
 /// Profile context
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
@@ -20,9 +19,8 @@ impl ProfileContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::Context;
-
     use super::*;
+    use crate::protocol::Context;
 
     #[test]
     pub(crate) fn test_trace_context_roundtrip() {

--- a/relay-general/src/protocol/contexts/response.rs
+++ b/relay-general/src/protocol/contexts/response.rs
@@ -43,15 +43,12 @@ impl ResponseContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::{
-        pii::{DataScrubbingConfig, PiiProcessor},
-        processor::{process_value, ProcessingState},
-        protocol::{Context, Event, PairList},
-        store::{StoreConfig, StoreProcessor},
-        testutils::assert_annotated_snapshot,
-        types::{Annotated, FromValue},
-    };
+    use crate::pii::{DataScrubbingConfig, PiiProcessor};
+    use crate::processor::{process_value, ProcessingState};
+    use crate::protocol::{Context, Event, PairList};
+    use crate::store::{StoreConfig, StoreProcessor};
+    use crate::testutils::assert_annotated_snapshot;
+    use crate::types::{Annotated, FromValue};
 
     #[test]
     fn test_response_context_roundtrip() {

--- a/relay-general/src/protocol/contexts/trace.rs
+++ b/relay-general/src/protocol/contexts/trace.rs
@@ -190,9 +190,8 @@ impl TraceContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::Context;
-
     use super::*;
+    use crate::protocol::Context;
 
     #[test]
     pub(crate) fn test_trace_context_roundtrip() {

--- a/relay-general/src/protocol/debugmeta.rs
+++ b/relay-general/src/protocol/debugmeta.rs
@@ -2,15 +2,13 @@ use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
+use enumset::EnumSet;
+use relay_common::Uuid;
 #[cfg(feature = "jsonschema")]
 use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
-
-use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
-
-use relay_common::Uuid;
 
 use crate::processor::{ProcessValue, ProcessingState, Processor, ValueType};
 use crate::protocol::Addr;
@@ -535,9 +533,8 @@ pub struct DebugMeta {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_debug_image_proguard_roundtrip() {

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -1,14 +1,12 @@
 use std::fmt;
 use std::str::FromStr;
 
+use relay_common::Uuid;
 #[cfg(feature = "jsonschema")]
 use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
-
 use serde::{Serialize, Serializer};
-
-use relay_common::Uuid;
 
 use crate::macros::derive_string_meta_structure;
 use crate::processor::ProcessValue;
@@ -588,10 +586,9 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::protocol::TagEntry;
     use crate::types::{Map, Meta};
-
-    use super::*;
 
     #[test]
     fn test_event_roundtrip() {

--- a/relay-general/src/protocol/exception.rs
+++ b/relay-general/src/protocol/exception.rs
@@ -72,9 +72,8 @@ pub struct Exception {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_exception_roundtrip() {

--- a/relay-general/src/protocol/fingerprint.rs
+++ b/relay-general/src/protocol/fingerprint.rs
@@ -118,9 +118,8 @@ impl ProcessValue for Fingerprint {}
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Meta;
-
     use super::*;
+    use crate::types::Meta;
 
     #[test]
     fn test_fingerprint_string() {

--- a/relay-general/src/protocol/measurements.rs
+++ b/relay-general/src/protocol/measurements.rs
@@ -145,9 +145,8 @@ mod tests {
     use relay_common::DurationUnit;
     use similar_asserts::assert_eq;
 
-    use crate::protocol::Event;
-
     use super::*;
+    use crate::protocol::Event;
 
     #[test]
     fn test_measurements_serialization() {

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -260,9 +260,8 @@ impl FromValue for Mechanism {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_mechanism_roundtrip() {

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -311,8 +311,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use crate::pii::{DataScrubbingConfig, PiiProcessor};
-    use crate::processor::process_value;
-    use crate::processor::ProcessingState;
+    use crate::processor::{process_value, ProcessingState};
     use crate::protocol::{
         BrowserContext, Context, ContextInner, DeviceContext, EventId, OsContext, Replay, TagEntry,
         Tags,

--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -1,12 +1,11 @@
 use std::iter::{FromIterator, IntoIterator};
 
 use cookie::Cookie;
-use url::form_urlencoded;
-
 #[cfg(feature = "jsonschema")]
 use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
+use url::form_urlencoded;
 
 use crate::protocol::{JsonLenientString, LenientString, PairList};
 use crate::types::{Annotated, Error, FromValue, Object, Value};

--- a/relay-general/src/protocol/security_report.rs
+++ b/relay-general/src/protocol/security_report.rs
@@ -564,8 +564,9 @@ struct ExpectCtRaw {
 }
 
 mod serde_date_time_3339 {
-    use super::*;
     use serde::de::Visitor;
+
+    use super::*;
 
     pub fn serialize<S>(date_time: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1083,7 +1084,6 @@ impl SecurityReportType {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::testutils::assert_annotated_snapshot;
 
     #[test]

--- a/relay-general/src/protocol/session.rs
+++ b/relay-general/src/protocol/session.rs
@@ -2,9 +2,8 @@ use std::fmt::{self, Display};
 use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-
 use relay_common::Uuid;
+use serde::{Deserialize, Serialize};
 
 use crate::macros::derive_fromstr_and_display;
 use crate::protocol::utils::null_to_default;

--- a/relay-general/src/protocol/span.rs
+++ b/relay-general/src/protocol/span.rs
@@ -62,9 +62,8 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use similar_asserts::assert_eq;
 
-    use crate::protocol::HttpElement;
-
     use super::*;
+    use crate::protocol::HttpElement;
 
     #[test]
     fn test_span_serialization() {

--- a/relay-general/src/protocol/tags.rs
+++ b/relay-general/src/protocol/tags.rs
@@ -76,9 +76,8 @@ impl std::ops::DerefMut for Tags {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::protocol::Event;
-
     use super::*;
+    use crate::protocol::Event;
 
     #[test]
     fn test_tags_from_object() {

--- a/relay-general/src/protocol/templateinfo.rs
+++ b/relay-general/src/protocol/templateinfo.rs
@@ -36,9 +36,8 @@ pub struct TemplateInfo {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_template_roundtrip() {

--- a/relay-general/src/protocol/thread.rs
+++ b/relay-general/src/protocol/thread.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::processor::ProcessValue;
-use crate::protocol::RawStacktrace;
-use crate::protocol::Stacktrace;
+use crate::protocol::{RawStacktrace, Stacktrace};
 use crate::types::{
     Annotated, Empty, Error, FromValue, IntoValue, Object, SkipSerialization, Value,
 };
@@ -138,9 +137,8 @@ pub struct Thread {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Map;
-
     use super::*;
+    use crate::types::Map;
 
     #[test]
     fn test_thread_id() {

--- a/relay-general/src/protocol/types.rs
+++ b/relay-general/src/protocol/types.rs
@@ -1,19 +1,17 @@
 //! Common types of the protocol.
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::fmt;
 use std::iter::{FromIterator, IntoIterator};
-use std::net;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
+use std::{fmt, net};
 
 use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDateTime, TimeZone, Utc};
+use enumset::EnumSet;
 #[cfg(feature = "jsonschema")]
 use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
-
-use enumset::EnumSet;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};

--- a/relay-general/src/protocol/user.rs
+++ b/relay-general/src/protocol/user.rs
@@ -82,9 +82,8 @@ pub struct User {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::{Error, Map};
-
     use super::*;
+    use crate::types::{Error, Map};
 
     #[test]
     fn test_geo_roundtrip() {

--- a/relay-general/src/protocol/user_report.rs
+++ b/relay-general/src/protocol/user_report.rs
@@ -1,7 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 use crate::protocol::utils::null_to_default;
 use crate::protocol::EventId;
-
-use serde::{Deserialize, Serialize};
 
 /// User feedback for an event as sent by the client to the userfeedback/userreport endpoint.
 ///

--- a/relay-general/src/store/clock_drift.rs
+++ b/relay-general/src/store/clock_drift.rs
@@ -152,13 +152,12 @@ mod tests {
     use chrono::offset::TimeZone;
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::processor::process_value;
     use crate::protocol::{
         Context, ContextInner, Contexts, EventType, SpanId, TraceContext, TraceId,
     };
     use crate::types::{Annotated, Object};
-
-    use super::*;
 
     fn create_transaction(start: DateTime<Utc>, end: DateTime<Utc>) -> Annotated<Event> {
         Annotated::new(Event {

--- a/relay-general/src/store/event_error.rs
+++ b/relay-general/src/store/event_error.rs
@@ -64,11 +64,10 @@ impl Processor for EmitEventErrors {
 mod tests {
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::processor::process_value;
     use crate::protocol::{Breadcrumb, Values};
     use crate::types::{ErrorKind, Object, Value};
-
-    use super::*;
 
     #[test]
     fn test_no_errors() {

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -22,11 +22,12 @@ mod schema;
 mod transactions;
 mod trimming;
 
-pub use self::clock_drift::*;
-pub use self::geo::*;
 pub use normalize::breakdowns::*;
 pub use normalize::*;
 pub use transactions::*;
+
+pub use self::clock_drift::*;
+pub use self::geo::*;
 
 /// The config for store.
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -7,10 +7,9 @@ use chrono::{DateTime, Duration, Utc};
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use regex::Regex;
+use relay_common::{DurationUnit, FractionUnit, MetricUnit};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-
-use relay_common::{DurationUnit, FractionUnit, MetricUnit};
 
 use super::{schema, transactions, BreakdownsConfig, TransactionNameRule};
 use crate::processor::{MaxChars, ProcessValue, ProcessingState, Processor};
@@ -1000,6 +999,7 @@ mod tests {
     use serde_json::json;
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::processor::process_value;
     use crate::protocol::{
         ContextInner, Csp, DebugMeta, Frame, Geo, LenientString, LogEntry, PairList, RawStacktrace,
@@ -1008,8 +1008,6 @@ mod tests {
     use crate::testutils::{get_path, get_value};
     use crate::types::{FromValue, SerializableAnnotated};
     use crate::user_agent::ClientHints;
-
-    use super::*;
 
     impl Default for NormalizeProcessor<'_> {
         fn default() -> Self {

--- a/relay-general/src/store/normalize/breakdowns.rs
+++ b/relay-general/src/store/normalize/breakdowns.rs
@@ -6,9 +6,8 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
-
 use relay_common::{DurationUnit, MetricUnit};
+use serde::{Deserialize, Serialize};
 
 use crate::protocol::{Breakdowns, Event, Measurement, Measurements, Timestamp};
 use crate::types::Annotated;
@@ -236,10 +235,9 @@ mod tests {
     use chrono::{TimeZone, Timelike, Utc};
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::protocol::{EventType, Span, SpanId, SpanStatus, TraceId};
     use crate::types::Object;
-
-    use super::*;
 
     #[test]
     fn test_skip_with_empty_breakdowns_config() {

--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -250,9 +250,8 @@ pub fn normalize_context(context: &mut Context) {
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::protocol::LenientString;
-
     use super::*;
+    use crate::protocol::LenientString;
 
     #[test]
     fn test_dotnet_framework_48_without_build_id() {

--- a/relay-general/src/store/normalize/logentry.rs
+++ b/relay-general/src/store/normalize/logentry.rs
@@ -84,9 +84,8 @@ pub fn normalize_logentry(logentry: &mut LogEntry, meta: &mut Meta) -> Processin
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::Object;
-
     use super::*;
+    use crate::types::Object;
 
     #[test]
     fn test_format_python() {

--- a/relay-general/src/store/normalize/mechanism.rs
+++ b/relay-general/src/store/normalize/mechanism.rs
@@ -1,8 +1,7 @@
-use crate::protocol::{Context, ContextInner, Event, Mechanism};
-use crate::types::{Annotated, Error, ProcessingAction, ProcessingResult};
-
 #[cfg(test)]
 use crate::protocol::{CError, MachException, MechanismMeta, PosixSignal};
+use crate::protocol::{Context, ContextInner, Event, Mechanism};
+use crate::types::{Annotated, Error, ProcessingAction, ProcessingResult};
 
 fn get_errno_name(errno: i64, os_hint: OsHint) -> Option<&'static str> {
     Some(match os_hint {
@@ -657,9 +656,8 @@ pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) -
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::SerializableAnnotated;
-
     use super::*;
+    use crate::types::SerializableAnnotated;
 
     #[test]
     fn test_normalize_missing() {

--- a/relay-general/src/store/normalize/request.rs
+++ b/relay-general/src/store/normalize/request.rs
@@ -191,10 +191,9 @@ pub fn normalize_request(request: &mut Request) -> ProcessingResult {
 mod tests {
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::protocol::{Cookies, Headers, PairList, Query};
     use crate::types::Object;
-
-    use super::*;
 
     #[test]
     fn test_url_truncation() {

--- a/relay-general/src/store/normalize/spans.rs
+++ b/relay-general/src/store/normalize/spans.rs
@@ -144,13 +144,12 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::protocol::{
         Context, ContextInner, Contexts, Event, EventType, Span, SpanId, Timestamp, TraceContext,
         TraceId,
     };
     use crate::types::Object;
-
-    use super::*;
 
     fn make_event(
         start: Timestamp,

--- a/relay-general/src/store/normalize/user_agent.rs
+++ b/relay-general/src/store/normalize/user_agent.rs
@@ -89,9 +89,8 @@ pub fn get_version(
 
 #[cfg(test)]
 mod tests {
-    use crate::testutils::{self, assert_annotated_snapshot};
-
     use super::*;
+    use crate::testutils::{self, assert_annotated_snapshot};
 
     const GOOD_UA: &str =
             "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19";

--- a/relay-general/src/store/remove_other.rs
+++ b/relay-general/src/store/remove_other.rs
@@ -76,11 +76,10 @@ impl Processor for RemoveOtherProcessor {
 mod tests {
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::processor::process_value;
     use crate::protocol::{Context, ContextInner, Contexts, OsContext, User, Values};
     use crate::testutils::get_value;
-
-    use super::*;
 
     #[test]
     fn test_remove_legacy_attributes() {

--- a/relay-general/src/store/schema.rs
+++ b/relay-general/src/store/schema.rs
@@ -105,14 +105,13 @@ fn verify_value_characters(
 mod tests {
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::processor::{process_value, ProcessingState};
     use crate::protocol::{
         CError, ClientSdkInfo, Event, MachException, Mechanism, MechanismMeta, PosixSignal,
         RawStacktrace, User,
     };
     use crate::types::{Annotated, Array, Error, ErrorKind, Object};
-
-    use super::*;
 
     fn assert_nonempty_base<T>()
     where

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2,14 +2,13 @@ use std::borrow::Cow;
 
 use relay_common::SpanStatus;
 
+use super::TransactionNameRule;
 use crate::processor::{ProcessValue, ProcessingState, Processor};
 use crate::protocol::{
     Context, ContextInner, Event, EventType, Span, Timestamp, TransactionInfo, TransactionSource,
 };
 use crate::store::regexes::TRANSACTION_NAME_NORMALIZER_REGEX;
 use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Remark, RemarkType};
-
-use super::TransactionNameRule;
 
 /// Rejects transactions based on required fields.
 #[derive(Default)]
@@ -426,13 +425,12 @@ mod tests {
     use insta::assert_debug_snapshot;
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::processor::process_value;
     use crate::protocol::{Contexts, SpanId, TraceContext, TraceId, TransactionSource};
     use crate::store::LazyGlob;
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::Object;
-
-    use super::*;
 
     fn new_test_event() -> Annotated<Event> {
         let start = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -164,8 +164,9 @@ impl TransactionNameRule {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use chrono::{DateTime, Utc};
+
+    use super::*;
 
     #[test]
     fn test_rule_format() {

--- a/relay-general/src/store/trimming.rs
+++ b/relay-general/src/store/trimming.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 
-use crate::processor::{estimate_size_flat, process_chunked_value, BagSize, Chunk, MaxChars};
-use crate::processor::{process_value, ProcessValue, ProcessingState, Processor, ValueType};
+use crate::processor::{
+    estimate_size_flat, process_chunked_value, process_value, BagSize, Chunk, MaxChars,
+    ProcessValue, ProcessingState, Processor, ValueType,
+};
 use crate::protocol::{Frame, RawStacktrace};
 use crate::types::{
     Annotated, Array, Empty, Meta, Object, ProcessingAction, ProcessingResult, RemarkType, Value,
@@ -390,9 +392,11 @@ fn slim_frame_data(frames: &mut Array<Frame>, frame_allowance: usize) {
 
 #[cfg(test)]
 mod tests {
-    use similar_asserts::assert_eq;
     use std::iter::repeat;
 
+    use similar_asserts::assert_eq;
+
+    use super::*;
     use crate::processor::MaxChars;
     use crate::protocol::{
         Breadcrumb, Context, ContextInner, Contexts, Event, Exception, ExtraValue, Frame,
@@ -401,8 +405,6 @@ mod tests {
     use crate::types::{
         Annotated, Map, Meta, Object, Remark, RemarkType, SerializableAnnotated, Value,
     };
-
-    use super::*;
 
     #[test]
     fn test_string_trimming() {

--- a/relay-general/src/types/annotated.rs
+++ b/relay-general/src/types/annotated.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
-
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -439,9 +438,8 @@ where
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::types::ErrorKind;
-
     use super::*;
+    use crate::types::ErrorKind;
 
     #[test]
     fn test_annotated_deserialize_with_meta() {

--- a/relay-general/src/types/impls.rs
+++ b/relay-general/src/types/impls.rs
@@ -1,7 +1,6 @@
+use relay_common::Uuid;
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
-
-use relay_common::Uuid;
 
 use crate::macros::derive_string_meta_structure;
 use crate::types::{

--- a/relay-general/src/types/meta.rs
+++ b/relay-general/src/types/meta.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::str::FromStr;
 
-use serde::{de, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+use serde::ser::SerializeSeq;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
 
 use crate::processor::estimate_size;

--- a/relay-general/src/types/value.rs
+++ b/relay-general/src/types/value.rs
@@ -1,12 +1,10 @@
 use std::collections::BTreeMap;
-use std::fmt;
-use std::str;
+use std::{fmt, str};
 
 #[cfg(feature = "jsonschema")]
 use schemars::gen::SchemaGenerator;
 #[cfg(feature = "jsonschema")]
 use schemars::schema::Schema;
-
 use serde::de::{Deserialize, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 

--- a/relay-general/src/user_agent.rs
+++ b/relay-general/src/user_agent.rs
@@ -8,13 +8,12 @@
 
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+#[doc(inline)]
+pub use uaparser::{Device, UserAgent, OS};
 use uaparser::{Parser, UserAgentParser};
 
 use crate::protocol::{HeaderName, HeaderValue, Headers, Request};
 use crate::types::Annotated;
-
-#[doc(inline)]
-pub use uaparser::{Device, UserAgent, OS};
 
 /// The global [`UserAgentParser`] already configured with a user agent database.
 ///

--- a/relay-general/src/utils.rs
+++ b/relay-general/src/utils.rs
@@ -1,9 +1,7 @@
-use std::fmt;
-use std::str;
+use std::{fmt, str};
 
 use once_cell::sync::OnceCell;
 use regex::Regex;
-
 use relay_common::impl_str_serde;
 
 /// Glob options represent the underlying regex emulating the globs.

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -4,9 +4,8 @@ use std::sync::Arc;
 
 use rdkafka::producer::BaseRecord;
 use rdkafka::ClientConfig;
-use thiserror::Error;
-
 use relay_statsd::metric;
+use thiserror::Error;
 
 use crate::config::{KafkaConfig, KafkaParams, KafkaTopic};
 use crate::statsd::KafkaHistograms;

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -1,6 +1,5 @@
 use rdkafka::producer::{DeliveryResult, ProducerContext};
 use rdkafka::{ClientContext, Message};
-
 use relay_log::LogError;
 use relay_statsd::metric;
 

--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -121,17 +121,14 @@ mod test;
 pub use test::*;
 
 mod utils;
-pub use utils::*;
-
 // Expose the minimal log facade.
 #[doc(inline)]
 pub use log::{debug, error, info, log, trace, warn};
-
-// Expose the minimal error reporting API.
-#[doc(inline)]
-pub use sentry_core::{capture_error, configure_scope, protocol, with_scope, Hub};
-
 // Required for the temporarily vendored actix integration.
 #[doc(hidden)]
 #[cfg(feature = "sentry")]
 pub use sentry as _sentry;
+// Expose the minimal error reporting API.
+#[doc(inline)]
+pub use sentry_core::{capture_error, configure_scope, protocol, with_scope, Hub};
+pub use utils::*;

--- a/relay-metrics/benches/aggregator.rs
+++ b/relay-metrics/benches/aggregator.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-
 use relay_common::{ProjectKey, UnixTimestamp};
 use relay_metrics::{AggregatorConfig, AggregatorService, Metric, MetricValue};
 

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1,22 +1,21 @@
-use std::collections::{btree_map, hash_map::Entry, BTreeMap, BTreeSet, HashMap};
-use std::fmt;
+use std::collections::hash_map::Entry;
+use std::collections::{btree_map, BTreeMap, BTreeSet, HashMap};
 use std::hash::Hasher;
 use std::iter::{FromIterator, FusedIterator};
-use std::mem;
 use std::time::Duration;
+use std::{fmt, mem};
 
 use float_ord::FloatOrd;
 use fnv::FnvHasher;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-use tokio::time::Instant;
-
 use relay_common::{MonotonicResult, ProjectKey, UnixTimestamp};
 use relay_log::LogError;
 use relay_system::{
     AsyncResponse, Controller, FromMessage, Interface, NoResponse, Recipient, Sender, Service,
     Shutdown,
 };
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::time::Instant;
 
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
 use crate::{

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -4,13 +4,12 @@ use std::hash::Hasher as _;
 use std::iter::FusedIterator;
 
 use hash32::{FnvHasher, Hasher as _};
-use serde::{Deserialize, Serialize};
-
 #[doc(inline)]
 pub use relay_common::{
     CustomUnit, DurationUnit, FractionUnit, InformationUnit, MetricUnit, ParseMetricUnitError,
     UnixTimestamp,
 };
+use serde::{Deserialize, Serialize};
 
 /// Type used for Counter metric
 pub type CounterType = f64;

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -83,8 +83,9 @@ pub fn process_check_in(payload: &[u8]) -> Result<Vec<u8>, ProcessCheckInError> 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use similar_asserts::assert_eq;
+
+    use super::*;
 
     #[test]
     fn test_json_roundtrip() {

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -3,9 +3,8 @@ use std::collections::{HashMap, HashSet};
 use android_trace_log::chrono::{DateTime, Utc};
 use android_trace_log::{AndroidTraceLog, Clock, Time, Vm};
 use data_encoding::BASE64_NOPAD;
-use serde::{Deserialize, Serialize};
-
 use relay_general::protocol::EventId;
+use serde::{Deserialize, Serialize};
 
 use crate::measurements::Measurement;
 use crate::transaction_metadata::TransactionMetadata;

--- a/relay-profiling/src/cocoa.rs
+++ b/relay-profiling/src/cocoa.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
-use serde::{de, Deserialize, Serialize};
-
 use relay_general::protocol::{Addr, EventId};
+use serde::{de, Deserialize, Serialize};
 
 use crate::error::ProfileError;
 use crate::native_debug_image::NativeDebugImage;

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -109,10 +109,9 @@ use relay_general::protocol::EventId;
 
 use crate::android::parse_android_profile;
 use crate::cocoa::parse_cocoa_profile;
-use crate::sample::{parse_sample_profile, Version};
-
 pub use crate::error::ProfileError;
 pub use crate::outcomes::discard_reason;
+use crate::sample::{parse_sample_profile, Version};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]

--- a/relay-profiling/src/native_debug_image.rs
+++ b/relay-profiling/src/native_debug_image.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use relay_general::protocol::{Addr, DebugId, NativeImagePath};
+use serde::{Deserialize, Serialize};
 
 use crate::utils::deserialize_number_from_string;
 
@@ -31,10 +30,10 @@ pub struct NativeDebugImage {
 
 #[cfg(test)]
 mod tests {
-    use super::NativeDebugImage;
-
     use relay_general::protocol::{Addr, DebugImage, NativeDebugImage as RelayNativeDebugImage};
     use relay_general::types::{Annotated, Map};
+
+    use super::NativeDebugImage;
 
     #[test]
     fn test_native_debug_image_compatibility() {

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -1,9 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-
 use relay_general::protocol::{Addr, EventId};
+use serde::{Deserialize, Serialize};
 
 use crate::error::ProfileError;
 use crate::measurements::Measurement;

--- a/relay-profiling/src/transaction_metadata.rs
+++ b/relay-profiling/src/transaction_metadata.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use relay_general::protocol::EventId;
+use serde::{Deserialize, Serialize};
 
 use crate::utils::{deserialize_number_from_string, is_zero};
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 use std::str::FromStr;
 
+use relay_common::{ProjectId, ProjectKey};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-
-use relay_common::{ProjectId, ProjectKey};
 
 /// Data scoping information.
 ///
@@ -313,8 +312,9 @@ impl Quota {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use smallvec::smallvec;
+
+    use super::*;
 
     #[test]
     fn test_parse_quota_reject_all() {

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -342,9 +342,10 @@ impl<'a> IntoIterator for &'a RateLimits {
 
 #[cfg(test)]
 mod tests {
+    use smallvec::smallvec;
+
     use super::*;
     use crate::quota::DataCategory;
-    use smallvec::smallvec;
 
     #[test]
     fn test_parse_retry_after() {

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 use std::sync::Arc;
 
-use thiserror::Error;
-
 use relay_common::UnixTimestamp;
 use relay_log::protocol::value;
-use relay_redis::{redis::Script, RedisError, RedisPool};
+use relay_redis::redis::Script;
+use relay_redis::{RedisError, RedisPool};
+use thiserror::Error;
 
 use crate::quota::{ItemScoping, Quota, QuotaScope};
 use crate::rate_limit::{RateLimit, RateLimits, RetryAfter};
@@ -258,12 +258,12 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use relay_common::{ProjectId, ProjectKey};
-    use relay_redis::{redis::Commands, RedisConfigOptions};
-
-    use crate::quota::{DataCategories, DataCategory, ReasonCode, Scoping};
-    use crate::rate_limit::RateLimitScope;
+    use relay_redis::redis::Commands;
+    use relay_redis::RedisConfigOptions;
 
     use super::*;
+    use crate::quota::{DataCategories, DataCategory, ReasonCode, Scoping};
+    use crate::rate_limit::RateLimitScope;
 
     fn build_rate_limiter() -> RedisRateLimiter {
         let url = std::env::var("RELAY_REDIS_URL")

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -1,12 +1,11 @@
 use std::fmt;
 
 use r2d2::{Pool, PooledConnection};
+pub use redis;
 use redis::ConnectionLike;
 use thiserror::Error;
 
 use crate::config::{RedisConfig, RedisConfigOptions};
-
-pub use redis;
 
 /// An error returned from `RedisPool`.
 #[derive(Debug, Error)]

--- a/relay-replays/benches/benchmarks.rs
+++ b/relay-replays/benches/benchmarks.rs
@@ -1,8 +1,8 @@
 use std::io::Read;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use flate2::{bufread::ZlibEncoder, Compression};
-
+use flate2::bufread::ZlibEncoder;
+use flate2::Compression;
 use relay_general::pii::DataScrubbingConfig;
 use relay_replays::recording::RecordingScrubber;
 

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -17,14 +17,15 @@ use std::fmt;
 use std::io::Read;
 use std::rc::Rc;
 
-use flate2::{bufread::ZlibDecoder, write::ZlibEncoder, Compression};
+use flate2::bufread::ZlibDecoder;
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
 use once_cell::sync::Lazy;
-use serde::{de, ser, Deserializer};
-use serde_json::value::RawValue;
-
 use relay_general::pii::{PiiConfig, PiiProcessor};
 use relay_general::processor::{FieldAttrs, Pii, ProcessingState, Processor, ValueType};
 use relay_general::types::Meta;
+use serde::{de, ser, Deserializer};
+use serde_json::value::RawValue;
 
 use crate::transform::Transform;
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -13,15 +13,15 @@ use std::net::IpAddr;
 use std::num::ParseIntError;
 
 use chrono::{DateTime, Utc};
-use rand::{distributions::Uniform, Rng};
+use rand::distributions::Uniform;
+use rand::Rng;
 use rand_pcg::Pcg32;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::{Number, Value};
-
 use relay_common::{EventType, ProjectKey, Uuid};
 use relay_filter::GlobPatterns;
 use relay_general::protocol::{Context, Event, TraceContext};
 use relay_general::store;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Number, Value};
 
 /// Defines the type of dynamic rule, i.e. to which type of events it will be applied and how.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -1251,18 +1251,16 @@ pub fn pseudo_random_from_uuid(id: Uuid) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use similar_asserts::assert_eq;
-
     use std::net::{IpAddr as NetIpAddr, Ipv4Addr};
     use std::str::FromStr;
 
     use chrono::{TimeZone, Utc};
-
     use relay_general::protocol::{
         Contexts, Csp, DeviceContext, EventId, Exception, Headers, IpAddr, JsonLenientString,
         LenientString, LogEntry, OsContext, PairList, Request, TagEntry, Tags, User, Values,
     };
     use relay_general::types::Annotated;
+    use similar_asserts::assert_eq;
 
     use super::*;
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -4,8 +4,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use chrono::Utc;
-use tokio::sync::oneshot;
-
 use relay_common::ProjectKey;
 use relay_config::{Config, HttpEncoding};
 use relay_general::protocol::ClientReport;
@@ -14,10 +12,13 @@ use relay_metrics::{Bucket, MergeBuckets};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse};
+use tokio::sync::oneshot;
 
 use crate::actors::outcome::{DiscardReason, Outcome};
 use crate::actors::processor::{EncodeEnvelope, EnvelopeProcessor};
 use crate::actors::project_cache::{ProjectCache, UpdateRateLimits};
+#[cfg(feature = "processing")]
+use crate::actors::store::{Store, StoreEnvelope, StoreError};
 use crate::actors::test_store::{Capture, TestStore};
 use crate::actors::upstream::{
     Method, SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
@@ -28,9 +29,6 @@ use crate::http::{HttpError, Request, RequestBuilder, Response};
 use crate::service::{Registry, REGISTRY};
 use crate::statsd::RelayHistograms;
 use crate::utils::EnvelopeContext;
-
-#[cfg(feature = "processing")]
-use crate::actors::store::{Store, StoreEnvelope, StoreError};
 
 /// Error created while handling [`SendEnvelope`].
 #[derive(Debug, thiserror::Error)]

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -7,18 +7,14 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::fmt;
-use std::mem;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{fmt, mem};
 
 #[cfg(feature = "processing")]
 use anyhow::Context;
 use chrono::{DateTime, SecondsFormat, Utc};
-use relay_system::{Interface, NoResponse};
-use serde::{Deserialize, Serialize};
-
 use relay_common::{DataCategory, ProjectId, UnixTimestamp};
 use relay_config::{Config, EmitOutcomes};
 use relay_filter::FilterStatKey;
@@ -30,7 +26,8 @@ use relay_log::LogError;
 use relay_quotas::{ReasonCode, Scoping};
 use relay_sampling::MatchedRuleIds;
 use relay_statsd::metric;
-use relay_system::{Addr, FromMessage, Service};
+use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
+use serde::{Deserialize, Serialize};
 
 use crate::actors::envelopes::{EnvelopeManager, SendClientReports};
 use crate::actors::upstream::{Method, SendQuery, UpstreamQuery, UpstreamRelay};

--- a/relay-server/src/actors/outcome_aggregator.rs
+++ b/relay-server/src/actors/outcome_aggregator.rs
@@ -6,7 +6,6 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use chrono::Utc;
-
 use relay_common::{DataCategory, UnixTimestamp};
 use relay_config::{Config, EmitOutcomes};
 use relay_quotas::Scoping;

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1,6 +1,3 @@
-use bytes::Bytes;
-use relay_general::user_agent::RawUserAgentInfo;
-use relay_replays::recording::RecordingScrubber;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::io::Write;
@@ -10,20 +7,17 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use brotli2::write::BrotliEncoder;
+use bytes::Bytes;
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
 use once_cell::sync::OnceCell;
-use serde_json::Value as SerdeValue;
-use tokio::sync::Semaphore;
-
 use relay_auth::RelayVersion;
 use relay_common::{ProjectId, ProjectKey, UnixTimestamp};
 use relay_config::{Config, HttpEncoding};
 use relay_dynamic_config::{ErrorBoundary, Feature, ProjectConfig, SessionMetricsConfig};
 use relay_filter::FilterStatKey;
-use relay_general::pii::PiiConfigError;
-use relay_general::pii::{PiiAttachmentsProcessor, PiiProcessor};
+use relay_general::pii::{PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventType, ExpectCt, ExpectStaple, Hpkp, IpAddr,
@@ -32,13 +26,29 @@ use relay_general::protocol::{
 };
 use relay_general::store::{ClockDriftProcessor, LightNormalizationConfig};
 use relay_general::types::{Annotated, Array, FromValue, Object, ProcessingAction, Value};
+use relay_general::user_agent::RawUserAgentInfo;
 use relay_log::LogError;
 use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric};
 use relay_quotas::{DataCategory, ReasonCode};
 use relay_redis::RedisPool;
+use relay_replays::recording::RecordingScrubber;
 use relay_sampling::{DynamicSamplingContext, MatchedRuleIds};
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
+use serde_json::Value as SerdeValue;
+use tokio::sync::Semaphore;
+#[cfg(feature = "processing")]
+use {
+    crate::actors::envelopes::SendMetrics,
+    crate::actors::project_cache::UpdateRateLimits,
+    crate::service::ServiceError,
+    crate::utils::{EnvelopeLimiter, MetricsLimiter},
+    anyhow::Context,
+    relay_general::protocol::{Context as SentryContext, Contexts, ProfileContext},
+    relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
+    relay_quotas::{RateLimitingError, RedisRateLimiter},
+    symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
+};
 
 use crate::actors::envelopes::{EnvelopeManager, SendEnvelope, SendEnvelopeError, SubmitEnvelope};
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
@@ -53,19 +63,6 @@ use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 use crate::utils::{
     self, get_sampling_key, ChunkedFormDataAggregator, EnvelopeContext, FormDataIter,
     SamplingResult,
-};
-
-#[cfg(feature = "processing")]
-use {
-    crate::actors::envelopes::SendMetrics,
-    crate::actors::project_cache::UpdateRateLimits,
-    crate::service::ServiceError,
-    crate::utils::{EnvelopeLimiter, MetricsLimiter},
-    anyhow::Context,
-    relay_general::protocol::{Context as SentryContext, Contexts, ProfileContext},
-    relay_general::store::{GeoIpLookup, StoreConfig, StoreProcessor},
-    relay_quotas::{RateLimitingError, RedisRateLimiter},
-    symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
 };
 
 /// The minimum clock drift for correction to apply.
@@ -2546,22 +2543,19 @@ impl Service for EnvelopeProcessorService {
 
 #[cfg(test)]
 mod tests {
-    use similar_asserts::assert_eq;
-
     use std::str::FromStr;
 
     use chrono::{DateTime, TimeZone, Utc};
-
     use relay_general::pii::{DataScrubbingConfig, PiiConfig};
     use relay_general::protocol::EventId;
     use relay_sampling::{RuleCondition, RuleId, RuleType, SamplingMode};
+    use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::extractors::RequestMeta;
     use crate::service::ServiceState;
     use crate::testutils::{new_envelope, state_with_rule_and_condition};
     use crate::utils::Semaphore as TestSemaphore;
-
-    use super::*;
 
     struct TestProcessSessionArguments<'a> {
         item: Item,

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -2,12 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-
-use smallvec::SmallVec;
-use tokio::time::Instant;
-use url::Url;
-
 use relay_common::{ProjectId, ProjectKey};
 use relay_config::Config;
 use relay_dynamic_config::{Feature, LimitedProjectConfig, ProjectConfig};
@@ -16,21 +10,23 @@ use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric, MetricsContaine
 use relay_quotas::{Quota, RateLimits, Scoping};
 use relay_statsd::metric;
 use relay_system::BroadcastChannel;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+use tokio::time::Instant;
+use url::Url;
 
 use crate::actors::envelopes::{EnvelopeManager, SendMetrics};
 use crate::actors::outcome::{DiscardReason, Outcome};
 #[cfg(feature = "processing")]
 use crate::actors::processor::EnvelopeProcessor;
+#[cfg(feature = "processing")]
+use crate::actors::processor::RateLimitFlushBuckets;
 use crate::actors::project_cache::{CheckedEnvelope, ProjectCache, RequestUpdate};
 use crate::envelope::Envelope;
 use crate::extractors::RequestMeta;
-
 use crate::service::Registry;
 use crate::statsd::RelayCounters;
 use crate::utils::{EnvelopeContext, EnvelopeLimiter, MetricsLimiter, RetryBackoff};
-
-#[cfg(feature = "processing")]
-use crate::actors::processor::RateLimitFlushBuckets;
 
 /// The expiry status of a project state. Return value of [`ProjectState::check_expiry`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -1,9 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use tokio::sync::mpsc;
-
 use relay_common::ProjectKey;
 use relay_system::{FromMessage, Interface, Service};
+use tokio::sync::mpsc;
 
 use crate::envelope::Envelope;
 use crate::utils::EnvelopeContext;

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,9 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
-use tokio::time::Instant;
-
 use relay_common::ProjectKey;
 use relay_config::{Config, RelayMode};
 use relay_metrics::{self, FlushBuckets, InsertMetrics, MergeBuckets};
@@ -11,6 +8,8 @@ use relay_quotas::RateLimits;
 use relay_redis::RedisPool;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, Interface, Sender, Service};
+use tokio::sync::mpsc;
+use tokio::time::Instant;
 
 use crate::actors::outcome::DiscardReason;
 use crate::actors::processor::{EnvelopeProcessor, ProcessEnvelope};
@@ -19,14 +18,13 @@ use crate::actors::project_buffer::{
     Buffer, BufferService, DequeueMany, Enqueue, QueueKey, RemoveMany,
 };
 use crate::actors::project_local::{LocalProjectSource, LocalProjectSourceService};
+#[cfg(feature = "processing")]
+use crate::actors::project_redis::RedisProjectSource;
 use crate::actors::project_upstream::{UpstreamProjectSource, UpstreamProjectSourceService};
 use crate::envelope::Envelope;
 use crate::service::REGISTRY;
 use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::{self, EnvelopeContext, GarbageDisposal};
-
-#[cfg(feature = "processing")]
-use crate::actors::project_redis::RedisProjectSource;
 
 /// Requests a refresh of a project state from one of the available sources.
 ///

--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -193,9 +193,8 @@ mod tests {
 
     use relay_common::{ProjectId, ProjectKey};
 
-    use crate::actors::project::{ProjectState, PublicKeyConfig};
-
     use super::load_local_states;
+    use crate::actors::project::{ProjectState, PublicKeyConfig};
 
     /// Tests that we can follow the symlinks and read the project file properly.
     #[tokio::test]

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -1,14 +1,11 @@
 use std::borrow::Cow;
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
-use tokio::time::Instant;
-
 use relay_common::ProjectKey;
 use relay_config::Config;
 use relay_dynamic_config::ErrorBoundary;
@@ -17,6 +14,9 @@ use relay_statsd::metric;
 use relay_system::{
     BroadcastChannel, BroadcastResponse, BroadcastSender, FromMessage, Interface, Service,
 };
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio::time::Instant;
 
 use crate::actors::project::ProjectState;
 use crate::actors::project_cache::FetchProjectState;

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -3,15 +3,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
-
 use relay_auth::{PublicKey, RelayId};
 use relay_config::{Config, RelayInfo};
 use relay_log::LogError;
 use relay_system::{
     Addr, BroadcastChannel, BroadcastResponse, BroadcastSender, FromMessage, Interface, Service,
 };
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 
 use crate::actors::upstream::{Method, RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay};
 use crate::service::REGISTRY;

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -1,7 +1,6 @@
 use actix_web::{server, App};
 use anyhow::{Context, Result};
 use listenfd::ListenFd;
-
 use relay_config::Config;
 use relay_statsd::metric;
 use relay_system::{Addr, Controller, Service, Shutdown};
@@ -90,9 +89,10 @@ where
         config.tls_identity_path(),
         config.tls_identity_password(),
     ) {
-        use native_tls::{Identity, TlsAcceptor};
         use std::fs::File;
         use std::io::Read;
+
+        use native_tls::{Identity, TlsAcceptor};
 
         let mut file = File::open(path).unwrap();
         let mut data = vec![];

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -7,8 +7,6 @@ use std::time::Instant;
 
 use bytes::Bytes;
 use once_cell::sync::OnceCell;
-use serde::{ser::Error, Serialize};
-
 use relay_common::{ProjectId, UnixTimestamp, Uuid};
 use relay_config::Config;
 use relay_general::protocol::{self, EventId, SessionAggregates, SessionStatus, SessionUpdate};
@@ -18,6 +16,8 @@ use relay_metrics::{Bucket, BucketValue, MetricNamespace, MetricResourceIdentifi
 use relay_quotas::Scoping;
 use relay_statsd::metric;
 use relay_system::{AsyncResponse, FromMessage, Interface, Sender, Service};
+use serde::ser::Error;
+use serde::Serialize;
 
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::service::ServiceError;
@@ -1147,8 +1147,9 @@ fn is_slow_item(item: &Item) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_common::ProjectKey;
+
+    use super::*;
 
     /// Helper function to get the arguments for the `fn extract_kafka_messages(...)` method.
     fn arguments_extract_kafka_msgs() -> (Instant, EventId, Scoping, Vec<ChunkedAttachment>) {

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -12,11 +12,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use reqwest::header;
-use serde::{de::DeserializeOwned, Serialize};
-use tokio::sync::mpsc;
-use tokio::time::Instant;
-
 use relay_auth::{RegisterChallenge, RegisterRequest, RegisterResponse, Registration};
 use relay_config::{Config, Credentials, RelayMode};
 use relay_log::LogError;
@@ -26,13 +21,17 @@ use relay_quotas::{
 use relay_system::{
     Addr, AsyncResponse, FromMessage, Interface, MessageResponse, NoResponse, Sender, Service,
 };
+use reqwest::header;
+pub use reqwest::Method;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
 
 use crate::http::{HttpError, Request, RequestBuilder, Response, StatusCode};
 use crate::service::REGISTRY;
 use crate::statsd::{RelayHistograms, RelayTimers};
 use crate::utils::{self, ApiErrorResponse, RelayErrorAction, RetryBackoff};
-
-pub use reqwest::Method;
 
 /// Rate limits returned by the upstream.
 ///

--- a/relay-server/src/body/peek_line.rs
+++ b/relay-server/src/body/peek_line.rs
@@ -58,8 +58,9 @@ pub async fn peek_line<S>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_test::TestRequest;
+
+    use super::*;
 
     #[tokio::test]
     async fn test_empty() {

--- a/relay-server/src/body/request_body.rs
+++ b/relay-server/src/body/request_body.rs
@@ -1,4 +1,5 @@
-use actix_web::{error::PayloadError, HttpRequest};
+use actix_web::error::PayloadError;
+use actix_web::HttpRequest;
 use bytes::Bytes;
 
 use crate::extractors::{Decoder, SharedPayload};

--- a/relay-server/src/body/store_body.rs
+++ b/relay-server/src/body/store_body.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
 use std::io::{self, ErrorKind, Read};
 
-use actix_web::{error::PayloadError, HttpRequest};
+use actix_web::error::PayloadError;
+use actix_web::HttpRequest;
 use bytes::Bytes;
 use data_encoding::BASE64;
 use flate2::read::ZlibDecoder;
-use url::form_urlencoded;
-
 use relay_statsd::metric;
+use url::form_urlencoded;
 
 use crate::body;
 use crate::statsd::RelayHistograms;

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -1,5 +1,5 @@
-use actix_web::{http::Method, App, HttpRequest, HttpResponse};
-
+use actix_web::http::Method;
+use actix_web::{App, HttpRequest, HttpResponse};
 use relay_general::protocol::EventId;
 
 use crate::endpoints::common::{self, BadStoreRequest};

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -3,15 +3,15 @@
 use std::fmt::Write;
 use std::future::Future;
 
+use actix_web::error::PayloadError;
 use actix_web::http::{header, StatusCode};
 use actix_web::middleware::cors::{Cors, CorsBuilder};
-use actix_web::{error::PayloadError, App, HttpResponse};
-use serde::Deserialize;
-
+use actix_web::{App, HttpResponse};
 use relay_general::protocol::{EventId, EventType};
 use relay_log::LogError;
 use relay_quotas::RateLimits;
 use relay_statsd::metric;
+use serde::Deserialize;
 
 use crate::actors::outcome::{DiscardReason, Outcome};
 use crate::actors::processor::{EnvelopeProcessor, ProcessMetrics};

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -1,9 +1,8 @@
 //! Handles envelope store requests.
 
 use actix_web::{App, HttpRequest, HttpResponse};
-use serde::Serialize;
-
 use relay_general::protocol::EventId;
+use serde::Serialize;
 
 use crate::body;
 use crate::endpoints::common::{self, BadStoreRequest};

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -1,8 +1,9 @@
 //! Returns captured events.
 
-use actix_web::{actix::MailboxError, http::Method, App, HttpResponse, Path};
+use actix_web::actix::MailboxError;
+use actix_web::http::Method;
+use actix_web::{App, HttpResponse, Path};
 use futures::TryFutureExt;
-
 use relay_general::protocol::EventId;
 
 use crate::actors::test_store::{GetCapturedEnvelope, TestStore};

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -11,16 +11,16 @@ use std::pin::Pin;
 use actix::ResponseFuture;
 use actix_web::error::{ParseError, ResponseError};
 use actix_web::http::header::{self, HeaderName, HeaderValue};
-use actix_web::http::{uri::PathAndQuery, HeaderMap, StatusCode};
+use actix_web::http::uri::PathAndQuery;
+use actix_web::http::{HeaderMap, StatusCode};
 use actix_web::{App, Error, HttpMessage, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use futures::TryFutureExt;
 use once_cell::sync::Lazy;
-use tokio::sync::oneshot;
-
 use relay_config::Config;
 use relay_general::utils::GlobMatcher;
 use relay_log::LogError;
+use tokio::sync::oneshot;
 
 use crate::actors::upstream::{
     Method, SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -3,7 +3,6 @@ use actix_web::{App, HttpMessage, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
 use futures01::{stream, Stream};
-
 use relay_general::protocol::EventId;
 
 use crate::body;

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -3,10 +3,9 @@ use std::collections::HashMap;
 use actix::MailboxError;
 use actix_web::{App, Error, FromRequest, Json};
 use futures::{future, TryFutureExt};
-use serde::{Deserialize, Serialize};
-
 use relay_common::ProjectKey;
 use relay_dynamic_config::ErrorBoundary;
+use serde::{Deserialize, Serialize};
 
 use crate::actors::project::{LimitedProjectState, ProjectState};
 use crate::actors::project_cache::{GetCachedProjectState, GetProjectState, ProjectCache};

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use actix_web::{actix::MailboxError, App, Error, Json};
+use actix_web::actix::MailboxError;
+use actix_web::{App, Error, Json};
 use futures::{future, TryFutureExt};
 
 use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse, RelayCache};

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -1,9 +1,8 @@
 //! Endpoints for security reports.
 
 use actix_web::{pred, App, HttpMessage, HttpRequest, HttpResponse, Query, Request};
-use serde::Deserialize;
-
 use relay_general::protocol::EventId;
+use serde::Deserialize;
 
 use crate::body;
 use crate::endpoints::common::{self, BadStoreRequest};

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -1,10 +1,10 @@
 //! Handles event store requests.
 
-use actix_web::{http::Method, App, HttpMessage, HttpRequest, HttpResponse};
+use actix_web::http::Method;
+use actix_web::{App, HttpMessage, HttpRequest, HttpResponse};
 use bytes::{Bytes, BytesMut};
-use serde::Serialize;
-
 use relay_general::protocol::EventId;
+use serde::Serialize;
 
 use crate::body;
 use crate::endpoints::common::{self, BadStoreRequest};

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -1,5 +1,4 @@
 use actix_web::{App, HttpRequest, HttpResponse};
-
 use relay_general::protocol::EventId;
 
 use crate::body;

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -38,13 +38,13 @@ use std::io::{self, Write};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use relay_common::UnixTimestamp;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use smallvec::SmallVec;
-
 use relay_dynamic_config::ErrorBoundary;
 use relay_general::protocol::{EventId, EventType};
 use relay_general::types::Value;
 use relay_sampling::DynamicSamplingContext;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use crate::constants::DEFAULT_EVENT_RETENTION;
 use crate::extractors::{PartialMeta, RequestMeta};
@@ -1152,9 +1152,9 @@ impl Envelope {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_common::ProjectId;
+
+    use super::*;
 
     fn request_meta() -> RequestMeta {
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"

--- a/relay-server/src/extractors/decoder.rs
+++ b/relay-server/src/extractors/decoder.rs
@@ -8,7 +8,6 @@ use brotli2::write::BrotliDecoder;
 use bytes::Bytes;
 use flate2::write::{GzDecoder, ZlibDecoder};
 use futures01::{Async, Poll, Stream};
-
 use relay_config::HttpEncoding;
 
 use crate::extractors::SharedPayload;

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -7,15 +7,14 @@ use actix_web::dev::AsyncResult;
 use actix_web::http::header;
 use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use futures::TryFutureExt;
-use relay_general::user_agent::{ClientHints, RawUserAgentInfo};
-use serde::{Deserialize, Serialize};
-use url::Url;
-
 use relay_common::{
     Auth, Dsn, ParseAuthError, ParseDsnError, ParseProjectIdError, ParseProjectKeyError, ProjectId,
     ProjectKey, Scheme,
 };
+use relay_general::user_agent::{ClientHints, RawUserAgentInfo};
 use relay_quotas::Scoping;
+use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::body;
 use crate::extractors::ForwardedFor;

--- a/relay-server/src/extractors/shared_payload.rs
+++ b/relay-server/src/extractors/shared_payload.rs
@@ -5,7 +5,8 @@ use actix_web::dev::Payload;
 use actix_web::error::PayloadError;
 use actix_web::{FromRequest, HttpMessage, HttpRequest};
 use bytes::Bytes;
-use futures::{compat::Stream01CompatExt, TryStreamExt};
+use futures::compat::Stream01CompatExt;
+use futures::TryStreamExt;
 use futures01::{Async, Poll, Stream};
 
 /// A shared reference to an actix request payload.

--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -2,11 +2,10 @@ use actix_web::actix::*;
 use actix_web::http::StatusCode;
 use actix_web::{Error, FromRequest, HttpMessage, HttpRequest, HttpResponse, ResponseError};
 use futures::{FutureExt, TryFutureExt};
-use serde::de::DeserializeOwned;
-
 use relay_auth::{RelayId, UnpackError};
 use relay_config::RelayInfo;
 use relay_log::Hub;
+use serde::de::DeserializeOwned;
 
 use crate::actors::relays::{GetRelay, RelayCache};
 use crate::body;

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -10,12 +10,10 @@
 ///! logic.
 use std::io;
 
-use serde::de::DeserializeOwned;
-
 use relay_config::HttpEncoding;
-
 #[doc(inline)]
 pub use reqwest::StatusCode;
+use serde::de::DeserializeOwned;
 
 #[derive(Debug, thiserror::Error)]
 pub enum HttpError {

--- a/relay-server/src/metrics_extraction/transactions.rs
+++ b/relay-server/src/metrics_extraction/transactions.rs
@@ -7,8 +7,9 @@ use relay_general::protocol::{
 };
 use relay_general::store;
 use relay_general::types::Annotated;
-use relay_metrics::AggregatorConfig;
-use relay_metrics::{DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue};
+use relay_metrics::{
+    AggregatorConfig, DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue,
+};
 
 use crate::metrics_extraction::conditional_tagging::run_conditional_tagging;
 use crate::statsd::RelayCounters;
@@ -467,8 +468,6 @@ fn get_measurement_rating(name: &str, value: f64) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use relay_dynamic_config::TaggingRule;
     use relay_general::protocol::{Contexts, Timestamp, User};
     use relay_general::store::{
@@ -476,6 +475,8 @@ mod tests {
     };
     use relay_general::types::Annotated;
     use relay_metrics::DurationUnit;
+
+    use super::*;
 
     /// Returns an aggregator config that permits every timestamp.
     fn aggregator_config() -> AggregatorConfig {

--- a/relay-server/src/middlewares.rs
+++ b/relay-server/src/middlewares.rs
@@ -6,13 +6,14 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use actix_web::error::Error;
+use actix_web::http::header;
 use actix_web::middleware::{Finished, Middleware, Response, Started};
-use actix_web::{http::header, Body, HttpMessage, HttpRequest, HttpResponse};
+use actix_web::{Body, HttpMessage, HttpRequest, HttpResponse};
 use failure::Fail;
 use futures::TryFutureExt;
-
-use relay_log::_sentry::{integrations::backtrace::parse_stacktrace, parse_type_from_debug};
-use relay_log::_sentry::{types::Uuid, Hub, Level, ScopeGuard};
+use relay_log::_sentry::integrations::backtrace::parse_stacktrace;
+use relay_log::_sentry::types::Uuid;
+use relay_log::_sentry::{parse_type_from_debug, Hub, Level, ScopeGuard};
 use relay_log::protocol::{ClientSdkPackage, Event, Exception, Request};
 use relay_statsd::metric;
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -3,13 +3,12 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use once_cell::race::OnceBox;
-use tokio::runtime::Runtime;
-
 use relay_aws_extension::AwsExtension;
 use relay_config::Config;
 use relay_metrics::{Aggregator, AggregatorService};
 use relay_redis::RedisPool;
 use relay_system::{Addr, Service};
+use tokio::runtime::Runtime;
 
 use crate::actors::envelopes::{EnvelopeManager, EnvelopeManagerService};
 use crate::actors::health_check::{HealthCheck, HealthCheckService};

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -3,7 +3,6 @@
 use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
-
 use relay_common::ProjectKey;
 use relay_general::protocol::Event;
 use relay_sampling::{
@@ -158,22 +157,18 @@ pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
 
 #[cfg(test)]
 mod tests {
-    use similar_asserts::assert_eq;
-
     use chrono::Duration as DateDuration;
-    use relay_common::Uuid;
-
-    use relay_common::EventType;
+    use relay_common::{EventType, Uuid};
     use relay_general::protocol::{EventId, LenientString};
     use relay_general::types::Annotated;
     use relay_sampling::{
         DecayingFunction, EqCondOptions, EqCondition, RuleCondition, RuleId, RuleType,
         SamplingConfig, SamplingMatch, SamplingRule, SamplingValue, TimeRange,
     };
-
-    use crate::testutils::project_state_with_config;
+    use similar_asserts::assert_eq;
 
     use super::*;
+    use crate::testutils::project_state_with_config;
 
     macro_rules! assert_transaction_match {
         ($res:expr, $sr:expr, $sd:expr, $( $id:expr ),*) => {

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -4,7 +4,6 @@ use std::net;
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
-
 use relay_common::DataCategory;
 use relay_general::protocol::EventId;
 use relay_quotas::Scoping;

--- a/relay-server/src/utils/garbage.rs
+++ b/relay-server/src/utils/garbage.rs
@@ -60,10 +60,8 @@ impl<T: Send + 'static> GarbageDisposal<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{Arc, Mutex},
-        thread::ThreadId,
-    };
+    use std::sync::{Arc, Mutex};
+    use std::thread::ThreadId;
 
     use super::GarbageDisposal;
 

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -1,6 +1,5 @@
 //! Quota and rate limiting helpers for metrics and metrics buckets.
 use chrono::Utc;
-
 use relay_common::{DataCategory, UnixTimestamp};
 use relay_metrics::{MetricNamespace, MetricResourceIdentifier, MetricsContainer};
 use relay_quotas::{ItemScoping, Quota, RateLimits, Scoping};

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -25,6 +25,8 @@ pub use self::envelope_context::*;
 pub use self::garbage::*;
 pub use self::metrics_rate_limits::*;
 pub use self::multipart::*;
+#[cfg(feature = "processing")]
+pub use self::native::*;
 pub use self::param_parser::*;
 pub use self::rate_limits::*;
 pub use self::request::*;
@@ -32,8 +34,5 @@ pub use self::retry::*;
 pub use self::semaphore::*;
 pub use self::sizes::*;
 pub use self::sleep_handle::*;
-
-#[cfg(feature = "processing")]
-pub use self::native::*;
 #[cfg(feature = "processing")]
 pub use self::unreal::*;

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -2,7 +2,8 @@ use std::convert::TryInto;
 use std::io;
 
 use actix::prelude::*;
-use actix_web::{error::PayloadError, multipart, HttpMessage, HttpRequest};
+use actix_web::error::PayloadError;
+use actix_web::{multipart, HttpMessage, HttpRequest};
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
 use futures01::{Async, Future, Poll, Stream};

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -7,7 +7,6 @@ use std::collections::BTreeMap;
 
 use chrono::{TimeZone, Utc};
 use minidump::{MinidumpAnnotation, MinidumpCrashpadInfo, MinidumpModuleList, Module};
-
 use relay_general::protocol::{
     Context, ContextInner, Contexts, Event, Exception, JsonLenientString, Level, Mechanism, Values,
 };

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -616,16 +616,14 @@ impl<F> fmt::Debug for EnvelopeLimiter<'_, F> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::collections::BTreeMap;
-
-    use smallvec::smallvec;
 
     use relay_common::{ProjectId, ProjectKey};
     use relay_dynamic_config::TransactionMetricsConfig;
     use relay_quotas::{ItemScoping, RetryAfter};
+    use smallvec::smallvec;
 
+    use super::*;
     use crate::envelope::{AttachmentType, ContentType};
 
     #[test]

--- a/relay-server/src/utils/request.rs
+++ b/relay-server/src/utils/request.rs
@@ -1,4 +1,5 @@
-use actix_web::{http::header, HttpMessage};
+use actix_web::http::header;
+use actix_web::HttpMessage;
 
 // Resolve the content length from HTTP request headers.
 pub fn get_content_length<T>(req: &T) -> Option<usize>

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -1,8 +1,4 @@
 use chrono::{TimeZone, Utc};
-use symbolic_unreal::{
-    Unreal4Context, Unreal4Crash, Unreal4Error, Unreal4ErrorKind, Unreal4FileType, Unreal4LogEntry,
-};
-
 use relay_config::Config;
 use relay_general::protocol::{
     AsPair, Breadcrumb, ClientSdkInfo, Context, Contexts, DeviceContext, Event, EventId,
@@ -10,6 +6,9 @@ use relay_general::protocol::{
     User, UserReport, Values,
 };
 use relay_general::types::{self, Annotated, Array, Object, Value};
+use symbolic_unreal::{
+    Unreal4Context, Unreal4Crash, Unreal4Error, Unreal4ErrorKind, Unreal4FileType, Unreal4LogEntry,
+};
 
 use crate::constants::{
     ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT, UNREAL_USER_HEADER,

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -66,7 +66,6 @@ use cadence::{
 };
 use parking_lot::RwLock;
 use rand::distributions::{Distribution, Uniform};
-
 use relay_log::LogError;
 
 /// Maximum number of metric events that can be queued before we start dropping them

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -2,12 +2,11 @@ use std::fmt;
 use std::time::Duration;
 
 use actix::actors::signal;
+#[doc(inline)]
+pub use actix::actors::signal::{Signal, SignalType};
 use actix::prelude::*;
 use once_cell::sync::OnceCell;
 use tokio::sync::watch;
-
-#[doc(inline)]
-pub use actix::actors::signal::{Signal, SignalType};
 
 type ShutdownChannel = (
     watch::Sender<Option<Shutdown>>,

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -30,9 +30,8 @@
 use std::cell::RefCell;
 
 use actix::{System, SystemRunner};
-use futures01::{future, IntoFuture};
-
 pub use actix_web::test::*;
+use futures01::{future, IntoFuture};
 
 thread_local! {
     static SYSTEM: RefCell<Inner> = RefCell::new(Inner::new());

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -1,22 +1,18 @@
-use std::env;
-use std::io;
 use std::path::{Path, PathBuf};
+use std::{env, io};
 
 use anyhow::{anyhow, bail, Result};
 use clap::ArgMatches;
 use clap_complete::Shell;
-use dialoguer::Confirm;
-use dialoguer::Select;
-
+use dialoguer::{Confirm, Select};
 use relay_common::Uuid;
 use relay_config::{
     Config, ConfigError, ConfigErrorKind, Credentials, MinimalConfig, OverridableConfig, RelayMode,
 };
 
 use crate::cliapp::make_app;
-use crate::setup;
-use crate::utils;
 use crate::utils::get_theme;
+use crate::{setup, utils};
 
 fn load_config(path: impl AsRef<Path>, require: bool) -> Result<Config> {
     match Config::from_path(path) {

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -1,7 +1,7 @@
 //! This module implements the definition of the command line app.
 
-use clap::ArgAction;
-use clap::{builder::ValueParser, Arg, ArgGroup, Command, ValueHint};
+use clap::builder::ValueParser;
+use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint};
 use clap_complete::Shell;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-
 use relay_config::{Config, RelayMode};
 
 pub fn check_config(config: &Config) -> Result<()> {

--- a/tools/process-event/src/main.rs
+++ b/tools/process-event/src/main.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
+use anyhow::{format_err, Context, Result};
 use clap::Parser;
 use relay_general::pii::{PiiConfig, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
@@ -15,8 +16,6 @@ use relay_general::store::{
     light_normalize_event, LightNormalizationConfig, StoreConfig, StoreProcessor,
 };
 use relay_general::types::Annotated;
-
-use anyhow::{format_err, Context, Result};
 
 /// Processes a Sentry event payload.
 ///

--- a/tools/scrub-minidump/src/main.rs
+++ b/tools/scrub-minidump/src/main.rs
@@ -7,7 +7,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{format_err, Context, Result};
-
 use clap::Parser;
 use relay_general::pii::{PiiAttachmentsProcessor, PiiConfig};
 


### PR DESCRIPTION
Applies the Sentry [import order guidelines](https://develop.sentry.dev/rust/#import-order) on the entire codebase. One notable difference is that public re-exports (`pub use`) are grouped with other imports.

On top of default settings, this is equivalent to the following `rustfmt` configuration:

```toml
imports_granularity = "Module"
group_imports = "StdExternalCrate"  # nightly only
```

Since the latter option is nightly-only at the time of this PR, we do not add a rustfmt configuration to the codebase yet. For more information on the used options, refer to the [official documentation](https://rust-lang.github.io/rustfmt/?version=v1.5.2&search=import).

See also https://github.com/getsentry/develop/pull/869.

#skip-changelog
