### PR TITLE
ref(spool): Simplify the spool states

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -55,6 +55,9 @@ pub enum BufferError {
 
     #[error("failed to run migrations")]
     MigrationFailed(#[from] MigrateError),
+
+    #[error("on-disk spool is full")]
+    SpoolIsFull,
 }
 
 /// This key represents the index element in the queue.
@@ -403,15 +406,6 @@ impl OnDisk {
             .send(UpdateBufferIndex::new(project_key, unused_keys))
     }
 
-    /// Returns `true` if the provided used memory can fit on the disk.
-    async fn can_fit(&self, used_memory: usize) -> bool {
-        self.estimate_spool_size()
-            .await
-            .ok()
-            .and_then(|spool_size| self.max_disk_size.checked_sub(spool_size as usize))
-            .map_or(false, |s| s > used_memory)
-    }
-
     /// Estimates the db size by multiplying `page_count * page_size`.
     async fn estimate_spool_size(&self) -> Result<i64, BufferError> {
         let size: i64 = sql::current_size()
@@ -473,10 +467,6 @@ enum BufferState {
     /// The disk will be used when the memory limit will be hit.
     MemoryFileStandby { ram: InMemory, disk: OnDisk },
 
-    /// THe disk is full and we use the memory to save incoming envelopes as much as we can. But
-    /// the disk still used to read from.
-    MemoryFileRead { ram: InMemory, disk: OnDisk },
-
     /// Only disk used for read/write operations.
     Disk(OnDisk),
 }
@@ -500,7 +490,7 @@ impl BufferState {
                 if disk.is_empty().await.unwrap_or_default() {
                     Self::MemoryFileStandby { ram, disk }
                 } else {
-                    BufferState::MemoryFileRead { ram, disk }
+                    BufferState::Disk(disk)
                 }
             }
             None => Self::Memory(ram),
@@ -526,26 +516,7 @@ impl BufferState {
                     disk,
                 }
             }
-            Self::Disk(disk) if disk.is_full().await.unwrap_or_default() => Self::MemoryFileRead {
-                ram: InMemory::new(config.spool_envelopes_max_memory_size()),
-                disk,
-            },
-            Self::MemoryFileRead { ram, disk } if disk.is_empty().await.unwrap_or_default() => {
-                Self::MemoryFileStandby { ram, disk }
-            }
-            Self::MemoryFileRead { ram, disk } if disk.can_fit(ram.used_memory).await => {
-                if let Err(err) = disk.spool(ram.buffer).await {
-                    relay_log::error!(
-                        "failed to spool the in-memory buffer to disk: {}",
-                        LogError(&err)
-                    );
-                }
-                Self::Disk(disk)
-            }
-            Self::Memory(_)
-            | Self::MemoryFileStandby { .. }
-            | Self::Disk(_)
-            | Self::MemoryFileRead { .. } => self,
+            Self::Memory(_) | Self::MemoryFileStandby { .. } | Self::Disk(_) => self,
         }
     }
 }
