### PR TITLE
fix(spans): Use span's timestamps for span durations

### DIFF
--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn extract_span_metrics(
     if event.ty.value() != Some(&EventType::Transaction) {
         return Ok(());
     }
-    let (Some(&start), Some(&end)) = (event.start_timestamp.value(), event.timestamp.value()) else {
+    let (Some(&_start), Some(&end)) = (event.start_timestamp.value(), event.timestamp.value()) else {
         relay_log::debug!("failed to extract the start and the end timestamps from the event");
         return Err(ExtractMetricsError::MissingTimestamp);
     };

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -231,16 +231,22 @@ pub(crate) fn extract_span_metrics(
                 ));
             }
 
-            // The `duration` of a span. This metric also serves as the
-            // counter metric `throughput`.
-            metrics.push(Metric::new_mri(
-                MetricNamespace::Spans,
-                "duration",
-                MetricUnit::Duration(DurationUnit::MilliSecond),
-                MetricValue::Distribution(relay_common::chrono_to_positive_millis(end - start)),
-                timestamp,
-                span_tags.clone(),
-            ));
+            if let (Some(&span_start), Some(&span_end)) =
+                (span.start_timestamp.value(), span.timestamp.value())
+            {
+                // The `duration` of a span. This metric also serves as the
+                // counter metric `throughput`.
+                metrics.push(Metric::new_mri(
+                    MetricNamespace::Spans,
+                    "duration",
+                    MetricUnit::Duration(DurationUnit::MilliSecond),
+                    MetricValue::Distribution(relay_common::chrono_to_positive_millis(
+                        span_end - span_start,
+                    )),
+                    timestamp,
+                    span_tags.clone(),
+                ));
+            };
         }
     }
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -990,7 +990,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1034,7 +1034,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1087,7 +1087,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1144,7 +1144,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1205,7 +1205,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1270,7 +1270,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1334,7 +1334,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1395,7 +1395,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1455,7 +1455,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1513,7 +1513,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1572,7 +1572,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1636,7 +1636,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1702,7 +1702,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1764,7 +1764,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1822,7 +1822,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1877,7 +1877,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {


### PR DESCRIPTION
To calculate a span's duration, we were using a transaction's start and end timestamps. This PR fixes this by using the span's timestamps.

#skip-changelog