### PR TITLE
ref(buffering): Refactor relay config

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -764,7 +764,11 @@ pub struct EnvelopeSpool {
     /// If not set the befault is 524288000 bytes (500MB).
     #[serde(default = "spool_envelopes_max_disk_size")]
     max_disk_size: usize,
-    /// The maximum number of envelopes to keep in the memory buffer before spooling them to disk.
+    /// The maximum bytes to keep in the memory buffer before spooling envelopes to disk, in bytes.
+    ///
+    /// This is a hard upper bound. Internally, this is converted to an envelope count by dividing
+    /// this number by the maximum envelope size, so in practice, because the avg. envelope
+    /// size is well below the maximum, we start spooling to disk long before this hard limit is reached.
     #[serde(default = "spool_envelopes_max_memory_size")]
     max_memory_size: usize,
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -726,31 +726,66 @@ impl Default for Http {
     }
 }
 
-fn buffer_max_connections() -> u32 {
-    30
+/// Default for max memory size, 500 MB.
+fn spool_envelopes_max_memory_size() -> usize {
+    524288000
 }
 
-fn buffer_min_connections() -> u32 {
+/// Default for max disk size, 500 MB.
+fn spool_envelopes_max_disk_size() -> usize {
+    524288000
+}
+
+/// Default for min connections to keep open in the pool.
+fn spool_envelopes_min_connections() -> u32 {
     10
 }
 
-/// Controls internal caching behavior.
+/// Default for max connections to keep open in the pool.
+fn spool_envelopes_max_connections() -> u32 {
+    20
+}
+
+/// Persistent buffering configuration for incoming envelopes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PersistentBuffer {
-    /// The path to the persistent buffer file.
-    path: PathBuf,
+pub struct EnvelopeSpool {
+    /// The path to the persistent spool file.
+    ///
+    /// If set, this will enable the buffering for incoming envelopes.
+    path: Option<PathBuf>,
     /// Maximum number of connections, which will be maintained by the pool.
-    #[serde(default = "buffer_max_connections")]
+    #[serde(default = "spool_envelopes_max_connections")]
     max_connections: u32,
     /// Minimal number of connections, which will be maintained by the pool.
-    #[serde(default = "buffer_min_connections")]
+    #[serde(default = "spool_envelopes_min_connections")]
     min_connections: u32,
     /// The maximum size of the buffer to keep, in bytes.
     ///
-    /// If not set the befault is 10737418240 bytes or 10 GB.
-    max_disk_size: Option<usize>,
+    /// If not set the befault is 524288000 bytes (500MB).
+    #[serde(default = "spool_envelopes_max_disk_size")]
+    max_disk_size: usize,
     /// The maximum number of envelopes to keep in the memory buffer before spooling them to disk.
-    max_memory_size: Option<usize>,
+    #[serde(default = "spool_envelopes_max_memory_size")]
+    max_memory_size: usize,
+}
+
+impl Default for EnvelopeSpool {
+    fn default() -> Self {
+        Self {
+            path: None,
+            max_connections: spool_envelopes_max_connections(),
+            min_connections: spool_envelopes_min_connections(),
+            max_disk_size: spool_envelopes_max_disk_size(),
+            max_memory_size: spool_envelopes_max_memory_size(),
+        }
+    }
+}
+
+/// Persistent buffering configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Spool {
+    #[serde(default)]
+    envelopes: EnvelopeSpool,
 }
 
 /// Controls internal caching behavior.
@@ -786,11 +821,6 @@ struct Cache {
     file_interval: u32,
     /// Interval for evicting outdated project configs from memory.
     eviction_interval: u32,
-    /// The settings to configure persistent buffering.
-    ///
-    /// When enabled all incoming envelopes will be persisted to the disk instead of keeping
-    /// them in memory.
-    persistent_envelope_buffer: Option<PersistentBuffer>,
 }
 
 impl Default for Cache {
@@ -806,7 +836,6 @@ impl Default for Cache {
             batch_size: 500,
             file_interval: 10,     // 10 seconds
             eviction_interval: 60, // 60 seconds
-            persistent_envelope_buffer: None,
         }
     }
 }
