### PR TITLE
Introduce relay pipedream

### DIFF
--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -22,3 +22,15 @@ jobs:
           echo "GoCD YAML Linting"
           find "gocd" -name "*.yaml" -type f -print0 | \
           xargs -0 -I'{}' bash -c 'printf  "\n🔎 Linting {}\n\t" && gocd-cli configrepo syntax --yaml --raw "{}"'
+
+  render:
+    name: Render GoCD Pipelines with Jsonnet
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
+        - uses: getsentry/action-gocd-jsonnet@v0
+          with:
+            jb-install: true
+            check-for-changes: true
+            jsonnet-dir: gocd/templates
+            generated-dir: gocd/generated-pipelines

--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -32,5 +32,6 @@ jobs:
           with:
             jb-install: true
             check-for-changes: true
+            convert-to-yaml: true
             jsonnet-dir: gocd/templates
             generated-dir: gocd/generated-pipelines

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target
 # NPM utilities for building docs
 /node_modules/
 package-lock.json
+
+# Jsonnet-bundler
+gocd/templates/vendor/

--- a/Makefile
+++ b/Makefile
@@ -182,3 +182,12 @@ clean-target-dir:
 help: ## this help
 	@ awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m\t%s\n", $$1, $$2 }' $(MAKEFILE_LIST) | column -s$$'\t' -t
 .PHONY: help
+
+gocd: ## Build GoCD pipelines
+	@ rm -rf ./gocd/generated-pipelines
+	@ mkdir -p ./gocd/generated-pipelines
+	@ cd ./gocd/templates && jb install
+	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
+	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
+	@ cd ./gocd/templates && jsonnet -J vendor -m ../generated-pipelines ./relay.jsonnet
+.PHONY: gocd

--- a/Makefile
+++ b/Makefile
@@ -190,4 +190,5 @@ gocd: ## Build GoCD pipelines
 	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
 	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
 	@ cd ./gocd/templates && jsonnet -J vendor -m ../generated-pipelines ./relay.jsonnet
+	@ cd ./gocd/generated-pipelines && find . -type f \( -name '*.yaml' \) -print0 | xargs -n 1 -0 yq -p json -o yaml -i
 .PHONY: gocd

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -1,0 +1,14 @@
+# Relay Pipelines
+
+Relay is in the process of moving to a set of rendered jsonnet pipelines.
+
+## Jsonnet
+
+You can render the jsonnet pipelines by running:
+
+```
+make gocd
+```
+
+This will clean, fmt, lint and generate the GoCD pipelines to
+`./gocd/generated-pipelines`.

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -12,3 +12,7 @@ make gocd
 
 This will clean, fmt, lint and generate the GoCD pipelines to
 `./gocd/generated-pipelines`.
+
+
+The Relay pipelines are using the https://github.com/getsentry/gocd-jsonnet
+libraries to generate the pipeline for each region.

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -31,7 +31,7 @@ The `gocd/templates/relay.jsonnet` file is the entry point for the
 relay pipelines.
 
 `gocd/templates/libs/*.libsonnet` define the pipeline behaviors for
