### PR TITLE
test(scrubbing): Add tests for PII scrubbing in breadcrumb.data

### DIFF
--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -393,8 +393,8 @@ mod tests {
     use crate::pii::{DataScrubbingConfig, PiiConfig, ReplaceRedaction};
     use crate::processor::process_value;
     use crate::protocol::{
-        Addr, DataElement, DebugImage, DebugMeta, Event, ExtraValue, Headers, HttpElement,
-        LogEntry, NativeDebugImage, Request, Span, TagEntry, Tags,
+        Addr, Breadcrumb, DataElement, DebugImage, DebugMeta, Event, ExtraValue, Headers,
+        HttpElement, LogEntry, NativeDebugImage, Request, Span, TagEntry, Tags,
     };
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::{Annotated, FromValue, Object, Value};
@@ -1118,5 +1118,113 @@ mod tests {
 
         process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(span);
+    }
+
+    #[test]
+    fn test_scrub_breadcrumb_data_http_not_scrubbed() {
+        let mut breadcrumb: Annotated<Breadcrumb> = Annotated::from_json(
+            r#"{
+                "data": {
+                    "http": {
+                        "query": "dance=true"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+        process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(breadcrumb);
+    }
+
+    #[test]
+    fn test_scrub_breadcrumb_data_http_strings_are_scrubbed() {
+        let mut breadcrumb: Annotated<Breadcrumb> = Annotated::from_json(
+            r#"{
+                "data": {
+                    "http": {
+                        "query": "ccnumber=5105105105105100&process_id=123",
+                        "fragment": "ccnumber=5105105105105100,process_id=123"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+        process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(breadcrumb);
+    }
+
+    #[test]
+    fn test_scrub_breadcrumb_data_http_objects_are_scrubbed() {
+        let mut breadcrumb: Annotated<Breadcrumb> = Annotated::from_json(
+            r#"{
+                "data": {
+                    "http": {
+                        "query": {
+                            "ccnumber": "5105105105105100",
+                            "process_id": "123"
+                        },
+                        "fragment": {
+                            "ccnumber": "5105105105105100",
+                            "process_id": "123"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(breadcrumb);
+    }
+
+    #[test]
+    fn test_scrub_breadcrumb_data_untyped_props_are_scrubbed() {
+        let mut breadcrumb: Annotated<Breadcrumb> = Annotated::from_json(
+            r#"{
+                "data": {
+                    "untyped": "ccnumber=5105105105105100",
+                    "more_untyped": {
+                        "typed": "no",
+                        "scrubbed": "yes",
+                        "ccnumber": "5105105105105100"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let ds_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+        process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(breadcrumb);
     }
 }

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_http_not_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_http_not_scrubbed.snap
@@ -1,0 +1,11 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: breadcrumb
+---
+{
+  "data": {
+    "http": {
+      "query": "dance=true"
+    }
+  }
+}

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_http_objects_are_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_http_objects_are_scrubbed.snap
@@ -1,0 +1,54 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: breadcrumb
+---
+{
+  "data": {
+    "http": {
+      "fragment": {
+        "ccnumber": "[Filtered]",
+        "process_id": "123"
+      },
+      "query": {
+        "ccnumber": "[Filtered]",
+        "process_id": "123"
+      }
+    }
+  },
+  "_meta": {
+    "data": {
+      "http": {
+        "fragment": {
+          "ccnumber": {
+            "": {
+              "rem": [
+                [
+                  "@creditcard:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 16
+            }
+          }
+        },
+        "query": {
+          "ccnumber": {
+            "": {
+              "rem": [
+                [
+                  "@creditcard:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 16
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_http_strings_are_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_http_strings_are_scrubbed.snap
@@ -1,0 +1,44 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: breadcrumb
+---
+{
+  "data": {
+    "http": {
+      "fragment": "ccnumber=[Filtered],process_id=123",
+      "query": "ccnumber=[Filtered]&process_id=123"
+    }
+  },
+  "_meta": {
+    "data": {
+      "http": {
+        "fragment": {
+          "": {
+            "rem": [
+              [
+                "@creditcard:filter",
+                "s",
+                9,
+                19
+              ]
+            ],
+            "len": 40
+          }
+        },
+        "query": {
+          "": {
+            "rem": [
+              [
+                "@creditcard:filter",
+                "s",
+                9,
+                19
+              ]
+            ],
+            "len": 40
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_untyped_props_are_scrubbed.snap
+++ b/relay-general/src/pii/snapshots/relay_general__pii__processor__tests__scrub_breadcrumb_data_untyped_props_are_scrubbed.snap
@@ -1,0 +1,46 @@
+---
+source: relay-general/src/pii/processor.rs
+expression: breadcrumb
+---
+{
+  "data": {
+    "more_untyped": {
+      "ccnumber": "[Filtered]",
+      "scrubbed": "yes",
+      "typed": "no"
+    },
+    "untyped": "ccnumber=[Filtered]"
+  },
+  "_meta": {
+    "data": {
+      "more_untyped": {
+        "ccnumber": {
+          "": {
+            "rem": [
+              [
+                "@creditcard:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 16
+          }
+        }
+      },
+      "untyped": {
+        "": {
+          "rem": [
+            [
+              "@creditcard:filter",
+              "s",
+              9,
+              19
+            ]
+          ],
+          "len": 25
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Apparently, `breadcrumb.data` [was already](https://github.com/getsentry/relay/commit/c8122cb670b40ef3540f13f9cdfc95ddae500b47#diff-585c87040669787c074fdfda09f594d2949dbbc4d86352e5ca9b640b11123a7bR33) `pii = "true"` and we've been
scrubbing it. As a result, this PR doesn't add any functionality and
only adds tests for that.

Related to: https://github.com/getsentry/relay/pull/1953.
Ref: https://github.com/getsentry/relay/issues/1855, https://github.com/getsentry/relay/issues/1915.

#skip-changelog