### PR TITLE
instr(txnames): Use explicit none tag in yet another statsd metric

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -67,8 +67,8 @@ use crate::extractors::RequestMeta;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::statsd::{PlatformTag, RelayCounters, RelayHistograms, RelayTimers};
 use crate::utils::{
-    self, get_sampling_key, log_transaction_name_metrics, ChunkedFormDataAggregator, FormDataIter,
-    ItemAction, ManagedEnvelope, SamplingResult,
+    self, get_sampling_key, log_transaction_name_metrics, transaction_source_tag,
+    ChunkedFormDataAggregator, FormDataIter, ItemAction, ManagedEnvelope, SamplingResult,
 };
 
 /// The minimum clock drift for correction to apply.
@@ -1833,20 +1833,9 @@ impl EnvelopeProcessorService {
             event._metrics = Annotated::new(metrics);
 
             if event.ty.value() == Some(&EventType::Transaction) {
-                // The `get_transaction_source` helper maps `None` to `Unknown`. Get the value
-                // manually for a more accurate metric:
-                let source = event
-                    .transaction_info
-                    .value()
-                    .and_then(|i| i.source.value());
-
                 metric!(
                     counter(RelayCounters::EventTransaction) += 1,
-                    source = match &source {
-                        None => "none",
-                        Some(&TransactionSource::Other(_)) => "other",
-                        Some(source) => source.as_str(),
-                    },
+                    source = transaction_source_tag(event),
                     platform =
                         PlatformTag::from(event.platform.as_str().unwrap_or("other")).as_str(),
                     contains_slashes =

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -27,12 +27,12 @@ use relay_filter::FilterStatKey;
 use relay_general::pii::{PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
 use relay_general::processor::{process_value, ProcessingState};
 use relay_general::protocol::Context::Trace;
+use relay_general::protocol::Contexts;
 use relay_general::protocol::{
     self, Breadcrumb, ClientReport, Csp, Event, EventType, ExpectCt, ExpectStaple, Hpkp, IpAddr,
     LenientString, Metrics, RelayInfo, Replay, ReplayError, SecurityReportType, SessionAggregates,
     SessionAttributes, SessionStatus, SessionUpdate, Timestamp, TraceContext, UserReport, Values,
 };
-use relay_general::protocol::{Contexts, TransactionSource};
 use relay_general::store::GeoIpLookup;
 use relay_general::store::{
     ClockDriftProcessor, LightNormalizationConfig, MeasurementsConfig, TransactionNameConfig,

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -1,9 +1,22 @@
 use relay_common::EventType;
-use relay_general::protocol::Event;
+use relay_general::protocol::{Event, TransactionSource};
 use relay_general::types::{Annotated, RemarkType};
 
 use crate::metrics_extraction::utils::extract_http_status_code;
 use crate::statsd::RelayCounters;
+
+/// Maps the event's transaction source to a low-cardinality statsd tag.
+pub fn transaction_source_tag(event: &Event) -> &str {
+    let source = event
+        .transaction_info
+        .value()
+        .and_then(|i| i.source.value());
+    match source {
+        None => "none",
+        Some(TransactionSource::Other(_)) => "other",
+        Some(source) => source.as_str(),
+    }
+}
 
 /// Log statsd metrics about transaction name modifications.
 ///
@@ -21,7 +34,7 @@ where
         return f(event);
     }
 
-    let old_source = inner.get_transaction_source().to_string();
+    let old_source = transaction_source_tag(inner);
     let old_remarks = inner.transaction.meta().iter_remarks().count();
 
     let res = f(event);
@@ -51,14 +64,14 @@ where
         (false, false) => "none",
     };
 
-    let new_source = inner.get_transaction_source();
+    let new_source = transaction_source_tag(inner);
     let is_404 = extract_http_status_code(inner).map_or(false, |s| s == "404");
 
     relay_statsd::metric!(
         counter(RelayCounters::TransactionNameChanges) += 1,
-        source_in = old_source.as_str(),
+        source_in = old_source,
         changes = changes,
-        source_out = new_source.as_str(),
+        source_out = new_source,
         is_404 = if is_404 { "true" } else { "false" },
     );
 

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -34,7 +34,7 @@ where
         return f(event);
     }
 
-    let old_source = transaction_source_tag(inner);
+    let old_source = transaction_source_tag(inner).to_string();
     let old_remarks = inner.transaction.meta().iter_remarks().count();
 
     let res = f(event);
@@ -69,7 +69,7 @@ where
 
     relay_statsd::metric!(
         counter(RelayCounters::TransactionNameChanges) += 1,
-        source_in = old_source,
+        source_in = old_source.as_str(),
         changes = changes,
         source_out = new_source,
         is_404 = if is_404 { "true" } else { "false" },


### PR DESCRIPTION
As in https://github.com/getsentry/relay/pull/2235: `source:unknown` and `source:none` have different semantics, so make sure that statsd metrics differentiate between them. Create a helper function to reuse code.

ref: https://github.com/getsentry/team-ingest/issues/129

#skip-changelog