### PR TITLE
build(py): Use same commands as actions-rs

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -64,9 +64,10 @@ jobs:
 
       - name: Install Rust Toolchain
         run: |
-          rustup toolchain install stable-${{ matrix.target }} --profile minimal --no-self-update --force-non-host
-          rustup target add ${{ matrix.target }}
-          rustup default stable-${{ matrix.target }}
+          rustup set profile minimal
+          rustup toolchain install stable
+          rustup override set stable
+          rustup target add --toolchain stable ${{ matrix.target }}
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/1922, we switched from `actions-rs` actions to manual rustup calls. However, this resulted in incorrect configuration for the arm64 library build (see [failed build](https://github.com/getsentry/relay/actions/runs/4732178644)).

This PR mimics the old `actions-rs` behavior by running the exact same `rustup` commands, taken from the last successful library build [here](https://github.com/getsentry/relay/actions/runs/4312685076/jobs/7523544518#step:3:22).

#skip-changelog