### PR TITLE
feat(spans): Extract metrics on scrubbed cache descriptions

### DIFF
--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -75,3 +75,16 @@ pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static CACHE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?xi)
+        # Don't scrub the first segment.
+        # Capture hex.
+        (([\s.+:/\-])+(?P<hex>[a-fA-F0-9]+\b)+) |
+        # Capture segments, in form of`:{hi}:`
+        (([\s.+:/\-])+(?P<segment>\{[^\}]*\})+)
+    "#,
+    )
+    .unwrap()
+});

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -76,6 +76,11 @@ pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Regex with multiple capture groups for cache tokens we should scrub.
+///
+/// The regex attempts to identify all tokens based on hex chars and segments,
+/// excluding the first token. A segment is a string inside curly braces after a
+/// separator, for example `notsegment:{segment}:notsegment`.
 pub static CACHE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"(?xi)

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2601,4 +2601,11 @@ mod tests {
         "cache.get_item",
         "abc:*:*:*:*:*:zookeeper"
     );
+
+    span_description_test!(
+        span_description_scrub_nothing_cache,
+        "abc-dontscrubme-meneither:stillno:ohplsstop",
+        "cache.get_item",
+        ""
+    );
 }

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2594,4 +2594,11 @@ mod tests {
         "db.sql.query",
         ""
     );
+
+    span_description_test!(
+        span_description_scrub_cache,
+        "abc:12:{def}:{34}:{fg56}:EAB38:zookeeper",
+        "cache.get_item",
+        "abc:*:*:*:*:*:zookeeper"
+    );
 }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -833,6 +833,16 @@ mod tests {
                         "db.system": "MyDatabase",
                         "db.operation": "SELECT"
                     }
+                },
+                {
+                    "description": "GET cache:user:{123}",
+                    "op": "cache.get_item",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976393.4619668,
+                    "timestamp": 1597976393.4718769,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok"
                 }
             ],
             "request": {
@@ -1205,6 +1215,38 @@ mod tests {
                     "span.op": "db",
                     "span.status": "ok",
                     "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "s:transactions/span.user@none",
+                value: Set(
+                    933084975,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.description": "GET cache:user:*",
+                    "span.module": "cache",
+                    "span.op": "cache.get_item",
+                    "span.status": "ok",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.duration@millisecond",
+                value: Distribution(
+                    59000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.description": "GET cache:user:*",
+                    "span.module": "cache",
+                    "span.op": "cache.get_item",
+                    "span.status": "ok",
                     "transaction": "mytransaction",
                     "transaction.op": "myop",
                 },

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -842,7 +842,10 @@ mod tests {
                     "start_timestamp": 1597976393.4619668,
                     "timestamp": 1597976393.4718769,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
-                    "status": "ok"
+                    "status": "ok",
+                    "data": {
+                        "cache.hit": false
+                    }
                 }
             ],
             "request": {


### PR DESCRIPTION
Scrubs span descriptions on cache-like spans (e.g. Redis) on extracted metrics.

#skip-changelog