### PR TITLE
ref(crons): Remove SDK from check-in body + extract from header

### DIFF
--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -100,17 +100,6 @@ struct MonitorConfig {
     timezone: Option<String>,
 }
 
-// XXX(epurkhiser): This is a duplicate of the ClientSdkInfo that is part of the relay-general
-// crate. Until we're able to migrate the checkin payload over to it's own protocol using
-// metastructure we'll need to have this duplicated here
-//
-/// The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.
-#[derive(Debug, Deserialize, Serialize)]
-struct MinimalClientSdkInfo {
-    pub name: String,
-    pub version: String,
-}
-
 /// The monitor check-in payload.
 #[derive(Debug, Deserialize, Serialize)]
 struct CheckIn {
@@ -123,10 +112,6 @@ struct CheckIn {
 
     /// Status of this check-in. Defaults to `"unknown"`.
     status: CheckInStatus,
-
-    /// monitor configuration to support upserts.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    sdk: Option<MinimalClientSdkInfo>,
 
     /// The environment to associate the check-in with
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,10 +176,6 @@ mod tests {
   "check_in_id": "a460c25ff2554577b920fcfacae4e5eb",
   "monitor_slug": "my-monitor",
   "status": "in_progress",
-  "sdk": {
-    "name": "sentry.rust",
-    "version": "1.0.0"
-  },
   "environment": "production",
   "duration": 21.0
 }"#;
@@ -211,10 +192,6 @@ mod tests {
   "check_in_id": "a460c25ff2554577b920fcfacae4e5eb",
   "monitor_slug": "my-monitor",
   "status": "in_progress",
-  "sdk": {
-    "name": "sentry.rust",
-    "version": "1.0.0"
-  },
   "monitor_config": {
     "schedule": {
       "type": "crontab",
@@ -235,10 +212,6 @@ mod tests {
   "check_in_id": "a460c25ff2554577b920fcfacae4e5eb",
   "monitor_slug": "my-monitor",
   "status": "in_progress",
-  "sdk": {
-    "name": "sentry.rust",
-    "version": "1.0.0"
-  },
   "monitor_config": {
     "schedule": {
       "type": "interval",
@@ -263,10 +236,6 @@ mod tests {
   "check_in_id": "a460c25ff2554577b920fcfacae4e5eb",
   "monitor_slug": "my-monitor",
   "status": "in_progress",
-  "sdk": {
-    "name": "sentry.rust",
-    "version": "1.0.0"
-  },
   "monitor_config": {
     "schedule": {
       "type": "crontab",

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -199,6 +199,7 @@ impl StoreService {
                     scoping.organization_id,
                     scoping.project_id,
                     start_time,
+                    client,
                     retention,
                     item,
                 )?,
@@ -783,6 +784,7 @@ impl StoreService {
         organization_id: u64,
         project_id: ProjectId,
         start_time: Instant,
+        client: Option<&str>,
         retention_days: u16,
         item: &Item,
     ) -> Result<(), StoreError> {
@@ -790,6 +792,7 @@ impl StoreService {
             project_id,
             retention_days,
             start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+            sdk: client.map(str::to_owned),
             payload: item.payload(),
         });
 
@@ -1052,6 +1055,8 @@ struct CheckInKafkaMessage {
     payload: Bytes,
     /// Time at which the event was received by Relay.
     start_time: u64,
+    /// The SDK client which produced the event.
+    sdk: Option<String>,
     /// The project id for the current event.
     project_id: ProjectId,
     // Number of days to retain.


### PR DESCRIPTION
After a bit of discussion we think it doesn't make sense for this to be
part of the body, since this information is already available in the
envelope headers.

Instead we pass the client SDK name in the kafka message (not the
payload).

This is a follow up from 753995836

#skip-changelog