### PR TITLE
instr(metrics): Add separate buckets for aggregated spans metrics observability

### DIFF
--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -174,5 +174,12 @@ pub fn metric_name_tag(value: &str) -> &str {
         return "d:transactions/measurements.*";
     }
 
+    if value.starts_with("s:spans/") {
+        return "s:spans/";
+    }
+    if value.starts_with("d:spans/") {
+        return "d:spans/";
+    }
+
     "other"
 }


### PR DESCRIPTION
Currently, we don't have any observability around how many span metrics we emit, and these go into the `"other"` bucket. This PR adds this observability.

#skip-changelog