### PR TITLE
fix(py): Compile regex patterns in PII config validation

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Compile regexes in PII config validation. ([2152](https://github.com/getsentry/relay/pull/2152))
+
 ## 0.8.23
 
 - Add `txNameReady` flag to project config. ([#2128](https://github.com/getsentry/relay/pull/2128))

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn run_dynamic_sampling(
 }
 
 #[test]
-fn pii_config_needs_to_compile() {
+fn pii_config_validation_invalid_regex() {
     let config = r#"
         {
           "rules": {
@@ -408,5 +408,30 @@ fn pii_config_needs_to_compile() {
     assert_eq!(
         unsafe { relay_validate_pii_config(&RelayStr::from(config)).as_str() },
         "regex parse error:\n    (not valid regex\n    ^\nerror: unclosed group"
+    );
+}
+
+#[test]
+fn pii_config_validation_valid_regex() {
+    let config = r#"
+        {
+          "rules": {
+            "strip-fields": {
+              "type": "redact_pair",
+              "keyPattern": "(\\w+)?+",
+              "redaction": {
+                "method": "replace",
+                "text": "[Filtered]"
+              }
+            }
+          },
+          "applications": {
+            "*.everything": ["strip-fields"]
+          }
+        }
+    "#;
+    assert_eq!(
+        unsafe { relay_validate_pii_config(&RelayStr::from(config)).as_str() },
+        ""
     );
 }

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -13,7 +13,7 @@ use once_cell::sync::OnceCell;
 use relay_common::{codeowners_match_bytes, glob_match_bytes, GlobOptions};
 use relay_dynamic_config::{validate_json, ProjectConfig};
 use relay_general::pii::{
-    selector_suggestions_from_value, DataScrubbingConfig, PiiConfig, PiiProcessor,
+    selector_suggestions_from_value, DataScrubbingConfig, PiiConfig, PiiConfigError, PiiProcessor,
 };
 use relay_general::processor::{process_value, split_chunks, ProcessingState};
 use relay_general::protocol::{Event, VALID_PLATFORMS};
@@ -152,8 +152,11 @@ pub unsafe extern "C" fn relay_translate_legacy_python_json(event: *mut RelayStr
 #[no_mangle]
 #[relay_ffi::catch_unwind]
 pub unsafe extern "C" fn relay_validate_pii_config(value: *const RelayStr) -> RelayStr {
-    match serde_json::from_str((*value).as_str()) {
-        Ok(PiiConfig { .. }) => RelayStr::new(""),
+    match serde_json::from_str::<PiiConfig>((*value).as_str()) {
+        Ok(config) => match config.compiled().force_compile() {
+            Ok(_) => RelayStr::new(""),
+            Err(PiiConfigError::RegexError(source)) => RelayStr::from_string(source.to_string()),
+        },
         Err(e) => RelayStr::from_string(e.to_string()),
     }
 }
@@ -390,17 +393,20 @@ fn pii_config_needs_to_compile() {
           "rules": {
             "strip-fields": {
               "type": "redact_pair",
-              "keyPattern": "\/",
+              "keyPattern": "(not valid regex",
               "redaction": {
                 "method": "replace",
                 "text": "[Filtered]"
               }
             }
+          },
+          "applications": {
+            "*.everything": ["strip-fields"]
           }
         }
     "#;
     assert_eq!(
         unsafe { relay_validate_pii_config(&RelayStr::from(config)).as_str() },
-        ""
+        "regex parse error:\n    (not valid regex\n    ^\nerror: unclosed group"
     );
 }

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -382,3 +382,25 @@ pub unsafe extern "C" fn run_dynamic_sampling(
 
     RelayStr::from(serde_json::to_string(&result).unwrap())
 }
+
+#[test]
+fn pii_config_needs_to_compile() {
+    let config = r#"
+        {
+          "rules": {
+            "strip-fields": {
+              "type": "redact_pair",
+              "keyPattern": "\/",
+              "redaction": {
+                "method": "replace",
+                "text": "[Filtered]"
+              }
+            }
+          }
+        }
+    "#;
+    assert_eq!(
+        unsafe { relay_validate_pii_config(&RelayStr::from(config)).as_str() },
+        ""
+    );
+}

--- a/relay-general/src/pii/compiledconfig.rs
+++ b/relay-general/src/pii/compiledconfig.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
 use crate::pii::builtin::BUILTIN_RULES_MAP;
-use crate::pii::{LazyPattern, PiiConfig, PiiConfigError, Redaction, RuleSpec, RuleType};
+use crate::pii::{PiiConfig, PiiConfigError, Redaction, RuleSpec, RuleType};
 use crate::processor::SelectorSpec;
 
 /// A representation of `PiiConfig` that is more (CPU-)efficient for use in `PiiProcessor`. It is
@@ -28,7 +28,7 @@ impl CompiledPiiConfig {
         CompiledPiiConfig { applications }
     }
 
-    /// Force compilation of all [`LazyPattern`]s in this config.
+    /// Force compilation of all regex patterns in this config.
     ///
     /// Used to verify that all patterns are valid regex.
     pub fn force_compile(&self) -> Result<(), PiiConfigError> {

--- a/relay-general/src/pii/compiledconfig.rs
+++ b/relay-general/src/pii/compiledconfig.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
 use crate::pii::builtin::BUILTIN_RULES_MAP;
-use crate::pii::{PiiConfig, PiiConfigError, Redaction, RuleSpec, RuleType};
+use crate::pii::{LazyPattern, PiiConfig, PiiConfigError, Redaction, RuleSpec, RuleType};
 use crate::processor::SelectorSpec;
 
 /// A representation of `PiiConfig` that is more (CPU-)efficient for use in `PiiProcessor`. It is
@@ -30,7 +30,7 @@ impl CompiledPiiConfig {
 
     /// Force compilation of all [`LazyPattern`]s in this config.
     ///
-    /// Useful for validation.
+    /// Used to verify that all patterns are valid regex.
     pub fn force_compile(&self) -> Result<(), PiiConfigError> {
         for rule in self.applications.iter().flat_map(|(_, rules)| rules.iter()) {
             match &rule.ty {


### PR DESCRIPTION
In `relay_validate_pii_config`, compile all regex patterns contained in PII config, such that invalid patterns configured in the UI cannot be saved.

Fixes https://github.com/getsentry/relay/issues/1626

#skip-changelog