### PR TITLE
chore: Start Relay even if the geoip db cannot be opened

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -137,7 +137,7 @@ impl ServiceState {
             outcome_aggregator.clone(),
             project_cache.clone(),
             upstream_relay.clone(),
-        )?
+        )
         .start();
 
         let aggregator = AggregatorService::new(


### PR DESCRIPTION
Currently Relay will refuse to start with a cryptic error when it cannot open provided path to GeoIP db:

```shell
 INFO relay::setup: launching relay from config folder /relay/.relay
 INFO relay::setup:   relay mode: managed
 INFO relay::setup:   relay id: XXXXX
 INFO relay::setup:   public key: XXXXX
 INFO relay::setup:   log level: TRACE
 INFO relay_server: relay server starting
 INFO relay_server::actors::upstream: registering with upstream descriptor=https://XXXXXX/
 INFO relay_server::actors::outcome: Configured to emit outcomes as client reports
 INFO relay_server::actors::outcome: OutcomeProducer started.
 INFO relay_server::actors::outcome_aggregator: outcome aggregator started
thread 'main' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /src/index.crates.io-6f17d22bba15001f/tokio-1.28.0/src/runtime/blocking/shutdown.rs:51:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR adds the explicit error reporting when something goes wrong,

```shell
...
 INFO relay_server::actors::outcome_aggregator: outcome aggregator started
ERROR relay_server::actors::processor: failed to open GeoIP db "/tmp/GeoIP2-Enterprise-Test.mmdb-no-file": could not load the Geoip Db

Caused by:
    IoError: No such file or directory (os error 2)
 INFO relay_server::actors::processor: starting 1 envelope processing workers

...

```

and also continues to work in degraded state (without geoip lookup possibility).
This way we ensure that the service still stays up, but with some limited functionality.

/cc @beezz  @jan-auer 

#skip-changelog