### PR TITLE
chore(docs): Add a note about why `trust-dns` option enabled on reqwest

### DIFF
--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -713,6 +713,9 @@ impl SharedClient {
             // In the forward endpoint, this means that content negotiation is done twice, and the
             // response body is first decompressed by the client, then re-compressed by the server.
             .gzip(true)
+            // Enables async resolver through the `trust-dns-resolver` crate, which uses an LRU cache for the resolved entries.
+            // This helps to limit the amount of requests made to upstream DNS server (important
+            // for K8s infrastructure).
             .trust_dns(true)
             .build()
             .unwrap();


### PR DESCRIPTION
Add more docs.

supersedes https://github.com/getsentry/relay/pull/2160

#skip-changelog