### PR TITLE
Fragments are URI only

### DIFF
--- a/relay-general/src/protocol/request.rs
+++ b/relay-general/src/protocol/request.rs
@@ -460,7 +460,7 @@ pub struct Request {
     #[metastructure(skip_serialization = "empty")]
     pub query_string: Annotated<Query>,
 
-    /// The fragment of the request URL.
+    /// The fragment of the request URI.
     #[metastructure(pii = "true", max_chars = "summary")]
     #[metastructure(skip_serialization = "empty")]
     pub fragment: Annotated<String>,

--- a/relay-general/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-general/tests/snapshots/test_fixtures__event_schema.snap
@@ -2896,7 +2896,7 @@ expression: "relay_general::protocol::event_json_schema()"
               "additionalProperties": true
             },
             "fragment": {
-              "description": " The fragment of the request URL.",
+              "description": " The fragment of the request URI.",
               "default": null,
               "type": [
                 "string",


### PR DESCRIPTION
Related to https://www.notion.so/sentry/Update-Docs-for-URI-Fragments-65e8e6db3ad3467abb165d75118b103c

_#skip-changelog_



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
