### PR TITLE
fix(spans): Fix missing snapshot

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -1257,7 +1257,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
@@ -1320,7 +1320,7 @@ mod tests {
             Metric {
                 name: "d:spans/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    2000.0,
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {


### PR DESCRIPTION
It seems there were some missing updates when merging master in some PRs. For some reason, CI passed in these PRs but not in master, and it's now red. This PR should fix it.

#skip-changelog