### PR TITLE
Introduce relay pipedream

### DIFF
--- a/gocd/pipelines/relay-next-monitor.yaml
+++ b/gocd/pipelines/relay-next-monitor.yaml
@@ -1,0 +1,103 @@
+format_version: 10
+pipelines:
+  region-deploy-relay-next-monitor:
+    environment_variables:
+      SENTRY_REGION: monitor
+    group: relay-next-region-deployments
+    lock_behavior: unlockWhenFinished
+    materials:
+      relay_repo:
+        branch: master
+        destination: relay
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+      upstream_pipeline:
+        pipeline: region-deploy-relay-next-us
+        stage: pipeline-complete
+    stages:
+      - ready:
+          jobs:
+            ready:
+              tasks:
+                - exec:
+                    command: true
+      - wait:
+          approval:
+            type: manual
+          jobs:
+            wait:
+              tasks:
+                - exec:
+                    command: true
+      - checks:
+          fetch_materials: true
+          jobs:
+            checks:
+              elastic_profile_id: relay
+              environment_variables:
+                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
+              tasks:
+                - script: |
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                        getsentry/relay \
+                        "${GO_REVISION_RELAY_REPO}" \
+                        "Integration Tests" \
+                        "Test (macos-latest)" \
+                        "Test (windows-latest)" \
+                        "Test All Features (ubuntu-latest)" \
+                        "Push GCR Docker Image"
+              timeout: 1800
+      - deploy-production:
+          fetch_materials: true
+          jobs:
+            create_sentry_release:
+              elastic_profile_id: relay
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: relay
+                SENTRY_URL: https://sentry.my.sentry.io/
+              tasks:
+                - script: |
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"
+              timeout: 1200
+            deploy:
+              elastic_profile_id: relay
+              tasks:
+                - script: |
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay,deploy_if_production=true" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - deploy-pops:
+          fetch_materials: true
+          jobs:
+            deploy-pops-monitor:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: monitor
+              tasks:
+                - script: |
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - pipeline-complete:
+          approval:
+            allow_only_on_success: true
+            type: success
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/pipelines/relay-next-us.yaml
+++ b/gocd/pipelines/relay-next-us.yaml
@@ -1,0 +1,175 @@
+format_version: 10
+pipelines:
+  region-deploy-relay-next-us:
+    environment_variables:
+      SENTRY_REGION: us
+    group: relay-next-region-deployments
+    lock_behavior: unlockWhenFinished
+    materials:
+      relay_repo:
+        branch: master
+        destination: relay
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+      upstream_pipeline:
+        pipeline: deploy-relay-next
+        stage: pipeline-complete
+    stages:
+      - ready:
+          jobs:
+            ready:
+              tasks:
+                - exec:
+                    command: true
+      - wait:
+          approval:
+            type: manual
+          jobs:
+            wait:
+              tasks:
+                - exec:
+                    command: true
+      - checks:
+          fetch_materials: true
+          jobs:
+            checks:
+              elastic_profile_id: relay
+              environment_variables:
+                GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                        getsentry/relay \
+                        "${GO_REVISION_RELAY_REPO}" \
+                        "Integration Tests" \
+                        "Test (macos-latest)" \
+                        "Test (windows-latest)" \
+                        "Test All Features (ubuntu-latest)" \
+                        "Push GCR Docker Image"
+              timeout: 1800
+      - deploy-production:
+          fetch_materials: true
+          jobs:
+            create_sentry_release:
+              elastic_profile_id: relay
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: relay
+                SENTRY_URL: https://sentry.my.sentry.io/
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"
+              timeout: 1200
+            deploy:
+              elastic_profile_id: relay
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay,deploy_if_production=true" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - deploy-pops:
+          fetch_materials: true
+          jobs:
+            create_sentry_release:
+              elastic_profile_id: relay
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: pop-relay
+                SENTRY_URL: https://sentry.my.sentry.io/
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}"
+              timeout: 1200
+            deploy-pops-us-pop-1:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-1
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+            deploy-pops-us-pop-2:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-2
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+            deploy-pops-us-pop-3:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-3
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+            deploy-pops-us-pop-4:
+              elastic_profile_id: relay-pop
+              environment_variables:
+                SENTRY_REGION: us-pop-4
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                        --label-selector="service=relay-pop" \
+                        --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
+                        --container-name="relay"
+              timeout: 1200
+      - pipeline-complete:
+          approval:
+            allow_only_on_success: true
+            type: success
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/pipelines/relay-next.yaml
+++ b/gocd/pipelines/relay-next.yaml
@@ -1,0 +1,20 @@
+format_version: 10
+pipelines:
+  deploy-relay-next:
+    group: relay-next
+    lock_behavior: unlockWhenFinished
+    materials:
+      relay_repo:
+        branch: master
+        destination: relay
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+    stages:
+      - pipeline-complete:
+          approval:
+            type: manual
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true


### PR DESCRIPTION
This introduces a new set of GoCD pipelines.

The pipelines produced are:

- deploy-relay
- deploy-us
- deploy-monitor

`deploy-relay` is a simple pipeline that triggers a deployment of relay but doesn't actually deploy anything.
`deploy-us` is the equivalent and deploy-relay and deploy-relay-pops that currently exist. The only difference is that the pops pipeline has been turned into a stage. `deploy-monitor` is a new pipeline that deploys to a single-tenant style environment.

Note: This is labeled as relay-next as I don't expect the ingest team to use it quite yet and I'll work with the team when its ready to test.
