### PR TITLE
fix(profiles): Enforce profile quotas on metrics buckets

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -854,6 +854,10 @@ impl MetricsContainer for Bucket {
     fn tag(&self, name: &str) -> Option<&str> {
         self.tags.get(name).map(|s| s.as_str())
     }
+
+    fn remove_tag(&mut self, name: &str) {
+        self.tags.remove(name);
+    }
 }
 
 /// Any error that may occur during aggregation.

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -591,6 +591,9 @@ pub trait MetricsContainer {
 
     /// Returns the value of the given tag, if present.
     fn tag(&self, name: &str) -> Option<&str>;
+
+    /// Removes the given tag, if present.
+    fn remove_tag(&mut self, name: &str);
 }
 
 impl MetricsContainer for Metric {
@@ -604,6 +607,10 @@ impl MetricsContainer for Metric {
 
     fn tag(&self, name: &str) -> Option<&str> {
         self.tags.get(name).map(|s| s.as_str())
+    }
+
+    fn remove_tag(&mut self, name: &str) {
+        self.tags.remove(name);
     }
 }
 

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -374,6 +374,7 @@ mod tests {
         // Profile tag has been removed:
         assert!(metrics[0].tags.is_empty());
         assert!(metrics[1].tags.is_empty());
+        assert!(!metrics[2].tags.is_empty());
 
         rx.close();
 


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/2163 we decided not to enforce rate limits on processed profiles with `limit > 0`, to prevent complexity (see PR description).

I wrongly assumed that quotas (i.e. rate limits with `limit:0`) would be correctly enforced by dropping the profile envelope item before metrics are extracted. I overlooked the fact that PoP Relays (where metrics are extracted) do not _receive_ quota configuration, because they do not request it:

https://github.com/getsentry/relay/blob/0505c88f932d89bd42ee75114440f7f08fe7d938/relay-server/src/actors/project_upstream.rs#L273

Note that this only affects rate limits that are issued _only_ for profiles. Rate limits issued for _transactions_ correctly drop the processed profiles.

This PR fixes the issue by stripping the `has_profile` tag off metrics buckets if a `Profile` rate limit is active.

Fixes https://github.com/getsentry/relay/issues/2207

#skip-changelog