### PR TITLE
fix(build): the global flags must be in the beginning of the regex

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 from distutils.command.sdist import sdist
 
 
-_version_re = re.compile(r'^version\s*=\s*"(.*?)"\s*$(?m)')
+_version_re = re.compile(r'(?m)^version\s*=\s*"(.*?)"\s*$')
 
 
 DEBUG_BUILD = os.environ.get("RELAY_DEBUG") == "1"


### PR DESCRIPTION
The `setup.py` script produced the following error:
```python
re.error: global flags not at the start of the expression at position 26
```

This change moves the global flags to beginning of the regex.


#skip-changelog