### PR TITLE
fix(feat-flags): Fix serialization of unknown feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Internal**:
 
-- Forward unknown project config feature flags to downstream relays. ([#2040](https://github.com/getsentry/relay/pull/2040))
+- Include unknown feature flags in project config when serializing it. ([#2040](https://github.com/getsentry/relay/pull/2040))
 
 ## 23.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Forward unknown project config feature flags to downstream relays. ([#2040](https://github.com/getsentry/relay/pull/2040))
+
 ## 23.4.0
 
 **Breaking Changes**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
 - Changes how device class is determined for iPhone devices. Instead of checking processor frequency, the device model is mapped to a device class. ([#1970](https://github.com/getsentry/relay/pull/1970))
 - Don't sanitize transactions if no clustering rules exist and no UUIDs were scrubbed. ([#1976](https://github.com/getsentry/relay/pull/1976))
+- Include unknown feature flags in project config when serializing it. ([#2040](https://github.com/getsentry/relay/pull/2040))
 
 ## 0.8.19
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -1,30 +1,62 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 /// Features exposed by project config.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum Feature {
     /// Enables ingestion and normalization of profiles.
-    #[serde(rename = "organizations:profiling")]
     Profiling,
     /// Enables ingestion of Session Replays (Replay Recordings and Replay Events).
-    #[serde(rename = "organizations:session-replay")]
     SessionReplay,
     /// Enables data scrubbing of replay recording payloads.
-    #[serde(rename = "organizations:session-replay-recording-scrubbing")]
     SessionReplayRecordingScrubbing,
     /// Enables device.class synthesis
     ///
     /// Enables device.class tag synthesis on mobile events.
-    #[serde(rename = "organizations:device-class-synthesis")]
     DeviceClassSynthesis,
     /// Unused.
     ///
     /// This used to control the initial experimental metrics extraction for sessions and has been
     /// discontinued.
-    #[serde(rename = "organizations:metrics-extraction")]
     Deprecated1,
-
     /// Forward compatibility.
-    #[serde(other)]
-    Unknown,
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for Feature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let feature_name = Cow::<str>::deserialize(deserializer)?;
+        match feature_name.trim() {
+            "organizations:profiling" => Ok(Feature::Profiling),
+            "organizations:session-replay" => Ok(Feature::SessionReplay),
+            "organizations:session-replay-recording-scrubbing" => {
+                Ok(Feature::SessionReplayRecordingScrubbing)
+            }
+            "organizations:device-class-synthesis" => Ok(Feature::DeviceClassSynthesis),
+            "organizations:metrics-extraction" => Ok(Feature::Deprecated1),
+            _ => Ok(Feature::Unknown(feature_name.to_string())),
+        }
+    }
+}
+
+impl Serialize for Feature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self {
+            Feature::Profiling => "organizations:profiling",
+            Feature::SessionReplay => "organizations:session-replay",
+            Feature::SessionReplayRecordingScrubbing => {
+                "organizations:session-replay-recording-scrubbing"
+            }
+            Feature::DeviceClassSynthesis => "organizations:device-class-synthesis",
+            Feature::Deprecated1 => "organizations:metrics-extraction",
+            Feature::Unknown(s) => s,
+        })
+    }
 }

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -30,16 +30,16 @@ impl<'de> Deserialize<'de> for Feature {
         D: serde::Deserializer<'de>,
     {
         let feature_name = Cow::<str>::deserialize(deserializer)?;
-        match feature_name.trim() {
-            "organizations:profiling" => Ok(Feature::Profiling),
-            "organizations:session-replay" => Ok(Feature::SessionReplay),
+        Ok(match feature_name.as_ref() {
+            "organizations:profiling" => Feature::Profiling,
+            "organizations:session-replay" => Feature::SessionReplay,
             "organizations:session-replay-recording-scrubbing" => {
-                Ok(Feature::SessionReplayRecordingScrubbing)
+                Feature::SessionReplayRecordingScrubbing
             }
-            "organizations:device-class-synthesis" => Ok(Feature::DeviceClassSynthesis),
-            "organizations:metrics-extraction" => Ok(Feature::Deprecated1),
-            _ => Ok(Feature::Unknown(feature_name.to_string())),
-        }
+            "organizations:device-class-synthesis" => Feature::DeviceClassSynthesis,
+            "organizations:metrics-extraction" => Feature::Deprecated1,
+            _ => Feature::Unknown(feature_name.to_string()),
+        })
     }
 }
 

--- a/relay-dynamic-config/src/utils.rs
+++ b/relay-dynamic-config/src/utils.rs
@@ -30,7 +30,13 @@ mod tests {
         a: i32,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         b: Option<Box<TestMe>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        features: Option<BTreeSet<Feature>>,
     }
+
+    use std::collections::BTreeSet;
+
+    use crate::Feature;
 
     use super::*;
 
@@ -54,6 +60,13 @@ mod tests {
                 r#"{"a": 1, "b": {"a": 2, "other": 666}}"#,
                 true,
                 "json atom at path \".b.other\" is missing from rhs",
+            ),
+            (
+                // An unknown feature flag for this relay is still serialized
+                // for the following relays in chain.
+                r#"{"a": 1, "features": ["organizations:is-cool"]}"#,
+                true,
+                "",
             ),
         ] {
             let res = validate_json::<TestMe>(input, strict);


### PR DESCRIPTION
Currently, unknown feature flags that end up in the `Unknown` bucket are serialized as `"Unknown"`, so the actual feature flags don't reach downstream relays. Since `serde` doesn't yet support types with `"other"` fields, I've manually implemented the required serialization and deserialization methods.

As a result of this change, feature flags that have been removed in relay and are no longer required will still be sent to downstream relays. This is a trade-off we must accept to address the issue above, and this new issue should be resolved by not adding the feature flags to project configs in Sentry in the first place.