### PR TITLE
fix: Pin schemars so that we avoid bumping it accidentally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Metrics:
 - Upgrade the web framework and related dependencies. ([#1938](https://github.com/getsentry/relay/pull/1938))
 - Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
 - Use exposed device-class-synthesis feature flag to gate device.class synthesis in light normalization. ([#1974](https://github.com/getsentry/relay/pull/1974))
+- Pin schemars dependency to un-break schema docs generation. ([#2014](https://github.com/getsentry/relay/pull/2014))
 
 ## 23.3.1
 

--- a/relay-general/Cargo.toml
+++ b/relay-general/Cargo.toml
@@ -27,7 +27,11 @@ regex = "1.5.5"
 relay-common = { path = "../relay-common" }
 relay-general-derive = { path = "derive" }
 relay-log = { path = "../relay-log" }
-schemars = { version = "0.8.1", features = ["uuid1", "chrono"], optional = true }
+# schemars has made some changes to its generated schemas that break the docs
+# generator. For now, pin since we only have a singular use for it, otherwise I
+# think we could also just live with the bad docs.
+# https://github.com/getsentry/develop/issues/892
+schemars = { version = "=0.8.10", features = ["uuid1", "chrono"], optional = true }
 sentry-release-parser = { version = "1.3.1" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"


### PR DESCRIPTION
See accidental lockfile changes in https://github.com/getsentry/relay/pull/2013
