### PR TITLE
Revert "instr(txnames): Measure unique tx names"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,7 +3120,6 @@ dependencies = [
  "chrono",
  "data-encoding",
  "flate2",
- "fnv",
  "futures",
  "hashbrown 0.13.2",
  "insta",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -36,7 +36,6 @@ bytes = { version = "1.4.0" }
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "serde"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"
-fnv = "1.0.7"
 futures = "0.3"
 hashbrown = "0.13.2"
 itertools = "0.10.5"

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3389,7 +3389,6 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:url",
-            "event.unique_transaction_name_changes:6195281337519401496|s|#source_in:url,changes:none,source_out:url",
         ]
         "###);
     }
@@ -3400,7 +3399,6 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:rule,source_out:sanitized",
-            "event.unique_transaction_name_changes:3756704504880761228|s|#source_in:url,changes:rule,source_out:sanitized",
         ]
         "###);
     }
@@ -3411,7 +3409,6 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:url",
-            "event.unique_transaction_name_changes:4519663072515272991|s|#source_in:url,changes:pattern,source_out:url",
         ]
         "###);
     }
@@ -3422,7 +3419,6 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:both,source_out:sanitized",
-            "event.unique_transaction_name_changes:5223952678704220359|s|#source_in:url,changes:both,source_out:sanitized",
         ]
         "###);
     }
@@ -3433,7 +3429,6 @@ mod tests {
         insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:route,changes:none,source_out:route",
-            "event.unique_transaction_name_changes:5223952678704220359|s|#source_in:route,changes:none,source_out:route",
         ]
         "###);
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, SetMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
 
 /// Gauge metrics used by Relay
 pub enum RelayGauges {
@@ -532,28 +532,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
-        }
-    }
-}
-
-/// Set metrics used by Relay.
-pub enum RelaySets {
-    /// The number of unique transaction names grouped by transaction name modifications.
-    /// This metric is tagged with:
-    ///  - `source_in`: The source of the transaction name before normalization.
-    ///    See the [transaction source
-    ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
-    ///    for all valid values.
-    ///  - `change`: The mechanism that changed the transaction name.
-    ///    Either `"none"`, `"pattern"`, `"rule"`, or `"both"`.
-    ///  - `source_out`: The source of the transaction name after normalization.
-    TransactionNameChanges,
-}
-
-impl SetMetric for RelaySets {
-    fn name(&self) -> &'static str {
-        match self {
-            RelaySets::TransactionNameChanges => "event.unique_transaction_name_changes",
         }
     }
 }

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -1,11 +1,8 @@
-use std::hash::Hasher;
-
-use fnv::FnvHasher;
 use relay_common::EventType;
 use relay_general::protocol::Event;
 use relay_general::types::{Annotated, RemarkType};
 
-use crate::statsd::{RelayCounters, RelaySets};
+use crate::statsd::RelayCounters;
 
 /// Log statsd metrics about transaction name modifications.
 ///
@@ -23,13 +20,6 @@ where
         return f(event);
     }
 
-    // Create a hash of the old name so we can track it in a set metric.
-    let old_name = {
-        let old_name = inner.transaction.as_str().unwrap_or_default();
-        let mut hasher = FnvHasher::default();
-        std::hash::Hash::hash(old_name, &mut hasher);
-        hasher.finish() as i64 // 2-complement
-    };
     let old_source = inner.get_transaction_source().to_string();
     let old_remarks = inner.transaction.meta().iter_remarks().count();
 
@@ -64,12 +54,6 @@ where
 
     relay_statsd::metric!(
         counter(RelayCounters::TransactionNameChanges) += 1,
-        source_in = old_source.as_str(),
-        changes = changes,
-        source_out = new_source.as_str(),
-    );
-    relay_statsd::metric!(
-        set(RelaySets::TransactionNameChanges) = old_name,
         source_in = old_source.as_str(),
         changes = changes,
         source_out = new_source.as_str(),


### PR DESCRIPTION
Reverts getsentry/relay#1996

This metric was meant to be temporary anyway, and it seems to create "channel full" errors.

#skip-changelog