### PR TITLE
chore(build): bump Rust version to 1.68.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM centos:7 AS relay-deps
 
 # Pin the Rust version for now
-ARG RUST_TOOLCHAIN_VERSION=1.68.0
+ARG RUST_TOOLCHAIN_VERSION=1.68.2
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM centos:7 AS relay-deps
 
 # Pin the Rust version for now
-ARG RUST_TOOLCHAIN_VERSION=1.68.0
+ARG RUST_TOOLCHAIN_VERSION=1.68.2
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \


### PR DESCRIPTION
Bumps toolchain to the latest current one: `1.68.2`

#skip-changelog