### PR TITLE
feat(metrics): Add more shared tags for span metrics

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -757,8 +757,8 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
+                    "domain": "myhost",
                     "environment": "fake_environment",
-                    "server_name": "myhost",
                     "transaction": "mytransaction",
                     "transaction.op": "myop",
                     "transaction.status": "ok",


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/2069.

Adds the remaining shared tags that are available, for span metrics. Span-specific tags are still missing.

#skip-changelog