### PR TITLE
ci(gha): Remove unmaintained actions-rs actions

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -29,13 +29,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --component clippy --no-self-update
 
       - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --all-features --no-deps -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 
       - name: Run Cargo Tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features
+        run: cargo test --workspace --all-features

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -2,7 +2,7 @@ name: Beta CI
 
 on:
   schedule:
-    - cron: "11 7 * * 1,4"
+    - cron: "11 7 * * 1,4" # At 07:11 AM, only on Monday and Thursday
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,12 +25,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-          components: clippy
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy --no-self-update
 
       - name: Run Clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -48,12 +48,9 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run Cargo Build
-        uses: actions-rs/cargo@v1
+        run: cargo build --manifest-path=relay/Cargo.toml --release --features ssl
         env:
           CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
-        with:
-          command: build
-          args: --manifest-path=relay/Cargo.toml --release --features ssl
 
       - name: Bundle dSYM
         run: |
@@ -79,10 +76,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run Cargo Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path=relay/Cargo.toml --release --features ssl
+        run: cargo build --manifest-path=relay/Cargo.toml --release --features ssl
 
       - name: Bundle PDB
         run: |

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -44,11 +44,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run Cargo Build
         uses: actions-rs/cargo@v1
@@ -78,11 +75,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run Cargo Build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -62,12 +62,10 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install stable-${{ matrix.target }} --profile minimal --no-self-update
+          rustup default stable-${{ matrix.target }}
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,8 @@ jobs:
       - name: Run Flake8
         run: flake8 py
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy, rustfmt, rust-docs
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy rustfmt rust-docs --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -85,12 +81,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -120,11 +112,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -167,11 +156,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -200,11 +186,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: actions/setup-python@v4
         with:
@@ -361,11 +344,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,24 +48,15 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --all-features --no-deps -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 
       - name: Check Docs
-        uses: actions-rs/cargo@v1
+        run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -Dwarnings
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps --document-private-items
 
   lint_default:
     name: Lint Rust Default Features
@@ -89,10 +80,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --no-deps -- -D warnings
+        run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
   test:
     timeout-minutes: 20
@@ -120,12 +108,9 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Cargo Tests
-        uses: actions-rs/cargo@v1
+        run: cargo test --workspace
         env:
           RUSTFLAGS: -Dwarnings
-        with:
-          command: test
-          args: --workspace
 
   test_all:
     timeout-minutes: 15
@@ -164,10 +149,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Cargo Tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features
+        run: cargo test --workspace --all-features
 
   test_py:
     strategy:
@@ -352,10 +334,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-features
+        run: cargo build --all-features
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,12 +26,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rust-docs
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component rust-docs --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -63,11 +59,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -117,11 +110,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,9 @@ jobs:
           key: ${{ github.job }}
 
       - name: Build Docs
-        uses: actions-rs/cargo@v1
+        run: cargo doc --workspace --all-features --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps
 
       - run: echo '<meta http-equiv="refresh" content="0; url=relay/" />Redirecting to <a href="relay/">relay</a>' > target/doc/index.html
 
@@ -67,10 +64,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Generate Schema
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p generate-schema -- -o event.schema.json
+        run: cargo run -p generate-schema -- -o event.schema.json
 
       - name: Deploy
         if: github.ref == 'refs/heads/master'
@@ -118,14 +112,11 @@ jobs:
           key: ${{ github.job }}
 
       - name: Document Metrics
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p document-metrics -- -o relay_metrics.json
-            relay-kafka/src/statsd.rs
-            relay-metrics/src/statsd.rs
-            relay-server/src/statsd.rs
-            relay-system/src/statsd.rs
+        run: cargo run -p document-metrics -- -o relay_metrics.json
+          relay-kafka/src/statsd.rs
+          relay-metrics/src/statsd.rs
+          relay-server/src/statsd.rs
+          relay-system/src/statsd.rs
 
       - name: Deploy
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Removes the unmaintained Rust actions from `actions-rs`, since they contain a
deprecated command that will be removed soon. While GitHub frequently updates
its preinstalled rust toolchain, we keep explicit `rustup toolchain install` in
our jobs to ensure we're always on latest.

The `cargo` invocations remain in CI for readability, instead of calling the
equivalent in the Makefile for now.

For more information on the actions, see the original issue.

Fixes #1919
#skip-changelog

