### PR TITLE
fix(dynamic-sampling): Remove error sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Sample only transaction events instead of sampling both transactions and errors. ([#2130](https://github.com/getsentry/relay/pull/2130))
+
 **Internal**:
 
 - Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))
@@ -13,7 +17,6 @@
 - Enforce rate limits for monitor check-ins. ([#2065](https://github.com/getsentry/relay/pull/2065))
 - Allow rate limits greater than `u32::MAX`. ([#2079](https://github.com/getsentry/relay/pull/2079))
 - Do not drop envelope when client closes connection. ([#2089](https://github.com/getsentry/relay/pull/2089))
-- Sample only transaction events instead of sampling both transactions and errors. ([#2130](https://github.com/getsentry/relay/pull/2130))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Enforce rate limits for monitor check-ins. ([#2065](https://github.com/getsentry/relay/pull/2065))
 - Allow rate limits greater than `u32::MAX`. ([#2079](https://github.com/getsentry/relay/pull/2079))
 - Do not drop envelope when client closes connection. ([#2089](https://github.com/getsentry/relay/pull/2089))
+- Sample only transaction events instead of sampling both transactions and errors. ([#2130](https://github.com/getsentry/relay/pull/2130))
 
 **Features**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2250,14 +2250,17 @@ impl EnvelopeProcessorService {
     /// Apply the dynamic sampling decision from `compute_sampling_decision`.
     fn sample_envelope(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
         match std::mem::take(&mut state.sampling_result) {
-            SamplingResult::Drop(rule_ids) => {
+            // We assume that sampling is only supposed to work on transactions.
+            SamplingResult::Drop(rule_ids)
+                if state.event_type() == Some(EventType::Transaction) =>
+            {
                 state
                     .managed_envelope
                     .reject(Outcome::FilteredSampling(rule_ids.clone()));
 
                 Err(ProcessingError::Sampled(rule_ids))
             }
-            SamplingResult::Keep => Ok(()),
+            _ => Ok(()),
         }
     }
 

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -224,7 +224,7 @@ def _create_error_envelope():
         public_key="abd0f232775f45feab79864e580d160b",
         client_sample_rate=0.5,
         transaction="/transaction",
-        release=["1.0"],
+        release="1.0",
     )
     return envelope, event_id
 

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -252,7 +252,7 @@ def test_it_removes_events(mini_sentry, relay):
 
 def test_it_does_not_sample_error(mini_sentry, relay):
     """
-    Tests that when sampling is set to 0% for the trace context project the events are removed
+    Tests that we keep an event if it is of type error.
     """
     project_id = 42
     relay = relay(mini_sentry, _outcomes_enabled_config())
@@ -281,9 +281,9 @@ def test_it_does_not_sample_error(mini_sentry, relay):
     assert evt_id == event_id
 
 
-def test_it_keeps_error_event(mini_sentry, relay):
+def test_it_keeps_events(mini_sentry, relay):
     """
-    Tests that we keep an event if it is of type error.
+    Tests that when sampling is set to 100% for the trace context project the events are kept
     """
     project_id = 42
     relay = relay(mini_sentry, _outcomes_enabled_config())

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -205,7 +205,7 @@ def _create_transaction_envelope(
     return envelope, trace_id, event_id
 
 
-def _create_error_envelope():
+def _create_error_envelope(public_key):
     envelope = Envelope()
     event_id = "abbcea72-abc7-4ac6-93d2-2b8f366e58d7"
     trace_id = "f26fdb98-68f7-4e10-b9bc-2d2dd9256e53"
@@ -221,8 +221,8 @@ def _create_error_envelope():
     _add_trace_info(
         envelope,
         trace_id=trace_id,
-        public_key="abd0f232775f45feab79864e580d160b",
-        client_sample_rate=0.5,
+        public_key=public_key,
+        client_sample_rate=1.0,
         transaction="/transaction",
         release="1.0",
     )
@@ -276,7 +276,7 @@ def test_it_does_not_sample_error(mini_sentry, relay):
     )
 
     # create an envelope with a trace context that is initiated by this project (for simplicity)
-    envelope, event_id = _create_error_envelope()
+    envelope, event_id = _create_error_envelope(public_key)
 
     # send the event, the transaction should be removed.
     relay.send_envelope(project_id, envelope)


### PR DESCRIPTION
This PR removes the support of `error` rules in dynamic sampling.