### PR TITLE
fix: Revert sentry-kafka-schemas for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Metrics:
 - Upgrade the web framework and related dependencies. ([#1938](https://github.com/getsentry/relay/pull/1938))
 - Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
 - Use exposed device-class-synthesis feature flag to gate device.class synthesis in light normalization. ([#1974](https://github.com/getsentry/relay/pull/1974))
-- Use types from `sentry-kafka-schemas` crate to validate metrics messages into kafka. ([#1981](https://github.com/getsentry/relay/pull/1981))
 
 ## 23.3.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,16 +2513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
-dependencies = [
- "proc-macro2",
- "syn 2.0.11",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,16 +2740,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "regress"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d995d590bd8ec096d1893f414bf3f5e8b0ee4c9eed9a5642b9766ef2c8e2e8e9"
-dependencies = [
- "hashbrown 0.13.2",
- "memchr",
-]
 
 [[package]]
 name = "relay"
@@ -3153,7 +3133,6 @@ dependencies = [
  "relay-test",
  "reqwest",
  "rmp-serde",
- "sentry-kafka-schemas",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -3370,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -3384,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3535,22 +3514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-kafka-schemas"
-version = "0.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8b8dca924b6679663dd23d25406a36a18d68d9c3bf375b909edb36a6354db9"
-dependencies = [
- "prettyplease",
- "regress",
- "schemars",
- "serde",
- "serde_json",
- "serde_yaml 0.9.17",
- "syn 2.0.11",
- "typify",
-]
-
-[[package]]
 name = "sentry-log"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3676,17 +3639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3611210d2d67e3513204742004d6ac6f589e521861dabb0f649b070eea8bed9e"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
-dependencies = [
- "proc-macro2",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4407,50 +4359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "typify"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bfde96849e25d7feef1bbf652e9cfc51deb63203fdc07b115b8bc3bcfe20b9"
-dependencies = [
- "typify-impl",
- "typify-macro",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d27d749378ceab6ec22188ed7ad102205c89ddb92ab662371c850ffc71aa1a"
-dependencies = [
- "heck",
- "log",
- "proc-macro2",
- "quote",
- "regress",
- "schemars",
- "serde_json",
- "syn 1.0.109",
- "thiserror",
- "unicode-ident",
-]
-
-[[package]]
-name = "typify-macro"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35db6fc2bd9220ecdac6eeb88158824b83610de3dda0c6d0f2142b49efd858b0"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn 1.0.109",
- "typify-impl",
-]
-
-[[package]]
 name = "uaparser"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4496,9 +4404,9 @@ checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -1427,56 +1427,15 @@ expression: "relay_general::protocol::event_json_schema()"
     },
     "EventType": {
       "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring.",
-      "oneOf": [
-        {
-          "description": "Events that carry an exception payload.",
-          "type": "string",
-          "enum": [
-            "error"
-          ]
-        },
-        {
-          "description": "A CSP violation payload.",
-          "type": "string",
-          "enum": [
-            "csp"
-          ]
-        },
-        {
-          "description": "An HPKP violation payload.",
-          "type": "string",
-          "enum": [
-            "hpkp"
-          ]
-        },
-        {
-          "description": "An ExpectCT violation payload.",
-          "type": "string",
-          "enum": [
-            "expectct"
-          ]
-        },
-        {
-          "description": "An ExpectStaple violation payload.",
-          "type": "string",
-          "enum": [
-            "expectstaple"
-          ]
-        },
-        {
-          "description": "Performance monitoring transactions carrying spans.",
-          "type": "string",
-          "enum": [
-            "transaction"
-          ]
-        },
-        {
-          "description": "All events that do not qualify as any other type.",
-          "type": "string",
-          "enum": [
-            "default"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "error",
+        "csp",
+        "hpkp",
+        "expectct",
+        "expectstaple",
+        "transaction",
+        "default"
       ]
     },
     "Exception": {
@@ -2036,35 +1995,12 @@ expression: "relay_general::protocol::event_json_schema()"
     },
     "InstructionAddrAdjustment": {
       "description": "Controls the mechanism by which the `instruction_addr` of a [`Stacktrace`] [`Frame`] is adjusted.\n\nThe adjustment tries to transform *return addresses* to *call addresses* for symbolication. Typically, this adjustment needs to be done for all frames but the first, as the first frame is usually taken directly from the cpu context of a hardware exception or a suspended thread and the stack trace is created from that.\n\nWhen the stack walking implementation truncates frames from the top, `\"all\"` frames should be adjusted. In case the stack walking implementation already does the adjustment when producing stack frames, `\"none\"` should be used here.",
-      "oneOf": [
-        {
-          "description": "The default. Applies a heuristic based on other event / exception attributes.",
-          "type": "string",
-          "enum": [
-            "auto"
-          ]
-        },
-        {
-          "description": "All but the first frame needs to be adjusted. The first frame's address is not a *return address*, but points directly to the faulty instruction.",
-          "type": "string",
-          "enum": [
-            "all_but_first"
-          ]
-        },
-        {
-          "description": "All frames should be adjusted, for example because the stack walking implementation truncated frames from the top of the stack, and all remaining frames' addresses are *return addresses*.",
-          "type": "string",
-          "enum": [
-            "all"
-          ]
-        },
-        {
-          "description": "The stack walking implementation already provides correct addresses and no adjustment should be performed when symbolicating.",
-          "type": "string",
-          "enum": [
-            "none"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "auto",
+        "all_but_first",
+        "all",
+        "none"
       ]
     },
     "JsonLenientString": {
@@ -2077,42 +2013,13 @@ expression: "relay_general::protocol::event_json_schema()"
     },
     "Level": {
       "description": "Severity level of an event or breadcrumb.",
-      "oneOf": [
-        {
-          "description": "Indicates very spammy debug information.",
-          "type": "string",
-          "enum": [
-            "debug"
-          ]
-        },
-        {
-          "description": "Informational messages.",
-          "type": "string",
-          "enum": [
-            "info"
-          ]
-        },
-        {
-          "description": "A warning.",
-          "type": "string",
-          "enum": [
-            "warning"
-          ]
-        },
-        {
-          "description": "An error.",
-          "type": "string",
-          "enum": [
-            "error"
-          ]
-        },
-        {
-          "description": "Similar to error but indicates a critical event that usually causes a shutdown.",
-          "type": "string",
-          "enum": [
-            "fatal"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "fatal"
       ]
     },
     "LogEntry": {
@@ -3051,126 +2958,25 @@ expression: "relay_general::protocol::event_json_schema()"
     },
     "SpanStatus": {
       "description": "Trace status.\n\nValues from <https://github.com/open-telemetry/opentelemetry-specification/blob/8fb6c14e4709e75a9aaa64b0dbbdf02a6067682a/specification/api-tracing.md#status> Mapping to HTTP from <https://github.com/open-telemetry/opentelemetry-specification/blob/8fb6c14e4709e75a9aaa64b0dbbdf02a6067682a/specification/data-http.md#status>",
-      "oneOf": [
-        {
-          "description": "The operation completed successfully.\n\nHTTP status 100..299 + successful redirects from the 3xx range.",
-          "type": "string",
-          "enum": [
-            "ok"
-          ]
-        },
-        {
-          "description": "The operation was cancelled (typically by the user).",
-          "type": "string",
-          "enum": [
-            "cancelled"
-          ]
-        },
-        {
-          "description": "Unknown. Any non-standard HTTP status code.\n\n\"We do not know whether the transaction failed or succeeded\"",
-          "type": "string",
-          "enum": [
-            "unknown"
-          ]
-        },
-        {
-          "description": "Client specified an invalid argument. 4xx.\n\nNote that this differs from FailedPrecondition. InvalidArgument indicates arguments that are problematic regardless of the state of the system.",
-          "type": "string",
-          "enum": [
-            "invalid_argument"
-          ]
-        },
-        {
-          "description": "Deadline expired before operation could complete.\n\nFor operations that change the state of the system, this error may be returned even if the operation has been completed successfully.\n\nHTTP redirect loops and 504 Gateway Timeout",
-          "type": "string",
-          "enum": [
-            "deadline_exceeded"
-          ]
-        },
-        {
-          "description": "404 Not Found. Some requested entity (file or directory) was not found.",
-          "type": "string",
-          "enum": [
-            "not_found"
-          ]
-        },
-        {
-          "description": "Already exists (409)\n\nSome entity that we attempted to create already exists.",
-          "type": "string",
-          "enum": [
-            "already_exists"
-          ]
-        },
-        {
-          "description": "403 Forbidden\n\nThe caller does not have permission to execute the specified operation.",
-          "type": "string",
-          "enum": [
-            "permission_denied"
-          ]
-        },
-        {
-          "description": "429 Too Many Requests\n\nSome resource has been exhausted, perhaps a per-user quota or perhaps the entire file system is out of space.",
-          "type": "string",
-          "enum": [
-            "resource_exhausted"
-          ]
-        },
-        {
-          "description": "Operation was rejected because the system is not in a state required for the operation's execution",
-          "type": "string",
-          "enum": [
-            "failed_precondition"
-          ]
-        },
-        {
-          "description": "The operation was aborted, typically due to a concurrency issue.",
-          "type": "string",
-          "enum": [
-            "aborted"
-          ]
-        },
-        {
-          "description": "Operation was attempted past the valid range.",
-          "type": "string",
-          "enum": [
-            "out_of_range"
-          ]
-        },
-        {
-          "description": "501 Not Implemented\n\nOperation is not implemented or not enabled.",
-          "type": "string",
-          "enum": [
-            "unimplemented"
-          ]
-        },
-        {
-          "description": "Other/generic 5xx.",
-          "type": "string",
-          "enum": [
-            "internal_error"
-          ]
-        },
-        {
-          "description": "503 Service Unavailable",
-          "type": "string",
-          "enum": [
-            "unavailable"
-          ]
-        },
-        {
-          "description": "Unrecoverable data loss or corruption",
-          "type": "string",
-          "enum": [
-            "data_loss"
-          ]
-        },
-        {
-          "description": "401 Unauthorized (actually does mean unauthenticated according to RFC 7235)\n\nPrefer PermissionDenied if a user is logged in.",
-          "type": "string",
-          "enum": [
-            "unauthenticated"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "ok",
+        "cancelled",
+        "unknown",
+        "invalid_argument",
+        "deadline_exceeded",
+        "not_found",
+        "already_exists",
+        "permission_denied",
+        "resource_exhausted",
+        "failed_precondition",
+        "aborted",
+        "out_of_range",
+        "unimplemented",
+        "internal_error",
+        "unavailable",
+        "data_loss",
+        "unauthenticated"
       ]
     },
     "Stacktrace": {
@@ -3586,63 +3392,16 @@ expression: "relay_general::protocol::event_json_schema()"
     },
     "TransactionSource": {
       "description": "Describes how the name of the transaction was determined.",
-      "oneOf": [
-        {
-          "description": "User-defined name set through `set_transaction_name`.",
-          "type": "string",
-          "enum": [
-            "custom"
-          ]
-        },
-        {
-          "description": "Raw URL, potentially containing identifiers.",
-          "type": "string",
-          "enum": [
-            "url"
-          ]
-        },
-        {
-          "description": "Parametrized URL or route.",
-          "type": "string",
-          "enum": [
-            "route"
-          ]
-        },
-        {
-          "description": "Name of the view handling the request.",
-          "type": "string",
-          "enum": [
-            "view"
-          ]
-        },
-        {
-          "description": "Named after a software component, such as a function or class name.",
-          "type": "string",
-          "enum": [
-            "component"
-          ]
-        },
-        {
-          "description": "The transaction name was updated to reduce the name cardinality.",
-          "type": "string",
-          "enum": [
-            "sanitized"
-          ]
-        },
-        {
-          "description": "Name of a background task (e.g. a Celery task).",
-          "type": "string",
-          "enum": [
-            "task"
-          ]
-        },
-        {
-          "description": "This is the default value set by Relay for legacy SDKs.",
-          "type": "string",
-          "enum": [
-            "unknown"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "custom",
+        "url",
+        "route",
+        "view",
+        "component",
+        "sanitized",
+        "task",
+        "unknown"
       ]
     },
     "User": {

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -79,7 +79,6 @@ tower-http = { version = "0.4.0", default-features = false, features = ["catch-p
 tracing = "0.1.37"
 url = { version = "2.1.1", features = ["serde"] }
 zstd = { version = "0.12.3", optional = true }
-sentry-kafka-schemas = "0.0.22"
 
 [target."cfg(not(windows))".dependencies]
 libc = "0.2.71"


### PR DESCRIPTION
Reverts #1981

https://github.com/getsentry/relay/commit/26291de5cf2efd17e1ecd71c93a707ddb2ed3b1b

The ingest team would like to see other options prototyped out first
before committing to this one.

Suggestion is to try schema validation in unittesting/integration testing.

Concerns:

* Additional dependencies (can we flatten types before publish?)
* Impediments on iteration speed (don't want to update a separate repo
  to change specific types)
* Suboptimal codegen (Vec vs BTreeSet)

#skip-changelog
