### PR TITLE
ref(sampling): Remove unused custom rule condition

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -370,13 +370,7 @@ pub unsafe extern "C" fn run_dynamic_sampling(
     // Only if we have both dsc and event we want to run dynamic sampling, otherwise we just return
     // the merged sampling configs.
     let match_result = if let (Ok(event), Ok(dsc)) = (event, dsc) {
-        SamplingMatch::match_against_rules(
-            rules.iter(),
-            event.value(),
-            Some(&dsc),
-            None,
-            Utc::now(),
-        )
+        SamplingMatch::match_against_rules(rules.iter(), event.value(), Some(&dsc), Utc::now())
     } else {
         None
     };

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2266,7 +2266,6 @@ impl EnvelopeProcessorService {
             state.sampling_project_state.as_deref(),
             state.envelope().dsc(),
             state.event.value(),
-            state.envelope().meta().client_addr(),
         );
     }
 
@@ -2297,7 +2296,6 @@ impl EnvelopeProcessorService {
                 Some(root_project_state),
                 Some(dsc),
                 None,
-                state.envelope().meta().client_addr(),
             )
         } else {
             return;

--- a/relay-server/src/metrics_extraction/conditional_tagging.rs
+++ b/relay-server/src/metrics_extraction/conditional_tagging.rs
@@ -6,7 +6,7 @@ pub fn run_conditional_tagging(event: &Event, config: &[TaggingRule], metrics: &
     for rule in config {
         if !rule.condition.supported()
             || rule.target_metrics.is_empty()
-            || !rule.condition.matches(event, None)
+            || !rule.condition.matches(event)
         {
             continue;
         }


### PR DESCRIPTION
The initial implementation of rule evaluation for dynamic sampling was
supposed to support all inbound filters. Since those filters have more
complex conditions, such as `is_legacy_browser` or `is_web_crawler`,
virtual fields and custom conditions were added.

These have since been unused, so this PR removes them without
replacement. This further allows to remove the `client_ip` from the rule
matcher interface.

#skip-changelog
