### PR TITLE
ref(crons): Support GET in the check-in endpoint

### DIFF
--- a/relay-server/src/endpoints/cron.rs
+++ b/relay-server/src/endpoints/cron.rs
@@ -1,6 +1,6 @@
 use axum::extract::{DefaultBodyLimit, FromRequest, Path, Query};
 use axum::response::IntoResponse;
-use axum::routing::{post, MethodRouter};
+use axum::routing::{on, MethodFilter, MethodRouter};
 use relay_common::Uuid;
 use relay_config::Config;
 use relay_general::protocol::EventId;
@@ -81,5 +81,6 @@ where
     B::Data: Send,
     B::Error: Into<axum::BoxError>,
 {
-    post(handle).route_layer(DefaultBodyLimit::max(config.max_event_size()))
+    on(MethodFilter::GET | MethodFilter::POST, handle)
+        .route_layer(DefaultBodyLimit::max(config.max_event_size()))
 }

--- a/tests/integration/test_crons.py
+++ b/tests/integration/test_crons.py
@@ -31,7 +31,31 @@ def test_monitors_with_processing(
     }
 
 
-def test_crons_endpoint_with_processing(
+def test_crons_endpoint_get_with_processing(
+    mini_sentry, relay_with_processing, monitors_consumer
+):
+    project_id = 42
+    options = {"processing": {}}
+    relay = relay_with_processing(options)
+    monitors_consumer = monitors_consumer()
+
+    mini_sentry.add_full_project_config(project_id)
+
+    monitor_slug = "my-monitor"
+    public_key = relay.get_dsn_public_key(project_id)
+    relay.get("/api/cron/{}/{}?status=ok".format(monitor_slug, public_key))
+
+    check_in, message = monitors_consumer.get_check_in()
+    assert message["start_time"] is not None
+    assert message["project_id"] == 42
+    assert check_in == {
+        "check_in_id": "00000000000000000000000000000000",
+        "monitor_slug": "my-monitor",
+        "status": "ok",
+    }
+
+
+def test_crons_endpoint_post_auth_basic_with_processing(
     mini_sentry, relay_with_processing, monitors_consumer
 ):
     project_id = 42


### PR DESCRIPTION
We would like to support both `GET` and `POST`.

#skip-changelog