### PR TITLE
chore(replays): Remove unwrap and map the error

### DIFF
--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -245,7 +245,7 @@ where
         // then at the redundant parsing.
 
         while let Some(raw) = v.next_element::<&'de RawValue>()? {
-            let helper = serde_json::from_str::<TypeHelper>(raw.get()).unwrap();
+            let helper = serde_json::from_str::<TypeHelper>(raw.get()).map_err(s2d)?;
             // Scrub only sentry-specific events and serialize all others without modification.
             if helper.ty == Self::SENTRY_EVENT_TYPE {
                 seq.serialize_element(&ScrubbedValue(raw, self.scrubber.clone()))


### PR DESCRIPTION
If it's not possible to deserialize the data, we must not panic, but rather report the error. 

fix: https://github.com/getsentry/team-ingest/issues/113

#skip-changelog