### PR TITLE
test(spool): Fix test, sending only 1 test event

### DIFF
--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -102,6 +102,10 @@ def test_readiness_depends_on_aggregator_being_full(mini_sentry, relay):
 
 
 def test_readiness_disk_spool(mini_sentry, relay):
+    @mini_sentry.app.endpoint("store_internal_error_event")
+    def store_internal_error_event():
+        return {}
+
     try:
         temp = tempfile.mkdtemp()
         dbfile = os.path.join(temp, "buffer.db")

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -148,8 +148,6 @@ def test_readiness_disk_spool(mini_sentry, relay):
         try:
             # These events will consume all the disk sapce and we will report not ready.
             relay.send_event(project_key)
-            relay.send_event(project_key)
-            relay.send_event(project_key)
         finally:
             # Authentication failures would fail the test
             mini_sentry.test_failures.clear()


### PR DESCRIPTION
Try to generate fewer events and produce fewer errors. 
This test still should pass and validate the health of the underlying buffer service. 

#skip-changelog