### PR TITLE
fix(build): Add Rust target explicitly

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -64,7 +64,8 @@ jobs:
 
       - name: Install Rust Toolchain
         run: |
-          rustup toolchain install stable-${{ matrix.target }} --profile minimal --no-self-update
+          rustup toolchain install stable-${{ matrix.target }} --profile minimal --no-self-update --force-non-host
+          rustup target add {{ matrix.target }}
           rustup default stable-${{ matrix.target }}
 
       - uses: actions/setup-python@v4


### PR DESCRIPTION
In this change 
* add the Rust target explicitly 
* remove depreciation warning  by adding `--force-non-host` to install toolchain on host with different architecture 

#skip-changelog