### PR TITLE
hot-fix, disable generation for new transaction tags

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -16,7 +16,7 @@ use crate::metrics_extraction::transactions::types::{
     TransactionMeasurementTags, TransactionMetric,
 };
 use crate::metrics_extraction::utils::{
-    extract_http_status_code, extract_transaction_op, get_eventuser_tag, get_trace_context,
+    extract_transaction_op, get_eventuser_tag, get_trace_context,
 };
 use crate::metrics_extraction::IntoMetric;
 use crate::statsd::RelayCounters;
@@ -39,6 +39,7 @@ fn extract_http_method(transaction: &Event) -> Option<String> {
 }
 
 /// Extract the browser name from the [`Context::Browser`] context.
+#[allow(dead_code)]
 fn extract_browser_name(event: &Event) -> Option<String> {
     let contexts = event.contexts.value()?;
     let browser = contexts.get("browser").and_then(Annotated::value);
@@ -50,6 +51,7 @@ fn extract_browser_name(event: &Event) -> Option<String> {
 }
 
 /// Extract the OS name from the [`Context::Os`] context.
+#[allow(dead_code)]
 fn extract_os_name(event: &Event) -> Option<String> {
     let contexts = event.contexts.value()?;
     let os = contexts.get("os").and_then(Annotated::value);
@@ -61,6 +63,7 @@ fn extract_os_name(event: &Event) -> Option<String> {
 }
 
 /// Extract the GEO country code from the [`relay_general::protocol::User`] context.
+#[allow(dead_code)]
 fn extract_geo_country_code(event: &Event) -> Option<String> {
     if let Some(user) = event.user.value() {
         if let Some(geo) = user.geo.value() {
@@ -595,13 +598,10 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
-                    "browser.name": "Chrome",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
-                    "geo.country_code": "US",
                     "http.method": "post",
-                    "os.name": "Windows",
                     "platform": "javascript",
                     "release": "1.2.3",
                     "transaction": "gEt /api/:version/users/",
@@ -616,14 +616,11 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
-                    "browser.name": "Chrome",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
-                    "geo.country_code": "US",
                     "http.method": "post",
                     "measurement_rating": "meh",
-                    "os.name": "Windows",
                     "platform": "javascript",
                     "release": "1.2.3",
                     "transaction": "gEt /api/:version/users/",
@@ -638,13 +635,10 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
-                    "browser.name": "Chrome",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
-                    "geo.country_code": "US",
                     "http.method": "post",
-                    "os.name": "Windows",
                     "platform": "javascript",
                     "release": "1.2.3",
                     "transaction": "gEt /api/:version/users/",
@@ -659,13 +653,10 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
-                    "browser.name": "Chrome",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
-                    "geo.country_code": "US",
                     "http.method": "post",
-                    "os.name": "Windows",
                     "platform": "javascript",
                     "release": "1.2.3",
                     "transaction": "gEt /api/:version/users/",
@@ -680,13 +671,10 @@ mod tests {
                 ),
                 timestamp: UnixTimestamp(1619420400),
                 tags: {
-                    "browser.name": "Chrome",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
-                    "geo.country_code": "US",
                     "http.method": "post",
-                    "os.name": "Windows",
                     "platform": "javascript",
                     "release": "1.2.3",
                     "transaction": "gEt /api/:version/users/",
@@ -1366,7 +1354,6 @@ mod tests {
             BTreeMap::from([
                 ("transaction.status".to_string(), "unknown".to_string()),
                 ("platform".to_string(), "other".to_string()),
-                ("http.status_code".to_string(), "200".to_string())
             ])
         );
     }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -201,21 +201,21 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
         tags.insert(CommonTag::HttpMethod, http_method);
     }
 
-    if let Some(browser_name) = extract_browser_name(event) {
-        tags.insert(CommonTag::BrowserName, browser_name);
-    }
-
-    if let Some(os_name) = extract_os_name(event) {
-        tags.insert(CommonTag::OsName, os_name);
-    }
-
-    if let Some(geo_country_code) = extract_geo_country_code(event) {
-        tags.insert(CommonTag::GeoCountryCode, geo_country_code);
-    }
-
-    if let Some(status_code) = extract_http_status_code(event) {
-        tags.insert(CommonTag::HttpStatusCode, status_code);
-    }
+    // if let Some(browser_name) = extract_browser_name(event) {
+    //     tags.insert(CommonTag::BrowserName, browser_name);
+    // }
+    //
+    // if let Some(os_name) = extract_os_name(event) {
+    //     tags.insert(CommonTag::OsName, os_name);
+    // }
+    //
+    // if let Some(geo_country_code) = extract_geo_country_code(event) {
+    //     tags.insert(CommonTag::GeoCountryCode, geo_country_code);
+    // }
+    //
+    // if let Some(status_code) = extract_http_status_code(event) {
+    //     tags.insert(CommonTag::HttpStatusCode, status_code);
+    // }
 
     let custom_tags = &config.extract_custom_tags;
     if !custom_tags.is_empty() {

--- a/relay-server/src/metrics_extraction/utils.rs
+++ b/relay-server/src/metrics_extraction/utils.rs
@@ -32,6 +32,7 @@ pub(crate) fn http_status_code_from_span(span: &Span) -> Option<String> {
 }
 
 /// Extracts the HTTP status code.
+#[allow(dead_code)]
 pub(crate) fn extract_http_status_code(event: &Event) -> Option<String> {
     if let Some(spans) = event.spans.value() {
         for span in spans {


### PR DESCRIPTION
Temporarily disable generation of new transaction metric tags
They seem to cause too many buckets in production
disable htt.status_code, browser_name, os.name and geo.country_code they are creating too many buckets.

#skip-changelog