### PR TITLE
fix(quota): New reason code for fallback rate limit

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -148,11 +148,11 @@ def test_store_rate_limit(mini_sentry, relay):
     with pytest.raises(HTTPError):
         relay.send_event(project_id, {"message": "invalid"})
 
-    # Generated outcome has no reason code:
+    # Generated outcome has reason code 'generic':
     outcome_envelope = mini_sentry.captured_events.get(timeout=1)
     outcome = json.loads(outcome_envelope.items[0].payload.bytes)
     assert outcome["rate_limited_events"] == [
-        {"reason": "", "category": "error", "quantity": 1}
+        {"reason": "generic", "category": "error", "quantity": 1}
     ]
 
     # This event should arrive

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -135,7 +135,7 @@ def test_store_rate_limit(mini_sentry, relay):
             return "", 429, {"retry-after": "2"}
 
     # Disable outcomes so client report envelopes do not interfere with the events we are looking for
-    config = {"outcomes": {"emit_outcomes": False}}
+    config = {"outcomes": {"emit_outcomes": "as_client_reports"}}
     relay = relay(mini_sentry, config)
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
@@ -147,6 +147,13 @@ def test_store_rate_limit(mini_sentry, relay):
     sleep(1)
     with pytest.raises(HTTPError):
         relay.send_event(project_id, {"message": "invalid"})
+
+    # Generated outcome has no reason code:
+    outcome_envelope = mini_sentry.captured_events.get(timeout=1)
+    outcome = json.loads(outcome_envelope.items[0].payload.bytes)
+    assert outcome["rate_limited_events"] == [
+        {"reason": "", "category": "error", "quantity": 1}
+    ]
 
     # This event should arrive
     sleep(2)


### PR DESCRIPTION
When a non-processing Relay receives a 429 response when sending envelopes to the upstream, it logs a `RateLimited` outcome with a reason code that is parsed from the `X-Sentry-Rate-Limits` header. However, if that header is not available, it logs an outcome with `RateLimited(None)`. This happens for example when Sentry SaaS rejects the envelope on the nginx layer.

Because reason code `None` is hard to debug, replace it with a dedicated reason code that we can search for.

Follow-up work: Modify the nginx anti-abuse layer to send an `X-Sentry-Rate-Limits` header.

Fixes https://github.com/getsentry/relay/issues/1929.

#skip-changelog