### PR TITLE
fix(pii): Early return if no text left

### DIFF
--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -263,11 +263,20 @@ fn apply_regex_to_chunks<'a>(
     // on the chunks, but the `regex` crate does not support that.
 
     let mut search_string = String::new();
+    let mut has_text = false;
     for chunk in &chunks {
         match chunk {
-            Chunk::Text { text } => search_string.push_str(&text.replace('\x00', "")),
+            Chunk::Text { text } => {
+                has_text = true;
+                search_string.push_str(&text.replace('\x00', ""));
+            }
             Chunk::Redaction { .. } => search_string.push('\x00'),
         }
+    }
+
+    if !has_text {
+        // Nothing to replace.
+        return chunks;
     }
 
     // Early exit if this regex does not match and return the original chunks.

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -1033,6 +1033,30 @@ mod tests {
     }
 
     #[test]
+    fn test_replace_replaced_text_anything() {
+        let chunks = vec![Chunk::Redaction {
+            text: "[Filtered]".into(),
+            rule_id: "@password:filter".into(),
+            ty: RemarkType::Substituted,
+        }];
+        let rule = RuleRef {
+            id: "@anything:filter".into(),
+            origin: "@anything:filter".into(),
+            ty: RuleType::Anything,
+            redaction: Redaction::Replace(ReplaceRedaction {
+                text: "[Filtered]".into(),
+            }),
+        };
+        let res = apply_regex_to_chunks(
+            chunks.clone(),
+            &rule,
+            &Regex::new(r#".*"#).unwrap(),
+            ReplaceBehavior::Groups(smallvec::smallvec![0]),
+        );
+        assert_eq!(chunks, res);
+    }
+
+    #[test]
     fn test_scrub_span_data_not_scrubbed() {
         let mut span = Annotated::new(Span {
             data: Annotated::new(DataElement {


### PR DESCRIPTION
If a list of chunks consists only of replacements, the following debug assertion at the end of `apply_replacement_chunks` might fail (see test):

https://github.com/getsentry/relay/blob/a8ee53cc26b8d7bd10cfa919e672894edbd65916/relay-general/src/pii/processor.rs#L346

Add an early return to prevent this failure.

This popped up in a test case in #1951.

#skip-changelog