### PR TITLE
feat(spans): Collapse SQL columns in SELECT

### DIFF
--- a/relay-general/src/store/normalize/span/description.rs
+++ b/relay-general/src/store/normalize/span/description.rs
@@ -545,9 +545,9 @@ mod tests {
 
     span_description_test!(
         span_description_strip_prefixes,
-        r#"SELECT \"table\".\"foo\", \"table\".\"bar\" from \"table\" WHERE sku = %s"#,
+        r#"SELECT \"table\".\"foo\", \"table\".\"bar\", count(*) from \"table\" WHERE sku = %s"#,
         "db.sql.query",
-        r#"SELECT foo, bar from table WHERE sku = %s"#
+        r#"SELECT foo, bar, count(*) from table WHERE sku = %s"#
     );
 
     span_description_test!(


### PR DESCRIPTION
Replace lists of column names in SQL `SELECT` queries with `..`, e.g. 

```sql
SELECT .. FROM table WHERE x = %s
```

This only works for simple lists of column names, not for aliases, aggregations, etc.

#skip-changelog