### PR TITLE
instr(txnames): Log error when placeholder is used

### DIFF
--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -110,7 +110,7 @@ fn get_transaction_name(event: &Event) -> Option<String> {
         Some(original_transaction_name.clone())
     } else {
         // Pick a sentinel based on the transaction source:
-        match source {
+        let placeholder = match source {
             None | Some(TransactionSource::Other(_)) => {
                 name_used = "none";
                 None
@@ -119,7 +119,15 @@ fn get_transaction_name(event: &Event) -> Option<String> {
                 name_used = "placeholder";
                 Some("<< unparameterized >>".to_owned())
             }
-        }
+        };
+        relay_log::error!(
+            // project ID is already set by envelope processor.
+            tags.placeholder = placeholder.as_deref().unwrap_or("none"),
+            tags.source = transaction_source_tag(event),
+            original_transaction_name = original_transaction_name,
+            "Using placeholder as transaction tag"
+        );
+        placeholder
     };
 
     relay_statsd::metric!(


### PR DESCRIPTION
https://github.com/getsentry/team-ingest/issues/129 brought us closed to 100% useful transaction tags, but we're still seeing some cases where a placeholder is used (~3 per second in SaaS).

Temporarily log an error to get more details.

#skip-changelog