### PR TITLE
feat(normalization): Scrub span description URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Scrub sensitive keys (`passwd`, `token`, ...) in Replay recording data. ([#2034](https://github.com/getsentry/relay/pull/2034))
 - Add document_uri to csp filter. ([#2059](https://github.com/getsentry/relay/pull/2059))
 - Store `geo.subdivision` of the end user location. ([#2058](https://github.com/getsentry/relay/pull/2058))
+- Scrub URLs in span descriptions. ([#2095](https://github.com/getsentry/relay/pull/2095))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Store `geo.subdivision` of the end user location. ([#2058](https://github.com/getsentry/relay/pull/2058))
+- Scrub URLs in span descriptions. ([#2095](https://github.com/getsentry/relay/pull/2095))
 
 ## 0.8.21
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -126,6 +126,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         transaction_name_config: Default::default(), // only supported in relay
         is_renormalize: config.is_renormalize.unwrap_or(false),
         device_class_synthesis_config: false, // only supported in relay
+        scrub_span_descriptions: false,
     };
     light_normalize_event(&mut event, light_normalization_config)?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -699,6 +699,7 @@ pub struct LightNormalizationConfig<'a> {
     pub transaction_name_config: TransactionNameConfig<'a>,
     pub is_renormalize: bool,
     pub device_class_synthesis_config: bool,
+    pub scrub_span_descriptions: bool,
 }
 
 pub fn light_normalize_event(
@@ -714,8 +715,10 @@ pub fn light_normalize_event(
         // (internally noops for non-transaction events).
         // TODO: Parts of this processor should probably be a filter so we
         // can revert some changes to ProcessingAction)
-        let mut transactions_processor =
-            transactions::TransactionsProcessor::new(config.transaction_name_config);
+        let mut transactions_processor = transactions::TransactionsProcessor::new(
+            config.transaction_name_config,
+            config.scrub_span_descriptions,
+        );
         transactions_processor.process_event(event, meta, ProcessingState::root())?;
 
         // Check for required and non-empty values

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2274,4 +2274,6 @@ mod tests {
         "GET /clients/8ff81d74-606d-4c75-ac5e-cee65cbbc866/project/01234",
         "GET /clients/*/project/*"
     );
+
+    // TODO(iker): Add span description test for URLs with paths
 }

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2199,4 +2199,28 @@ mod tests {
 
         assert_annotated_snapshot!(event);
     }
+
+    #[test]
+    fn test_span_description_urls_parameterized() {
+        let json = r#"
+        {
+            "description": "GET http://whatever/api/0987654321",
+            "span_id": "bd2eb23da2beb459",
+            "start_timestamp": 1597976393.4619668,
+            "timestamp": 1597976393.4718769,
+            "trace_id": "ff62a8b040f340bda5d830223def1d81"
+        }
+        "#;
+
+        let mut span: Annotated<Span> = Annotated::from_json(json).unwrap();
+
+        process_value(
+            &mut span,
+            &mut TransactionsProcessor::default(),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(span);
+    }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2279,6 +2279,9 @@ impl EnvelopeProcessorService {
                 device_class_synthesis_config: state
                     .project_state
                     .has_feature(Feature::DeviceClassSynthesis),
+                scrub_span_descriptions: state
+                    .project_state
+                    .has_feature(Feature::SpanMetricsExtraction),
                 is_renormalize: false,
             };
 


### PR DESCRIPTION
Scrub identifiers from URLs in span description. The scrubbed description is available in the span as `data['description.scrubbed']`, and in case something was scrubbed, a `span.description` tag is added to span metrics. This only happens to these projects with the feature flag enabled.