### PR TITLE
feat(spans): Extract transaction's HTTP status code into span tags as `http.status_code`

### DIFF
--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -1,5 +1,5 @@
-use crate::metrics_extraction::transactions::extract_http_status_code;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
+use crate::metrics_extraction::utils::extract_http_status_code;
 use crate::metrics_extraction::utils::http_status_code_from_span;
 use crate::metrics_extraction::utils::{
     extract_transaction_op, get_eventuser_tag, get_trace_context,

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -1,3 +1,4 @@
+use crate::metrics_extraction::transactions::extract_http_status_code;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::metrics_extraction::utils::{
     extract_transaction_op, get_eventuser_tag, get_trace_context,
@@ -65,6 +66,10 @@ pub(crate) fn extract_span_metrics(
         if let Some(op) = extract_transaction_op(trace_context) {
             shared_tags.insert("transaction.op".to_owned(), op.to_lowercase());
         }
+    }
+
+    if let Some(transaction_http_status_code) = extract_http_status_code(event) {
+        shared_tags.insert("http.status_code".to_owned(), transaction_http_status_code);
     }
 
     let Some(spans) = event.spans.value_mut() else { return Ok(()) };

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -932,6 +932,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.op": "react.mount",
                     "transaction": "gEt /api/:version/users/",
                     "transaction.method": "GET",
@@ -946,6 +947,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.op": "react.mount",
                     "transaction": "gEt /api/:version/users/",
                     "transaction.method": "GET",
@@ -960,6 +962,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.op": "react.mount",
                     "transaction": "gEt /api/:version/users/",
                     "transaction.method": "GET",
@@ -974,6 +977,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "ui.react",
                     "span.op": "ui.react.render",
                     "transaction": "gEt /api/:version/users/",
@@ -989,6 +993,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "ui.react",
                     "span.op": "ui.react.render",
                     "transaction": "gEt /api/:version/users/",
@@ -1004,6 +1009,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "ui.react",
                     "span.op": "ui.react.render",
                     "transaction": "gEt /api/:version/users/",
@@ -1019,6 +1025,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1039,6 +1046,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1059,6 +1067,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1079,6 +1088,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "targetdomain.tld:targetport",
@@ -1099,6 +1109,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "targetdomain.tld:targetport",
@@ -1119,6 +1130,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "targetdomain.tld:targetport",
@@ -1139,6 +1151,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.description": "POST http://targetdomain:targetport/api/id/*",
@@ -1161,6 +1174,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.description": "POST http://targetdomain:targetport/api/id/*",
@@ -1183,6 +1197,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.description": "POST http://targetdomain:targetport/api/id/*",
@@ -1205,6 +1220,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1225,6 +1241,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1245,6 +1262,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1265,6 +1283,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1285,6 +1304,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1305,6 +1325,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "POST",
                     "span.category": "http",
                     "span.domain": "*.domain.tld:targetport",
@@ -1325,6 +1346,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SeLeCt column FROM tAbLe WHERE id IN (%s)",
@@ -1347,6 +1369,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SeLeCt column FROM tAbLe WHERE id IN (%s)",
@@ -1369,6 +1392,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SeLeCt column FROM tAbLe WHERE id IN (%s)",
@@ -1391,6 +1415,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "select column FROM table WHERE id IN (%s)",
@@ -1412,6 +1437,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "select column FROM table WHERE id IN (%s)",
@@ -1433,6 +1459,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "select column FROM table WHERE id IN (%s)",
@@ -1454,6 +1481,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1474,6 +1502,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1494,6 +1523,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1514,6 +1544,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "from_date",
@@ -1534,6 +1565,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "from_date",
@@ -1554,6 +1586,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "from_date",
@@ -1574,6 +1607,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1593,6 +1627,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1612,6 +1647,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "INSERT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1631,6 +1667,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1651,6 +1688,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1671,6 +1709,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.domain": "table",
@@ -1691,6 +1730,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
@@ -1713,6 +1753,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
@@ -1735,6 +1776,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
@@ -1757,6 +1799,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SELECT 'TABLE'.'col' FROM 'TABLE' WHERE 'TABLE'.'col' = %s",
@@ -1779,6 +1822,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SELECT 'TABLE'.'col' FROM 'TABLE' WHERE 'TABLE'.'col' = %s",
@@ -1801,6 +1845,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.action": "SELECT",
                     "span.category": "db",
                     "span.description": "SELECT 'TABLE'.'col' FROM 'TABLE' WHERE 'TABLE'.'col' = %s",
@@ -1823,6 +1868,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "db",
                     "span.description": "SAVEPOINT %s",
                     "span.group": "3f955cbde39e04b9",
@@ -1843,6 +1889,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "db",
                     "span.description": "SAVEPOINT %s",
                     "span.group": "3f955cbde39e04b9",
@@ -1863,6 +1910,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "db",
                     "span.description": "SAVEPOINT %s",
                     "span.group": "3f955cbde39e04b9",
@@ -1883,6 +1931,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "cache",
                     "span.description": "GET cache:user:*",
                     "span.group": "325fa5feb926f121",
@@ -1902,6 +1951,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "cache",
                     "span.description": "GET cache:user:*",
                     "span.group": "325fa5feb926f121",
@@ -1921,6 +1971,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "cache",
                     "span.description": "GET cache:user:*",
                     "span.group": "325fa5feb926f121",
@@ -1940,6 +1991,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "resource",
                     "span.description": "http://domain/static/myscript-*.js",
                     "span.group": "022f81fdf31228bf",
@@ -1958,6 +2010,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "resource",
                     "span.description": "http://domain/static/myscript-*.js",
                     "span.group": "022f81fdf31228bf",
@@ -1976,6 +2029,7 @@ mod tests {
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "environment": "fake_environment",
+                    "http.status_code": "200",
                     "span.category": "resource",
                     "span.description": "http://domain/static/myscript-*.js",
                     "span.group": "022f81fdf31228bf",

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -31,6 +31,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -80,6 +81,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -135,6 +137,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -208,6 +211,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -284,6 +288,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -365,6 +370,9 @@ expression: event.value().unwrap().spans
             "http.method": String(
                 "POST",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -436,6 +444,9 @@ expression: event.value().unwrap().spans
             ),
             "http.method": String(
                 "POST",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "release": String(
                 "1.2.3",
@@ -516,6 +527,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -592,6 +604,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -668,6 +681,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -741,6 +755,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -808,6 +823,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -878,6 +894,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -954,6 +971,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -1036,6 +1054,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -1115,6 +1134,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -1188,6 +1208,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),
@@ -1255,6 +1276,7 @@ expression: event.value().unwrap().spans
             ),
             "http.status_code": String(
                 "200",
+            ),
             "release": String(
                 "1.2.3",
             ),

--- a/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
+++ b/relay-server/src/metrics_extraction/transactions/snapshots/relay_server__metrics_extraction__transactions__tests__extract_transaction_metrics.snap
@@ -29,6 +29,9 @@ expression: event.value().unwrap().spans
             "environment": String(
                 "fake_environment",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "span.op": String(
                 "react.mount",
             ),
@@ -69,6 +72,9 @@ expression: event.value().unwrap().spans
         data: {
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.category": String(
                 "ui.react",
@@ -116,6 +122,9 @@ expression: event.value().unwrap().spans
             ),
             "http.method": String(
                 "PoSt",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "POST",
@@ -178,6 +187,9 @@ expression: event.value().unwrap().spans
             ),
             "http.method": String(
                 "POST",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "POST",
@@ -243,6 +255,9 @@ expression: event.value().unwrap().spans
             ),
             "http.method": String(
                 "POST",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "POST",
@@ -318,6 +333,9 @@ expression: event.value().unwrap().spans
             "environment": String(
                 "fake_environment",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "span.action": String(
                 "SELECT",
             ),
@@ -385,6 +403,9 @@ expression: event.value().unwrap().spans
             ),
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "SELECT",
@@ -454,6 +475,9 @@ expression: event.value().unwrap().spans
             "environment": String(
                 "fake_environment",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "span.action": String(
                 "INSERT",
             ),
@@ -519,6 +543,9 @@ expression: event.value().unwrap().spans
             "environment": String(
                 "fake_environment",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "span.action": String(
                 "INSERT",
             ),
@@ -577,6 +604,9 @@ expression: event.value().unwrap().spans
         data: {
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "INSERT",
@@ -639,6 +669,9 @@ expression: event.value().unwrap().spans
             ),
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "SELECT",
@@ -704,6 +737,9 @@ expression: event.value().unwrap().spans
             ),
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "SELECT",
@@ -772,6 +808,9 @@ expression: event.value().unwrap().spans
             ),
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.action": String(
                 "SELECT",
@@ -844,6 +883,9 @@ expression: event.value().unwrap().spans
             "environment": String(
                 "fake_environment",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "span.category": String(
                 "db",
             ),
@@ -909,6 +951,9 @@ expression: event.value().unwrap().spans
             "environment": String(
                 "fake_environment",
             ),
+            "http.status_code": String(
+                "200",
+            ),
             "span.category": String(
                 "cache",
             ),
@@ -967,6 +1012,9 @@ expression: event.value().unwrap().spans
             ),
             "environment": String(
                 "fake_environment",
+            ),
+            "http.status_code": String(
+                "200",
             ),
             "span.category": String(
                 "resource",


### PR DESCRIPTION
Each span has its own status code, but also information on the status code of the parent transaction they belong to. We're not looking for perfect results here and `extract_http_status_code` provides good enough values.

#skip-changelog