### PR TITLE
ci(gocd): Disable commit association during deployments

### DIFF
--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -43,7 +43,8 @@ sentry-cli upload-dif lib/x86_64-linux-gnu
 RELEASE=$(< ./release-name)
 echo "Creating a new release and deploy for ${RELEASE} in Sentry..."
 sentry-cli releases new "${RELEASE}"
-sentry-cli releases set-commits "${RELEASE}" --commit "${GITHUB_PROJECT}@${REVISION}"
+# NOTE: Disabled until the repository is properly configured in Sentry
+# sentry-cli releases set-commits "${RELEASE}" --commit "${GITHUB_PROJECT}@${REVISION}"
 sentry-cli releases deploys "${RELEASE}" new -e production
 sentry-cli releases finalize "${RELEASE}"
 echo 'Deploy created.'


### PR DESCRIPTION
The GitHub integration in Sentry is not yet configured, which means git commits
cannot be associated to releases created during deployments. Until that
configuration has been completed, `set-commits` needs to be disabled so that
the gocd deployment step succeeds.

#skip-changelog

