### PR TITLE
fix(spans): Extract span http_status tag from span tags

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -936,6 +936,39 @@ mod tests {
                     }
                 },
                 {
+                    "description": "POST http://sth.subdomain.domain.tld:targetport/api/hi",
+                    "op": "http.client",
+                    "tags": {
+                        "http.status_code": "200"
+                    },
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bd2eb23da2beb459",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "http.method": "POST"
+                    }
+                },
+                {
+                    "description": "POST http://sth.subdomain.domain.tld:targetport/api/hi",
+                    "op": "http.client",
+                    "tags": {
+                        "http.status_code": "200"
+                    },
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bd2eb23da2beb459",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "http.method": "POST",
+                        "status_code": "200"
+                    }
+                },
+                {
                     "description": "POST http://targetdomain.tld:targetport/api/hi",
                     "op": "http.client",
                     "parent_span_id": "8f5a2b8768cafb4e",
@@ -1313,6 +1346,114 @@ mod tests {
                 tags: {
                     "environment": "fake_environment",
                     "span.op": "react.mount",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "s:transactions/span.user@none",
+                value: Set(
+                    933084975,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "POST",
+                    "span.domain": "*.domain.tld:targetport",
+                    "span.module": "http",
+                    "span.op": "http.client",
+                    "span.status": "ok",
+                    "span.status_code": "200",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.exclusive_time@millisecond",
+                value: Distribution(
+                    2000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "POST",
+                    "span.domain": "*.domain.tld:targetport",
+                    "span.module": "http",
+                    "span.op": "http.client",
+                    "span.status": "ok",
+                    "span.status_code": "200",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.duration@millisecond",
+                value: Distribution(
+                    59000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "POST",
+                    "span.domain": "*.domain.tld:targetport",
+                    "span.module": "http",
+                    "span.op": "http.client",
+                    "span.status": "ok",
+                    "span.status_code": "200",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "s:transactions/span.user@none",
+                value: Set(
+                    933084975,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "POST",
+                    "span.domain": "*.domain.tld:targetport",
+                    "span.module": "http",
+                    "span.op": "http.client",
+                    "span.status": "ok",
+                    "span.status_code": "200",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.exclusive_time@millisecond",
+                value: Distribution(
+                    2000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "POST",
+                    "span.domain": "*.domain.tld:targetport",
+                    "span.module": "http",
+                    "span.op": "http.client",
+                    "span.status": "ok",
+                    "span.status_code": "200",
+                    "transaction": "mytransaction",
+                    "transaction.op": "myop",
+                },
+            },
+            Metric {
+                name: "d:transactions/span.duration@millisecond",
+                value: Distribution(
+                    59000.0,
+                ),
+                timestamp: UnixTimestamp(1619420400),
+                tags: {
+                    "environment": "fake_environment",
+                    "span.action": "POST",
+                    "span.domain": "*.domain.tld:targetport",
+                    "span.module": "http",
+                    "span.op": "http.client",
+                    "span.status": "ok",
+                    "span.status_code": "200",
                     "transaction": "mytransaction",
                     "transaction.op": "myop",
                 },

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -95,12 +95,30 @@ fn extract_geo_country_code(event: &Event) -> Option<String> {
 }
 
 /// Extract the HTTP status code from the span data.
-fn http_status_code_from_span_data(span: &Span) -> Option<String> {
-    span.data
+fn http_status_code_from_span(span: &Span) -> Option<String> {
+    // For SDKs which put the HTTP status code into the span data.
+    if let Some(status_code) = span
+        .data
         .value()
         .and_then(|v| v.get("status_code"))
         .and_then(|v| v.as_str())
         .map(|v| v.to_string())
+    {
+        return Some(status_code);
+    }
+
+    // For SDKs which put the HTTP status code into the span tags.
+    if let Some(status_code) = span
+        .tags
+        .value()
+        .and_then(|tags| tags.get("http.status_code"))
+        .and_then(|v| v.as_str())
+        .map(|v| v.to_owned())
+    {
+        return Some(status_code);
+    }
+
+    None
 }
 
 /// Extracts the HTTP status code.
@@ -108,18 +126,8 @@ pub(crate) fn extract_http_status_code(event: &Event) -> Option<String> {
     if let Some(spans) = event.spans.value() {
         for span in spans {
             if let Some(span_value) = span.value() {
-                // For SDKs which put the HTTP status code into the span data.
-                if let Some(status_code) = http_status_code_from_span_data(span_value) {
+                if let Some(status_code) = http_status_code_from_span(span_value) {
                     return Some(status_code);
-                }
-
-                // For SDKs which put the HTTP status code into the span tags.
-                if let Some(status_code) = span_value
-                    .tags
-                    .value()
-                    .and_then(|tags| tags.get("http.status_code"))
-                {
-                    return status_code.value().map(|v| v.as_str().to_string());
                 }
             }
         }
@@ -641,7 +649,7 @@ fn extract_span_metrics(
                 span_tags.insert("span.status".to_owned(), span_status.to_string());
             }
 
-            if let Some(status_code) = http_status_code_from_span_data(span) {
+            if let Some(status_code) = http_status_code_from_span(span) {
                 span_tags.insert("span.status_code".to_owned(), status_code);
             }
 

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -108,6 +108,129 @@ expression: event.value().unwrap().spans
             2020-08-21T02:18:20Z,
         ),
         exclusive_time: 2000.0,
+        description: "POST http://sth.subdomain.domain.tld:targetport/api/hi",
+        op: "http.client",
+        span_id: SpanId(
+            "bd2eb23da2beb459",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: {
+            "http.status_code": JsonLenientString(
+                "200",
+            ),
+        },
+        origin: ~,
+        data: {
+            "environment": String(
+                "fake_environment",
+            ),
+            "http.method": String(
+                "POST",
+            ),
+            "span.action": String(
+                "POST",
+            ),
+            "span.domain": String(
+                "*.domain.tld:targetport",
+            ),
+            "span.module": String(
+                "http",
+            ),
+            "span.op": String(
+                "http.client",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.status_code": String(
+                "200",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:18:22Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:18:20Z,
+        ),
+        exclusive_time: 2000.0,
+        description: "POST http://sth.subdomain.domain.tld:targetport/api/hi",
+        op: "http.client",
+        span_id: SpanId(
+            "bd2eb23da2beb459",
+        ),
+        parent_span_id: SpanId(
+            "8f5a2b8768cafb4e",
+        ),
+        trace_id: TraceId(
+            "ff62a8b040f340bda5d830223def1d81",
+        ),
+        status: Ok,
+        tags: {
+            "http.status_code": JsonLenientString(
+                "200",
+            ),
+        },
+        origin: ~,
+        data: {
+            "environment": String(
+                "fake_environment",
+            ),
+            "http.method": String(
+                "POST",
+            ),
+            "span.action": String(
+                "POST",
+            ),
+            "span.domain": String(
+                "*.domain.tld:targetport",
+            ),
+            "span.module": String(
+                "http",
+            ),
+            "span.op": String(
+                "http.client",
+            ),
+            "span.status": String(
+                "ok",
+            ),
+            "span.status_code": String(
+                "200",
+            ),
+            "status_code": String(
+                "200",
+            ),
+            "transaction": String(
+                "mytransaction",
+            ),
+            "transaction.op": String(
+                "myop",
+            ),
+        },
+        other: {},
+    },
+    Span {
+        timestamp: Timestamp(
+            2020-08-21T02:18:22Z,
+        ),
+        start_timestamp: Timestamp(
+            2020-08-21T02:18:20Z,
+        ),
+        exclusive_time: 2000.0,
         description: "POST http://targetdomain.tld:targetport/api/hi",
         op: "http.client",
         span_id: SpanId(


### PR DESCRIPTION
Extract `span.http_status` code tag from a span's tag when it's not present in the data. The logic was already implemented for transactions, but applied to spans.

#skip-changelog