### PR TITLE
ref(profiling): Remove platform validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Deprecate fields on the profiling sample format. ([#1878](https://github.com/getsentry/relay/pull/1878))
 - Remove idle samples at the start and end of a profile and useless metadata. ([#1894](https://github.com/getsentry/relay/pull/1894))
 - Move the pending envelopes buffering into the project cache. ([#1907](https://github.com/getsentry/relay/pull/1907))
+- Remove platform validation for profiles. ([#1933](https://github.com/getsentry/relay/pull/1933))
 
 ## 23.2.0
 

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -93,7 +93,7 @@
 //! }
 //! ```
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 mod android;
 mod cocoa;
@@ -113,24 +113,11 @@ pub use crate::error::ProfileError;
 pub use crate::outcomes::discard_reason;
 use crate::sample::{parse_sample_profile, Version};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-enum Platform {
-    Android,
-    Cocoa,
-    Dotnet,
-    Javascript,
-    Node,
-    Php,
-    Python,
-    Rust,
-}
-
 #[derive(Debug, Deserialize)]
 struct MinimalProfile {
     #[serde(alias = "profile_id")]
     event_id: EventId,
-    platform: Platform,
+    platform: String,
     #[serde(default)]
     version: Version,
 }
@@ -146,9 +133,9 @@ pub fn expand_profile(payload: &[u8]) -> Result<(EventId, Vec<u8>), ProfileError
     };
     let processed_payload = match profile.version {
         Version::V1 => parse_sample_profile(payload),
-        Version::Unknown => match profile.platform {
-            Platform::Android => parse_android_profile(payload),
-            Platform::Cocoa => parse_cocoa_profile(payload),
+        Version::Unknown => match profile.platform.as_str() {
+            "android" => parse_android_profile(payload),
+            "cocoa" => parse_cocoa_profile(payload),
             _ => return Err(ProfileError::PlatformNotSupported),
         },
     };


### PR DESCRIPTION
Let's align with the event protocol and not validate platform for profiles.

`runtime` is not a required field, the profile is valid even if those fields are omitted. I'd remove the validation for `cocoa` as well but we do have some code relying on these fields for Snuba ingestion so we'll need to deal with that first in order to treat everything as optional like for the event.

We can close https://github.com/getsentry/relay/pull/1902 in favor of this.