### PR TITLE
feat(global-config): Request Relay global config from upstream

### DIFF
--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -102,15 +102,12 @@ impl GlobalConfigService {
         tokio::spawn(async move {
             let query = GetGlobalConfig::query();
             match self.upstream_relay.send(SendQuery(query)).await {
-                Ok(response) => {
-                    // TODO(iker): store the result in the service
-                    match response {
-                        Ok(config_response) => config_tx.send(config_response.into()),
-                        Err(request_error) => {
-                            todo!()
-                        }
+                Ok(request_response) => match request_response {
+                    Ok(config_response) => config_tx.send(config_response.into()),
+                    Err(request_error) => {
+                        todo!()
                     }
-                }
+                },
                 Err(send_error) => {
                     todo!()
                 }
@@ -136,6 +133,7 @@ impl Service for GlobalConfigService {
 
                     Some(message) = config_rx.recv() => self.update_global_config(message),
                     _ = ticker.tick() => self.request_global_config(config_tx.clone()),
+
                     else => break,
                 }
             }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -188,7 +188,8 @@ impl ServiceState {
         .spawn_handler(project_cache_rx);
         drop(guard);
 
-        let global_config = GlobalConfigService::new(project_cache.clone()).start();
+        let global_config =
+            GlobalConfigService::new(project_cache.clone(), upstream_relay.clone()).start();
 
         let health_check = HealthCheckService::new(
             config.clone(),

--- a/tests/integration/test_globalconfigs.py
+++ b/tests/integration/test_globalconfigs.py
@@ -1,0 +1,11 @@
+"""
+Tests the global_config endpoint (/api/0/relays/projectconfigs/)
+"""
+
+
+def test_global_config_deserialization(mini_sentry, relay):
+    """Verify Relay can deserialize the global config Sentry returns."""
+    mini_sentry.add_basic_global_config()
+    assert mini_sentry.global_config["measurements"] is not None
+    # Relay requests global config at start-up
+    relay = relay(mini_sentry, wait_health_check=True)


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/52421.

---

Requests Relay's global config from upstream periodically, every few seconds.

### Approaches

1. The global config service accepts config update requests. The project cache service requests the global config to the project config service periodically, and the global config service fetches it and forwards it to the project cache service. Creating new services that require the global config would also need to send messages to request the global config.
2. The global config service proactively fetches the global config from upstream. The project cache service receives the new global config when it's updated. Creating new services that require the global config should be provided during global config service initialization.

Beyond what the above points mention, I don't see any major pros/cons of either approach. For Relay instances that don't receive much traffic, option 1 will generate more network requests than option 2. On the other hand, option 2 is technically more complex to implement, so I've decided to go with option 2; I'm happy to update the implementation if there's something important I'm missing.

It's possible that option 2 also allows to only forward the global config once if it won't be modified, in cases where the config is defined statically in a local configuration file (e.g. for proxy relays). Note that I haven't thought about this in detail.

#skip-changelog