### PR TITLE
fix(spans): Truncate span descriptions for span metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,6 +3308,7 @@ dependencies = [
  "axum-server",
  "backoff",
  "brotli",
+ "bytecount",
  "bytes",
  "chrono",
  "data-encoding",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -30,8 +30,8 @@ axum = { version = "0.6.15", features = ["headers", "macros", "matched-path", "m
 axum-server = "0.4.7"
 backoff = "0.4.0"
 brotli = "3.3.4"
-bytes = { version = "1.4.0" }
 bytecount = "0.6.0"
+bytes = { version = "1.4.0" }
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "serde"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -31,6 +31,7 @@ axum-server = "0.4.7"
 backoff = "0.4.0"
 brotli = "3.3.4"
 bytes = { version = "1.4.0" }
+bytecount = "0.6.0"
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "serde"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -568,7 +568,14 @@ mod tests {
 
     use relay_metrics::AggregatorConfig;
 
-    use crate::metrics_extraction::spans::extract_span_metrics;
+    use crate::metrics_extraction::spans::{extract_span_metrics, truncate_string};
+
+    #[test]
+    fn test_truncate_string_no_panic() {
+        let string = "ÆÆÆÆÆÆ".to_owned();
+        let truncated = truncate_string(string, 3);
+        assert_eq!(truncated, "Æ*");
+    }
 
     macro_rules! span_transaction_method_test {
         // Tests transaction.method is picked from the right place.

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -11,7 +11,6 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use relay_common::{EventType, UnixTimestamp};
 use relay_filter::csp::SchemeDomainPort;
-use relay_general::processor::MaxChars;
 use relay_general::protocol::Event;
 use relay_general::types::{Annotated, Value};
 use relay_metrics::{AggregatorConfig, Metric};
@@ -321,13 +320,22 @@ fn sanitized_span_description(
 /// doesn't use this type; this method uses it for simplicity, and because at
 /// the time of writing this the values are the same. If the limit this type
 /// provides is longer, this method may be ineffective.
-fn truncate_span_description(description: String) -> String {
-    let mut truncated = description;
-    if bytecount::num_chars(truncated.as_bytes()) > MaxChars::TagValue.limit() {
-        truncated.truncate(MaxChars::TagValue.limit() - 1);
-        truncated.push('*');
+fn truncate_span_description(mut description: String) -> String {
+    let max_limit = 200;
+
+    if bytecount::num_chars(description.as_bytes()) < max_limit {
+        return description;
     }
-    truncated
+
+    let mut cutoff = max_limit - 1; // Leave space for `*`
+
+    while cutoff > 0 && description.is_char_boundary(cutoff) {
+        cutoff -= 1;
+    }
+
+    description.truncate(cutoff);
+    description.push('*');
+    description
 }
 
 /// Regex with a capture group to extract the database action from a query.

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -310,8 +310,8 @@ fn sanitized_span_description(
     Some(sanitized)
 }
 
-/// Trims the given string to ensure
-/// [`relay-metrics::AggregatorService`] doesn't drop it for being too long.
+/// Trims the given string with the given maximum bytes. Splitting only happens
+/// on char boundaries.
 ///
 /// If the string is short, it remains unchanged. If it's long, this method
 /// truncates it to the maximum allowed size and sets the last character to

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -195,7 +195,10 @@ pub(crate) fn extract_span_metrics(
                     span_group.truncate(16);
                     span_tags.insert(SpanTagKey::Group, span_group);
 
-                    let truncated = truncate_span_description(scrubbed_desc);
+                    let truncated = truncate_span_description(
+                        scrubbed_desc,
+                        aggregator_config.max_tag_value_length,
+                    );
                     span_tags.insert(SpanTagKey::Description, truncated);
                 }
             }
@@ -320,14 +323,12 @@ fn sanitized_span_description(
 /// doesn't use this type; this method uses it for simplicity, and because at
 /// the time of writing this the values are the same. If the limit this type
 /// provides is longer, this method may be ineffective.
-fn truncate_span_description(mut description: String) -> String {
-    let max_limit = 200;
-
-    if bytecount::num_chars(description.as_bytes()) < max_limit {
+fn truncate_span_description(mut description: String, max_bytes: usize) -> String {
+    if bytecount::num_chars(description.as_bytes()) < max_bytes {
         return description;
     }
 
-    let mut cutoff = max_limit - 1; // Leave space for `*`
+    let mut cutoff = max_bytes - 1; // Leave space for `*`
 
     while cutoff > 0 && description.is_char_boundary(cutoff) {
         cutoff -= 1;

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -573,6 +573,10 @@ mod tests {
     #[test]
     fn test_truncate_string_no_panic() {
         let string = "ÆÆÆÆÆÆ".to_owned();
+
+        let truncated = truncate_string(string.clone(), 3);
+        assert_eq!(truncated, "Æ*");
+
         let truncated = truncate_string(string, 4);
         assert_eq!(truncated, "Æ*");
     }

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -317,7 +317,7 @@ fn sanitized_span_description(
 /// truncates it to the maximum allowed size and sets the last character to
 /// `*`.
 fn truncate_string(mut string: String, max_bytes: usize) -> String {
-    if string.len() < max_bytes {
+    if string.len() <= max_bytes {
         return string;
     }
 

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     fn test_truncate_string_no_panic() {
         let string = "ÆÆÆÆÆÆ".to_owned();
-        let truncated = truncate_string(string, 3);
+        let truncated = truncate_string(string, 4);
         assert_eq!(truncated, "Æ*");
     }
 

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -321,6 +321,10 @@ fn truncate_string(mut string: String, max_bytes: usize) -> String {
         return string;
     }
 
+    if max_bytes == 0 {
+        return String::new();
+    }
+
     let mut cutoff = max_bytes - 1; // Leave space for `*`
 
     while cutoff > 0 && !string.is_char_boundary(cutoff) {
@@ -572,13 +576,25 @@ mod tests {
 
     #[test]
     fn test_truncate_string_no_panic() {
-        let string = "ÆÆÆÆÆÆ".to_owned();
+        let string = "aÆÆ".to_owned();
+
+        let truncated = truncate_string(string.clone(), 0);
+        assert_eq!(truncated, "");
+
+        let truncated = truncate_string(string.clone(), 1);
+        assert_eq!(truncated, "*");
+
+        let truncated = truncate_string(string.clone(), 2);
+        assert_eq!(truncated, "*");
 
         let truncated = truncate_string(string.clone(), 3);
         assert_eq!(truncated, "Æ*");
 
-        let truncated = truncate_string(string, 4);
-        assert_eq!(truncated, "Æ*");
+        let truncated = truncate_string(string.clone(), 4);
+        assert_eq!(truncated, "ÆÆ");
+
+        let truncated = truncate_string(string.clone(), 5);
+        assert_eq!(truncated, "ÆÆ");
     }
 
     macro_rules! span_transaction_method_test {

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -593,7 +593,7 @@ mod tests {
         let truncated = truncate_string(string.clone(), 4);
         assert_eq!(truncated, "ÆÆ");
 
-        let truncated = truncate_string(string.clone(), 5);
+        let truncated = truncate_string(string, 5);
         assert_eq!(truncated, "ÆÆ");
     }
 

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -316,13 +316,8 @@ fn sanitized_span_description(
 /// [`relay-metrics::AggregatorService`] doesn't drop it for being too long.
 ///
 /// If the description is short, it remains unchanged. If it's long, this method
-/// truncates it to the maximum allowed length and sets the last character to
-/// `*`. The maximum length is determined by [`MaxChars::TagValue`].
-///
-/// Note [`relay-metrics::AggregatorService`] is configured independently and
-/// doesn't use this type; this method uses it for simplicity, and because at
-/// the time of writing this the values are the same. If the limit this type
-/// provides is longer, this method may be ineffective.
+/// truncates it to the maximum allowed size and sets the last character to
+/// `*`.
 fn truncate_span_description(mut description: String, max_bytes: usize) -> String {
     if bytecount::num_chars(description.as_bytes()) < max_bytes {
         return description;

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn test_truncate_string_no_panic() {
-        let string = "aÆÆ".to_owned();
+        let string = "ÆÆ".to_owned();
 
         let truncated = truncate_string(string.clone(), 0);
         assert_eq!(truncated, "");

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -195,10 +195,8 @@ pub(crate) fn extract_span_metrics(
                     span_group.truncate(16);
                     span_tags.insert(SpanTagKey::Group, span_group);
 
-                    let truncated = truncate_span_description(
-                        scrubbed_desc,
-                        aggregator_config.max_tag_value_length,
-                    );
+                    let truncated =
+                        truncate_string(scrubbed_desc, aggregator_config.max_tag_value_length);
                     span_tags.insert(SpanTagKey::Description, truncated);
                 }
             }
@@ -312,26 +310,26 @@ fn sanitized_span_description(
     Some(sanitized)
 }
 
-/// Trims the given span description to ensure
+/// Trims the given string to ensure
 /// [`relay-metrics::AggregatorService`] doesn't drop it for being too long.
 ///
-/// If the description is short, it remains unchanged. If it's long, this method
+/// If the string is short, it remains unchanged. If it's long, this method
 /// truncates it to the maximum allowed size and sets the last character to
 /// `*`.
-fn truncate_span_description(mut description: String, max_bytes: usize) -> String {
-    if bytecount::num_chars(description.as_bytes()) < max_bytes {
-        return description;
+fn truncate_string(mut string: String, max_bytes: usize) -> String {
+    if string.len() < max_bytes {
+        return string;
     }
 
     let mut cutoff = max_bytes - 1; // Leave space for `*`
 
-    while cutoff > 0 && description.is_char_boundary(cutoff) {
+    while cutoff > 0 && !string.is_char_boundary(cutoff) {
         cutoff -= 1;
     }
 
-    description.truncate(cutoff);
-    description.push('*');
-    description
+    string.truncate(cutoff);
+    string.push('*');
+    string
 }
 
 /// Regex with a capture group to extract the database action from a query.

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,3 +1,4 @@
+import hashlib
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -1137,6 +1138,8 @@ def test_span_metrics(
     transaction, _ = tx_consumer.get_event()
     assert transaction["spans"][0]["description"] == sent_description
 
+    expected_group = hashlib.md5(sent_description.encode("utf-8")).hexdigest()[:16]
+
     metrics = metrics_consumer.get_metrics()
     span_metrics = [
         metric for metric in metrics if metric["name"].startswith("spans", 2)
@@ -1144,3 +1147,4 @@ def test_span_metrics(
     assert len(span_metrics) == 3
     for metric in span_metrics:
         assert metric["tags"]["span.description"] == expected_description
+        assert metric["tags"]["span.group"] == expected_group

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1066,3 +1066,81 @@ def test_limit_custom_measurements(
         "d:transactions/measurements.foo@none",
         "d:transactions/measurements.bar@none",
     }
+
+
+@pytest.mark.parametrize(
+    "sent_description, expected_description",
+    [
+        (
+            "SELECT column FROM table WHERE another_col = %s",
+            "SELECT column FROM table WHERE another_col = %s",
+        ),
+        (
+            "SELECT column FROM table WHERE another_col = %s AND yet_another_col = something_very_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+            "SELECT column FROM table WHERE another_col = %s AND yet_another_col = something_very_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*",
+        ),
+    ],
+    ids=["Must not truncate short descriptions", "Must truncate long descriptions"],
+)
+def test_span_metrics(
+    transactions_consumer,
+    metrics_consumer,
+    mini_sentry,
+    relay_with_processing,
+    sent_description,
+    expected_description,
+):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    config = mini_sentry.project_configs[project_id]["config"]
+    config["transactionMetrics"] = {
+        "version": 1,
+    }
+    config.setdefault("features", []).append("projects:span-metrics-extraction")
+
+    transaction = {
+        "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",
+        "type": "transaction",
+        "transaction": "/organizations/:orgId/performance/:eventSlug/",
+        "transaction_info": {"source": "route"},
+        "start_timestamp": 1597976392.6542819,
+        "timestamp": 1597976400.6189718,
+        "user": {"id": "user123", "geo": {"country_code": "ES"}},
+        "contexts": {
+            "trace": {
+                "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
+                "span_id": "FA90FDEAD5F74052",
+                "type": "trace",
+            }
+        },
+        "spans": [
+            {
+                "description": sent_description,
+                "op": "db",
+                "parent_span_id": "8f5a2b8768cafb4e",
+                "span_id": "bd429c44b67a3eb4",
+                "start_timestamp": 1597976393.4619668,
+                "timestamp": 1597976393.4718769,
+                "trace_id": "ff62a8b040f340bda5d830223def1d81",
+            }
+        ],
+    }
+    # Default timestamp is so old that relay drops metrics, setting a more recent one avoids the drop.
+    timestamp = datetime.now(tz=timezone.utc)
+    transaction["timestamp"] = timestamp.isoformat()
+
+    metrics_consumer = metrics_consumer()
+    tx_consumer = transactions_consumer()
+    processing = relay_with_processing(options=TEST_CONFIG)
+    processing.send_transaction(project_id, transaction)
+
+    transaction, _ = tx_consumer.get_event()
+    assert transaction["spans"][0]["description"] == sent_description
+
+    metrics = metrics_consumer.get_metrics()
+    span_metrics = [
+        metric for metric in metrics if metric["name"].startswith("spans", 2)
+    ]
+    assert len(span_metrics) == 3
+    for metric in span_metrics:
+        assert metric["tags"]["span.description"] == expected_description


### PR DESCRIPTION
Metrics have tags, and their length is configured statically in the `AggregatorService`, with a [default value of 200 bytes](https://github.com/getsentry/relay/blob/e13d231441bbfe43ec7ca992a39eeb1beb1e92e3/relay-metrics/src/aggregation.rs#L994) for tag values. The metrics aggregator service [silently drops tags that exceed such limit](https://github.com/getsentry/relay/blob/dcad1bdad65ab0a7cf70692f0bd66fa3566b90a1/relay-metrics/src/aggregation.rs#L1629) (not ideal), which is often the case with some span descriptions. Truncating span description tags allows us to keep them.

This PR truncates the descriptions, and sets a `*` as the last character of the string if truncated. Note this only impacts span metrics (and corresponding values in `span.data`), leaving the descriptions in the original payload unmodified.

This change must only affect `span.description`, and not other tags that depend on it like `span.group`.

#skip-changelog