### PR TITLE
fix(config): Keep separate project config states per configured public key

### DIFF
--- a/relay-server/src/actors/project_local.rs
+++ b/relay-server/src/actors/project_local.rs
@@ -107,9 +107,11 @@ async fn load_local_states(
             }
         }
 
-        let arc = Arc::new(sanitized);
-        for key in &arc.public_keys {
-            states.insert(key.public_key, arc.clone());
+        // Keep a separate project state per key.
+        let keys = std::mem::take(&mut sanitized.public_keys);
+        for key in keys {
+            sanitized.public_keys = smallvec::smallvec![key.clone()];
+            states.insert(key.public_key, Arc::new(sanitized.clone()));
         }
     }
 


### PR DESCRIPTION
Makes sure to support the following configuration for Relay in `static` or `proxy` mode described in the docs:  https://docs.sentry.io/product/relay/projects/

Makes sure we distinguish the config associated with configured public key. 



fix: https://github.com/getsentry/relay/issues/2120


#skip-changelog