### PR TITLE
ref(tx-processor): Apply transaction rules after UUID scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
+
 ## 23.3.1
 
 **Features**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `thread.state` field to protocol. ([#1896](https://github.com/getsentry/relay/pull/1896))
 - PII scrub `span.data` by default. ([#1953](https://github.com/getsentry/relay/pull/1953))
 - Scrub sensitive cookies. ([#1951](https://github.com/getsentry/relay/pull/1951))
+- Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
 
 ## 0.8.19
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -362,10 +362,8 @@ impl Processor for TransactionsProcessor<'_> {
                 event.transaction_info.value_mut(),
             )?;
 
-            if !matches!(
-                event.get_transaction_source(),
-                &TransactionSource::Sanitized
-            ) && self.name_config.mark_scrubbed_as_sanitized
+            if matches!(event.get_transaction_source(), &TransactionSource::Url)
+                && self.name_config.mark_scrubbed_as_sanitized
             {
                 event
                     .transaction_info

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1925,7 +1925,7 @@ mod tests {
         let json = r#"
         {
             "type": "transaction",
-            "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user",
+            "transaction": "/foo/rule-target/user",
             "transaction_info": {
               "source": "url"
             },
@@ -1999,7 +1999,7 @@ mod tests {
                      "s"
                    ]
                  ],
-                 "val": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user"
+                 "val": "/foo/rule-target/user"
                }
              }
            }

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2232,7 +2232,7 @@ mod tests {
                 scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: true,
                 rules: &[TransactionNameRule {
-                    pattern: LazyGlob::new("/remains/*/*/".to_owned()),
+                    pattern: LazyGlob::new("/remains/*/**".to_owned()),
                     expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
                     scope: RuleScope::default(),
                     redaction: RedactionRule::default(),

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -341,12 +341,6 @@ impl Processor for TransactionsProcessor<'_> {
                 .set_value(Some("<unlabeled transaction>".to_owned()))
         }
 
-        // Apply the rule if any found
-        self.apply_transaction_rename_rule(
-            &mut event.transaction,
-            event.transaction_info.value_mut(),
-        )?;
-
         // Normalize transaction names for URLs and Sanitized transaction sources.
         // This in addition to renaming rules can catch some high cardinality parts.
         if matches!(
@@ -363,6 +357,12 @@ impl Processor for TransactionsProcessor<'_> {
                 source.set_value(Some(TransactionSource::Sanitized));
             }
         }
+
+        // Apply the rule if any found
+        self.apply_transaction_rename_rule(
+            &mut event.transaction,
+            event.transaction_info.value_mut(),
+        )?;
 
         validate_transaction(event)?;
 

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_and_apply_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_and_apply_rules.snap
@@ -1,0 +1,41 @@
+---
+source: relay-general/src/store/transactions/processor.rs
+expression: event
+---
+{
+  "type": "transaction",
+  "transaction": "/remains/*/*",
+  "transaction_info": {
+    "source": "sanitized"
+  },
+  "timestamp": 1619420400.0,
+  "start_timestamp": 1619420341.0,
+  "contexts": {
+    "trace": {
+      "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+      "span_id": "fa90fdead5f74053",
+      "op": "default",
+      "type": "trace"
+    }
+  },
+  "spans": [],
+  "_meta": {
+    "transaction": {
+      "": {
+        "rem": [
+          [
+            "int",
+            "s",
+            21,
+            31
+          ],
+          [
+            "/remains/*/*/",
+            "s"
+          ]
+        ],
+        "val": "/remains/rule-target/1234567890"
+      }
+    }
+  }
+}

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_and_apply_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_and_apply_rules.snap
@@ -30,7 +30,7 @@ expression: event
             31
           ],
           [
-            "/remains/*/*/",
+            "/remains/*/**",
             "s"
           ]
         ],

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_before_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_before_rules.snap
@@ -1,0 +1,37 @@
+---
+source: relay-general/src/store/transactions/processor.rs
+expression: event
+---
+{
+  "type": "transaction",
+  "transaction": "/remains/rule-target/*",
+  "transaction_info": {
+    "source": "url"
+  },
+  "timestamp": 1619420400.0,
+  "start_timestamp": 1619420341.0,
+  "contexts": {
+    "trace": {
+      "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+      "span_id": "fa90fdead5f74053",
+      "op": "default",
+      "type": "trace"
+    }
+  },
+  "spans": [],
+  "_meta": {
+    "transaction": {
+      "": {
+        "rem": [
+          [
+            "int",
+            "s",
+            21,
+            31
+          ]
+        ],
+        "val": "/remains/rule-target/1234567890"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Applying transaction rules before UUID scrubbing makes it impossible to track what rules were applied. It's interesting to know what rules are useful to reduce the high cardinality, so that we can use them again over other rules that are less interesting or provide no value. Applying these rules after UUID scrubbing leaves no room for further modification of the transaction name, so the resulting transaction name is guaranteed to be the direct output of a rule.

This is the first step in the process of discarding the rules that provide no value and prioritizing those that do.

Ref: https://github.com/getsentry/team-ingest/issues/14.