### PR TITLE
feat(txnames): Use txNameReady flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))
+- Mark all URL transactions as `sanitized` when `txNameReady` flag is set. ([#2128](https://github.com/getsentry/relay/pull/2128), [#2139](https://github.com/getsentry/relay/pull/2139))
 
 ## 23.5.0
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2294,6 +2294,7 @@ impl EnvelopeProcessorService {
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
                     rules: &state.project_state.config.tx_name_rules,
+                    ready: state.project_state.config.tx_name_ready,
                 },
                 device_class_synthesis_config: state
                     .project_state
@@ -3468,6 +3469,7 @@ mod tests {
                                 substitution: "*".to_owned(),
                             },
                         }],
+                        ready: false,
                     },
                     ..Default::default()
                 };


### PR DESCRIPTION
Start using the flag introduced by https://github.com/getsentry/sentry/pull/48993 and https://github.com/getsentry/relay/pull/2128.

Once the clusterer has run ~10 times, trust that all the rules than can be discovered have been discovered, and mark all incoming URL transactions as sanitized.

ref: https://github.com/getsentry/team-ingest/issues/124