### PR TITLE
feat(general): Make selectorspec forward compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Features**:
 
+- Add . ([#2171](https://github.com/getsentry/relay/pull/2171))
 - Add `data` and `api_target` fields to `ResponseContext` and scrub `graphql` bodies. ([#2141](https://github.com/getsentry/relay/pull/2141))
 - Add support for X-Vercel-Forwarded-For header. ([#2124](https://github.com/getsentry/relay/pull/2124))
 - Add `lock` attribute to the frame protocol. ([#2171](https://github.com/getsentry/relay/pull/2171))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 **Features**:
 
-- Add . ([#2171](https://github.com/getsentry/relay/pull/2171))
 - Add `data` and `api_target` fields to `ResponseContext` and scrub `graphql` bodies. ([#2141](https://github.com/getsentry/relay/pull/2141))
 - Add support for X-Vercel-Forwarded-For header. ([#2124](https://github.com/getsentry/relay/pull/2124))
 - Add `lock` attribute to the frame protocol. ([#2171](https://github.com/getsentry/relay/pull/2171))

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -717,7 +717,10 @@ impl<'a> Path<'a> {
             SelectorSpec::And(ref xs) => xs.iter().all(|x| self.matches_selector(x)),
             SelectorSpec::Or(ref xs) => xs.iter().any(|x| self.matches_selector(x)),
             SelectorSpec::Not(ref x) => !self.matches_selector(x),
-            SelectorSpec::Other(_) => false,
+            SelectorSpec::Other(_) => {
+                relay_log::warn!("Incoming selector is not supported");
+                false
+            }
         }
     }
 }

--- a/relay-general/src/processor/attrs.rs
+++ b/relay-general/src/processor/attrs.rs
@@ -717,6 +717,7 @@ impl<'a> Path<'a> {
             SelectorSpec::And(ref xs) => xs.iter().all(|x| self.matches_selector(x)),
             SelectorSpec::Or(ref xs) => xs.iter().any(|x| self.matches_selector(x)),
             SelectorSpec::Not(ref x) => !self.matches_selector(x),
+            SelectorSpec::Other(_) => false,
         }
     }
 }

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -263,9 +263,6 @@ fn handle_selector(pair: Pair<Rule>) -> Result<SelectorSpec, InvalidSelectorErro
         }
     }
 
-    // dbg!(&pair);
-    dbg!(&pair.as_rule());
-
     match pair.as_rule() {
         Rule::ParenthesisOrPath | Rule::MaybeNotSelector => {
             handle_selector(pair.into_inner().next().unwrap())

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -225,15 +225,12 @@ impl FromStr for SelectorSpec {
             _ => {}
         }
 
-        handle_selector(
-            SelectorParser::parse(Rule::RootSelector, s)
-                .map_err(|e| InvalidSelectorError::ParseError(Box::new(e)))?
-                .next()
-                .unwrap()
-                .into_inner()
-                .next()
-                .unwrap(),
-        )
+        let rule_pair = match SelectorParser::parse(Rule::RootSelector, s) {
+            Ok(mut rule_pairs) => rule_pairs.next().unwrap().into_inner().next().unwrap(),
+            Err(e) => return Ok(SelectorSpec::Other(e.to_string())),
+        };
+
+        handle_selector(rule_pair)
     }
 }
 
@@ -265,6 +262,9 @@ fn handle_selector(pair: Pair<Rule>) -> Result<SelectorSpec, InvalidSelectorErro
             Ok(f(items))
         }
     }
+
+    // dbg!(&pair);
+    dbg!(&pair.as_rule());
 
     match pair.as_rule() {
         Rule::ParenthesisOrPath | Rule::MaybeNotSelector => {


### PR DESCRIPTION
#1751 

Should make selectorspec forward compatible by adding a fall-back enum variant

#skip-changelog