### PR TITLE
cd: add placeholder deployment pipeline

### DIFF
--- a/gocd/pipelines/relay.yaml
+++ b/gocd/pipelines/relay.yaml
@@ -1,0 +1,26 @@
+# More information on gocd-flavor YAML can be found here:
+# - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
+# - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
+format_version: 10
+pipelines:
+    deploy-relay:
+        group: relay
+        lock_behavior: unlockWhenFinished
+        materials:
+            relay_repo:
+                git: git@github.com:getsentry/relay.git
+                shallow_clone: true
+                branch: master
+                destination: relay
+        stages:
+            # For now, this is just a placeholder so we can get deploy refs
+            # in GoCD for the purposes of ST deploys.
+            - deploy-production:
+                  approval:
+                      type: manual
+                  jobs:
+                      deploy:
+                          elastic_profile_id: relay
+                          tasks:
+                              - script: |
+                                    true


### PR DESCRIPTION
As the relay pipeline isn't ready yet, I need this to unblock ST deploys as I've chosen an approach that requires successful deploys in GoCD.

#skip-changelog