### PR TITLE
build(deps): Update `spin` to 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
follow up for https://github.com/getsentry/relay/pull/2001

Updating `spin` to latest one to fix reported issues, see linked PR. 

### Fixed
* Unsoundness in Once::try_call_once caused by an Err(_) result
* Relaxed accidentally restricted Send/Sync bounds for Mutex guards



#skip-changelog