### PR TITLE
chore(spool): Integrate the health check into the spooler

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -738,7 +738,7 @@ impl BufferService {
             // memory usage and the number of the envelopes in the memory.
             // Note: in the future we want to switch to `spool.envelopes.max_memory_size` option.
             BufferState::Memory(_) | BufferState::MemoryFileStandby { .. } => health.0.send(true),
-            BufferState::Disk(ref disk) => health.0.send(disk.is_full().await.unwrap_or_default()),
+            BufferState::Disk(ref disk) => health.0.send(!disk.is_full().await.unwrap_or_default()),
         }
 
         Ok(())

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -7,7 +7,7 @@ use futures::stream::{self, StreamExt};
 use relay_common::ProjectKey;
 use relay_config::Config;
 use relay_log::LogError;
-use relay_system::{Addr, Controller, FromMessage, Interface, Service};
+use relay_system::{Addr, Controller, FromMessage, Interface, Sender, Service};
 use sqlx::migrate::MigrateError;
 use sqlx::sqlite::{
     SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteRow,
@@ -131,6 +131,10 @@ impl RemoveMany {
     }
 }
 
+/// Checks the health of the spooler.
+#[derive(Debug)]
+pub struct Health(pub Sender<bool>);
+
 /// The interface for [`BufferService`].
 ///
 /// Buffer maintaince internal storage (internal buffer) of the envelopes, which keep accumulating
@@ -151,6 +155,7 @@ pub enum Buffer {
     Enqueue(Enqueue),
     DequeueMany(DequeueMany),
     RemoveMany(RemoveMany),
+    Health(Health),
 }
 
 impl Interface for Buffer {}
@@ -176,6 +181,14 @@ impl FromMessage<RemoveMany> for Buffer {
 
     fn from_message(message: RemoveMany, _: ()) -> Self {
         Self::RemoveMany(message)
+    }
+}
+
+impl FromMessage<Health> for Buffer {
+    type Response = relay_system::NoResponse;
+
+    fn from_message(message: Health, _: ()) -> Self {
+        Self::Health(message)
     }
 }
 
@@ -719,12 +732,25 @@ impl BufferService {
         Ok(())
     }
 
+    async fn handle_health(&mut self, health: Health) -> Result<(), BufferError> {
+        match self.state {
+            // We do not check the ram, since we rely on `cache.envelope_buffer_size` to limit the
+            // memory usage and the number of the envelopes in the memory.
+            // Note: in the future we want to switch to `spool.envelopes.max_memory_size` option.
+            BufferState::Memory(_) | BufferState::MemoryFileStandby { .. } => health.0.send(true),
+            BufferState::Disk(ref disk) => health.0.send(disk.is_full().await.unwrap_or_default()),
+        }
+
+        Ok(())
+    }
+
     /// Handles all the incoming messages from the [`Buffer`] interface.
     async fn handle_message(&mut self, message: Buffer) -> Result<(), BufferError> {
         match message {
             Buffer::Enqueue(message) => self.handle_enqueue(message).await,
             Buffer::DequeueMany(message) => self.handle_dequeue(message).await,
             Buffer::RemoveMany(message) => self.handle_remove(message).await,
+            Buffer::Health(message) => self.handle_health(message).await,
         }
     }
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -187,9 +187,13 @@ impl ServiceState {
         .spawn_handler(project_cache_rx);
         drop(guard);
 
-        let health_check =
-            HealthCheckService::new(config.clone(), aggregator.clone(), upstream_relay.clone())
-                .start();
+        let health_check = HealthCheckService::new(
+            config.clone(),
+            aggregator.clone(),
+            upstream_relay.clone(),
+            project_cache.clone(),
+        )
+        .start();
         let relay_cache = RelayCacheService::new(config.clone(), upstream_relay.clone()).start();
 
         if let Some(aws_api) = config.aws_runtime_api() {


### PR DESCRIPTION
Once the disk is full, we will report the unhealthy to the client, to signal that the Relay cannot accept any more envelopes.

related: https://github.com/getsentry/team-ingest/issues/110

#skip-changelog