### PR TITLE
feat(normalization): Mark scrubbed transactions as sanitized

### DIFF
--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -354,13 +354,13 @@ impl Processor for TransactionsProcessor<'_> {
             &TransactionSource::Url | &TransactionSource::Sanitized
         ) && self.name_config.scrub_identifiers
         {
-            let changed = scrub_identifiers(&mut event.transaction)?;
-            if changed && self.name_config.mark_scrubbed_as_sanitized {
-                let source = &mut event
+            scrub_identifiers(&mut event.transaction)?;
+            if self.name_config.mark_scrubbed_as_sanitized {
+                event
                     .transaction_info
                     .get_or_insert_with(Default::default)
-                    .source;
-                source.set_value(Some(TransactionSource::Sanitized));
+                    .source
+                    .set_value(Some(TransactionSource::Sanitized));
             }
         }
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1787,45 +1787,51 @@ mod tests {
         .unwrap();
 
         assert_annotated_snapshot!(event, @r###"
-         {
-           "type": "transaction",
-           "transaction": "/foo/*/user/123/0/",
-           "transaction_info": {
-             "source": "sanitized"
-           },
-           "modules": {
-             "rack": "1.2.3"
-           },
-           "timestamp": 1619420400.0,
-           "start_timestamp": 1619420341.0,
-           "contexts": {
-             "trace": {
-               "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
-               "span_id": "fa90fdead5f74053",
-               "op": "rails.request",
-               "status": "ok",
-               "type": "trace"
-             }
-           },
-           "sdk": {
-             "name": "sentry.ruby"
-           },
-           "spans": [],
-           "_meta": {
-             "transaction": {
-               "": {
-                 "rem": [
-                   [
-                     "/foo/*/**",
-                     "s"
-                   ]
-                 ],
-                 "val": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0/"
-               }
-             }
-           }
-         }
-         "###);
+        {
+          "type": "transaction",
+          "transaction": "/foo/*/user/*/0/",
+          "transaction_info": {
+            "source": "sanitized"
+          },
+          "modules": {
+            "rack": "1.2.3"
+          },
+          "timestamp": 1619420400.0,
+          "start_timestamp": 1619420341.0,
+          "contexts": {
+            "trace": {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74053",
+              "op": "rails.request",
+              "status": "ok",
+              "type": "trace"
+            }
+          },
+          "sdk": {
+            "name": "sentry.ruby"
+          },
+          "spans": [],
+          "_meta": {
+            "transaction": {
+              "": {
+                "rem": [
+                  [
+                    "/foo/*/**",
+                    "s"
+                  ],
+                  [
+                    "int",
+                    "s",
+                    12,
+                    15
+                  ]
+                ],
+                "val": "/foo/*/user/123/0/"
+              }
+            }
+          }
+        }
+        "###);
     }
 
     #[test]

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1721,6 +1721,7 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
+                scrub_identifiers: true,
                 rules: rules.as_ref(),
                 ..Default::default()
             }),
@@ -1777,6 +1778,7 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
+                scrub_identifiers: true,
                 rules: rules.as_ref(),
                 ..Default::default()
             }),
@@ -1934,6 +1936,7 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
+                scrub_identifiers: true,
                 rules: &[rule],
                 ..Default::default()
             }),


### PR DESCRIPTION
All transactions that got their names scrubbed will be marked as sanitized, as long as the org feature flag is enabled.

6961c5e includes a small refactor around the usage of feature flags. Although it may seem like it, this doesn't change the behavior of relay around the application of transaction rules, since the initial flag belonging to `scrub_identifiers` controls the generation of rules in `sentry`, [see](https://github.com/getsentry/sentry/blob/242fd1dd0654e85bf027df59131db516a0b55395/src/sentry/relay/config/__init__.py#L203).

Ref: https://github.com/getsentry/team-ingest/issues/93

#skip-changelog