### PR TITLE
feat(txname): Mark all URL transactions as sanitized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 **Internal**:
 
 - Extract app identifier from app context for profiles. ([#2172](https://github.com/getsentry/relay/pull/2172))
+- Mark all URL transactions as sanitized after applying rules. ([#2210](https://github.com/getsentry/relay/pull/2210))
 
 ## 23.5.2
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -2873,7 +2873,6 @@ mod tests {
                         scope: TransactionNameRuleScope::default(),
                         redaction: RedactionRule::default(),
                     }],
-                    ..Default::default()
                 },
                 true,
                 None,
@@ -2974,7 +2973,6 @@ mod tests {
                         scope: TransactionNameRuleScope::default(),
                         redaction: RedactionRule::default(),
                     }],
-                    ..Default::default()
                 },
                 true,
                 Some(&Vec::from([SpanDescriptionRule {

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1806,7 +1806,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig { rules: &[] }, false, None),
+            &mut TransactionsProcessor::default(),
             ProcessingState::root(),
         )
         .unwrap();

--- a/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__no_sanitized_if_no_rules.snap
+++ b/relay-general/src/store/transactions/snapshots/relay_general__store__transactions__processor__tests__no_sanitized_if_no_rules.snap
@@ -6,7 +6,7 @@ expression: event
   "type": "transaction",
   "transaction": "/remains/rule-target/whatever",
   "transaction_info": {
-    "source": "url"
+    "source": "sanitized"
   },
   "timestamp": 1619420400.0,
   "start_timestamp": 1619420341.0,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2357,7 +2357,6 @@ impl EnvelopeProcessorService {
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
                     rules: &state.project_state.config.tx_name_rules,
-                    ready: state.project_state.config.tx_name_ready,
                 },
                 device_class_synthesis_config: state
                     .project_state
@@ -3716,7 +3715,6 @@ mod tests {
                                 substitution: "*".to_owned(),
                             },
                         }],
-                        ready: false,
                     },
                     ..Default::default()
                 };


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/2139, we transitioned to marking all URL transactions as "sanitized" once sentry provides the "ready" flag. However, this results in a bad onboarding experience for new projects because they still see `<< unparameterized >>` for the first ~10 hours.

This PR removes the "ready" condition, such that _all_ transactions with source URL will now get their transaction name added as a metric tag. Since we were already doing this for all but the newest projects, this should not add much cardinality after all. But we have to keep an eye on the cardinality limiter in the first few hours / days after deploying this.

Fixes https://github.com/getsentry/relay/issues/2186