### PR TITLE
instr(txnames): Tag 404s

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3750,7 +3750,7 @@ mod tests {
         let captures = capture_test_event("/nothing", TransactionSource::Url);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:sanitized",
+            "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:sanitized,is_404:false",
         ]
         "###);
     }
@@ -3770,7 +3770,7 @@ mod tests {
         let captures = capture_test_event("/something/12345", TransactionSource::Url);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:sanitized",
+            "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:sanitized,is_404:false",
         ]
         "###);
     }
@@ -3780,7 +3780,7 @@ mod tests {
         let captures = capture_test_event("/foo/john/12345", TransactionSource::Url);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:url,changes:both,source_out:sanitized",
+            "event.transaction_name_changes:1|c|#source_in:url,changes:both,source_out:sanitized,is_404:false",
         ]
         "###);
     }
@@ -3790,7 +3790,7 @@ mod tests {
         let captures = capture_test_event("/foo/john/12345", TransactionSource::Route);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:route,changes:none,source_out:route",
+            "event.transaction_name_changes:1|c|#source_in:route,changes:none,source_out:route,is_404:false",
         ]
         "###);
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3760,7 +3760,7 @@ mod tests {
         let captures = capture_test_event("/foo/john/denver", TransactionSource::Url);
         insta::assert_debug_snapshot!(captures, @r###"
         [
-            "event.transaction_name_changes:1|c|#source_in:url,changes:rule,source_out:sanitized",
+            "event.transaction_name_changes:1|c|#source_in:url,changes:rule,source_out:sanitized,is_404:false",
         ]
         "###);
     }

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -51,12 +51,16 @@ where
     };
 
     let new_source = inner.get_transaction_source();
+    let is_404 = inner
+        .get_tag_value("http.status_code")
+        .map_or(false, |s| s == "404");
 
     relay_statsd::metric!(
         counter(RelayCounters::TransactionNameChanges) += 1,
         source_in = old_source.as_str(),
         changes = changes,
         source_out = new_source.as_str(),
+        is_404 = if is_404 { "true" } else { "false" },
     );
 
     res


### PR DESCRIPTION
We now mark all URL transactions as sanitized after 10 clusterer runs (see https://github.com/getsentry/sentry/pull/48993), except 404s. Tag those explicitly on the metric so we can confirm that non-404s are now sanitized at 100%.

ref: https://github.com/getsentry/team-ingest/issues/124

#skip-changelog