### PR TITLE
ref(relay_cache): Inject upstream realy into the service

### DIFF
--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -194,11 +194,12 @@ pub struct RelayCacheService {
     backoff: RetryBackoff,
     delay: SleepHandle,
     config: Arc<Config>,
+    upstream_relay: Addr<UpstreamRelay>,
 }
 
 impl RelayCacheService {
     /// Creates a new [`RelayCache`] service.
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Arc<Config>, upstream_relay: Addr<UpstreamRelay>) -> Self {
         Self {
             static_relays: config.static_relays().clone(),
             relays: HashMap::new(),
@@ -207,6 +208,7 @@ impl RelayCacheService {
             backoff: RetryBackoff::new(config.http_max_retry_interval()),
             delay: SleepHandle::idle(),
             config,
+            upstream_relay,
         }
     }
 
@@ -243,15 +245,13 @@ impl RelayCacheService {
         );
 
         let fetch_tx = self.fetch_tx();
+        let upstream_relay = self.upstream_relay.clone();
         tokio::spawn(async move {
             let request = GetRelays {
                 relay_ids: channels.keys().cloned().collect(),
             };
 
-            let query_result = match UpstreamRelay::from_registry()
-                .send(SendQuery(request))
-                .await
-            {
+            let query_result = match upstream_relay.send(SendQuery(request)).await {
                 Ok(inner) => inner,
                 // Drop the channels to propagate the `SendError` up.
                 Err(_send_error) => return,

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -144,7 +144,7 @@ impl ServiceState {
         .start_in(&project_runtime);
 
         let health_check = HealthCheckService::new(config.clone()).start();
-        let relay_cache = RelayCacheService::new(config.clone()).start();
+        let relay_cache = RelayCacheService::new(config.clone(), upstream_relay.clone()).start();
 
         if let Some(aws_api) = config.aws_runtime_api() {
             if let Ok(aws_extension) = AwsExtension::new(aws_api) {


### PR DESCRIPTION
This removes `from_registry` call to `UpstreamRelayService` and injects it as dep in the `RelayCacheService`

ref: #1818 

#skip-changelog