### PR TITLE
feat(protocol) Add new `mechanism` fields to protocol to support exception groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-**Internal**:
-
-- Add BufferService with SQLite backend. ([#1920](https://github.com/getsentry/relay/pull/1920))
-- Adds iPad support for device.class synthesis in light normalization. ([#2008](https://github.com/getsentry/relay/pull/2008))
-
 **Breaking Changes**:
 
 This release contains major changes to the web layer, including TCP and HTTP handling as well as all web endpoint handlers. Due to these changes, some functionality was retired and Relay responds differently in specific cases.
@@ -40,9 +35,11 @@ Metrics:
 
 **Internal**:
 
+- Add BufferService with SQLite backend. ([#1920](https://github.com/getsentry/relay/pull/1920))
 - Upgrade the web framework and related dependencies. ([#1938](https://github.com/getsentry/relay/pull/1938))
 - Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
 - Use exposed device-class-synthesis feature flag to gate device.class synthesis in light normalization. ([#1974](https://github.com/getsentry/relay/pull/1974))
+- Adds iPad support for device.class synthesis in light normalization. ([#2008](https://github.com/getsentry/relay/pull/2008))
 - Pin schemars dependency to un-break schema docs generation. ([#2014](https://github.com/getsentry/relay/pull/2014))
 
 ## 23.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Metrics:
 - Don't sanitize transactions if no clustering rules exist and no UUIDs were scrubbed. ([#1976](https://github.com/getsentry/relay/pull/1976))
 - Add `thread.lock_mechanism` field to protocol. ([#1979](https://github.com/getsentry/relay/pull/1979))
 - Add `origin` to trace context and span. ([#1984](https://github.com/getsentry/relay/pull/1984))
+- Add new `mechanism` fields to protocol to support exception groups. ([#2020](https://github.com/getsentry/relay/pull/2020))
 
 **Internal**:
 

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -155,7 +155,12 @@ pub struct Mechanism {
     /// - .NET Examples:  `"InnerException"`, `"InnerExceptions[0]"`, `"InnerExceptions[1]"`
     ///
     /// - JavaScript Examples: `"cause"`, `"errors[0]"`, `"errors[1]"`
-    #[metastructure(required = "false", nonempty = "true", max_chars = "enumlike")]
+    #[metastructure(
+        required = "false",
+        nonempty = "true",
+        max_chars = "enumlike",
+        deny_chars = " \t\r\n"
+    )]
     pub source: Annotated<String>,
 
     /// An optional boolean value, set `true` when the exception is the platform-specific exception

--- a/relay-general/src/protocol/mechanism.rs
+++ b/relay-general/src/protocol/mechanism.rs
@@ -144,6 +144,43 @@ pub struct Mechanism {
     ///   as the user explicitly captured the exception (and therefore kind of handled it)
     pub handled: Annotated<bool>,
 
+    /// An optional string value describing the source of the exception.
+    ///
+    /// For chained exceptions, this should contain the platform-specific name of the property or
+    /// attribute (on the parent exception) that this exception was acquired from. In the case of
+    /// an array, it should include the zero-based array index as well.
+    ///
+    /// - Python Examples: `"__context__"`, `"__cause__"`, `"exceptions[0]"`, `"exceptions[1]"`
+    ///
+    /// - .NET Examples:  `"InnerException"`, `"InnerExceptions[0]"`, `"InnerExceptions[1]"`
+    ///
+    /// - JavaScript Examples: `"cause"`, `"errors[0]"`, `"errors[1]"`
+    #[metastructure(required = "false", nonempty = "true", max_chars = "enumlike")]
+    pub source: Annotated<String>,
+
+    /// An optional boolean value, set `true` when the exception is the platform-specific exception
+    /// group type.  Defaults to `false`.
+    ///
+    /// For example, exceptions of type `ExceptionGroup` (Python), `AggregateException` (.NET), and
+    /// `AggregateError` (JavaScript) should have `"is_exception_group": true`.  Other exceptions
+    /// can omit this field.
+    pub is_exception_group: Annotated<bool>,
+
+    /// An optional numeric value providing an ID for the exception relative to this specific event.
+    /// It is referenced by the `parent_id` to reconstruct the logical tree of exceptions in an
+    /// exception group.
+    ///
+    /// This should contain an unsigned integer value starting with `0` for the last exception in
+    /// the exception values list, then `1` for the previous exception, etc.
+    pub exception_id: Annotated<u64>,
+
+    /// An optional numeric value pointing at the `exception_id` that is the direct parent of this
+    /// exception, used to reconstruct the logical tree of exceptions in an exception group.
+    ///
+    /// The last exception in the exception values list should omit this field, because it is the
+    /// root exception and thus has no parent.
+    pub parent_id: Annotated<u64>,
+
     /// Arbitrary extra data that might help the user understand the error thrown by this mechanism.
     #[metastructure(pii = "true", bag_size = "medium")]
     #[metastructure(skip_serialization = "empty")]
@@ -168,6 +205,10 @@ impl FromValue for Mechanism {
             pub description: Annotated<String>,
             pub help_link: Annotated<String>,
             pub handled: Annotated<bool>,
+            pub source: Annotated<String>,
+            pub is_exception_group: Annotated<bool>,
+            pub exception_id: Annotated<u64>,
+            pub parent_id: Annotated<u64>,
             pub data: Annotated<Object<Value>>,
             pub meta: Annotated<MechanismMeta>,
             #[metastructure(additional_properties)]
@@ -210,6 +251,10 @@ impl FromValue for Mechanism {
                         description: mechanism.description,
                         help_link: mechanism.help_link,
                         handled: mechanism.handled,
+                        source: mechanism.source,
+                        is_exception_group: mechanism.is_exception_group,
+                        exception_id: mechanism.exception_id,
+                        parent_id: mechanism.parent_id,
                         data: mechanism.data,
                         meta: mechanism.meta,
                         other: mechanism.other,
@@ -222,6 +267,10 @@ impl FromValue for Mechanism {
                         description: Annotated::empty(),
                         help_link: Annotated::empty(),
                         handled: Annotated::empty(),
+                        source: Annotated::empty(),
+                        is_exception_group: Annotated::empty(),
+                        exception_id: Annotated::empty(),
+                        parent_id: Annotated::empty(),
                         data: Annotated::new(legacy.other),
                         meta: Annotated::new(MechanismMeta {
                             errno: Annotated::empty(),
@@ -270,6 +319,10 @@ mod tests {
   "description": "mydescription",
   "help_link": "https://developer.apple.com/library/content/qa/qa1367/_index.html",
   "handled": false,
+  "source": "errors[0]",
+  "is_exception_group": false,
+  "exception_id": 1,
+  "parent_id": 0,
   "data": {
     "relevant_address": "0x1"
   },
@@ -306,6 +359,10 @@ mod tests {
                 "https://developer.apple.com/library/content/qa/qa1367/_index.html".to_string(),
             ),
             handled: Annotated::new(false),
+            source: Annotated::new("errors[0]".to_string()),
+            is_exception_group: Annotated::new(false),
+            exception_id: Annotated::new(1),
+            parent_id: Annotated::new(0),
             data: {
                 let mut map = Map::new();
                 map.insert(
@@ -420,6 +477,10 @@ mod tests {
             description: Annotated::empty(),
             help_link: Annotated::empty(),
             handled: Annotated::empty(),
+            source: Annotated::empty(),
+            is_exception_group: Annotated::empty(),
+            exception_id: Annotated::empty(),
+            parent_id: Annotated::empty(),
             data: {
                 let mut map = Map::new();
                 map.insert(

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2206,6 +2206,16 @@ expression: "relay_general::protocol::event_json_schema()"
                 "null"
               ]
             },
+            "exception_id": {
+              "description": " An optional numeric value providing an ID for the exception relative to this specific event.\n It is referenced by the `parent_id` to reconstruct the logical tree of exceptions in an\n exception group.\n\n This should contain an unsigned integer value starting with `0` for the last exception in\n the exception values list, then `1` for the previous exception, etc.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "handled": {
               "description": " Flag indicating whether this exception was handled.\n\n This is a best-effort guess at whether the exception was handled by user code or not. For\n example:\n\n - Exceptions leading to a 500 Internal Server Error or to a hard process crash are\n   `handled=false`, as the SDK typically has an integration that automatically captures the\n   error.\n\n - Exceptions captured using `capture_exception` (called from user code) are `handled=true`\n   as the user explicitly captured the exception (and therefore kind of handled it)",
               "default": null,
@@ -2222,6 +2232,14 @@ expression: "relay_general::protocol::event_json_schema()"
                 "null"
               ]
             },
+            "is_exception_group": {
+              "description": " An optional boolean value, set `true` when the exception is the platform-specific exception\n group type.  Defaults to `false`.\n\n For example, exceptions of type `ExceptionGroup` (Python), `AggregateException` (.NET), and\n `AggregateError` (JavaScript) should have `\"is_exception_group\": true`.  Other exceptions\n can omit this field.",
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "meta": {
               "description": " Operating system or runtime meta information.",
               "default": null,
@@ -2232,6 +2250,24 @@ expression: "relay_general::protocol::event_json_schema()"
                 {
                   "type": "null"
                 }
+              ]
+            },
+            "parent_id": {
+              "description": " An optional numeric value pointing at the `exception_id` that is the direct parent of this\n exception, used to reconstruct the logical tree of exceptions in an exception group.\n\n The last exception in the exception values list should omit this field, because it is the\n root exception and thus has no parent.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "source": {
+              "description": " An optional string value describing the source of the exception.\n\n For chained exceptions, this should contain the platform-specific name of the property or\n attribute (on the parent exception) that this exception was acquired from. In the case of\n an array, it should include the zero-based array index as well.\n\n - Python Examples: `\"__context__\"`, `\"__cause__\"`, `\"exceptions[0]\"`, `\"exceptions[1]\"`\n\n - .NET Examples:  `\"InnerException\"`, `\"InnerExceptions[0]\"`, `\"InnerExceptions[1]\"`\n\n - JavaScript Examples: `\"cause\"`, `\"errors[0]\"`, `\"errors[1]\"`",
+              "default": null,
+              "type": [
+                "string",
+                "null"
               ]
             },
             "synthetic": {


### PR DESCRIPTION
Adds 4 new fields to the `mechanism` protocol to support exception groups, per [Sentry RFC 79](https://github.com/getsentry/rfcs/blob/main/text/0079-exception-groups.md)