### PR TITLE
chore(py): Bump `requests` lib version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest-xdist==3.0.2
 pytest==7.1.2
 PyYAML==6.0
 redis==4.5.4
-requests==2.28.1
+requests==2.31.0
 sentry_sdk==1.14.0
 werkzeug==2.2.3
 sentry-relay==0.8.15


### PR DESCRIPTION
Fixes one of the security warning https://github.com/getsentry/relay/security/dependabot/64

#skip-changelog