### PR TITLE
chore(gocd): Auto approve and run deploy if the check stage succeeds

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -47,7 +47,8 @@ pipelines:
 
       - deploy-experimental:
           approval:
-            type: manual
+            type: success
+            allow_only_on_success: true
           fetch_materials: true
 
           jobs:

--- a/gocd/pipelines/relay.yaml
+++ b/gocd/pipelines/relay.yaml
@@ -47,7 +47,7 @@ pipelines:
 
       - deploy-production:
           approval:
-            type: manual
+            type: success
             allow_only_on_success: true
           fetch_materials: true
 
@@ -82,7 +82,7 @@ pipelines:
           # Manually completes this pipeline run.
           # This will trigger relay-pop deployments.
           approval:
-            type: manual
+            type: success
             allow_only_on_success: true
           jobs:
             deploy:


### PR DESCRIPTION
Currently every stage must be approved manually, but it makes more sense to automate this.

This change makes sure that if the `check` stage succeeds the `deploy` stage will start automatically, and if it fails it should not be possible to trigger it even manually.

 
#skip-changelog