### PR TITLE
instr(server): Measure ratio between project keys, projects and orgs

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -528,9 +528,17 @@ impl ProjectCacheBroker {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
-        let expired = self
-            .projects
-            .drain_filter(|_, entry| entry.last_updated_at() + delta <= eviction_start);
+        // Count org and project IDs for stats.
+        let mut project_ids = HashSet::new();
+        let mut org_ids = HashSet::new();
+
+        let expired = self.projects.drain_filter(|_, entry| {
+            if let Some(scoping) = entry.scoping() {
+                project_ids.insert(scoping.project_id);
+                org_ids.insert(scoping.organization_id);
+            }
+            entry.last_updated_at() + delta <= eviction_start
+        });
 
         // Defer dropping the projects to a dedicated thread:
         let mut count = 0;
@@ -543,6 +551,15 @@ impl ProjectCacheBroker {
             count += 1;
         }
         metric!(counter(RelayCounters::EvictingStaleProjectCaches) += count);
+
+        metric!(
+            gauge(RelayGauges::ProjectCacheKeysPerProject) =
+                self.projects.len() as f64 / project_ids.len() as f64
+        );
+        metric!(
+            gauge(RelayGauges::ProjectCacheProjectsPerOrg) =
+                project_ids.len() as f64 / org_ids.len() as f64
+        );
 
         // Log garbage queue size:
         let queue_size = self.garbage_disposal.queue_size() as f64;

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -529,6 +529,7 @@ impl ProjectCacheBroker {
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
         // Count org and project IDs for stats.
+        let project_keys = self.projects.len();
         let mut project_ids = HashSet::new();
         let mut org_ids = HashSet::new();
 
@@ -554,7 +555,7 @@ impl ProjectCacheBroker {
 
         metric!(
             gauge(RelayGauges::ProjectCacheKeysPerProject) =
-                self.projects.len() as f64 / project_ids.len() as f64
+                project_keys as f64 / project_ids.len() as f64
         );
         metric!(
             gauge(RelayGauges::ProjectCacheProjectsPerOrg) =

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -8,8 +8,8 @@ pub enum RelayGauges {
     /// The ratio between project keys (DSNs) and project IDs, i.e. the average number of keys
     /// per project.
     ProjectCacheKeysPerProject,
-    /// The ratio between project IDs and organization IDS, i.e. the average number of projects per
-    /// org.
+    /// The ratio between project IDs and organization IDs, i.e. the average number of projects per
+    /// organization.
     ProjectCacheProjectsPerOrg,
     /// The number of items currently in the garbage disposal queue.
     ProjectCacheGarbageQueueSize,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -5,6 +5,12 @@ pub enum RelayGauges {
     /// The state of Relay with respect to the upstream connection.
     /// Possible values are `0` for normal operations and `1` for a network outage.
     NetworkOutage,
+    /// The ratio between project keys (DSNs) and project IDs, i.e. the average number of keys
+    /// per project.
+    ProjectCacheKeysPerProject,
+    /// The ratio between project IDs and organization IDS, i.e. the average number of projects per
+    /// org.
+    ProjectCacheProjectsPerOrg,
     /// The number of items currently in the garbage disposal queue.
     ProjectCacheGarbageQueueSize,
     /// The number of envelopes waiting for project states in memory.
@@ -26,6 +32,8 @@ impl GaugeMetric for RelayGauges {
     fn name(&self) -> &'static str {
         match self {
             RelayGauges::NetworkOutage => "upstream.network_outage",
+            RelayGauges::ProjectCacheKeysPerProject => "project_cache.avg_keys_per_project",
+            RelayGauges::ProjectCacheProjectsPerOrg => "project_cache.avg_projects_per_org",
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",


### PR DESCRIPTION
Add two statsd metrics to keep track of the ratio between cached organizations, projects, and project keys (DSNs). This lets us estimate how much memory we could save by pushing parts of the config into the project and organization scope.

ref: https://github.com/getsentry/team-ingest/issues/132

#skip-changelog