### PR TITLE
fix(build): Remove SSL feature in build binary

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -51,7 +51,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run Cargo Build
-        run: cargo build --manifest-path=relay/Cargo.toml --release --features ssl
+        run: cargo build --manifest-path=relay/Cargo.toml --release
         env:
           CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
 
@@ -79,7 +79,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run Cargo Build
-        run: cargo build --manifest-path=relay/Cargo.toml --release --features ssl
+        run: cargo build --manifest-path=relay/Cargo.toml --release
 
       - name: Bundle PDB
         run: |


### PR DESCRIPTION
We have SSL feature enabled by default, we do not have to specify it separately. 

#skip-changelog