### PR TITLE
ref(dynamic-config): Remove transaction metrics allowlist from Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Internal**:
 
+- Remove transaction metrics allowlist. ([#2092](https://github.com/getsentry/relay/pull/2092))
 - Include unknown feature flags in project config when serializing it. ([#2040](https://github.com/getsentry/relay/pull/2040))
 - Copy transaction tags to the profile. ([#1982](https://github.com/getsentry/relay/pull/1982))
 - Lower default max compressed replay recording segment size to 10 MiB. ([#2031](https://github.com/getsentry/relay/pull/2031))

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -102,8 +102,6 @@ impl Default for AcceptTransactionNames {
 pub struct TransactionMetricsConfig {
     /// The required version to extract transaction metrics.
     pub version: u16,
-    /// Deprecated. Still here to be forwarded to external relays.
-    pub extract_metrics: BTreeSet<String>,
     /// Custom event tags that are transferred from the transaction to metrics.
     pub extract_custom_tags: BTreeSet<String>,
     /// Deprecated in favor of top-level config field. Still here to be forwarded to external relays.


### PR DESCRIPTION
#1632 

With this change, old external relays will have to be upgraded in order to extract metrics. 

