### PR TITLE
ref: Use different error message for empty strings in schema processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Use different error message for empty strings in schema processing. ([#2151](https://github.com/getsentry/relay/pull/2151))
+
 ## 23.5.1
 
 **Bug Fixes**:

--- a/relay-general/src/store/schema.rs
+++ b/relay-general/src/store/schema.rs
@@ -13,7 +13,7 @@ impl Processor for SchemaProcessor {
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
         value_trim_whitespace(value, meta, state);
-        verify_value_nonempty(value, meta, state)?;
+        verify_value_nonempty_string(value, meta, state)?;
         verify_value_characters(value, meta, state)?;
         Ok(())
     }
@@ -78,6 +78,22 @@ where
 {
     if state.attrs().nonempty && value.is_empty() {
         meta.add_error(Error::nonempty());
+        Err(ProcessingAction::DeleteValueHard)
+    } else {
+        Ok(())
+    }
+}
+
+fn verify_value_nonempty_string<T>(
+    value: &mut T,
+    meta: &mut Meta,
+    state: &ProcessingState<'_>,
+) -> ProcessingResult
+where
+    T: Empty,
+{
+    if state.attrs().nonempty && value.is_empty() {
+        meta.add_error(Error::nonempty_string());
         Err(ProcessingAction::DeleteValueHard)
     } else {
         Ok(())

--- a/relay-general/src/store/schema.rs
+++ b/relay-general/src/store/schema.rs
@@ -155,9 +155,35 @@ mod tests {
         );
     }
 
+    fn assert_nonempty_string<String>()
+    where
+        String: Default + PartialEq + crate::processor::ProcessValue,
+    {
+        #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+        struct Foo<String> {
+            #[metastructure(required = "true", nonempty = "true")]
+            bar: Annotated<String>,
+            bar2: Annotated<String>,
+        }
+
+        let mut wrapper = Annotated::new(Foo {
+            bar: Annotated::new(String::default()),
+            bar2: Annotated::new(String::default()),
+        });
+        process_value(&mut wrapper, &mut SchemaProcessor, ProcessingState::root()).unwrap();
+
+        assert_eq!(
+            wrapper,
+            Annotated::new(Foo {
+                bar: Annotated::from_error(Error::expected("a non-empty string"), None),
+                bar2: Annotated::new(String::default())
+            })
+        );
+    }
+
     #[test]
     fn test_nonempty_string() {
-        assert_nonempty_base::<String>();
+        assert_nonempty_string::<String>();
     }
 
     #[test]

--- a/relay-general/src/store/schema.rs
+++ b/relay-general/src/store/schema.rs
@@ -129,7 +129,7 @@ mod tests {
     };
     use crate::types::{Annotated, Array, Error, ErrorKind, Object};
 
-    fn assert_nonempty_base<T>()
+    fn assert_nonempty_base<T>(expected_error: &str)
     where
         T: Default + PartialEq + crate::processor::ProcessValue,
     {
@@ -149,51 +149,25 @@ mod tests {
         assert_eq!(
             wrapper,
             Annotated::new(Foo {
-                bar: Annotated::from_error(Error::expected("a non-empty value"), None),
+                bar: Annotated::from_error(Error::expected(expected_error), None),
                 bar2: Annotated::new(T::default())
-            })
-        );
-    }
-
-    fn assert_nonempty_string<String>()
-    where
-        String: Default + PartialEq + crate::processor::ProcessValue,
-    {
-        #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
-        struct Foo<String> {
-            #[metastructure(required = "true", nonempty = "true")]
-            bar: Annotated<String>,
-            bar2: Annotated<String>,
-        }
-
-        let mut wrapper = Annotated::new(Foo {
-            bar: Annotated::new(String::default()),
-            bar2: Annotated::new(String::default()),
-        });
-        process_value(&mut wrapper, &mut SchemaProcessor, ProcessingState::root()).unwrap();
-
-        assert_eq!(
-            wrapper,
-            Annotated::new(Foo {
-                bar: Annotated::from_error(Error::expected("a non-empty string"), None),
-                bar2: Annotated::new(String::default())
             })
         );
     }
 
     #[test]
     fn test_nonempty_string() {
-        assert_nonempty_string::<String>();
+        assert_nonempty_base::<String>("a non-empty string");
     }
 
     #[test]
     fn test_nonempty_array() {
-        assert_nonempty_base::<Array<u64>>();
+        assert_nonempty_base::<Array<u64>>("a non-empty value");
     }
 
     #[test]
     fn test_nonempty_object() {
-        assert_nonempty_base::<Object<u64>>();
+        assert_nonempty_base::<Object<u64>>("a non-empty value");
     }
 
     #[test]

--- a/relay-general/src/types/meta.rs
+++ b/relay-general/src/types/meta.rs
@@ -314,6 +314,12 @@ impl Error {
         Error::invalid("expected a non-empty value")
     }
 
+    /// Creates an error that describes an expected non-empty string.
+    pub fn nonempty_string() -> Self {
+        // TODO: Replace `invalid_data` this with an explicity error constant for empty values
+        Error::invalid("expected a non-empty string")
+    }
+
     /// Returns the kind of this error.
     pub fn kind(&self) -> &ErrorKind {
         &self.kind


### PR DESCRIPTION
Fixes #2137