### PR TITLE
feat(replays): add replay_id to DSC

### DIFF
--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -1164,6 +1164,8 @@ pub struct DynamicSamplingContext {
     /// user object).
     #[serde(flatten, default)]
     pub user: TraceUserContext,
+    /// if the event occured during a session replay, the associated replay_id is added to the DSC
+    pub replay_id: Option<Uuid>,
     /// Additional arbitrary fields for forwards compatibility.
     #[serde(flatten, default)]
     pub other: BTreeMap<String, Value>,
@@ -1197,6 +1199,7 @@ impl DynamicSamplingContext {
             release: event.release.as_str().map(str::to_owned),
             environment: event.environment.value().cloned(),
             transaction: event.transaction.value().cloned(),
+            replay_id: None,
             sample_rate: None,
             user: TraceUserContext {
                 user_segment: user
@@ -1311,6 +1314,7 @@ mod tests {
             transaction: None,
             sample_rate: None,
             user: TraceUserContext::default(),
+            replay_id: None,
             other: BTreeMap::new(),
         }
     }
@@ -1413,6 +1417,7 @@ mod tests {
                 user_segment: user_segment.to_string(),
                 user_id: user_id.to_string(),
             },
+            replay_id: Default::default(),
             other: Default::default(),
         }
     }
@@ -1587,6 +1592,7 @@ mod tests {
             environment: Some("prod".into()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
+            replay_id: Some(Uuid::new_v4()),
             other: BTreeMap::new(),
         };
 
@@ -1622,6 +1628,7 @@ mod tests {
             environment: None,
             transaction: None,
             sample_rate: None,
+            replay_id: None,
             other: BTreeMap::new(),
         };
         assert_eq!(Value::Null, dsc.get_value("trace.release"));
@@ -1638,6 +1645,7 @@ mod tests {
             environment: None,
             transaction: None,
             sample_rate: None,
+            replay_id: None,
             other: BTreeMap::new(),
         };
         assert_eq!(Value::Null, dsc.get_value("trace.user.id"));
@@ -1742,6 +1750,7 @@ mod tests {
                 user_segment: "vip".into(),
                 user_id: "user-id".into(),
             },
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".into()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -1917,6 +1926,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".to_string()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -1979,6 +1989,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".to_string()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -2018,6 +2029,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".to_string()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -2080,6 +2092,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".to_string()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -2467,6 +2480,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".to_string()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -2487,6 +2501,7 @@ mod tests {
             public_key: ProjectKey::parse("abd0f232775f45feab79864e580d160b").unwrap(),
             release: Some("1.1.1".to_string()),
             user: TraceUserContext::default(),
+            replay_id: Some(Uuid::new_v4()),
             environment: Some("debug".to_string()),
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -2510,6 +2525,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: None,
             environment: None,
             transaction: Some("transaction1".into()),
             sample_rate: None,
@@ -2533,6 +2549,7 @@ mod tests {
                 user_segment: "vip".to_owned(),
                 user_id: "user-id".to_owned(),
             },
+            replay_id: None,
             environment: Some("debug".to_string()),
             transaction: None,
             sample_rate: None,
@@ -2549,6 +2566,7 @@ mod tests {
             public_key: ProjectKey::parse("abd0f232775f45feab79864e580d160b").unwrap(),
             release: None,
             user: TraceUserContext::default(),
+            replay_id: None,
             environment: None,
             transaction: None,
             sample_rate: None,
@@ -2944,6 +2962,7 @@ mod tests {
           "environment": None,
           "transaction": None,
           "user_id": "hello",
+          "replay_id": None,
         }
         "###);
     }
@@ -2968,6 +2987,7 @@ mod tests {
           "transaction": None,
           "sample_rate": "0.5",
           "user_id": "hello",
+          "replay_id": None,
         }
         "###);
     }
@@ -2992,6 +3012,7 @@ mod tests {
           "transaction": None,
           "sample_rate": "0.00001",
           "user_id": "hello",
+          "replay_id": None,
         }
         "###);
     }

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -48,6 +48,7 @@ pub fn create_sampling_context(sample_rate: Option<f64>) -> DynamicSamplingConte
         transaction: None,
         sample_rate,
         user: Default::default(),
+        replay_id: None,
         other: Default::default(),
     }
 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -226,6 +226,7 @@ mod tests {
             transaction: transaction.map(|value| value.to_string()),
             sample_rate,
             user: Default::default(),
+            replay_id: Default::default(),
             other: Default::default(),
         }
     }


### PR DESCRIPTION
- adds the replay_id to the dynamic sampling context schema defined in relay

TODO: add replay_id to the event from DSC.


Related: https://github.com/getsentry/rfcs/pull/60 https://github.com/getsentry/team-webplatform-meta/issues/41
https://github.com/getsentry/sentry/issues/45529


Closes: https://github.com/getsentry/relay/issues/1958
(note that ticket now doesn't make sense as i started this -- we don't need to add a whole new context for this, the replay_id can simply exist on the trace context)

