### PR TITLE
chore(build): Provide rust toolchain from CI job

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -18,8 +18,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
       - name: Build in Docker
-        run: scripts/docker-build-linux.sh
+        run: |
+          TOOLCHAIN=$(cargo version | awk '{print $2}')
+          scripts/docker-build-linux.sh "$TOOLCHAIN"
         env:
           BUILD_ARCH: x86_64
           RELAY_FEATURES:

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -18,12 +18,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
-
       - name: Build in Docker
         run: |
-          TOOLCHAIN=$(cargo version | awk '{print $2}')
+          # Get the latest stable rust toolchain version available
+          TOOLCHAIN=$(curl -s 'https://static.rust-lang.org/dist/channel-rust-stable.toml' | awk '/\[pkg.rust\]/ {getline;print;}' | sed -r 's/^version = "([0-9.]+) .*/\1/')
           scripts/docker-build-linux.sh "$TOOLCHAIN"
         env:
           BUILD_ARCH: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,9 +217,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
-
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}-${{ matrix.arch }}
@@ -229,7 +226,8 @@ jobs:
 
       - name: Build
         run: |
-          TOOLCHAIN=$(cargo version | awk '{print $2}')
+          # Get the latest stable rust toolchain version available
+          TOOLCHAIN=$(curl -s 'https://static.rust-lang.org/dist/channel-rust-stable.toml' | awk '/\[pkg.rust\]/ {getline;print;}' | sed -r 's/^version = "([0-9.]+) .*/\1/')
           ./scripts/build-docker-image.sh "$ARCH" "$TOOLCHAIN"
 
       - name: Export Docker Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}-${{ matrix.arch }}
@@ -225,7 +228,9 @@ jobs:
         if: matrix.arch == 'arm64'
 
       - name: Build
-        run: ./scripts/build-docker-image.sh "$ARCH"
+        run: |
+          TOOLCHAIN=$(cargo version | awk '{print $2}')
+          ./scripts/build-docker-image.sh "$ARCH" "$TOOLCHAIN"
 
       - name: Export Docker Image
         run: docker save -o relay-docker-image.tgz $IMG_VERSIONED

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM centos:7 AS relay-deps
 
-# Pin the Rust version for now
-ARG RUST_TOOLCHAIN_VERSION=1.68.2
+# Rust version must be provided by the caller.
+ARG RUST_TOOLCHAIN_VERSION
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,8 +1,8 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM centos:7 AS relay-deps
 
-# Pin the Rust version for now
-ARG RUST_TOOLCHAIN_VERSION=1.68.2
+# Rust version must be provided by the caller.
+ARG RUST_TOOLCHAIN_VERSION
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \

--- a/scripts/build-docker-image.sh
+++ b/scripts/build-docker-image.sh
@@ -4,6 +4,7 @@
 set -euxo pipefail
 
 ARCH=${1:-$(uname -m)}
+TOOLCHAIN=$2
 
 # Set the correct build target and update the arch if required.
 case "$ARCH" in
@@ -31,6 +32,7 @@ fi
 
 docker buildx build \
     "${args[@]}" \
+    --build-arg RUST_TOOLCHAIN_VERSION="$TOOLCHAIN" \
     --build-arg UID="$(id -u)" \
     --build-arg GID="$(id -g)" \
     --cache-to type=inline \

--- a/scripts/docker-build-linux.sh
+++ b/scripts/docker-build-linux.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux
 
+TOOLCHAIN=$1
+
 if [ "${BUILD_ARCH}" = "x86_64" ]; then
   DOCKER_ARCH="amd64"
 elif [ "${BUILD_ARCH}" = "i686" ]; then
@@ -16,6 +18,7 @@ BUILD_IMAGE="us.gcr.io/sentryio/relay:deps"
 # Prepare build environment first
 docker pull $BUILD_IMAGE || true
 docker buildx build \
+     --build-arg RUST_TOOLCHAIN_VERSION="$TOOLCHAIN" \
      --platform "linux/${DOCKER_ARCH}" \
      --cache-from=${BUILD_IMAGE} \
      --target relay-deps \


### PR DESCRIPTION
Make sure we automatically use the latest rust toolchain in the docker, when we build a new image. 

In this PR:
* make sure the latest toolchain is available
* get the version of the installed toolchain
* use it when we build a new builder docker image

#skip-changelog