### PR TITLE
feat(spans): Add span metrics to span.data

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -572,12 +572,12 @@ fn extract_span_metrics(
             }
 
             // Even if we emit metrics, we want this info to be duplicated in every span.
-            for (key, value) in &span_tags {
-                span.data.get_or_insert_with(BTreeMap::new).insert(
-                    key.to_owned(),
-                    Annotated::from(Value::String(value.to_owned())),
-                );
-            }
+            span.data.get_or_insert_with(BTreeMap::new).extend(
+                span_tags
+                    .clone()
+                    .into_iter()
+                    .map(|(k, v)| (k, Annotated::new(Value::String(v)))),
+            );
 
             if let Some(user) = event.user.value() {
                 if let Some(value) = get_eventuser_tag(user) {

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -1,0 +1,451 @@
+---
+source: relay-server/src/metrics_extraction/transactions/mod.rs
+expression: event.value().unwrap().spans
+---
+[
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "<OrganizationContext>",
+        op: "react.mount",
+        span_id: SpanId(
+            "bd429c44b67a3eb4",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: ~,
+        tags: ~,
+        origin: ~,
+        data: {
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.op": String(
+                "react.mount",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "POST http://sth.subdomain.domain.tld:targetport/api/hi",
+        op: "http.client",
+        span_id: SpanId(
+            "bd2eb23da2beb459",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "environment": String(
+                "fake_environment",
+            ),
+            "http.method": String(
+                "POST",
+            ),
+            "span.action": String(
+                "POST",
+            ),
+            "span.domain": String(
+                "*.domain.tld:targetport",
+            ),
+            "span.module": String(
+                "http",
+            ),
+            "span.op": String(
+                "http.client",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.status_code": String(
+                "200",
+            ),
+            "status_code": String(
+                "200",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "POST http://targetdomain.tld:targetport/api/hi",
+        op: "http.client",
+        span_id: SpanId(
+            "bd2eb23da2beb459",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "environment": String(
+                "fake_environment",
+            ),
+            "http.method": String(
+                "POST",
+            ),
+            "span.action": String(
+                "POST",
+            ),
+            "span.domain": String(
+                "targetdomain.tld:targetport",
+            ),
+            "span.module": String(
+                "http",
+            ),
+            "span.op": String(
+                "http.client",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.status_code": String(
+                "200",
+            ),
+            "status_code": String(
+                "200",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "POST http://targetdomain:targetport/api/id/0987654321",
+        op: "http.client",
+        span_id: SpanId(
+            "bd2eb23da2beb459",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "description.scrubbed": String(
+                "POST http://targetdomain:targetport/api/id/*",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "http.method": String(
+                "POST",
+            ),
+            "span.action": String(
+                "POST",
+            ),
+            "span.description": String(
+                "POST http://targetdomain:targetport/api/id/*",
+            ),
+            "span.domain": String(
+                "targetdomain:targetport",
+            ),
+            "span.module": String(
+                "http",
+            ),
+            "span.op": String(
+                "http.client",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.status_code": String(
+                "200",
+            ),
+            "status_code": String(
+                "200",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "SELECT column FROM table WHERE id IN (1, 2, 3)",
+        op: "db",
+        span_id: SpanId(
+            "bb7af8b99e95af5f",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "db.operation": String(
+                "SELECT",
+            ),
+            "db.system": String(
+                "MyDatabase",
+            ),
+            "description.scrubbed": String(
+                "SELECT column FROM table WHERE id IN (%s)",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.action": String(
+                "SELECT",
+            ),
+            "span.description": String(
+                "SELECT column FROM table WHERE id IN (%s)",
+            ),
+            "span.module": String(
+                "db",
+            ),
+            "span.op": String(
+                "db",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.system": String(
+                "MyDatabase",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "SAVEPOINT save_this_one",
+        op: "db",
+        span_id: SpanId(
+            "bb7af8b99e95af5f",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "db.operation": String(
+                "SELECT",
+            ),
+            "db.system": String(
+                "MyDatabase",
+            ),
+            "description.scrubbed": String(
+                "SAVEPOINT %s",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.action": String(
+                "SELECT",
+            ),
+            "span.description": String(
+                "SAVEPOINT %s",
+            ),
+            "span.module": String(
+                "db",
+            ),
+            "span.op": String(
+                "db",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.system": String(
+                "MyDatabase",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "GET cache:user:{123}",
+        op: "cache.get_item",
+        span_id: SpanId(
+            "bb7af8b99e95af5f",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "cache.hit": Bool(
+                false,
+            ),
+            "description.scrubbed": String(
+                "GET cache:user:*",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.description": String(
+                "GET cache:user:*",
+            ),
+            "span.module": String(
+                "cache",
+            ),
+            "span.op": String(
+                "cache.get_item",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:19:53.471876859Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:19:53.461966753Z,
+        ),
+        exclusive_time: ~,
+        description: "http://domain/static/myscript-v1.9.23.js",
+        op: "resource.script",
+        span_id: SpanId(
+            "bb7af8b99e95af5f",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "description.scrubbed": String(
+                "http://domain/static/myscript-*.js",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.description": String(
+                "http://domain/static/myscript-*.js",
+            ),
+            "span.op": String(
+                "resource.script",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+]


### PR DESCRIPTION
Adds span metrics to `span.data`, even if metrics are extracted. This is useful to have metrics available when querying spans.

#skip-changelog