### PR TITLE
docs: Be very clear that the `.relay` folder is in the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ make test-python
 
 To develop Relay with an existing Sentry devserver, self-hosted Sentry
 installation, or Sentry SaaS, configure the upstream to the URL of the Sentry
-server in `.relay/config.yml`. For example, in local development set
+server in `./.relay/config.yml`. For example, in local development set
 `relay.upstream` to `http://localhost:8000/`.
 
 To test processing mode with a local development Sentry, use this configuration:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ make test-python
 
 To develop Relay with an existing Sentry devserver, self-hosted Sentry
 installation, or Sentry SaaS, configure the upstream to the URL of the Sentry
-server in `./.relay/config.yml`. For example, in local development set
+server in `.relay/config.yml` in the project root directory. For example, in local development set
 `relay.upstream` to `http://localhost:8000/`.
 
 To test processing mode with a local development Sentry, use this configuration:


### PR DESCRIPTION
I was stuck forever before realizing that this folder is actually supposed to be in my local checkout of relay.

#skip-changelog