### PR TITLE
ref(profiles): Count processed profiles with metrics

### DIFF
--- a/relay-profiling/src/error.rs
+++ b/relay-profiling/src/error.rs
@@ -26,4 +26,6 @@ pub enum ProfileError {
     MalformedSamples,
     #[error("exceed size limit")]
     ExceedSizeLimit,
+    #[error("too many profiles")]
+    TooManyProfiles,
 }

--- a/relay-profiling/src/outcomes.rs
+++ b/relay-profiling/src/outcomes.rs
@@ -14,5 +14,6 @@ pub fn discard_reason(err: ProfileError) -> &'static str {
         ProfileError::NoTransactionAssociated => "profiling_no_transaction_associated",
         ProfileError::NotEnoughSamples => "profiling_not_enough_samples",
         ProfileError::PlatformNotSupported => "profiling_platform_not_supported",
+        ProfileError::TooManyProfiles => "profiling_too_many_profiles",
     }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2729,7 +2729,6 @@ mod tests {
     use std::str::FromStr;
 
     use chrono::{DateTime, TimeZone, Utc};
-    use insta::assert_debug_snapshot;
     use similar_asserts::assert_eq;
 
     use relay_common::{DurationUnit, MetricUnit, Uuid};

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1067,23 +1067,23 @@ impl EnvelopeProcessorService {
     fn filter_profiles(&self, state: &mut ProcessEnvelopeState) {
         let mut found_profile = false;
         state.managed_envelope.retain_items(|item| match item.ty() {
-            ItemType::Profile => match relay_profiling::parse_metadata(&item.payload()) {
-                Ok(_) => {
-                    if !found_profile {
-                        // Found first profile, keep it.
-                        found_profile = true;
-                        ItemAction::Keep
-                    } else {
-                        // We found a second profile, drop it.
-                        ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
-                            relay_profiling::discard_reason(ProfileError::TooManyProfiles),
-                        )))
-                    }
+            ItemType::Profile => {
+                if !found_profile {
+                    // Found first profile, keep it.
+                    found_profile = true;
+                } else {
+                    // We found a second profile, drop it.
+                    return ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
+                        relay_profiling::discard_reason(ProfileError::TooManyProfiles),
+                    )));
                 }
-                Err(err) => ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
-                    relay_profiling::discard_reason(err),
-                ))),
-            },
+                match relay_profiling::parse_metadata(&item.payload()) {
+                    Ok(_) => ItemAction::Keep,
+                    Err(err) => ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
+                        relay_profiling::discard_reason(err),
+                    ))),
+                }
+            }
             _ => ItemAction::Keep,
         });
         state.has_profile = found_profile;
