### PR TITLE
fix(profiling): Filter idle thread at the edge per thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Filter idle samples at the edge per thread. ([#2321](https://github.com/getsentry/relay/pull/2321))
+
 **Internal**:
 
 - Add support for `sampled` field in the DSC and error tagging. ([#2290](https://github.com/getsentry/relay/pull/2290))


### PR DESCRIPTION
When filtering idle threads, it needs to be done on a per-thread basis otherwise short-lived threads that have only idle samples will persist in the profile.