### PR TITLE
ref(server): Log sentry errors for web handler panics

### DIFF
--- a/relay-server/src/middlewares/handle_panic.rs
+++ b/relay-server/src/middlewares/handle_panic.rs
@@ -16,6 +16,8 @@ pub fn handle_panic(err: Box<dyn Any + Send + 'static>) -> Response {
         "no error details"
     };
 
+    relay_log::error!("panic in web handler: {}", detail);
+
     let response = (
         StatusCode::INTERNAL_SERVER_ERROR,
         ApiErrorResponse::with_detail(detail),


### PR DESCRIPTION
Panics in web endpoint handlers are caught by a middleware and transformed into
a 500 Internal Server Error. With this PR, we additionally log a sentry error
with stack trace.

#skip-changelog

