### PR TITLE
feat(metrics): Extract more tags for span metrics

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -415,7 +415,7 @@ fn extract_span_metrics(
         return Ok(());
     }
 
-    // Collect the shared tags for all the metrics and spans on this transaction
+    // Collect the shared tags for all the metrics and spans on this transaction.
     let mut shared_tags = BTreeMap::new();
 
     if let Some(environment) = event.environment.as_str() {
@@ -437,7 +437,7 @@ fn extract_span_metrics(
         );
     }
 
-    // server_name is extracted into an event tag during light_normalization
+    // The `server_name` is extracted into an event tag during light normalization.
     if let Some(event_tags) = event.tags.value() {
         if let Some(server_name) = event_tags.get("server_name") {
             shared_tags.insert("span.domain".to_owned(), server_name.to_owned());

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -449,7 +449,7 @@ fn extract_span_metrics(
     // - action
     // - event platform (e.g. MySQL, Redis).
 
-    if let Some(spans) = event.spans.value_mut() {
+    if let Some(spans) = event.spans.value() {
         if let Some(user) = event.user.value() {
             if let Some(value) = get_eventuser_tag(user) {
                 metrics.push(Metric::new_mri(

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -469,7 +469,7 @@ fn extract_span_metrics(
                 // TODO(iker): missing tag: span.group
 
                 if let Some(span_op) = span.op.value() {
-                    span_tags.insert("span.operation".to_owned(), span_op.to_owned());
+                    span_tags.insert("span.op".to_owned(), span_op.to_owned());
 
                     let span_module = if span_op.starts_with("http") {
                         Some("http")

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -440,7 +440,7 @@ fn extract_span_metrics(
     // server_name is extracted into an event tag during light_normalization
     if let Some(event_tags) = event.tags.value() {
         if let Some(server_name) = event_tags.get("server_name") {
-            shared_tags.insert("domain".to_owned(), server_name.to_owned());
+            shared_tags.insert("span.domain".to_owned(), server_name.to_owned());
         }
     }
 
@@ -481,13 +481,13 @@ fn extract_span_metrics(
                         None
                     };
                     if let Some(module) = span_module {
-                        span_tags.insert("module".to_owned(), module.to_owned());
+                        span_tags.insert("span.module".to_owned(), module.to_owned());
                     }
                 }
 
                 if let Some(description) = span.description.value() {
                     // TODO(iker): needs sanitization
-                    span_tags.insert("description".to_owned(), description.to_owned());
+                    span_tags.insert("span.description".to_owned(), description.to_owned());
                 }
 
                 // TODO(iker): emit span metrics
@@ -793,8 +793,8 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
-                    "domain": "myhost",
                     "environment": "fake_environment",
+                    "span.domain": "myhost",
                     "transaction": "mytransaction",
                     "transaction.op": "myop",
                     "transaction.status": "ok",

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -485,11 +485,6 @@ fn extract_span_metrics(
                     }
                 }
 
-                if let Some(description) = span.description.value() {
-                    // TODO(iker): needs sanitization
-                    span_tags.insert("span.description".to_owned(), description.to_owned());
-                }
-
                 // TODO(iker): emit span metrics
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/2069.

Adds more tags for the extracted metrics from spans.

#skip-changelog