### PR TITLE
feat(profiles): Count as "indexed" after metrics extraction

### DIFF
--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -550,7 +550,11 @@ impl Item {
             ItemType::Metrics | ItemType::MetricBuckets => None,
             ItemType::FormData => None,
             ItemType::UserReport => None,
-            ItemType::Profile => Some(DataCategory::Profile),
+            ItemType::Profile => Some(if indexed {
+                DataCategory::ProfileIndexed
+            } else {
+                DataCategory::Profile
+            }),
             ItemType::ReplayEvent | ItemType::ReplayRecording => Some(DataCategory::Replay),
             ItemType::ClientReport => None,
             ItemType::CheckIn => Some(DataCategory::Monitor),

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -326,7 +326,11 @@ impl ManagedEnvelope {
         if self.context.summary.profile_quantity > 0 {
             self.track_outcome(
                 outcome,
-                DataCategory::Profile,
+                if self.use_index_category() {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
                 self.context.summary.profile_quantity,
             );
         }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -510,8 +510,15 @@ where
 
             // It makes no sense to store profiles without transactions, so if the event
             // is rate limited, rate limit profiles as well.
-            enforcement.profiles =
-                CategoryLimit::new(DataCategory::Profile, summary.profile_quantity, longest);
+            enforcement.profiles = CategoryLimit::new(
+                if summary.event_metrics_extracted {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
+                summary.profile_quantity,
+                longest,
+            );
 
             rate_limits.merge(event_limits);
         }
@@ -548,7 +555,11 @@ where
             let item_scoping = scoping.item(DataCategory::Profile);
             let profile_limits = (self.check)(item_scoping, summary.profile_quantity)?;
             enforcement.profiles = CategoryLimit::new(
-                DataCategory::Profile,
+                if summary.event_metrics_extracted {
+                    DataCategory::ProfileIndexed
+                } else {
+                    DataCategory::Profile
+                },
                 summary.profile_quantity,
                 profile_limits.longest(),
             );

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1198,7 +1198,7 @@ def test_profile_outcomes(
             "source": expected_source,
         },
         {
-            "category": 11,
+            "category": 11,  # ProfileIndexed
             "key_id": 123,
             "org_id": 1,
             "outcome": 1,  # Filtered
@@ -1278,7 +1278,7 @@ def test_profile_outcomes_invalid(
     outcomes = outcomes_consumer.get_outcomes()
     outcomes.sort(key=lambda o: sorted(o.items()))
 
-    # Expect ProfileIndexed, except when no metrics have been extracted.
+    # Expect ProfileIndexed if metrics have been extracted, else Profile
     expected_category = 11 if metrics_already_extracted else 6
 
     expected_outcomes = [


### PR DESCRIPTION
With https://github.com/getsentry/relay/pull/2165, "processed" profiles are represented by their raw payload _before_ metrics extraction, and represented by the `transaction.duration` metric _after_ metrics extraction, as it is the case for transactions:

```mermaid
flowchart LR
    . --"payload\n(DataCategory::Profile)"--> MetricsExtraction
    MetricsExtraction --"payloads\n(TransactionIndexed, ProfileIndexed)"-->..
    MetricsExtraction --"metrics\n(Transaction, Profile)"-->...
 ```


To prevent double counting, emit any profile-related outcome after metrics extraction as `DataCategory::ProfileIndexed`.

#skip-changelog