### PR TITLE
ref(crons): Remove monitor slugification

### DIFF
--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn truncte_basic() {
+    fn truncate_basic() {
         let mut test1 = "test_".repeat(50);
         trim_slug(&mut test1);
         assert_eq!("test_test_test_test_test_test_test_test_test_test_", test1,);

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -16,8 +16,6 @@
 )]
 #![warn(missing_docs)]
 
-use once_cell::sync::Lazy;
-use regex::Regex;
 use relay_common::Uuid;
 use serde::{Deserialize, Serialize};
 
@@ -135,7 +133,8 @@ pub fn process_check_in(payload: &[u8]) -> Result<Vec<u8>, ProcessCheckInError> 
         check_in.status = CheckInStatus::Unknown;
     }
 
-    check_in.monitor_slug = slugify(&check_in.monitor_slug);
+    trim_slug(&mut check_in.monitor_slug);
+
     if check_in.monitor_slug.is_empty() {
         return Err(ProcessCheckInError::EmptySlug);
     }
@@ -143,25 +142,10 @@ pub fn process_check_in(payload: &[u8]) -> Result<Vec<u8>, ProcessCheckInError> 
     Ok(serde_json::to_vec(&check_in)?)
 }
 
-fn slugify(input: &str) -> String {
-    static SLUG_CLEANER: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^a-zA-Z0-9\s_-]").unwrap());
-    static SLUGIFIER: Lazy<Regex> = Lazy::new(|| Regex::new(r"[\s\-]+").unwrap());
-
-    let cleaned = SLUG_CLEANER.replace_all(input, "");
-    let mut slug = SLUGIFIER
-        .replace_all(&cleaned, "-")
-        .trim_matches('-')
-        .to_owned();
-
-    slug.truncate(SLUG_LENGTH);
-
-    // Truncate may leave a trailing '-', so we may need to truncate again.
-    if slug.ends_with('-') {
-        slug.truncate(slug.len() - 1);
+fn trim_slug(slug: &mut String) {
+    if let Some((overflow, _)) = slug.char_indices().nth(SLUG_LENGTH) {
+        slug.truncate(overflow);
     }
-
-    slug.make_ascii_lowercase();
-    slug
 }
 
 #[cfg(test)]
@@ -169,6 +153,17 @@ mod tests {
     use similar_asserts::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn truncte_basic() {
+        let mut test1 = "test_".repeat(50);
+        trim_slug(&mut test1);
+        assert_eq!("test_test_test_test_test_test_test_test_test_test_", test1,);
+
+        let mut test2 = "🦀".repeat(SLUG_LENGTH + 10);
+        trim_slug(&mut test2);
+        assert_eq!("🦀".repeat(SLUG_LENGTH), test2);
+    }
 
     #[test]
     fn process_json_roundtrip() {
@@ -257,36 +252,11 @@ mod tests {
     fn process_empty_slug() {
         let json = r#"{
           "check_in_id": "a460c25ff2554577b920fcfacae4e5eb",
-          "monitor_slug": "🚀🚀🚀",
+          "monitor_slug": "",
           "status": "in_progress"
         }"#;
 
         let result = process_check_in(json.as_bytes());
         assert!(matches!(result, Err(ProcessCheckInError::EmptySlug)));
-    }
-
-    #[test]
-    fn slugify_empty_string() {
-        assert_eq!("", slugify(""));
-    }
-
-    #[test]
-    fn slugify_truncate_honors_trim() {
-        let input = "-".repeat(SLUG_LENGTH + 10) + "hello";
-        assert_eq!("hello", slugify(&input));
-    }
-
-    #[test]
-    fn slugify_trim_at_truncate() {
-        let expected = "a".repeat(SLUG_LENGTH - 1);
-        let input = expected.clone() + "-stripped";
-        assert_eq!(expected, slugify(&input));
-    }
-
-    #[test]
-    fn slugify_unicode() {
-        let input = "🚀🚀🚀\tmyComplicated_slug\u{200A}name is here...";
-        let expected = "mycomplicated_slug-name-is-here";
-        assert_eq!(expected, slugify(input));
     }
 }


### PR DESCRIPTION
We had a user who was sending a monitor slug with a `_` in it, which we trim in our slug validation here **but not trim in our python backend**. For now I think we would prefer to simply limit the length and let the validation of monitor slugs happen at the consumer side.

This way we do not need to try and match the slugification logic that python uses.

With the slugification happening in relay it becomes very opaque why a check-in my not be getting through.

#skip-changelog