### PR TITLE
chore(spooler): Add errors per operation and increase robustness 

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -854,6 +854,7 @@ mod tests {
             "buffer.envelopes_mem:2000|h",
             "buffer.reads:1|c",
             "buffer.reads:1|c",
+            "buffer.disk_size:24576|h",
             "buffer.envelopes_mem:0|h",
         ]
         "###);

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -38,9 +38,20 @@ pub enum BufferError {
     #[error("failed to get the size of the buffer on the filesystem")]
     DatabaseFileError(#[from] std::io::Error),
 
-    /// Describes the errors linked with the `Sqlite` backed buffer.
-    #[error("failed to fetch data from the database")]
-    DatabaseError(#[from] sqlx::Error),
+    #[error("failed to insert data into database: {0}")]
+    InsertFailed(sqlx::Error),
+
+    #[error("failed to delete data from the database: {0}")]
+    DeleteFailed(sqlx::Error),
+
+    #[error("failed to fetch data from the database: {0}")]
+    FetchFailed(sqlx::Error),
+
+    #[error("failed to get database file size: {0}")]
+    FileSizeReadFailed(sqlx::Error),
+
+    #[error("failed to setup the database: {0}")]
+    SetupFailed(sqlx::Error),
 
     #[error(transparent)]
     EnvelopeError(#[from] EnvelopeError),
@@ -204,9 +215,12 @@ impl BufferService {
             .journal_mode(SqliteJournalMode::Wal)
             .create_if_missing(true);
 
-        let db = SqlitePoolOptions::new().connect_with(options).await?;
-        sqlx::migrate!("../migrations").run(&db).await?;
+        let db = SqlitePoolOptions::new()
+            .connect_with(options)
+            .await
+            .map_err(BufferError::SetupFailed)?;
 
+        sqlx::migrate!("../migrations").run(&db).await?;
         Ok(())
     }
 
@@ -271,7 +285,8 @@ impl BufferService {
                 .max_connections(config.spool_envelopes_max_connections())
                 .min_connections(config.spool_envelopes_min_connections())
                 .connect_with(options)
-                .await?;
+                .await
+                .map_err(BufferError::SetupFailed)?;
 
             let spool_config = BufferSpoolConfig {
                 db,
@@ -290,12 +305,16 @@ impl BufferService {
     async fn estimate_buffer_size(db: &Pool<Sqlite>) -> Result<i64, BufferError> {
         let mut rows = sql::current_size().fetch(db);
         let page_count: i64 = match rows.next().await {
-            Some(row) => row?.try_get(0)?,
-            None => return Err(BufferError::DatabaseError(sqlx::Error::RowNotFound)),
+            Some(row) => row
+                .and_then(|r| r.try_get(0))
+                .map_err(BufferError::FileSizeReadFailed)?,
+            None => return Err(BufferError::FileSizeReadFailed(sqlx::Error::RowNotFound)),
         };
         let page_size: i64 = match rows.next().await {
-            Some(row) => row?.try_get(0)?,
-            None => return Err(BufferError::DatabaseError(sqlx::Error::RowNotFound)),
+            Some(row) => row
+                .and_then(|r| r.try_get(0))
+                .map_err(BufferError::FileSizeReadFailed)?,
+            None => return Err(BufferError::FileSizeReadFailed(sqlx::Error::RowNotFound)),
         };
         let size = page_count * page_size;
 
@@ -330,7 +349,7 @@ impl BufferService {
 
         sql::do_insert(stream::iter(envelopes), db)
             .await
-            .map_err(BufferError::from)
+            .map_err(BufferError::InsertFailed)
     }
 
     /// Tries to save in-memory buffer to disk.
@@ -375,11 +394,13 @@ impl BufferService {
     ///
     /// Reads the bytes and tries to perse them into `Envelope`.
     fn extract_envelope(&self, row: SqliteRow) -> Result<ManagedEnvelope, BufferError> {
-        let envelope_row: Vec<u8> = row.try_get("envelope")?;
+        let envelope_row: Vec<u8> = row.try_get("envelope").map_err(BufferError::FetchFailed)?;
         let envelope_bytes = bytes::Bytes::from(envelope_row);
         let mut envelope = Envelope::parse_bytes(envelope_bytes)?;
 
-        let received_at: i64 = row.try_get("received_at")?;
+        let received_at: i64 = row
+            .try_get("received_at")
+            .map_err(BufferError::FetchFailed)?;
         let start_time = StartTime::from_timestamp_millis(received_at as u64);
 
         envelope.set_start_time(start_time.into_inner());
@@ -559,7 +580,10 @@ impl BufferService {
 
         if let Some(BufferSpoolConfig { db, .. }) = &self.spool_config {
             for key in keys {
-                let result = sql::delete(key).execute(db).await?;
+                let result = sql::delete(key)
+                    .execute(db)
+                    .await
+                    .map_err(BufferError::DeleteFailed)?;
                 count += result.rows_affected() as usize;
             }
             self.refresh_spool_state().await?;

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -859,7 +859,6 @@ mod tests {
             "buffer.envelopes_mem:2000|h",
             "buffer.reads:1|c",
             "buffer.reads:1|c",
-            "buffer.disk_size:24576|h",
             "buffer.envelopes_mem:0|h",
         ]
         "###);

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -508,11 +508,6 @@ impl BufferService {
             ref mut is_disk_full, ..
         }) = &mut self.spool_config else { return; };
 
-        // If disk is not full, we can ignore this check and exit earlier.
-        if !*is_disk_full {
-            return;
-        }
-
         // Refresh DB state only if we get the proper reading on the file.
         if let Ok(estimated_size) = Self::estimate_buffer_size(db).await {
             *is_disk_full = (estimated_size as usize) >= *max_disk_size;

--- a/relay-server/src/actors/spooler/sql.rs
+++ b/relay-server/src/actors/spooler/sql.rs
@@ -46,7 +46,9 @@ pub fn delete<'a>(key: QueueKey) -> Query<'a, Sqlite, SqliteArguments<'a>> {
 ///
 /// This info used to calculate the current allocated database size.
 pub fn current_size<'a>() -> Query<'a, Sqlite, SqliteArguments<'a>> {
-    sqlx::query("pragma page_count; pragma page_size;")
+    sqlx::query(
+        "SELECT page_count * page_size as size FROM pragma_page_count(), pragma_page_size();",
+    )
 }
 
 /// Descibes the chunk item which is handled by insert statement.


### PR DESCRIPTION
Adding more defined and separate errors to each operations to have better observability in what part of the spooling could fail and why. 

Also include few protective checks, in order to limit the DB file hits when not necessary. 


#skip-changelog