### PR TITLE
feat(spans): Add span description tag on in-like sql queries

### DIFF
--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -50,3 +50,10 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+    // Slightly modified regex from
+    // https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132
+    Regex::new(r#" IN \((?P<in_condition_params>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)"#)
+        .unwrap()
+});

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -54,7 +54,7 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
 /// Regex with multiple capture groups for SQL tokens we should scrub.
 ///
 /// Slightly modified from
-/// https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132
+/// <https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132>
 pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r#"(?i)(IN \((?P<in>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\))"#).unwrap()
 });

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -51,9 +51,10 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Regex with multiple capture groups for SQL tokens we should scrub.
+///
+/// Slightly modified from
+/// https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132
 pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
-    // Slightly modified regex from
-    // https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132
-    Regex::new(r#"(?i) IN \((?P<in_condition_params>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)"#)
-        .unwrap()
+    Regex::new(r#"(?i)(IN \((?P<in>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\))"#).unwrap()
 });

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -54,6 +54,6 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
 pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     // Slightly modified regex from
     // https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132
-    Regex::new(r#" IN \((?P<in_condition_params>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)"#)
+    Regex::new(r#"(?i) IN \((?P<in_condition_params>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)"#)
         .unwrap()
 });

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2329,6 +2329,13 @@ mod tests {
     );
 
     span_description_test!(
+        span_description_scrub_only_urllike_on_http_ops,
+        "GET https://www.service.io/resources/01234",
+        "db.sql.query",
+        ""
+    );
+
+    span_description_test!(
         span_description_scrub_path_ids_end,
         "GET https://www.service.io/resources/01234",
         "http.client",
@@ -2368,6 +2375,48 @@ mod tests {
         "GET /clients/8ff81d74-606d-4c75-ac5e-cee65cbbc866/project/01234",
         "http.client",
         "GET /clients/*/project/*"
+    );
+
+    span_description_test!(
+        span_description_scrub_only_dblike_on_db_ops,
+        "SELECT count() FROM table WHERE id IN (%s, %s)",
+        "http.client",
+        ""
+    );
+
+    span_description_test!(
+        span_description_scrub_various_parameterized_ins_percentage,
+        "SELECT count() FROM table WHERE id IN (%s, %s) AND id IN (%s, %s, %s)",
+        "db.sql.query",
+        "SELECT count() FROM table WHERE id IN (*) AND id IN (*)"
+    );
+
+    span_description_test!(
+        span_description_scrub_various_parameterized_ins_dollar,
+        "SELECT count() FROM table WHERE id IN ($1, $2, $3)",
+        "db.sql.query",
+        "SELECT count() FROM table WHERE id IN (*)"
+    );
+
+    span_description_test!(
+        span_description_scrub_various_parameterized_questionmarks,
+        "SELECT count() FROM table WHERE id IN (?, ?, ?)",
+        "db.sql.query",
+        "SELECT count() FROM table WHERE id IN (*)"
+    );
+
+    span_description_test!(
+        span_description_scrub_unparameterized_ins_uppercase,
+        "SELECT count() FROM table WHERE id IN (100, 101, 102)",
+        "db.sql.query",
+        "SELECT count() FROM table WHERE id IN (*)"
+    );
+
+    span_description_test!(
+        span_description_scrub_various_parameterized_ins_lowercase,
+        "select count() from table where id in (100, 101, 102)",
+        "db.sql.query",
+        "select count() from table where id in (*)"
     );
 
     // TODO(iker): Add span description test for URLs with paths

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -487,17 +487,16 @@ fn scrub_span_description(span: &mut Span) -> Result<(), ProcessingAction> {
     }
 
     if did_scrub {
-        let Some(new_desc) = scrubbed.into_value() else {
-            return Ok(());
+        if let Some(new_desc) = scrubbed.into_value() {
+            span.data
+                .get_or_insert_with(BTreeMap::new)
+                // We don't care what the cause of scrubbing was, since we assume
+                // that after scrubbing the value is sanitized.
+                .insert(
+                    "description.scrubbed".to_owned(),
+                    Annotated::new(Value::String(new_desc)),
+                );
         };
-        span.data
-            .get_or_insert_with(BTreeMap::new)
-            // We don't care what the cause of scrubbing was, since we assume
-            // that after scrubbing the value is sanitized.
-            .insert(
-                "description.scrubbed".to_owned(),
-                Annotated::new(Value::String(new_desc)),
-            );
     }
 
     Ok(())

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -487,7 +487,7 @@ fn scrub_span_description(span: &mut Span) -> Result<(), ProcessingAction> {
     }
 
     if did_scrub {
-        let Some(new_desc) = scrubbed.value() else {
+        let Some(new_desc) = scrubbed.into_value() else {
             return Ok(());
         };
         span.data
@@ -496,7 +496,7 @@ fn scrub_span_description(span: &mut Span) -> Result<(), ProcessingAction> {
             // that after scrubbing the value is sanitized.
             .insert(
                 "description.scrubbed".to_owned(),
-                Annotated::new(Value::String(new_desc.to_owned())),
+                Annotated::new(Value::String(new_desc)),
             );
     }
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2267,6 +2267,8 @@ mod tests {
     }
 
     macro_rules! span_description_test {
+        // Tests the scrubbed span description for the given op.
+        // An empty output `""` means the span description was not scrubbed at all.
         ($name:ident, $description_in:literal, $op_in:literal, $output:literal) => {
             #[test]
             fn $name() {

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -288,15 +288,15 @@ fn scrub_sql_queries(string: &mut Annotated<String>) -> Result<bool, ProcessingA
 
 fn scrub_identifiers_with_regex(
     string: &mut Annotated<String>,
-    regex: &Lazy<Regex>,
+    pattern: &Lazy<Regex>,
 ) -> Result<bool, ProcessingAction> {
-    let capture_names = regex.capture_names().flatten().collect::<Vec<_>>();
+    let capture_names = pattern.capture_names().flatten().collect::<Vec<_>>();
 
     let mut did_change = false;
     string.apply(|trans, meta| {
         let mut caps = Vec::new();
         // Collect all the remarks if anything matches.
-        for captures in regex.captures_iter(trans) {
+        for captures in pattern.captures_iter(trans) {
             for name in &capture_names {
                 if let Some(capture) = captures.name(name) {
                     let remark = Remark::with_range(

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2267,7 +2267,7 @@ mod tests {
     }
 
     macro_rules! span_description_test {
-        ($name:ident, $input:literal, $output:literal) => {
+        ($name:ident, $description_in:literal, $op_in:literal, $output:literal) => {
             #[test]
             fn $name() {
                 let json = format!(
@@ -2278,10 +2278,10 @@ mod tests {
                         "start_timestamp": 1597976393.4619668,
                         "timestamp": 1597976393.4718769,
                         "trace_id": "ff62a8b040f340bda5d830223def1d81",
-                        "op": "http.client"
+                        "op": "{}"
                     }}
                 "#,
-                    $input
+                    $description_in, $op_in
                 );
 
                 let mut span = Annotated::<Span>::from_json(&json).unwrap();
@@ -2293,7 +2293,10 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!($input, span.value().unwrap().description.value().unwrap());
+                assert_eq!(
+                    $description_in,
+                    span.value().unwrap().description.value().unwrap()
+                );
                 if $output == "" {
                     assert!(span
                         .value()
@@ -2314,47 +2317,54 @@ mod tests {
         };
     }
 
-    span_description_test!(span_description_scrub_empty, "", "");
+    span_description_test!(span_description_scrub_empty, "", "http.client", "");
 
     span_description_test!(
         span_description_scrub_only_domain,
         "GET http://service.io",
+        "http.client",
         ""
     );
 
     span_description_test!(
         span_description_scrub_path_ids_end,
         "GET https://www.service.io/resources/01234",
+        "http.client",
         "GET https://www.service.io/resources/*"
     );
 
     span_description_test!(
         span_description_scrub_path_ids_middle,
         "GET https://www.service.io/resources/01234/details",
+        "http.client",
         "GET https://www.service.io/resources/*/details"
     );
 
     span_description_test!(
         span_description_scrub_path_multiple_ids,
         "GET https://www.service.io/users/01234-qwerty/settings/98765-adfghj",
+        "http.client",
         "GET https://www.service.io/users/*/settings/*"
     );
 
     span_description_test!(
         span_description_scrub_path_md5_hashes,
         "GET /clients/563712f9722fb0996ac8f3905b40786f/project/01234",
+        "http.client",
         "GET /clients/*/project/*"
     );
 
     span_description_test!(
         span_description_scrub_path_sha_hashes,
         "GET /clients/403926033d001b5279df37cbbe5287b7c7c267fa/project/01234",
+        "http.client",
         "GET /clients/*/project/*"
     );
 
     span_description_test!(
         span_description_scrub_path_uuids,
         "GET /clients/8ff81d74-606d-4c75-ac5e-cee65cbbc866/project/01234",
+        "http.client",
         "GET /clients/*/project/*"
     );
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -721,7 +721,7 @@ mod tests {
                     }
                 },
                 {
-                    "description": "SELECT column FROM table WHERE id = %s",
+                    "description": "SELECT column FROM table WHERE id IN (1, 2, 3)",
                     "op": "db",
                     "parent_span_id": "8f5a2b8768cafb4e",
                     "span_id": "bb7af8b99e95af5f",
@@ -995,6 +995,7 @@ mod tests {
                 tags: {
                     "environment": "fake_environment",
                     "span.action": "SELECT",
+                    "span.description": "SELECT column FROM table WHERE id IN (*)",
                     "span.module": "db",
                     "span.op": "db",
                     "span.status": "ok",
@@ -1012,6 +1013,7 @@ mod tests {
                 tags: {
                     "environment": "fake_environment",
                     "span.action": "SELECT",
+                    "span.description": "SELECT column FROM table WHERE id IN (*)",
                     "span.module": "db",
                     "span.op": "db",
                     "span.status": "ok",


### PR DESCRIPTION
On `db.*`-like span statuses, scrub the span description looking for SQL queries and add the scrubbed strings as tags to span metrics. This PR only considers one use case of SQL queries: `IN ...`-like queries; new use cases will come in future PRs.

#skip-changelog