-deploy relay and relay-pops. These libraries are use to create a
+deploy relay and relay-pops. These libraries are used to create a
 GoCD pipeline, following the same naming as the
 [GoCD yaml pipelines](https://github.com/tomzo/gocd-yaml-config-plugin#readme).
 

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -16,3 +16,44 @@ This will clean, fmt, lint and generate the GoCD pipelines to
 
 The Relay pipelines are using the https://github.com/getsentry/gocd-jsonnet
 libraries to generate the pipeline for each region.
+
+## Files
+
+Below is a description of the directories in the `gocd/` directory.
+
+### `gocd/templates/`
+
+These are a set of jsonnet and libsonnet files which are used
+to generate the relay pipelines. This avoids duplication across
+our GoCD pipeline files as we deploy to multiple regions.
+
+The `gocd/templates/relay.jsonnet` file is the entry point for the
+relay pipelines.
+
+`gocd/templates/libs/*.libsonnet` define the pipeline behaviors for
+deploy relay and relay-pops. These libraries are use to create a
+GoCD pipeline, following the same naming as the
+[GoCD yaml pipelines](https://github.com/tomzo/gocd-yaml-config-plugin#readme).
+
+`gocd/templates/bash/*.sh` are shell scripts that are inlined in the
+result pipelines. This seperation means syntax highlighting and
+extra tooling works for relay's bash scripts.
+
+`gocd/templates/jsonnetfile.json` and `gocd/templates/jsonnetfile.lock.json`
+are used by [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler#readme), a package manager for jsonnet.
+
+You can update jsonnet dependencies by runnning `jb update`.
+
+### `gocd/generated-pipelines/`
+
+The current setup of GoCD at sentry is only able to look for
+yaml pipelines in a repo, so relay has to commit the generated
+pipelines.
+
+The dev-infra team is working on a GoCD plugin that will accept
+the jsonnet directly, removing the need for the generated-pipelines.
+
+### `gocd/pipelines/`
+
+These are the original relay pipelines and will be used until we move
+to the jsonnet pipelines.

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -5,7 +5,7 @@
          "environment_variables": {
             "SENTRY_REGION": "monitor"
          },
-         "group": "relay-next",
+         "group": "relay-next-region-deployments",
          "lock_behavior": "unlockWhenFinished",
          "materials": {
             "relay_repo": {

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -1,0 +1,144 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "region-deploy-relay-next-monitor": {
+         "environment_variables": {
+            "SENTRY_REGION": "monitor"
+         },
+         "group": "relay-next",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "relay_repo": {
+               "branch": "master",
+               "destination": "relay",
+               "git": "git@github.com:getsentry/relay.git",
+               "shallow_clone": true
+            },
+            "upstream_pipeline": {
+               "pipeline": "region-deploy-relay-next-us",
+               "stage": "pipeline-complete"
+            }
+         },
+         "stages": [
+            {
+               "ready": {
+                  "jobs": {
+                     "ready": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "wait": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "wait": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "checks": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "checks": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "GITHUB_TOKEN": "{{SECRET:[devinfra-github][token]}}"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n/devinfra/scripts/checks/githubactions/checkruns.py \\\n    getsentry/relay \\\n    \"${GO_REVISION_RELAY_REPO}\" \\\n    \"Integration Tests\" \\\n    \"Test (macos-latest)\" \\\n    \"Test (windows-latest)\" \\\n    \"Test All Features (ubuntu-latest)\" \\\n    \"Push GCR Docker Image\"\n"
+                           }
+                        ],
+                        "timeout": 1800
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-production": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "create_sentry_release": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
+                           "SENTRY_ORG": "sentry",
+                           "SENTRY_PROJECT": "relay",
+                           "SENTRY_URL": "https://sentry.my.sentry.io/"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy": {
+                        "elastic_profile_id": "relay",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay,deploy_if_production=true\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-pops": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "deploy-pops-monitor": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -15,20 +15,6 @@ pipelines:
         pipeline: region-deploy-relay-next-us
         stage: pipeline-complete
     stages:
-      - ready:
-          jobs:
-            ready:
-              tasks:
-                - exec:
-                    command: true
-      - wait:
-          approval:
-            type: manual
-          jobs:
-            wait:
-              tasks:
-                - exec:
-                    command: true
       - checks:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -1,19 +1,20 @@
 format_version: 10
 pipelines:
-  region-deploy-relay-next-monitor:
+  deploy-relay-next-monitor:
+    display_order: 2
     environment_variables:
       SENTRY_REGION: monitor
-    group: relay-next-region-deployments
+    group: relay-next
     lock_behavior: unlockWhenFinished
     materials:
+      deploy-relay-next-us-pipeline-complete:
+        pipeline: deploy-relay-next-us
+        stage: pipeline-complete
       relay_repo:
         branch: master
         destination: relay
         git: git@github.com:getsentry/relay.git
         shallow_clone: true
-      upstream_pipeline:
-        pipeline: region-deploy-relay-next-us
-        stage: pipeline-complete
     stages:
       - checks:
           fetch_materials: true

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -109,6 +109,9 @@
                   "jobs": {
                      "deploy-pops-monitor": {
                         "elastic_profile_id": "relay-pop",
+                        "environment_variables": {
+                           "SENTRY_REGION": "monitor"
+                        },
                         "tasks": [
                            {
                               "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -66,6 +66,17 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
+      - progress-to-pops:
+          approval:
+            allow_only_on_success: true
+            type: manual
+          jobs:
+            progress-to-pops:
+              elastic_profile_id: relay
+              tasks:
+                - exec:
+                    command: true
+              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -1,147 +1,111 @@
-{
-   "format_version": 10,
-   "pipelines": {
-      "region-deploy-relay-next-monitor": {
-         "environment_variables": {
-            "SENTRY_REGION": "monitor"
-         },
-         "group": "relay-next-region-deployments",
-         "lock_behavior": "unlockWhenFinished",
-         "materials": {
-            "relay_repo": {
-               "branch": "master",
-               "destination": "relay",
-               "git": "git@github.com:getsentry/relay.git",
-               "shallow_clone": true
-            },
-            "upstream_pipeline": {
-               "pipeline": "region-deploy-relay-next-us",
-               "stage": "pipeline-complete"
-            }
-         },
-         "stages": [
-            {
-               "ready": {
-                  "jobs": {
-                     "ready": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            },
-            {
-               "wait": {
-                  "approval": {
-                     "type": "manual"
-                  },
-                  "jobs": {
-                     "wait": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            },
-            {
-               "checks": {
-                  "fetch_materials": true,
-                  "jobs": {
-                     "checks": {
-                        "elastic_profile_id": "relay",
-                        "environment_variables": {
-                           "GITHUB_TOKEN": "{{SECRET:[devinfra-github][token]}}"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\n/devinfra/scripts/checks/githubactions/checkruns.py \\\n    getsentry/relay \\\n    \"${GO_REVISION_RELAY_REPO}\" \\\n    \"Integration Tests\" \\\n    \"Test (macos-latest)\" \\\n    \"Test (windows-latest)\" \\\n    \"Test All Features (ubuntu-latest)\" \\\n    \"Push GCR Docker Image\"\n"
-                           }
-                        ],
-                        "timeout": 1800
-                     }
-                  }
-               }
-            },
-            {
-               "deploy-production": {
-                  "fetch_materials": true,
-                  "jobs": {
-                     "create_sentry_release": {
-                        "elastic_profile_id": "relay",
-                        "environment_variables": {
-                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
-                           "SENTRY_ORG": "sentry",
-                           "SENTRY_PROJECT": "relay",
-                           "SENTRY_URL": "https://sentry.my.sentry.io/"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     },
-                     "deploy": {
-                        "elastic_profile_id": "relay",
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay,deploy_if_production=true\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     }
-                  }
-               }
-            },
-            {
-               "deploy-pops": {
-                  "fetch_materials": true,
-                  "jobs": {
-                     "deploy-pops-monitor": {
-                        "elastic_profile_id": "relay-pop",
-                        "environment_variables": {
-                           "SENTRY_REGION": "monitor"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     }
-                  }
-               }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      }
-   }
-}
+format_version: 10
+pipelines:
+  region-deploy-relay-next-monitor:
+    environment_variables:
+      SENTRY_REGION: monitor
+    group: relay-next-region-deployments
+    lock_behavior: unlockWhenFinished
+    materials:
+      relay_repo:
+        branch: master
+        destination: relay
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+      upstream_pipeline:
+        pipeline: region-deploy-relay-next-us
+        stage: pipeline-complete
+    stages:
+      - ready:
+          jobs:
+            ready:
+              tasks:
+                - exec:
+                    command: true
+      - wait:
+          approval:
+            type: manual
+          jobs:
+            wait:
+              tasks:
+                - exec:
+                    command: true
+      - checks:
+          fetch_materials: true
+          jobs:
+            checks:
+              elastic_profile_id: relay
+              environment_variables:
+                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                        getsentry/relay \
+                        "${GO_REVISION_RELAY_REPO}" \
+                        "Integration Tests" \
+                        "Test (macos-latest)" \
+                        "Test (windows-latest)" \
+                        "Test All Features (ubuntu-latest)" \
+                        "Push GCR Docker Image"
+              timeout: 1800
+      - deploy-production:
+          fetch_materials: true
+          jobs:
+            create_sentry_release:
+              elastic_profile_id: relay
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: relay
+                SENTRY_URL: https://sentry.my.sentry.io/
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"
+              timeout: 1200
+            deploy:
+              elastic_profile_id: relay
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay,deploy_if_production=true" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - deploy-pops:
+          fetch_materials: true
+          jobs:
+            deploy-pops-monitor:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: monitor
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - pipeline-complete:
+          approval:
+            allow_only_on_success: true
+            type: success
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -5,7 +5,7 @@
          "environment_variables": {
             "SENTRY_REGION": "us"
          },
-         "group": "relay-next",
+         "group": "relay-next-region-deployments",
          "lock_behavior": "unlockWhenFinished",
          "materials": {
             "relay_repo": {

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -1,0 +1,186 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "region-deploy-relay-next-us": {
+         "environment_variables": {
+            "SENTRY_REGION": "us"
+         },
+         "group": "relay-next",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "relay_repo": {
+               "branch": "master",
+               "destination": "relay",
+               "git": "git@github.com:getsentry/relay.git",
+               "shallow_clone": true
+            },
+            "upstream_pipeline": {
+               "pipeline": "deploy-relay-next",
+               "stage": "pipeline-complete"
+            }
+         },
+         "stages": [
+            {
+               "ready": {
+                  "jobs": {
+                     "ready": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "wait": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "wait": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            },
+            {
+               "checks": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "checks": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "GITHUB_TOKEN": "{{SECRET:[devinfra-github][token]}}"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n/devinfra/scripts/checks/githubactions/checkruns.py \\\n    getsentry/relay \\\n    \"${GO_REVISION_RELAY_REPO}\" \\\n    \"Integration Tests\" \\\n    \"Test (macos-latest)\" \\\n    \"Test (windows-latest)\" \\\n    \"Test All Features (ubuntu-latest)\" \\\n    \"Push GCR Docker Image\"\n"
+                           }
+                        ],
+                        "timeout": 1800
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-production": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "create_sentry_release": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
+                           "SENTRY_ORG": "sentry",
+                           "SENTRY_PROJECT": "relay",
+                           "SENTRY_URL": "https://sentry.my.sentry.io/"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy": {
+                        "elastic_profile_id": "relay",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay,deploy_if_production=true\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "deploy-pops": {
+                  "fetch_materials": true,
+                  "jobs": {
+                     "create_sentry_release": {
+                        "elastic_profile_id": "relay",
+                        "environment_variables": {
+                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
+                           "SENTRY_ORG": "sentry",
+                           "SENTRY_PROJECT": "pop-relay",
+                           "SENTRY_URL": "https://sentry.my.sentry.io/"
+                        },
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-pops-us-pop-1": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-pops-us-pop-2": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-pops-us-pop-3": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     },
+                     "deploy-pops-us-pop-4": {
+                        "elastic_profile_id": "relay-pop",
+                        "tasks": [
+                           {
+                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
+                           }
+                        ],
+                        "timeout": 1200
+                     }
+                  }
+               }
+            },
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "allow_only_on_success": true,
+                     "type": "success"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -15,20 +15,6 @@ pipelines:
         pipeline: deploy-relay-next
         stage: pipeline-complete
     stages:
-      - ready:
-          jobs:
-            ready:
-              tasks:
-                - exec:
-                    command: true
-      - wait:
-          approval:
-            type: manual
-          jobs:
-            wait:
-              tasks:
-                - exec:
-                    command: true
       - checks:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -1,19 +1,20 @@
 format_version: 10
 pipelines:
-  region-deploy-relay-next-us:
+  deploy-relay-next-us:
+    display_order: 1
     environment_variables:
       SENTRY_REGION: us
-    group: relay-next-region-deployments
+    group: relay-next
     lock_behavior: unlockWhenFinished
     materials:
+      deploy-relay-next-pipeline-complete:
+        pipeline: deploy-relay-next
+        stage: pipeline-complete
       relay_repo:
         branch: master
         destination: relay
         git: git@github.com:getsentry/relay.git
         shallow_clone: true
-      upstream_pipeline:
-        pipeline: deploy-relay-next
-        stage: pipeline-complete
     stages:
       - checks:
           fetch_materials: true

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -1,198 +1,175 @@
-{
-   "format_version": 10,
-   "pipelines": {
-      "region-deploy-relay-next-us": {
-         "environment_variables": {
-            "SENTRY_REGION": "us"
-         },
-         "group": "relay-next-region-deployments",
-         "lock_behavior": "unlockWhenFinished",
-         "materials": {
-            "relay_repo": {
-               "branch": "master",
-               "destination": "relay",
-               "git": "git@github.com:getsentry/relay.git",
-               "shallow_clone": true
-            },
-            "upstream_pipeline": {
-               "pipeline": "deploy-relay-next",
-               "stage": "pipeline-complete"
-            }
-         },
-         "stages": [
-            {
-               "ready": {
-                  "jobs": {
-                     "ready": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            },
-            {
-               "wait": {
-                  "approval": {
-                     "type": "manual"
-                  },
-                  "jobs": {
-                     "wait": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            },
-            {
-               "checks": {
-                  "fetch_materials": true,
-                  "jobs": {
-                     "checks": {
-                        "elastic_profile_id": "relay",
-                        "environment_variables": {
-                           "GITHUB_TOKEN": "{{SECRET:[devinfra-github][token]}}"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\n/devinfra/scripts/checks/githubactions/checkruns.py \\\n    getsentry/relay \\\n    \"${GO_REVISION_RELAY_REPO}\" \\\n    \"Integration Tests\" \\\n    \"Test (macos-latest)\" \\\n    \"Test (windows-latest)\" \\\n    \"Test All Features (ubuntu-latest)\" \\\n    \"Push GCR Docker Image\"\n"
-                           }
-                        ],
-                        "timeout": 1800
-                     }
-                  }
-               }
-            },
-            {
-               "deploy-production": {
-                  "fetch_materials": true,
-                  "jobs": {
-                     "create_sentry_release": {
-                        "elastic_profile_id": "relay",
-                        "environment_variables": {
-                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
-                           "SENTRY_ORG": "sentry",
-                           "SENTRY_PROJECT": "relay",
-                           "SENTRY_URL": "https://sentry.my.sentry.io/"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     },
-                     "deploy": {
-                        "elastic_profile_id": "relay",
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay,deploy_if_production=true\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     }
-                  }
-               }
-            },
-            {
-               "deploy-pops": {
-                  "fetch_materials": true,
-                  "jobs": {
-                     "create_sentry_release": {
-                        "elastic_profile_id": "relay",
-                        "environment_variables": {
-                           "SENTRY_AUTH_TOKEN": "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}",
-                           "SENTRY_ORG": "sentry",
-                           "SENTRY_PROJECT": "pop-relay",
-                           "SENTRY_URL": "https://sentry.my.sentry.io/"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\n./relay/scripts/create-sentry-release \"${GO_REVISION_RELAY_REPO}\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     },
-                     "deploy-pops-us-pop-1": {
-                        "elastic_profile_id": "relay-pop",
-                        "environment_variables": {
-                           "SENTRY_REGION": "us-pop-1"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     },
-                     "deploy-pops-us-pop-2": {
-                        "elastic_profile_id": "relay-pop",
-                        "environment_variables": {
-                           "SENTRY_REGION": "us-pop-2"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     },
-                     "deploy-pops-us-pop-3": {
-                        "elastic_profile_id": "relay-pop",
-                        "environment_variables": {
-                           "SENTRY_REGION": "us-pop-3"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     },
-                     "deploy-pops-us-pop-4": {
-                        "elastic_profile_id": "relay-pop",
-                        "environment_variables": {
-                           "SENTRY_REGION": "us-pop-4"
-                        },
-                        "tasks": [
-                           {
-                              "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
-                           }
-                        ],
-                        "timeout": 1200
-                     }
-                  }
-               }
-            },
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "allow_only_on_success": true,
-                     "type": "success"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      }
-   }
-}
+format_version: 10
+pipelines:
+  region-deploy-relay-next-us:
+    environment_variables:
+      SENTRY_REGION: us
+    group: relay-next-region-deployments
+    lock_behavior: unlockWhenFinished
+    materials:
+      relay_repo:
+        branch: master
+        destination: relay
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+      upstream_pipeline:
+        pipeline: deploy-relay-next
+        stage: pipeline-complete
+    stages:
+      - ready:
+          jobs:
+            ready:
+              tasks:
+                - exec:
+                    command: true
+      - wait:
+          approval:
+            type: manual
+          jobs:
+            wait:
+              tasks:
+                - exec:
+                    command: true
+      - checks:
+          fetch_materials: true
+          jobs:
+            checks:
+              elastic_profile_id: relay
+              environment_variables:
+                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                        getsentry/relay \
+                        "${GO_REVISION_RELAY_REPO}" \
+                        "Integration Tests" \
+                        "Test (macos-latest)" \
+                        "Test (windows-latest)" \
+                        "Test All Features (ubuntu-latest)" \
+                        "Push GCR Docker Image"
+              timeout: 1800
+      - deploy-production:
+          fetch_materials: true
+          jobs:
+            create_sentry_release:
+              elastic_profile_id: relay
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: relay
+                SENTRY_URL: https://sentry.my.sentry.io/
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"
+              timeout: 1200
+            deploy:
+              elastic_profile_id: relay
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay,deploy_if_production=true" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - deploy-pops:
+          fetch_materials: true
+          jobs:
+            create_sentry_release:
+              elastic_profile_id: relay
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: pop-relay
+                SENTRY_URL: https://sentry.my.sentry.io/
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"
+              timeout: 1200
+            deploy-pops-us-pop-1:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-1
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+            deploy-pops-us-pop-2:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-2
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+            deploy-pops-us-pop-3:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-3
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+            deploy-pops-us-pop-4:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-4
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - pipeline-complete:
+          approval:
+            allow_only_on_success: true
+            type: success
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -124,6 +124,9 @@
                      },
                      "deploy-pops-us-pop-1": {
                         "elastic_profile_id": "relay-pop",
+                        "environment_variables": {
+                           "SENTRY_REGION": "us-pop-1"
+                        },
                         "tasks": [
                            {
                               "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
@@ -133,6 +136,9 @@
                      },
                      "deploy-pops-us-pop-2": {
                         "elastic_profile_id": "relay-pop",
+                        "environment_variables": {
+                           "SENTRY_REGION": "us-pop-2"
+                        },
                         "tasks": [
                            {
                               "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
@@ -142,6 +148,9 @@
                      },
                      "deploy-pops-us-pop-3": {
                         "elastic_profile_id": "relay-pop",
+                        "environment_variables": {
+                           "SENTRY_REGION": "us-pop-3"
+                        },
                         "tasks": [
                            {
                               "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"
@@ -151,6 +160,9 @@
                      },
                      "deploy-pops-us-pop-4": {
                         "elastic_profile_id": "relay-pop",
+                        "environment_variables": {
+                           "SENTRY_REGION": "us-pop-4"
+                        },
                         "tasks": [
                            {
                               "script": "##!/bin/bash\n\neval $(/devinfra/scripts/regions/project_env_vars.py --region=\"${SENTRY_REGION}\")\n\n/devinfra/scripts/k8s/k8stunnel\n\n/devinfra/scripts/k8s/k8s-deploy.py \\\n    --label-selector=\"service=relay-pop\" \\\n    --image=\"us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}\" \\\n    --container-name=\"relay\"\n"

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -66,6 +66,17 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
+      - progress-to-pops:
+          approval:
+            allow_only_on_success: true
+            type: manual
+          jobs:
+            progress-to-pops:
+              elastic_profile_id: relay
+              tasks:
+                - exec:
+                    command: true
+              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-next.yaml
+++ b/gocd/generated-pipelines/relay-next.yaml
@@ -1,0 +1,37 @@
+{
+   "format_version": 10,
+   "pipelines": {
+      "deploy-relay-next": {
+         "group": "relay-next",
+         "lock_behavior": "unlockWhenFinished",
+         "materials": {
+            "relay_repo": {
+               "branch": "master",
+               "destination": "relay",
+               "git": "git@github.com:getsentry/relay.git",
+               "shallow_clone": true
+            }
+         },
+         "stages": [
+            {
+               "pipeline-complete": {
+                  "approval": {
+                     "type": "manual"
+                  },
+                  "jobs": {
+                     "pipeline-complete": {
+                        "tasks": [
+                           {
+                              "exec": {
+                                 "command": true
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/gocd/generated-pipelines/relay-next.yaml
+++ b/gocd/generated-pipelines/relay-next.yaml
@@ -1,6 +1,7 @@
 format_version: 10
 pipelines:
   deploy-relay-next:
+    display_order: 0
     group: relay-next
     lock_behavior: unlockWhenFinished
     materials:

--- a/gocd/generated-pipelines/relay-next.yaml
+++ b/gocd/generated-pipelines/relay-next.yaml
@@ -1,37 +1,20 @@
-{
-   "format_version": 10,
-   "pipelines": {
-      "deploy-relay-next": {
-         "group": "relay-next",
-         "lock_behavior": "unlockWhenFinished",
-         "materials": {
-            "relay_repo": {
-               "branch": "master",
-               "destination": "relay",
-               "git": "git@github.com:getsentry/relay.git",
-               "shallow_clone": true
-            }
-         },
-         "stages": [
-            {
-               "pipeline-complete": {
-                  "approval": {
-                     "type": "manual"
-                  },
-                  "jobs": {
-                     "pipeline-complete": {
-                        "tasks": [
-                           {
-                              "exec": {
-                                 "command": true
-                              }
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         ]
-      }
-   }
-}
+format_version: 10
+pipelines:
+  deploy-relay-next:
+    group: relay-next
+    lock_behavior: unlockWhenFinished
+    materials:
+      relay_repo:
+        branch: master
+        destination: relay
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+    stages:
+      - pipeline-complete:
+          approval:
+            type: manual
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/templates/bash/create-sentry-release.sh
+++ b/gocd/templates/bash/create-sentry-release.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"

--- a/gocd/templates/bash/deploy-pop.sh
+++ b/gocd/templates/bash/deploy-pop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-deploy.py \
+    --label-selector="service=relay-pop" \
+    --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+    --container-name="relay"

--- a/gocd/templates/bash/deploy-relay.sh
+++ b/gocd/templates/bash/deploy-relay.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-deploy.py \
+    --label-selector="service=relay,deploy_if_production=true" \
+    --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+    --container-name="relay"

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/githubactions/checkruns.py \
+    getsentry/relay \
+    "${GO_REVISION_RELAY_REPO}" \
+    "Integration Tests" \
+    "Test (macos-latest)" \
+    "Test (windows-latest)" \
+    "Test All Features (ubuntu-latest)" \
+    "Push GCR Docker Image"

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "5155697f36f3ad38bb220c9352a0dbf0ad3ee6e8",
+      "sum": "Sv/sgSHjlryA2oC9TDn5yYlJV0PQKpg/LfCPPaGj47s="
+    }
+  ],
+  "legacyImports": false
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "v1.0.0"
         }
       },
-      "version": "5155697f36f3ad38bb220c9352a0dbf0ad3ee6e8",
-      "sum": "Sv/sgSHjlryA2oC9TDn5yYlJV0PQKpg/LfCPPaGj47s="
+      "version": "7a5534e235e080c16aaf462463d86199be598bd2",
+      "sum": "AB82Md+IyaEqogsDnthjGSl9X0tRRB3xDWiUHFRaCI4="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "v1.0.0"
         }
       },
-      "version": "7a5534e235e080c16aaf462463d86199be598bd2",
-      "sum": "AB82Md+IyaEqogsDnthjGSl9X0tRRB3xDWiUHFRaCI4="
+      "version": "7636a8579792e6e1e66b0b567583e5e05764c39f",
+      "sum": "eOpSoGZ9y3+6O3qllOXVBdiHfQ2xwcnAJWqlE4k3Rj8="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/libs/relay-pops.libsonnet
+++ b/gocd/templates/libs/relay-pops.libsonnet
@@ -6,6 +6,9 @@ local deploy_pop_job(region) =
   {
     timeout: 1200,
     elastic_profile_id: 'relay-pop',
+    environment_variables: {
+      SENTRY_REGION: region,
+    },
     tasks: [
       gocdtasks.script(importstr '../bash/deploy-pop.sh'),
     ],

--- a/gocd/templates/libs/relay-pops.libsonnet
+++ b/gocd/templates/libs/relay-pops.libsonnet
@@ -1,0 +1,73 @@
+local STAGE_NAME = 'deploy-pops';
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
+
+// Create a gocd job that will run the deploy-pop script
+local deploy_pop_job(region) =
+  {
+    timeout: 1200,
+    elastic_profile_id: 'relay-pop',
+    tasks: [
+      gocdtasks.script(importstr '../bash/deploy-pop.sh'),
+    ],
+  };
+
+// Iterate over a list of regions and create a job for each
+local deploy_pop_jobs(regions) =
+  {
+    [STAGE_NAME + '-' + region]: deploy_pop_job(region)
+    for region in regions
+  };
+
+local us_pops_stage() =
+  {
+    [STAGE_NAME]: {
+      fetch_materials: true,
+      jobs: {
+        // PoPs have their own Sentry project, which requires separate symbol upload via
+        // create-sentry-release. They could be moved into the same project with a different
+        // environment to avoid this.
+        create_sentry_release: {
+          timeout: 1200,
+          elastic_profile_id: 'relay',
+          environment_variables: {
+            SENTRY_ORG: 'sentry',
+            SENTRY_PROJECT: 'pop-relay',
+            SENTRY_URL: 'https://sentry.my.sentry.io/',
+            // Temporary; self-service encrypted secrets aren't implemented yet.
+            // This should really be rotated to an internal integration token.
+            SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+          },
+          tasks: [
+            gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
+          ],
+        },
+      },
+    },
+  } {
+    [STAGE_NAME]+: {
+      jobs+: deploy_pop_jobs([
+        'us-pop-1',
+        'us-pop-2',
+        'us-pop-3',
+        'us-pop-4',
+      ]),
+    },
+  };
+
+local generic_pops_stage(region) =
+  {
+    [STAGE_NAME]: {
+      fetch_materials: true,
+      jobs: deploy_pop_jobs([region]),
+    },
+  };
+
+// The US region deploys create a sentry release and deploys to a number
+// of clusters, other regions only deploy to a single cluster.
+{
+  stage(region)::
+    if region == 'us' then
+      us_pops_stage()
+    else
+      generic_pops_stage(region),
+}

--- a/gocd/templates/libs/relay.libsonnet
+++ b/gocd/templates/libs/relay.libsonnet
@@ -1,0 +1,75 @@
+local pops = import './relay-pops.libsonnet';
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
+
+{
+  pipeline(region):: {
+    environment_variables: {
+      SENTRY_REGION: region,
+    },
+    group: 'relay-next',
+    lock_behavior: 'unlockWhenFinished',
+    materials: {
+      relay_repo: {
+        git: 'git@github.com:getsentry/relay.git',
+        shallow_clone: true,
+        branch: 'master',
+        destination: 'relay',
+      },
+    },
+    stages: [
+
+      // Check that github status is good
+      {
+        checks: {
+          fetch_materials: true,
+          jobs: {
+            checks: {
+              environment_variables: {
+                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+              },
+              timeout: 1800,
+              elastic_profile_id: 'relay',
+              tasks: [
+                gocdtasks.script(importstr '../bash/github-check-runs.sh'),
+              ],
+            },
+          },
+        },
+      },
+
+      // Deploy relay
+      {
+        'deploy-production': {
+          fetch_materials: true,
+          jobs: {
+            create_sentry_release: {
+              environment_variables: {
+                SENTRY_ORG: 'sentry',
+                SENTRY_PROJECT: 'relay',
+                SENTRY_URL: 'https://sentry.my.sentry.io/',
+                // Temporary; self-service encrypted secrets aren't implemented yet.
+                // This should really be rotated to an internal integration token.
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+              },
+              timeout: 1200,
+              elastic_profile_id: 'relay',
+              tasks: [
+                gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
+              ],
+            },
+            deploy: {
+              timeout: 1200,
+              elastic_profile_id: 'relay',
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy-relay.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ] + [
+      // Append the relay-pops deployment stages
+      pops.stage(region),
+    ],
+  },
+}

--- a/gocd/templates/libs/relay.libsonnet
+++ b/gocd/templates/libs/relay.libsonnet
@@ -1,75 +1,73 @@
 local pops = import './relay-pops.libsonnet';
 local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
 
-{
-  pipeline(region):: {
-    environment_variables: {
-      SENTRY_REGION: region,
-    },
-    group: 'relay-next',
-    lock_behavior: 'unlockWhenFinished',
-    materials: {
-      relay_repo: {
-        git: 'git@github.com:getsentry/relay.git',
-        shallow_clone: true,
-        branch: 'master',
-        destination: 'relay',
-      },
-    },
-    stages: [
-
-      // Check that github status is good
-      {
-        checks: {
-          fetch_materials: true,
-          jobs: {
-            checks: {
-              environment_variables: {
-                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
-              },
-              timeout: 1800,
-              elastic_profile_id: 'relay',
-              tasks: [
-                gocdtasks.script(importstr '../bash/github-check-runs.sh'),
-              ],
-            },
-          },
-        },
-      },
-
-      // Deploy relay
-      {
-        'deploy-production': {
-          fetch_materials: true,
-          jobs: {
-            create_sentry_release: {
-              environment_variables: {
-                SENTRY_ORG: 'sentry',
-                SENTRY_PROJECT: 'relay',
-                SENTRY_URL: 'https://sentry.my.sentry.io/',
-                // Temporary; self-service encrypted secrets aren't implemented yet.
-                // This should really be rotated to an internal integration token.
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
-              },
-              timeout: 1200,
-              elastic_profile_id: 'relay',
-              tasks: [
-                gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
-              ],
-            },
-            deploy: {
-              timeout: 1200,
-              elastic_profile_id: 'relay',
-              tasks: [
-                gocdtasks.script(importstr '../bash/deploy-relay.sh'),
-              ],
-            },
-          },
-        },
-      },
-    ] + [
-      // Append the relay-pops deployment stages
-      pops.stage(region),
-    ],
+function(region) {
+  environment_variables: {
+    SENTRY_REGION: region,
   },
+  group: 'relay-next',
+  lock_behavior: 'unlockWhenFinished',
+  materials: {
+    relay_repo: {
+      git: 'git@github.com:getsentry/relay.git',
+      shallow_clone: true,
+      branch: 'master',
+      destination: 'relay',
+    },
+  },
+  stages: [
+
+    // Check that github status is good
+    {
+      checks: {
+        fetch_materials: true,
+        jobs: {
+          checks: {
+            environment_variables: {
+              GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+            },
+            timeout: 1800,
+            elastic_profile_id: 'relay',
+            tasks: [
+              gocdtasks.script(importstr '../bash/github-check-runs.sh'),
+            ],
+          },
+        },
+      },
+    },
+
+    // Deploy relay
+    {
+      'deploy-production': {
+        fetch_materials: true,
+        jobs: {
+          create_sentry_release: {
+            environment_variables: {
+              SENTRY_ORG: 'sentry',
+              SENTRY_PROJECT: 'relay',
+              SENTRY_URL: 'https://sentry.my.sentry.io/',
+              // Temporary; self-service encrypted secrets aren't implemented yet.
+              // This should really be rotated to an internal integration token.
+              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+            },
+            timeout: 1200,
+            elastic_profile_id: 'relay',
+            tasks: [
+              gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
+            ],
+          },
+          deploy: {
+            timeout: 1200,
+            elastic_profile_id: 'relay',
+            tasks: [
+              gocdtasks.script(importstr '../bash/deploy-relay.sh'),
+            ],
+          },
+        },
+      },
+    },
+  ] + [
+    // Append the relay-pops deployment stages
+    pops.stage(region),
+  ],
 }

--- a/gocd/templates/libs/relay.libsonnet
+++ b/gocd/templates/libs/relay.libsonnet
@@ -66,6 +66,24 @@ function(region) {
         },
       },
     },
+
+    {
+      'progress-to-pops': {
+        approval: {
+          type: 'manual',
+          allow_only_on_success: true,
+        },
+        jobs: {
+          'progress-to-pops': {
+            timeout: 1200,
+            elastic_profile_id: 'relay',
+            tasks: [
+              gocdtasks.noop,
+            ],
+          },
+        },
+      },
+    },
   ] + [
     // Append the relay-pops deployment stages
     pops.stage(region),

--- a/gocd/templates/relay.jsonnet
+++ b/gocd/templates/relay.jsonnet
@@ -1,0 +1,18 @@
+local relay = import './libs/relay.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'relay-next',
+  auto_deploy: false,
+  auto_pipeline_progression: false,
+  materials: {
+    relay_repo: {
+      git: 'git@github.com:getsentry/relay.git',
+      shallow_clone: true,
+      branch: 'master',
+      destination: 'relay',
+    },
+  },
+};
+
+pipedream.render(pipedream_config, relay.pipeline)

--- a/gocd/templates/relay.jsonnet
+++ b/gocd/templates/relay.jsonnet
@@ -4,7 +4,6 @@ local pipedream = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/pipedream.lib
 local pipedream_config = {
   name: 'relay-next',
   auto_deploy: false,
-  auto_pipeline_progression: false,
   materials: {
     relay_repo: {
       git: 'git@github.com:getsentry/relay.git',

--- a/gocd/templates/relay.jsonnet
+++ b/gocd/templates/relay.jsonnet
@@ -15,4 +15,4 @@ local pipedream_config = {
   },
 };
 
-pipedream.render(pipedream_config, relay.pipeline)
+pipedream.render(pipedream_config, relay)


### PR DESCRIPTION
This introduces a new set of GoCD pipelines generated from jsonnet.

The pipelines produced are:

- deploy-relay
- deploy-us
- deploy-monitor

`deploy-relay` is a simple pipeline that triggers a deployment of relay but doesn't actually deploy anything.
`deploy-us` is the equivalent and deploy-relay and deploy-relay-pops that currently exist. The only difference is that the pops pipeline has been turned into a stage. `deploy-monitor` is a new pipeline that deploys to a single-tenant style environment.

#skip-changelog