### PR TITLE
fix(kafka): Update default topic for transaction metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for X-Vercel-Forwarded-For header. ([#2124](https://github.com/getsentry/relay/pull/2124))
 - Add `lock` attribute to the frame protocol. ([#2171](https://github.com/getsentry/relay/pull/2171))
 - Reject profiles longer than 30s. ([#2168](https://github.com/getsentry/relay/pull/2168))
+- Change default topic for transaction metrics to `ingest-performance-metrics`. ([#2180](https://github.com/getsentry/relay/pull/2180))
 
 ## 23.5.2
 

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -89,7 +89,7 @@ pub struct TopicAssignments {
     /// Topic name for metrics extracted from sessions. Defaults to the assignment of `metrics`.
     pub metrics_sessions: Option<TopicAssignment>,
     /// Topic name for metrics extracted from transactions. Defaults to the assignment of `metrics`.
-    pub metrics_transactions: Option<TopicAssignment>,
+    pub metrics_transactions: TopicAssignment,
     /// Stacktrace topic name
     pub profiles: TopicAssignment,
     /// Replay Events topic name.
@@ -112,9 +112,7 @@ impl TopicAssignments {
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
             KafkaTopic::MetricsSessions => self.metrics_sessions.as_ref().unwrap_or(&self.metrics),
-            KafkaTopic::MetricsTransactions => {
-                self.metrics_transactions.as_ref().unwrap_or(&self.metrics)
-            }
+            KafkaTopic::MetricsTransactions => &self.metrics_transactions,
             KafkaTopic::Profiles => &self.profiles,
             KafkaTopic::ReplayEvents => &self.replay_events,
             KafkaTopic::ReplayRecordings => &self.replay_recordings,
@@ -134,7 +132,7 @@ impl Default for TopicAssignments {
             sessions: "ingest-sessions".to_owned().into(),
             metrics: "ingest-metrics".to_owned().into(),
             metrics_sessions: None,
-            metrics_transactions: None,
+            metrics_transactions: "ingest-performance-metrics".to_owned().into(),
             profiles: "profiles".to_owned().into(),
             replay_events: "ingest-replay-events".to_owned().into(),
             replay_recordings: "ingest-replay-recordings".to_owned().into(),

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -44,13 +44,15 @@ def processing_config(get_topic_name):
                 # {'name': 'batch.size', 'value': '0'}  # do not batch messages
             ]
         if processing.get("topics") is None:
+            metrics_topic = get_topic_name("metrics")
             processing["topics"] = {
                 "events": get_topic_name("events"),
                 "attachments": get_topic_name("attachments"),
                 "transactions": get_topic_name("transactions"),
                 "outcomes": get_topic_name("outcomes"),
                 "sessions": get_topic_name("sessions"),
-                "metrics": get_topic_name("metrics"),
+                "metrics": metrics_topic,
+                "metrics_transactions": metrics_topic,
                 "replay_events": get_topic_name("replay_events"),
                 "replay_recordings": get_topic_name("replay_recordings"),
                 "monitors": get_topic_name("monitors"),

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -211,7 +211,7 @@ def test_metrics_with_sharded_kafka(
         "processing": {
             "secondary_kafka_configs": {"foo": default_config, "baz": default_config},
             "topics": {
-                "metrics": {
+                "metrics_transactions": {
                     "shards": 3,
                     "mapping": {
                         0: {


### PR DESCRIPTION
In sentry, the default topic for transaction a.k.a. performance metrics is defined as



```python
KAFKA_INGEST_PERFORMANCE_METRICS = "ingest-performance-metrics"
```

([source](https://github.com/getsentry/sentry/blob/75833f69cea56d4d0f7c7dbde6b8026b1110376f/src/sentry/conf/server.py#L2925))

But Relay still sends all metrics to the same topic by default.

During a local end-to-end test, I noticed that the metrics indexer crashes when it receives buckets from multiple use cases on the same topic:

```python
            raise ValueError(
                f"The set of use_case_ids: {use_case_ids} maps to multiple metric path keys"
            )
 ```

([source](https://github.com/getsentry/sentry/blob/75833f69cea56d4d0f7c7dbde6b8026b1110376f/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py#L288-L290))

To make development setup easier, use the same default topic in Relay as in Sentry.