### PR TITLE
instr(txnames): Measure unique tx names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "flate2",
+ "fnv",
  "futures",
  "hashbrown 0.13.2",
  "insta",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -36,6 +36,7 @@ bytes = { version = "1.4.0" }
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "serde"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"
+fnv = "1.0.7"
 futures = "0.3"
 hashbrown = "0.13.2"
 itertools = "0.10.5"

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3387,6 +3387,7 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:url",
+            "event.unique_transaction_name_changes:6195281337519401496|s|#source_in:url,changes:none,source_out:url",
         ]
         "###);
     }
@@ -3397,6 +3398,7 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:rule,source_out:sanitized",
+            "event.unique_transaction_name_changes:3756704504880761228|s|#source_in:url,changes:rule,source_out:sanitized",
         ]
         "###);
     }
@@ -3407,6 +3409,7 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:url",
+            "event.unique_transaction_name_changes:4519663072515272991|s|#source_in:url,changes:pattern,source_out:url",
         ]
         "###);
     }
@@ -3417,6 +3420,7 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:both,source_out:sanitized",
+            "event.unique_transaction_name_changes:5223952678704220359|s|#source_in:url,changes:both,source_out:sanitized",
         ]
         "###);
     }
@@ -3427,6 +3431,7 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:route,changes:none,source_out:route",
+            "event.unique_transaction_name_changes:5223952678704220359|s|#source_in:route,changes:none,source_out:route",
         ]
         "###);
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, SetMetric, TimerMetric};
 
 /// Gauge metrics used by Relay
 pub enum RelayGauges {
@@ -532,6 +532,28 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
+        }
+    }
+}
+
+/// Set metrics used by Relay.
+pub enum RelaySets {
+    /// The number of unique transaction names grouped by transaction name modifications.
+    /// This metric is tagged with:
+    ///  - `source_in`: The source of the transaction name before normalization.
+    ///    See the [transaction source
+    ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
+    ///    for all valid values.
+    ///  - `change`: The mechanism that changed the transaction name.
+    ///    Either `"none"`, `"pattern"`, `"rule"`, or `"both"`.
+    ///  - `source_out`: The source of the transaction name after normalization.
+    TransactionNameChanges,
+}
+
+impl SetMetric for RelaySets {
+    fn name(&self) -> &'static str {
+        match self {
+            RelaySets::TransactionNameChanges => "event.unique_transaction_name_changes",
         }
     }
 }

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -23,8 +23,7 @@ where
         return f(event);
     }
 
-    // Create a hash of the old name so we can track it in a set metric:
-
+    // Create a hash of the old name so we can track it in a set metric.
     let old_name = {
         let old_name = inner.transaction.as_str().unwrap_or_default();
         let mut hasher = FnvHasher::default();


### PR DESCRIPTION
Same as https://github.com/getsentry/relay/pull/1978, but counting unique transaction names.

> Log changes made to the transaction name by the TransactionProcessor to get an idea of what percentage of transactions is affected, and by which mechanism.
>
> We can consider this a temporary metric and delete it once we are done with this initiative.

#skip-changelog