### PR TITLE
ref(crons): Remove endpoints w/o project ID

### DIFF
--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -54,15 +54,7 @@ where
     let store_routes = Router::new()
         // Legacy store path that is missing the project parameter.
         .route("/api/store/", store::route(config))
-        // cron level routes.  These are user facing APIs and as such avoid the project ID and
-        // they support optional trailing slashes.
-        .route("/api/cron/:monitor_slug/:sentry_key", cron::route(config))
-        .route("/api/cron/:monitor_slug/:sentry_key/", cron::route(config))
-        .route("/api/cron/:monitor_slug", cron::route(config))
-        .route("/api/cron/:monitor_slug/", cron::route(config))
-        // XXX(epurkhiser): While deciding how we want these routes to work we'll also be including
-        // the project_id version, to quickly iterate without waiting for ops to make special cases
-        // for these routes.
+        // cron level routes.  These are user facing APIs and as such support trailing slashes.
         .route("/api/:project_id/cron/:monitor_slug/:sentry_key", cron::route(config))
         .route("/api/:project_id/cron/:monitor_slug/:sentry_key/", cron::route(config))
         .route("/api/:project_id/cron/:monitor_slug", cron::route(config))

--- a/tests/integration/test_crons.py
+++ b/tests/integration/test_crons.py
@@ -43,30 +43,6 @@ def test_crons_endpoint_get_with_processing(
 
     monitor_slug = "my-monitor"
     public_key = relay.get_dsn_public_key(project_id)
-    relay.get(f"/api/cron/{monitor_slug}/{public_key}?status=ok")
-
-    check_in, message = monitors_consumer.get_check_in()
-    assert message["start_time"] is not None
-    assert message["project_id"] == project_id
-    assert check_in == {
-        "check_in_id": "00000000000000000000000000000000",
-        "monitor_slug": "my-monitor",
-        "status": "ok",
-    }
-
-
-def test_crons_endpoint_get_with_processing_with_project_id(
-    mini_sentry, relay_with_processing, monitors_consumer
-):
-    project_id = 42
-    options = {"processing": {}}
-    relay = relay_with_processing(options)
-    monitors_consumer = monitors_consumer()
-
-    mini_sentry.add_full_project_config(project_id)
-
-    monitor_slug = "my-monitor"
-    public_key = relay.get_dsn_public_key(project_id)
     relay.get(f"/api/{project_id}/cron/{monitor_slug}/{public_key}?status=ok")
 
     check_in, message = monitors_consumer.get_check_in()
@@ -93,7 +69,7 @@ def test_crons_endpoint_post_auth_basic_with_processing(
     public_key = relay.get_dsn_public_key(project_id)
     basic_auth = base64.b64encode((public_key + ":").encode("utf-8")).decode("utf-8")
     relay.post(
-        f"/api/cron/{monitor_slug}?status=ok",
+        f"/api/{project_id}/cron/{monitor_slug}?status=ok",
         headers={"Authorization": "Basic " + basic_auth},
     )
 
@@ -120,7 +96,7 @@ def test_crons_endpoint_embedded_auth_with_processing(
     monitor_slug = "my-monitor"
     public_key = relay.get_dsn_public_key(project_id)
     relay.post(
-        f"/api/cron/{monitor_slug}/{public_key}?status=ok",
+        f"/api/{project_id}/cron/{monitor_slug}/{public_key}?status=ok",
     )
 
     check_in, message = monitors_consumer.get_check_in()


### PR DESCRIPTION
We've decided to go ahead and keep the project ID for now, since it will
allow us in the future to more easily understand who may have been
affected during potential outages.

#skip-changelog