### PR TITLE
feat(inbound filters): Add `file:///` url to localhost inbound filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Reject profiles longer than 30s. ([#2168](https://github.com/getsentry/relay/pull/2168))
 - Change default topic for transaction metrics to `ingest-performance-metrics`. ([#2180](https://github.com/getsentry/relay/pull/2180))
 - Add Firefox "dead object" error to browser extension filter ([#2215](https://github.com/getsentry/relay/pull/2215))
+- Add events whose `url` starts with `file://` to localhost inbound filter ([#2214](https://github.com/getsentry/relay/pull/2214))
 
 **Internal**:
 

--- a/relay-filter/src/localhost.rs
+++ b/relay-filter/src/localhost.rs
@@ -25,6 +25,9 @@ pub fn matches(event: &Event) -> bool {
                 }
             }
         }
+        if url.scheme() == "file" {
+            return true;
+        }
     }
 
     false
@@ -72,6 +75,16 @@ mod tests {
         Event {
             request: Annotated::from(Request {
                 url: Annotated::from(format!("http://{val}:8080/")),
+                ..Request::default()
+            }),
+            ..Event::default()
+        }
+    }
+
+    fn get_event_with_url(val: &str) -> Event {
+        Event {
+            request: Annotated::from(Request {
+                url: Annotated::from(val.to_string()),
                 ..Request::default()
             }),
             ..Event::default()
@@ -150,5 +163,25 @@ mod tests {
                 "Filtered perfectly valid domain '{domain}'"
             );
         }
+    }
+
+    #[test]
+    fn test_filter_file_urls() {
+        let url = "file:///Users/Maisey/work/squirrelchasers/src/leaderboard.html";
+        let event = get_event_with_url(url);
+        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        assert_ne!(
+            filter_result,
+            Ok(()),
+            "Failed to filter event with url '{url}'"
+        );
+    }
+
+    #[test]
+    fn test_dont_filter_non_file_urls() {
+        let url = "http://www.squirrelchasers.com/leaderboard";
+        let event = get_event_with_url(url);
+        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        assert_eq!(filter_result, Ok(()), "Filtered valid url '{url}'");
     }
 }


### PR DESCRIPTION
This adds a filter for events whose `url` value starts with `file://` to the existing localhost inbound filter, as such events similarly represent errors on pages opened locally.

Ref: https://github.com/getsentry/sentry/issues/49519