### PR TITLE
ref(registry): Remove global service registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add BufferService with SQLite backend. ([#1920](https://github.com/getsentry/relay/pull/1920))
 - Adds iPad support for device.class synthesis in light normalization. ([#2008](https://github.com/getsentry/relay/pull/2008))
+- Remove global service registry. ([#2022](https://github.com/getsentry/relay/pull/2022))
 
 **Breaking Changes**:
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -59,6 +59,7 @@ impl From<relay_system::SendError> for SendEnvelopeError {
 pub struct SendEnvelope {
     pub envelope_body: Vec<u8>,
     pub envelope_meta: RequestMeta,
+    pub project_cache: Addr<ProjectCache>,
     pub scoping: Scoping,
     pub http_encoding: HttpEncoding,
     pub response_sender: oneshot::Sender<Result<(), SendEnvelopeError>>,
@@ -104,7 +105,7 @@ impl UpstreamRequest for SendEnvelope {
                 Ok(mut response) => response.consume().await.map_err(UpstreamRequestError::Http),
                 Err(error) => {
                     if let UpstreamRequestError::RateLimited(ref upstream_limits) = error {
-                        ProjectCache::from_registry().send(UpdateRateLimits::new(
+                        self.project_cache.send(UpdateRateLimits::new(
                             self.project_key,
                             upstream_limits.clone().scope(&self.scoping),
                         ));
@@ -197,6 +198,7 @@ pub struct EnvelopeManagerService {
     config: Arc<Config>,
     aggregator: Addr<Aggregator>,
     enveloper_processor: Addr<EnvelopeProcessor>,
+    project_cache: Addr<ProjectCache>,
     test_store: Addr<TestStore>,
     upstream_relay: Addr<UpstreamRelay>,
     #[cfg(feature = "processing")]
@@ -209,6 +211,7 @@ impl EnvelopeManagerService {
         config: Arc<Config>,
         aggregator: Addr<Aggregator>,
         enveloper_processor: Addr<EnvelopeProcessor>,
+        project_cache: Addr<ProjectCache>,
         test_store: Addr<TestStore>,
         upstream_relay: Addr<UpstreamRelay>,
     ) -> Self {
@@ -216,6 +219,7 @@ impl EnvelopeManagerService {
             config,
             aggregator,
             enveloper_processor,
+            project_cache,
             test_store,
             upstream_relay,
             #[cfg(feature = "processing")]
@@ -271,6 +275,7 @@ impl EnvelopeManagerService {
         let request = SendEnvelope {
             envelope_body,
             envelope_meta: envelope.meta().clone(),
+            project_cache: self.project_cache.clone(),
             scoping,
             http_encoding: self.config.http_encoding(),
             response_sender: tx,

--- a/relay-server/src/actors/health_check.rs
+++ b/relay-server/src/actors/health_check.rs
@@ -7,7 +7,6 @@ use relay_statsd::metric;
 use relay_system::{Addr, AsyncResponse, Controller, FromMessage, Interface, Sender, Service};
 
 use crate::actors::upstream::{IsAuthenticated, IsNetworkOutage, UpstreamRelay};
-use crate::service::REGISTRY;
 use crate::statsd::RelayGauges;
 
 /// Checks whether Relay is alive and healthy based on its variant.
@@ -24,20 +23,6 @@ pub enum IsHealthy {
 
 /// Service interface for the [`IsHealthy`] message.
 pub struct HealthCheck(IsHealthy, Sender<bool>);
-
-impl HealthCheck {
-    /// Returns the [`Addr`] of the [`HealthCheck`] service.
-    ///
-    /// Prior to using this, the service must be started using [`HealthCheckService::start`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the service was not started using [`HealthCheckService::start`] prior to this
-    /// being used.
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().health_check.clone()
-    }
-}
 
 impl Interface for HealthCheck {}
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -33,7 +33,6 @@ use crate::actors::envelopes::{EnvelopeManager, SendClientReports};
 use crate::actors::upstream::{Method, SendQuery, UpstreamQuery, UpstreamRelay};
 #[cfg(feature = "processing")]
 use crate::service::ServiceError;
-use crate::service::REGISTRY;
 use crate::statsd::RelayCounters;
 use crate::utils::SleepHandle;
 
@@ -124,12 +123,6 @@ pub struct TrackOutcome {
     pub category: DataCategory,
     /// The number of events or total attachment size in bytes.
     pub quantity: u32,
-}
-
-impl TrackOutcome {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().outcome_aggregator.clone()
-    }
 }
 
 impl TrackOutcomeLike for TrackOutcome {
@@ -747,12 +740,6 @@ impl KafkaOutcomesProducer {
 pub enum OutcomeProducer {
     TrackOutcome(TrackOutcome),
     TrackRawOutcome(TrackRawOutcome),
-}
-
-impl OutcomeProducer {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().outcome_producer.clone()
-    }
 }
 
 impl Interface for OutcomeProducer {}

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -60,7 +60,6 @@ use crate::extractors::RequestMeta;
 use crate::metrics_extraction::sessions::extract_session_metrics;
 use crate::metrics_extraction::transactions::extract_transaction_metrics;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
-use crate::service::REGISTRY;
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 use crate::utils::{
     self, get_sampling_key, log_transaction_name_metrics, ChunkedFormDataAggregator, FormDataIter,
@@ -481,12 +480,6 @@ pub enum EnvelopeProcessor {
     EncodeEnvelope(Box<EncodeEnvelope>),
     #[cfg(feature = "processing")]
     RateLimitFlushBuckets(RateLimitFlushBuckets),
-}
-
-impl EnvelopeProcessor {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().processor.clone()
-    }
 }
 
 impl relay_system::Interface for EnvelopeProcessor {}
@@ -2591,8 +2584,8 @@ mod tests {
     use similar_asserts::assert_eq;
 
     use super::*;
+    use crate::actors::test_store::TestStore;
     use crate::extractors::RequestMeta;
-    use crate::service::ServiceState;
     use crate::testutils::{new_envelope, state_with_rule_and_condition};
     use crate::utils::Semaphore as TestSemaphore;
 
@@ -2737,21 +2730,22 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn test_it_keeps_or_drops_transactions() {
+    fn services() -> (Addr<TrackOutcome>, Addr<TestStore>) {
+        let (outcome_aggregator, _) = mock_service("outcome_aggregator", (), |&mut (), _| {});
+        let (test_store, _) = mock_service("test_store", (), |&mut (), _| {});
+        (outcome_aggregator, test_store)
+    }
+
+    #[tokio::test]
+    async fn test_it_keeps_or_drops_transactions() {
         relay_test::setup();
+
+        let (outcome_aggregator, test_store) = services();
 
         // an empty json still produces a valid config
         let json_config = serde_json::json!({});
 
-        let config = Config::from_json_value(json_config.clone()).unwrap();
-        let arconfig = Arc::new(Config::from_json_value(json_config).unwrap());
-
-        // it really shouldn't be necessary to start an entire service for a unit test
-        // it was ported from a python integration test. Instead, we should inject dependencies
-        let runtime = crate::service::create_runtime("test-rt", 1);
-        let _guard = runtime.enter();
-        ServiceState::start(arconfig).unwrap();
+        let config = Config::from_json_value(json_config).unwrap();
 
         let service = create_test_processor(config);
 
@@ -2786,6 +2780,8 @@ mod tests {
                 managed_envelope: ManagedEnvelope::new(
                     new_envelope(false, "foo"),
                     TestSemaphore::new(42).try_acquire().unwrap(),
+                    outcome_aggregator.clone(),
+                    test_store.clone(),
                 ),
             };
 
@@ -2938,6 +2934,7 @@ mod tests {
     #[tokio::test]
     async fn test_user_report_invalid() {
         let processor = create_test_processor(Default::default());
+        let (outcome_aggregator, test_store) = services();
         let event_id = protocol::EventId::new();
 
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
@@ -2960,7 +2957,7 @@ mod tests {
         });
 
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope),
+            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
         };
@@ -2976,6 +2973,7 @@ mod tests {
     #[tokio::test]
     async fn test_browser_version_extraction_with_pii_like_data() {
         let processor = create_test_processor(Default::default());
+        let (outcome_aggregator, test_store) = services();
         let event_id = protocol::EventId::new();
 
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
@@ -3029,7 +3027,7 @@ mod tests {
         let mut project_state = ProjectState::allowed();
         project_state.config = config;
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope),
+            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
             project_state: Arc::new(project_state),
             sampling_project_state: None,
         };
@@ -3061,12 +3059,10 @@ mod tests {
         );
     }
 
-    #[test]
-    #[ignore = "The REGISTRY panics if the Addr of an service (that is not yet started) is queried,
-                hence this test fails. The old SystemRegistry returned dummy Addr's hence this did
-                not fail."]
-    fn test_client_report_removal() {
+    #[tokio::test]
+    async fn test_client_report_removal() {
         relay_test::setup();
+        let (outcome_aggregator, test_store) = services();
 
         let config = Config::from_json_value(serde_json::json!({
             "outcomes": {
@@ -3101,7 +3097,7 @@ mod tests {
         });
 
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope),
+            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
         };
@@ -3113,6 +3109,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_report_forwarding() {
         relay_test::setup();
+        let (outcome_aggregator, test_store) = services();
 
         let config = Config::from_json_value(serde_json::json!({
             "outcomes": {
@@ -3148,7 +3145,7 @@ mod tests {
         });
 
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope),
+            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
         };
@@ -3161,11 +3158,11 @@ mod tests {
         ctx.accept(); // do not try to capture or emit outcomes
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(feature = "processing")]
-    #[ignore = "requires registry for the TestStore"]
-    fn test_client_report_removal_in_processing() {
+    async fn test_client_report_removal_in_processing() {
         relay_test::setup();
+        let (outcome_aggregator, test_store) = services();
 
         let config = Config::from_json_value(serde_json::json!({
             "outcomes": {
@@ -3204,7 +3201,7 @@ mod tests {
         });
 
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope),
+            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
         };

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -781,17 +781,17 @@ mod tests {
 
         assert_debug_snapshot!(captures, @r###"
         [
-            "buffer.envelopes_mem:1700|h",
-            "buffer.envelopes_mem:3400|h",
+            "buffer.envelopes_mem:2000|h",
+            "buffer.envelopes_mem:4000|h",
             "buffer.disk_size:24576|h",
             "buffer.envelopes_mem:0|h",
             "buffer.writes:1|c",
-            "buffer.envelopes_mem:1700|h",
-            "buffer.envelopes_mem:3400|h",
+            "buffer.envelopes_mem:2000|h",
+            "buffer.envelopes_mem:4000|h",
             "buffer.disk_size:24576|h",
             "buffer.envelopes_mem:0|h",
             "buffer.writes:1|c",
-            "buffer.envelopes_mem:1700|h",
+            "buffer.envelopes_mem:2000|h",
             "buffer.reads:1|c",
             "buffer.reads:1|c",
             "buffer.disk_size:24576|h",

--- a/relay-server/src/actors/project_buffer.rs
+++ b/relay-server/src/actors/project_buffer.rs
@@ -778,7 +778,7 @@ mod tests {
         // Collect only the buffer metrics.
         let captures: Vec<_> = captures
             .into_iter()
-            .filter(|name| !name.contains("#service"))
+            .filter(|name| name.contains("buffer."))
             .collect();
 
         assert_debug_snapshot!(captures, @r###"

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -23,9 +23,9 @@ use crate::actors::project_local::{LocalProjectSource, LocalProjectSourceService
 #[cfg(feature = "processing")]
 use crate::actors::project_redis::RedisProjectSource;
 use crate::actors::project_upstream::{UpstreamProjectSource, UpstreamProjectSourceService};
+use crate::actors::test_store::TestStore;
 use crate::actors::upstream::UpstreamRelay;
 
-use crate::service::REGISTRY;
 use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::{self, BufferGuard, GarbageDisposal, ManagedEnvelope};
 
@@ -210,12 +210,6 @@ pub enum ProjectCache {
     MergeBuckets(MergeBuckets),
     FlushBuckets(FlushBuckets),
     UpdateBufferIndex(UpdateBufferIndex),
-}
-
-impl ProjectCache {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().project_cache.clone()
-    }
 }
 
 impl Interface for ProjectCache {}
@@ -407,33 +401,33 @@ struct UpdateProjectState {
 /// Holds the addresses of all services required for [`ProjectCache`].
 #[derive(Debug, Clone)]
 pub struct Services {
-    buffer: Arc<BufferGuard>,
     pub aggregator: Addr<Aggregator>,
     pub envelope_processor: Addr<EnvelopeProcessor>,
     pub envelope_manager: Addr<EnvelopeManager>,
     pub outcome_aggregator: Addr<TrackOutcome>,
     pub project_cache: Addr<ProjectCache>,
+    pub test_store: Addr<TestStore>,
     pub upstream_relay: Addr<UpstreamRelay>,
 }
 
 impl Services {
     /// Creates new [`Services`] context.
     pub fn new(
-        buffer: Arc<BufferGuard>,
         aggregator: Addr<Aggregator>,
         envelope_processor: Addr<EnvelopeProcessor>,
         envelope_manager: Addr<EnvelopeManager>,
         outcome_aggregator: Addr<TrackOutcome>,
         project_cache: Addr<ProjectCache>,
+        test_store: Addr<TestStore>,
         upstream_relay: Addr<UpstreamRelay>,
     ) -> Self {
         Self {
-            buffer,
             aggregator,
             envelope_processor,
             envelope_manager,
             outcome_aggregator,
             project_cache,
+            test_store,
             upstream_relay,
         }
     }
@@ -798,6 +792,7 @@ impl ProjectCacheBroker {
 /// Service implementing the [`ProjectCache`] interface.
 #[derive(Debug)]
 pub struct ProjectCacheService {
+    buffer_guard: Arc<BufferGuard>,
     config: Arc<Config>,
     services: Services,
     redis: Option<RedisPool>,
@@ -805,8 +800,14 @@ pub struct ProjectCacheService {
 
 impl ProjectCacheService {
     /// Creates a new `ProjectCacheService`.
-    pub fn new(config: Arc<Config>, services: Services, redis: Option<RedisPool>) -> Self {
+    pub fn new(
+        config: Arc<Config>,
+        buffer_guard: Arc<BufferGuard>,
+        services: Services,
+        redis: Option<RedisPool>,
+    ) -> Self {
         Self {
+            buffer_guard,
             config,
             services,
             redis,
@@ -819,12 +820,14 @@ impl Service for ProjectCacheService {
 
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
         let Self {
+            buffer_guard,
             config,
             services,
             redis,
         } = self;
-        let buffer_guard = services.buffer.clone();
         let project_cache = services.project_cache.clone();
+        let outcome_aggregator = services.outcome_aggregator.clone();
+        let test_store = services.test_store.clone();
 
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(config.cache_eviction_interval());
@@ -835,16 +838,23 @@ impl Service for ProjectCacheService {
 
             // Channel for envelope buffering.
             let (buffer_tx, mut buffer_rx) = mpsc::unbounded_channel();
-            let buffer =
-                match BufferService::create(buffer_guard, project_cache, config.clone()).await {
-                    Ok(buffer) => buffer.start(),
-                    Err(err) => {
-                        relay_log::error!("failed to start buffer service: {}", LogError(&err));
-                        // NOTE: The process will exit with error if the buffer file could not be
-                        // opened or the migrations could not be run.
-                        std::process::exit(1);
-                    }
-                };
+            let buffer = match BufferService::create(
+                buffer_guard,
+                outcome_aggregator,
+                project_cache,
+                test_store,
+                config.clone(),
+            )
+            .await
+            {
+                Ok(buffer) => buffer.start(),
+                Err(err) => {
+                    relay_log::error!("failed to start buffer service: {}", LogError(&err));
+                    // NOTE: The process will exit with error if the buffer file could not be
+                    // opened or the migrations could not be run.
+                    std::process::exit(1);
+                }
+            };
 
             // Main broker that serializes public and internal messages, and triggers project state
             // fetches via the project source.

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use crate::actors::upstream::{Method, RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay};
-use crate::service::REGISTRY;
 use crate::utils::{RetryBackoff, SleepHandle};
 
 /// Resolves [`RelayInfo`] by it's [identifier](RelayId).
@@ -36,12 +35,6 @@ pub type GetRelayResult = Option<RelayInfo>;
 /// Manages authentication information for downstream Relays.
 #[derive(Debug)]
 pub struct RelayCache(GetRelay, BroadcastSender<GetRelayResult>);
-
-impl RelayCache {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().relay_cache.clone()
-    }
-}
 
 impl Interface for RelayCache {}
 

--- a/relay-server/src/actors/test_store.rs
+++ b/relay-server/src/actors/test_store.rs
@@ -3,11 +3,10 @@ use std::sync::Arc;
 
 use relay_config::{Config, RelayMode};
 use relay_general::protocol::EventId;
-use relay_system::{Addr, AsyncResponse, FromMessage, NoResponse, Sender};
+use relay_system::{AsyncResponse, FromMessage, NoResponse, Sender};
 
 use crate::actors::outcome::Outcome;
 use crate::envelope::Envelope;
-use crate::service::REGISTRY;
 
 /// Either a captured envelope or an error that occured during processing.
 pub type CapturedEnvelope = Result<Box<Envelope>, String>;
@@ -59,12 +58,6 @@ pub struct GetCapturedEnvelope {
 pub enum TestStore {
     Capture(Box<Capture>),
     Get(GetCapturedEnvelope, Sender<Option<CapturedEnvelope>>),
-}
-
-impl TestStore {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().test_store.clone()
-    }
 }
 
 impl relay_system::Interface for TestStore {}

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -20,7 +20,7 @@ use relay_quotas::{
     Scoping,
 };
 use relay_system::{
-    Addr, AsyncResponse, FromMessage, Interface, MessageResponse, NoResponse, Sender, Service,
+    AsyncResponse, FromMessage, Interface, MessageResponse, NoResponse, Sender, Service,
 };
 use reqwest::header;
 pub use reqwest::Method;
@@ -30,7 +30,6 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::http::{HttpError, Request, RequestBuilder, Response, StatusCode};
-use crate::service::REGISTRY;
 use crate::statsd::{RelayHistograms, RelayTimers};
 use crate::utils::{self, ApiErrorResponse, RelayErrorAction, RetryBackoff};
 
@@ -515,12 +514,6 @@ pub enum UpstreamRelay {
     IsNetworkOutage(IsNetworkOutage, Sender<bool>),
     /// Sends a [request](SendRequest) or [query](SendQuery) to the upstream.
     SendRequest(Box<dyn UpstreamRequest>),
-}
-
-impl UpstreamRelay {
-    pub fn from_registry() -> Addr<Self> {
-        REGISTRY.get().unwrap().upstream_relay.clone()
-    }
 }
 
 impl Interface for UpstreamRelay {}

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -9,8 +9,8 @@ use relay_statsd::metric;
 use serde::Deserialize;
 
 use crate::actors::outcome::{DiscardReason, Outcome};
-use crate::actors::processor::{EnvelopeProcessor, ProcessMetrics};
-use crate::actors::project_cache::{CheckEnvelope, ProjectCache, ValidateEnvelope};
+use crate::actors::processor::ProcessMetrics;
+use crate::actors::project_cache::{CheckEnvelope, ValidateEnvelope};
 use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
 use crate::service::ServiceState;
 use crate::statsd::RelayCounters;
@@ -254,6 +254,7 @@ pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreReq
 /// Queueing can fail if the queue exceeds `envelope_buffer_size`. In this case, `Err` is
 /// returned and the envelope is not queued.
 fn queue_envelope(
+    state: &ServiceState,
     mut managed_envelope: ManagedEnvelope,
     buffer_guard: &BufferGuard,
 ) -> Result<(), BadStoreRequest> {
@@ -267,7 +268,7 @@ fn queue_envelope(
 
     if !metric_items.is_empty() {
         relay_log::trace!("sending metrics into processing queue");
-        EnvelopeProcessor::from_registry().send(ProcessMetrics {
+        state.registry.processor.send(ProcessMetrics {
             items: metric_items,
             project_key: envelope.meta().public_key(),
             start_time: envelope.meta().start_time(),
@@ -283,11 +284,18 @@ fn queue_envelope(
         relay_log::trace!("queueing separate envelope for non-event items");
 
         // The envelope has been split, so we need to fork the context.
-        let event_context = buffer_guard.enter(event_envelope)?;
+        let event_context = buffer_guard.enter(
+            event_envelope,
+            state.registry.outcome_aggregator.clone(),
+            state.registry.test_store.clone(),
+        )?;
 
         // Update the old context after successful forking.
         managed_envelope.update();
-        ProjectCache::from_registry().send(ValidateEnvelope::new(event_context));
+        state
+            .registry
+            .project_cache
+            .send(ValidateEnvelope::new(event_context));
     }
 
     if managed_envelope.envelope().is_empty() {
@@ -296,7 +304,10 @@ fn queue_envelope(
         managed_envelope.accept();
     } else {
         relay_log::trace!("queueing envelope");
-        ProjectCache::from_registry().send(ValidateEnvelope::new(managed_envelope));
+        state
+            .registry
+            .project_cache
+            .send(ValidateEnvelope::new(managed_envelope));
     }
 
     Ok(())
@@ -316,7 +327,11 @@ pub async fn handle_envelope(
 ) -> Result<Option<EventId>, BadStoreRequest> {
     let buffer_guard = state.buffer_guard();
     let mut managed_envelope = buffer_guard
-        .enter(envelope)
+        .enter(
+            envelope,
+            state.registry.outcome_aggregator.clone(),
+            state.registry.test_store.clone(),
+        )
         .map_err(BadStoreRequest::QueueFailed)?;
 
     // If configured, remove unknown items at the very beginning. If the envelope is
@@ -330,7 +345,9 @@ pub async fn handle_envelope(
         return Ok(event_id);
     }
 
-    let checked = ProjectCache::from_registry()
+    let checked = state
+        .registry
+        .project_cache
         .send(CheckEnvelope::new(managed_envelope))
         .await
         .map_err(|_| BadStoreRequest::ScheduleFailed)?
@@ -345,7 +362,7 @@ pub async fn handle_envelope(
         return Err(BadStoreRequest::Overflow);
     }
 
-    queue_envelope(managed_envelope, buffer_guard)?;
+    queue_envelope(state, managed_envelope, buffer_guard)?;
 
     if checked.rate_limits.is_limited() {
         Err(BadStoreRequest::RateLimited(checked.rate_limits))

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -5,14 +5,18 @@ use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
 use relay_general::protocol::EventId;
 
-use crate::actors::test_store::{GetCapturedEnvelope, TestStore};
+use crate::actors::test_store::GetCapturedEnvelope;
 use crate::endpoints::common::ServiceUnavailable;
 use crate::envelope;
+use crate::service::ServiceState;
 
 pub async fn handle(
+    state: ServiceState,
     Path(event_id): Path<EventId>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
-    let envelope_opt = TestStore::from_registry()
+    let envelope_opt = state
+        .registry
+        .test_store
         .send(GetCapturedEnvelope { event_id })
         .await?;
 

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -8,15 +8,14 @@ use relay_general::protocol::EventId;
 use crate::actors::test_store::GetCapturedEnvelope;
 use crate::endpoints::common::ServiceUnavailable;
 use crate::envelope;
-use crate::service::{ServiceRegistry, ServiceState};
+use crate::service::ServiceState;
 
 pub async fn handle(
     state: ServiceState,
     Path(event_id): Path<EventId>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
     let envelope_opt = state
-        .registry()
-        .test_store
+        .test_store()
         .send(GetCapturedEnvelope { event_id })
         .await?;
 

--- a/relay-server/src/endpoints/events.rs
+++ b/relay-server/src/endpoints/events.rs
@@ -8,14 +8,14 @@ use relay_general::protocol::EventId;
 use crate::actors::test_store::GetCapturedEnvelope;
 use crate::endpoints::common::ServiceUnavailable;
 use crate::envelope;
-use crate::service::ServiceState;
+use crate::service::{ServiceRegistry, ServiceState};
 
 pub async fn handle(
     state: ServiceState,
     Path(event_id): Path<EventId>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
     let envelope_opt = state
-        .registry
+        .registry()
         .test_store
         .send(GetCapturedEnvelope { event_id })
         .await?;

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -23,7 +23,7 @@ use tokio::sync::oneshot::error::RecvError;
 use crate::actors::upstream::{Method, SendRequest, UpstreamRequest, UpstreamRequestError};
 use crate::extractors::ForwardedFor;
 use crate::http::{HttpError, RequestBuilder, Response as UpstreamResponse};
-use crate::service::{ServiceRegistry, ServiceState};
+use crate::service::ServiceState;
 
 /// Headers that this endpoint must handle and cannot forward.
 static HOP_BY_HOP_HEADERS: &[HeaderName] = &[
@@ -213,7 +213,7 @@ async fn handle(
         sender: tx,
     };
 
-    state.registry().upstream_relay.send(SendRequest(request));
+    state.upstream_relay().send(SendRequest(request));
     let (status, headers, body) = rx.await??;
 
     Ok(if headers.contains_key(header::CONTENT_TYPE) {

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -23,7 +23,7 @@ use tokio::sync::oneshot::error::RecvError;
 use crate::actors::upstream::{Method, SendRequest, UpstreamRequest, UpstreamRequestError};
 use crate::extractors::ForwardedFor;
 use crate::http::{HttpError, RequestBuilder, Response as UpstreamResponse};
-use crate::service::ServiceState;
+use crate::service::{ServiceRegistry, ServiceState};
 
 /// Headers that this endpoint must handle and cannot forward.
 static HOP_BY_HOP_HEADERS: &[HeaderName] = &[
@@ -213,7 +213,7 @@ async fn handle(
         sender: tx,
     };
 
-    state.registry.upstream_relay.send(SendRequest(request));
+    state.registry().upstream_relay.send(SendRequest(request));
     let (status, headers, body) = rx.await??;
 
     Ok(if headers.contains_key(header::CONTENT_TYPE) {

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -20,9 +20,7 @@ use relay_log::LogError;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
 
-use crate::actors::upstream::{
-    Method, SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
-};
+use crate::actors::upstream::{Method, SendRequest, UpstreamRequest, UpstreamRequestError};
 use crate::extractors::ForwardedFor;
 use crate::http::{HttpError, RequestBuilder, Response as UpstreamResponse};
 use crate::service::ServiceState;
@@ -215,7 +213,7 @@ async fn handle(
         sender: tx,
     };
 
-    UpstreamRelay::from_registry().send(SendRequest(request));
+    state.registry.upstream_relay.send(SendRequest(request));
     let (status, headers, body) = rx.await??;
 
     Ok(if headers.contains_key(header::CONTENT_TYPE) {

--- a/relay-server/src/endpoints/health_check.rs
+++ b/relay-server/src/endpoints/health_check.rs
@@ -6,7 +6,7 @@ use axum::response::IntoResponse;
 use serde::Serialize;
 
 use crate::actors::health_check::IsHealthy;
-use crate::service::{ServiceRegistry, ServiceState};
+use crate::service::ServiceState;
 
 #[derive(Serialize)]
 struct Status {
@@ -14,7 +14,7 @@ struct Status {
 }
 
 pub async fn handle(state: ServiceState, Path(kind): Path<IsHealthy>) -> impl IntoResponse {
-    match state.registry().health_check.send(kind).await {
+    match state.health_check().send(kind).await {
         Ok(true) => (StatusCode::OK, axum::Json(Status { is_healthy: true })),
         _ => (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/relay-server/src/endpoints/health_check.rs
+++ b/relay-server/src/endpoints/health_check.rs
@@ -6,7 +6,7 @@ use axum::response::IntoResponse;
 use serde::Serialize;
 
 use crate::actors::health_check::IsHealthy;
-use crate::service::ServiceState;
+use crate::service::{ServiceRegistry, ServiceState};
 
 #[derive(Serialize)]
 struct Status {
@@ -14,7 +14,7 @@ struct Status {
 }
 
 pub async fn handle(state: ServiceState, Path(kind): Path<IsHealthy>) -> impl IntoResponse {
-    match state.registry.health_check.send(kind).await {
+    match state.registry().health_check.send(kind).await {
         Ok(true) => (StatusCode::OK, axum::Json(Status { is_healthy: true })),
         _ => (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -4,14 +4,14 @@ use relay_config::EmitOutcomes;
 
 use crate::actors::outcome::{SendOutcomes, SendOutcomesResponse};
 use crate::extractors::SignedJson;
-use crate::service::{ServiceRegistry, ServiceState};
+use crate::service::ServiceState;
 
 pub async fn handle(state: ServiceState, body: SignedJson<SendOutcomes>) -> impl IntoResponse {
     if !body.relay.internal || state.config().emit_outcomes() != EmitOutcomes::AsOutcomes {
         return StatusCode::FORBIDDEN.into_response();
     }
 
-    let producer = &state.registry().outcome_producer;
+    let producer = &state.outcome_producer();
     for outcome in body.inner.outcomes {
         producer.send(outcome);
     }

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -4,14 +4,14 @@ use relay_config::EmitOutcomes;
 
 use crate::actors::outcome::{SendOutcomes, SendOutcomesResponse};
 use crate::extractors::SignedJson;
-use crate::service::ServiceState;
+use crate::service::{ServiceRegistry, ServiceState};
 
 pub async fn handle(state: ServiceState, body: SignedJson<SendOutcomes>) -> impl IntoResponse {
     if !body.relay.internal || state.config().emit_outcomes() != EmitOutcomes::AsOutcomes {
         return StatusCode::FORBIDDEN.into_response();
     }
 
-    let producer = state.registry.outcome_producer;
+    let producer = &state.registry().outcome_producer;
     for outcome in body.inner.outcomes {
         producer.send(outcome);
     }

--- a/relay-server/src/endpoints/outcomes.rs
+++ b/relay-server/src/endpoints/outcomes.rs
@@ -2,7 +2,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use relay_config::EmitOutcomes;
 
-use crate::actors::outcome::{OutcomeProducer, SendOutcomes, SendOutcomesResponse};
+use crate::actors::outcome::{SendOutcomes, SendOutcomesResponse};
 use crate::extractors::SignedJson;
 use crate::service::ServiceState;
 
@@ -11,7 +11,7 @@ pub async fn handle(state: ServiceState, body: SignedJson<SendOutcomes>) -> impl
         return StatusCode::FORBIDDEN.into_response();
     }
 
-    let producer = OutcomeProducer::from_registry();
+    let producer = state.registry.outcome_producer;
     for outcome in body.inner.outcomes {
         producer.send(outcome);
     }

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -15,7 +15,7 @@ use crate::actors::project_cache::{GetCachedProjectState, GetProjectState};
 use crate::endpoints::common::ServiceUnavailable;
 use crate::endpoints::forward;
 use crate::extractors::SignedJson;
-use crate::service::ServiceState;
+use crate::service::{ServiceRegistry, ServiceState};
 
 /// V2 version of this endpoint.
 ///
@@ -98,7 +98,7 @@ async fn inner(
     body: SignedJson<GetProjectStatesRequest>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
     let SignedJson { inner, relay } = body;
-    let project_cache = &state.registry.project_cache.clone();
+    let project_cache = &state.registry().project_cache.clone();
 
     let no_cache = inner.no_cache;
     let keys_len = inner.public_keys.len();

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -11,7 +11,7 @@ use relay_dynamic_config::ErrorBoundary;
 use serde::{Deserialize, Serialize};
 
 use crate::actors::project::{LimitedProjectState, ProjectState};
-use crate::actors::project_cache::{GetCachedProjectState, GetProjectState, ProjectCache};
+use crate::actors::project_cache::{GetCachedProjectState, GetProjectState};
 use crate::endpoints::common::ServiceUnavailable;
 use crate::endpoints::forward;
 use crate::extractors::SignedJson;
@@ -93,10 +93,12 @@ struct GetProjectStatesRequest {
 }
 
 async fn inner(
+    state: ServiceState,
     Query(version): Query<VersionQuery>,
     body: SignedJson<GetProjectStatesRequest>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
     let SignedJson { inner, relay } = body;
+    let project_cache = &state.registry.project_cache.clone();
 
     let no_cache = inner.no_cache;
     let keys_len = inner.public_keys.len();
@@ -105,11 +107,11 @@ async fn inner(
     let valid_keys = inner.public_keys.into_iter().filter_map(|e| e.ok());
     let futures = valid_keys.map(|project_key| async move {
         let state_result = if version.version >= ENDPOINT_V3 && !no_cache {
-            ProjectCache::from_registry()
+            project_cache
                 .send(GetCachedProjectState::new(project_key))
                 .await
         } else {
-            ProjectCache::from_registry()
+            project_cache
                 .send(GetProjectState::new(project_key).no_cache(no_cache))
                 .await
                 .map(Some)

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -15,7 +15,7 @@ use crate::actors::project_cache::{GetCachedProjectState, GetProjectState};
 use crate::endpoints::common::ServiceUnavailable;
 use crate::endpoints::forward;
 use crate::extractors::SignedJson;
-use crate::service::{ServiceRegistry, ServiceState};
+use crate::service::ServiceState;
 
 /// V2 version of this endpoint.
 ///
@@ -98,7 +98,7 @@ async fn inner(
     body: SignedJson<GetProjectStatesRequest>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
     let SignedJson { inner, relay } = body;
-    let project_cache = &state.registry().project_cache.clone();
+    let project_cache = &state.project_cache().clone();
 
     let no_cache = inner.no_cache;
     let keys_len = inner.public_keys.len();

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -3,17 +3,21 @@ use std::collections::HashMap;
 use axum::response::IntoResponse;
 use futures::future;
 
-use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse, RelayCache};
+use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse};
 use crate::endpoints::common::ServiceUnavailable;
 use crate::extractors::SignedJson;
+use crate::service::ServiceState;
 
 /// Handles the Relay public keys endpoint.
 ///
 /// Note that this has nothing to do with Sentry public keys, which refer to the public key portion
 /// of a DSN used for authenticating event submission. This endpoint is for Relay's public keys,
 /// which authenticate entire Relays.
-pub async fn handle(body: SignedJson<GetRelays>) -> Result<impl IntoResponse, ServiceUnavailable> {
-    let relay_cache = RelayCache::from_registry();
+pub async fn handle(
+    state: ServiceState,
+    body: SignedJson<GetRelays>,
+) -> Result<impl IntoResponse, ServiceUnavailable> {
+    let relay_cache = state.registry.relay_cache;
 
     let relay_ids = body.inner.relay_ids.into_iter();
     let futures = relay_ids.map(|relay_id| {

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -6,7 +6,7 @@ use futures::future;
 use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse};
 use crate::endpoints::common::ServiceUnavailable;
 use crate::extractors::SignedJson;
-use crate::service::{ServiceRegistry, ServiceState};
+use crate::service::ServiceState;
 
 /// Handles the Relay public keys endpoint.
 ///
@@ -17,7 +17,7 @@ pub async fn handle(
     state: ServiceState,
     body: SignedJson<GetRelays>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
-    let relay_cache = &state.registry().relay_cache;
+    let relay_cache = &state.relay_cache();
 
     let relay_ids = body.inner.relay_ids.into_iter();
     let futures = relay_ids.map(|relay_id| {

--- a/relay-server/src/endpoints/public_keys.rs
+++ b/relay-server/src/endpoints/public_keys.rs
@@ -6,7 +6,7 @@ use futures::future;
 use crate::actors::relays::{GetRelay, GetRelays, GetRelaysResponse};
 use crate::endpoints::common::ServiceUnavailable;
 use crate::extractors::SignedJson;
-use crate::service::ServiceState;
+use crate::service::{ServiceRegistry, ServiceState};
 
 /// Handles the Relay public keys endpoint.
 ///
@@ -17,7 +17,7 @@ pub async fn handle(
     state: ServiceState,
     body: SignedJson<GetRelays>,
 ) -> Result<impl IntoResponse, ServiceUnavailable> {
-    let relay_cache = state.registry.relay_cache;
+    let relay_cache = &state.registry().relay_cache;
 
     let relay_ids = body.inner.relay_ids.into_iter();
     let futures = relay_ids.map(|relay_id| {

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -83,7 +83,7 @@ pub fn create_runtime(name: &str, threads: usize) -> Runtime {
 struct StateInner {
     config: Arc<Config>,
     buffer_guard: Arc<BufferGuard>,
-    registry: Box<Registry>,
+    registry: Registry,
     _aggregator_runtime: Arc<Runtime>,
     _outcome_runtime: Arc<Runtime>,
     _project_runtime: Arc<Runtime>,
@@ -198,7 +198,7 @@ impl ServiceState {
             }
         }
 
-        let registry = Box::new(Registry {
+        let registry = Registry {
             aggregator,
             processor,
             health_check,
@@ -209,7 +209,7 @@ impl ServiceState {
             relay_cache,
             project_cache,
             upstream_relay,
-        });
+        };
 
         let state = StateInner {
             buffer_guard: buffer,

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -43,7 +43,7 @@ pub enum ServiceError {
     Redis,
 }
 
-/// Adds registry function to the implementer.
+/// Service registry which contains all the central services running in Relay.
 pub trait ServiceRegistry {
     /// Returns the services registry.
     fn registry(&self) -> &Registry;
@@ -90,7 +90,7 @@ pub fn create_runtime(name: &str, threads: usize) -> Runtime {
 pub struct ServiceState {
     config: Arc<Config>,
     buffer_guard: Arc<BufferGuard>,
-    pub registry: Box<Registry>,
+    registry: Box<Registry>,
     _aggregator_runtime: Arc<Runtime>,
     _outcome_runtime: Arc<Runtime>,
     _project_runtime: Arc<Runtime>,

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -334,11 +334,11 @@ impl ManagedEnvelope {
     /// This is just an estimated size, which in reality can be somewhat bigger, depending on the
     /// list of additional attributes allocated on all of the inner types.
     pub fn estimated_size(&self) -> usize {
-        // Always round it up to next 100 bytes.
+        // Always round it up to next 1KB.
         (f64::ceil(
             (self.context.summary.payload_size + size_of::<Self>() + size_of::<Envelope>()) as f64
-                / 100.,
-        ) * 100.) as usize
+                / 1000.,
+        ) * 1000.) as usize
     }
 
     /// Returns the instant at which the envelope was received at this Relay.

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use chrono::{DateTime, Utc};
 use relay_common::DataCategory;
 use relay_quotas::Scoping;
+use relay_system::Addr;
 
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::test_store::{Capture, TestStore};
@@ -80,11 +81,18 @@ struct EnvelopeContext {
 pub struct ManagedEnvelope {
     envelope: Box<Envelope>,
     context: EnvelopeContext,
+    outcome_aggregator: Addr<TrackOutcome>,
+    test_store: Addr<TestStore>,
 }
 
 impl ManagedEnvelope {
     /// Computes a managed envelope from the given envelope.
-    fn new_internal(envelope: Box<Envelope>, slot: Option<SemaphorePermit>) -> Self {
+    fn new_internal(
+        envelope: Box<Envelope>,
+        slot: Option<SemaphorePermit>,
+        outcome_aggregator: Addr<TrackOutcome>,
+        test_store: Addr<TestStore>,
+    ) -> Self {
         let meta = &envelope.meta();
         let summary = EnvelopeSummary::compute(envelope.as_ref());
         let scoping = meta.get_partial_scoping();
@@ -96,6 +104,8 @@ impl ManagedEnvelope {
                 slot,
                 done: false,
             },
+            outcome_aggregator,
+            test_store,
         }
     }
 
@@ -104,13 +114,21 @@ impl ManagedEnvelope {
     /// As opposed to [`new`](Self::new), this does not require a queue permit. This makes it
     /// suitable for unit testing internals of the processing pipeline.
     #[cfg(test)]
-    pub fn standalone(envelope: Box<Envelope>) -> Self {
-        Self::new_internal(envelope, None)
+    pub fn standalone(
+        envelope: Box<Envelope>,
+        outcome_aggregator: Addr<TrackOutcome>,
+        test_store: Addr<TestStore>,
+    ) -> Self {
+        Self::new_internal(envelope, None, outcome_aggregator, test_store)
     }
 
     #[cfg(test)]
-    pub fn untracked(envelope: Box<Envelope>) -> Self {
-        let mut envelope = Self::new_internal(envelope, None);
+    pub fn untracked(
+        envelope: Box<Envelope>,
+        outcome_aggregator: Addr<TrackOutcome>,
+        test_store: Addr<TestStore>,
+    ) -> Self {
+        let mut envelope = Self::new_internal(envelope, None, outcome_aggregator, test_store);
         envelope.context.done = true;
         envelope
     }
@@ -118,8 +136,13 @@ impl ManagedEnvelope {
     /// Computes a managed envelope from the given envelope and binds it to the processing queue.
     ///
     /// To provide additional scoping, use [`ManagedEnvelope::scope`].
-    pub fn new(envelope: Box<Envelope>, slot: SemaphorePermit) -> Self {
-        Self::new_internal(envelope, Some(slot))
+    pub fn new(
+        envelope: Box<Envelope>,
+        slot: SemaphorePermit,
+        outcome_aggregator: Addr<TrackOutcome>,
+        test_store: Addr<TestStore>,
+    ) -> Self {
+        Self::new_internal(envelope, Some(slot), outcome_aggregator, test_store)
     }
 
     /// Returns a reference to the contained [`Envelope`].
@@ -205,8 +228,7 @@ impl ManagedEnvelope {
     /// This managed envelope should be updated using [`update`](Self::update) soon after this
     /// operation to ensure that subsequent outcomes are consistent.
     fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
-        let outcome_aggregator = TrackOutcome::from_registry();
-        outcome_aggregator.send(TrackOutcome {
+        self.outcome_aggregator.send(TrackOutcome {
             timestamp: self.received_at(),
             scoping: self.context.scoping,
             outcome,
@@ -271,7 +293,8 @@ impl ManagedEnvelope {
         }
 
         // TODO: This could be optimized with Capture::should_capture
-        TestStore::from_registry().send(Capture::rejected(self.envelope.event_id(), &outcome));
+        self.test_store
+            .send(Capture::rejected(self.envelope.event_id(), &outcome));
 
         if let Some(category) = self.event_category() {
             self.track_outcome(outcome.clone(), category, 1);


### PR DESCRIPTION
This PR finalizes migration to service dependencies injection instead of using the global registry.

In this part the changes mostly located in the endpoints, and their dependencies.

This also allowed to uncomment few `ignored` tests as they are no longer depend on the global registry or all the services. 


related to: https://github.com/getsentry/relay/issues/1818
fixes: https://github.com/getsentry/relay/issues/1610

