### PR TITLE
feat(profiling): Set release as optional by defaulting to an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Refactor dynamic sampling implementation across `relay-server` and `relay-sampling`. ([#2066](https://github.com/getsentry/relay/pull/2066))
 - Adds support for `replay_id` field for the `DynamicSamplingContext`'s `FieldValueProvider`. ([#2070](https://github.com/getsentry/relay/pull/2070))
 - On Linux, switch to `jemalloc` instead of the system memory allocator to reduce Relay's memory footprint. ([#2084](https://github.com/getsentry/relay/pull/2084))
+- Set release as optional by defaulting to an empty string for profiles. ([#2098](https://github.com/getsentry/relay/pull/2098))
 
 ## 23.4.0
 

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -151,6 +151,8 @@ struct SampleProfile {
     event_id: EventId,
     platform: String,
     profile: Profile,
+
+    #[serde(default)]
     release: String,
     timestamp: DateTime<Utc>,
 


### PR DESCRIPTION
Events don't require the release by default but profiling does. It is not necessarily something we need, we just started requiring it since we required it at Specto and coming from mobile platforms where this is usually set, we didn't really think about it.

It causes some issues with customers on backend platforms and setting it to an empty string by default will keep the backend compatible but allows customers not to set it.