### PR TITLE
test(document-pii): Fix flaky test

### DIFF
--- a/tools/document-pii/src/main.rs
+++ b/tools/document-pii/src/main.rs
@@ -176,7 +176,8 @@ mod tests {
     #[test]
     fn test_find_rs_files() {
         let rust_crate = PathBuf::from_slash(RUST_TEST_CRATE);
-        let rust_file_paths = find_rs_files(&rust_crate);
+        let mut rust_file_paths = find_rs_files(&rust_crate);
+        rust_file_paths.sort();
         insta::assert_debug_snapshot!(rust_file_paths);
     }
 

--- a/tools/document-pii/src/main.rs
+++ b/tools/document-pii/src/main.rs
@@ -177,7 +177,7 @@ mod tests {
     fn test_find_rs_files() {
         let rust_crate = PathBuf::from_slash(RUST_TEST_CRATE);
         let mut rust_file_paths = find_rs_files(&rust_crate);
-        rust_file_paths.sort();
+        rust_file_paths.sort_unstable();
         insta::assert_debug_snapshot!(rust_file_paths);
     }
 


### PR DESCRIPTION
This test has resulted flaky in CI only on ubuntu machines (OSX and Windows seem ok), see [latest example](https://github.com/getsentry/relay/actions/runs/5204020888/jobs/9387669570#step:7:61). Sorting the file paths should remove the flakiness.

#skip-changelog