### PR TITLE
ref(server): Move Envelope into EnvelopeContext

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use chrono::Utc;
-use relay_common::{Dsn, ProjectKey};
+use relay_common::ProjectKey;
 use relay_config::{Config, HttpEncoding};
 use relay_general::protocol::ClientReport;
 use relay_log::LogError;

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use chrono::Utc;
-use relay_common::ProjectKey;
+use relay_common::{Dsn, ProjectKey};
 use relay_config::{Config, HttpEncoding};
 use relay_general::protocol::ClientReport;
 use relay_log::LogError;
@@ -293,10 +293,9 @@ impl EnvelopeManagerService {
         } = message;
 
         let scoping = envelope_context.scoping();
-        match self
-            .submit_envelope(envelope_context.envelope(), scoping, None)
-            .await
-        {
+
+        let envelope = envelope_context.take_envelope();
+        match self.submit_envelope(envelope, scoping, None).await {
             Ok(_) => {
                 envelope_context.accept();
             }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -292,8 +292,8 @@ impl EnvelopeManagerService {
 
         let scoping = envelope.scoping();
 
-        let envelope = envelope.take_envelope();
-        match self.submit_envelope(envelope, scoping, None).await {
+        let inner_envelope = envelope.take_envelope();
+        match self.submit_envelope(inner_envelope, scoping, None).await {
             Ok(_) => {
                 envelope.accept();
             }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -128,7 +128,6 @@ impl UpstreamRequest for SendEnvelope {
 /// Sends an envelope to the upstream or Kafka.
 #[derive(Debug)]
 pub struct SubmitEnvelope {
-    pub envelope: Box<Envelope>,
     pub envelope_context: EnvelopeContext,
 }
 
@@ -290,12 +289,14 @@ impl EnvelopeManagerService {
 
     async fn handle_submit(&self, message: SubmitEnvelope) {
         let SubmitEnvelope {
-            envelope,
             mut envelope_context,
         } = message;
 
         let scoping = envelope_context.scoping();
-        match self.submit_envelope(envelope, scoping, None).await {
+        match self
+            .submit_envelope(envelope_context.envelope(), scoping, None)
+            .await
+        {
             Ok(_) => {
                 envelope_context.accept();
             }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -28,7 +28,7 @@ use crate::extractors::{PartialDsn, RequestMeta};
 use crate::http::{HttpError, Request, RequestBuilder, Response};
 use crate::service::{Registry, REGISTRY};
 use crate::statsd::RelayHistograms;
-use crate::utils::EnvelopeContext;
+use crate::utils::ManagedEnvelope;
 
 /// Error created while handling [`SendEnvelope`].
 #[derive(Debug, thiserror::Error)]
@@ -128,7 +128,7 @@ impl UpstreamRequest for SendEnvelope {
 /// Sends an envelope to the upstream or Kafka.
 #[derive(Debug)]
 pub struct SubmitEnvelope {
-    pub envelope_context: EnvelopeContext,
+    pub envelope: ManagedEnvelope,
 }
 
 /// Sends a client report to the upstream.
@@ -288,19 +288,17 @@ impl EnvelopeManagerService {
     }
 
     async fn handle_submit(&self, message: SubmitEnvelope) {
-        let SubmitEnvelope {
-            mut envelope_context,
-        } = message;
+        let SubmitEnvelope { mut envelope } = message;
 
-        let scoping = envelope_context.scoping();
+        let scoping = envelope.scoping();
 
-        let envelope = envelope_context.take_envelope();
+        let envelope = envelope.take_envelope();
         match self.submit_envelope(envelope, scoping, None).await {
             Ok(_) => {
-                envelope_context.accept();
+                envelope.accept();
             }
             Err(SendEnvelopeError::UpstreamRequestFailed(e)) if e.is_received() => {
-                envelope_context.accept();
+                envelope.accept();
             }
             Err(error) => {
                 // Errors are only logged for what we consider an internal discard reason. These
@@ -309,7 +307,7 @@ impl EnvelopeManagerService {
                     |scope| scope.set_tag("project_key", scoping.project_key),
                     || relay_log::error!("error sending envelope: {}", LogError(&error)),
                 );
-                envelope_context.reject(Outcome::Invalid(DiscardReason::Internal));
+                envelope.reject(Outcome::Invalid(DiscardReason::Internal));
             }
         }
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -811,14 +811,14 @@ impl EnvelopeProcessorService {
         let received = state.envelope_context.received_at();
         let extracted_metrics = &mut state.extracted_metrics.project_metrics;
         let metrics_config = state.project_state.config().session_metrics;
-        let envelope = state.envelope_context.envelope();
+        let envelope = state.envelope_context.envelope_mut();
         let client = envelope.meta().client().map(|x| x.to_owned());
         let client_addr = envelope.meta().client_addr();
 
         let clock_drift_processor =
             ClockDriftProcessor::new(envelope.sent_at(), received).at_least(MINIMUM_CLOCK_DRIFT);
 
-        state.envelope_context.envelope_mut().retain_items(|item| {
+        envelope.retain_items(|item| {
             match item.ty() {
                 ItemType::Session => self.process_session(
                     item,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2014,7 +2014,7 @@ impl EnvelopeProcessorService {
             debug_assert!(state.envelope().is_empty());
         }
 
-        enforcement.track_outcomes(&state.envelope(), &state.envelope_context.scoping());
+        enforcement.track_outcomes(state.envelope(), &state.envelope_context.scoping());
 
         Ok(())
     }

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -717,11 +717,11 @@ impl Project {
     /// pipeline.
     pub fn check_envelope(
         &mut self,
-        mut envelope: Box<Envelope>,
         mut envelope_context: EnvelopeContext,
     ) -> Result<CheckedEnvelope, DiscardReason> {
         let state = self.valid_state().filter(|state| !state.invalid());
         let mut scoping = envelope_context.scoping();
+        let envelope = envelope_context.envelope_mut();
 
         if let Some(ref state) = state {
             scoping = state.scope_request(envelope.meta());
@@ -743,7 +743,7 @@ impl Project {
 
         let (enforcement, rate_limits) = envelope_limiter.enforce(&mut envelope, &scoping)?;
         enforcement.track_outcomes(&envelope, &scoping);
-        envelope_context.update(&envelope);
+        envelope_context.update();
 
         let envelope = if envelope.is_empty() {
             // Individual rate limits have already been issued above

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -744,7 +744,7 @@ impl Project {
 
         let (enforcement, rate_limits) =
             envelope_limiter.enforce(envelope_context.envelope_mut(), &scoping)?;
-        enforcement.track_outcomes(&envelope_context.envelope(), &scoping);
+        enforcement.track_outcomes(envelope_context.envelope(), &scoping);
         envelope_context.update();
 
         let envelope = if envelope_context.envelope().is_empty() {

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -22,7 +22,7 @@ use crate::actors::processor::EnvelopeProcessor;
 #[cfg(feature = "processing")]
 use crate::actors::processor::RateLimitFlushBuckets;
 use crate::actors::project_cache::{CheckedEnvelope, ProjectCache, RequestUpdate};
-use crate::envelope::Envelope;
+
 use crate::extractors::RequestMeta;
 use crate::service::Registry;
 use crate::statsd::RelayCounters;
@@ -750,7 +750,7 @@ impl Project {
             envelope_context.reject(Outcome::RateLimited(None));
             None
         } else {
-            Some((envelope, envelope_context))
+            Some(envelope_context)
         };
 
         Ok(CheckedEnvelope {

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -4,7 +4,6 @@ use relay_common::ProjectKey;
 use relay_system::{FromMessage, Interface, Service};
 use tokio::sync::mpsc;
 
-use crate::envelope::Envelope;
 use crate::utils::EnvelopeContext;
 
 /// This key represents the index element in the queue.

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -4,7 +4,7 @@ use relay_common::ProjectKey;
 use relay_system::{FromMessage, Interface, Service};
 use tokio::sync::mpsc;
 
-use crate::utils::EnvelopeContext;
+use crate::utils::ManagedEnvelope;
 
 /// This key represents the index element in the queue.
 ///
@@ -26,15 +26,15 @@ impl QueueKey {
     }
 }
 
-/// Adds the envelope and the envelope context to the internal buffer.
+/// Adds the envelope and the managed envelope to the internal buffer.
 #[derive(Debug)]
 pub struct Enqueue {
     key: QueueKey,
-    value: EnvelopeContext,
+    value: ManagedEnvelope,
 }
 
 impl Enqueue {
-    pub fn new(key: QueueKey, value: EnvelopeContext) -> Self {
+    pub fn new(key: QueueKey, value: ManagedEnvelope) -> Self {
         Self { key, value }
     }
 }
@@ -43,11 +43,11 @@ impl Enqueue {
 #[derive(Debug)]
 pub struct DequeueMany {
     keys: Vec<QueueKey>,
-    sender: mpsc::UnboundedSender<EnvelopeContext>,
+    sender: mpsc::UnboundedSender<ManagedEnvelope>,
 }
 
 impl DequeueMany {
-    pub fn new(keys: Vec<QueueKey>, sender: mpsc::UnboundedSender<EnvelopeContext>) -> Self {
+    pub fn new(keys: Vec<QueueKey>, sender: mpsc::UnboundedSender<ManagedEnvelope>) -> Self {
         Self { keys, sender }
     }
 }
@@ -117,7 +117,7 @@ impl FromMessage<RemoveMany> for Buffer {
 #[derive(Debug)]
 pub struct BufferService {
     /// Contains the cache of the incoming envelopes.
-    buffer: BTreeMap<QueueKey, Vec<EnvelopeContext>>,
+    buffer: BTreeMap<QueueKey, Vec<ManagedEnvelope>>,
 }
 
 impl BufferService {

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -31,11 +31,11 @@ impl QueueKey {
 #[derive(Debug)]
 pub struct Enqueue {
     key: QueueKey,
-    value: (Box<Envelope>, EnvelopeContext),
+    value: EnvelopeContext,
 }
 
 impl Enqueue {
-    pub fn new(key: QueueKey, value: (Box<Envelope>, EnvelopeContext)) -> Self {
+    pub fn new(key: QueueKey, value: EnvelopeContext) -> Self {
         Self { key, value }
     }
 }
@@ -44,14 +44,11 @@ impl Enqueue {
 #[derive(Debug)]
 pub struct DequeueMany {
     keys: Vec<QueueKey>,
-    sender: mpsc::UnboundedSender<(Box<Envelope>, EnvelopeContext)>,
+    sender: mpsc::UnboundedSender<EnvelopeContext>,
 }
 
 impl DequeueMany {
-    pub fn new(
-        keys: Vec<QueueKey>,
-        sender: mpsc::UnboundedSender<(Box<Envelope>, EnvelopeContext)>,
-    ) -> Self {
+    pub fn new(keys: Vec<QueueKey>, sender: mpsc::UnboundedSender<EnvelopeContext>) -> Self {
         Self { keys, sender }
     }
 }
@@ -121,7 +118,7 @@ impl FromMessage<RemoveMany> for Buffer {
 #[derive(Debug)]
 pub struct BufferService {
     /// Contains the cache of the incoming envelopes.
-    buffer: BTreeMap<QueueKey, Vec<(Box<Envelope>, EnvelopeContext)>>,
+    buffer: BTreeMap<QueueKey, Vec<EnvelopeContext>>,
 }
 
 impl BufferService {

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -579,8 +579,7 @@ impl ProjectCacheBroker {
     /// Calling this function without envelope's project state available will cause the envelope to
     /// be dropped and outcome will be logged.
     fn handle_processing(&mut self, envelope_context: EnvelopeContext) {
-        let envelope = envelope_context.envelope();
-        let project_key = envelope.meta().public_key();
+        let project_key = envelope_context.envelope().meta().public_key();
 
         let Some(project) = self.projects.get_mut(&project_key) else {
             relay_log::with_scope(
@@ -605,7 +604,7 @@ impl ProjectCacheBroker {
             ..
         }) = project.check_envelope(envelope_context)
         {
-            let sampling_state = utils::get_sampling_key(&envelope)
+            let sampling_state = utils::get_sampling_key(envelope_context.envelope())
                 .and_then(|key| self.projects.get(&key))
                 .and_then(|p| p.valid_state());
 

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -22,7 +22,7 @@ use crate::actors::project_local::{LocalProjectSource, LocalProjectSourceService
 use crate::actors::project_redis::RedisProjectSource;
 use crate::actors::project_upstream::{UpstreamProjectSource, UpstreamProjectSourceService};
 use crate::actors::upstream::UpstreamRelay;
-use crate::envelope::Envelope;
+
 use crate::service::REGISTRY;
 use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::{self, EnvelopeContext, GarbageDisposal};

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -102,7 +102,7 @@ impl GetCachedProjectState {
 /// from the envelope, `None` is returned in place of the envelope.
 #[derive(Debug)]
 pub struct CheckedEnvelope {
-    pub envelope: Option<(Box<Envelope>, EnvelopeContext)>,
+    pub envelope: Option<EnvelopeContext>,
     pub rate_limits: RateLimits,
 }
 
@@ -117,14 +117,13 @@ pub struct CheckedEnvelope {
 ///  - Cached rate limits
 #[derive(Debug)]
 pub struct CheckEnvelope {
-    envelope: Box<Envelope>,
     context: EnvelopeContext,
 }
 
 impl CheckEnvelope {
     /// Uses a cached project state and checks the envelope.
-    pub fn new(envelope: Box<Envelope>, context: EnvelopeContext) -> Self {
-        Self { envelope, context }
+    pub fn new(context: EnvelopeContext) -> Self {
+        Self { context }
     }
 }
 
@@ -141,13 +140,12 @@ impl CheckEnvelope {
 /// [`EnvelopeProcessor`]: crate::actors::processor::EnvelopeProcessor
 #[derive(Debug)]
 pub struct ValidateEnvelope {
-    envelope: Box<Envelope>,
     context: EnvelopeContext,
 }
 
 impl ValidateEnvelope {
-    pub fn new(envelope: Box<Envelope>, context: EnvelopeContext) -> Self {
-        Self { envelope, context }
+    pub fn new(context: EnvelopeContext) -> Self {
+        Self { context }
     }
 }
 
@@ -393,14 +391,14 @@ struct ProjectCacheBroker {
     source: ProjectSource,
     state_tx: mpsc::UnboundedSender<UpdateProjectState>,
     /// Index of the buffered project keys.
-    buffer_tx: mpsc::UnboundedSender<(Box<Envelope>, EnvelopeContext)>,
+    buffer_tx: mpsc::UnboundedSender<EnvelopeContext>,
     index: BTreeMap<ProjectKey, BTreeSet<QueueKey>>,
     buffer: Addr<Buffer>,
 }
 
 impl ProjectCacheBroker {
     /// Adds the value to the queue for the provided key.
-    pub fn enqueue(&mut self, key: QueueKey, value: (Box<Envelope>, EnvelopeContext)) {
+    pub fn enqueue(&mut self, key: QueueKey, value: EnvelopeContext) {
         self.index.entry(key.own_key).or_default().insert(key);
         self.index.entry(key.sampling_key).or_default().insert(key);
         self.buffer.send(Enqueue::new(key, value));
@@ -563,13 +561,13 @@ impl ProjectCacheBroker {
         &mut self,
         message: CheckEnvelope,
     ) -> Result<CheckedEnvelope, DiscardReason> {
-        let CheckEnvelope { envelope, context } = message;
-        let project = self.get_or_create_project(envelope.meta().public_key());
+        let CheckEnvelope { context } = message;
+        let project = self.get_or_create_project(context.envelope().meta().public_key());
         // Preload the project cache so that it arrives a little earlier in processing. However,
         // do not pass `no_cache`. In case the project is rate limited, we do not want to force
         // a full reload. Fetching must not block the store request.
         project.prefetch(false);
-        project.check_envelope(envelope, context)
+        project.check_envelope(context)
     }
 
     /// Handles the processing of the provided envelope.
@@ -580,7 +578,8 @@ impl ProjectCacheBroker {
     ///
     /// Calling this function without envelope's project state available will cause the envelope to
     /// be dropped and outcome will be logged.
-    fn handle_processing(&mut self, envelope: Box<Envelope>, envelope_context: EnvelopeContext) {
+    fn handle_processing(&mut self, envelope_context: EnvelopeContext) {
+        let envelope = envelope_context.envelope();
         let project_key = envelope.meta().public_key();
 
         let Some(project) = self.projects.get_mut(&project_key) else {
@@ -602,16 +601,15 @@ impl ProjectCacheBroker {
         // The `Envelope` and `EnvelopeContext` will be dropped if the `Project::check_envelope()`
         // function returns any error, which will also be ignored here.
         if let Ok(CheckedEnvelope {
-            envelope: Some((envelope, envelope_context)),
+            envelope: Some(envelope_context),
             ..
-        }) = project.check_envelope(envelope, envelope_context)
+        }) = project.check_envelope(envelope_context)
         {
             let sampling_state = utils::get_sampling_key(&envelope)
                 .and_then(|key| self.projects.get(&key))
                 .and_then(|p| p.valid_state());
 
             let mut process = ProcessEnvelope {
-                envelope,
                 envelope_context,
                 project_state: own_project_state.clone(),
                 sampling_project_state: None,
@@ -641,7 +639,8 @@ impl ProjectCacheBroker {
     ///
     /// The flushing of the buffered envelopes happens in `update_state`.
     fn handle_validate_envelope(&mut self, message: ValidateEnvelope) {
-        let ValidateEnvelope { envelope, context } = message;
+        let ValidateEnvelope { context } = message;
+        let envelope = context.envelope();
 
         // Fetch the project state for our key and make sure it's not invalid.
         let own_key = envelope.meta().public_key();
@@ -661,11 +660,11 @@ impl ProjectCacheBroker {
         // Trigger processing once we have a project state and we either have a sampling project
         // state or we do not need one.
         if project_state.is_some() && (sampling_state.is_some() || sampling_key.is_none()) {
-            return self.handle_processing(envelope, context);
+            return self.handle_processing(context);
         }
 
         let key = QueueKey::new(own_key, sampling_key.unwrap_or(own_key));
-        self.enqueue(key, (envelope, context));
+        self.enqueue(key, context);
     }
 
     fn handle_rate_limits(&mut self, message: UpdateRateLimits) {
@@ -775,7 +774,7 @@ impl Service for ProjectCacheService {
                     biased;
 
                     Some(message) = state_rx.recv() => broker.merge_state(message),
-                    Some((envelope, context)) = buffer_rx.recv() => broker.handle_processing(envelope, context),
+                    Some(context) = buffer_rx.recv() => broker.handle_processing(context),
                     _ = ticker.tick() => broker.evict_stale_project_caches(),
                     Some(message) = rx.recv() => broker.handle_message(message),
                     else => break,

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -117,13 +117,13 @@ pub struct CheckedEnvelope {
 ///  - Cached rate limits
 #[derive(Debug)]
 pub struct CheckEnvelope {
-    context: ManagedEnvelope,
+    envelope: ManagedEnvelope,
 }
 
 impl CheckEnvelope {
     /// Uses a cached project state and checks the envelope.
-    pub fn new(context: ManagedEnvelope) -> Self {
-        Self { context }
+    pub fn new(envelope: ManagedEnvelope) -> Self {
+        Self { envelope }
     }
 }
 
@@ -140,12 +140,12 @@ impl CheckEnvelope {
 /// [`EnvelopeProcessor`]: crate::actors::processor::EnvelopeProcessor
 #[derive(Debug)]
 pub struct ValidateEnvelope {
-    context: ManagedEnvelope,
+    envelope: ManagedEnvelope,
 }
 
 impl ValidateEnvelope {
-    pub fn new(context: ManagedEnvelope) -> Self {
-        Self { context }
+    pub fn new(envelope: ManagedEnvelope) -> Self {
+        Self { envelope }
     }
 }
 
@@ -561,7 +561,7 @@ impl ProjectCacheBroker {
         &mut self,
         message: CheckEnvelope,
     ) -> Result<CheckedEnvelope, DiscardReason> {
-        let CheckEnvelope { context } = message;
+        let CheckEnvelope { envelope: context } = message;
         let project = self.get_or_create_project(context.envelope().meta().public_key());
         // Preload the project cache so that it arrives a little earlier in processing. However,
         // do not pass `no_cache`. In case the project is rate limited, we do not want to force
@@ -638,7 +638,7 @@ impl ProjectCacheBroker {
     ///
     /// The flushing of the buffered envelopes happens in `update_state`.
     fn handle_validate_envelope(&mut self, message: ValidateEnvelope) {
-        let ValidateEnvelope { context } = message;
+        let ValidateEnvelope { envelope: context } = message;
         let envelope = context.envelope();
 
         // Fetch the project state for our key and make sure it's not invalid.

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -649,7 +649,7 @@ impl ProjectCacheBroker {
             .filter(|st| !st.invalid());
 
         // Also, fetch the project state for sampling key and make sure it's not invalid.
-        let sampling_key = utils::get_sampling_key(&envelope);
+        let sampling_key = utils::get_sampling_key(envelope);
         let sampling_state = sampling_key.and_then(|key| {
             self.get_or_create_project(key)
                 .get_cached_state(envelope.meta().no_cache())

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -309,7 +309,7 @@ fn queue_envelope(
         ProjectCache::from_registry().send(ValidateEnvelope::new(event_context));
     }
 
-    if envelope.is_empty() {
+    if envelope_context.envelope().is_empty() {
         // The envelope can be empty here if it contained only metrics items which were removed
         // above. In this case, the envelope was accepted and needs no further queueing.
         envelope_context.accept();

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -273,13 +273,13 @@ pub fn cors(app: App<ServiceState>) -> CorsBuilder<ServiceState> {
 /// Queueing can fail if the queue exceeds `envelope_buffer_size`. In this case, `Err` is
 /// returned and the envelope is not queued.
 fn queue_envelope(
-    mut envelope: Box<Envelope>,
     mut envelope_context: EnvelopeContext,
     buffer_guard: &BufferGuard,
 ) -> Result<(), BadStoreRequest> {
     // Remove metrics from the envelope and queue them directly on the project's `Aggregator`.
     let mut metric_items = Vec::new();
     let is_metric = |i: &Item| matches!(i.ty(), ItemType::Metrics | ItemType::MetricBuckets);
+    let envelope = envelope_context.envelope_mut();
     while let Some(item) = envelope.take_item_by(is_metric) {
         metric_items.push(item);
     }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -20,7 +20,7 @@ use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, I
 use crate::service::ServiceState;
 use crate::statsd::RelayCounters;
 use crate::utils::{
-    self, ApiErrorResponse, BufferError, BufferGuard, EnvelopeContext, FormDataIter, MultipartError,
+    self, ApiErrorResponse, BufferError, BufferGuard, FormDataIter, ManagedEnvelope, MultipartError,
 };
 
 /// Error type for all store-like requests.
@@ -273,13 +273,13 @@ pub fn cors(app: App<ServiceState>) -> CorsBuilder<ServiceState> {
 /// Queueing can fail if the queue exceeds `envelope_buffer_size`. In this case, `Err` is
 /// returned and the envelope is not queued.
 fn queue_envelope(
-    mut envelope_context: EnvelopeContext,
+    mut envelope: ManagedEnvelope,
     buffer_guard: &BufferGuard,
 ) -> Result<(), BadStoreRequest> {
     // Remove metrics from the envelope and queue them directly on the project's `Aggregator`.
     let mut metric_items = Vec::new();
     let is_metric = |i: &Item| matches!(i.ty(), ItemType::Metrics | ItemType::MetricBuckets);
-    let envelope = envelope_context.envelope_mut();
+    let envelope = envelope.envelope_mut();
     while let Some(item) = envelope.take_item_by(is_metric) {
         metric_items.push(item);
     }
@@ -305,17 +305,17 @@ fn queue_envelope(
         let event_context = buffer_guard.enter(event_envelope)?;
 
         // Update the old context after successful forking.
-        envelope_context.update();
+        envelope.update();
         ProjectCache::from_registry().send(ValidateEnvelope::new(event_context));
     }
 
-    if envelope_context.envelope().is_empty() {
+    if envelope.envelope().is_empty() {
         // The envelope can be empty here if it contained only metrics items which were removed
         // above. In this case, the envelope was accepted and needs no further queueing.
-        envelope_context.accept();
+        envelope.accept();
     } else {
         relay_log::trace!("queueing envelope");
-        ProjectCache::from_registry().send(ValidateEnvelope::new(envelope_context));
+        ProjectCache::from_registry().send(ValidateEnvelope::new(envelope));
     }
 
     Ok(())
@@ -339,32 +339,32 @@ pub async fn handle_envelope(
     utils::remove_unknown_items(state.config(), &mut envelope);
 
     let buffer_guard = state.buffer_guard();
-    let mut envelope_context = buffer_guard
+    let mut managed_envelope = buffer_guard
         .enter(envelope)
         .map_err(BadStoreRequest::QueueFailed)?;
 
-    let event_id = envelope_context.envelope().event_id();
-    if envelope_context.envelope().is_empty() {
-        envelope_context.reject(Outcome::Invalid(DiscardReason::EmptyEnvelope));
+    let event_id = managed_envelope.envelope().event_id();
+    if managed_envelope.envelope().is_empty() {
+        managed_envelope.reject(Outcome::Invalid(DiscardReason::EmptyEnvelope));
         return Ok(event_id);
     }
 
     let checked = ProjectCache::from_registry()
-        .send(CheckEnvelope::new(envelope_context))
+        .send(CheckEnvelope::new(managed_envelope))
         .await
         .map_err(|_| BadStoreRequest::ScheduleFailed)?
         .map_err(BadStoreRequest::EventRejected)?;
 
-    let Some(mut envelope_context) = checked.envelope else {
+    let Some(mut managed_envelope) = checked.envelope else {
         return Err(BadStoreRequest::RateLimited(checked.rate_limits));
     };
 
-    if !utils::check_envelope_size_limits(state.config(), envelope_context.envelope()) {
-        envelope_context.reject(Outcome::Invalid(DiscardReason::TooLarge));
+    if !utils::check_envelope_size_limits(state.config(), managed_envelope.envelope()) {
+        managed_envelope.reject(Outcome::Invalid(DiscardReason::TooLarge));
         return Err(PayloadError::Overflow.into());
     }
 
-    queue_envelope(envelope_context, buffer_guard)?;
+    queue_envelope(managed_envelope, buffer_guard)?;
 
     if checked.rate_limits.is_limited() {
         Err(BadStoreRequest::RateLimited(checked.rate_limits))

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -861,6 +861,15 @@ impl Envelope {
         Ok(Box::new(Envelope { headers, items }))
     }
 
+    /// Move the envelope's items into an envelope with the same headers.
+    pub fn take_items(&mut self) -> Envelope {
+        let Self { headers, items } = self;
+        Self {
+            headers: headers.clone(),
+            items: std::mem::take(items),
+        }
+    }
+
     /// Returns the number of items in this envelope.
     #[allow(dead_code)]
     pub fn len(&self) -> usize {

--- a/relay-server/src/utils/buffer.rs
+++ b/relay-server/src/utils/buffer.rs
@@ -52,7 +52,7 @@ impl BufferGuard {
     /// be reused by a subsequent call to `enter`.
     ///
     /// If the buffer is full, this function returns `Err`.
-    pub fn enter(&self, envelope: &Envelope) -> Result<EnvelopeContext, BufferError> {
+    pub fn enter(&self, envelope: Box<Envelope>) -> Result<EnvelopeContext, BufferError> {
         let permit = self.inner.try_acquire().ok_or(BufferError)?;
 
         relay_statsd::metric!(histogram(RelayHistograms::EnvelopeQueueSize) = self.used() as u64);

--- a/relay-server/src/utils/buffer.rs
+++ b/relay-server/src/utils/buffer.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::envelope::Envelope;
 use crate::statsd::RelayHistograms;
-use crate::utils::{EnvelopeContext, Semaphore};
+use crate::utils::{ManagedEnvelope, Semaphore};
 
 /// An error returned by [`BufferGuard::enter`] indicating that the buffer capacity has been
 /// exceeded.
@@ -48,11 +48,11 @@ impl BufferGuard {
     /// Reserves resources for processing an envelope in Relay.
     ///
     /// Returns `Ok(EnvelopeContext)` on success, which internally holds a handle to the reserved
-    /// resources. When the envelope context is dropped, the slot is automatically reclaimed and can
+    /// resources. When the managed envelope is dropped, the slot is automatically reclaimed and can
     /// be reused by a subsequent call to `enter`.
     ///
     /// If the buffer is full, this function returns `Err`.
-    pub fn enter(&self, envelope: Box<Envelope>) -> Result<EnvelopeContext, BufferError> {
+    pub fn enter(&self, envelope: Box<Envelope>) -> Result<ManagedEnvelope, BufferError> {
         let permit = self.inner.try_acquire().ok_or(BufferError)?;
 
         relay_statsd::metric!(histogram(RelayHistograms::EnvelopeQueueSize) = self.used() as u64);
@@ -64,6 +64,6 @@ impl BufferGuard {
             }
         );
 
-        Ok(EnvelopeContext::new(envelope, permit))
+        Ok(ManagedEnvelope::new(envelope, permit))
     }
 }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -77,14 +77,18 @@ impl EnvelopeContext {
     fn new_internal(envelope: Box<Envelope>, slot: Option<SemaphorePermit>) -> Self {
         let meta = &envelope.meta();
         let summary = EnvelopeSummary::compute(envelope.as_ref());
+        let event_id = envelope.event_id();
+        let start_time = meta.start_time();
+        let remote_addr = meta.client_addr();
+        let scoping = meta.get_partial_scoping();
         Self {
             envelope,
             summary,
-            start_time: meta.start_time(),
-            received_at: relay_common::instant_to_date_time(meta.start_time()),
-            event_id: envelope.event_id(),
-            remote_addr: meta.client_addr(),
-            scoping: meta.get_partial_scoping(),
+            start_time,
+            received_at: relay_common::instant_to_date_time(start_time),
+            event_id,
+            remote_addr,
+            scoping,
             slot,
             done: false,
         }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -76,15 +76,16 @@ impl EnvelopeContext {
     fn new_internal(envelope: Box<Envelope>, slot: Option<SemaphorePermit>) -> Self {
         let meta = &envelope.meta();
         let summary = EnvelopeSummary::compute(envelope.as_ref());
-        let event_id = envelope.event_id();
         let start_time = meta.start_time();
+        let received_at = relay_common::instant_to_date_time(start_time);
+        let event_id = envelope.event_id();
         let remote_addr = meta.client_addr();
         let scoping = meta.get_partial_scoping();
         Self {
             envelope,
             summary,
             start_time,
-            received_at: relay_common::instant_to_date_time(start_time),
+            received_at,
             event_id,
             remote_addr,
             scoping,
@@ -126,7 +127,7 @@ impl EnvelopeContext {
         Box::new(self.envelope.take_items())
     }
 
-    /// Update the context with new envelope information.
+    /// Update the context with envelope information.
     ///
     /// This updates the item summary as well as the event id.
     pub fn update(&mut self) -> &mut Self {

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -1,6 +1,5 @@
 //! Envelope context type and helpers to ensure outcomes.
 
-use bytes::Bytes;
 use std::net;
 use std::time::Instant;
 
@@ -124,8 +123,7 @@ impl EnvelopeContext {
     ///
     /// Note that after taking out the envelope, the envelope summary is incorrect.
     pub(crate) fn take_envelope(&mut self) -> Box<Envelope> {
-        let dummy_envelope = Envelope::parse_bytes(Bytes::from("{}")).unwrap();
-        std::mem::replace(&mut self.envelope, dummy_envelope)
+        Box::new(self.envelope.take_items())
     }
 
     /// Update the context with new envelope information.
@@ -271,27 +269,5 @@ impl EnvelopeContext {
 impl Drop for EnvelopeContext {
     fn drop(&mut self) {
         self.reject(Outcome::Invalid(DiscardReason::Internal));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::extractors::RequestMeta;
-
-    use super::*;
-
-    fn request_meta() -> RequestMeta {
-        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
-            .parse()
-            .unwrap();
-
-        RequestMeta::new(dsn)
-    }
-
-    #[test]
-    fn take_envelope_works() {
-        let envelope = Envelope::from_request(None, request_meta());
-        let mut context = EnvelopeContext::standalone(envelope);
-        context.take_envelope();
     }
 }

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -1,5 +1,6 @@
 //! Envelope context type and helpers to ensure outcomes.
 
+use bytes::Bytes;
 use std::net;
 use std::time::Instant;
 
@@ -113,6 +114,14 @@ impl EnvelopeContext {
     /// Returns a mutable reference to the contained [`Envelope`].
     pub fn envelope_mut(&mut self) -> &mut Envelope {
         self.envelope.as_mut()
+    }
+
+    /// Take the envelope out of the context and replace it with a dummy.
+    ///
+    /// Note that after taking out the envelope, the envelope summary is incorrect.
+    pub(crate) fn take_envelope(&mut self) -> Box<Envelope> {
+        let dummy_envelope = Envelope::parse_bytes(Bytes::from("{}")).unwrap();
+        std::mem::replace(&mut self.envelope, dummy_envelope)
     }
 
     /// Update the context with new envelope information.

--- a/relay-server/src/utils/envelope_context.rs
+++ b/relay-server/src/utils/envelope_context.rs
@@ -273,3 +273,25 @@ impl Drop for EnvelopeContext {
         self.reject(Outcome::Invalid(DiscardReason::Internal));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::extractors::RequestMeta;
+
+    use super::*;
+
+    fn request_meta() -> RequestMeta {
+        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
+            .parse()
+            .unwrap();
+
+        RequestMeta::new(dsn)
+    }
+
+    #[test]
+    fn take_envelope_works() {
+        let envelope = Envelope::from_request(None, request_meta());
+        let mut context = EnvelopeContext::standalone(envelope);
+        context.take_envelope();
+    }
+}

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -45,7 +45,7 @@ impl Handling {
 
 /// Tracks the lifetime of an [`Envelope`] in Relay.
 ///
-/// The envelope context accompanies envelopes through the processing pipeline in Relay and ensures
+/// The managed envelope accompanies envelopes through the processing pipeline in Relay and ensures
 /// that outcomes are recorded when the Envelope is dropped. They can be dropped in one of three
 /// ways:
 ///
@@ -53,13 +53,13 @@ impl Handling {
 ///    another service, and no further outcomes need to be recorded.
 ///  - By calling [`reject`](Self::reject). The entire envelope was dropped, and the outcome
 ///    specifies the reason.
-///  - By dropping the envelope context. This indicates an issue or a bug and raises the
+///  - By dropping the managed envelope. This indicates an issue or a bug and raises the
 ///    `"internal"` outcome. There should be additional error handling to report an error to Sentry.
 ///
-/// The envelope context also holds a processing queue permit which is used for backpressure
+/// The managed envelope also holds a processing queue permit which is used for backpressure
 /// management. It is automatically reclaimed when the context is dropped along with the envelope.
 #[derive(Debug)]
-pub struct EnvelopeContext {
+pub struct ManagedEnvelope {
     envelope: Box<Envelope>,
     summary: EnvelopeSummary,
     start_time: Instant,
@@ -71,8 +71,8 @@ pub struct EnvelopeContext {
     done: bool,
 }
 
-impl EnvelopeContext {
-    /// Computes an envelope context from the given envelope.
+impl ManagedEnvelope {
+    /// Computes an managed envelope from the given envelope.
     fn new_internal(envelope: Box<Envelope>, slot: Option<SemaphorePermit>) -> Self {
         let meta = &envelope.meta();
         let summary = EnvelopeSummary::compute(envelope.as_ref());
@@ -103,7 +103,7 @@ impl EnvelopeContext {
         Self::new_internal(envelope, None)
     }
 
-    /// Computes an envelope context from the given envelope and binds it to the processing queue.
+    /// Computes an managed envelope from the given envelope and binds it to the processing queue.
     ///
     /// To provide additional scoping, use [`EnvelopeContext::scope`].
     pub fn new(envelope: Box<Envelope>, slot: SemaphorePermit) -> Self {
@@ -154,7 +154,7 @@ impl EnvelopeContext {
 
     /// Records an outcome scoped to this envelope's context.
     ///
-    /// This envelope context should be updated using [`update`](Self::update) soon after this
+    /// This managed envelope should be updated using [`update`](Self::update) soon after this
     /// operation to ensure that subsequent outcomes are consistent.
     pub fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
         let outcome_aggregator = TrackOutcome::from_registry();
@@ -267,7 +267,7 @@ impl EnvelopeContext {
     }
 }
 
-impl Drop for EnvelopeContext {
+impl Drop for ManagedEnvelope {
     fn drop(&mut self) {
         self.reject(Outcome::Invalid(DiscardReason::Internal));
     }

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -105,7 +105,7 @@ impl ManagedEnvelope {
 
     /// Computes an managed envelope from the given envelope and binds it to the processing queue.
     ///
-    /// To provide additional scoping, use [`EnvelopeContext::scope`].
+    /// To provide additional scoping, use [`ManagedEnvelope::scope`].
     pub fn new(envelope: Box<Envelope>, slot: SemaphorePermit) -> Self {
         Self::new_internal(envelope, Some(slot))
     }

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -1,8 +1,8 @@
 mod api;
 mod buffer;
 mod dynamic_sampling;
-mod envelope_context;
 mod garbage;
+mod managed_envelope;
 mod metrics_rate_limits;
 mod multipart;
 mod param_parser;
@@ -21,8 +21,8 @@ mod unreal;
 pub use self::api::*;
 pub use self::buffer::*;
 pub use self::dynamic_sampling::*;
-pub use self::envelope_context::*;
 pub use self::garbage::*;
+pub use self::managed_envelope::*;
 pub use self::metrics_rate_limits::*;
 pub use self::multipart::*;
 #[cfg(feature = "processing")]


### PR DESCRIPTION
Make `EnvelopeContext` the owner of `Envelope`. and rename it to `ManagedEnvelope`.

In follow-up PRs, this will allow us to:

- Move outcome tracking into `retain_item`.
- Let `ManagedEnvelope` manage all modifications to `Envelope`, such that the `EnvelopeSummary` is always up-to-date.

#skip-changelog

ref: https://github.com/getsentry/relay/issues/1888