### PR TITLE
feat(metrics): Support access to structured release fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 **Internal**:
 
 - Implement basic generic metrics extraction for transaction events. ([#2252](https://github.com/getsentry/relay/pull/2252), [#2257](https://github.com/getsentry/relay/pull/2257))
-- Support more fields in dynamic sampling, metric extraction, and conditional tagging. The added fields are `dist`, `user.{email,ip_address,name}`, `breakdowns.*`, and `extra.*`. ([#2259](https://github.com/getsentry/relay/pull/2259))
+- Support more fields in dynamic sampling, metric extraction, and conditional tagging. The added fields are `dist`, `release.*`, `user.{email,ip_address,name}`, `breakdowns.*`, and `extra.*`. ([#2259](https://github.com/getsentry/relay/pull/2259), [#2276](https://github.com/getsentry/relay/pull/2276))
 
 ## 23.6.1
 

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -568,7 +568,7 @@ impl Event {
             .unwrap_or(false)
     }
 
-    /// Return the identifier of the client SDK if available.
+    /// Returns the identifier of the client SDK if available.
     ///
     /// Sentry's own SDKs use a naming schema prefixed with `sentry.`. Defaults to `"unknown"`.
     pub fn sdk_name(&self) -> &str {
@@ -581,7 +581,7 @@ impl Event {
         "unknown"
     }
 
-    /// Return the version of the client SDK if available.
+    /// Returns the version of the client SDK if available.
     ///
     /// Defaults to `"unknown"`.
     pub fn sdk_version(&self) -> &str {

--- a/relay-general/src/protocol/event.rs
+++ b/relay-general/src/protocol/event.rs
@@ -538,14 +538,21 @@ pub struct Event {
 }
 
 impl Event {
-    pub fn get_transaction_source(&self) -> &TransactionSource {
+    /// Returns the source of the transaction name if specified by the client.
+    ///
+    /// See the [type docs](TransactionSource) for more information.
+    pub fn transaction_source(&self) -> &TransactionSource {
         self.transaction_info
             .value()
             .and_then(|info| info.source.value())
             .unwrap_or(&TransactionSource::Unknown)
     }
 
-    pub fn get_tag_value(&self, tag_key: &str) -> Option<&str> {
+    /// Returns the value of a tag with the given key.
+    ///
+    /// If tags are specified in a pair list and the tag is declared multiple times, this function
+    /// returns the first match.
+    pub fn tag_value(&self, tag_key: &str) -> Option<&str> {
         if let Some(tags) = self.tags.value() {
             tags.get(tag_key)
         } else {
@@ -553,6 +560,7 @@ impl Event {
         }
     }
 
+    /// Returns `true` if [`modules`](Self::modules) contains the given module.
     pub fn has_module(&self, module_name: &str) -> bool {
         self.modules
             .value()
@@ -560,6 +568,9 @@ impl Event {
             .unwrap_or(false)
     }
 
+    /// Return the identifier of the client SDK if available.
+    ///
+    /// Sentry's own SDKs use a naming schema prefixed with `sentry.`. Defaults to `"unknown"`.
     pub fn sdk_name(&self) -> &str {
         if let Some(client_sdk) = self.client_sdk.value() {
             if let Some(name) = client_sdk.name.as_str() {
@@ -570,6 +581,9 @@ impl Event {
         "unknown"
     }
 
+    /// Return the version of the client SDK if available.
+    ///
+    /// Defaults to `"unknown"`.
     pub fn sdk_version(&self) -> &str {
         if let Some(client_sdk) = self.client_sdk.value() {
             if let Some(version) = client_sdk.version.as_str() {
@@ -600,6 +614,10 @@ impl Event {
         }
 
         Some(value)
+    }
+
+    pub fn parse_release(&self) -> Option<crate::protocol::ParsedRelease> {
+        sentry_release_parser::Release::parse(self.release.as_str()?).ok()
     }
 }
 

--- a/relay-general/src/protocol/mod.rs
+++ b/relay-general/src/protocol/mod.rs
@@ -33,7 +33,7 @@ mod user;
 mod user_report;
 mod utils;
 
-pub use sentry_release_parser::{validate_environment, validate_release};
+pub use sentry_release_parser::{validate_environment, validate_release, Release as ParsedRelease};
 
 pub use self::breadcrumb::*;
 pub use self::breakdowns::*;

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -354,7 +354,7 @@ pub fn is_high_cardinality_sdk(event: &Event) -> bool {
         return true;
     }
 
-    let is_http_status_404 = event.get_tag_value("http.status_code") == Some("404");
+    let is_http_status_404 = event.tag_value("http.status_code") == Some("404");
     if sdk_name == "sentry.python" && is_http_status_404 && client_sdk.has_integration("django") {
         return true;
     }

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -692,6 +692,23 @@ impl FieldValueProvider for Event {
                 }
                 _ => Value::Null,
             },
+            "release.version.build" => self
+                .parse_release()
+                .as_ref()
+                .and_then(|r| r.version())
+                .and_then(|v| v.build_code())
+                .map_or(Value::Null, Value::from),
+            "release.package" => self
+                .parse_release()
+                .as_ref()
+                .and_then(|r| r.package())
+                .map_or(Value::Null, Value::from),
+            "release.version.short" => self
+                .parse_release()
+                .as_ref()
+                .and_then(|r| r.version())
+                .map(|v| v.raw_short())
+                .map_or(Value::Null, Value::from),
 
             // Dynamic access to certain data bags
             _ => {

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -692,16 +692,15 @@ impl FieldValueProvider for Event {
                 }
                 _ => Value::Null,
             },
+            "release.build" => self
+                .parse_release()
+                .as_ref()
+                .and_then(|r| r.build_hash())
+                .map_or(Value::Null, Value::from),
             "release.package" => self
                 .parse_release()
                 .as_ref()
                 .and_then(|r| r.package())
-                .map_or(Value::Null, Value::from),
-            "release.version.build" => self
-                .parse_release()
-                .as_ref()
-                .and_then(|r| r.version())
-                .and_then(|v| v.build_code())
                 .map_or(Value::Null, Value::from),
             "release.version.short" => self
                 .parse_release()

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -692,16 +692,16 @@ impl FieldValueProvider for Event {
                 }
                 _ => Value::Null,
             },
+            "release.package" => self
+                .parse_release()
+                .as_ref()
+                .and_then(|r| r.package())
+                .map_or(Value::Null, Value::from),
             "release.version.build" => self
                 .parse_release()
                 .as_ref()
                 .and_then(|r| r.version())
                 .and_then(|v| v.build_code())
-                .map_or(Value::Null, Value::from),
-            "release.package" => self
-                .parse_release()
-                .as_ref()
-                .and_then(|r| r.package())
                 .map_or(Value::Null, Value::from),
             "release.version.short" => self
                 .parse_release()

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -120,7 +120,7 @@ fn get_transaction_name(
         AcceptTransactionNames::ClientBased
     ) && !store::is_high_cardinality_sdk(event);
 
-    let source = event.get_transaction_source();
+    let source = event.transaction_source();
     let use_original_name = is_low_cardinality(source, treat_unknown_as_low_cardinality);
 
     let name_used;

--- a/relay-server/src/metrics_extraction/utils.rs
+++ b/relay-server/src/metrics_extraction/utils.rs
@@ -34,7 +34,7 @@ pub(crate) fn http_status_code_from_span(span: &Span) -> Option<String> {
 /// Extracts the HTTP status code.
 pub(crate) fn extract_http_status_code(event: &Event) -> Option<String> {
     // For SDKs which put the HTTP status code in the event tags.
-    if let Some(status_code) = event.get_tag_value("http.status_code") {
+    if let Some(status_code) = event.tag_value("http.status_code") {
         return Some(status_code.to_owned());
     }
 


### PR DESCRIPTION
Add support for virtual version fields to `FieldValueProvider`, which makes them
accessible to dynamic sampling and generic metrics extraction.

SemVer comparisons are not yet possible on the release version.

