### PR TITLE
fix(test): Fixes broken snapshot test due to device.class feature flag

### DIFF
--- a/relay-general/tests/snapshots/test_fixtures__cocoa__pii_stripping.snap
+++ b/relay-general/tests/snapshots/test_fixtures__cocoa__pii_stripping.snap
@@ -620,8 +620,6 @@ threads:
 tags:
   - - a
     - b
-  - - device.class
-    - "2"
 extra:
   c: d
 debug_meta:


### PR DESCRIPTION
Fixes a snapshot test failure due to feature flag preventing device.class calculation
_#skip-changelog_