### PR TITLE
ref(normalization): Always mark scrubbed transactions as sanitized

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -12,11 +12,6 @@ pub enum Feature {
     /// Enables data scrubbing of replay recording payloads.
     #[serde(rename = "organizations:session-replay-recording-scrubbing")]
     SessionReplayRecordingScrubbing,
-    /// True if transaction names scrubbed by regex patterns should be marked as "sanitized".
-    ///
-    /// Transaction names modified by clusterer rules are always marked as such.
-    #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]
-    TransactionNameMarkScrubbedAsSanitized,
     /// Enables device.class synthesis
     ///
     /// Enables device.class tag synthesis on mobile events.

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -13,10 +13,6 @@ use crate::types::{Annotated, Meta, ProcessingAction, ProcessingResult, Remark, 
 /// Configuration around removing high-cardinality parts of URL transactions.
 #[derive(Clone, Debug, Default)]
 pub struct TransactionNameConfig<'r> {
-    /// True if transaction names scrubbed by regex patterns should be marked as [`TransactionSource::Sanitized`].
-    ///
-    /// Transaction names modified by clusterer rules are always marked as such.
-    pub mark_scrubbed_as_sanitized: bool,
     /// Rules for identifier replacement that were discovered by Sentry's transaction clusterer.
     pub rules: &'r [TransactionNameRule],
 }
@@ -367,10 +363,7 @@ impl Processor for TransactionsProcessor<'_> {
             sanitized = true;
         }
 
-        if sanitized
-            && matches!(event.get_transaction_source(), &TransactionSource::Url)
-            && self.name_config.mark_scrubbed_as_sanitized
-        {
+        if sanitized && matches!(event.get_transaction_source(), &TransactionSource::Url) {
             event
                 .transaction_info
                 .get_or_insert_with(Default::default)

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1455,7 +1455,7 @@ mod tests {
           "type": "transaction",
           "transaction": "/foo/*/user/*/0",
           "transaction_info": {
-            "source": "url"
+            "source": "sanitized"
           },
           "modules": {
             "rack": "1.2.3"
@@ -1563,10 +1563,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig {
-                mark_scrubbed_as_sanitized: true,
-                ..Default::default()
-            }),
+            &mut TransactionsProcessor::new(TransactionNameConfig::default()),
             ProcessingState::root(),
         )
         .unwrap();
@@ -1666,7 +1663,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                mark_scrubbed_as_sanitized: false, // ensure `source` is set by rule application
                 rules: rules.as_ref(),
             }),
             ProcessingState::root(),
@@ -1728,7 +1724,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                mark_scrubbed_as_sanitized: false, // ensure `source` is set by rule application
                 rules: rules.as_ref(),
             }),
             ProcessingState::root(),
@@ -1890,10 +1885,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig {
-                rules: &[rule],
-                ..Default::default()
-            }),
+            &mut TransactionsProcessor::new(TransactionNameConfig { rules: &[rule] }),
             ProcessingState::root(),
         )
         .unwrap();
@@ -2113,7 +2105,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                mark_scrubbed_as_sanitized: true,
                 rules: &[TransactionNameRule {
                     pattern: LazyGlob::new("/remains/*/1234567890/".to_owned()),
                     expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
@@ -2157,7 +2148,6 @@ mod tests {
         process_value(
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
-                mark_scrubbed_as_sanitized: true,
                 rules: &[TransactionNameRule {
                     pattern: LazyGlob::new("/remains/*/**".to_owned()),
                     expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
@@ -2195,10 +2185,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig {
-                mark_scrubbed_as_sanitized: true,
-                rules: &[],
-            }),
+            &mut TransactionsProcessor::new(TransactionNameConfig::default()),
             ProcessingState::root(),
         )
         .unwrap();

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1820,7 +1820,6 @@ mod tests {
             &mut event,
             &mut TransactionsProcessor::new(TransactionNameConfig {
                 rules: rules.as_ref(),
-                ..Default::default()
             }),
             ProcessingState::root(),
         )

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2209,9 +2209,6 @@ impl EnvelopeProcessorService {
                 breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
-                    mark_scrubbed_as_sanitized: state
-                        .project_state
-                        .has_feature(Feature::TransactionNameMarkScrubbedAsSanitized),
                     rules: &state.project_state.config.tx_name_rules,
                 },
                 device_class_synthesis_config: state

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3358,7 +3358,6 @@ mod tests {
             log_transaction_name_metrics(&mut event, |event| {
                 let config = LightNormalizationConfig {
                     transaction_name_config: TransactionNameConfig {
-                        mark_scrubbed_as_sanitized: false,
                         rules: &[TransactionNameRule {
                             pattern: LazyGlob::new("/foo/*/**".to_owned()),
                             expiry: DateTime::<Utc>::MAX_UTC,
@@ -3381,7 +3380,7 @@ mod tests {
         let captures = capture_test_event("/nothing", TransactionSource::Url);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:url",
+            "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:sanitized",
         ]
         "###);
     }
@@ -3401,7 +3400,7 @@ mod tests {
         let captures = capture_test_event("/something/12345", TransactionSource::Url);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:url",
+            "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:sanitized",
         ]
         "###);
     }


### PR DESCRIPTION
Currently, Relay only marks scrubbed transactions as sanitized with the feature flag enabled. Since we've GA-d this, there's no need to keep the feature flag.

The feature flag is `organizations:transaction-name-mark-scrubbed-as-sanitized`.

#skip-changelog