### PR TITLE
fix(spans): Consider quotes to extract the domain

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -690,7 +690,7 @@ fn extract_span_metrics(
 }
 
 static SQL_TABLE_EXTRACTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)(from|into)(\s|"|\()+(?P<table>(\w+(\.\w+)*))(\s|"|\))+"#).unwrap()
+    Regex::new(r#"(?i)(from|into)(\s|"|'|\()+(?P<table>(\w+(\.\w+)*))(\s|"|'|\))+"#).unwrap()
 });
 
 /// Returns the table in the SQL query, if any.
@@ -990,6 +990,20 @@ mod tests {
                 },
                 {
                     "description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
+                    "op": "db",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "db.system": "MyDatabase",
+                        "db.operation": "SELECT"
+                    }
+                },
+                {
+                    "description": "SELECT 'table'.'col' FROM 'table' WHERE 'table'.'col' = %s",
                     "op": "db",
                     "parent_span_id": "8f5a2b8768cafb4e",
                     "span_id": "bb7af8b99e95af5f",
@@ -1682,6 +1696,63 @@ mod tests {
                 tags: {
                     "environment": "fake_environment",
                     "span.action": "SELECT",
+                    "span.domain": "table",
+                    "span.module": "db",
+                    "span.op": "db",
+                    "span.status": "ok",
+                    "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "s:transactions/span.user@none",
+                value: Set(
+                    933084975,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "SELECT",
+                    "span.description": "SELECT %s.%s FROM %s WHERE %s.%s = %s",
+                    "span.domain": "table",
+                    "span.module": "db",
+                    "span.op": "db",
+                    "span.status": "ok",
+                    "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.exclusive_time@millisecond",
+                value: Distribution(
+                    2000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "SELECT",
+                    "span.description": "SELECT %s.%s FROM %s WHERE %s.%s = %s",
+                    "span.domain": "table",
+                    "span.module": "db",
+                    "span.op": "db",
+                    "span.status": "ok",
+                    "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.duration@millisecond",
+                value: Distribution(
+                    59000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "SELECT",
+                    "span.description": "SELECT %s.%s FROM %s WHERE %s.%s = %s",
                     "span.domain": "table",
                     "span.module": "db",
                     "span.op": "db",

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -607,7 +607,7 @@ fn extract_span_metrics(
                     span.description
                         .value()
                         .and_then(|url| domain_from_http_url(url))
-                } else if span_op == "db.sql.query" {
+                } else if span_op.starts_with("db") {
                     span.description
                         .value()
                         .and_then(|query| sql_table_from_query(query))
@@ -689,8 +689,9 @@ fn extract_span_metrics(
     Ok(())
 }
 
-static SQL_TABLE_EXTRACTOR_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"(?i)(from|into)(\s|\()+(?P<table>(\w+(\.\w+)*))(\s|\))+"#).unwrap());
+static SQL_TABLE_EXTRACTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)(from|into)(\s|"|\()+(?P<table>(\w+(\.\w+)*))(\s|"|\))+"#).unwrap()
+});
 
 /// Returns the table in the SQL query, if any.
 ///

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -989,6 +989,20 @@ mod tests {
                     }
                 },
                 {
+                    "description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
+                    "op": "db",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "db.system": "MyDatabase",
+                        "db.operation": "SELECT"
+                    }
+                },
+                {
                     "description": "SAVEPOINT save_this_one",
                     "op": "db",
                     "parent_span_id": "8f5a2b8768cafb4e",
@@ -1617,6 +1631,60 @@ mod tests {
                     "span.domain": "table",
                     "span.module": "db",
                     "span.op": "db.sql.query",
+                    "span.status": "ok",
+                    "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "s:transactions/span.user@none",
+                value: Set(
+                    933084975,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "SELECT",
+                    "span.domain": "table",
+                    "span.module": "db",
+                    "span.op": "db",
+                    "span.status": "ok",
+                    "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.exclusive_time@millisecond",
+                value: Distribution(
+                    2000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "SELECT",
+                    "span.domain": "table",
+                    "span.module": "db",
+                    "span.op": "db",
+                    "span.status": "ok",
+                    "span.system": "MyDatabase",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.duration@millisecond",
+                value: Distribution(
+                    59000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "SELECT",
+                    "span.domain": "table",
+                    "span.module": "db",
+                    "span.op": "db",
                     "span.status": "ok",
                     "span.system": "MyDatabase",
                     "transaction": "mytransaction",

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -533,6 +533,71 @@ expression: event.value().unwrap().spans
             2020-08-21T02:18:20Z,
         ),
         exclusive_time: 2000.0,
+        description: "SELECT 'table'.'col' FROM 'table' WHERE 'table'.'col' = %s",
+        op: "db",
+        span_id: SpanId(
+            "bb7af8b99e95af5f",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "db.operation": String(
+                "SELECT",
+            ),
+            "db.system": String(
+                "MyDatabase",
+            ),
+            "description.scrubbed": String(
+                "SELECT %s.%s FROM %s WHERE %s.%s = %s",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.action": String(
+                "SELECT",
+            ),
+            "span.description": String(
+                "SELECT %s.%s FROM %s WHERE %s.%s = %s",
+            ),
+            "span.domain": String(
+                "table",
+            ),
+            "span.module": String(
+                "db",
+            ),
+            "span.op": String(
+                "db",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.system": String(
+                "MyDatabase",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:18:22Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:18:20Z,
+        ),
+        exclusive_time: 2000.0,
         description: "SAVEPOINT save_this_one",
         op: "db",
         span_id: SpanId(

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -474,6 +474,65 @@ expression: event.value().unwrap().spans
             2020-08-21T02:18:20Z,
         ),
         exclusive_time: 2000.0,
+        description: "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
+        op: "db",
+        span_id: SpanId(
+            "bb7af8b99e95af5f",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: ~,
+        origin: ~,
+        data: {
+            "db.operation": String(
+                "SELECT",
+            ),
+            "db.system": String(
+                "MyDatabase",
+            ),
+            "environment": String(
+                "fake_environment",
+            ),
+            "span.action": String(
+                "SELECT",
+            ),
+            "span.domain": String(
+                "table",
+            ),
+            "span.module": String(
+                "db",
+            ),
+            "span.op": String(
+                "db",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.system": String(
+                "MyDatabase",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:18:22Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:18:20Z,
+        ),
+        exclusive_time: 2000.0,
         description: "SAVEPOINT save_this_one",
         op: "db",
         span_id: SpanId(


### PR DESCRIPTION
Consider `"`s in an SQL query to extract the domain, aka table name.

#skip-changelog