### PR TITLE
feat(monitors): Add trace context to CheckIns

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `lock` attribute to the frame protocol. ([#2171](https://github.com/getsentry/relay/pull/2171))
+- Add trace context to CheckIns. ([#2241](https://github.com/getsentry/relay/pull/2241))
 
 ## 0.8.25
 

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 [dependencies]
 relay-common = { path = "../relay-common" }
+relay-general = { path = "../relay-general" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 regex = "1.5.5"

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [dependencies]
 relay-common = { path = "../relay-common" }
-relay-general = { path = "../relay-general" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 regex = "1.5.5"

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -19,6 +19,8 @@
 use relay_common::Uuid;
 use serde::{Deserialize, Serialize};
 
+use crate::protocol::Contexts;
+
 /// Maximum length of monitor slugs.
 const SLUG_LENGTH: usize = 50;
 
@@ -77,7 +79,7 @@ enum IntervalName {
     Minute,
 }
 
-/// The monitor configuration playload for upserting monitors during check-in
+/// The monitor configuration payload for upserting monitors during check-in
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MonitorConfig {
     /// The monitor schedule configuration
@@ -122,6 +124,11 @@ pub struct CheckIn {
     /// monitor configuration to support upserts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub monitor_config: Option<MonitorConfig>,
+
+    /// Contexts describing the environment (e.g. device, os or browser).
+    #[metastructure(legacy_alias = "sentry.interfaces.Contexts")]
+    #[metastructure(skip_serialization = "empty")]
+    pub contexts: Annotated<Contexts>,
 }
 
 /// Normalizes a monitor check-in payload.
@@ -172,7 +179,13 @@ mod tests {
   "monitor_slug": "my-monitor",
   "status": "in_progress",
   "environment": "production",
-  "duration": 21.0
+  "duration": 21.0,
+  "contexts": {
+    "trace": {
+        "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe",
+        "span_id": "bb8f278130535c3c",
+    }
+  }
 }"#;
 
         let check_in = serde_json::from_str::<CheckIn>(json).unwrap();

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -98,7 +98,7 @@ pub struct MonitorConfig {
     timezone: Option<String>,
 }
 
-/// The trace context sent with a check-in
+/// The trace context sent with a check-in.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckInTrace {
     /// trace id of the check-in
@@ -106,10 +106,10 @@ pub struct CheckInTrace {
     trace_id: Uuid,
 }
 
-/// Any contexts sent in the check-in payload
+/// Any contexts sent in the check-in payload.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckInContexts {
-    /// Trace context sent with a check-n
+    /// Trace context sent with a check-in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     trace: Option<CheckInTrace>,
 }
@@ -139,7 +139,8 @@ pub struct CheckIn {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub monitor_config: Option<MonitorConfig>,
 
-    /// Contexts describing the environment (e.g. device, os or browser).
+    /// Contexts describing the associated environment of the job run.
+    /// Only supports trace for now
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub contexts: Option<CheckInContexts>,
 }

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -195,7 +195,7 @@ mod tests {
   "duration": 21.0,
   "contexts": {
     "trace": {
-        "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe"
+      "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe"
     }
   }
 }"#;

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -17,11 +17,9 @@
 #![warn(missing_docs)]
 
 use relay_common::Uuid;
+use relay_general::protocol::Contexts;
+use relay_general::types::Annotated;
 use serde::{Deserialize, Serialize};
-
-use crate::protocol::Contexts;
-
-use crate::types::Annotated;
 
 /// Maximum length of monitor slugs.
 const SLUG_LENGTH: usize = 50;

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -18,7 +18,6 @@
 
 use relay_common::Uuid;
 use relay_general::protocol::Contexts;
-use relay_general::types::Annotated;
 use serde::{Deserialize, Serialize};
 
 /// Maximum length of monitor slugs.
@@ -126,9 +125,8 @@ pub struct CheckIn {
     pub monitor_config: Option<MonitorConfig>,
 
     /// Contexts describing the environment (e.g. device, os or browser).
-    #[metastructure(legacy_alias = "sentry.interfaces.Contexts")]
-    #[metastructure(skip_serialization = "empty")]
-    pub contexts: Annotated<Contexts>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Contexts>,
 }
 
 /// Normalizes a monitor check-in payload.

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -101,7 +101,7 @@ pub struct MonitorConfig {
 /// The trace context sent with a check-in.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckInTrace {
-    /// trace id of the check-in
+    /// Trace-ID of the check-in.
     #[serde(serialize_with = "uuid_simple")]
     trace_id: Uuid,
 }

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -99,6 +99,22 @@ pub struct MonitorConfig {
     timezone: Option<String>,
 }
 
+/// The trace context sent with a check-in
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CheckInTrace {
+    /// How long (in minutes) after the expected checkin time will we wait until we consider the
+    /// checkin to have been missed.
+    #[serde(serialize_with = "uuid_simple")]
+    trace_id: Uuid,
+}
+
+/// Any contexts sent in the check-in payload
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CheckInContexts {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    trace: Option<CheckInTrace>,
+}
+
 /// The monitor check-in payload.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckIn {
@@ -126,7 +142,7 @@ pub struct CheckIn {
 
     /// Contexts describing the environment (e.g. device, os or browser).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contexts: Option<Contexts>,
+    pub contexts: Option<CheckInContexts>,
 }
 
 /// Normalizes a monitor check-in payload.

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -101,8 +101,7 @@ pub struct MonitorConfig {
 /// The trace context sent with a check-in
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckInTrace {
-    /// How long (in minutes) after the expected checkin time will we wait until we consider the
-    /// checkin to have been missed.
+    /// trace id of the check-in
     #[serde(serialize_with = "uuid_simple")]
     trace_id: Uuid,
 }
@@ -110,6 +109,7 @@ pub struct CheckInTrace {
 /// Any contexts sent in the check-in payload
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckInContexts {
+    /// Trace context sent with a check-n
     #[serde(default, skip_serializing_if = "Option::is_none")]
     trace: Option<CheckInTrace>,
 }

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -140,7 +140,7 @@ pub struct CheckIn {
     pub monitor_config: Option<MonitorConfig>,
 
     /// Contexts describing the associated environment of the job run.
-    /// Only supports trace for now
+    /// Only supports trace for now.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub contexts: Option<CheckInContexts>,
 }

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -17,7 +17,6 @@
 #![warn(missing_docs)]
 
 use relay_common::Uuid;
-use relay_general::protocol::Contexts;
 use serde::{Deserialize, Serialize};
 
 /// Maximum length of monitor slugs.
@@ -197,7 +196,6 @@ mod tests {
   "contexts": {
     "trace": {
         "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe",
-        "span_id": "bb8f278130535c3c",
     }
   }
 }"#;

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -21,6 +21,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::protocol::Contexts;
 
+use crate::types::Annotated;
+
 /// Maximum length of monitor slugs.
 const SLUG_LENGTH: usize = 50;
 

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -195,7 +195,7 @@ mod tests {
   "duration": 21.0,
   "contexts": {
     "trace": {
-        "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe",
+        "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe"
     }
   }
 }"#;

--- a/relay-server/src/endpoints/cron.rs
+++ b/relay-server/src/endpoints/cron.rs
@@ -51,6 +51,7 @@ impl CronParams {
                 environment: query.environment,
                 duration: query.duration,
                 monitor_config: None,
+                contexts: None,
             })
             .map_err(BadStoreRequest::InvalidJson)?,
         );


### PR DESCRIPTION
Adds `contexts` to the CheckIn payload in order to enable tracing. See https://github.com/getsentry/sentry-php/blob/master/src/Serializer/PayloadSerializer.php#L74 for PHP example payload

Closes https://github.com/getsentry/sentry/issues/51383