### PR TITLE
ref(txnames): Remove temporary feature flag

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -19,10 +19,6 @@ pub enum Feature {
     /// Enables metric extraction from spans.
     #[serde(rename = "projects:span-metrics-extraction")]
     SpanMetricsExtraction,
-    /// Apply transaction normalization rules to transactions from legacy SDKs.
-    #[serde(rename = "organizations:transaction-name-normalize-legacy")]
-    NormalizeLegacyTransactions,
-
     /// Deprecated, still forwarded for older downstream Relays.
     #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]
     Deprecated1,

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1881,7 +1881,6 @@ mod tests {
             &mut TransactionsProcessor::new(
                 TransactionNameConfig {
                     rules: rules.as_ref(),
-                    ..Default::default()
                 },
                 false,
                 None,
@@ -1947,7 +1946,6 @@ mod tests {
             &mut TransactionsProcessor::new(
                 TransactionNameConfig {
                     rules: rules.as_ref(),
-                    ..Default::default()
                 },
                 false,
                 None,
@@ -2037,7 +2035,6 @@ mod tests {
         let mut processor = TransactionsProcessor::new(
             TransactionNameConfig {
                 rules: rules.as_ref(),
-                ..Default::default()
             },
             false,
             None,
@@ -2170,7 +2167,6 @@ mod tests {
             &mut TransactionsProcessor::new(
                 TransactionNameConfig {
                     rules: rules.as_ref(),
-                    ..Default::default()
                 },
                 false,
                 None,
@@ -2358,14 +2354,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(
-                TransactionNameConfig {
-                    rules: &[rule],
-                    ..Default::default()
-                },
-                false,
-                None,
-            ),
+            &mut TransactionsProcessor::new(TransactionNameConfig { rules: &[rule] }, false, None),
             ProcessingState::root(),
         )
         .unwrap();
@@ -2591,7 +2580,6 @@ mod tests {
                         expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
                         redaction: RedactionRule::default(),
                     }],
-                    ..Default::default()
                 },
                 false,
                 None,
@@ -2638,7 +2626,6 @@ mod tests {
                         expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
                         redaction: RedactionRule::default(),
                     }],
-                    ..Default::default()
                 },
                 false,
                 None,
@@ -3124,7 +3111,6 @@ mod tests {
                         expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
                         redaction: RedactionRule::default(),
                     }],
-                    ..Default::default()
                 },
                 true,
                 None,
@@ -3224,7 +3210,6 @@ mod tests {
                         expiry: Utc.with_ymd_and_hms(3000, 1, 1, 1, 1, 1).unwrap(),
                         redaction: RedactionRule::default(),
                     }],
-                    ..Default::default()
                 },
                 true,
                 Some(&Vec::from([SpanDescriptionRule {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2393,9 +2393,6 @@ impl EnvelopeProcessorService {
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
                     rules: &state.project_state.config.tx_name_rules,
-                    normalize_legacy: state
-                        .project_state
-                        .has_feature(Feature::NormalizeLegacyTransactions),
                 },
                 device_class_synthesis_config: state
                     .project_state
@@ -3752,7 +3749,6 @@ mod tests {
                                 substitution: "*".to_owned(),
                             },
                         }],
-                        ..Default::default()
                     },
                     ..Default::default()
                 };


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/2250 introduced a temporary feature flag because I wanted to do a gradual rollout. That flag can now be removed.

#skip-changelog