### PR TITLE
Introduce relay pipedream

### DIFF
--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -22,3 +22,15 @@ jobs:
           echo "GoCD YAML Linting"
           find "gocd" -name "*.yaml" -type f -print0 | \
           xargs -0 -I'{}' bash -c 'printf  "\n🔎 Linting {}\n\t" && gocd-cli configrepo syntax --yaml --raw "{}"'
+
+  render:
+    name: Render GoCD Pipelines with Jsonnet
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
+        - uses: getsentry/action-gocd-jsonnet@v0
+          with:
+            jb-install: true
+            check-for-changes: true
+            jsonnet-dir: gocd/templates
+            generated-dir: gocd/generated-pipelines

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target
 # NPM utilities for building docs
 /node_modules/
 package-lock.json
+
+# Jsonnet-bundler
+gocd/templates/vendor/

--- a/Makefile
+++ b/Makefile
@@ -182,3 +182,12 @@ clean-target-dir:
 help: ## this help
 	@ awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m\t%s\n", $$1, $$2 }' $(MAKEFILE_LIST) | column -s$$'\t' -t
 .PHONY: help
+
+gocd: ## Build GoCD pipelines
+	@ rm -rf ./gocd/generated-pipelines
+	@ mkdir -p ./gocd/generated-pipelines
+	@ cd ./gocd/templates && jb install
+	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
+	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
+	@ cd ./gocd/templates && jsonnet -J vendor -m ../generated-pipelines ./relay.jsonnet
+.PHONY: gocd

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -1,0 +1,14 @@
+# Relay Pipelines
+
+Relay is in the process of moving to a set of rendered jsonnet pipelines.
+
+## Jsonnet
+
+You can render the jsonnet pipelines by running:
+
+```
+make gocd
+```
+
+This will clean, fmt, lint and generate the GoCD pipelines to
+`./gocd/generated-pipelines`.

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -1,0 +1,142 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "region-deploy-relay-next-monitor": {
+         "environment_variables": {
+            "SENTRY_REGION": "monitor"
+         },
+         "group": "relay-next",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "relay_repo": {
+               "branch": "master",
+               "destination": "relay",
+               "git": "git@github.com:getsentry/relay.git",
+               "shallow_clone": true
+            },
+            "upstream_pipeline": {
+               "pipeline": "region-deploy-relay-next-us",
+               "stage": "pipeline-complete"
+            }
+         },
+         "stages": [
+            {
+               "ready": {
+                  "jobs": {
+                     "ready": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "wait": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "wait": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "checks": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "checks": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "GITHUB_TOKEN": "{{SECRET:[devinfra-github][token]}}"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n/devinfra/scripts/checks/githubactions/checkruns.py \\\n    getsentry/relay \\\n    \"${GO_REVISION_RELAY_REPO}\" \\\n    \"Integration Tests\" \\\n    \"Test (macos-latest)\" \\\n    \"Test (windows-latest)\" \\\n    \"Test All Features (ubuntu-latest)\" \\\n    \"Push GCR Docker Image\"\n"
+                           }
+                        ],
+                        "timeout": 1800
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-production": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "create_sentry_release": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
+                           "SENTRY_ORG": "sentry",
+                           "SENTRY_PROJECT": "relay",
+                           "SENTRY_URL": "https://sentry.my.sentry.io/"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy": {
+                        "elastic_profile_id": "relay",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay,deploy_if_production=true\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-pops": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "elastic_profile_id": "relay-pop",
+                     "tasks": [
+                        {
+                           "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                        }
+                     ],
+                     "timeout": 1200
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -1,0 +1,186 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "region-deploy-relay-next-us": {
+         "environment_variables": {
+            "SENTRY_REGION": "us"
+         },
+         "group": "relay-next",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "relay_repo": {
+               "branch": "master",
+               "destination": "relay",
+               "git": "git@github.com:getsentry/relay.git",
+               "shallow_clone": true
+            },
+            "upstream_pipeline": {
+               "pipeline": "deploy-relay-next",
+               "stage": "pipeline-complete"
+            }
+         },
+         "stages": [
+            {
+               "ready": {
+                  "jobs": {
+                     "ready": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "wait": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "wait": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "checks": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "checks": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "GITHUB_TOKEN": "{{SECRET:[devinfra-github][token]}}"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n/devinfra/scripts/checks/githubactions/checkruns.py \\\n    getsentry/relay \\\n    \"${GO_REVISION_RELAY_REPO}\" \\\n    \"Integration Tests\" \\\n    \"Test (macos-latest)\" \\\n    \"Test (windows-latest)\" \\\n    \"Test All Features (ubuntu-latest)\" \\\n    \"Push GCR Docker Image\"\n"
+                           }
+                        ],
+                        "timeout": 1800
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-production": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "create_sentry_release": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
+                           "SENTRY_ORG": "sentry",
+                           "SENTRY_PROJECT": "relay",
+                           "SENTRY_URL": "https://sentry.my.sentry.io/"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy": {
+                        "elastic_profile_id": "relay",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay,deploy_if_production=true\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-pops": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "create_sentry_release": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
+                           "SENTRY_ORG": "sentry",
+                           "SENTRY_PROJECT": "pop-relay",
+                           "SENTRY_URL": "https://sentry.my.sentry.io/"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-us-pop-1": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-us-pop-2": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-us-pop-3": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-us-pop-4": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/gocd/generated-pipelines/relay-next.yaml
+++ b/gocd/generated-pipelines/relay-next.yaml
@@ -1,0 +1,37 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-relay-next": {
+         "group": "relay-next",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "relay_repo": {
+               "branch": "master",
+               "destination": "relay",
+               "git": "git@github.com:getsentry/relay.git",
+               "shallow_clone": true
+            }
+         },
+         "stages": [
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/gocd/templates/bash/create-sentry-release.sh
+++ b/gocd/templates/bash/create-sentry-release.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"

--- a/gocd/templates/bash/deploy-pop.sh
+++ b/gocd/templates/bash/deploy-pop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-deploy.py \
+    --label-selector="service=relay-pop" \
+    --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+    --container-name="relay"

--- a/gocd/templates/bash/deploy-relay.sh
+++ b/gocd/templates/bash/deploy-relay.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-deploy.py \
+    --label-selector="service=relay,deploy_if_production=true" \
+    --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+    --container-name="relay"

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/githubactions/checkruns.py \
+    getsentry/relay \
+    "${GO_REVISION_RELAY_REPO}" \
+    "Integration Tests" \
+    "Test (macos-latest)" \
+    "Test (windows-latest)" \
+    "Test All Features (ubuntu-latest)" \
+    "Push GCR Docker Image"

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "d101833baf4bfd4e06910790a95d2d253c88b6b0",
+      "sum": "nl0bw8V53AFhyrK3HhBp7GIKaAOUv6/bJAltB/3efLU="
+    }
+  ],
+  "legacyImports": false
+}

--- a/gocd/templates/libs/relay-pops.libsonnet
+++ b/gocd/templates/libs/relay-pops.libsonnet
@@ -1,0 +1,73 @@
+local STAGE_NAME = 'deploy-pops';
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
+
+// Create a gocd job that will run the deploy-pop script
+local deploy_pop_job(region) =
+  {
+    timeout: 1200,
+    elastic_profile_id: 'relay-pop',
+    tasks: [
+      gocdtasks.script(importstr '../bash/deploy-pop.sh'),
+    ],
+  };
+
+// Iterate over a list of regions and create a job for each
+local deploy_pop_jobs(regions) =
+  {
+    ['deploy-' + region]: deploy_pop_job(region)
+    for region in regions
+  };
+
+local us_pops_stage() =
+  {
+    [STAGE_NAME]: {
+      fetch_materials: true,
+      jobs: {
+        // PoPs have their own Sentry project, which requires separate symbol upload via
+        // create-sentry-release. They could be moved into the same project with a different
+        // environment to avoid this.
+        create_sentry_release: {
+          timeout: 1200,
+          elastic_profile_id: 'relay',
+          environment_variables: {
+            SENTRY_ORG: 'sentry',
+            SENTRY_PROJECT: 'pop-relay',
+            SENTRY_URL: 'https://sentry.my.sentry.io/',
+            // Temporary; self-service encrypted secrets aren't implemented yet.
+            // This should really be rotated to an internal integration token.
+            SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+          },
+          tasks: [
+            gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
+          ],
+        },
+      },
+    },
+  } {
+    [STAGE_NAME]+: {
+      jobs+: deploy_pop_jobs([
+        'us-pop-1',
+        'us-pop-2',
+        'us-pop-3',
+        'us-pop-4',
+      ]),
+    },
+  };
+
+local generic_pops_stage(region) =
+  {
+    [STAGE_NAME]: {
+      fetch_materials: true,
+      jobs: deploy_pop_job([region]),
+    },
+  };
+
+// The US region deploys create a sentry release and deploys to a number
+// of clusters, other regions only deploy to a single cluster.
+{
+  stage(region)::
+    if region == 'us' then
+      us_pops_stage()
+    else
+      generic_pops_stage(region),
+}

--- a/gocd/templates/libs/relay.libsonnet
+++ b/gocd/templates/libs/relay.libsonnet
@@ -1,0 +1,75 @@
+local pops = import './relay-pops.libsonnet';
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
+
+{
+  pipeline(region):: {
+    environment_variables: {
+      SENTRY_REGION: region,
+    },
+    group: 'relay-next',
+    lock_behavior: 'unlockWhenFinished',
+    materials: {
+      relay_repo: {
+        git: 'git@github.com:getsentry/relay.git',
+        shallow_clone: true,
+        branch: 'master',
+        destination: 'relay',
+      },
+    },
+    stages: [
+
+      // Check that github status is good
+      {
+        checks: {
+          fetch_materials: true,
+          jobs: {
+            checks: {
+              environment_variables: {
+                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+              },
+              timeout: 1800,
+              elastic_profile_id: 'relay',
+              tasks: [
+                gocdtasks.script(importstr '../bash/github-check-runs.sh'),
+              ],
+            },
+          },
+        },
+      },
+
+      // Deploy relay
+      {
+        'deploy-production': {
+          fetch_materials: true,
+          jobs: {
+            create_sentry_release: {
+              environment_variables: {
+                SENTRY_ORG: 'sentry',
+                SENTRY_PROJECT: 'relay',
+                SENTRY_URL: 'https://sentry.my.sentry.io/',
+                // Temporary; self-service encrypted secrets aren't implemented yet.
+                // This should really be rotated to an internal integration token.
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+              },
+              timeout: 1200,
+              elastic_profile_id: 'relay',
+              tasks: [
+                gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
+              ],
+            },
+            deploy: {
+              timeout: 1200,
+              elastic_profile_id: 'relay',
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy-relay.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ] + [
+      // Append the relay-pops deployment stages
+      pops.stage(region),
+    ],
+  },
+}

--- a/gocd/templates/relay.jsonnet
+++ b/gocd/templates/relay.jsonnet
@@ -1,0 +1,18 @@
+local relay = import './libs/relay.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'relay-next',
+  auto_deploy: false,
+  auto_pipeline_progression: false,
+  materials: {
+    relay_repo: {
+      git: 'git@github.com:getsentry/relay.git',
+      shallow_clone: true,
+      branch: 'master',
+      destination: 'relay',
+    },
+  },
+};
+
+pipedream.render(pipedream_config, relay.pipeline)


### PR DESCRIPTION
This introduces a new set of GoCD pipelines generated from jsonnet.

The pipelines produced are:

- deploy-relay
- deploy-us
- deploy-monitor

`deploy-relay` is a simple pipeline that triggers a deployment of relay but doesn't actually deploy anything.
`deploy-us` is the equivalent and deploy-relay and deploy-relay-pops that currently exist. The only difference is that the pops pipeline has been turned into a stage. `deploy-monitor` is a new pipeline that deploys to a single-tenant style environment.

This initial version will require manual approvals to trigger the pipeline and to progress between pipelines.