### PR TITLE
ref(envelope_manager): Remove from_registry calls from the service

### DIFF
--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -11,9 +11,7 @@ use relay_log::LogError;
 use relay_metrics::{Aggregator, Bucket, MergeBuckets};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
-#[cfg(feature = "processing")]
-use relay_system::Addr;
-use relay_system::{FromMessage, NoResponse};
+use relay_system::{Addr, FromMessage, NoResponse};
 use tokio::sync::oneshot;
 
 use crate::actors::outcome::{DiscardReason, Outcome};

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -111,7 +111,10 @@ impl ServiceState {
         };
 
         let buffer = Arc::new(BufferGuard::new(config.envelope_buffer_size()));
-        let (envelope_manager, envelope_manager_rx) = channel(EnvelopeProcessorService::name());
+
+        // Create an address for the `EnvelopeManagerService`, which can be injected into the
+        // other services. This also solves the issue of circular dependencies with `EnvelopeProcessorService`.
+        let (envelope_manager, envelope_manager_rx) = channel(EnvelopeManagerService::name());
         let outcome_producer = OutcomeProducerService::create(
             config.clone(),
             upstream_relay.clone(),


### PR DESCRIPTION
This PR removes the `from_registry` calls from the `EnvelopeMangerService`.
Removed un-used code.


#skip-changelog

ref: #1818 