### PR TITLE
fix(filter): Apply transaction name filter to transaction events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
+- Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118), [#2284](https://github.com/getsentry/relay/pull/2284))
 - Use GeoIP lookup also in non-processing Relays. Lookup from now on will be also run in light normalization. ([#2229](https://github.com/getsentry/relay/pull/2229))
 - Metrics extracted from transactions from old SDKs now get a useful `transaction` tag. ([#2250](https://github.com/getsentry/relay/pull/2250), [#2272](https://github.com/getsentry/relay/pull/2272)).
 

--- a/relay-filter/src/transaction_name.rs
+++ b/relay-filter/src/transaction_name.rs
@@ -2,18 +2,24 @@
 //!
 //! If this filter is enabled transactions from healthcheck endpoints will be filtered out.
 
+use relay_common::EventType;
 use relay_general::protocol::Event;
 
 use crate::{FilterStatKey, GlobPatterns, IgnoreTransactionsFilterConfig};
 
 fn matches(event: &Event, patterns: &GlobPatterns) -> bool {
+    if event.ty.value() != Some(&EventType::Transaction) {
+        return false;
+    }
+
     event
         .transaction
         .value()
         .map_or(false, |transaction| patterns.is_match(transaction))
 }
 
-/// Filters transaction events for calls to healthcheck endpoints
+/// Filters [Transaction](EventType::Transaction) events based on a list of provided transaction
+/// name globs.
 pub fn should_filter(
     event: &Event,
     config: &IgnoreTransactionsFilterConfig,


### PR DESCRIPTION
The transaction name filter is used to drop health check and ping transaction
events. The original PR missed to check for the event type and also dropped
errors. This patch adds a check for the event type and lets all errors through.