@@ -2725,9 +2725,11 @@ impl Service for EnvelopeProcessorService {
 
 #[cfg(test)]
 mod tests {
+    use std::env;
     use std::str::FromStr;
 
     use chrono::{DateTime, TimeZone, Utc};
+    use insta::assert_debug_snapshot;
     use similar_asserts::assert_eq;
 
     use relay_common::{DurationUnit, MetricUnit, Uuid};

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -550,7 +550,11 @@ impl Item {
             ItemType::Metrics | ItemType::MetricBuckets => None,
             ItemType::FormData => None,
             ItemType::UserReport => None,
-            ItemType::Profile => Some(DataCategory::Profile),
+            ItemType::Profile => Some(if indexed {
+                DataCategory::ProfileIndexed
+            } else {
+                DataCategory::Profile
+            }),
             ItemType::ReplayEvent | ItemType::ReplayRecording => Some(DataCategory::Replay),
             ItemType::ClientReport => None,
             ItemType::CheckIn => Some(DataCategory::Monitor),

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -15,8 +15,8 @@ use relay_metrics::{AggregatorConfig, Metric, MetricNamespace, MetricValue};
 
 use crate::metrics_extraction::conditional_tagging::run_conditional_tagging;
 use crate::metrics_extraction::transactions::types::{
-    CommonTag, CommonTags, ExtractMetricsError, TransactionCPRTags, TransactionMeasurementTags,
-    TransactionMetric,
+    CommonTag, CommonTags, ExtractMetricsError, TransactionCPRTags, TransactionDurationTags,
+    TransactionMeasurementTags, TransactionMetric,
 };
 use crate::metrics_extraction::IntoMetric;
 use crate::statsd::RelayCounters;
@@ -462,7 +462,10 @@ fn extract_transaction_metrics_inner(
         TransactionMetric::Duration {
             unit: DurationUnit::MilliSecond,
             value: relay_common::chrono_to_positive_millis(end - start),
-            tags: tags.clone(),
+            tags: TransactionDurationTags {
+                has_profile,
+                universal_tags: tags.clone(),
+            },
         }
         .into_metric(timestamp),
     );

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -334,6 +334,7 @@ pub fn extract_transaction_metrics(
     event: &mut Event,
     transaction_from_dsc: Option<&str>,
     sampling_result: &SamplingResult,
+    has_profile: bool,
     project_metrics: &mut Vec<Metric>,  // output parameter
     sampling_metrics: &mut Vec<Metric>, // output parameter
 ) -> Result<bool, ExtractMetricsError> {
@@ -345,6 +346,7 @@ pub fn extract_transaction_metrics(
         event,
         transaction_from_dsc,
         sampling_result,
+        has_profile,
         project_metrics,
         sampling_metrics,
     )?;
@@ -364,6 +366,7 @@ fn extract_transaction_metrics_inner(
     event: &Event,
     transaction_from_dsc: Option<&str>,
     sampling_result: &SamplingResult,
+    has_profile: bool,
     metrics: &mut Vec<Metric>,          // output parameter
     sampling_metrics: &mut Vec<Metric>, // output parameter
 ) -> Result<(), ExtractMetricsError> {
@@ -1079,6 +1082,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -1813,6 +1817,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -1906,6 +1911,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -1986,6 +1992,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2062,6 +2069,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2173,6 +2181,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2261,6 +2270,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2311,6 +2321,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2351,6 +2362,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2400,6 +2412,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         );
@@ -2426,6 +2439,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2466,6 +2480,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("root_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )
@@ -2840,6 +2855,7 @@ mod tests {
             event.value_mut().as_mut().unwrap(),
             Some("test_transaction"),
             &SamplingResult::Keep,
+            false,
             &mut metrics,
             &mut sampling_metrics,
         )

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -19,7 +19,7 @@ pub enum TransactionMetric {
     Duration {
         unit: DurationUnit,
         value: DistributionType,
-        tags: CommonTags,
+        tags: TransactionDurationTags,
     },
     /// An internal counter metric used to compute dynamic sampling biases.
     ///
@@ -93,6 +93,22 @@ impl IntoMetric for TransactionMetric {
                 tags.into(),
             ),
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+pub struct TransactionDurationTags {
+    pub has_profile: bool,
+    pub universal_tags: CommonTags,
+}
+
+impl From<TransactionDurationTags> for BTreeMap<String, String> {
+    fn from(tags: TransactionDurationTags) -> Self {
+        let mut map: BTreeMap<String, String> = tags.universal_tags.into();
+        if tags.has_profile {
+            map.insert("has_profile".to_string(), "true".to_string());
+        }
+        map
     }
 }
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -326,7 +326,11 @@ impl ManagedEnvelope {
         if self.context.summary.profile_quantity > 0 {
             self.track_outcome(
                 outcome,
-                DataCategory::Profile,
+                if self.use_index_category() {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
                 self.context.summary.profile_quantity,
             );
         }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -510,8 +510,15 @@ where
 
             // It makes no sense to store profiles without transactions, so if the event
             // is rate limited, rate limit profiles as well.
-            enforcement.profiles =
-                CategoryLimit::new(DataCategory::Profile, summary.profile_quantity, longest);
+            enforcement.profiles = CategoryLimit::new(
+                if summary.event_metrics_extracted {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
+                summary.profile_quantity,
+                longest,
+            );
 
             rate_limits.merge(event_limits);
         }
@@ -548,7 +555,11 @@ where
             let item_scoping = scoping.item(DataCategory::Profile);
             let profile_limits = (self.check)(item_scoping, summary.profile_quantity)?;
             enforcement.profiles = CategoryLimit::new(
-                DataCategory::Profile,
+                if summary.event_metrics_extracted {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
                 summary.profile_quantity,
                 profile_limits.longest(),
             );

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1224,11 +1224,13 @@ def test_profile_outcomes_invalid(
     mini_sentry,
     relay_with_processing,
     outcomes_consumer,
+    metrics_consumer,
 ):
     """
     Tests that Relay reports correct outcomes for invalid profiles as `Profile`.
     """
     outcomes_consumer = outcomes_consumer(timeout=2)
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
@@ -1306,16 +1308,22 @@ def test_profile_outcomes_invalid(
 
     assert outcomes == expected_outcomes, outcomes
 
+    # Make sure the profile will not be counted as accepted:
+    metric = metrics_by_name(metrics_consumer, 2)["d:transactions/duration@millisecond"]
+    assert "has_profile" not in metric["tags"]
+
 
 def test_profile_outcomes_data_invalid(
     mini_sentry,
     relay_with_processing,
     outcomes_consumer,
+    metrics_consumer,
 ):
     """
     Tests that Relay reports correct outcomes for invalid profiles as `Profile`.
     """
     outcomes_consumer = outcomes_consumer(timeout=2)
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
@@ -1393,6 +1401,10 @@ def test_profile_outcomes_data_invalid(
 
     assert outcomes == expected_outcomes, outcomes
 
+    # Make sure the profile will not be counted as accepted:
+    metric = metrics_by_name(metrics_consumer, 2)["d:transactions/duration@millisecond"]
+    assert "has_profile" not in metric["tags"]
+
 
 @pytest.mark.parametrize("metrics_already_extracted", [False, True])
 @pytest.mark.parametrize("quota_category", ["transaction", "profile"])
@@ -1400,6 +1412,7 @@ def test_profile_outcomes_rate_limited(
     mini_sentry,
     relay_with_processing,
     outcomes_consumer,
+    metrics_consumer,
     metrics_already_extracted,
     quota_category,
 ):
@@ -1408,6 +1421,7 @@ def test_profile_outcomes_rate_limited(
     Profiles that are rate limited after metrics extraction should count towards `ProfileIndexed`.
     """
     outcomes_consumer = outcomes_consumer(timeout=2)
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
@@ -1490,3 +1504,7 @@ def test_profile_outcomes_rate_limited(
         outcome.pop("event_id", None)
 
     assert outcomes == expected_outcomes, outcomes
+
+    # Make sure the profile will not be counted as accepted:
+    metric = metrics_by_name(metrics_consumer, 2)["d:transactions/duration@millisecond"]
+    assert "has_profile" not in metric["tags"]


### PR DESCRIPTION
As described in https://github.com/getsentry/relay/issues/2158, track the number of processed profiles by tagging the corresponding transaction metric.

Also: Do not accept multiple profiles per envelope.

**Not in this PR:**
* Distinguishing between `Profile` and `ProfileIndexed`
* Rate limiting processed profiles based on metrics

#skip-changelog