### PR TITLE
feat(general): Indicate if OS-version may be frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+
+- Indicate if OS-version may be frozen with '>=' prefix. ([#1945](https://github.com/getsentry/relay/pull/1945))
+
 ## 23.3.0
 
 **Features**:

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -253,6 +253,7 @@ OsContext {
 
         let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
+        // Checks that the '>=' prefix is added.
         assert_eq!(os.version.value().unwrap(), ">=10.15.7");
     }
 

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -73,14 +73,33 @@ impl FromUserAgentInfo for OsContext {
 
     fn parse_user_agent(user_agent: &str) -> Option<Self> {
         let os = parse_os(user_agent);
+        let mut version = get_version(&os.major, &os.minor, &os.patch);
 
         if !is_known(&os.family) {
             return None;
         }
 
+        let name = os.family.into_owned();
+
+        // Since user-agent strings freeze the OS-version at windows 10 and mac os 10.15.7,
+        // we will indicate that the version may in reality be higher.
+        if name == "Windows" {
+            if let Some(v) = version.as_mut() {
+                if v == "10" {
+                    v.insert_str(0, ">=");
+                }
+            }
+        } else if name == "Mac OS X" {
+            if let Some(v) = version.as_mut() {
+                if v == "10.15.7" {
+                    v.insert_str(0, ">=");
+                }
+            }
+        }
+
         Some(Self {
-            name: Annotated::new(os.family.into_owned()),
-            version: Annotated::from(get_version(&os.major, &os.minor, &os.patch)),
+            name: Annotated::new(name),
+            version: Annotated::from(version),
             ..OsContext::default()
         })
     }
@@ -191,7 +210,7 @@ OsContext {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_string().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
             )),
             Annotated::new((
                 Annotated::new("invalid header".to_string().into()),
@@ -210,7 +229,7 @@ OsContext {
         insta::assert_debug_snapshot!(os, @r###"
 OsContext {
     name: "Mac OS X",
-    version: "10.15.7",
+    version: "10.15.6",
     build: ~,
     kernel_version: ~,
     rooted: ~,
@@ -218,6 +237,23 @@ OsContext {
     other: {},
 }
         "###);
+    }
+
+    #[test]
+    fn test_indicate_frozen_os() {
+        let headers = Headers({
+            let headers = vec![
+            Annotated::new((
+                Annotated::new("user-agent".to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+            )),
+        ];
+            PairList(headers)
+        });
+
+        let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
+
+        assert_eq!(os.version.value().unwrap(), ">=10.15.7");
     }
 
     #[test]

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -240,7 +240,25 @@ OsContext {
     }
 
     #[test]
-    fn test_indicate_frozen_os() {
+    fn test_indicate_frozen_os_windows() {
+        let headers = Headers({
+            let headers = vec![
+            Annotated::new((
+                Annotated::new("user-agent".to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"#.to_string().into()),
+            )),
+        ];
+            PairList(headers)
+        });
+
+        let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
+
+        // Checks that the '>=' prefix is added.
+        assert_eq!(os.version.value().unwrap(), ">=10");
+    }
+
+    #[test]
+    fn test_indicate_frozen_os_mac() {
         let headers = Headers({
             let headers = vec![
             Annotated::new((

--- a/relay-general/src/protocol/replay.rs
+++ b/relay-general/src/protocol/replay.rs
@@ -397,7 +397,7 @@ mod tests {
     fn test_set_user_agent_meta() {
         let os_context = Annotated::new(ContextInner(Context::Os(Box::new(OsContext {
             name: Annotated::new("Mac OS X".to_string()),
-            version: Annotated::new("10.15.7".to_string()),
+            version: Annotated::new(">=10.15.7".to_string()),
             ..Default::default()
         }))));
         let browser_context =

--- a/tests/integration/fixtures/security_report/csp.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp.no_processing.output.json
@@ -9,7 +9,7 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
   "csp": {
@@ -29,7 +29,10 @@
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "request": {
     "headers": [
-      ["Referer", "https://www.google.com/"],
+      [
+        "Referer",
+        "https://www.google.com/"
+      ],
       [
         "User-Agent",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
@@ -38,8 +41,16 @@
     "url": "https://example.com/foo/bar"
   },
   "tags": [
-    ["effective-directive", "default-src"],
-    ["blocked-uri", "http://evilhackerscripts.com"]
+    [
+      "effective-directive",
+      "default-src"
+    ],
+    [
+      "blocked-uri",
+      "http://evilhackerscripts.com"
+    ]
   ],
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/fixtures/security_report/csp.normalized.output.json
+++ b/tests/integration/fixtures/security_report/csp.normalized.output.json
@@ -21,7 +21,7 @@
     },
     "client_os": {
       "name": "Windows",
-      "version": "10",
+      "version": ">=10",
       "type": "os"
     }
   },

--- a/tests/integration/fixtures/security_report/csp_chrome.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_chrome.no_processing.output.json
@@ -9,7 +9,7 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
   "csp": {
@@ -38,8 +38,16 @@
     "url": "http://localhost:8000/"
   },
   "tags": [
-    ["effective-directive", "style-src"],
-    ["blocked-uri", "http://localhost:8000/lol.css"]
+    [
+      "effective-directive",
+      "style-src"
+    ],
+    [
+      "blocked-uri",
+      "http://localhost:8000/lol.css"
+    ]
   ],
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/fixtures/security_report/csp_chrome_blocked_asset.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_chrome_blocked_asset.no_processing.output.json
@@ -9,7 +9,7 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
   "csp": {
@@ -38,8 +38,16 @@
     "url": "http://notlocalhost:8000/"
   },
   "tags": [
-    ["effective-directive", "style-src"],
-    ["blocked-uri", "http://notlocalhost:8000/lol.css"]
+    [
+      "effective-directive",
+      "style-src"
+    ],
+    [
+      "blocked-uri",
+      "http://notlocalhost:8000/lol.css"
+    ]
   ],
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/fixtures/security_report/csp_firefox_blocked_asset.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_firefox_blocked_asset.no_processing.output.json
@@ -9,7 +9,7 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
   "csp": {
@@ -37,8 +37,16 @@
     "url": "http://notlocalhost:8000/"
   },
   "tags": [
-    ["effective-directive", "style-src"],
-    ["blocked-uri", "http://notlocalhost:8000/lol.css"]
+    [
+      "effective-directive",
+      "style-src"
+    ],
+    [
+      "blocked-uri",
+      "http://notlocalhost:8000/lol.css"
+    ]
   ],
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/fixtures/security_report/expect_ct.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/expect_ct.no_processing.output.json
@@ -9,7 +9,7 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
   "culprit": "www.example.com",
@@ -29,8 +29,14 @@
     "url": "www.example.com"
   },
   "tags": [
-    ["hostname", "www.example.com"],
-    ["port", "443"]
+    [
+      "hostname",
+      "www.example.com"
+    ],
+    [
+      "port",
+      "443"
+    ]
   ],
   "expectct": {
     "date_time": "2014-04-06T13:00:50+00:00",
@@ -52,5 +58,7 @@
       }
     ]
   },
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/fixtures/security_report/expect_staple.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/expect_staple.no_processing.output.json
@@ -9,7 +9,7 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
   "culprit": "www.example.com",
@@ -29,10 +29,22 @@
     "url": "www.example.com"
   },
   "tags": [
-    ["hostname", "www.example.com"],
-    ["port", "443"],
-    ["response_status", "ERROR_RESPONSE"],
-    ["cert_status", "REVOKED"]
+    [
+      "hostname",
+      "www.example.com"
+    ],
+    [
+      "port",
+      "443"
+    ],
+    [
+      "response_status",
+      "ERROR_RESPONSE"
+    ],
+    [
+      "cert_status",
+      "REVOKED"
+    ]
   ],
   "expectstaple": {
     "date_time": "2014-04-06T13:00:50+00:00",
@@ -48,5 +60,7 @@
       "-----BEGIN CERTIFICATE-----\nCDE\n-----END CERTIFICATE-----"
     ]
   },
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/fixtures/security_report/hpkp.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/hpkp.no_processing.output.json
@@ -9,10 +9,9 @@
     "client_os": {
       "name": "Windows",
       "type": "os",
-      "version": "10"
+      "version": ">=10"
     }
   },
-
   "logentry": {
     "formatted": "Public key pinning validation failed for 'www.example.com'"
   },
@@ -29,9 +28,18 @@
     "url": "www.example.com"
   },
   "tags": [
-    ["hostname", "www.example.com"],
-    ["port", "443"],
-    ["include-subdomains", "false"]
+    [
+      "hostname",
+      "www.example.com"
+    ],
+    [
+      "port",
+      "443"
+    ],
+    [
+      "include-subdomains",
+      "false"
+    ]
   ],
   "hpkp": {
     "date_time": "2014-04-06T13:00:50+00:00",
@@ -50,5 +58,7 @@
       "pin-sha256=\"E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=\""
     ]
   },
-  "user": { "ip_address": "127.0.0.1" }
+  "user": {
+    "ip_address": "127.0.0.1"
+  }
 }

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -103,7 +103,7 @@ def test_replay_event_with_processing(
     assert parsed_replay["contexts"] == {
         "browser": {"name": "Safari", "version": "15.5", "type": "browser"},
         "device": {"brand": "Apple", "family": "Mac", "model": "Mac", "type": "device"},
-        "os": {"name": "Mac OS X", "version": "10.15.7", "type": "os"},
+        "os": {"name": "Mac OS X", "version": ">=10.15.7", "type": "os"},
         "replay": {
             "type": "replay",
             "error_sample_rate": replay["contexts"]["replay"]["error_sample_rate"],


### PR DESCRIPTION
Implements the following Sentry-PR: https://github.com/getsentry/sentry/pull/45369


Figured relay would be a better fit, a benefit to implementing it in relay is that the OS-version is only potentially frozen if it's from the user-agent, not from the client hints, which is easier to figure out here. 
