### PR TITLE
instr(project-config): Remove temporary metrics

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
 use std::sync::Arc;
-use std::time::Duration;
 
 use relay_common::ProjectKey;
 use relay_config::{Config, RelayMode};
@@ -447,34 +446,6 @@ impl Services {
     }
 }
 
-/// Tracks how many projects are accessed every second.
-#[derive(Debug)]
-struct AccessTracker {
-    keys: HashSet<ProjectKey>,
-    last_reset: Instant,
-}
-
-impl AccessTracker {
-    fn new() -> Self {
-        Self {
-            keys: Default::default(),
-            last_reset: Instant::now(),
-        }
-    }
-
-    fn track(&mut self, project_key: ProjectKey) {
-        if self.last_reset.elapsed() > Duration::from_secs(1) {
-            let count = self.keys.len();
-            // When we get < 1 access per second, this will log results from the past.
-            // Does not matter for our use case though.
-            metric!(gauge(RelayGauges::ProjectCacheKeysAccessed) = count as u64);
-            self.keys.clear();
-            self.last_reset = Instant::now();
-        }
-        self.keys.insert(project_key);
-    }
-}
-
 /// Main broker of the [`ProjectCacheService`].
 ///
 /// This handles incoming public messages, merges resolved project states, and maintains the actual
@@ -485,7 +456,6 @@ struct ProjectCacheBroker {
     services: Services,
     // Need hashbrown because drain_filter is not stable in std yet.
     projects: hashbrown::HashMap<ProjectKey, Project>,
-    access: AccessTracker,
     garbage_disposal: GarbageDisposal<Project>,
     source: ProjectSource,
     state_tx: mpsc::UnboundedSender<UpdateProjectState>,
@@ -601,7 +571,6 @@ impl ProjectCacheBroker {
 
     fn get_or_create_project(&mut self, project_key: ProjectKey) -> &mut Project {
         metric!(histogram(RelayHistograms::ProjectStateCacheSize) = self.projects.len() as u64);
-        self.access.track(project_key);
 
         let config = self.config.clone();
 
@@ -715,7 +684,6 @@ impl ProjectCacheBroker {
     fn handle_processing(&mut self, managed_envelope: ManagedEnvelope) {
         let project_key = managed_envelope.envelope().meta().public_key();
 
-        self.access.track(project_key);
         let Some(project) = self.projects.get_mut(&project_key) else {
             relay_log::error!(
                 tags.project_key = %project_key,
@@ -740,10 +708,7 @@ impl ProjectCacheBroker {
         }) = project.check_envelope(managed_envelope, self.services.outcome_aggregator.clone())
         {
             let sampling_state = utils::get_sampling_key(managed_envelope.envelope())
-                .and_then(|key| {
-                    self.access.track(project_key);
-                    self.projects.get(&key)
-                })
+                .and_then(|key| self.projects.get(&key))
                 .and_then(|p| p.valid_state());
 
             let mut process = ProcessEnvelope {
@@ -939,7 +904,6 @@ impl Service for ProjectCacheService {
             let mut broker = ProjectCacheBroker {
                 config: config.clone(),
                 projects: hashbrown::HashMap::new(),
-                access: AccessTracker::new(),
                 garbage_disposal: GarbageDisposal::new(),
                 source: ProjectSource::start(config, services.upstream_relay.clone(), redis),
                 services,
@@ -1061,7 +1025,6 @@ mod tests {
             ProjectCacheBroker {
                 config: config.clone(),
                 projects: hashbrown::HashMap::new(),
-                access: AccessTracker::new(),
                 garbage_disposal: GarbageDisposal::new(),
                 source: ProjectSource::start(config, services.upstream_relay.clone(), None),
                 services,

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -528,18 +528,9 @@ impl ProjectCacheBroker {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
-        // Count org and project IDs for stats.
-        let project_keys = self.projects.len();
-        let mut project_ids = HashSet::new();
-        let mut org_ids = HashSet::new();
-
-        let expired = self.projects.drain_filter(|_, entry| {
-            if let Some(scoping) = entry.scoping() {
-                project_ids.insert(scoping.project_id);
-                org_ids.insert(scoping.organization_id);
-            }
-            entry.last_updated_at() + delta <= eviction_start
-        });
+        let expired = self
+            .projects
+            .drain_filter(|_, entry| entry.last_updated_at() + delta <= eviction_start);
 
         // Defer dropping the projects to a dedicated thread:
         let mut count = 0;
@@ -552,15 +543,6 @@ impl ProjectCacheBroker {
             count += 1;
         }
         metric!(counter(RelayCounters::EvictingStaleProjectCaches) += count);
-
-        metric!(
-            gauge(RelayGauges::ProjectCacheKeysPerProject) =
-                project_keys as f64 / project_ids.len() as f64
-        );
-        metric!(
-            gauge(RelayGauges::ProjectCacheProjectsPerOrg) =
-                project_ids.len() as f64 / org_ids.len() as f64
-        );
 
         // Log garbage queue size:
         let queue_size = self.garbage_disposal.queue_size() as f64;

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -13,10 +13,6 @@ pub enum RelayGauges {
     ProjectCacheProjectsPerOrg,
     /// The number of items currently in the garbage disposal queue.
     ProjectCacheGarbageQueueSize,
-    /// The number of accessed projects per second.
-    ///
-    /// This is intended as a temporary metric, can be removed once the experiment is over.
-    ProjectCacheKeysAccessed,
     /// The number of envelopes waiting for project states in memory.
     ///
     /// This number is always <= `EnvelopeQueueSize`.
@@ -39,7 +35,6 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::ProjectCacheKeysPerProject => "project_cache.avg_keys_per_project",
             RelayGauges::ProjectCacheProjectsPerOrg => "project_cache.avg_projects_per_org",
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
-            RelayGauges::ProjectCacheKeysAccessed => "project_cache.keys_accessed",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",
         }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -5,12 +5,6 @@ pub enum RelayGauges {
     /// The state of Relay with respect to the upstream connection.
     /// Possible values are `0` for normal operations and `1` for a network outage.
     NetworkOutage,
-    /// The ratio between project keys (DSNs) and project IDs, i.e. the average number of keys
-    /// per project.
-    ProjectCacheKeysPerProject,
-    /// The ratio between project IDs and organization IDs, i.e. the average number of projects per
-    /// organization.
-    ProjectCacheProjectsPerOrg,
     /// The number of items currently in the garbage disposal queue.
     ProjectCacheGarbageQueueSize,
     /// The number of envelopes waiting for project states in memory.
@@ -32,8 +26,6 @@ impl GaugeMetric for RelayGauges {
     fn name(&self) -> &'static str {
         match self {
             RelayGauges::NetworkOutage => "upstream.network_outage",
-            RelayGauges::ProjectCacheKeysPerProject => "project_cache.avg_keys_per_project",
-            RelayGauges::ProjectCacheProjectsPerOrg => "project_cache.avg_projects_per_org",
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",


### PR DESCRIPTION
This PR reverts https://github.com/getsentry/relay/pull/2270 and https://github.com/getsentry/relay/pull/2274. They increased the envelope queue size and cache eviction times in production, and we have the numbers we need for now.

#skip-changelog