### PR TITLE
feat(project_cache): Avoid evicting projects while they cannot be fetched

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -448,7 +448,7 @@ impl Project {
         }
     }
 
-    /// Return `true` if the backoff currently in progress.
+    /// Return `true` if the backoff is currently in progress.
     pub fn backoff_started(&self) -> bool {
         self.backoff.started()
     }

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -448,6 +448,11 @@ impl Project {
         }
     }
 
+    /// Return `true` if the backoff currently in progress.
+    pub fn backoff_started(&self) -> bool {
+        self.backoff.started()
+    }
+
     /// Returns the next attempt `Instant` if backoff is initiated, or None otherwise.
     pub fn next_fetch_attempt(&self) -> Option<Instant> {
         self.next_fetch_attempt

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -536,7 +536,7 @@ impl Project {
         if let Some(next_attempt_at) = self.next_fetch_attempt {
             return next_attempt_at <= Instant::now();
         }
-        // Initiate a first attemt.
+        // Initiate a first attempt.
         self.backoff.next_backoff();
         true
     }
@@ -965,7 +965,7 @@ mod tests {
 
         // This tests that we actually initiate the backoff and the backoff mechanism works:
         // * first call to `update_state` with invalid ProjectState starts the backoff, but since
-        //   it's the first attemt, we get Duration of 0.
+        //   it's the first attempt, we get Duration of 0.
         // * second call to `update_state` here will bumpt the `next_backoff` Duration to somehing
         //   like ~ 1s
         // * and now, by calling `fetch_state` we test that it's a noop, since if backoff is active

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -531,7 +531,7 @@ impl ProjectCacheBroker {
         // Remove only unused project states.
         //
         // If the project cannot be fetched because of the network outage, etc., still keep it
-        // and all spooled envleopes if any.
+        // and all spooled envelopes if any.
         let expired = self.projects.drain_filter(|_, entry| {
             !entry.backoff_started() && entry.last_updated_at() + delta <= eviction_start
         });
@@ -971,21 +971,12 @@ mod tests {
     }
 
     async fn project_cache_broker_setup(
+        config: Arc<Config>,
         services: Services,
         buffer_guard: Arc<BufferGuard>,
         state_tx: mpsc::UnboundedSender<UpdateProjectState>,
         buffer_tx: mpsc::UnboundedSender<ManagedEnvelope>,
     ) -> (ProjectCacheBroker, Addr<Buffer>) {
-        let config: Arc<_> = Config::from_json_value(serde_json::json!({
-            "spool": {
-                "envelopes": {
-                    "path": std::env::temp_dir().join(Uuid::new_v4().to_string()),
-                    "max_memory_size": 0, // 0 bytes, to force to spool to disk all the envelopes.
-                }
-            }
-        }))
-        .unwrap()
-        .into();
         let buffer_services = spooler::Services {
             outcome_aggregator: services.outcome_aggregator.clone(),
             project_cache: services.project_cache.clone(),
@@ -1031,9 +1022,24 @@ mod tests {
         let services = mocked_services();
         let (state_tx, _) = mpsc::unbounded_channel();
         let (buffer_tx, mut buffer_rx) = mpsc::unbounded_channel();
-        let (mut broker, buffer_svc) =
-            project_cache_broker_setup(services.clone(), buffer_guard.clone(), state_tx, buffer_tx)
-                .await;
+        let config = Config::from_json_value(serde_json::json!({
+            "spool": {
+                "envelopes": {
+                    "path": std::env::temp_dir().join(Uuid::new_v4().to_string()),
+                    "max_memory_size": 0, // 0 bytes, to force to spool to disk all the envelopes.
+                }
+            }
+        }))
+        .unwrap()
+        .into();
+        let (mut broker, buffer_svc) = project_cache_broker_setup(
+            config,
+            services.clone(),
+            buffer_guard.clone(),
+            state_tx,
+            buffer_tx,
+        )
+        .await;
 
         for _ in 0..8 {
             let envelope = buffer_guard
@@ -1084,7 +1090,7 @@ mod tests {
         envelopes.pop().unwrap();
         assert_eq!(buffer_guard.available(), 1);
 
-        // Till now we should have enqueued 5 envleopes and dequeued only 1, it means the index is
+        // Till now we should have enqueued 5 envelopes and dequeued only 1, it means the index is
         // still populated with same keys and values.
         assert_eq!(broker.index.keys().len(), 1);
         assert_eq!(broker.index.values().count(), 1);
@@ -1109,5 +1115,55 @@ mod tests {
             // Nothing will be dequeued.
             assert!(buffer_rx.try_recv().is_err())
         }
+    }
+
+    #[tokio::test]
+    async fn test_eviction() {
+        let num_permits = 5;
+        let buffer_guard: Arc<_> = BufferGuard::new(num_permits).into();
+        let services = mocked_services();
+        let (state_tx, _) = mpsc::unbounded_channel();
+        let (buffer_tx, _) = mpsc::unbounded_channel();
+
+        // Projects should be expired after 2 seconds.
+        let config: Arc<_> = Config::from_json_value(serde_json::json!({
+            "cache": {
+              "project_expiry": 1
+            }
+        }))
+        .unwrap()
+        .into();
+
+        let (mut broker, _) = project_cache_broker_setup(
+            config.clone(),
+            services.clone(),
+            buffer_guard,
+            state_tx,
+            buffer_tx,
+        )
+        .await;
+
+        let key1 = ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap();
+        let project1 = Project::new(key1, config.clone());
+        let key2 = ProjectKey::parse("eeed836b15bb49d7bbf99e64295d9bbb").unwrap();
+        let mut project2 = Project::new(key2, config);
+
+        // Simulate the project state update.
+        project2.get_cached_state(services.project_cache.clone(), true);
+
+        broker.projects.insert(key1, project1);
+        broker.projects.insert(key2, project2);
+
+        // Let's wait for a expiry timeout.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // One of the project will be removed.
+        broker.evict_stale_project_caches();
+
+        // The `project1` is removed, since the state was never requested, so there is no attempts there
+        // either, and we know it's definitely expired. But we have tried to fetch `project2` and
+        // failed so far, so the backoff is in progress.
+        assert_eq!(broker.projects.len(), 1);
+        assert!(broker.projects.get(&key2).is_some());
     }
 }

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -528,9 +528,10 @@ impl ProjectCacheBroker {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
-        // Remove only un-unsed project states.
-        // If the project cannot be fetched because of the network outage, still keep it and all
-        // linked envelopes if any.
+        // Remove only unsed project states.
+        //
+        // If the project cannot be fetched because of the network outage, etc., still keep it
+        // and all spooled envleopes if any.
         let expired = self.projects.drain_filter(|_, entry| {
             !entry.backoff_started() && entry.last_updated_at() + delta <= eviction_start
         });

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -528,7 +528,7 @@ impl ProjectCacheBroker {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
-        // Remove only unsed project states.
+        // Remove only unused project states.
         //
         // If the project cannot be fetched because of the network outage, etc., still keep it
         // and all spooled envleopes if any.

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -467,10 +467,6 @@ struct ProjectCacheBroker {
 }
 
 impl ProjectCacheBroker {
-    /// Hours to wait till the [`ProjectState`] is evictd from the cache if the current incident is
-    /// ongoing, e.g. backoff is initiated and new proejct state cannot be fetched.
-    const INCIDENT_EVICTON_TIMEOUT: u32 = 12;
-
     /// Adds the value to the queue for the provided key.
     pub fn enqueue(&mut self, key: QueueKey, value: ManagedEnvelope) {
         self.index.entry(key.own_key).or_default().insert(key);
@@ -530,15 +526,13 @@ impl ProjectCacheBroker {
     /// [`super::project_upstream`].
     fn evict_stale_project_caches(&mut self) {
         let eviction_start = Instant::now();
-        let mut delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
+        let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
+        // Remove only un-unsed project states.
+        // If the project cannot be fetched because of the network outage, still keep it and all
+        // linked envelopes if any.
         let expired = self.projects.drain_filter(|_, entry| {
-            // If for some reasons the project cannot be updated, we avoid evicting its envelopes
-            // for the next 12 hours.
-            if entry.backoff_started() {
-                delta *= Self::INCIDENT_EVICTON_TIMEOUT
-            }
-            entry.last_updated_at() + delta <= eviction_start
+            !entry.backoff_started() && entry.last_updated_at() + delta <= eviction_start
         });
 
         // Defer dropping the projects to a dedicated thread:


### PR DESCRIPTION
Handle the eviction of the cached projects differently when they cannot be fetched. 

Let's say:
* there is ongoing incident
* temporary network issues

So, we want to keep those projects and linked envelopes longer. 



#skip-changelog