### PR TITLE
fix(quota): Parse large limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Enforce rate limits for monitor check-ins. ([#2065](https://github.com/getsentry/relay/pull/2065))
+- Allow rate limits greater than `u32::MAX`. ([#2079](https://github.com/getsentry/relay/pull/2079))
 
 **Features**:
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -244,8 +244,10 @@ pub struct Quota {
     /// Maximum number of matching events allowed. Can be `0` to reject all events, `None` for an
     /// unlimited counted quota, or a positive number for enforcement. Requires `window` if the
     /// limit is not `0`.
+    ///
+    /// For attachments, this limit expresses the number of allowed bytes.
     #[serde(default)]
-    pub limit: Option<u32>,
+    pub limit: Option<u64>,
 
     /// The time window in seconds to enforce this quota in. Required in all cases except `limit=0`,
     /// since those quotas are not measured.
@@ -403,6 +405,32 @@ mod tests {
           scope: project,
           scopeId: Some("1"),
           limit: Some(4711),
+          window: Some(42),
+          reasonCode: Some(ReasonCode("not_so_fast")),
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_parse_quota_project_large() {
+        let json = r#"{
+            "id": "p",
+            "scope": "project",
+            "scopeId": "1",
+            "limit": 4294967296,
+            "window": 42,
+            "reasonCode": "not_so_fast"
+        }"#;
+
+        let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
+
+        insta::assert_ron_snapshot!(quota, @r###"
+        Quota(
+          id: Some("p"),
+          categories: [],
+          scope: project,
+          scopeId: Some("1"),
+          limit: Some(4294967296),
           window: Some(42),
           reasonCode: Some(ReasonCode("not_so_fast")),
         )

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -79,7 +79,10 @@ impl<'a> RedisQuota<'a> {
 
     /// Returns the limit value for Redis (`-1` for unlimited, otherwise the limit value).
     fn limit(&self) -> i64 {
-        self.limit.map(i64::from).unwrap_or(-1)
+        self.limit
+            // If it does not fit into i64, treat as unlimited:
+            .and_then(|limit| limit.try_into().ok())
+            .unwrap_or(-1)
     }
 
     fn shift(&self) -> u64 {
@@ -653,6 +656,33 @@ mod tests {
         let timestamp = UnixTimestamp::from_secs(234_531);
         let redis_quota = RedisQuota::new(&quota, scoping, timestamp).unwrap();
         assert_eq!(redis_quota.key(), "quota:foo{69420}:23453");
+    }
+
+    #[test]
+    fn test_large_redis_limit_large() {
+        let quota = Quota {
+            id: Some("foo".to_owned()),
+            categories: DataCategories::new(),
+            scope: QuotaScope::Organization,
+            scope_id: None,
+            window: Some(10),
+            limit: Some(9223372036854775808), // i64::MAX + 1
+            reason_code: None,
+        };
+
+        let scoping = ItemScoping {
+            category: DataCategory::Error,
+            scoping: &Scoping {
+                organization_id: 69420,
+                project_id: ProjectId::new(42),
+                project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+                key_id: Some(4711),
+            },
+        };
+
+        let timestamp = UnixTimestamp::from_secs(234_531);
+        let redis_quota = RedisQuota::new(&quota, scoping, timestamp).unwrap();
+        assert_eq!(redis_quota.limit(), -1);
     }
 
     #[test]


### PR DESCRIPTION
Rate limits for attachments are measured in bytes, but Relay cannot parse rate limits that do not fit into a `u32`. This means that the highest possible rate limit is 4 gibibytes (GiB), which became a problem in [INC-362](https://getsentry.atlassian.net/browse/INC-362).

Change the internal datatype to `u64` to support larger numbers for rate limits.

[INC-362]: https://getsentry.atlassian.net/browse/INC-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