@@ -1156,6 +1185,8 @@ struct ConfigValues {
     http: Http,
     #[serde(default)]
     cache: Cache,
+    #[serde(default)]
+    spool: Spool,
     #[serde(default)]
     limits: Limits,
     #[serde(default)]
@@ -1699,63 +1730,34 @@ impl Config {
         Duration::from_secs(self.values.cache.eviction_interval.into())
     }
 
-    /// Returns `true` if the persistent envelope buffer is enabled, `false` otherwise.
-    pub fn cache_persistent_buffer_enabled(&self) -> bool {
-        self.values.cache.persistent_envelope_buffer.is_some()
-    }
-
     /// Returns the path of the buffer file if the `cache.persistent_envelope_buffer.path` is configured.
-    pub fn cache_persistent_buffer_path(&self) -> Option<PathBuf> {
+    pub fn spool_envelopes_path(&self) -> Option<PathBuf> {
         self.values
-            .cache
-            .persistent_envelope_buffer
+            .spool
+            .envelopes
+            .path
             .as_ref()
-            .map(|b| b.path.to_owned())
+            .map(|path| path.to_owned())
     }
 
     /// Maximum number of connections to create to buffer file.
-    pub fn cache_persistent_buffer_max_connections(&self) -> u32 {
-        self.values
-            .cache
-            .persistent_envelope_buffer
-            .as_ref()
-            .map(|b| b.max_connections)
-            .unwrap_or_else(buffer_max_connections)
+    pub fn spool_envelopes_max_connections(&self) -> u32 {
+        self.values.spool.envelopes.max_connections
     }
 
     /// Minimum number of connections to create to buffer file.
-    pub fn cache_persistent_buffer_min_connections(&self) -> u32 {
-        self.values
-            .cache
-            .persistent_envelope_buffer
-            .as_ref()
-            .map(|b| b.min_connections)
-            .unwrap_or_else(buffer_min_connections)
+    pub fn spool_envelopes_min_connections(&self) -> u32 {
+        self.values.spool.envelopes.min_connections
     }
 
     /// The maximum size of the buffer, in bytes.
-    ///
-    /// Default: 10737418240 bytes or 10 GB.
-    pub fn cache_persistent_buffer_max_disk_size(&self) -> usize {
-        self.values
-            .cache
-            .persistent_envelope_buffer
-            .as_ref()
-            .and_then(|b| b.max_disk_size)
-            .unwrap_or(10 * 1024 * 1024 * 1024)
+    pub fn spool_envelopes_max_disk_size(&self) -> usize {
+        self.values.spool.envelopes.max_disk_size
     }
 
-    /// The maximum size of the memory buffer.
-    ///
-    /// Set to smaller between `cache.persistent_envelope_buffer.max_memory_size` and `cache.envelope_buffer_size`.
-    /// Default set to half of `cache.envelope_buffer_size`
-    pub fn cache_persistent_buffer_max_memory_size(&self) -> usize {
-        self.values
-            .cache
-            .persistent_envelope_buffer
-            .as_ref()
-            .and_then(|b| b.max_memory_size)
-            .unwrap_or(self.envelope_buffer_size() / 2)
+    /// The maximum size of the memory buffer, in bytes.
+    pub fn spool_envelopes_max_memory_size(&self) -> usize {
+        self.values.spool.envelopes.max_memory_size
     }
 
     /// Returns the maximum size of an event payload in bytes.

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -38,7 +38,7 @@ pub enum BufferError {
     CapacityExceeded(#[from] crate::utils::BufferError),
 
     #[error("failed to get the size of the buffer on the filesystem")]
-    DatabaseSizeError(#[from] std::io::Error),
+    DatabaseFileError(#[from] std::io::Error),
 
     /// Describes the errors linked with the `Sqlite` backed buffer.
     #[error("failed to fetch data from the database")]
@@ -174,7 +174,7 @@ impl FromMessage<RemoveMany> for Buffer {
 struct BufferSpoolConfig {
     db: Pool<Sqlite>,
     max_disk_size: usize,
-    max_memory_size: usize,
+    max_envelopes_count: usize,
 }
 
 /// [`Buffer`] interface implementation backed by SQLite.
@@ -216,8 +216,8 @@ impl BufferService {
             spool_config: None,
         };
 
-        // Only if persistent buffer enabled, we create the pool and set the config.
-        if let Some(path) = config.cache_persistent_buffer_path() {
+        // Only if persistent envelopes buffer file path provided, we create the pool and set the config.
+        if let Some(path) = config.spool_envelopes_path() {
             relay_log::info!("Using the buffer file: {}", path.to_string_lossy());
 
             Self::setup(&path).await?;
@@ -243,15 +243,19 @@ impl BufferService {
                 .shared_cache(true);
 
             let db = SqlitePoolOptions::new()
-                .max_connections(config.cache_persistent_buffer_max_connections())
-                .min_connections(config.cache_persistent_buffer_min_connections())
+                .max_connections(config.spool_envelopes_max_connections())
+                .min_connections(config.spool_envelopes_min_connections())
                 .connect_with(options)
                 .await?;
 
             let spool_config = BufferSpoolConfig {
                 db,
-                max_disk_size: config.cache_persistent_buffer_max_disk_size(),
-                max_memory_size: config.cache_persistent_buffer_max_memory_size(),
+                max_disk_size: config.spool_envelopes_max_disk_size(),
+                // It is a rough extimation for how many envelopes we can fit in the
+                // configured memory limit, taking that 1 enveloper is 1 MB.
+                //
+                // TODO: Can we calculate the size of the envelope?
+                max_envelopes_count: config.spool_envelopes_max_memory_size() / (1024 * 1024),
             };
 
             service.spool_config = Some(spool_config);
@@ -264,7 +268,7 @@ impl BufferService {
     fn estimate_buffer_size(path: Option<PathBuf>) -> Result<u64, BufferError> {
         path.and_then(|path| std::fs::metadata(path).ok())
             .map(|m| m.len())
-            .ok_or(BufferError::DatabaseSizeError(Error::from(
+            .ok_or(BufferError::DatabaseFileError(Error::from(
                 ErrorKind::NotFound,
             )))
     }
@@ -324,21 +328,19 @@ impl BufferService {
         if let Some(BufferSpoolConfig {
             db,
             max_disk_size,
-            max_memory_size,
+            max_envelopes_count,
         }) = spool_config
         {
-            if self.count_mem_envelopes < *max_memory_size as i64 {
+            if self.count_mem_envelopes < *max_envelopes_count as i64 {
                 return Ok(());
             }
 
-            let estimated_db_size =
-                Self::estimate_buffer_size(self.config.cache_persistent_buffer_path())?;
+            let estimated_db_size = Self::estimate_buffer_size(self.config.spool_envelopes_path())?;
 
             // Reject all the enqueue requests if we exceed the max size of the buffer.
             if estimated_db_size as usize > *max_disk_size {
                 return Err(BufferError::Full(estimated_db_size));
             }
-
             let buf = std::mem::take(buffer);
             self.count_mem_envelopes = 0;
             Self::do_spool(db, buf).await?;

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -254,8 +254,9 @@ impl BufferService {
                 // It is a rough extimation for how many envelopes we can fit in the
                 // configured memory limit, taking that 1 enveloper is 1 MB.
                 //
-                // TODO: Can we calculate the size of the envelope?
-                max_envelopes_count: config.spool_envelopes_max_memory_size() / (1024 * 1024),
+                // TODO: Can we calculate the real size of the envelope?
+                max_envelopes_count: config.spool_envelopes_max_memory_size()
+                    / config.max_envelope_size(),
             };
 
             service.spool_config = Some(spool_config);

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -259,9 +259,8 @@ def test_unparsable_project_config(buffer_config, mini_sentry, relay):
         temp = tempfile.mkdtemp()
         dbfile = os.path.join(temp, "buffer.db")
         # set the buffer to something low to force the spooling
-        relay_config["cache"]["persistent_envelope_buffer"] = {
-            "path": dbfile,
-            "max_memory_size": 1,
+        relay_config["spool"] = {
+            "envelopes": {"path": dbfile, "max_memory_size": 1024 * 1024}
         }
 
     relay = relay(mini_sentry, relay_config, wait_health_check=True)


### PR DESCRIPTION
Refactor the configuration setup for persistent buffering:
* add the top level `spool` option
* currently `spool` contains the `envelopes` configuration - this is done this way because we are planning to add more spooling to more places, which might require different setup
* add very rough estimate of how many envelopes can we fit into configured memory limit - should we have some pre-defined minimum which we must enforce?  

#skip-changelog