### PR TITLE
instr(server): Count transactions by platform, source

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1839,7 +1839,7 @@ impl EnvelopeProcessorService {
                     },
                     platform =
                         PlatformTag::from(event.platform.as_str().unwrap_or("other")).as_str(),
-                    contains_slashes = if event.transaction.as_str().unwrap_or("").contains('/') {
+                    contains_slashes = if event.transaction.as_str().unwrap_or_default().contains('/') {
                         "true"
                     } else {
                         "false"

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -25,12 +25,12 @@ use relay_filter::FilterStatKey;
 use relay_general::pii::{PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::Context::Trace;
-use relay_general::protocol::Contexts;
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventType, ExpectCt, ExpectStaple, Hpkp, IpAddr,
     LenientString, Metrics, RelayInfo, Replay, ReplayError, SecurityReportType, SessionAggregates,
     SessionAttributes, SessionStatus, SessionUpdate, Timestamp, TraceContext, UserReport, Values,
 };
+use relay_general::protocol::{Contexts, TransactionSource};
 use relay_general::store::{
     ClockDriftProcessor, LightNormalizationConfig, MeasurementsConfig, TransactionNameConfig,
 };
@@ -66,7 +66,7 @@ use crate::extractors::RequestMeta;
 use crate::metrics_extraction::sessions::extract_session_metrics;
 use crate::metrics_extraction::transactions::extract_transaction_metrics;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
-use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
+use crate::statsd::{PlatformTag, RelayCounters, RelayHistograms, RelayTimers};
 use crate::utils::{
     self, get_sampling_key, log_transaction_name_metrics, ChunkedFormDataAggregator, FormDataIter,
     ItemAction, ManagedEnvelope, SamplingResult,
@@ -1832,10 +1832,18 @@ impl EnvelopeProcessorService {
                 let source = event.get_transaction_source();
 
                 metric!(
-                    counter(RelayCounters::EventTransactionSource) += 1,
-                    source = &source.to_string(),
-                    sdk = envelope.meta().client_name().unwrap_or("proprietary"),
-                    platform = event.platform.as_str().unwrap_or("other"),
+                    counter(RelayCounters::EventTransaction) += 1,
+                    source = match &source {
+                        TransactionSource::Other(_) => "other",
+                        source => source.as_str(),
+                    },
+                    platform =
+                        PlatformTag::from(event.platform.as_str().unwrap_or("other")).as_str(),
+                    contains_slashes = if event.transaction.as_str().unwrap_or("").contains('/') {
+                        "true"
+                    } else {
+                        "false"
+                    }
                 );
 
                 let span_count = event.spans.value().map(Vec::len).unwrap_or(0) as u64;

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1839,11 +1839,12 @@ impl EnvelopeProcessorService {
                     },
                     platform =
                         PlatformTag::from(event.platform.as_str().unwrap_or("other")).as_str(),
-                    contains_slashes = if event.transaction.as_str().unwrap_or_default().contains('/') {
-                        "true"
-                    } else {
-                        "false"
-                    }
+                    contains_slashes =
+                        if event.transaction.as_str().unwrap_or_default().contains('/') {
+                            "true"
+                        } else {
+                            "false"
+                        }
                 );
 
                 let span_count = event.spans.value().map(Vec::len).unwrap_or(0) as u64;

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -491,11 +491,11 @@ pub enum RelayCounters {
     ///
     /// This metric is tagged with:
     ///  - `platform`: The event's platform, such as `"javascript"`.
-    ///  - `sdk`: The name of the Sentry SDK sending the transaction. This tag is only set for
-    ///    Sentry's SDKs and defaults to "proprietary".
     ///  - `source`: The source of the transaction name on the client. See the [transaction source
     ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
     ///    for all valid values.
+    ///  - `contains_slashes`: Whether the transaction name contains `/`. We use this as a heuristic
+    ///    to represent URL transactions.
     EventTransaction,
     /// The number of transaction events processed grouped by transaction name modifications.
     /// This metric is tagged with:

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
 
 /// Gauge metrics used by Relay

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, TimerMetric};
 
 /// Gauge metrics used by Relay
@@ -496,7 +498,7 @@ pub enum RelayCounters {
     ///  - `source`: The source of the transaction name on the client. See the [transaction source
     ///    documentation](https://develop.sentry.dev/sdk/event-payloads/properties/transaction_info/)
     ///    for all valid values.
-    EventTransactionSource,
+    EventTransaction,
     /// The number of transaction events processed grouped by transaction name modifications.
     /// This metric is tagged with:
     ///  - `source_in`: The source of the transaction name before normalization.
@@ -567,7 +569,7 @@ impl CounterMetric for RelayCounters {
             #[cfg(feature = "processing")]
             RelayCounters::ProcessingMessageProduced => "processing.event.produced",
             RelayCounters::EventProtocol => "event.protocol",
-            RelayCounters::EventTransactionSource => "event.transaction_source",
+            RelayCounters::EventTransaction => "event.transaction",
             RelayCounters::TransactionNameChanges => "event.transaction_name_changes",
             RelayCounters::Requests => "requests",
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
@@ -575,6 +577,72 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
+        }
+    }
+}
+
+/// Low-cardinality platform that can be used as a statsd tag.
+pub enum PlatformTag {
+    Cocoa,
+    Csharp,
+    Edge,
+    Go,
+    Java,
+    Javascript,
+    Julia,
+    Native,
+    Node,
+    Objc,
+    Other,
+    Perl,
+    Php,
+    Python,
+    Ruby,
+    Swift,
+}
+
+impl PlatformTag {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Cocoa => "cocoa",
+            Self::Csharp => "csharp",
+            Self::Edge => "edge",
+            Self::Go => "go",
+            Self::Java => "java",
+            Self::Javascript => "javascript",
+            Self::Julia => "julia",
+            Self::Native => "native",
+            Self::Node => "node",
+            Self::Objc => "objc",
+            Self::Other => "other",
+            Self::Perl => "perl",
+            Self::Php => "php",
+            Self::Python => "python",
+            Self::Ruby => "ruby",
+            Self::Swift => "swift",
+        }
+    }
+}
+
+impl<S: AsRef<str>> From<S> for PlatformTag {
+    fn from(value: S) -> Self {
+        match value.as_ref() {
+            "cocoa" => Self::Cocoa,
+            "csharp" => Self::Csharp,
+            "edge" => Self::Edge,
+            "go" => Self::Go,
+            "java" => Self::Java,
+            "javascript" => Self::Javascript,
+            "julia" => Self::Julia,
+            "native" => Self::Native,
+            "node" => Self::Node,
+            "objc" => Self::Objc,
+            "perl" => Self::Perl,
+            "php" => Self::Php,
+            "python" => Self::Python,
+            "ruby" => Self::Ruby,
+            "swift" => Self::Swift,
+            _ => Self::Other,
         }
     }
 }


### PR DESCRIPTION
Collect counts of transactions per `(platform, source, contains_slashes)`. The goal of this metric is to verify a suspicion that most `unknown` transactions from javascript projects are URL transactions.

This metric replaces the now unused `transaction_source` metric, which is unused and produced some high-cardinality tags.

ref: https://github.com/getsentry/team-ingest/issues/129

#skip-changelog