### PR TITLE
feat(inbound filters): Add Firefox "dead object" error to browser extension filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `lock` attribute to the frame protocol. ([#2171](https://github.com/getsentry/relay/pull/2171))
 - Reject profiles longer than 30s. ([#2168](https://github.com/getsentry/relay/pull/2168))
 - Change default topic for transaction metrics to `ingest-performance-metrics`. ([#2180](https://github.com/getsentry/relay/pull/2180))
+- Add Firefox "dead object" error to browser extension filter ([#2215](https://github.com/getsentry/relay/pull/2215))
 
 **Internal**:
 

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -40,7 +40,10 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         plugin\.setSuspendState\sis\snot\sa\sfunction|
         # Chrome extension message passing failure
         Extension\scontext\sinvalidated|
-        webkit-masked-url:
+        webkit-masked-url:|
+        # Firefox message when an extension tries to modify a no-longer-existing DOM node
+        # See https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/
+        can't\saccess\sdead\sobject
     "#,
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex")
@@ -252,6 +255,7 @@ mod tests {
             "plugin.setSuspendState is not a function",
             "Extension context invalidated",
             "useless error webkit-masked-url: please filter",
+            "TypeError: can't access dead object because dead stuff smells bad",
         ];
 
         for exc_value in &exceptions {

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -264,7 +264,7 @@ mod tests {
             assert_ne!(
                 filter_result,
                 Ok(()),
-                "Event filter not recognizing events with known values {exc_value}"
+                "Event filter not recognizing events with known value '{exc_value}'"
             )
         }
     }


### PR DESCRIPTION
This adds `“can’t access dead object”` to the browser extension inbound filter. From the [Mozilla blog post](https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/) on the topic:

>Firefox 15 introduced a major improvement in memory usage, by disallowing add-ons to keep references to DOM objects after their parent document was destroyed. This eliminates the most common cause of memory leaks in add-ons, and should reduce memory consumption for many users.
>
>If you install an add-on that causes this kind of memory leak, starting with Firefox 15 you’ll see errors like this in the Error Console:
>
>`Error: TypeError: can't access dead object`
>`Source File: chrome://addon/content/file.js`
>`Line: 42`
>
>This means that Firefox did the right thing and prevented the add-on from holding on to this object. However, it also means that the add-on probably won’t work correctly.

Ref: https://github.com/getsentry/sentry/issues/49520