### PR TITLE
ref(test): Remove actix test utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,10 +3628,8 @@ dependencies = [
 name = "relay-test"
 version = "23.2.0"
 dependencies = [
- "futures 0.1.31",
  "relay-log",
  "relay-system",
- "tokio 1.25.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,8 +3628,6 @@ dependencies = [
 name = "relay-test"
 version = "23.2.0"
 dependencies = [
- "actix",
- "actix-web",
  "futures 0.1.31",
  "relay-log",
  "relay-system",

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2922,18 +2922,15 @@ mod tests {
             item
         });
 
-        let new_envelope = relay_test::with_system(move || {
-            let envelope_response = processor
-                .process(ProcessEnvelope {
-                    envelope_context: EnvelopeContext::standalone(&envelope),
-                    envelope,
-                    project_state: Arc::new(ProjectState::allowed()),
-                    sampling_project_state: None,
-                })
-                .unwrap();
+        let message = ProcessEnvelope {
+            envelope_context: EnvelopeContext::standalone(&envelope),
+            envelope,
+            project_state: Arc::new(ProjectState::allowed()),
+            sampling_project_state: None,
+        };
 
-            envelope_response.envelope.unwrap().0
-        });
+        let envelope_response = processor.process(message).unwrap();
+        let new_envelope = envelope_response.envelope.unwrap().0;
 
         assert_eq!(new_envelope.len(), 1);
         assert_eq!(new_envelope.items().next().unwrap().ty(), &ItemType::Event);
@@ -2971,43 +2968,41 @@ mod tests {
             item
         });
 
-        let new_envelope = relay_test::with_system(move || {
-            let mut datascrubbing_settings = DataScrubbingConfig::default();
-            // enable all the default scrubbing
-            datascrubbing_settings.scrub_data = true;
-            datascrubbing_settings.scrub_defaults = true;
-            datascrubbing_settings.scrub_ip_addresses = true;
+        let mut datascrubbing_settings = DataScrubbingConfig::default();
+        // enable all the default scrubbing
+        datascrubbing_settings.scrub_data = true;
+        datascrubbing_settings.scrub_defaults = true;
+        datascrubbing_settings.scrub_ip_addresses = true;
 
-            // Make sure to mask any IP-like looking data
-            let pii_config = PiiConfig::from_json(
-                r##"
+        // Make sure to mask any IP-like looking data
+        let pii_config = PiiConfig::from_json(
+            r##"
                 {
                     "applications": {
                         "**": ["@ip:mask"]
                     }
                 }
                 "##,
-            )
-            .unwrap();
+        )
+        .unwrap();
 
-            let config = ProjectConfig {
-                datascrubbing_settings,
-                pii_config: Some(pii_config),
-                ..Default::default()
-            };
+        let config = ProjectConfig {
+            datascrubbing_settings,
+            pii_config: Some(pii_config),
+            ..Default::default()
+        };
 
-            let mut project_state = ProjectState::allowed();
-            project_state.config = config;
-            let envelope_response = processor
-                .process(ProcessEnvelope {
-                    envelope_context: EnvelopeContext::standalone(&envelope),
-                    envelope,
-                    project_state: Arc::new(project_state),
-                    sampling_project_state: None,
-                })
-                .unwrap();
-            envelope_response.envelope.unwrap().0
-        });
+        let mut project_state = ProjectState::allowed();
+        project_state.config = config;
+        let message = ProcessEnvelope {
+            envelope_context: EnvelopeContext::standalone(&envelope),
+            envelope,
+            project_state: Arc::new(project_state),
+            sampling_project_state: None,
+        };
+
+        let envelope_response = processor.process(message).unwrap();
+        let new_envelope = envelope_response.envelope.unwrap().0;
 
         let event_item = new_envelope.items().last().unwrap();
         let annotated_event: Annotated<Event> =
@@ -3071,17 +3066,14 @@ mod tests {
             item
         });
 
-        let envelope_response = relay_test::with_system(move || {
-            processor
-                .process(ProcessEnvelope {
-                    envelope_context: EnvelopeContext::standalone(&envelope),
-                    envelope,
-                    project_state: Arc::new(ProjectState::allowed()),
-                    sampling_project_state: None,
-                })
-                .unwrap()
-        });
+        let message = ProcessEnvelope {
+            envelope_context: EnvelopeContext::standalone(&envelope),
+            envelope,
+            project_state: Arc::new(ProjectState::allowed()),
+            sampling_project_state: None,
+        };
 
+        let envelope_response = processor.process(message).unwrap();
         assert!(envelope_response.envelope.is_none());
     }
 
@@ -3122,17 +3114,14 @@ mod tests {
             item
         });
 
-        let envelope_response = relay_test::with_system(move || {
-            processor
-                .process(ProcessEnvelope {
-                    envelope_context: EnvelopeContext::standalone(&envelope),
-                    envelope,
-                    project_state: Arc::new(ProjectState::allowed()),
-                    sampling_project_state: None,
-                })
-                .unwrap()
-        });
+        let message = ProcessEnvelope {
+            envelope_context: EnvelopeContext::standalone(&envelope),
+            envelope,
+            project_state: Arc::new(ProjectState::allowed()),
+            sampling_project_state: None,
+        };
 
