### PR TITLE
fix(test): Increase timeout of each iteration for `BufferGuard` enter

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1042,7 +1042,7 @@ mod tests {
             let message = ValidateEnvelope { envelope };
 
             broker.handle_validate_envelope(message);
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
             // Nothing will be dequeued.
             assert!(buffer_rx.try_recv().is_err())
         }


### PR DESCRIPTION
I notice it's usually fails when it tries to enter the `BufferGuard`, meaning we do not have any permits left at this point. 
In this test it can happen only if we are not fast enough to spool the incoming envelopes out of the memory to the disk. 

Increasing the timeout for the iteration in the for loop, should help to avoid this, when e.g. actions runners get somewhat slow. 

#skip-changelog