### PR TITLE
instr(txname): Log sentry error for remaining URL transactions

### DIFF
--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -1,5 +1,5 @@
 use relay_common::EventType;
-use relay_general::protocol::Event;
+use relay_general::protocol::{Event, TransactionSource};
 use relay_general::types::{Annotated, RemarkType};
 
 use crate::metrics_extraction::transactions::extract_http_status_code;
@@ -27,13 +27,13 @@ where
     let res = f(event);
 
     // Need to reborrow event so the reference's lifetime does not overlap with `f`:
-    let Some(inner) = event.value() else {
+    let Some(event) = event.value() else {
         return res;
     };
 
     let mut pattern_based_changes = false;
     let mut rule_based_changes = false;
-    let remarks = inner.transaction.meta().iter_remarks().skip(old_remarks);
+    let remarks = event.transaction.meta().iter_remarks().skip(old_remarks);
     for remark in remarks {
         if remark.ty() == RemarkType::Substituted {
             if remark.range().is_some() {
@@ -51,8 +51,20 @@ where
         (false, false) => "none",
     };
 
-    let new_source = inner.get_transaction_source();
-    let is_404 = extract_http_status_code(inner).map_or(false, |s| s == "404");
+    let new_source = event.get_transaction_source();
+    let is_404 = extract_http_status_code(event).map_or(false, |s| s == "404");
+
+    // Temporarily log a sentry error for every 100th transaction that goes out as URL.
+    // This block can be deleted once the investigation is done.
+    if let Some(event_id) = event.id.value() {
+        if new_source == &TransactionSource::Url && (event_id.0.as_u128() % 100) == 0 {
+            relay_log::error!(
+                tags.project_id = event.project.0.unwrap_or_default(),
+                event_id = event_id.0.to_string(),
+                "Transaction marked as URL"
+            );
+        }
+    }
 
     relay_statsd::metric!(
         counter(RelayCounters::TransactionNameChanges) += 1,


### PR DESCRIPTION
Temporarily log a sentry error for 1% of transactions that are still `source:url` after normalization to get some project IDs / event IDs to investigate.

Assumes that event IDs are randomly distributed.

#skip-changelog