### PR TITLE
fix(profiles): Log sampling outcome as ProfileIndexed

### DIFF
--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -895,7 +895,10 @@ impl OutcomeBroker {
 /// Returns true if the outcome represents profiles dropped by dynamic sampling.
 #[cfg(feature = "processing")]
 fn is_sampled_profile(outcome: &TrackRawOutcome) -> bool {
-    outcome.category == Some(DataCategory::Profile as u8)
+    // Older external Relays will still emit a `Profile` outcome.
+    // Newer Relays will emit a `ProfileIndexed` outcome.
+    (outcome.category == Some(DataCategory::Profile as u8)
+        || outcome.category == Some(DataCategory::ProfileIndexed as u8))
         && outcome.outcome == OutcomeId::FILTERED
         && outcome
             .reason

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -312,7 +312,11 @@ impl ManagedEnvelope {
         if self.context.summary.profile_quantity > 0 {
             self.track_outcome(
                 outcome,
-                DataCategory::Profile,
+                if self.context.summary.event_metrics_extracted {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
                 self.context.summary.profile_quantity,
             );
         }


### PR DESCRIPTION
Improvement to https://github.com/getsentry/relay/pull/2054:

Since #2054 already introduced a translation from `Profile` to `ProfileIndexed` for sampling outcomes, this PR does not change anything functionally. It is merely an attempt to be consistent with #2056 and #2060, such that we consider the `metrics_extracted` flag any time we generate a profiling outcome.