+        let envelope_response = processor.process(message).unwrap();
         let (envelope, ctx) = envelope_response.envelope.unwrap();
         let item = envelope.items().next().unwrap();
         assert_eq!(item.ty(), &ItemType::ClientReport);
@@ -3182,17 +3171,14 @@ mod tests {
             item
         });
 
-        let envelope_response = relay_test::with_system(move || {
-            processor
-                .process(ProcessEnvelope {
-                    envelope_context: EnvelopeContext::standalone(&envelope),
-                    envelope,
-                    project_state: Arc::new(ProjectState::allowed()),
-                    sampling_project_state: None,
-                })
-                .unwrap()
-        });
+        let message = ProcessEnvelope {
+            envelope_context: EnvelopeContext::standalone(&envelope),
+            envelope,
+            project_state: Arc::new(ProjectState::allowed()),
+            sampling_project_state: None,
+        };
 
+        let envelope_response = processor.process(message).unwrap();
         assert!(envelope_response.envelope.is_none());
     }
 

--- a/relay-server/src/body/peek_line.rs
+++ b/relay-server/src/body/peek_line.rs
@@ -58,7 +58,7 @@ pub async fn peek_line<S>(
 
 #[cfg(test)]
 mod tests {
-    use relay_test::TestRequest;
+    use actix_web::test::TestRequest;
 
     use super::*;
 

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -10,8 +10,6 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-actix = "0.7.9"
-actix-web = { version = "0.7.19", default-features = false}
 futures01 = { version = "0.1.28", package = "futures" }
 relay-log = { path = "../relay-log", features = ["test"] }
 relay-system = { path = "../relay-system" }

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -10,7 +10,5 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-futures01 = { version = "0.1.28", package = "futures" }
 relay-log = { path = "../relay-log", features = ["test"] }
 relay-system = { path = "../relay-system" }
-tokio = "1.0"

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -6,19 +6,15 @@
 //!    captured by the test runner. All logs emitted with [`relay_log`] will show up for test
 //!    failures or when run with `--nocapture`.
 //!
-//!  - Wrap all code that spawns futures into [`block_fn`]. This ensures the actix system is both
-//!    registered and running.
+//! # Example
 //!
 //! ```
-//! relay_test::setup();
+//! #[test]
+//! fn my_test() {
+//!     relay_test::setup();
 //!
-//! // Access to the actix System is possible outside of `block_fn`.
-//! let system = actix::System::current();
-//!
-//! relay_test::block_fn(|| {
-//!     // `actix::spawn` can be called in here.
-//!     Ok::<(), ()>(())
-//! });
+//!     relay_log::debug!("hello, world!");
+//! }
 //! ```
 
 #![doc(
@@ -27,93 +23,9 @@
 )]
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use std::cell::RefCell;
-
-use actix::{System, SystemRunner};
-pub use actix_web::test::*;
-use futures01::{future, IntoFuture};
-
-thread_local! {
-    static SYSTEM: RefCell<Inner> = RefCell::new(Inner::new());
-}
-
-struct Inner {
-    system: Option<System>,
-    runner: Option<SystemRunner>,
-}
-
-impl Inner {
-    fn new() -> Self {
-        let runner = System::new("relay tests");
-        let system = System::current();
-
-        Self {
-            system: Some(system),
-            runner: Some(runner),
-        }
-    }
-
-    fn set_current(&self) {
-        System::set_current(self.system.clone().unwrap());
-    }
-
-    fn runner(&mut self) -> &mut SystemRunner {
-        self.runner.as_mut().unwrap()
-    }
-}
-
-impl Drop for Inner {
-    fn drop(&mut self) {
-        self.system.take();
-        std::mem::forget(self.runner.take().unwrap())
-    }
-}
-
 /// Setup the test environment.
 ///
 ///  - Initializes logs: The logger only captures logs from this crate and mutes all other logs.
-///  - Initializes an actix actor system and registers it as current. This allows to call
-///    `System::current`.
 pub fn setup() {
     relay_log::init_test!();
-
-    // Force initialization of the actix system
-    SYSTEM.with(|_sys| ());
-}
-
-/// Runs the provided function, blocking the current thread until the result future completes.
-///
-/// This function can be used to synchronously block the current thread until the provided `future`
-/// has resolved either successfully or with an error. The result of the future is then returned
-/// from this function call.
-///
-/// This is provided rather than a `block_on`-like interface to avoid accidentally calling a
-/// function which spawns before creating a future, which would attempt to spawn before actix is
-/// initialised.
-///
-/// Note that this function is intended to be used only for testing purpose.
-///
-/// # Panics
-///
-/// This function panics on nested call.
-pub fn block_fn<F, R>(future: F) -> Result<R::Item, R::Error>
-where
-    F: FnOnce() -> R,
-    R: IntoFuture,
-{
-    SYSTEM.with(|cell| {
-        let mut inner = cell.borrow_mut();
-        inner.set_current();
-        inner.runner().block_on(future::lazy(future))
-    })
-}
-
-/// Runs the provided function with an active actix system.
-///
-/// This function otherwise functions exactly as [`block_fn`].
-pub fn with_system<F, R>(func: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    block_fn(move || future::ok::<_, ()>(func())).unwrap()
 }


### PR DESCRIPTION
Removes test utilities for testing with an actix system. Relay's services no
longer use actix, and asynchronous tests can be written directly as tokio test.

Fixes https://github.com/getsentry/relay/issues/1614
#skip-changelog

