### PR TITLE
feat(services): Create service for global configs

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -1,0 +1,58 @@
+use relay_general::store::MeasurementsConfig;
+use serde::{Deserialize, Serialize};
+
+use crate::TaggingRule;
+
+/// A dynamic configuration for all Relays passed down from Sentry.
+///
+/// Values shared across all projects may also be included here, to keep
+/// [`ProjectConfig`](crate::ProjectConfig)s small.
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct GlobalConfig {
+    /// Project configuration for measurements.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    measurements: Option<MeasurementsConfig>,
+    /// Project configuration for rules for applying metrics tags depending on
+    /// the event's content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metric_conditional_tagging: Option<Vec<TaggingRule>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::GlobalConfig;
+
+    #[test]
+    fn test_global_config_roundtrip() {
+        let json = r#"{
+  "measurements": {
+    "builtinMeasurements": [
+      {
+        "name": "plate.size",
+        "unit": "5"
+      }
+    ],
+    "maxCustomMeasurements": 2
+  },
+  "metricConditionalTagging": [
+    {
+      "condition": {
+        "op": "gt",
+        "name": "food.deliciousness",
+        "value": 8
+      },
+      "targetMetrics": [
+        "tummy.satisfaction"
+      ],
+      "targetTag": "satisfied",
+      "tagValue": "hellyeah"
+    }
+  ]
+}"#;
+
+        let deserialized: GlobalConfig = serde_json::from_str(json).unwrap();
+        let reserialized = serde_json::to_string_pretty(&deserialized).unwrap();
+        assert_eq!(json, reserialized);
+    }
+}

--- a/relay-dynamic-config/src/lib.rs
+++ b/relay-dynamic-config/src/lib.rs
@@ -35,6 +35,38 @@
 //! }
 //! ```
 //!
+//! # Global configuration
+//!
+//! This is the configuration for all Relays, independently from what per-project configuration is, and is defined in [`GlobalConfig`].
+//!
+//! ## Example Config
+//!
+//! ```json
+//! {
+//!     "measurements": {
+//!        "builtinMeasurements": [
+//!            {
+//!                "name": "app_start_cold",
+//!                "unit": "millisecond"
+//!            }
+//!        ],
+//!        "maxCustomMeasurements": 1
+//!     },
+//!     "metricsConditionalTagging": {
+//!        {
+//!            "condition": {
+//!                "op": "gt",
+//!                "name": "event.duration",
+//!                "value": 1200
+//!            },
+//!            "targetMetrics": [
+//!                "s:transactions/user@none"
+//!            ],
+//!            "targetTag": "satisfaction",
+//!            "tagValue": "frustrated"
+//!        }
+//!     }
+//! }
 //!
 #![warn(missing_docs)]
 #![doc(
@@ -45,12 +77,14 @@
 
 mod error_boundary;
 mod feature;
+mod global;
 mod metrics;
 mod project;
 mod utils;
 
 pub use error_boundary::*;
 pub use feature::*;
+pub use global::*;
 pub use metrics::*;
 pub use project::*;
 pub use utils::*;

--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use relay_dynamic_config::GlobalConfig;
+use relay_system::{Addr, Interface, Service};
+use tokio::sync::mpsc;
+
+use crate::actors::project_cache::ProjectCache;
+
+// No messages are accepted for now.
+#[derive(Debug)]
+pub enum GlobalConfigMessage {}
+
+impl Interface for GlobalConfigMessage {}
+
+/// Helper type to forward global config updates.
+pub struct UpdateGlobalConfig {
+    global_config: Arc<GlobalConfig>,
+}
+
+/// Service implementing the [`GlobalConfig`] interface.
+///
+/// The service is responsible to fetch the global config appropriately and
+/// forward it to the services that require it.
+#[derive(Debug)]
+pub struct GlobalConfigService {
+    project_cache: Addr<ProjectCache>,
+}
+
+impl GlobalConfigService {
+    pub fn new(project_cache: Addr<ProjectCache>) -> Self {
+        GlobalConfigService { project_cache }
+    }
+
+    /// Forwards the given global config to the services that require it.
+    fn update_global_config(&mut self, new_config: UpdateGlobalConfig) {
+        self.project_cache.send(new_config.global_config);
+    }
+}
+
+impl Service for GlobalConfigService {
+    type Interface = GlobalConfigMessage;
+
+    fn spawn_handler(mut self, _rx: relay_system::Receiver<Self::Interface>) {
+        tokio::spawn(async move {
+            relay_log::info!("global config started");
+
+            let (_config_tx, mut config_rx) = mpsc::unbounded_channel();
+            loop {
+                tokio::select! {
+                    biased;
+
+                    Some(message) = config_rx.recv() => self.update_global_config(message),
+                    // TODO(iker): request global config
+                    else => break,
+                }
+            }
+            relay_log::info!("global config stopped");
+        });
+    }
+}

--- a/relay-server/src/actors/mod.rs
+++ b/relay-server/src/actors/mod.rs
@@ -29,6 +29,7 @@
 //!     .expect("failed to start relay");
 //! ```
 pub mod envelopes;
+pub mod global_config;
 pub mod health_check;
 pub mod outcome;
 pub mod outcome_aggregator;

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -13,6 +13,7 @@ use relay_system::{channel, Addr, Service};
 use tokio::runtime::Runtime;
 
 use crate::actors::envelopes::{EnvelopeManager, EnvelopeManagerService};
+use crate::actors::global_config::{GlobalConfigMessage, GlobalConfigService};
 use crate::actors::health_check::{HealthCheck, HealthCheckService};
 use crate::actors::outcome::{OutcomeProducer, OutcomeProducerService, TrackOutcome};
 use crate::actors::outcome_aggregator::OutcomeAggregator;
@@ -52,6 +53,7 @@ pub struct Registry {
     pub envelope_manager: Addr<EnvelopeManager>,
     pub test_store: Addr<TestStore>,
     pub relay_cache: Addr<RelayCache>,
+    pub global_config: Addr<GlobalConfigMessage>,
     pub project_cache: Addr<ProjectCache>,
     pub upstream_relay: Addr<UpstreamRelay>,
 }
@@ -186,6 +188,8 @@ impl ServiceState {
         .spawn_handler(project_cache_rx);
         drop(guard);
 
+        let global_config = GlobalConfigService::new(project_cache.clone()).start();
+
         let health_check = HealthCheckService::new(
             config.clone(),
             aggregator.clone(),
@@ -210,6 +214,7 @@ impl ServiceState {
             envelope_manager,
             test_store,
             relay_cache,
+            global_config,
             project_cache,
             upstream_relay,
         };


### PR DESCRIPTION
Creates a new service to handle Relay global configs. This service is a WIP and only implements the global config forwarding functionality to the project cache service (which doesn't do anything with the config). Future PRs will implement the config fetching and application in the project cache service, where the `TODO` placeholders are. PRs with functional changes will also contain tests.

#skip-changelog