### PR TITLE
fix(ci): Give experimental relay pipeline a unique name

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -3,7 +3,7 @@
 # - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
 format_version: 10
 pipelines:
-  deploy-relay:
+  deploy-relay-experimental:
     environment_variables:
       GCP_PROJECT: internal-sentry
       GKE_CLUSTER: zdpwkxst


### PR DESCRIPTION
Fixes Error in GoCD:

> Parsing configuration repository using Plugin yaml.config.plugin failed for material: URL: git@github.com:getsentry/relay.git, Branch: master30 Mar, 2023 at 12:51:01 Local Time
>> You have defined multiple pipelines called 'deploy-relay'. Pipeline names must be unique.

#skip-changelog

