### PR TITLE
feat(normalization): Trim logger smartly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - Normalize monitor slug parameters into slugs. ([#1913](https://github.com/getsentry/relay/pull/1913))
+- Smart trim loggers for Java platforms. ([#1941](https://github.com/getsentry/relay/pull/1941))
 
 ## 23.3.0
 

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -1048,7 +1048,7 @@ fn shorten_logger(logger: String) -> String {
     }
 
     tokens.reverse();
-    "*".to_owned() + &tokens.iter().join("")
+    format!("*{}", tokens.join(""))
 }
 
 /// Remove as many tokens as needed to match the maximum char limit defined in

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -810,7 +810,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
             if let Some(event_logger) = event.logger.value_mut() {
                 let shortened = shorten_logger(event_logger.clone());
                 if shortened != event_logger.as_str() {
-                    *event_logger = shortened.to_owned();
+                    *event_logger = shortened;
                 }
             }
         }

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_empty.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_empty.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_exact_length.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_exact_length.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "this_is-exactly-the_max_len.012345678901234567890123456789012345",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_short_no_trimming.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_short_no_trimming.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "my.short-logger.isnt_trimmed",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_too_long_single_word.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_too_long_single_word.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "*is-way_too_long-and_we_only_have_one_word-so_we_cant_smart_trim",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_too_long_single_word.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_too_long_single_word.snap
@@ -7,5 +7,18 @@ expression: event
   "level": "error",
   "type": "default",
   "logger": "*is-way_too_long-and_we_only_have_one_word-so_we_cant_smart_trim",
-  "platform": "java"
+  "platform": "java",
+  "_meta": {
+    "": {
+      "rem": [
+        [
+          "@logger:replace",
+          "s",
+          0,
+          5
+        ]
+      ],
+      "len": 68
+    }
+  }
 }

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_trimmed.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_trimmed.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_trimmed.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_trimmed.snap
@@ -7,5 +7,18 @@ expression: event
   "level": "error",
   "type": "default",
   "logger": "",
-  "platform": "java"
+  "platform": "java",
+  "_meta": {
+    "": {
+      "rem": [
+        [
+          "@logger:remove",
+          "x",
+          0,
+          8
+        ]
+      ],
+      "len": 8
+    }
+  }
 }

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_leading_dots.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_leading_dots.snap
@@ -7,5 +7,18 @@ expression: event
   "level": "error",
   "type": "default",
   "logger": "*this-tests-the-smart-trimming-and-word-removal-around-dot.words",
-  "platform": "java"
+  "platform": "java",
+  "_meta": {
+    "": {
+      "rem": [
+        [
+          "@logger:replace",
+          "s",
+          0,
+          3
+        ]
+      ],
+      "len": 66
+    }
+  }
 }

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_leading_dots.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_leading_dots.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "*this-tests-the-smart-trimming-and-word-removal-around-dot.words",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_at_max.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_at_max.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "*.in.this_part-is-kept.this_right_here-is_an-extremely_long_word",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_at_max.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_at_max.snap
@@ -7,5 +7,18 @@ expression: event
   "level": "error",
   "type": "default",
   "logger": "*.in.this_part-is-kept.this_right_here-is_an-extremely_long_word",
-  "platform": "java"
+  "platform": "java",
+  "_meta": {
+    "": {
+      "rem": [
+        [
+          "@logger:replace",
+          "s",
+          0,
+          15
+        ]
+      ],
+      "len": 78
+    }
+  }
 }

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_before_max.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_before_max.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/store/normalize.rs
+expression: event
+---
+{
+  "event_id": "7637af36578e4e4592692e28a1d6e2ca",
+  "level": "error",
+  "type": "default",
+  "logger": "*.this_part-is-kept.this_right_here-is_a-very_long_word",
+  "platform": "java"
+}

--- a/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_before_max.snap
+++ b/relay-general/src/store/snapshots/relay_general__store__normalize__tests__normalize_logger_word_trimmed_before_max.snap
@@ -7,5 +7,18 @@ expression: event
   "level": "error",
   "type": "default",
   "logger": "*.this_part-is-kept.this_right_here-is_a-very_long_word",
-  "platform": "java"
+  "platform": "java",
+  "_meta": {
+    "": {
+      "rem": [
+        [
+          "@logger:replace",
+          "s",
+          0,
+          33
+        ]
+      ],
+      "len": 87
+    }
+  }
 }


### PR DESCRIPTION
This PR changes how we trim loggers for events coming from Java platforms. Chars from the end are now prioritized (so the string is trimmed from the beginning), and it's also attempted to trim full words in `.`s.

We are only interested in doing this for Java at this moment; because loggers in Java are fully qualified names (including the package, so potentially very long strings) where the class name at the end is more important, and because it's the only platform we've received this type of feedback on.

Resolves https://github.com/getsentry/relay/issues/1827.

### Examples

These examples are from the tests, see the diff for more examples and/or edge cases.

```txt
# Before
this_is-way_too_long-and_we_only_have_one_word-so_we_cant_smart_trim

# After
*is-way_too_long-and_we_only_have_one_word-so_we_cant_smart_trim
```

```txt
# Before
super_out.this_is_already_out_too.this_part-is-kept.this_right_here-is_a-very_long_word

# After
*.this_part-is-kept.this_right_here-is_a-very_long_word
```