### PR TITLE
fix(gocd): Remove cloudbuild check

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -44,11 +44,6 @@ pipelines:
                     "Test (windows-latest)" \
                     "Test All Features (ubuntu-latest)" \
                     "Push GCR Docker Image"
-                - script: |
-                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
-                    ${GO_REVISION_RELAY_REPO} \
-                    sentryio \
-                    "us.gcr.io/sentryio/relay"
 
       - deploy-experimental:
           approval:

--- a/gocd/pipelines/relay.yaml
+++ b/gocd/pipelines/relay.yaml
@@ -44,11 +44,6 @@ pipelines:
                     "Test (windows-latest)" \
                     "Test All Features (ubuntu-latest)" \
                     "Push GCR Docker Image"
-                - script: |
-                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
-                    ${GO_REVISION_RELAY_REPO} \
-                    sentryio \
-                    "us.gcr.io/sentryio/relay"
 
       - deploy-production:
           approval:


### PR DESCRIPTION
We no longer use cloud build and should remove this check. It will just block and timeout since there is nothing to be found. 

#skip-changelog