### PR TITLE
fix(dynamic-sampling): Fix missing sampling project state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Sample only transaction events instead of sampling both transactions and errors. ([#2130](https://github.com/getsentry/relay/pull/2130))
+- Fix tagging of incoming errors with `sampled` that was not done due to lack of sampling state. ([#2148](https://github.com/getsentry/relay/pull/2148))
 
 **Internal**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2325,6 +2325,7 @@ impl EnvelopeProcessorService {
             // we will end up overriding the value set by downstream Relays and this will lead
             // to more complex debugging in case of problems.
             if boxed_context.sampled.is_empty() {
+                relay_log::trace!("tagging error with `sampled` flag");
                 boxed_context.sampled = Annotated::new(match sampling_result {
                     SamplingResult::Keep => true,
                     SamplingResult::Drop(_) => false,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2325,11 +2325,12 @@ impl EnvelopeProcessorService {
             // we will end up overriding the value set by downstream Relays and this will lead
             // to more complex debugging in case of problems.
             if boxed_context.sampled.is_empty() {
-                relay_log::trace!("tagging error with `sampled` flag");
-                boxed_context.sampled = Annotated::new(match sampling_result {
+                let sampled = match sampling_result {
                     SamplingResult::Keep => true,
                     SamplingResult::Drop(_) => false,
-                });
+                };
+                relay_log::trace!("tagging error with `sampled = {}` flag", sampled);
+                boxed_context.sampled = Annotated::new(sampled);
             }
         }
     }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -109,7 +109,7 @@ pub fn get_sampling_result(
 ///  - there is no [`DynamicSamplingContext`] in the envelope headers.
 ///  - there are no transactions or events in the envelope, since in this case sampling by trace is redundant.
 pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
-    // If we the envelope item is not of type transaction or event, we will not return a sampling key
+    // If the envelope item is not of type transaction or event, we will not return a sampling key
     // because it doesn't make sense to load the root project state if we don't perform trace
     // sampling.
     envelope

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -1,6 +1,5 @@
 //! Functionality for calculating if a trace should be processed or dropped.
 //!
-use brotli::enc::threading::InternalOwned::Item;
 use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -292,6 +292,48 @@ def test_it_does_not_sample_error(mini_sentry, relay):
     assert evt_id == event_id
 
 
+@pytest.mark.parametrize(
+    "expected_sampled, sample_rate",
+    [
+        (True, 1.0),
+        (False, 0.0),
+    ],
+)
+def test_it_tags_error(mini_sentry, relay, expected_sampled, sample_rate):
+    """
+    Tests that it tags an incoming error if the trace connected to it its sampled or not.
+    """
+    project_id = 42
+    relay = relay(mini_sentry, _outcomes_enabled_config())
+
+    # create a basic project config
+    config = mini_sentry.add_basic_project_config(project_id)
+    public_key = config["publicKeys"][0]["publicKey"]
+
+    # add a sampling rule to project config that keeps all events (sample_rate=1)
+    _add_sampling_config(
+        config, sample_rate=sample_rate, rule_type="trace", releases=["1.0"]
+    )
+
+    # create an envelope with a trace context that is initiated by this project (for simplicity)
+    envelope, event_id = _create_error_envelope(public_key)
+
+    # send the event, the transaction should be removed.
+    relay.send_envelope(project_id, envelope)
+    # test that error is kept by Relay
+    envelope = mini_sentry.captured_events.get(timeout=1)
+    assert envelope is not None
+    # double check that we get back our object
+    # we put the id in extra since Relay overrides the initial event_id
+    items = [item for item in envelope]
+    assert len(items) == 1
+    evt = items[0].payload.json
+    # we check if it is marked as sampled
+    assert evt["contexts"]["trace"]["sampled"] == expected_sampled
+    evt_id = evt.setdefault("extra", {}).get("id")
+    assert evt_id == event_id
+
+
 def test_it_keeps_events(mini_sentry, relay):
     """
     Tests that when sampling is set to 100% for the trace context project the events are kept


### PR DESCRIPTION
This PR fixes a problem in which the sampling project state was not loaded for incoming items of type event.