### PR TITLE
feat(profiling): Fix regression on making release optional and copy dist from transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,8 @@
 - On Linux, switch to `jemalloc` instead of the system memory allocator to reduce Relay's memory footprint. ([#2084](https://github.com/getsentry/relay/pull/2084))
 - Scrub sensitive cookies `__session`. ([#2105](https://github.com/getsentry/relay/pull/2105)))
 - Parse profiles' metadata to check if it should be marked as invalid. ([#2104](https://github.com/getsentry/relay/pull/2104))
-- Set release as optional by defaulting to an empty string for profiles. ([#2098](https://github.com/getsentry/relay/pull/2098))
+- Set release as optional by defaulting to an empty string and add a dist field for profiles. ([#2098](https://github.com/getsentry/relay/pull/2098), [#2107](https://github.com/getsentry/relay/pull/2107))
 - Accept source map debug images in debug meta for Profiling. ([#2097](https://github.com/getsentry/relay/pull/2097))
-- Fix regression on release being optional and copy missing dist field from transactions.([#2107](https://github.com/getsentry/relay/pull/2107))
 
 ## 23.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Parse profiles' metadata to check if it should be marked as invalid. ([#2104](https://github.com/getsentry/relay/pull/2104))
 - Set release as optional by defaulting to an empty string for profiles. ([#2098](https://github.com/getsentry/relay/pull/2098))
 - Accept source map debug images in debug meta for Profiling. ([#2097](https://github.com/getsentry/relay/pull/2097))
+- Fix regression on release being optional and copy missing dist field from transactions.([#2107](https://github.com/getsentry/relay/pull/2107))
 
 ## 23.4.0
 

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -203,6 +203,10 @@ pub fn parse_android_profile(
         profile.metadata.release = release.to_owned();
     }
 
+    if let Some(dist) = transaction_metadata.get("dist") {
+        profile.metadata.dist = dist.to_owned();
+    }
+
     if let Some(environment) = transaction_metadata.get("environment") {
         profile.metadata.environment = environment.to_owned();
     }

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -37,6 +37,8 @@ pub struct ProfileMetadata {
 
     #[serde(default, skip_serializing_if = "String::is_empty")]
     release: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    dist: String,
 
     version_code: String,
     version_name: String,

--- a/relay-profiling/src/extract_from_transaction.rs
+++ b/relay-profiling/src/extract_from_transaction.rs
@@ -12,6 +12,9 @@ pub fn extract_transaction_metadata(event: &Event) -> BTreeMap<String, String> {
     if let Some(release) = event.release.as_str() {
         tags.insert("release".to_owned(), release.to_owned());
     }
+    if let Some(dist) = event.dist.as_str() {
+        tags.insert("dist".to_owned(), dist.to_owned());
+    }
     if let Some(dist) = event.dist.value() {
         tags.insert("dist".to_owned(), dist.clone());
     }

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -152,10 +152,9 @@ pub struct ProfileMetadata {
     platform: String,
     timestamp: DateTime<Utc>,
 
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     release: String,
-
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     dist: String,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -150,8 +150,13 @@ pub struct ProfileMetadata {
     #[serde(alias = "profile_id")]
     event_id: EventId,
     platform: String,
-    release: String,
     timestamp: DateTime<Utc>,
+
+    #[serde(default)]
+    release: String,
+
+    #[serde(default)]
+    dist: String,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     transactions: Vec<TransactionMetadata>,
@@ -347,6 +352,10 @@ pub fn parse_sample_profile(
         profile.metadata.release = release.to_owned();
     }
 
+    if let Some(dist) = transaction_metadata.get("dist") {
+        profile.metadata.dist = dist.to_owned();
+    }
+
     if let Some(environment) = transaction_metadata.get("environment") {
         profile.metadata.environment = environment.to_owned();
     }
@@ -401,7 +410,8 @@ mod tests {
                 event_id: EventId::new(),
                 transaction: Option::None,
                 transactions: Vec::new(),
-                release: "1.0 (9999)".to_string(),
+                release: "1.0".to_string(),
+                dist: "9999".to_string(),
                 measurements: None,
                 transaction_metadata: BTreeMap::new(),
                 transaction_tags: BTreeMap::new(),


### PR DESCRIPTION
This PR aims to fix the regression introduced right after we started making the release field option.

At the same time, `dist` should also be copied from the transaction and should also be optional.