### PR TITLE
feat(profiling): Add a data category for indexed profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Internal**:
 
 - Include unknown feature flags in project config when serializing it. ([#2040](https://github.com/getsentry/relay/pull/2040))
-- Add a data category for indexed profiles. ([#2025](https://github.com/getsentry/relay/pull/2025))
+- Add a data category for indexed profiles. ([#2051](https://github.com/getsentry/relay/pull/2051))
 
 ## 23.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Include unknown feature flags in project config when serializing it. ([#2040](https://github.com/getsentry/relay/pull/2040))
+- Add a data category for indexed profiles. ([#2025](https://github.com/getsentry/relay/pull/2025))
 
 ## 23.4.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add a data category for indexed profiles. ([#2051](https://github.com/getsentry/relay/pull/2051))
+
 ## 0.8.20
 
 - Add `thread.state` field to protocol. ([#1896](https://github.com/getsentry/relay/pull/1896))

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -41,7 +41,9 @@ enum RelayDataCategory {
    */
   RELAY_DATA_CATEGORY_SESSION = 5,
   /**
-   * A profile
+   * Profile
+   *
+   * This is the category for processed profiles (all profiles, whether or not we store them).
    */
   RELAY_DATA_CATEGORY_PROFILE = 6,
   /**
@@ -62,6 +64,16 @@ enum RelayDataCategory {
    * contrast, `transaction` only guarantees that metrics have been accepted for the transaction.
    */
   RELAY_DATA_CATEGORY_TRANSACTION_INDEXED = 9,
+  /**
+   * Monitor check-ins.
+   */
+  RELAY_DATA_CATEGORY_MONITOR = 10,
+  /**
+   * Indexed Profile
+   *
+   * This is the category for indexed profiles that will be stored later.
+   */
+  RELAY_DATA_CATEGORY_PROFILE_INDEXED = 11,
   /**
    * Any other data category not known by this Relay.
    */
@@ -549,12 +561,10 @@ bool relay_is_glob_match(const struct RelayBuf *value,
                          GlobFlags flags);
 
 /**
- * Converts a codeowners path into a regex and searches for match against the provided value.
- *
- * Returns `true` if the regex matches, `false` otherwise.
+ * Returns `true` if the codeowners path matches the value, `false` otherwise.
  */
 bool relay_is_codeowners_path_match(const struct RelayBuf *value,
-                         const struct RelayStr *pat);
+                                    const struct RelayStr *pattern);
 
 /**
  * Parse a sentry release structure from a string.
@@ -580,9 +590,11 @@ struct RelayStr relay_validate_sampling_condition(const struct RelayStr *value);
 struct RelayStr relay_validate_sampling_configuration(const struct RelayStr *value);
 
 /**
- * Validate entire project config. If `strict` is true, verify that reserializing the parsed
- * config results in the same fields as the original.
+ * Validate entire project config.
+ *
+ * If `strict` is true, checks for unknown fields in the input.
  */
-struct RelayStr relay_validate_project_config(const struct RelayStr *value, bool strict);
+struct RelayStr relay_validate_project_config(const struct RelayStr *value,
+                                              bool strict);
 
 #endif /* RELAY_H_INCLUDED */

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -106,7 +106,9 @@ pub enum DataCategory {
     Attachment = 4,
     /// Session updates. Quantity is the number of updates in the batch.
     Session = 5,
-    /// A profile
+    /// Profile
+    ///
+    /// This is the category for processed profiles (all profiles, whether or not we store them).
     Profile = 6,
     /// Session Replays
     Replay = 7,
@@ -122,6 +124,10 @@ pub enum DataCategory {
     TransactionIndexed = 9,
     /// Monitor check-ins.
     Monitor = 10,
+    /// Indexed Profile
+    ///
+    /// This is the category for indexed profiles that will be stored later.
+    ProfileIndexed = 11,
     //
     // IMPORTANT: After adding a new entry to DataCategory, go to the `relay-cabi` subfolder and run
     // `make header` to regenerate the C-binding. This allows using the data category from Python.
@@ -144,6 +150,7 @@ impl DataCategory {
             "attachment" => Self::Attachment,
             "session" => Self::Session,
             "profile" => Self::Profile,
+            "profile_indexed" => Self::ProfileIndexed,
             "replay" => Self::Replay,
             "transaction_processed" => Self::TransactionProcessed,
             "transaction_indexed" => Self::TransactionIndexed,
@@ -163,6 +170,7 @@ impl DataCategory {
             Self::Attachment => "attachment",
             Self::Session => "session",
             Self::Profile => "profile",
+            Self::ProfileIndexed => "profile_indexed",
             Self::Replay => "replay",
             Self::TransactionProcessed => "transaction_processed",
             Self::TransactionIndexed => "transaction_indexed",

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -105,6 +105,7 @@ impl CategoryUnit {
             | DataCategory::Replay
             | DataCategory::Security
             | DataCategory::Profile
+            | DataCategory::ProfileIndexed
             | DataCategory::TransactionProcessed
             | DataCategory::TransactionIndexed
             | DataCategory::Monitor => Some(Self::Count),


### PR DESCRIPTION
This will add a data category for indexed profiles in order to let the current `DataCategory.PROFILE` be used for processed profiles.