### PR TITLE
feat(dynamic_config): Add config for dynamic metrics extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
+- Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
 - Scrub identifiers from transactions for old SDKs. ([#2250](https://github.com/getsentry/relay/pull/2250))
 
 **Bug Fixes**:
@@ -14,7 +15,6 @@
 
 **Internal**:
 
-- Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
 - Add the configuration protocol for generic metrics extraction. ([#2252](https://github.com/getsentry/relay/pull/2252))
 
 ## 23.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 **Features**:
 
-- Add is_enabled flag on transaction filter. ([#2251](https://github.com/getsentry/relay/pull/2251)) 
-- Keep stackframes closest to crash when quantity exceeds limit. ([#2236](https://github.com/getsentry/relay/pull/2236))
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
-- Drop profiles without a transaction in the same envelope. ([#2169](https://github.com/getsentry/relay/pull/2169))
-- Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
 - Scrub identifiers from transactions for old SDKs. ([#2250](https://github.com/getsentry/relay/pull/2250))
+
+**Bug Fixes**:
+
+- Keep stack frames closest to crash when quantity exceeds limit. ([#2236](https://github.com/getsentry/relay/pull/2236))
+- Drop profiles without a transaction in the same envelope. ([#2169](https://github.com/getsentry/relay/pull/2169))
+
+**Internal**:
+
+- Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
+- Add the configuration protocol for generic metrics extraction. ([#2252](https://github.com/getsentry/relay/pull/2252))
 
 ## 23.6.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,7 @@ dependencies = [
  "relay-sampling",
  "serde",
  "serde_json",
+ "similar-asserts",
  "smallvec",
 ]
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add the configuration protocol for generic metrics extraction. ([#2252](https://github.com/getsentry/relay/pull/2252))
+
 ## 0.8.27
 
 - Add is_enabled flag on transaction filter. ([#2251](https://github.com/getsentry/relay/pull/2251))

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -27,3 +27,4 @@ smallvec = "1.10.0"
 
 [dev-dependencies]
 insta = "1.26.0"
+similar-asserts = "1.4.2"

--- a/relay-dynamic-config/src/error_boundary.rs
+++ b/relay-dynamic-config/src/error_boundary.rs
@@ -55,6 +55,15 @@ impl<T> ErrorBoundary<T> {
     }
 }
 
+impl<T> Default for ErrorBoundary<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self::Ok(T::default())
+    }
+}
+
 impl<'de, T> Deserialize<'de> for ErrorBoundary<T>
 where
     T: Deserialize<'de>,

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -142,6 +142,13 @@ pub struct MetricExtractionConfig {
     pub tags: Vec<TagMapping>,
 }
 
+impl MetricExtractionConfig {
+    /// Returns `true` if metric extraction is disabled.
+    pub fn is_empty(&self) -> bool {
+        self.version == 0 || (self.metrics.is_empty() && self.tags.is_empty())
+    }
+}
+
 /// TODO(ja): Doc
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -130,7 +130,7 @@ impl TransactionMetricsConfig {
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetricExtractionConfig {
-    /// Versioning of metrics extration. Relay skips extraction if the version is not supported.
+    /// Versioning of metrics extraction. Relay skips extraction if the version is not supported.
     pub version: u16,
 
     /// A list of metric specifications to extract.

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -59,7 +59,7 @@ pub struct ProjectConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_metrics: Option<ErrorBoundary<TransactionMetricsConfig>>,
     /// Configuration for generic metrics extraction from all data categories.
-    #[serde(default, skip_serializing_if = "should_serialize_metrics_extraction")]
+    #[serde(default, skip_serializing_if = "skip_metrics_extraction")]
     pub metric_extraction: ErrorBoundary<MetricExtractionConfig>,
     /// The span attributes configuration.
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
@@ -108,10 +108,10 @@ impl Default for ProjectConfig {
     }
 }
 
-fn should_serialize_metrics_extraction(boundary: &ErrorBoundary<MetricExtractionConfig>) -> bool {
+fn skip_metrics_extraction(boundary: &ErrorBoundary<MetricExtractionConfig>) -> bool {
     match boundary {
-        ErrorBoundary::Err(_) => false,
-        ErrorBoundary::Ok(config) => !config.is_empty(),
+        ErrorBoundary::Err(_) => true,
+        ErrorBoundary::Ok(config) => config.is_empty(),
     }
 }
 

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::feature::Feature;
-use crate::{ErrorBoundary, SessionMetricsConfig, TaggingRule, TransactionMetricsConfig};
+use crate::metrics::{
+    MetricExtractionConfig, SessionMetricsConfig, TaggingRule, TransactionMetricsConfig,
+};
+use crate::ErrorBoundary;
 
 /// Dynamic, per-DSN configuration passed down from Sentry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,6 +58,9 @@ pub struct ProjectConfig {
     /// Configuration for extracting metrics from transaction events.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_metrics: Option<ErrorBoundary<TransactionMetricsConfig>>,
+    /// Configuration for generic metrics extraction from all data categories.
+    #[serde(default, skip_serializing_if = "should_serialize_metrics_extraction")]
+    pub metric_extraction: ErrorBoundary<MetricExtractionConfig>,
     /// The span attributes configuration.
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
     pub span_attributes: BTreeSet<SpanAttribute>,
@@ -91,6 +97,7 @@ impl Default for ProjectConfig {
             breakdowns_v2: None,
             session_metrics: SessionMetricsConfig::default(),
             transaction_metrics: None,
+            metric_extraction: Default::default(),
             span_attributes: BTreeSet::new(),
             metric_conditional_tagging: Vec::new(),
             features: BTreeSet::new(),
@@ -98,6 +105,13 @@ impl Default for ProjectConfig {
             tx_name_ready: false,
             span_description_rules: None,
         }
+    }
+}
+
+fn should_serialize_metrics_extraction(boundary: &ErrorBoundary<MetricExtractionConfig>) -> bool {
+    match boundary {
+        ErrorBoundary::Err(_) => false,
+        ErrorBoundary::Ok(config) => !config.is_empty(),
     }
 }
 

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -111,7 +111,7 @@ impl Default for ProjectConfig {
 fn skip_metrics_extraction(boundary: &ErrorBoundary<MetricExtractionConfig>) -> bool {
     match boundary {
         ErrorBoundary::Err(_) => true,
-        ErrorBoundary::Ok(config) => config.is_empty(),
+        ErrorBoundary::Ok(config) => !config.is_enabled(),
     }
 }
 

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -98,6 +98,12 @@ impl<'de> Deserialize<'de> for GlobPatterns {
     }
 }
 
+impl PartialEq for GlobPatterns {
+    fn eq(&self, other: &Self) -> bool {
+        self.patterns == other.patterns
+    }
+}
+
 /// Identifies which filter dropped an event for which reason.
 ///
 /// Ported from Sentry's same-named "enum". The enum variants are fed into outcomes in kebap-case

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -113,7 +113,7 @@ pub struct EqCondOptions {
 }
 
 /// A condition that checks for equality
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EqCondition {
     pub name: String,
@@ -174,7 +174,7 @@ impl EqCondition {
 
 macro_rules! impl_cmp_condition {
     ($struct_name:ident, $operator:tt) => {
-        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
         pub struct $struct_name {
             pub name: String,
             pub value: Number,
@@ -211,7 +211,7 @@ impl_cmp_condition!(LtCondition, <);
 impl_cmp_condition!(GtCondition, >);
 
 /// A condition that uses glob matching.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GlobCondition {
     pub name: String,
     pub value: GlobPatterns,
@@ -232,7 +232,7 @@ impl GlobCondition {
 /// Condition that cover custom operators which need
 /// special handling and have a custom implementation
 /// for each case.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CustomCondition {
     pub name: String,
     #[serde(default)]
@@ -254,7 +254,7 @@ impl CustomCondition {
 ///
 /// Creates a condition that is true when any
 /// of the inner conditions are true
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OrCondition {
     inner: Vec<RuleCondition>,
 }
@@ -276,7 +276,7 @@ impl OrCondition {
 ///
 /// Creates a condition that is true when all
 /// inner conditions are true.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AndCondition {
     inner: Vec<RuleCondition>,
 }
@@ -297,7 +297,7 @@ impl AndCondition {
 ///
 /// Creates a condition that is true when the wrapped
 /// condition si false.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NotCondition {
     inner: Box<RuleCondition>,
 }
@@ -316,7 +316,7 @@ impl NotCondition {
 }
 
 /// A condition from a sampling rule.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum RuleCondition {
     Eq(EqCondition),


### PR DESCRIPTION
Adds configuration for dynamic metrics extraction to project configuration. This is inactive at this moment, as actual extraction will be implemented in a follow-up.

Ref https://github.com/getsentry/relay/issues/2237