@@ -673,14 +644,14 @@ impl BufferService {
 
         match self.state {
             BufferState::Memory(ref mut ram)
-            | BufferState::MemoryFileStandby { ref mut ram, .. }
-            // In this state we had full disk, and if we continue spooling without removing
-            // anything from the on-disk spool, we will eventually hit the
-            // `cache.envelope_buffer_size` limit or OOM, whatever comes first.
-            | BufferState::MemoryFileRead { ref mut ram, .. } => {
+            | BufferState::MemoryFileStandby { ref mut ram, .. } => {
                 ram.enqueue(key, managed_envelope);
             }
-            BufferState::Disk(ref disk) =>{
+            BufferState::Disk(ref disk) => {
+                // The disk is full, drop the incoming envelopes.
+                if disk.is_full().await? {
+                    return Err(BufferError::SpoolIsFull);
+                }
                 disk.enqueue(key, managed_envelope).await?;
             }
         }
@@ -709,14 +680,6 @@ impl BufferService {
                 disk.dequeue(project_key, &mut keys, sender, &self.services)
                     .await;
             }
-            BufferState::MemoryFileRead {
-                ref mut ram,
-                ref disk,
-            } => {
-                ram.dequeue(&keys, sender.clone());
-                disk.dequeue(project_key, &mut keys, sender, &self.services)
-                    .await;
-            }
         }
         let state = std::mem::take(&mut self.state);
         self.state = state.transition(&self.config).await;
@@ -739,13 +702,6 @@ impl BufferService {
                 count += ram.remove(&keys);
             }
             BufferState::Disk(ref disk) => {
-                count += disk.remove(&keys).await?;
-            }
-            BufferState::MemoryFileRead {
-                ref mut ram,
-                ref disk,
-            } => {
-                count += ram.remove(&keys);
                 count += disk.remove(&keys).await?;
             }
         }
@@ -827,9 +783,7 @@ impl Drop for BufferService {
     fn drop(&mut self) {
         // Count only envelopes from in-memory buffer.
         match &self.state {
-            BufferState::Memory(ram)
-            | BufferState::MemoryFileStandby { ram, .. }
-            | BufferState::MemoryFileRead { ram, .. } => {
+            BufferState::Memory(ram) | BufferState::MemoryFileStandby { ram, .. } => {
                 let count = ram.count();
                 if count > 0 {
                     relay_log::error!("dropped {} envelopes", count);
@@ -944,7 +898,7 @@ mod tests {
                 "envelopes": {
                     "path": std::env::temp_dir().join(Uuid::new_v4().to_string()),
                     "max_memory_size": "4KB",
-                    "max_disk_size": "3KB",
+                    "max_disk_size": "20KB",
                 }
             }
         }))
@@ -969,14 +923,18 @@ mod tests {
                     .unwrap();
 
                 // Send 5 envelopes
-                for _ in 0..5 {
-                    service
+                for i in 0..5 {
+                    let res = service
                         .handle_enqueue(Enqueue {
                             key,
                             value: empty_envelope(),
                         })
-                        .await
-                        .unwrap();
+                        .await;
+                    if i > 2 {
+                        assert!(res.is_err());
+                    } else {
+                        assert!(res.is_ok());
+                    }
                 }
 
                 // Dequeue everything
@@ -996,7 +954,7 @@ mod tests {
                 while rx.recv().await.is_some() {
                     count += 1;
                 }
-                assert_eq!(count, 5);
+                assert_eq!(count, 3);
             })
         });
 
@@ -1013,11 +971,8 @@ mod tests {
             "buffer.envelopes_mem:6000|h",
             "buffer.envelopes_mem:0|h",
             "buffer.writes:1|c",
-            "buffer.writes:1|c",
             "buffer.disk_size:24576|h",
-            "buffer.envelopes_mem:2000|h",
             "buffer.disk_size:24576|h",
-            "buffer.envelopes_mem:0|h",
             "buffer.reads:1|c",
             "buffer.reads:1|c",
         ]

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -187,9 +187,13 @@ impl ServiceState {
         .spawn_handler(project_cache_rx);
         drop(guard);
 
-        let health_check =
-            HealthCheckService::new(config.clone(), aggregator.clone(), upstream_relay.clone())
-                .start();
+        let health_check = HealthCheckService::new(
+            config.clone(),
+            aggregator.clone(),
+            upstream_relay.clone(),
+            project_cache.clone(),
+        )
+        .start();
         let relay_cache = RelayCacheService::new(config.clone(), upstream_relay.clone()).start();
 
         if let Some(aws_api) = config.aws_runtime_api() {

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -3,6 +3,8 @@ Test the health check endpoints
 """
 
 import time
+import tempfile
+import os
 
 
 def failing_check_challenge(*args, **kwargs):
@@ -91,6 +93,59 @@ def test_readiness_depends_on_aggregator_being_full(mini_sentry, relay):
             {"aggregator": {"max_total_bucket_bytes": 0}},
             wait_health_check=False,
         )
+
+        response = wait_get(relay, "/api/relay/healthcheck/ready/")
+        assert response.status_code == 503
+    finally:
+        # Authentication failures would fail the test
+        mini_sentry.test_failures.clear()
+
+
+def test_readiness_disk_spool(mini_sentry, relay):
+    try:
+        temp = tempfile.mkdtemp()
+        dbfile = os.path.join(temp, "buffer.db")
+
+        project_key = 42
+        mini_sentry.add_full_project_config(project_key)
+        # Set the broken config, so we won't be able to dequeue the envelopes.
+        config = mini_sentry.project_configs[project_key]["config"]
+        ds = config.setdefault("dynamicSampling", {})
+        ds.setdefault("rules", [])
+        ds.setdefault("rulesV2", []).append(
+            {
+                "condition": {
+                    "op": "and",
+                    "inner": [
+                        {"op": "glob", "name": "releases", "value": ["1.1.1", "1.1.2"]}
+                    ],
+                },
+                "samplingValue": {"strategy": "sampleRate", "value": 0.7},
+                "type": "trace",
+                "id": 1,
+                "timeRange": {
+                    "start": "2022-10-10T00:00:00.000000Z",
+                    "end": "2022-10-20T00:00:00.000000Z",
+                },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.9},
+            }
+        )
+
+        relay_config = {
+            "spool": {
+                "envelopes": {"path": dbfile, "max_memory_size": 0, "max_disk_size": 0}
+            },
+        }
+
+        relay = relay(
+            mini_sentry,
+            relay_config,
+            wait_health_check=True,
+        )
+
+        # These events will consume all the disk sapce and we will report not ready.
+        relay.send_event(project_key)
+        relay.send_event(project_key)
 
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         assert response.status_code == 503


### PR DESCRIPTION
Simplify the state machine and have only 2 transition, from memory to disk and from disk to memory. 

Right now when the disk is full we start dropping the incoming envelopes and report the error.

In the followup will integrate the health check to report this issue to the user more gracefully. 

related: https://github.com/getsentry/team-ingest/issues/110

#skip-changelog