### PR TITLE
fix(crons): Rate limit enforcements for monitor check-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Enforce rate limits for monitor check-ins. ([#2065](https://github.com/getsentry/relay/pull/2065))
+
 **Features**:
 
 - Scrub sensitive keys (`passwd`, `token`, ...) in Replay recording data. ([#2034](https://github.com/getsentry/relay/pull/2034))

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -578,7 +578,7 @@ where
         if summary.checkin_quantity > 0 {
             let item_scoping = scoping.item(DataCategory::Monitor);
             let checkin_limits = (self.check)(item_scoping, summary.checkin_quantity)?;
-            enforcement.replays = CategoryLimit::new(
+            enforcement.check_ins = CategoryLimit::new(
                 DataCategory::Monitor,
                 summary.checkin_quantity,
                 checkin_limits.longest(),
@@ -977,9 +977,12 @@ mod tests {
 
         let outcomes = enforcement
             .get_outcomes(&envelope, &scoping())
-            .map(|outcome| (outcome.category, outcome.quantity))
+            .map(|outcome| (outcome.outcome, outcome.category, outcome.quantity))
             .collect::<Vec<_>>();
-        insta::assert_debug_snapshot!(outcomes, @"");
+        assert_eq!(
+            outcomes,
+            vec![(Outcome::RateLimited(None), DataCategory::Monitor, 1)]
+        )
     }
 
     #[test]


### PR DESCRIPTION
Due to a copy-paste error, rate limits were not enforced for monitor check-ins.