### PR TITLE
feat(dynamic-config): Introduce Relay global config

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -1,0 +1,58 @@
+use relay_general::store::MeasurementsConfig;
+use serde::{Deserialize, Serialize};
+
+use crate::TaggingRule;
+
+/// A dynamic configuration for all Relays passed down from Sentry.
+///
+/// Values shared across all projects may also be included here, to keep
+/// [`ProjectConfig`](crate::ProjectConfig)s small.
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct GlobalConfig {
+    /// Project configuration for measurements.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    measurements: Option<MeasurementsConfig>,
+    /// Project configuration for rules for applying metrics tags depending on
+    /// the event's content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metric_conditional_tagging: Option<Vec<TaggingRule>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::GlobalConfig;
+
+    #[test]
+    fn test_global_config_roundtrip() {
+        let json = r#"{
+  "measurements": {
+    "builtinMeasurements": [
+      {
+        "name": "plate.size",
+        "unit": "5"
+      }
+    ],
+    "maxCustomMeasurements": 2
+  },
+  "metricConditionalTagging": [
+    {
+      "condition": {
+        "op": "gt",
+        "name": "food.deliciousness",
+        "value": 8
+      },
+      "targetMetrics": [
+        "tummy.satisfaction"
+      ],
+      "targetTag": "satisfied",
+      "tagValue": "hellyeah"
+    }
+  ]
+}"#;
+
+        let deserialized: GlobalConfig = serde_json::from_str(json).unwrap();
+        let reserialized = serde_json::to_string_pretty(&deserialized).unwrap();
+        assert_eq!(json, reserialized);
+    }
+}

--- a/relay-dynamic-config/src/lib.rs
+++ b/relay-dynamic-config/src/lib.rs
@@ -35,6 +35,38 @@
 //! }
 //! ```
 //!
+//! # Global configuration
+//!
+//! This is the configuration for all Relays, independently from what per-project configuration is, and is defined in [`GlobalConfig`].
+//!
+//! ## Example Config
+//!
+//! ```json
+//! {
+//!     "measurements": {
+//!        "builtinMeasurements": [
+//!            {
+//!                "name": "app_start_cold",
+//!                "unit": "millisecond"
+//!            }
+//!        ],
+//!        "maxCustomMeasurements": 1
+//!     },
+//!     "metricsConditionalTagging": {
+//!        {
+//!            "condition": {
+//!                "op": "gt",
+//!                "name": "event.duration",
+//!                "value": 1200
+//!            },
+//!            "targetMetrics": [
+//!                "s:transactions/user@none"
+//!            ],
+//!            "targetTag": "satisfaction",
+//!            "tagValue": "frustrated"
+//!        }
+//!     }
+//! }
 //!
 #![warn(missing_docs)]
 #![doc(
@@ -45,12 +77,14 @@
 
 mod error_boundary;
 mod feature;
+mod global;
 mod metrics;
 mod project;
 mod utils;
 
 pub use error_boundary::*;
 pub use feature::*;
+pub use global::*;
 pub use metrics::*;
 pub use project::*;
 pub use utils::*;


### PR DESCRIPTION
Creates the new `GlobalConfig` structure, representing the global configuration of Relay. It's a NOOP in this PR.

#skip-changelog