### PR TITLE
fix(profiling): Return a proper outcome for processed profiles if a profile is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Refactor dynamic sampling implementation across `relay-server` and `relay-sampling`. ([#2066](https://github.com/getsentry/relay/pull/2066))
 - Adds support for `replay_id` field for the `DynamicSamplingContext`'s `FieldValueProvider`. ([#2070](https://github.com/getsentry/relay/pull/2070))
 - On Linux, switch to `jemalloc` instead of the system memory allocator to reduce Relay's memory footprint. ([#2084](https://github.com/getsentry/relay/pull/2084))
+- Parse profiles' metadata to check if it should be marked as invalid. ([#2104](https://github.com/getsentry/relay/pull/2104))
 
 ## 23.4.0
 

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -12,7 +12,7 @@ use crate::utils::{deserialize_number_from_string, is_zero};
 use crate::ProfileError;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-struct AndroidProfile {
+pub struct ProfileMetadata {
     android_api_level: u16,
 
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -65,12 +65,6 @@ struct AndroidProfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     transaction: Option<TransactionMetadata>,
 
-    #[serde(default, skip_serializing)]
-    sampled_profile: String,
-
-    #[serde(default = "AndroidProfile::default")]
-    profile: AndroidTraceLog,
-
     #[serde(default, skip_serializing_if = "Option::is_none")]
     measurements: Option<HashMap<String, Measurement>>,
 
@@ -79,6 +73,18 @@ struct AndroidProfile {
 
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     transaction_tags: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct AndroidProfile {
+    #[serde(flatten)]
+    metadata: ProfileMetadata,
+
+    #[serde(default, skip_serializing)]
+    sampled_profile: String,
+
+    #[serde(default = "AndroidProfile::default")]
+    profile: AndroidTraceLog,
 }
 
 impl AndroidProfile {
@@ -112,7 +118,7 @@ impl AndroidProfile {
     }
 
     fn has_transaction_metadata(&self) -> bool {
-        !self.transaction_name.is_empty() && self.duration_ns > 0
+        !self.metadata.transaction_name.is_empty() && self.metadata.duration_ns > 0
     }
 
     /// Removes an event with a duration of 0
@@ -140,26 +146,26 @@ fn parse_profile(payload: &[u8]) -> Result<AndroidProfile, ProfileError> {
     let mut profile: AndroidProfile =
         serde_json::from_slice(payload).map_err(ProfileError::InvalidJson)?;
 
-    let transaction_opt = profile.transactions.drain(..).next();
+    let transaction_opt = profile.metadata.transactions.drain(..).next();
     if let Some(transaction) = transaction_opt {
         if !transaction.valid() {
             return Err(ProfileError::InvalidTransactionMetadata);
         }
 
         // this is for compatibility
-        profile.active_thread_id = transaction.active_thread_id;
-        profile.duration_ns = transaction.duration_ns();
-        profile.trace_id = transaction.trace_id;
-        profile.transaction_id = transaction.id;
-        profile.transaction_name = transaction.name.clone();
+        profile.metadata.active_thread_id = transaction.active_thread_id;
+        profile.metadata.duration_ns = transaction.duration_ns();
+        profile.metadata.trace_id = transaction.trace_id;
+        profile.metadata.transaction_id = transaction.id;
+        profile.metadata.transaction_name = transaction.name.clone();
 
-        profile.transaction = Some(transaction);
+        profile.metadata.transaction = Some(transaction);
     } else if profile.has_transaction_metadata() {
-        profile.transaction = Some(TransactionMetadata {
-            active_thread_id: profile.active_thread_id,
-            id: profile.transaction_id,
-            name: profile.transaction_name.clone(),
-            trace_id: profile.trace_id,
+        profile.metadata.transaction = Some(TransactionMetadata {
+            active_thread_id: profile.metadata.active_thread_id,
+            id: profile.metadata.transaction_id,
+            name: profile.metadata.transaction_name.clone(),
+            trace_id: profile.metadata.trace_id,
             ..Default::default()
         });
     } else {
@@ -186,23 +192,23 @@ pub fn parse_android_profile(
     let mut profile = parse_profile(payload)?;
 
     if let Some(transaction_name) = transaction_metadata.get("transaction") {
-        profile.transaction_name = transaction_name.to_owned();
+        profile.metadata.transaction_name = transaction_name.to_owned();
 
-        if let Some(ref mut transaction) = profile.transaction {
-            transaction.name = profile.transaction_name.to_owned();
+        if let Some(ref mut transaction) = profile.metadata.transaction {
+            transaction.name = profile.metadata.transaction_name.to_owned();
         }
     }
 
     if let Some(release) = transaction_metadata.get("release") {
-        profile.release = release.to_owned();
+        profile.metadata.release = release.to_owned();
     }
 
     if let Some(environment) = transaction_metadata.get("environment") {
-        profile.environment = environment.to_owned();
+        profile.metadata.environment = environment.to_owned();
     }
 
-    profile.transaction_metadata = transaction_metadata;
-    profile.transaction_tags = transaction_tags;
+    profile.metadata.transaction_metadata = transaction_metadata;
+    profile.metadata.transaction_tags = transaction_tags;
 
     serde_json::to_vec(&profile).map_err(|_| ProfileError::CannotSerializePayload)
 }
@@ -283,16 +289,16 @@ mod tests {
             Ok(profile) => profile,
         };
         assert_eq!(
-            profile.transaction_id,
+            profile.metadata.transaction_id,
             "7d6db784355e4d7dbf98671c69cbcc77".parse().unwrap()
         );
         assert_eq!(
-            profile.trace_id,
+            profile.metadata.trace_id,
             "7d6db784355e4d7dbf98671c69cbcc77".parse().unwrap()
         );
-        assert_eq!(profile.active_thread_id, 12345);
-        assert_eq!(profile.transaction_name, "transaction1");
-        assert_eq!(profile.duration_ns, 1000000000);
+        assert_eq!(profile.metadata.active_thread_id, 12345);
+        assert_eq!(profile.metadata.transaction_name, "transaction1");
+        assert_eq!(profile.metadata.duration_ns, 1000000000);
     }
 
     #[test]
@@ -312,13 +318,13 @@ mod tests {
         let output: AndroidProfile = serde_json::from_slice(&profile_json.unwrap()[..])
             .map_err(ProfileError::InvalidJson)
             .unwrap();
-        assert_eq!(output.release, "some-random-release".to_string());
+        assert_eq!(output.metadata.release, "some-random-release".to_string());
         assert_eq!(
-            output.transaction_name,
+            output.metadata.transaction_name,
             "some-random-transaction".to_string()
         );
 
-        if let Some(transaction) = output.transaction {
+        if let Some(transaction) = output.metadata.transaction {
             assert_eq!(transaction.name, "some-random-transaction".to_string());
         }
     }

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -109,10 +109,7 @@ mod utils;
 
 use relay_general::protocol::{Event, EventId};
 
-use crate::android::parse_android_profile;
-use crate::cocoa::parse_cocoa_profile;
 use crate::extract_from_transaction::{extract_transaction_metadata, extract_transaction_tags};
-use crate::sample::{parse_sample_profile, Version};
 
 pub use crate::error::ProfileError;
 pub use crate::outcomes::discard_reason;
@@ -123,11 +120,42 @@ struct MinimalProfile {
     event_id: EventId,
     platform: String,
     #[serde(default)]
-    version: Version,
+    version: sample::Version,
 }
 
-fn minimal_profile_from_json(data: &[u8]) -> Result<MinimalProfile, ProfileError> {
-    serde_json::from_slice(data).map_err(ProfileError::InvalidJson)
+fn minimal_profile_from_json(payload: &[u8]) -> Result<MinimalProfile, ProfileError> {
+    serde_json::from_slice(payload).map_err(ProfileError::InvalidJson)
+}
+
+pub fn parse_metadata(payload: &[u8]) -> Result<(), ProfileError> {
+    let profile = match minimal_profile_from_json(payload) {
+        Ok(profile) => profile,
+        Err(err) => return Err(err),
+    };
+    match profile.version {
+        sample::Version::V1 => {
+            let _: sample::ProfileMetadata = match serde_json::from_slice(payload) {
+                Ok(profile) => profile,
+                Err(err) => return Err(ProfileError::InvalidJson(err)),
+            };
+        }
+        _ => match profile.platform.as_str() {
+            "android" => {
+                let _: android::ProfileMetadata = match serde_json::from_slice(payload) {
+                    Ok(profile) => profile,
+                    Err(err) => return Err(ProfileError::InvalidJson(err)),
+                };
+            }
+            "cocoa" => {
+                let _: cocoa::ProfileMetadata = match serde_json::from_slice(payload) {
+                    Ok(profile) => profile,
+                    Err(err) => return Err(ProfileError::InvalidJson(err)),
+                };
+            }
+            _ => return Err(ProfileError::PlatformNotSupported),
+        },
+    };
+    Ok(())
 }
 
 pub fn expand_profile(
@@ -145,12 +173,15 @@ pub fn expand_profile(
         ),
         _ => (BTreeMap::new(), BTreeMap::new()),
     };
-
     let processed_payload = match profile.version {
-        Version::V1 => parse_sample_profile(payload, transaction_metadata, transaction_tags),
-        Version::Unknown => match profile.platform.as_str() {
-            "android" => parse_android_profile(payload, transaction_metadata, transaction_tags),
-            "cocoa" => parse_cocoa_profile(payload),
+        sample::Version::V1 => {
+            sample::parse_sample_profile(payload, transaction_metadata, transaction_tags)
+        }
+        sample::Version::Unknown => match profile.platform.as_str() {
+            "android" => {
+                android::parse_android_profile(payload, transaction_metadata, transaction_tags)
+            }
+            "cocoa" => cocoa::parse_cocoa_profile(payload),
             _ => return Err(ProfileError::PlatformNotSupported),
         },
     };
@@ -166,7 +197,7 @@ mod tests {
         let data = r#"{"version":"1","platform":"cocoa","event_id":"751fff80-a266-467b-a6f5-eeeef65f4f84"}"#;
         let profile = minimal_profile_from_json(data.as_bytes());
         assert!(profile.is_ok());
-        assert_eq!(profile.unwrap().version, Version::V1);
+        assert_eq!(profile.unwrap().version, sample::Version::V1);
     }
 
     #[test]
@@ -174,7 +205,7 @@ mod tests {
         let data = r#"{"platform":"cocoa","event_id":"751fff80-a266-467b-a6f5-eeeef65f4f84"}"#;
         let profile = minimal_profile_from_json(data.as_bytes());
         assert!(profile.is_ok());
-        assert_eq!(profile.unwrap().version, Version::Unknown);
+        assert_eq!(profile.unwrap().version, sample::Version::Unknown);
     }
 
     #[test]

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -134,7 +134,7 @@ pub enum Version {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-struct SampleProfile {
+pub struct ProfileMetadata {
     version: Version,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -150,7 +150,6 @@ struct SampleProfile {
     #[serde(alias = "profile_id")]
     event_id: EventId,
     platform: String,
-    profile: Profile,
     release: String,
     timestamp: DateTime<Utc>,
 
@@ -169,15 +168,22 @@ struct SampleProfile {
     transaction_tags: BTreeMap<String, String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SampleProfile {
+    #[serde(flatten)]
+    metadata: ProfileMetadata,
+    profile: Profile,
+}
+
 impl SampleProfile {
     fn valid(&self) -> bool {
-        match self.platform.as_str() {
+        match self.metadata.platform.as_str() {
             "cocoa" => {
-                self.os.build_number.is_some()
-                    && self.device.is_emulator.is_some()
-                    && self.device.locale.is_some()
-                    && self.device.manufacturer.is_some()
-                    && self.device.model.is_some()
+                self.metadata.os.build_number.is_some()
+                    && self.metadata.device.is_emulator.is_some()
+                    && self.metadata.device.locale.is_some()
+                    && self.metadata.device.manufacturer.is_some()
+                    && self.metadata.device.model.is_some()
             }
             _ => true,
         }
@@ -222,8 +228,10 @@ impl SampleProfile {
     }
 
     fn strip_pointer_authentication_code(&mut self) {
-        self.profile
-            .strip_pointer_authentication_code(&self.platform, &self.device.architecture);
+        self.profile.strip_pointer_authentication_code(
+            &self.metadata.platform,
+            &self.metadata.device.architecture,
+        );
     }
 
     fn remove_idle_samples_at_the_edge(&mut self) {
@@ -277,11 +285,12 @@ fn parse_profile(payload: &[u8]) -> Result<SampleProfile, ProfileError> {
         return Err(ProfileError::MissingProfileMetadata);
     }
 
-    if profile.transaction.is_none() {
-        profile.transaction = profile.transactions.drain(..).next();
+    if profile.metadata.transaction.is_none() {
+        profile.metadata.transaction = profile.metadata.transactions.drain(..).next();
     }
 
     let transaction = profile
+        .metadata
         .transaction
         .as_ref()
         .ok_or(ProfileError::NoTransactionAssociated)?;
@@ -329,21 +338,21 @@ pub fn parse_sample_profile(
     let mut profile = parse_profile(payload)?;
 
     if let Some(transaction_name) = transaction_metadata.get("transaction") {
-        if let Some(ref mut transaction) = profile.transaction {
+        if let Some(ref mut transaction) = profile.metadata.transaction {
             transaction.name = transaction_name.to_owned();
         }
     }
 
     if let Some(release) = transaction_metadata.get("release") {
-        profile.release = release.to_owned();
+        profile.metadata.release = release.to_owned();
     }
 
     if let Some(environment) = transaction_metadata.get("environment") {
-        profile.environment = environment.to_owned();
+        profile.metadata.environment = environment.to_owned();
     }
 
-    profile.transaction_metadata = transaction_metadata;
-    profile.transaction_tags = transaction_tags;
+    profile.metadata.transaction_metadata = transaction_metadata;
+    profile.metadata.transaction_tags = transaction_tags;
 
     serde_json::to_vec(&profile).map_err(|_| ProfileError::CannotSerializePayload)
 }
@@ -370,25 +379,33 @@ mod tests {
 
     fn generate_profile() -> SampleProfile {
         SampleProfile {
-            debug_meta: Option::None,
-            version: Version::V1,
-            timestamp: Utc::now(),
-            runtime: Option::None,
-            device: DeviceMetadata {
-                architecture: "arm64e".to_string(),
-                is_emulator: Some(true),
-                locale: Some("en_US".to_string()),
-                manufacturer: Some("Apple".to_string()),
-                model: Some("iPhome11,3".to_string()),
+            metadata: ProfileMetadata {
+                debug_meta: Option::None,
+                version: Version::V1,
+                timestamp: Utc::now(),
+                runtime: Option::None,
+                device: DeviceMetadata {
+                    architecture: "arm64e".to_string(),
+                    is_emulator: Some(true),
+                    locale: Some("en_US".to_string()),
+                    manufacturer: Some("Apple".to_string()),
+                    model: Some("iPhome11,3".to_string()),
+                },
+                os: OSMetadata {
+                    build_number: Some("H3110".to_string()),
+                    name: "iOS".to_string(),
+                    version: "16.0".to_string(),
+                },
+                environment: "testing".to_string(),
+                platform: "cocoa".to_string(),
+                event_id: EventId::new(),
+                transaction: Option::None,
+                transactions: Vec::new(),
+                release: "1.0 (9999)".to_string(),
+                measurements: None,
+                transaction_metadata: BTreeMap::new(),
+                transaction_tags: BTreeMap::new(),
             },
-            os: OSMetadata {
-                build_number: Some("H3110".to_string()),
-                name: "iOS".to_string(),
-                version: "16.0".to_string(),
-            },
-            environment: "testing".to_string(),
-            platform: "cocoa".to_string(),
-            event_id: EventId::new(),
             profile: Profile {
                 queue_metadata: Some(HashMap::new()),
                 samples: Vec::new(),
@@ -396,12 +413,6 @@ mod tests {
                 frames: Vec::new(),
                 thread_metadata: Some(HashMap::new()),
             },
-            transaction: Option::None,
-            transactions: Vec::new(),
-            release: "1.0 (9999)".to_string(),
-            measurements: None,
-            transaction_metadata: BTreeMap::new(),
-            transaction_tags: BTreeMap::new(),
         }
     }
 
@@ -492,7 +503,7 @@ mod tests {
             lineno: Some(0),
             module: Some("".to_string()),
         });
-        profile.transaction = Some(TransactionMetadata {
+        profile.metadata.transaction = Some(TransactionMetadata {
             active_thread_id: 1,
             id: EventId::new(),
             name: "blah".to_string(),
@@ -550,7 +561,7 @@ mod tests {
             lineno: Some(0),
             module: Some("".to_string()),
         });
-        profile.transaction = Some(TransactionMetadata {
+        profile.metadata.transaction = Some(TransactionMetadata {
             active_thread_id: 1,
             id: EventId::new(),
             name: "blah".to_string(),
@@ -608,7 +619,7 @@ mod tests {
             trace_id: EventId::new(),
         };
 
-        profile.transactions.push(transaction.clone());
+        profile.metadata.transactions.push(transaction.clone());
         profile.profile.frames.push(Frame {
             abs_path: Some("".to_string()),
             colno: Some(0),
@@ -650,8 +661,8 @@ mod tests {
         let payload = serde_json::to_vec(&profile).unwrap();
         let profile = parse_profile(&payload[..]).unwrap();
 
-        assert_eq!(Some(transaction), profile.transaction);
-        assert!(profile.transactions.is_empty());
+        assert_eq!(Some(transaction), profile.metadata.transaction);
+        assert!(profile.metadata.transactions.is_empty());
     }
 
     #[test]
@@ -675,7 +686,7 @@ mod tests {
             trace_id: EventId::new(),
         };
 
-        profile.transaction = Some(transaction);
+        profile.metadata.transaction = Some(transaction);
         profile.profile.frames.push(Frame {
             abs_path: Some("".to_string()),
             colno: Some(0),
@@ -782,7 +793,7 @@ mod tests {
             trace_id: EventId::new(),
         };
 
-        profile.transaction = Some(transaction);
+        profile.metadata.transaction = Some(transaction);
         profile.profile.frames.push(Frame {
             abs_path: Some("".to_string()),
             colno: Some(0),
@@ -883,9 +894,9 @@ mod tests {
         let output: SampleProfile = serde_json::from_slice(&profile_json.unwrap()[..])
             .map_err(ProfileError::InvalidJson)
             .unwrap();
-        assert_eq!(output.release, "some-random-release".to_string());
+        assert_eq!(output.metadata.release, "some-random-release".to_string());
         assert_eq!(
-            output.transaction.unwrap().name,
+            output.metadata.transaction.unwrap().name,
             "some-random-transaction".to_string()
         );
     }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -15,7 +15,6 @@ default = []
 processing = [
     "dep:minidump",
     "dep:relay-monitors",
-    "dep:relay-profiling",
     "dep:symbolic-common",
     "dep:symbolic-unreal",
     "dep:zstd",
@@ -56,7 +55,7 @@ relay-kafka = { path = "../relay-kafka", optional = true }
 relay-log = { path = "../relay-log", features = ["sentry"] }
 relay-metrics = { path = "../relay-metrics" }
 relay-monitors = { path = "../relay-monitors", optional = true }
-relay-profiling = { path = "../relay-profiling", optional = true }
+relay-profiling = { path = "../relay-profiling" }
 relay-dynamic-config = { path = "../relay-dynamic-config"}
 relay-quotas = { path = "../relay-quotas" }
 relay-redis = { path = "../relay-redis" }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1042,18 +1042,14 @@ impl EnvelopeProcessorService {
     /// Remove profiles from the envelope if the feature flag is not enabled.
     fn filter_profiles(&self, state: &mut ProcessEnvelopeState) {
         let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
-        let timestamp = state.managed_envelope.received_at();
-        let scoping = state.managed_envelope.scoping();
         state.managed_envelope.retain_items(|item| match item.ty() {
             ItemType::Profile if !profiling_enabled => ItemAction::DropSilently,
             ItemType::Profile if profiling_enabled => {
                 match relay_profiling::parse_metadata(&item.payload()) {
                     Ok(_) => ItemAction::Keep,
-                    Err(err) => {
-                        ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
-                            relay_profiling::discard_reason(err),
-                        )))
-                    }
+                    Err(err) => ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
+                        relay_profiling::discard_reason(err),
+                    ))),
                 }
             }
             _ => ItemAction::Keep,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1050,18 +1050,9 @@ impl EnvelopeProcessorService {
                 match relay_profiling::parse_metadata(&item.payload()) {
                     Ok(_) => ItemAction::Keep,
                     Err(err) => {
-                        self.outcome_aggregator.send(TrackOutcome {
-                            timestamp,
-                            scoping,
-                            outcome: Outcome::Invalid(DiscardReason::Profiling(
-                                relay_profiling::discard_reason(err),
-                            )),
-                            event_id: None,
-                            remote_addr: None,
-                            category: DataCategory::Profile,
-                            quantity: 1,
-                        });
-                        ItemAction::DropSilently
+                        ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
+                            relay_profiling::discard_reason(err),
+                        )))
                     }
                 }
             }

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1332,9 +1332,8 @@ def test_profile_outcomes_data_invalid(
         )
         envelope.add_item(
             Item(
-                payload=PayloadRef(
-                    bytes=json.dumps(_get_profile_payload()), type="profile"
-                )
+                payload=PayloadRef(bytes=json.dumps(_get_profile_payload()).encode()),
+                type="profile",
             )
         )
         return envelope

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -283,7 +283,8 @@ def test_outcomes_not_sent_when_disabled(relay, mini_sentry):
 
     try:
         mini_sentry.captured_outcomes.get(timeout=0.2)
-        assert False  # we should not be here ( previous call should have failed)
+        # we should not be here ( previous call should have failed)
+        assert False
     except Empty:
         pass  # we do expect not to get anything since we have outcomes disabled
 
@@ -1080,7 +1081,8 @@ def test_profile_outcomes(
     expected_source = {
         0: "processing-relay",
         1: "pop-relay",
-        2: "pop-relay",  # outcomes from client reports do not have a correct source (known issue)
+        # outcomes from client reports do not have a correct source (known issue)
+        2: "pop-relay",
     }[num_intermediate_relays]
     expected_outcomes = [
         {
@@ -1188,20 +1190,9 @@ def test_profile_outcomes_invalid(
             "category": 6,  # Profile
             "key_id": 123,
             "org_id": 1,
-            "outcome": 0,  # Accepted
-            "project_id": 42,
-            "quantity": 1,
-            "source": "processing-relay",
-        },
-        {
-            "category": 11,  # ProfileIndexed
-            "key_id": 123,
-            "org_id": 1,
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": 1,
-            "reason": "profiling_invalid_json",
-            "remote_addr": "127.0.0.1",
             "source": "processing-relay",
         },
     ]

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -568,6 +568,87 @@ def _get_event_payload(event_type):
         raise Exception("Invalid event type")
 
 
+def _get_profile_payload(metadata_only=True):
+    profile = {
+        "event_id": "41fed0925670468bb0457f61a74688ec",
+        "version": "1",
+        "os": {"name": "iOS", "version": "16.0", "build_number": "19H253"},
+        "device": {
+            "architecture": "arm64e",
+            "is_emulator": False,
+            "locale": "en_US",
+            "manufacturer": "Apple",
+            "model": "iPhone14,3",
+        },
+        "timestamp": "2022-09-01T09:45:00.000Z",
+        "release": "0.1 (199)",
+        "platform": "cocoa",
+        "debug_meta": {
+            "images": [
+                {
+                    "debug_id": "32420279-25E2-34E6-8BC7-8A006A8F2425",
+                    "image_addr": "0x000000010258c000",
+                    "code_file": "/private/var/containers/Bundle/Application/C3511752-DD67-4FE8-9DA2-ACE18ADFAA61/TrendingMovies.app/TrendingMovies",
+                    "type": "macho",
+                    "image_size": 1720320,
+                    "image_vmaddr": "0x0000000100000000",
+                }
+            ]
+        },
+        "transactions": [
+            {
+                "name": "example_ios_movies_sources.MoviesViewController",
+                "trace_id": "4b25bc58f14243d8b208d1e22a054164",
+                "id": "30976f2ddbe04ac9b6bffe6e35d4710c",
+                "active_thread_id": "259",
+                "relative_start_ns": "500500",
+                "relative_end_ns": "50500500",
+            }
+        ],
+    }
+    if metadata_only:
+        return profile
+    profile["profile"] = {
+        "samples": [
+            {
+                "stack_id": 0,
+                "thread_id": "1",
+                "queue_address": "0x0000000102adc700",
+                "elapsed_since_start_ns": "10500500",
+            },
+            {
+                "stack_id": 1,
+                "thread_id": "1",
+                "queue_address": "0x0000000102adc700",
+                "elapsed_since_start_ns": "20500500",
+            },
+            {
+                "stack_id": 0,
+                "thread_id": "1",
+                "queue_address": "0x0000000102adc700",
+                "elapsed_since_start_ns": "30500500",
+            },
+            {
+                "stack_id": 1,
+                "thread_id": "1",
+                "queue_address": "0x0000000102adc700",
+                "elapsed_since_start_ns": "40500500",
+            },
+        ],
+        "stacks": [[0], [1]],
+        "frames": [
+            {"instruction_addr": "0xa722447ffffffffc"},
+            {"instruction_addr": "0x442e4b81f5031e58"},
+        ],
+        "thread_metadata": {"1": {"priority": 31}, "2": {}},
+        "queue_metadata": {
+            "0x0000000102adc700": {"label": "com.apple.main-thread"},
+            "0x000000016d8fb180": {"label": "com.apple.network.connections"},
+        },
+    }
+    return profile
+
+
 @pytest.mark.parametrize(
     "category,is_outcome_expected", [("session", False), ("transaction", True)]
 )
@@ -1132,13 +1213,13 @@ def test_profile_outcomes(
     assert outcomes == expected_outcomes, outcomes
 
 
-def test_profile_outcomes_invalid(
+def test_profile_outcomes_metadata_invalid(
     mini_sentry,
     relay_with_processing,
     outcomes_consumer,
 ):
     """
-    Tests that Relay reports correct outcomes for invalid profiles as `ProfileIndexed`.
+    Tests that Relay reports correct outcomes for invalid profiles as `Profile`.
     """
     outcomes_consumer = outcomes_consumer(timeout=2)
 
@@ -1159,7 +1240,7 @@ def test_profile_outcomes_invalid(
                 "bucket_interval": 1,
                 "flush_interval": 1,
             },
-            "source": "processing-relay",
+            "source": "pop-relay",
         },
         "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
     }
@@ -1193,6 +1274,96 @@ def test_profile_outcomes_invalid(
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": 1,
+            "reason": "profiling_invalid_json",
+            "remote_addr": "127.0.0.1",
+            "source": "pop-relay",
+        },
+    ]
+    for outcome in outcomes:
+        outcome.pop("timestamp")
+        outcome.pop("event_id", None)
+
+    assert outcomes == expected_outcomes, outcomes
+
+
+def test_profile_outcomes_data_invalid(
+    mini_sentry,
+    relay_with_processing,
+    outcomes_consumer,
+):
+    """
+    Tests that Relay reports correct outcomes for invalid profiles as `Profile`.
+    """
+    outcomes_consumer = outcomes_consumer(timeout=2)
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)["config"]
+
+    project_config.setdefault("features", []).append("organizations:profiling")
+    project_config["transactionMetrics"] = {
+        "version": 1,
+    }
+
+    config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+            "aggregator": {
+                "bucket_interval": 1,
+                "flush_interval": 1,
+            },
+            "source": "pop-relay",
+        },
+        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+    }
+
+    upstream = relay_with_processing(config)
+
+    # Create an envelope with an invalid profile:
+    def make_envelope():
+        payload = _get_event_payload("transaction")
+        envelope = Envelope()
+        envelope.add_item(
+            Item(
+                payload=PayloadRef(bytes=json.dumps(payload).encode()),
+                type="transaction",
+            )
+        )
+        envelope.add_item(
+            Item(
+                payload=PayloadRef(
+                    bytes=json.dumps(_get_profile_payload()), type="profile"
+                )
+            )
+        )
+        return envelope
+
+    envelope = make_envelope()
+    upstream.send_envelope(project_id, envelope)
+
+    outcomes = outcomes_consumer.get_outcomes()
+    outcomes.sort(key=lambda o: sorted(o.items()))
+
+    expected_outcomes = [
+        {
+            "category": 6,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            "quantity": 1,
+            "source": "processing-relay",
+        },
+        {
+            "category": 11,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "profiling_invalid_json",
+            "remote_addr": "127.0.0.1",
             "source": "processing-relay",
         },
     ]

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1313,7 +1313,7 @@ def test_profile_outcomes_data_invalid(
                 "bucket_interval": 1,
                 "flush_interval": 1,
             },
-            "source": "pop-relay",
+            "source": "processing-relay",
         },
         "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
     }


### PR DESCRIPTION
We want the profile to be parsed to then mark it as invalid if needed instead of marking it as accepted no matter if we discard it or not.

Now, on top of filtering profiles early if the flag is enabled, we also parse the metadata and discard them with the appropriate outcome if needed.

We're not parsing the profile data itself and that means an indexed profile can still be considered invalid even though we already sent an accepted outcome.