### PR TITLE
test(spans): Fix wrong action in the span

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -1026,8 +1026,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase",
-                        "db.operation": "SELECT"
+                        "db.system": "MyDatabase"
                     }
                 },
                 {
@@ -1770,7 +1769,6 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
-                    "span.action": "SELECT",
                     "span.description": "SAVEPOINT %s",
                     "span.module": "db",
                     "span.op": "db",
@@ -1788,7 +1786,6 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
-                    "span.action": "SELECT",
                     "span.description": "SAVEPOINT %s",
                     "span.module": "db",
                     "span.op": "db",
@@ -1806,7 +1803,6 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
-                    "span.action": "SELECT",
                     "span.description": "SAVEPOINT %s",
                     "span.module": "db",
                     "span.op": "db",

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -613,9 +613,6 @@ expression: event.value().unwrap().spans
         tags: ~,
         origin: ~,
         data: {
-            "db.operation": String(
-                "SELECT",
-            ),
             "db.system": String(
                 "MyDatabase",
             ),
@@ -624,9 +621,6 @@ expression: event.value().unwrap().spans
             ),
             "environment": String(
                 "fake_environment",
-            ),
-            "span.action": String(
-                "SELECT",
             ),
             "span.description": String(
                 "SAVEPOINT %s",


### PR DESCRIPTION
Removes wrong `db.operation` on a `SAVEPOINT` command, probably caused by me copy-pasting spans to generate test cases.

#skip-changelog