### PR TITLE
ref(filter): Extract URL path into `SchemaDomainPort`

### DIFF
--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -58,6 +58,8 @@ pub struct SchemeDomainPort {
     pub domain: Option<String>,
     /// The port of the url.
     pub port: Option<String>,
+    /// The path of the url.
+    pub path: Option<String>,
 }
 
 impl From<&str> for SchemeDomainPort {
@@ -84,10 +86,12 @@ impl From<&str> for SchemeDomainPort {
 
         //extract domain:port from the rest of the url
         let end_domain_idx = rest.find('/');
-        let domain_port = if let Some(end_domain_idx) = end_domain_idx {
-            &rest[..end_domain_idx] // remove the path from rest
+        let (domain_port, path) = if let Some(end_domain_idx) = end_domain_idx {
+            let domain = &rest[..end_domain_idx];
+            let path = &rest[end_domain_idx..];
+            (domain, Some(path.to_owned()))
         } else {
-            rest // no path, use everything
+            (rest, None)
         };
 
         //split the domain and the port
@@ -106,6 +110,7 @@ impl From<&str> for SchemeDomainPort {
             scheme,
             domain,
             port,
+            path,
         }
     }
 }

--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -47,7 +47,7 @@ pub fn should_filter(event: &Event, config: &CspFilterConfig) -> Result<(), Filt
 
 /// A pattern used to match allowed paths.
 ///
-/// Scheme, domain and port are extracted from an url,
+/// Scheme, domain, port and the remaining path are extracted from an URL,
 /// they may be either a string (to be matched exactly, case insensitive)
 /// or None (matches anything in the respective position).
 #[derive(Hash, PartialEq, Eq)]

--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -195,46 +195,73 @@ mod tests {
     #[test]
     fn test_scheme_domain_port() {
         let examples = &[
-            ("*", None, None, None),
-            ("*://*", None, None, None),
-            ("*://*:*", None, None, None),
-            ("https://*", Some("https"), None, None),
-            ("https://*.abc.net", Some("https"), Some("*.abc.net"), None),
-            ("https://*:*", Some("https"), None, None),
-            ("x.y.z", None, Some("x.y.z"), None),
-            ("x.y.z:*", None, Some("x.y.z"), None),
-            ("*://x.y.z:*", None, Some("x.y.z"), None),
-            ("*://*.x.y.z:*", None, Some("*.x.y.z"), None),
-            ("*:8000", None, None, Some("8000")),
-            ("*://*:8000", None, None, Some("8000")),
-            ("http://x.y.z", Some("http"), Some("x.y.z"), None),
-            ("http://*:8000", Some("http"), None, Some("8000")),
-            ("abc:8000", None, Some("abc"), Some("8000")),
-            ("*.abc.com:8000", None, Some("*.abc.com"), Some("8000")),
-            ("*.com:86", None, Some("*.com"), Some("86")),
+            ("*", None, None, None, None),
+            ("*://*", None, None, None, None),
+            ("*://*:*", None, None, None, None),
+            ("https://*", Some("https"), None, None, None),
             (
-                "http://abc.com:86",
+                "https://*.abc.net/def/ghi",
+                Some("https"),
+                Some("*.abc.net"),
+                None,
+                Some("/def/ghi"),
+            ),
+            (
+                "https://*:*/a/b/c",
+                Some("https"),
+                None,
+                None,
+                Some("/a/b/c"),
+            ),
+            ("x.y.z", None, Some("x.y.z"), None, None),
+            ("x.y.z:*/a/b/c", None, Some("x.y.z"), None, Some("/a/b/c")),
+            ("*://x.y.z:*", None, Some("x.y.z"), None, None),
+            ("*://*.x.y.z:*", None, Some("*.x.y.z"), None, None),
+            ("*:8000", None, None, Some("8000"), None),
+            ("*://*:8000", None, None, Some("8000"), None),
+            ("http://x.y.z", Some("http"), Some("x.y.z"), None, None),
+            (
+                "http://*:8000/a/b/c",
+                Some("http"),
+                None,
+                Some("8000"),
+                Some("/a/b/c"),
+            ),
+            ("abc:8000", None, Some("abc"), Some("8000"), None),
+            (
+                "*.abc.com:8000",
+                None,
+                Some("*.abc.com"),
+                Some("8000"),
+                None,
+            ),
+            ("*.com:86", None, Some("*.com"), Some("86"), None),
+            (
+                "http://abc.com:86/def/ghi",
                 Some("http"),
                 Some("abc.com"),
                 Some("86"),
+                Some("/def/ghi"),
             ),
             (
-                "http://x.y.z:4000",
+                "http://x.y.z:4000/a/b/c",
                 Some("http"),
                 Some("x.y.z"),
                 Some("4000"),
+                Some("/a/b/c"),
             ),
-            ("http://", Some("http"), Some(""), None),
+            ("http://", Some("http"), Some(""), None, None),
         ];
 
-        for (url, scheme, domain, port) in examples {
+        for (url, scheme, domain, port, path) in examples {
             let actual: SchemeDomainPort = (*url).into();
             assert_eq!(
-                (actual.scheme, actual.domain, actual.port),
+                (actual.scheme, actual.domain, actual.port, actual.path),
                 (
                     scheme.map(|x| x.to_string()),
                     domain.map(|x| x.to_string()),
-                    port.map(|x| x.to_string())
+                    port.map(|x| x.to_string()),
+                    path.map(|x| x.to_string())
                 )
             );
         }


### PR DESCRIPTION
`SchemaDomainPort` is a structure to extract the schema, domain, and port from a URL. This is used for filtering, but also to extract the domain from a URL in span metrics extraction. Adding the path to the structure means we have all the sections of the URL in it, easing the normalization and string rebuilding.

#skip-changelog