### PR TITLE
instr(buffer): Count number of envelopes

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1073,8 +1073,10 @@ mod tests {
             "buffer.envelopes_mem_count:3|g",
             "buffer.envelopes_mem:0|h",
             "buffer.writes:1|c",
-            "buffer.spooled:3|g",
-            "buffer.spooled:4|g",
+            "buffer.envelopes_written:3|c",
+            "buffer.envelopes_disk_count:3|g",
+            "buffer.envelopes_written:1|c",
+            "buffer.envelopes_disk_count:4|g",
             "buffer.writes:1|c",
             "buffer.disk_size:24576|h",
             "buffer.envelopes_mem:2000|h",
@@ -1083,7 +1085,8 @@ mod tests {
             "buffer.envelopes_mem:0|h",
             "buffer.envelopes_mem_count:0|g",
             "buffer.reads:1|c",
-            "buffer.spooled:0|g",
+            "buffer.envelopes_read:-4|c",
+            "buffer.envelopes_disk_count:0|g",
             "buffer.reads:1|c",
         ]
         "###);

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -502,7 +502,6 @@ impl OnDisk {
         };
         relay_statsd::metric!(counter(metric) += increment);
 
-        // If used, also track the total envelope count:
         if let Some(count) = &mut self.count {
             *count = count.saturating_add_signed(increment);
             relay_statsd::metric!(gauge(RelayGauges::BufferEnvelopesDiskCount) = *count);

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -303,7 +303,9 @@ impl OnDisk {
 
         self.spool_count += inserted as isize;
 
-        relay_statsd::metric!(gauge(RelayGauges::BufferSpooledCount) = self.spool_count as f64);
+        relay_statsd::metric!(
+            gauge(RelayGauges::BufferEnvelopesDiskCount) = self.spool_count as f64
+        );
 
         Ok(())
     }
@@ -322,7 +324,9 @@ impl OnDisk {
         }
 
         self.spool_count -= count as isize;
-        relay_statsd::metric!(gauge(RelayGauges::BufferSpooledCount) = self.spool_count as f64);
+        relay_statsd::metric!(
+            gauge(RelayGauges::BufferEnvelopesDiskCount) = self.spool_count as f64
+        );
 
         Ok(count as usize)
     }
@@ -396,7 +400,7 @@ impl OnDisk {
                         );
                         self.spool_count -= count;
                         relay_statsd::metric!(
-                            gauge(RelayGauges::BufferSpooledCount) = self.spool_count as f64
+                            gauge(RelayGauges::BufferEnvelopesDiskCount) = self.spool_count as f64
                         );
                         return Err(key);
                     }
@@ -414,7 +418,9 @@ impl OnDisk {
             }
 
             self.spool_count -= count;
-            relay_statsd::metric!(gauge(RelayGauges::BufferSpooledCount) = self.spool_count as f64);
+            relay_statsd::metric!(
+                gauge(RelayGauges::BufferEnvelopesDiskCount) = self.spool_count as f64
+            );
         }
     }
 
@@ -496,7 +502,9 @@ impl OnDisk {
         .map_err(BufferError::InsertFailed)?;
 
         self.spool_count += 1;
-        relay_statsd::metric!(gauge(RelayGauges::BufferSpooledCount) = self.spool_count as f64);
+        relay_statsd::metric!(
+            gauge(RelayGauges::BufferEnvelopesDiskCount) = self.spool_count as f64
+        );
         relay_statsd::metric!(counter(RelayCounters::BufferWrites) += 1);
         Ok(())
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -42,12 +42,18 @@ pub enum RelayHistograms {
     ///
     /// The queue size can be configured with `cache.event_buffer_size`.
     EnvelopeQueueSize,
+    /// The estimated number of envelope bytes buffered in memory.
+    ///
+    /// This number is always <= `EnvelopeQueueSize`.
+    ///
+    /// The memory buffer size can be configured with `spool.envelopes.max_memory_size`.
+    BufferEnvelopesMemoryBytes,
     /// The number of envelopes waiting for project states in memory.
     ///
     /// This number is always <= `EnvelopeQueueSize`.
     ///
     /// The memory buffer size can be configured with `spool.envelopes.max_memory_size`.
-    BufferEnvelopesMemory,
+    BufferEnvelopesMemoryCount,
     /// The file size of the buffer db on disk, in bytes.
     ///
     /// This metric is computed by multiplying `page_count * page_size`.
@@ -140,7 +146,8 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::EnvelopeQueueSizePct => "event.queue_size.pct",
             RelayHistograms::EnvelopeQueueSize => "event.queue_size",
             RelayHistograms::EventSpans => "event.spans",
-            RelayHistograms::BufferEnvelopesMemory => "buffer.envelopes_mem",
+            RelayHistograms::BufferEnvelopesMemoryBytes => "buffer.envelopes_mem",
+            RelayHistograms::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayHistograms::BufferDiskSize => "buffer.disk_size",
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -58,6 +58,15 @@ pub enum RelayHistograms {
     ///
     /// This metric is computed by multiplying `page_count * page_size`.
     BufferDiskSize,
+    /// The number of envelopes spooled to disk by this process.
+    ///
+    /// This metric gets incremented when we spool and decremented when we unspool,
+    /// but it does *not* necessarily represent the number of envelopes currently on disk,
+    /// because it does not take into account the initial database size.
+    ///
+    /// Initializing this counter with a `SELECT count(*)` query would be too expensive, because
+    /// sqlite cannot count the number of rows in a table in constant time.
+    BufferSpooledCount,
     /// The number of spans per processed transaction event.
     ///
     /// This metric is tagged with:
@@ -149,6 +158,7 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::BufferEnvelopesMemoryBytes => "buffer.envelopes_mem",
             RelayHistograms::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayHistograms::BufferDiskSize => "buffer.disk_size",
+            RelayHistograms::BufferSpooledCount => "buffer.spooled",
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",


### PR DESCRIPTION
Bring back envelope counts as statsd metrics for the spooling envelope buffer:

1. `envelopes_mem_count`: Number of envelopes currently in memory.
2. `envelopes_written`, `envelopes_read`: Number of envelopes flushed to and from disk in any given time frame.
3. `envelopes_disk_count`: Number of envelopes on disk: Because running a `SELECT count(*)` query on a large table is expensive, we _only_ track this number if there is nothing in the database on startup. This should be the default use case, so in general, this metric will be available. If there is data in the db on startup, only `envelopes_written` / `envelopes_read` will be available.

**Discarded options for `envelopes_disk_count`**

* We considered running the `SELECT count(*)` query async on startup, but that might still lock the database table.
* We considered running the counting query in a `tokio::timeout`, but it is unclear if this would actually unlock the database, or only cancel the future while the query keeps running in the background.
* We could limit the max. number of rows in the counting query, such that the metric still works for small leftovers in the db, but not for large buffers encountered on start up. This should be easy to implement in a follow-up if the need for it occurs.
* We could get track this number in the db itself (in a separate table), and update it every time we spool or unspool, from within a database transaction. We decided this is too much engineering effort for just a metric, but might reconsider if it turns out we really need this metric in the edge case that there's something in the db on startup.

Fixes https://github.com/getsentry/team-ingest/issues/115

#skip-changelog