### PR TITLE
ref(txnames): Treat legacy without `/` as low cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
 - Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
-- Scrub identifiers from transactions for old SDKs. ([#2250](https://github.com/getsentry/relay/pull/2250))
+- Metrics extracted from transactions from old SDKs now get a useful `transaction` tag. ([#2250](https://github.com/getsentry/relay/pull/2250), [#2272](https://github.com/getsentry/relay/pull/2272)).
 
 **Bug Fixes**:
 

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -94,7 +94,7 @@ pub enum AcceptTransactionNames {
 
 impl Default for AcceptTransactionNames {
     fn default() -> Self {
-        Self::Strict
+        Self::ClientBased
     }
 }
 
@@ -108,8 +108,10 @@ pub struct TransactionMetricsConfig {
     pub extract_custom_tags: BTreeSet<String>,
     /// Deprecated in favor of top-level config field. Still here to be forwarded to external relays.
     pub custom_measurements: CustomMeasurementConfig,
-    /// Defines whether URL transactions should be considered low cardinality.
-    pub accept_transaction_names: AcceptTransactionNames,
+    /// Deprecated. Defines whether URL transactions should be considered low cardinality.
+    /// Keep this around for external Relays.
+    #[serde(rename = "acceptTransactionNames")]
+    pub deprecated1: AcceptTransactionNames,
 }
 
 impl TransactionMetricsConfig {

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -79,17 +79,16 @@ pub struct CustomMeasurementConfig {
 /// The version is an integer scalar, incremented by one on each new version.
 const TRANSACTION_EXTRACT_VERSION: u16 = 1;
 
-/// Defines whether URL transactions should be considered low cardinality.
+/// Deprecated. Defines whether URL transactions should be considered low cardinality.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum AcceptTransactionNames {
-    /// For some SDKs, accept all transaction names, while for others, apply strict rules.
-    ClientBased,
-
     /// Only accept transaction names with a low-cardinality source.
-    /// Any value other than "clientBased" will be interpreted as "strict".
-    #[serde(other)]
     Strict,
+
+    /// For some SDKs, accept all transaction names, while for others, apply strict rules.
+    #[serde(other)]
+    ClientBased,
 }
 
 impl Default for AcceptTransactionNames {

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -14,7 +14,7 @@ use crate::protocol::{
     Breadcrumb, Breakdowns, ClientSdkInfo, Contexts, Csp, DebugMeta, Exception, ExpectCt,
     ExpectStaple, Fingerprint, Hpkp, LenientString, Level, LogEntry, Measurements, Metrics,
     RelayInfo, Request, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, TransactionInfo,
-    TransactionSource, User, Values,
+    User, Values,
 };
 use crate::types::{
     Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
@@ -538,13 +538,6 @@ pub struct Event {
 }
 
 impl Event {
-    pub fn get_transaction_source(&self) -> &TransactionSource {
-        self.transaction_info
-            .value()
-            .and_then(|info| info.source.value())
-            .unwrap_or(&TransactionSource::Unknown)
-    }
-
     pub fn get_tag_value(&self, tag_key: &str) -> Option<&str> {
         if let Some(tags) = self.tags.value() {
             tags.get(tag_key)

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -324,11 +324,8 @@ fn validate_transaction(event: &mut Event) -> ProcessingResult {
 /// Newer SDK send the [`TransactionSource`] attribute, which we can rely on to determine cardinality,
 /// but for old SDKs, we fall back to this list.
 pub fn is_high_cardinality_sdk(event: &Event) -> bool {
-    let client_sdk = match event.client_sdk.value() {
-        Some(info) => info,
-        None => {
-            return false;
-        }
+    let Some(client_sdk) = event.client_sdk.value() else {
+        return false;
     };
 
     let sdk_name = client_sdk
@@ -427,6 +424,8 @@ pub fn set_default_transaction_source(event: &mut Event) {
 
 fn is_high_cardinality_transaction(event: &Event) -> bool {
     let transaction = event.transaction.as_str().unwrap_or_default();
+    // We treat transactions from legacy SDKs as URLs if they contain slashes.
+    // Otherwise, we assume low cardinality.
     transaction.contains('/') && is_high_cardinality_sdk(event)
 }
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -72,34 +72,34 @@ fn extract_geo_country_code(event: &Event) -> Option<String> {
 }
 
 fn is_low_cardinality(source: Option<&TransactionSource>) -> bool {
+    // `None` is used to mark a legacy SDK that does not send the transaction name,
+    // and we assume sends high-cardinality data. See `is_high_cardinality_transaction`.
+    let Some(source) = source else { return false };
+
     match source {
         // For now, we hope that custom transaction names set by users are low-cardinality.
-        Some(TransactionSource::Custom) => true,
+        TransactionSource::Custom => true,
 
         // "url" are raw URLs, potentially containing identifiers.
-        Some(TransactionSource::Url) => false,
+        TransactionSource::Url => false,
 
         // These four are names of software components, which we assume to be low-cardinality.
-        Some(TransactionSource::Route)
-        | Some(TransactionSource::View)
-        | Some(TransactionSource::Component)
-        | Some(TransactionSource::Task) => true,
+        TransactionSource::Route
+        | TransactionSource::View
+        | TransactionSource::Component
+        | TransactionSource::Task => true,
 
         // We know now that the rules to remove high cardinality were applied, so we assume
         // low-cardinality now.
-        Some(TransactionSource::Sanitized) => true,
+        TransactionSource::Sanitized => true,
 
         // Explicit `Unknown` is used to mark a legacy SDK that does not send the transaction name,
         // but we assume sends low-cardinality data. See `is_high_cardinality_transaction`.
-        Some(TransactionSource::Unknown) => true,
+        TransactionSource::Unknown => true,
 
         // Any other value would be an SDK bug or users manually configuring the
         // source, assume high-cardinality and drop.
-        Some(TransactionSource::Other(_)) => false,
-
-        // `None` is used to mark a legacy SDK that does not send the transaction name,
-        // and we assume sends high-cardinality data. See `is_high_cardinality_transaction`.
-        None => false,
+        TransactionSource::Other(_) => false,
     }
 }
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -1504,7 +1504,24 @@ mod tests {
     }
 
     #[test]
-    fn test_js_unknown_client_based() {
+    fn test_legacy_js_looks_like_url() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "transaction": "foo/",
+            "timestamp": "2021-04-26T08:00:00+0100",
+            "start_timestamp": "2021-04-26T07:59:01+0100",
+            "contexts": {"trace": {}},
+            "sdk": {"name": "sentry.javascript.browser"}
+        }
+        "#;
+
+        let name = extract_transaction_name(json);
+        assert!(name.is_none());
+    }
+
+    #[test]
+    fn test_legacy_js_does_not_look_like_url() {
         let json = r#"
         {
             "type": "transaction",
@@ -1517,7 +1534,7 @@ mod tests {
         "#;
 
         let name = extract_transaction_name(json);
-        assert!(name.is_none());
+        assert_eq!(name.as_deref(), Some("foo"));
     }
 
     #[test]
@@ -1539,47 +1556,11 @@ mod tests {
     }
 
     #[test]
-    fn test_js_url_client_based() {
+    fn test_python_404() {
         let json = r#"
         {
             "type": "transaction",
-            "transaction": "foo",
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {"trace": {}},
-            "sdk": {"name": "sentry.javascript.browser"},
-            "transaction_info": {"source": "url"}
-        }
-        "#;
-
-        let name = extract_transaction_name(json);
-        assert_eq!(name, Some("<< unparameterized >>".to_owned()));
-    }
-
-    #[test]
-    fn test_python_404_strict() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "foo",
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {"trace": {}},
-            "sdk": {"name": "sentry.python", "integrations":["django"]},
-            "tags": {"http.status": "404"}
-        }
-        "#;
-
-        let name = extract_transaction_name(json);
-        assert!(name.is_none());
-    }
-
-    #[test]
-    fn test_python_404_client_based() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "foo",
+            "transaction": "foo/",
             "timestamp": "2021-04-26T08:00:00+0100",
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
@@ -1593,11 +1574,11 @@ mod tests {
     }
 
     #[test]
-    fn test_python_200_client_based() {
+    fn test_python_200() {
         let json = r#"
         {
             "type": "transaction",
-            "transaction": "foo",
+            "transaction": "foo/",
             "timestamp": "2021-04-26T08:00:00+0100",
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
@@ -1607,15 +1588,15 @@ mod tests {
         "#;
 
         let name = extract_transaction_name(json);
-        assert_eq!(name, Some("foo".to_owned()));
+        assert_eq!(name, Some("foo/".to_owned()));
     }
 
     #[test]
-    fn test_express_options_strict() {
+    fn test_express_options() {
         let json = r#"
         {
             "type": "transaction",
-            "transaction": "foo",
+            "transaction": "foo/",
             "timestamp": "2021-04-26T08:00:00+0100",
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
@@ -1629,29 +1610,11 @@ mod tests {
     }
 
     #[test]
-    fn test_express_options_client_based() {
+    fn test_express() {
         let json = r#"
         {
             "type": "transaction",
-            "transaction": "foo",
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {"trace": {}},
-            "sdk": {"name": "sentry.javascript.node", "integrations":["Express"]},
-            "request": {"method": "OPTIONS"}
-        }
-        "#;
-
-        let name = extract_transaction_name(json);
-        assert!(name.is_none());
-    }
-
-    #[test]
-    fn test_express_get_client_based() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "foo",
+            "transaction": "foo/",
             "timestamp": "2021-04-26T08:00:00+0100",
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
@@ -1661,15 +1624,15 @@ mod tests {
         "#;
 
         let name = extract_transaction_name(json);
-        assert_eq!(name, Some("foo".to_owned()));
+        assert_eq!(name, Some("foo/".to_owned()));
     }
 
     #[test]
-    fn test_other_client_unknown_strict() {
+    fn test_other_client_unknown() {
         let json = r#"
         {
             "type": "transaction",
-            "transaction": "foo",
+            "transaction": "foo/",
             "timestamp": "2021-04-26T08:00:00+0100",
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "contexts": {"trace": {}},
@@ -1678,28 +1641,11 @@ mod tests {
         "#;
 
         let name = extract_transaction_name(json);
-        assert!(name.is_none());
+        assert_eq!(name.as_deref(), Some("foo/"));
     }
 
     #[test]
-    fn test_other_client_unknown_client_based() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "foo",
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {"trace": {}},
-            "sdk": {"name": "some_client"}
-        }
-        "#;
-
-        let name = extract_transaction_name(json);
-        assert_eq!(name, Some("foo".to_owned()));
-    }
-
-    #[test]
-    fn test_other_client_url_strict() {
+    fn test_other_client_url() {
         let json = r#"
         {
             "type": "transaction",
@@ -1717,43 +1663,7 @@ mod tests {
     }
 
     #[test]
-    fn test_other_client_url_client_based() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "foo",
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {"trace": {}},
-            "sdk": {"name": "some_client"},
-            "transaction_info": {"source": "url"}
-        }
-        "#;
-
-        let name = extract_transaction_name(json);
-        assert_eq!(name, Some("<< unparameterized >>".to_owned()));
-    }
-
-    #[test]
-    fn test_any_client_route_strict() {
-        let json = r#"
-        {
-            "type": "transaction",
-            "transaction": "foo",
-            "timestamp": "2021-04-26T08:00:00+0100",
-            "start_timestamp": "2021-04-26T07:59:01+0100",
-            "contexts": {"trace": {}},
-            "sdk": {"name": "some_client"},
-            "transaction_info": {"source": "route"}
-        }
-        "#;
-
-        let name = extract_transaction_name(json);
-        assert_eq!(name, Some("foo".to_owned()));
-    }
-
-    #[test]
-    fn test_any_client_route_client_based() {
+    fn test_any_client_route() {
         let json = r#"
         {
             "type": "transaction",
@@ -1772,11 +1682,11 @@ mod tests {
 
     #[test]
     fn test_parse_transaction_name_strategy() {
-        for (config, expected_strategy) in [
-            (r#"{}"#, AcceptTransactionNames::Strict),
+        for (config_str, expected_strategy) in [
+            (r#"{}"#, AcceptTransactionNames::ClientBased),
             (
                 r#"{"acceptTransactionNames": "unknown-strategy"}"#,
-                AcceptTransactionNames::Strict,
+                AcceptTransactionNames::ClientBased,
             ),
             (
                 r#"{"acceptTransactionNames": "strict"}"#,
@@ -1787,8 +1697,8 @@ mod tests {
                 AcceptTransactionNames::ClientBased,
             ),
         ] {
-            let config: TransactionMetricsConfig = serde_json::from_str(config).unwrap();
-            assert_eq!(config.deprecated1, expected_strategy);
+            let config: TransactionMetricsConfig = serde_json::from_str(config_str).unwrap();
+            assert_eq!(config.deprecated1, expected_strategy, "{}", config_str);
         }
     }
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1216,6 +1216,7 @@ def test_profile_outcomes(
         for m in metrics_consumer.get_metrics()
         if m["name"] == "d:transactions/duration@millisecond"
     ]
+    assert len(metrics) == 2
     assert all(metric["tags"]["has_profile"] == "true" for metric in metrics)
 
     assert outcomes == expected_outcomes, outcomes

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1211,10 +1211,12 @@ def test_profile_outcomes(
     for outcome in outcomes:
         outcome.pop("timestamp")
 
-    metrics = metrics_by_name(metrics_consumer, 3)
-    assert (
-        metrics["d:transactions/duration@millisecond"]["tags"]["has_profile"] == "true"
-    )
+    metrics = [
+        m
+        for m in metrics_consumer.get_metrics()
+        if m["name"] == "d:transactions/duration@millisecond"
+    ]
+    assert all(metric["tags"]["has_profile"] == "true" for metric in metrics)
 
     assert outcomes == expected_outcomes, outcomes
 


### PR DESCRIPTION
Since https://github.com/getsentry/relay/pull/2250, we treat transactions without `transaction_info.source` from old SDKs as URLs if they look like URLs, that is: If it contains slashes, we apply all known clustering rules to the transaction name and then declare it as `sanitized`.

There is still a small group of transactions that ends up without a transaction tag on performance metrics, even though it _probably_ does not produce high cardinality: Transactions without `transaction_info.source` from old SDKs that _do not_ contain slashes.

Overview of transaction categories (by `transaction_info.source`) and whether we extract the transaction metrics tag for them:

* Has source
  * ✅ low cardinality (`route`, `component`, `custom`, ...)
  * high cardinality
    * ✅ `url` -> now all marked as `sanitized`
    * ❌ _other_ -> still marked as unparameterized. An unknown transaction source is an SDK bug, so this is fine.
* No source (legacy SDK)
  * ✅ `unknown` - assumed to be low cardinality by `is_high_cardinality_sdk` heuristic.
  * ✅ `None`
    * ✅ Looks like URL (contains `/`) -> marked as `sanitized`.
    * ❌ **Does not look like URL -> handled in this PR**
    
This PR amends the `is_high_cardinality_sdk` heuristic to mark legacy transactions without slashes as `source:unknown`, which makes metrics extraction assume low cardinality and extract the original transaction name as tag.

This PR also contains some cleanup work to simplify the control flow around `unknown` and `null` sources.

ref: https://github.com/getsentry/team-ingest/issues/129