### PR TITLE
chore(ci): Skip generating credentials file with google auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v1
         with:
+          create_credentials_file: false
           workload_identity_provider: projects/345757944225/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
           service_account: github-actions-gcr@sentryio.iam.gserviceaccount.com
 


### PR DESCRIPTION
We should not need this, since we do not pass the creds to other steps. And having only `gcloud` utility authenticated should be just enough. 

#skip-changelog