### PR TITLE
Simplify relay deployment label selector

### DIFF
--- a/gocd/generated-pipelines/relay-next-monitor.yaml
+++ b/gocd/generated-pipelines/relay-next-monitor.yaml
@@ -63,7 +63,7 @@ pipelines:
                     /devinfra/scripts/k8s/k8stunnel
 
                     /devinfra/scripts/k8s/k8s-deploy.py \
-                        --label-selector="service=relay,deploy_if_production=true" \
+                        --label-selector="service=relay" \
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200

--- a/gocd/generated-pipelines/relay-next-us.yaml
+++ b/gocd/generated-pipelines/relay-next-us.yaml
@@ -63,7 +63,7 @@ pipelines:
                     /devinfra/scripts/k8s/k8stunnel
 
                     /devinfra/scripts/k8s/k8s-deploy.py \
-                        --label-selector="service=relay,deploy_if_production=true" \
+                        --label-selector="service=relay" \
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200

--- a/gocd/templates/bash/deploy-relay.sh
+++ b/gocd/templates/bash/deploy-relay.sh
@@ -5,6 +5,6 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
 /devinfra/scripts/k8s/k8stunnel
 
 /devinfra/scripts/k8s/k8s-deploy.py \
-    --label-selector="service=relay,deploy_if_production=true" \
+    --label-selector="service=relay" \
     --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"


### PR DESCRIPTION
Removing the deploy_if_production label should not make a difference with the saas deployments from what I can see in the ops repo and it'll make the saas deployment the same as s4s and customer deployments.

I can keep the label selector as is for saas and update it for other deployments if preferred but I believe this is the better approach.

#skip-changelog