### PR TITLE
fix(outcomes): Report profiles when transaction metrics dropped

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -850,6 +850,10 @@ impl MetricsContainer for Bucket {
     fn len(&self) -> usize {
         self.value.len()
     }
+
+    fn tag(&self, name: &str) -> Option<&str> {
+        self.tags.get(name).map(|s| s.as_str())
+    }
 }
 
 /// Any error that may occur during aggregation.

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -588,6 +588,9 @@ pub trait MetricsContainer {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns the value of the given tag, if present.
+    fn tag(&self, name: &str) -> Option<&str>;
 }
 
 impl MetricsContainer for Metric {
@@ -597,6 +600,10 @@ impl MetricsContainer for Metric {
 
     fn len(&self) -> usize {
         1
+    }
+
+    fn tag(&self, name: &str) -> Option<&str> {
+        self.tags.get(name).map(|s| s.as_str())
     }
 }
 

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -748,6 +748,18 @@ impl<I: Interface> Addr<I> {
             inner: Box::new(self),
         }
     }
+
+    /// Dummy address used for testing.
+    pub fn custom() -> (Self, mpsc::UnboundedReceiver<I>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            Addr {
+                tx,
+                queue_size: Default::default(),
+            },
+            rx,
+        )
+    }
 }
 
 impl<I: Interface> fmt::Debug for Addr<I> {


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/2163:

When transaction metric buckets are rate limited, we only report outcomes for transactions, not profiles:

<img width="1247" alt="image" src="https://github.com/getsentry/relay/assets/1565449/5e0b6199-affb-41c3-9fc8-5f22b1d24fd5">

<img width="1250" alt="image" src="https://github.com/getsentry/relay/assets/1565449/6b6000b0-5517-4569-8b63-f1bc286832c4">

With this PR, `RateLimited` will be reported for the `Profile` category as well.

ref: https://github.com/getsentry/relay/issues/2158

#skip-changelog