### PR TITLE
build(py): Bump redis to 4.5.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ pytest-sentry==0.1.11
 pytest-xdist==3.0.2
 pytest==7.1.2
 PyYAML==6.0
-redis==3.4.1
+redis==4.5.4
 requests==2.28.1
 sentry_sdk==1.14.0
 werkzeug==2.2.3


### PR DESCRIPTION
Redis through 4.5.3 has two security issues rated as severe.

See https://github.com/getsentry/relay/security/dependabot/55
See https://github.com/getsentry/relay/security/dependabot/56

Requires https://github.com/getsentry/pypi/pull/246
#skip-changelog
