### PR TITLE
feat(csp): Add the request's origin to CSP events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Optionally mark scrubbed URL transactions as sanitized. ([#1917](https://github.com/getsentry/relay/pull/1917))
 - Perform PII scrubbing on meta's original_value field. ([#1892](https://github.com/getsentry/relay/pull/1892))
 - Add links to docs in YAML config file. ([#1923](https://github.com/getsentry/relay/pull/1923))
+- For security reports, add the request's `origin` header to sentry events. ([#1934](https://github.com/getsentry/relay/pull/1934))
 
 **Bug Fixes**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -56,6 +56,7 @@ use crate::actors::project::ProjectState;
 use crate::actors::project_cache::ProjectCache;
 use crate::actors::upstream::{SendRequest, UpstreamRelay};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
+use crate::extractors::RequestMeta;
 use crate::metrics_extraction::sessions::extract_session_metrics;
 use crate::metrics_extraction::transactions::{extract_transaction_metrics, ExtractMetricsError};
 use crate::service::REGISTRY;
@@ -1371,7 +1372,11 @@ impl EnvelopeProcessorService {
         Ok((event, item.len()))
     }
 
-    fn event_from_security_report(&self, item: Item) -> Result<ExtractedEvent, ProcessingError> {
+    fn event_from_security_report(
+        &self,
+        item: Item,
+        meta: &RequestMeta,
+    ) -> Result<ExtractedEvent, ProcessingError> {
         let len = item.len();
         let mut event = Event::default();
 
@@ -1405,6 +1410,15 @@ impl EnvelopeProcessorService {
             .and_then(Value::as_str)
         {
             event.environment = Annotated::from(env.to_owned());
+        }
+
+        if let Some(origin) = meta.origin() {
+            event
+                .request
+                .get_or_insert_with(Default::default)
+                .headers
+                .get_or_insert_with(Default::default)
+                .insert("Origin".into(), Annotated::new(origin.to_string().into()));
         }
 
         // Explicitly set the event type. This is required so that a `Security` item can be created
@@ -1644,10 +1658,11 @@ impl EnvelopeProcessorService {
         } else if let Some(mut item) = raw_security_item {
             relay_log::trace!("processing security report");
             state.sample_rates = item.take_sample_rates();
-            self.event_from_security_report(item).map_err(|error| {
-                relay_log::error!("failed to extract security report: {}", LogError(&error));
-                error
-            })?
+            self.event_from_security_report(item, envelope.meta())
+                .map_err(|error| {
+                    relay_log::error!("failed to extract security report: {}", LogError(&error));
+                    error
+                })?
         } else if attachment_item.is_some() || breadcrumbs1.is_some() || breadcrumbs2.is_some() {
             relay_log::trace!("extracting attached event data");
             Self::event_from_attachments(&self.config, attachment_item, breadcrumbs1, breadcrumbs2)?


### PR DESCRIPTION
The `Origin` header is useful when debugging CSP violations. This PR adds the
contents of the origin header, if present, to the event's request interface.

