### PR TITLE
feat(txname): Apply transaction rules to legacy SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
 - Drop profiles without a transaction in the same envelope. ([#2169](https://github.com/getsentry/relay/pull/2169))
 - Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
+- Scrub identifiers from transactions for old SDKs. ([#2250](https://github.com/getsentry/relay/pull/2250))
 
 ## 23.6.1
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -51,6 +51,7 @@ impl Serialize for Feature {
             }
             Feature::DeviceClassSynthesis => "organizations:device-class-synthesis",
             Feature::SpanMetricsExtraction => "projects:span-metrics-extraction",
+            Feature::NormalizeLegacyTransactions => "organizations:normalize-legacy-transactions",
             Feature::Unknown(s) => s,
         })
     }

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -15,6 +15,8 @@ pub enum Feature {
     DeviceClassSynthesis,
     /// Enables metric extraction from spans.
     SpanMetricsExtraction,
+    /// Apply transaction normalization rules to transactions from legacy SDKs.
+    NormalizeLegacyTransactions,
     /// Forward compatibility.
     Unknown(String),
 }

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -51,7 +51,9 @@ impl Serialize for Feature {
             }
             Feature::DeviceClassSynthesis => "organizations:device-class-synthesis",
             Feature::SpanMetricsExtraction => "projects:span-metrics-extraction",
-            Feature::NormalizeLegacyTransactions => "organizations:normalize-legacy-transactions",
+            Feature::NormalizeLegacyTransactions => {
+                "organizations:transaction-name-normalize-legacy"
+            }
             Feature::Unknown(s) => s,
         })
     }

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -196,9 +196,9 @@ impl<'r> TransactionsProcessor<'r> {
         let treat_as_url = matches!(
             source,
             Some(&TransactionSource::Url | &TransactionSource::Sanitized)
-        ) || self.name_config.normalize_legacy
+        ) || (self.name_config.normalize_legacy
             && matches!(source, None)
-            && event.transaction.value().map_or(false, |t| t.contains('/'));
+            && event.transaction.value().map_or(false, |t| t.contains('/')));
 
         if treat_as_url {
             // Normalize transaction names for URLs and Sanitized transaction sources.

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -8,7 +8,7 @@ use relay_common::SpanStatus;
 use super::TransactionNameRule;
 use crate::processor::{ProcessValue, ProcessingState, Processor};
 use crate::protocol::{
-    Context, ContextInner, Event, EventType, Span, Timestamp, TransactionInfo, TransactionSource,
+    Context, ContextInner, Event, EventType, Span, Timestamp, TransactionSource,
 };
 use crate::store::regexes::{
     CACHE_NORMALIZER_REGEX, RESOURCE_NORMALIZER_REGEX, SQL_ALREADY_NORMALIZED_REGEX,
@@ -650,9 +650,7 @@ mod tests {
     use crate::protocol::{
         ClientSdkInfo, Contexts, SpanId, TraceContext, TraceId, TransactionSource,
     };
-    use crate::store::{
-        LazyGlob, RedactionRule, SpanDescriptionRuleScope, TransactionNameRuleScope,
-    };
+    use crate::store::{LazyGlob, RedactionRule, SpanDescriptionRuleScope};
     use crate::testutils::assert_annotated_snapshot;
     use crate::types::Object;
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -200,13 +200,13 @@ impl<'r> TransactionsProcessor<'r> {
             && matches!(source, None)
             && event.transaction.value().map_or(false, |t| t.contains('/'));
 
-        if dbg!(treat_as_url) {
+        if treat_as_url {
             // Normalize transaction names for URLs and Sanitized transaction sources.
             // This in addition to renaming rules can catch some high cardinality parts.
-            dbg!(scrub_identifiers(&mut event.transaction)?);
+            scrub_identifiers(&mut event.transaction)?;
 
             // Apply rules discovered by the transaction clusterer in sentry.
-            if !dbg!(self.name_config.rules.is_empty()) {
+            if !self.name_config.rules.is_empty() {
                 self.apply_transaction_rename_rule(&mut event.transaction)?;
             }
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::protocol::{OperationType, TransactionSource};
+use crate::protocol::OperationType;
 use crate::utils::Glob;
 
 /// Wrapper type around the raw string pattern and the [`crate::utils::Glob`].
@@ -52,21 +52,6 @@ where
     D: Deserializer<'de>,
 {
     String::deserialize(deserializer).map(LazyGlob::new)
-}
-
-/// Contains transaction attribute the rule must only be applied to.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct TransactionNameRuleScope {
-    /// The source of the transaction.
-    pub source: TransactionSource,
-}
-
-impl Default for TransactionNameRuleScope {
-    fn default() -> Self {
-        Self {
-            source: TransactionSource::Url,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq)]

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -187,7 +187,7 @@ impl TransactionNameRule {
         if !slash_is_present {
             transaction.to_mut().push('/');
         }
-        let is_matched = dbg!(self.matches(&transaction));
+        let is_matched = self.matches(&transaction);
 
         if is_matched {
             let mut result = self.apply(&transaction);
@@ -219,7 +219,7 @@ impl TransactionNameRule {
     /// Returns `true` if the current rule pattern matches transaction, expected transaction
     /// source, and not expired yet.
     fn matches(&self, transaction: &str) -> bool {
-        dbg!(self.expiry > Utc::now()) && dbg!(self.pattern.compiled().is_match(transaction))
+        self.expiry > Utc::now() && self.pattern.compiled().is_match(transaction)
     }
 }
 

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -3,9 +3,8 @@ use std::borrow::Cow;
 use chrono::{DateTime, Utc};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 
-use crate::protocol::{OperationType, TransactionInfo, TransactionSource};
+use crate::protocol::{OperationType, TransactionSource};
 use crate::utils::Glob;
 
 /// Wrapper type around the raw string pattern and the [`crate::utils::Glob`].
@@ -309,9 +308,6 @@ mod tests {
         let json = r###"{
   "pattern": "/auth/login/*/**",
   "expiry": "2022-11-30T00:00:00Z",
-  "scope": {
-    "source": "url"
-  },
   "redaction": {
     "method": "replace",
     "substitution": ":id"

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2381,6 +2381,9 @@ impl EnvelopeProcessorService {
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
                     rules: &state.project_state.config.tx_name_rules,
+                    normalize_legacy: state
+                        .project_state
+                        .has_feature(Feature::NormalizeLegacyTransactions),
                 },
                 device_class_synthesis_config: state
                     .project_state
@@ -3734,7 +3737,7 @@ mod tests {
                         rules: &[TransactionNameRule {
                             pattern: LazyGlob::new("/foo/*/**".to_owned()),
                             expiry: DateTime::<Utc>::MAX_UTC,
-                            scope: TransactionNameRuleScope::default(),
+                            deprecated1: TransactionNameRuleScope::default(),
                             redaction: RedactionRule::Replace {
                                 substitution: "*".to_owned(),
                             },

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2763,9 +2763,7 @@ mod tests {
     use relay_common::{DurationUnit, MetricUnit, Uuid};
     use relay_general::pii::{DataScrubbingConfig, PiiConfig};
     use relay_general::protocol::{EventId, TransactionSource};
-    use relay_general::store::{
-        LazyGlob, MeasurementsConfig, RedactionRule, TransactionNameRule, TransactionNameRuleScope,
-    };
+    use relay_general::store::{LazyGlob, MeasurementsConfig, RedactionRule, TransactionNameRule};
     use relay_sampling::{
         RuleCondition, RuleId, RuleType, SamplingConfig, SamplingMode, SamplingRule, SamplingValue,
     };
@@ -3737,11 +3735,11 @@ mod tests {
                         rules: &[TransactionNameRule {
                             pattern: LazyGlob::new("/foo/*/**".to_owned()),
                             expiry: DateTime::<Utc>::MAX_UTC,
-                            deprecated1: TransactionNameRuleScope::default(),
                             redaction: RedactionRule::Replace {
                                 substitution: "*".to_owned(),
                             },
                         }],
+                        ..Default::default()
                     },
                     ..Default::default()
                 };


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/51437 expanded the scope of transaction name clustering to transactions from old SDKs that do not send a `source` annotation yet. This PR enables the application of rules to this type of transactions in Relay.

Because there is a potential of triggering the cardinality limiter, I gated this new behavior with a feature flag.

The condition for applying clusterer rules has now become more complicated, so I decided to remove / ignore the `scope` configuration flag entirely.

ref: https://github.com/getsentry/team-ingest/issues/129