### PR TITLE
build: Use sentry CLI v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ### Deps stage ###
 ##################
 
-FROM getsentry/sentry-cli:1 AS sentry-cli
+FROM getsentry/sentry-cli:2 AS sentry-cli
 FROM centos:7 AS relay-deps
 
 # Rust version must be provided by the caller.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM getsentry/sentry-cli:1 AS sentry-cli
+FROM getsentry/sentry-cli:2 AS sentry-cli
 FROM centos:7 AS relay-deps
 
 # Rust version must be provided by the caller.


### PR DESCRIPTION
We have recently encountered cases where the call to `sentry-cli` in the `create-sentry-release` script was killed by the OOM killer. Using a newer version of `sentry-cli` might help.

#skip-changelog