### PR TITLE
doc(py): Changelog

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## Unreleased
 
 - Add `thread.state` field to protocol. ([#1896](https://github.com/getsentry/relay/pull/1896))
+- Smart trim loggers for Java platforms. ([#1941](https://github.com/getsentry/relay/pull/1941))
+- Perform PII scrubbing on meta's original_value field. ([#1892](https://github.com/getsentry/relay/pull/1892))
 - PII scrub `span.data` by default. ([#1953](https://github.com/getsentry/relay/pull/1953))
 - Scrub sensitive cookies. ([#1951](https://github.com/getsentry/relay/pull/1951))
-- Apply transaction clustering rules before UUID scrubbing rules. ([#1964](https://github.com/getsentry/relay/pull/1964))
 - Changes how device class is determined for iPhone devices. Instead of checking processor frequency, the device model is mapped to a device class. ([#1970](https://github.com/getsentry/relay/pull/1970))
 - Don't sanitize transactions if no clustering rules exist and no UUIDs were scrubbed. ([#1976](https://github.com/getsentry/relay/pull/1976))
+- Add iPad support for device.class synthesis in light normalization. ([#2008](https://github.com/getsentry/relay/pull/2008))
 
 ## 0.8.19
 


### PR DESCRIPTION
Best-effort addition to python changelog, in accordance with https://github.com/getsentry/relay#instructions-for-changelogs.

#skip-changelog