### PR TITLE
feat(txnames): Add 'ready' flag to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))
+
 ## 23.5.0
 
 **Bug Fixes**:
@@ -33,7 +39,6 @@
 - Parse profiles' metadata to check if it should be marked as invalid. ([#2104](https://github.com/getsentry/relay/pull/2104))
 - Set release as optional by defaulting to an empty string and add a dist field for profiles. ([#2098](https://github.com/getsentry/relay/pull/2098), [#2107](https://github.com/getsentry/relay/pull/2107))
 - Accept source map debug images in debug meta for Profiling. ([#2097](https://github.com/getsentry/relay/pull/2097))
-- Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))
 
 ## 23.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Parse profiles' metadata to check if it should be marked as invalid. ([#2104](https://github.com/getsentry/relay/pull/2104))
 - Set release as optional by defaulting to an empty string and add a dist field for profiles. ([#2098](https://github.com/getsentry/relay/pull/2098), [#2107](https://github.com/getsentry/relay/pull/2107))
 - Accept source map debug images in debug meta for Profiling. ([#2097](https://github.com/getsentry/relay/pull/2097))
+- Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))
 
 ## 23.4.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))
+
 ## 0.8.22
 
 - Store `geo.subdivision` of the end user location. ([#2058](https://github.com/getsentry/relay/pull/2058))

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -65,6 +65,9 @@ pub struct ProjectConfig {
     /// Transaction renaming rules.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tx_name_rules: Vec<TransactionNameRule>,
+    /// Whether or not a project is ready to mark all URL transactions as "sanitized".
+    #[serde(skip_serializing_if = "is_false")]
+    pub tx_name_ready: bool,
 }
 
 impl Default for ProjectConfig {
@@ -87,6 +90,7 @@ impl Default for ProjectConfig {
             metric_conditional_tagging: Vec::new(),
             features: BTreeSet::new(),
             tx_name_rules: Vec::new(),
+            tx_name_ready: false,
         }
     }
 }
@@ -123,4 +127,11 @@ pub struct LimitedProjectConfig {
     pub features: BTreeSet<Feature>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tx_name_rules: Vec<TransactionNameRule>,
+    /// Whether or not a project is ready to mark all URL transactions as "sanitized".
+    #[serde(skip_serializing_if = "is_false")]
+    pub tx_name_ready: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }


### PR DESCRIPTION
Add a flag to project configs which indicates whether URL transaction names should always be considered `sanitized`, even if there are no clustering rules.

This PR does not yet _use_ the flag, it is just a prerequisite for merging https://github.com/getsentry/sentry/pull/48993.

ref: https://github.com/getsentry/team-ingest/issues/124