### PR TITLE
instr(txnames): Use extraction function to log status code

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -104,7 +104,7 @@ fn http_status_code_from_span_data(span: &Span) -> Option<String> {
 }
 
 /// Extracts the HTTP status code.
-fn extract_http_status_code(event: &Event) -> Option<String> {
+pub(crate) fn extract_http_status_code(event: &Event) -> Option<String> {
     if let Some(spans) = event.spans.value() {
         for span in spans {
             if let Some(span_value) = span.value() {

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -2,6 +2,7 @@ use relay_common::EventType;
 use relay_general::protocol::Event;
 use relay_general::types::{Annotated, RemarkType};
 
+use crate::metrics_extraction::transactions::extract_http_status_code;
 use crate::statsd::RelayCounters;
 
 /// Log statsd metrics about transaction name modifications.
@@ -51,9 +52,7 @@ where
     };
 
     let new_source = inner.get_transaction_source();
-    let is_404 = inner
-        .get_tag_value("http.status_code")
-        .map_or(false, |s| s == "404");
+    let is_404 = extract_http_status_code(inner).map_or(false, |s| s == "404");
 
     relay_statsd::metric!(
         counter(RelayCounters::TransactionNameChanges) += 1,


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/2155 introduced a new statsd tag on the transaction name change metric, but it does not look at fields other than the `http.status_code` tag on the top-level event, which seems to get normalized in sentry.

Use the new status code extraction function to get a better picture.

#skip-changelog