### PR TITLE
feat(normalization): Don't mark as sanitized if there aren't any rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,26 @@
 This release contains major changes to the web layer, including TCP and HTTP handling as well as all web endpoint handlers. Due to these changes, some functionality was retired and Relay responds differently in specific cases.
 
 Configuration:
+
 - SSL support has been dropped. As per [official guidelines](https://docs.sentry.io/product/relay/operating-guidelines/), Relay should be operated behind a reverse proxy, which can perform SSL termination.
 - Connection config options `max_connections`, `max_pending_connections`, and `max_connection_rate` no longer have an effect. Instead, configure the reverse proxy to handle connection concurrency as needed.
 
 Endpoints:
+
 - The security endpoint no longer forwards to upstream if the mime type doesn't match supported mime types. Instead, the request is rejected with a corresponding error.
 - Passing store payloads as `?sentry_data=<base64>` query parameter is restricted to `GET` requests on the store endpoint. Other endpoints require the payload to be passed in the request body.
 - Requests with an invalid `content-encoding` header will now be rejected. Exceptions to this are an empty string and `UTF-8`, which have been sent historically by some SDKs and are now treated as identity (no encoding). Previously, all unknown encodings were treated as identity.
 - Temporarily, response bodies for some errors are rendered as plain text instead of JSON. This will be addressed in an upcoming release.
 
 Metrics:
+
 - The `route` tag of request metrics uses the route pattern instead of schematic names. There is an exact replacement for every previous route. For example, `"store-default"` is now tagged as `"/api/:project_id/store/"`.
 - Statsd metrics `event.size_bytes.raw` and `event.size_bytes.uncompressed` have been removed.
 
 **Features**:
 
 - Allow monitor checkins to paass `monitor_config` for monitor upserts. ([#1962](https://github.com/getsentry/relay/pull/1962))
+- Don't sanitize transactions if no clustering rules exist and no UUIDs were scrubbed. ([#1976](https://github.com/getsentry/relay/pull/1976))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PII scrub `span.data` by default. ([#1953](https://github.com/getsentry/relay/pull/1953))
 - Scrub sensitive cookies. ([#1951](https://github.com/getsentry/relay/pull/1951))
 - Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
+- Don't sanitize transactions if no clustering rules exist and no UUIDs were scrubbed. ([#1976](https://github.com/getsentry/relay/pull/1976))
 
 ## 0.8.19
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -356,7 +356,8 @@ impl Processor for TransactionsProcessor<'_> {
                 event.get_transaction_source(),
                 &TransactionSource::Url | &TransactionSource::Sanitized
             ) {
-                if scrub_identifiers(&mut event.transaction).map_or(false, |scrubbed| scrubbed) {
+                let scrubbed_identifiers = scrub_identifiers(&mut event.transaction);
+                if scrubbed_identifiers.map_or(false, |scrubbed| scrubbed) {
                     sanitize_transaction = true;
                 }
             }

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -361,7 +361,7 @@ impl Processor for TransactionsProcessor<'_> {
                 }
             }
 
-            if self.name_config.rules.len() > 0 {
+            if !self.name_config.rules.is_empty() {
                 self.apply_transaction_rename_rule(
                     &mut event.transaction,
                     event.transaction_info.value_mut(),

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -350,19 +350,28 @@ impl Processor for TransactionsProcessor<'_> {
         if self.name_config.scrub_identifiers {
             // Normalize transaction names for URLs and Sanitized transaction sources.
             // This in addition to renaming rules can catch some high cardinality parts.
+            let mut sanitize_transaction = false;
+
             if matches!(
                 event.get_transaction_source(),
                 &TransactionSource::Url | &TransactionSource::Sanitized
             ) {
-                scrub_identifiers(&mut event.transaction)?;
+                if scrub_identifiers(&mut event.transaction).map_or(false, |scrubbed| scrubbed) {
+                    sanitize_transaction = true;
+                }
             }
 
-            self.apply_transaction_rename_rule(
-                &mut event.transaction,
-                event.transaction_info.value_mut(),
-            )?;
+            if self.name_config.rules.len() > 0 {
+                self.apply_transaction_rename_rule(
+                    &mut event.transaction,
+                    event.transaction_info.value_mut(),
+                )?;
+
+                sanitize_transaction = true;
+            }
 
             if matches!(event.get_transaction_source(), &TransactionSource::Url)
+                && sanitize_transaction
                 && self.name_config.mark_scrubbed_as_sanitized
             {
                 event
@@ -2183,13 +2192,13 @@ mod tests {
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
                 scrub_identifiers: true,
+                mark_scrubbed_as_sanitized: true,
                 rules: &[TransactionNameRule {
                     pattern: LazyGlob::new("/remains/*/1234567890/".to_owned()),
                     expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
                     scope: RuleScope::default(),
                     redaction: RedactionRule::default(),
                 }],
-                ..Default::default()
             }),
             ProcessingState::root(),
         )
@@ -2235,6 +2244,41 @@ mod tests {
                     scope: RuleScope::default(),
                     redaction: RedactionRule::default(),
                 }],
+            }),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(event);
+    }
+
+    #[test]
+    fn test_no_sanitized_if_no_rules() {
+        let mut event = Annotated::<Event>::from_json(
+            r#"{
+                "type": "transaction",
+                "transaction": "/remains/rule-target/whatever",
+                "transaction_info": {
+                    "source": "url"
+                },
+                "timestamp": "2021-04-26T08:00:00+0100",
+                "start_timestamp": "2021-04-26T07:59:01+0100",
+                "contexts": {
+                    "trace": {
+                        "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+                        "span_id": "fa90fdead5f74053"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        process_value(
+            &mut event,
+            &mut TransactionsProcessor::new(TransactionNameConfig {
+                scrub_identifiers: true,
+                mark_scrubbed_as_sanitized: true,
+                rules: &[],
             }),
             ProcessingState::root(),
         )

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__no_sanitized_if_no_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__no_sanitized_if_no_rules.snap
@@ -1,0 +1,22 @@
+---
+source: relay-general/src/store/transactions/processor.rs
+expression: event
+---
+{
+  "type": "transaction",
+  "transaction": "/remains/rule-target/whatever",
+  "transaction_info": {
+    "source": "url"
+  },
+  "timestamp": 1619420400.0,
+  "start_timestamp": 1619420341.0,
+  "contexts": {
+    "trace": {
+      "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+      "span_id": "fa90fdead5f74053",
+      "op": "default",
+      "type": "trace"
+    }
+  },
+  "spans": []
+}

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_before_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_identifiers_before_rules.snap
@@ -6,7 +6,7 @@ expression: event
   "type": "transaction",
   "transaction": "/remains/rule-target/*",
   "transaction_info": {
-    "source": "url"
+    "source": "sanitized"
   },
   "timestamp": 1619420400.0,
   "start_timestamp": 1619420341.0,


### PR DESCRIPTION
If there aren't any rules, a transaction should not be promoted to `source:sanitized` because the clusterer may not have generated enough rules yet. The exception is if we've scrubbed UUIDs, in which case we still consider the transaction as sanitized.