### PR TITLE
fix(filter): Added is_enabled field to transactions name filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Add is_enabled flag on transaction filter. ([#2251](https://github.com/getsentry/relay/pull/2251)) 
 - Keep stackframes closest to crash when quantity exceeds limit. ([#2236](https://github.com/getsentry/relay/pull/2236))
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
 - Drop profiles without a transaction in the same envelope. ([#2169](https://github.com/getsentry/relay/pull/2169))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add is_enabled flag on transaction filter. ([#2251](https://github.com/getsentry/relay/pull/2251)) 
+
 ## 0.8.26
 
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -138,10 +138,12 @@ pub struct ErrorMessagesFilterConfig {
 
 /// Configuration for transaction name filter.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IgnoreTransactionsFilterConfig {
     /// List of patterns for ignored transactions that should be filtered.
     pub patterns: GlobPatterns,
     /// True if the filter is enabled
+    #[serde(default)]
     pub is_enabled: bool,
 }
 

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -370,7 +370,7 @@ mod tests {
             "patterns": [
               "*health*"
             ],
-            "is_enabled": true
+            "isEnabled": true
           }
         }
         "###);

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -141,12 +141,14 @@ pub struct ErrorMessagesFilterConfig {
 pub struct IgnoreTransactionsFilterConfig {
     /// List of patterns for ignored transactions that should be filtered.
     pub patterns: GlobPatterns,
+    /// True if the filter is enabled
+    pub is_enabled: bool,
 }
 
 impl IgnoreTransactionsFilterConfig {
     /// Returns true if no configuration for this filter is given.
     pub fn is_empty(&self) -> bool {
-        self.patterns.is_empty()
+        self.patterns.is_empty() || !self.is_enabled
     }
 }
 
@@ -284,6 +286,7 @@ mod tests {
             },
             ignore_transactions: IgnoreTransactionsFilterConfig {
                 patterns: [],
+                is_enabled: false,
             },
         }
         "###);
@@ -320,6 +323,7 @@ mod tests {
             },
             ignore_transactions: IgnoreTransactionsFilterConfig {
                 patterns: GlobPatterns::new(vec!["*health*".to_string()]),
+                is_enabled: true,
             },
         };
 
@@ -363,7 +367,8 @@ mod tests {
           "ignoreTransactions": {
             "patterns": [
               "*health*"
-            ]
+            ],
+            "is_enabled": true
           }
         }
         "###);

--- a/relay-filter/src/transaction_name.rs
+++ b/relay-filter/src/transaction_name.rs
@@ -18,7 +18,7 @@ pub fn should_filter(
     event: &Event,
     config: &IgnoreTransactionsFilterConfig,
 ) -> Result<(), FilterStatKey> {
-    if !config.is_enabled || config.patterns.is_empty() {
+    if config.is_empty() {
         return Ok(());
     }
 

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -244,9 +244,15 @@ def test_ignore_transactions_filters_are_applied(
     project_config = mini_sentry.add_full_project_config(project_id)
     filter_settings = project_config["config"]["filterSettings"]
     if is_enabled:
-        filter_settings["ignoreTransactions"] = {"patterns": ["health*"]}
+        filter_settings["ignoreTransactions"] = {
+            "patterns": ["health*"],
+            "isEnabled": is_enabled,
+        }
     else:
-        filter_settings["ignoreTransactions"] = {"patterns": []}
+        filter_settings["ignoreTransactions"] = {
+            "patterns": [],
+            "isEnabled": is_enabled,
+        }
 
     transactions_consumer = transactions_consumer(timeout=10)
 


### PR DESCRIPTION
This PR adds the is_enabled field to the TransactionsName configuration.

The flag is added in order to make it easier to work with it in Sentry (since all inbound filters have it).