### PR TITLE
fix(spans): Scrub sequence of string literals in SQL

### DIFF
--- a/relay-general/src/store/normalize/span/description.rs
+++ b/relay-general/src/store/normalize/span/description.rs
@@ -18,17 +18,17 @@ use crate::types::{Annotated, ProcessingAction, ProcessingResult, Remark, Remark
 static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"(?xi)
-    # Capture `SAVEPOINT` savepoints.
-    ((?-x)SAVEPOINT (?P<savepoint>(?:(?:"[^"]+")|(?:'[^']+')|(?:`[^`]+`)|(?:[a-z]\w+)))) |
-    # Capture single-quoted strings, including the remaining substring if `\'` is found.
-    ((?-x)(?P<single_quoted_strs>'(?:\\'|[^'])*(?:'|$))) |
-    # Capture placeholders.
-    ((?-x)(?P<placeholder>(?:\?+|\$\d+))) |
-    # Capture numbers.
-    ((?-x)(?P<number>(-?\b(?:[0-9]+\.)?[0-9]+(?:[eE][+-]?[0-9]+)?\b))) |
-    # Capture booleans (as full tokens, not as substrings of other tokens).
-    ((?-x)(?P<bool>(\b(?:true|false)\b)))
-    "#,
+        # Capture `SAVEPOINT` savepoints.
+        ((?-x)SAVEPOINT (?P<savepoint>(?:(?:"[^"]+")|(?:'[^']+')|(?:`[^`]+`)|(?:[a-z]\w+)))) |
+        # Capture single-quoted strings, including the remaining substring if `\'` is found.
+        ((?-x)(?P<single_quoted_strs>'(?:\\'|[^'])*(?:'|$))) |
+        # Capture placeholders.
+        ((?-x)(?P<placeholder>(?:\?+|\$\d+))) |
+        # Capture numbers.
+        ((?-x)(?P<number>(-?\b(?:[0-9]+\.)?[0-9]+(?:[eE][+-]?[0-9]+)?\b))) |
+        # Capture booleans (as full tokens, not as substrings of other tokens).
+        ((?-x)(?P<bool>(\b(?:true|false)\b)))
+        "#,
     )
     .unwrap()
 });
@@ -51,7 +51,10 @@ static SQL_COLLAPSE_REGEX: Lazy<Regex> = Lazy::new(|| {
 static SQL_ALREADY_NORMALIZED_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"/\?|\$1|%s"#).unwrap());
 
-// TODO: docs
+/// Attempt to replace identifiers in the span description with placeholders.
+///
+/// The resulting scrubbed description is stored in `data.description.scrubbed`, and serves as input
+/// for the span group hash.
 pub(crate) fn scrub_span_description(
     span: &mut Span,
     rules: &Vec<SpanDescriptionRule>,

--- a/relay-general/src/store/normalize/span/description.rs
+++ b/relay-general/src/store/normalize/span/description.rs
@@ -330,6 +330,20 @@ mod tests {
     );
 
     span_description_test!(
+        span_description_scrub_various_parameterized_strings,
+        "select count() from table_1 where name in ('foo', %s, 1)",
+        "db.sql.query",
+        "select count() from table_1 where name in (%s)"
+    );
+
+    span_description_test!(
+        span_description_scrub_various_parameterized_cutoff,
+        "select count() from table where name in ('foo', 'bar', 'ba",
+        "db.sql.query",
+        "select count() from table where id in (%s)"
+    );
+
+    span_description_test!(
         span_description_scrub_mixed,
         "UPDATE foo SET a = %s, b = log(e + 5) * 600 + 12345 WHERE true",
         "db.sql.query",

--- a/relay-general/src/store/normalize/span/description.rs
+++ b/relay-general/src/store/normalize/span/description.rs
@@ -2,13 +2,54 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
+use once_cell::sync::Lazy;
+use regex::Regex;
+
 use crate::protocol::Span;
-use crate::store::regexes::{
-    REDIS_COMMAND_REGEX, RESOURCE_NORMALIZER_REGEX, SQL_ALREADY_NORMALIZED_REGEX,
-    SQL_NORMALIZER_REGEX,
-};
+use crate::store::regexes::{REDIS_COMMAND_REGEX, RESOURCE_NORMALIZER_REGEX};
 use crate::store::{scrub_identifiers, scrub_identifiers_with_regex, SpanDescriptionRule};
 use crate::types::{Annotated, ProcessingAction, ProcessingResult, Remark, RemarkType, Value};
+
+/// Regex with multiple capture groups for SQL tokens we should scrub.
+///
+/// Slightly modified from
+/// <https://github.com/getsentry/sentry/blob/65fb6fdaa0080b824ab71559ce025a9ec6818b3e/src/sentry/spans/grouping/strategy/base.py#L170>
+/// <https://github.com/getsentry/sentry/blob/17af7efe869007f85c5322e48aa9f80a8515bde4/src/sentry/spans/grouping/strategy/base.py#L163>
+static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?xi)
+    # Capture `SAVEPOINT` savepoints.
+    ((?-x)SAVEPOINT (?P<savepoint>(?:(?:"[^"]+")|(?:'[^']+')|(?:`[^`]+`)|(?:[a-z]\w+)))) |
+    # Capture single-quoted strings, including the remaining substring if `\'` is found.
+    ((?-x)(?P<single_quoted_strs>'(?:\\'|[^'])*(?:'|$))) |
+    # Capture placeholders.
+    ((?-x)(?P<placeholder>(?:\?+|\$\d+))) |
+    # Capture numbers.
+    ((?-x)(?P<number>(-?\b(?:[0-9]+\.)?[0-9]+(?:[eE][+-]?[0-9]+)?\b))) |
+    # Capture booleans (as full tokens, not as substrings of other tokens).
+    ((?-x)(?P<bool>(\b(?:true|false)\b)))
+    "#,
+    )
+    .unwrap()
+});
+
+/// Regex to make multiple placeholders collapse into one.
+/// This can be used as a second pass after [`SQL_NORMALIZER_REGEX`].
+static SQL_COLLAPSE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?xi)
+        (VALUES|IN) \s+ \( (?P<values> ( %s ( \)\s*,\s*\(\s*%s | \s*,\s*%s )* )) \)?
+        "#,
+    )
+    .unwrap()
+});
+
+/// Regex to identify SQL queries that are already normalized.
+///
+/// Looks for `?`, `$1` or `%s` identifiers, commonly used identifiers in
+/// Python, Ruby on Rails and PHP platforms.
+static SQL_ALREADY_NORMALIZED_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"/\?|\$1|%s"#).unwrap());
 
 // TODO: docs
 pub(crate) fn scrub_span_description(
@@ -51,6 +92,7 @@ pub(crate) fn scrub_span_description(
 fn scrub_sql_queries(string: &mut Annotated<String>) -> Result<bool, ProcessingAction> {
     let mut mark_as_scrubbed = is_sql_query_scrubbed(string);
     mark_as_scrubbed |= scrub_identifiers_with_regex(string, &SQL_NORMALIZER_REGEX, "%s")?;
+    mark_as_scrubbed |= scrub_identifiers_with_regex(string, &SQL_COLLAPSE_REGEX, "%s")?;
 
     Ok(mark_as_scrubbed)
 }
@@ -340,7 +382,7 @@ mod tests {
         span_description_scrub_various_parameterized_cutoff,
         "select count() from table where name in ('foo', 'bar', 'ba",
         "db.sql.query",
-        "select count() from table where id in (%s)"
+        "select count() from table where name in (%s"
     );
 
     span_description_test!(
@@ -520,9 +562,9 @@ mod tests {
 
     span_description_test!(
         span_description_scrub_values_multi,
-        "INSERT INTO a (b, c, d, e) VALUES (%s, %s, %s, %s), (%s, %s, %s, %s), (%s, %s, %s, %s) ON CONFLICT DO NOTHING",
+        "INSERT INTO a (b, c, d, e) VALuES (%s, %s, %s, %s), (%s, %s, %s, %s), (%s, %s, %s, %s) ON CONFLICT DO NOTHING",
         "db.sql.query",
-        "INSERT INTO a (b, c, d, e) VALUES (%s) ON CONFLICT DO NOTHING"
+        "INSERT INTO a (b, c, d, e) VALuES (%s) ON CONFLICT DO NOTHING"
     );
 
     span_description_test!(

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -51,40 +51,6 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Regex with multiple capture groups for SQL tokens we should scrub.
-///
-/// Slightly modified from
-/// <https://github.com/getsentry/sentry/blob/244b33e44bbbfa0dd680f5a15053e2efaaf6fd65/src/sentry/spans/grouping/strategy/base.py#L132>
-/// <https://github.com/getsentry/sentry/blob/65fb6fdaa0080b824ab71559ce025a9ec6818b3e/src/sentry/spans/grouping/strategy/base.py#L170>
-/// <https://github.com/getsentry/sentry/blob/17af7efe869007f85c5322e48aa9f80a8515bde4/src/sentry/spans/grouping/strategy/base.py#L163>
-pub static SQL_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?xi)
-    # Capture parameters in `IN` statements.
-    ((?-x)IN \((?P<in>(%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)) |
-    # Capture parameters in `VALUES`.
-    ((?-x)VALUES \((?P<values>(\)\s*,\s*\(|%s|\$?\d+|\?|,|\s)*)\)) |
-    # Capture `SAVEPOINT` savepoints.
-    ((?-x)SAVEPOINT (?P<savepoint>(?:(?:"[^"]+")|(?:'[^']+')|(?:`[^`]+`)|(?:[a-z]\w+)))) |
-    # Capture single-quoted strings, including the remaining substring if `\'` is found.
-    ((?-x)(?P<single_quoted_strs>'(?:\\'|[^'])*(?:'|$))) |
-    # Don't capture double-quoted strings (eg used for identifiers in PostgreSQL).
-    # Capture numbers.
-    ((?-x)(?P<number>(-?\b(?:[0-9]+\.)?[0-9]+(?:[eE][+-]?[0-9]+)?\b))) |
-    # Capture booleans (as full tokens, not as substrings of other tokens).
-    ((?-x)(?P<bool>(\b(?:true|false)\b)))
-    "#,
-    )
-    .unwrap()
-});
-
-/// Regex to identify SQL queries that are already normalized.
-///
-/// Looks for `?`, `$1` or `%s` identifiers, commonly used identifiers in
-/// Python, Ruby on Rails and PHP platforms.
-pub static SQL_ALREADY_NORMALIZED_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"/\?|\$1|%s"#).unwrap());
-
 /// Captures initial all-caps words as redis command, the rest as arguments.
 pub static REDIS_COMMAND_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"\s*(?P<command>[A-Z]+(\s+[A-Z]+)*\b)(?P<args>.+)?"#).unwrap());


### PR DESCRIPTION
Previous SQL regex would collapse multiple placeholders or numbers into one, but not for strings:

```
(1,2,3) -> (%s)
(%s, %s) -> (%s)
('foo', 'bar', 'baz') -> (%s, %s, %s)
```

This PR switches to a two-step approach:

1. First, detect all values and replace them by placeholders.
2. Then, detect sequences of placeholders and collapse them.

#skip-changelog

