### PR TITLE
build: Use jemalloc on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Split dynamic sampling implementation before refactoring. ([#2047](https://github.com/getsentry/relay/pull/2047))
 - Refactor dynamic sampling implementation across `relay-server` and `relay-sampling`. ([#2066](https://github.com/getsentry/relay/pull/2066))
 - Adds support for `replay_id` field for the `DynamicSamplingContext`'s `FieldValueProvider`. ([#2070](https://github.com/getsentry/relay/pull/2070))
+- On Linux, switch to `jemalloc` instead of the system memory allocator to reduce Relay's memory footprint. ([#2084](https://github.com/getsentry/relay/pull/2084))
 
 ## 23.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,6 +2897,7 @@ dependencies = [
  "relay-log",
  "relay-server",
  "relay-statsd",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -4237,6 +4238,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.11",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -27,3 +27,6 @@ relay-config = { path = "../relay-config" }
 relay-log = { path = "../relay-log", features = ["init"] }
 relay-server = { path = "../relay-server" }
 relay-statsd = { path = "../relay-statsd" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { version = "0.5.0", features = ["background_threads"] }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -111,6 +111,10 @@ use std::process;
 
 use relay_log::Hub;
 
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 pub fn main() {
     let exit_code = match cli::execute() {
         Ok(()) => 0,


### PR DESCRIPTION
Enables `jemalloc` as global allocator for Linux builds. This should reduce memory fragmentation and reclaim unused memory quicker, which is expected to lower Relay's overall memory footprint. 

Relay's processing profile frequently moves memory between threads and also spawns threads on the fly. To allow the allocator to reclaim this memory efficiently, we also enable the `background_threads` option. See https://github.com/jemalloc/jemalloc/issues/1128#issuecomment-378438622 for a mention of this.

See https://github.com/getsentry/relay/pull/344
See https://github.com/getsentry/relay/pull/1817