### PR TITLE
feat(spans): Apply transaction name rules to span descriptions

### DIFF
--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -41,11 +41,11 @@ impl<'r> TransactionsProcessor<'r> {
         let mut span_desc_rules = None;
         if scrub_span_descriptions && !name_config.rules.is_empty() {
             span_desc_rules = Some(
-                (*(name_config.rules))
+                name_config
+                    .rules
                     .iter()
-                    .clone()
-                    .map(|tx_rule| SpanDescriptionRule::from(tx_rule))
-                    .collect::<Vec<SpanDescriptionRule>>(),
+                    .map(SpanDescriptionRule::from)
+                    .collect::<Vec<_>>(),
             );
         }
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2832,6 +2832,19 @@ mod tests {
                         "status": "ok"
                     },
                     {
+                        "description": "POST http://example.com/remains/to-scrub/remains-too/1234567890",
+                        "op": "http.client",
+                        "parent_span_id": "8f5a2b8768cafb4e",
+                        "span_id": "bd2eb23da2beb450",
+                        "start_timestamp": 1597976393.4619668,
+                        "timestamp": 1597976393.4718769,
+                        "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                        "status": "ok",
+                        "data": {
+                            "description.scrubbed": "POST http://example.com/remains/to-scrub/remains-too/*"
+                        }
+                    },
+                    {
                         "description": "GET http://example.com/another/url/is/intact",
                         "op": "http.client",
                         "parent_span_id": "8f5a2b8768cafb4e",

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -109,9 +109,7 @@ impl<'r> TransactionsProcessor<'r> {
         let previously_scrubbed =
             matches!(span.data.value(), Some(data) if data.get("description.scrubbed").is_some());
         if !previously_scrubbed {
-            dbg!(&span.description.clone().value());
             if let Some(description) = span.description.clone().value() {
-                dbg!(&description);
                 span.data
                     .value_mut()
                     .get_or_insert_with(BTreeMap::new)

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -71,7 +71,7 @@ impl<'r> TransactionsProcessor<'r> {
         if let Some(info) = info.as_mut() {
             transaction.apply(|transaction, meta| {
                 let result = self.name_config.rules.iter().find_map(|rule| {
-                    rule.transaction_match_and_apply(Cow::Borrowed(transaction), info)
+                    rule.match_and_apply(Cow::Borrowed(transaction), info)
                         .map(|applied_result| (rule.pattern.compiled().pattern(), applied_result))
                 });
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -124,7 +124,6 @@ impl<'r> TransactionsProcessor<'r> {
 
         let mut scrubbed = false;
 
-        // TODO: only grab from span.data if exists. if not, take it from the span description.
         if let Some(data) = span.data.value_mut() {
             if let Some(description) = data.get_mut("description.scrubbed") {
                 description.apply(|name, meta| {

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2869,6 +2869,7 @@ mod tests {
                         scope: RuleScope::default(),
                         redaction: RedactionRule::default(),
                     }],
+                    ..Default::default()
                 },
                 true,
             ),

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -106,8 +106,11 @@ impl<'r> TransactionsProcessor<'r> {
         // Annotated<Value> vs Annotated<String>. The simplest and fastest
         // solution I found is to add span.description to span.data if it
         // doesn't exist already, scrub it, and remove it if we did nothing.
-        let previously_scrubbed =
-            matches!(span.data.value(), Some(data) if data.get("description.scrubbed").is_some());
+        let previously_scrubbed = span
+            .data
+            .value()
+            .map(|d| d.get("description.scrubbed"))
+            .is_some();
         if !previously_scrubbed {
             if let Some(description) = span.description.clone().value() {
                 span.data

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -57,7 +57,7 @@ impl<'r> TransactionsProcessor<'r> {
         if let Some(info) = info.as_mut() {
             transaction.apply(|transaction, meta| {
                 let result = self.name_config.rules.iter().find_map(|rule| {
-                    rule.match_and_apply(Cow::Borrowed(transaction), info)
+                    rule.transaction_match_and_apply(Cow::Borrowed(transaction), info)
                         .map(|applied_result| (rule.pattern.compiled().pattern(), applied_result))
                 });
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -12,7 +12,7 @@ use crate::utils::Glob;
 /// This allows to compile the Glob with internal regexes only then whent they are used.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LazyGlob {
-    raw: String,
+    pub raw: String,
     glob: OnceCell<Glob>,
 }
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -12,7 +12,7 @@ use crate::utils::Glob;
 /// This allows to compile the Glob with internal regexes only then whent they are used.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LazyGlob {
-    pub raw: String,
+    raw: String,
     glob: OnceCell<Glob>,
 }
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -97,7 +97,7 @@ impl Default for RedactionRule {
 /// The rule describes how span descriptions should be changed.
 #[derive(Debug, Clone)]
 pub struct SpanDescriptionRule {
-    /// The pattern which will be applied to transaction name.
+    /// The pattern which will be applied to the span description.
     pub pattern: LazyGlob,
     /// Date time when the rule expires and it should not be applied anymore.
     pub expiry: DateTime<Utc>,
@@ -110,7 +110,7 @@ pub struct SpanDescriptionRule {
 impl From<&TransactionNameRule> for SpanDescriptionRule {
     fn from(value: &TransactionNameRule) -> Self {
         SpanDescriptionRule {
-            pattern: LazyGlob::new(format!("**{}", rule.pattern.raw)),
+            pattern: LazyGlob::new(format!("**{}", value.pattern.raw)),
             expiry: value.expiry,
             scope: value.scope.clone(),
             redaction: value.redaction.clone(),

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -218,9 +218,8 @@ impl TransactionNameRule {
         }
     }
 
-    /// Returns `true` if the transaction info has a matching transaction source and
-    /// the transaction name matches the rule (see
-    /// [`TransactionNameRule::matches`]).
+    /// Returns `true` if the current rule pattern matches transaction, expected transaction
+    /// source, and not expired yet.
     fn matches(&self, transaction: &str, info: &TransactionInfo) -> bool {
         let now = Utc::now();
         info.source

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -109,15 +109,12 @@ pub struct SpanDescriptionRule {
 
 impl From<&TransactionNameRule> for SpanDescriptionRule {
     fn from(value: &TransactionNameRule) -> Self {
-        // let mut rule: SpanDescriptionRule = value.clone();
-        let mut rule = SpanDescriptionRule {
-            pattern: value.pattern.clone(),
+        SpanDescriptionRule {
+            pattern: LazyGlob::new(format!("**{}", rule.pattern.raw)),
             expiry: value.expiry,
             scope: value.scope.clone(),
             redaction: value.redaction.clone(),
-        };
-        rule.pattern = LazyGlob::new(format!("**{}", rule.pattern.raw));
-        rule
+        }
     }
 }
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -147,8 +147,6 @@ impl SpanDescriptionRule {
     }
 
     /// Applies the rule to the provided value.
-    ///
-    /// Note: currently only `url` source for rules supported.
     fn apply(&self, value: &str) -> String {
         match &self.redaction {
             RedactionRule::Replace { substitution } => self

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_span_identifiers_and_apply_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_span_identifiers_and_apply_rules.snap
@@ -35,6 +35,19 @@ expression: event
     {
       "timestamp": 1597976393.471877,
       "start_timestamp": 1597976393.461967,
+      "description": "POST http://example.com/remains/to-scrub/remains-too/1234567890",
+      "op": "http.client",
+      "span_id": "bd2eb23da2beb450",
+      "parent_span_id": "8f5a2b8768cafb4e",
+      "trace_id": "ff62a8b040f340bda5d830223def1d81",
+      "status": "ok",
+      "data": {
+        "description.scrubbed": "POST http://example.com/remains/*/remains-too/*"
+      }
+    },
+    {
+      "timestamp": 1597976393.471877,
+      "start_timestamp": 1597976393.461967,
       "description": "GET http://example.com/another/url/is/intact",
       "op": "http.client",
       "span_id": "bd2eb23da2beb451",
@@ -57,6 +70,20 @@ expression: event
   "_meta": {
     "spans": {
       "0": {
+        "data": {
+          "description.scrubbed": {
+            "": {
+              "rem": [
+                [
+                  "description.scrubbed:**/remains/*/**",
+                  "s"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      "1": {
         "data": {
           "description.scrubbed": {
             "": {

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_span_identifiers_and_apply_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_span_identifiers_and_apply_rules.snap
@@ -62,7 +62,7 @@ expression: event
             "": {
               "rem": [
                 [
-                  "description.scrubbed:/remains/*/**",
+                  "description.scrubbed:**/remains/*/**",
                   "s"
                 ]
               ]

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_span_identifiers_and_apply_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__scrub_span_identifiers_and_apply_rules.snap
@@ -1,0 +1,75 @@
+---
+source: relay-general/src/store/transactions/processor.rs
+expression: event
+---
+{
+  "type": "transaction",
+  "transaction": "/transaction-name/hi",
+  "transaction_info": {
+    "source": "sanitized"
+  },
+  "timestamp": 1619420400.0,
+  "start_timestamp": 1619420341.0,
+  "contexts": {
+    "trace": {
+      "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+      "span_id": "fa90fdead5f74053",
+      "op": "default",
+      "type": "trace"
+    }
+  },
+  "spans": [
+    {
+      "timestamp": 1597976393.471877,
+      "start_timestamp": 1597976393.461967,
+      "description": "POST http://example.com/remains/to-scrub/remains-too/1234567890",
+      "op": "http.client",
+      "span_id": "bd2eb23da2beb450",
+      "parent_span_id": "8f5a2b8768cafb4e",
+      "trace_id": "ff62a8b040f340bda5d830223def1d81",
+      "status": "ok",
+      "data": {
+        "description.scrubbed": "POST http://example.com/remains/*/remains-too/*"
+      }
+    },
+    {
+      "timestamp": 1597976393.471877,
+      "start_timestamp": 1597976393.461967,
+      "description": "GET http://example.com/another/url/is/intact",
+      "op": "http.client",
+      "span_id": "bd2eb23da2beb451",
+      "parent_span_id": "8f5a2b8768cafb4e",
+      "trace_id": "ff62a8b040f340bda5d830223def1d81",
+      "status": "ok",
+      "data": {}
+    },
+    {
+      "timestamp": 1597976393.471877,
+      "start_timestamp": 1597976393.461967,
+      "description": "POST http://example.com/remains/not-scrubbed-for-different-op/remains-too",
+      "op": "db.sql.query",
+      "span_id": "bd2eb23da2beb452",
+      "parent_span_id": "8f5a2b8768cafb4e",
+      "trace_id": "ff62a8b040f340bda5d830223def1d81",
+      "status": "ok"
+    }
+  ],
+  "_meta": {
+    "spans": {
+      "0": {
+        "data": {
+          "description.scrubbed": {
+            "": {
+              "rem": [
+                [
+                  "description.scrubbed:/remains/*/**",
+                  "s"
+                ]
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Applies transaction name rules to span descriptions with a URL-like pattern. Notes:

- We say a span description has a URL-like format when a span's operation starts with `http`.
- Transaction name rules are created on the assumption of a specific transaction name format. Span descriptions have a different format: there's an HTTP verb as a prefix of the string. Thus, I decided to adapt the rule (vs removing the prefix, for the edge cases) and add a leading `**` to match any leading substring (i.e. not only HTTP verbs). Since we're only applying this to URL-like transactions, we don't have to worry about other types.
- We'll consider in the future applying rules to resource-like span descriptions.

#skip-changelog