### PR TITLE
instr(project-cache): Track accessed keys

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -463,14 +463,13 @@ impl AccessTracker {
     }
 
     fn track(&mut self, project_key: ProjectKey) {
-        let now = Instant::now();
-        if (now - self.last_reset) > Duration::from_secs(1) {
+        if self.last_reset.elapsed() > Duration::from_secs(1) {
             let count = self.keys.len();
             // When we get < 1 access per second, this will log results from the past.
             // Does not matter for our use case though.
             metric!(gauge(RelayGauges::ProjectCacheKeysAccessed) = count as u64);
             self.keys.clear();
-            self.last_reset = now;
+            self.last_reset = Instant::now();
         }
         self.keys.insert(project_key);
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -13,6 +13,10 @@ pub enum RelayGauges {
     ProjectCacheProjectsPerOrg,
     /// The number of items currently in the garbage disposal queue.
     ProjectCacheGarbageQueueSize,
+    /// The number of accessed projects per second.
+    ///
+    /// This is intended as a temporary metric, can be removed once the experiment is over.
+    ProjectCacheKeysAccessed,
     /// The number of envelopes waiting for project states in memory.
     ///
     /// This number is always <= `EnvelopeQueueSize`.
@@ -35,6 +39,7 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::ProjectCacheKeysPerProject => "project_cache.avg_keys_per_project",
             RelayGauges::ProjectCacheProjectsPerOrg => "project_cache.avg_projects_per_org",
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
+            RelayGauges::ProjectCacheKeysAccessed => "project_cache.keys_accessed",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",
         }


### PR DESCRIPTION
Temporary metric:

Gauge the number of unique project keys being read each second.

This will help us decide whether it makes sense to keep all project configs in-memory an uncompressed at all times, or if parts of them may be kept in a more high-latency storage (e.g. disk, compressed memory).

ref: https://github.com/getsentry/team-ingest/issues/132

#skip-changelog