### PR TITLE
ref(normalization): Always scrub identifiers

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -12,11 +12,6 @@ pub enum Feature {
     /// Enables data scrubbing of replay recording payloads.
     #[serde(rename = "organizations:session-replay-recording-scrubbing")]
     SessionReplayRecordingScrubbing,
-    /// Enables transaction names normalization.
-    ///
-    /// Replacing UUIDs, SHAs and numerical IDs by placeholders.
-    #[serde(rename = "organizations:transaction-name-normalize")]
-    TransactionNameNormalize,
     /// True if transaction names scrubbed by regex patterns should be marked as "sanitized".
     ///
     /// Transaction names modified by clusterer rules are always marked as such.

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -13,8 +13,6 @@ use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Remark, 
 /// Configuration around removing high-cardinality parts of URL transactions.
 #[derive(Clone, Debug, Default)]
 pub struct TransactionNameConfig<'r> {
-    /// True if regex patterns should be applied to erase identifiers from the transaction name.
-    pub scrub_identifiers: bool,
     /// True if transaction names scrubbed by regex patterns should be marked as [`TransactionSource::Sanitized`].
     ///
     /// Transaction names modified by clusterer rules are always marked as such.
@@ -347,39 +345,37 @@ impl Processor for TransactionsProcessor<'_> {
                 .set_value(Some("<unlabeled transaction>".to_owned()))
         }
 
-        if self.name_config.scrub_identifiers {
-            // Normalize transaction names for URLs and Sanitized transaction sources.
-            // This in addition to renaming rules can catch some high cardinality parts.
-            let mut sanitized = false;
+        // Normalize transaction names for URLs and Sanitized transaction sources.
+        // This in addition to renaming rules can catch some high cardinality parts.
+        let mut sanitized = false;
 
-            if matches!(
-                event.get_transaction_source(),
-                &TransactionSource::Url | &TransactionSource::Sanitized
-            ) {
-                scrub_identifiers(&mut event.transaction)?.then(|| {
-                    sanitized = true;
-                });
-            }
-
-            if !self.name_config.rules.is_empty() {
-                self.apply_transaction_rename_rule(
-                    &mut event.transaction,
-                    event.transaction_info.value_mut(),
-                )?;
-
+        if matches!(
+            event.get_transaction_source(),
+            &TransactionSource::Url | &TransactionSource::Sanitized
+        ) {
+            scrub_identifiers(&mut event.transaction)?.then(|| {
                 sanitized = true;
-            }
+            });
+        }
 
-            if sanitized
-                && matches!(event.get_transaction_source(), &TransactionSource::Url)
-                && self.name_config.mark_scrubbed_as_sanitized
-            {
-                event
-                    .transaction_info
-                    .get_or_insert_with(Default::default)
-                    .source
-                    .set_value(Some(TransactionSource::Sanitized));
-            }
+        if !self.name_config.rules.is_empty() {
+            self.apply_transaction_rename_rule(
+                &mut event.transaction,
+                event.transaction_info.value_mut(),
+            )?;
+
+            sanitized = true;
+        }
+
+        if sanitized
+            && matches!(event.get_transaction_source(), &TransactionSource::Url)
+            && self.name_config.mark_scrubbed_as_sanitized
+        {
+            event
+                .transaction_info
+                .get_or_insert_with(Default::default)
+                .source
+                .set_value(Some(TransactionSource::Sanitized));
         }
 
         validate_transaction(event)?;
@@ -1429,60 +1425,6 @@ mod tests {
     }
 
     #[test]
-    fn test_transaction_name_dont_normalize() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0",
-            "transaction_info": {
-              "source": "url"
-            },
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {
-                "trace": {
-                    "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
-                    "span_id": "fa90fdead5f74053",
-                    "op": "rails.request",
-                    "status": "ok"
-                }
-            }
-        }
-        "#;
-        let mut event = Annotated::<Event>::from_json(json).unwrap();
-
-        // This must not normalize transaction name, since it's disabled.
-        process_value(
-            &mut event,
-            &mut TransactionsProcessor::default(),
-            ProcessingState::root(),
-        )
-        .unwrap();
-
-        assert_annotated_snapshot!(event, @r###"
-        {
-          "type": "transaction",
-          "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0",
-          "transaction_info": {
-            "source": "url"
-          },
-          "timestamp": 1619420400.0,
-          "start_timestamp": 1619420341.0,
-          "contexts": {
-            "trace": {
-              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
-              "span_id": "fa90fdead5f74053",
-              "op": "rails.request",
-              "status": "ok",
-              "type": "trace"
-            }
-          },
-          "spans": []
-        }
-        "###);
-    }
-
-    #[test]
     fn test_transaction_name_normalize() {
         let json = r#"
         {
@@ -1510,10 +1452,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
-                ..Default::default()
-            }),
+            &mut TransactionsProcessor::new(TransactionNameConfig::default()),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1597,10 +1536,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
-                ..Default::default()
-            }),
+            &mut TransactionsProcessor::new(TransactionNameConfig::default()),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1635,7 +1571,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: true,
                 ..Default::default()
             }),
@@ -1738,7 +1673,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: false, // ensure `source` is set by rule application
                 rules: rules.as_ref(),
             }),
@@ -1801,7 +1735,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: false, // ensure `source` is set by rule application
                 rules: rules.as_ref(),
             }),
@@ -1965,7 +1898,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 rules: &[rule],
                 ..Default::default()
             }),
@@ -2062,10 +1994,7 @@ mod tests {
 
                 process_value(
                     &mut event,
-                    &mut TransactionsProcessor::new(TransactionNameConfig {
-                        scrub_identifiers: true,
-                        ..Default::default()
-                    }),
+                    &mut TransactionsProcessor::new(TransactionNameConfig::default()),
                     ProcessingState::root(),
                 )
                 .unwrap();
@@ -2191,7 +2120,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: true,
                 rules: &[TransactionNameRule {
                     pattern: LazyGlob::new("/remains/*/1234567890/".to_owned()),
@@ -2236,7 +2164,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: true,
                 rules: &[TransactionNameRule {
                     pattern: LazyGlob::new("/remains/*/**".to_owned()),
@@ -2276,7 +2203,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                scrub_identifiers: true,
                 mark_scrubbed_as_sanitized: true,
                 rules: &[],
             }),

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2214,9 +2214,6 @@ impl EnvelopeProcessorService {
                 breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
-                    scrub_identifiers: state
-                        .project_state
-                        .has_feature(Feature::TransactionNameNormalize),
                     mark_scrubbed_as_sanitized: state
                         .project_state
                         .has_feature(Feature::TransactionNameMarkScrubbedAsSanitized),
@@ -3364,7 +3361,6 @@ mod tests {
             log_transaction_name_metrics(&mut event, |event| {
                 let config = LightNormalizationConfig {
                     transaction_name_config: TransactionNameConfig {
-                        scrub_identifiers: true,
                         mark_scrubbed_as_sanitized: false,
                         rules: &[TransactionNameRule {
                             pattern: LazyGlob::new("/foo/*/**".to_owned()),


### PR DESCRIPTION
Currently, Relay only scrubs identifiers for organizations with the feature flag enabled. Since we're GAing this out, there's no need to keep the feature flag.

The feature flag is `organizations:transaction-name-normalize`.

#skip-changelog