### PR TITLE
feat(dynamic-sampling): Add support for `trace.replay_id` in matching rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Differentiate between `Profile` and `ProfileIndexed` outcomes. ([#2054](https://github.com/getsentry/relay/pull/2054))
 - Split dynamic sampling implementation before refactoring. ([#2047](https://github.com/getsentry/relay/pull/2047))
 - Refactor dynamic sampling implementation across `relay-server` and `relay-sampling`. ([#2066](https://github.com/getsentry/relay/pull/2066))
-- Adds sample rate overriding for traces with a `replay_id`. ([#2070](https://github.com/getsentry/relay/pull/2070))
+- Adds support for `replay_id` field for the `DynamicSamplingContext` `FieldValueProvider`. ([#2070](https://github.com/getsentry/relay/pull/2070))
 
 ## 23.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Differentiate between `Profile` and `ProfileIndexed` outcomes. ([#2054](https://github.com/getsentry/relay/pull/2054))
 - Split dynamic sampling implementation before refactoring. ([#2047](https://github.com/getsentry/relay/pull/2047))
 - Refactor dynamic sampling implementation across `relay-server` and `relay-sampling`. ([#2066](https://github.com/getsentry/relay/pull/2066))
-- Adds support for `replay_id` field for the `DynamicSamplingContext` `FieldValueProvider`. ([#2070](https://github.com/getsentry/relay/pull/2070))
+- Adds support for `replay_id` field for the `DynamicSamplingContext`'s `FieldValueProvider`. ([#2070](https://github.com/getsentry/relay/pull/2070))
 
 ## 23.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Differentiate between `Profile` and `ProfileIndexed` outcomes. ([#2054](https://github.com/getsentry/relay/pull/2054))
 - Split dynamic sampling implementation before refactoring. ([#2047](https://github.com/getsentry/relay/pull/2047))
 - Refactor dynamic sampling implementation across `relay-server` and `relay-sampling`. ([#2066](https://github.com/getsentry/relay/pull/2066))
+- Adds sample rate overriding for traces with a `replay_id`. ([#2070](https://github.com/getsentry/relay/pull/2070))
 
 ## 23.4.0
 

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -3184,8 +3184,8 @@ mod tests {
     }
 
     #[test]
-    /// test that the override of the sample rate occurs when a dsc with replay id is present.
-    fn test_sampling_match_override_for_dsc_with_replay_id() {
+    /// test that the correct match is performed when replay id is present in the dsc.
+    fn test_sampling_match_with_trace_replay_id() {
         let event = mocked_event(EventType::Transaction, "healthcheck", "1.1.1", "testing");
         let dsc = mocked_dynamic_sampling_context(
             "root_transaction",


### PR DESCRIPTION
This PR adds the ability to read the `replay_id` field in the `DynamicSamplingContext`.

Closes: https://github.com/getsentry/sentry/issues/47769