### PR TITLE
Update name for old upstream material

### DIFF
--- a/gocd/pipelines/relay-pop.yaml
+++ b/gocd/pipelines/relay-pop.yaml
@@ -19,7 +19,7 @@ pipelines:
       # Relay PoPs can't be deployed until the relay deploy pipeline reaches
       # the promote-to-pops stage.
       pipeline-deploy-relay-completed:
-        pipeline: deploy-relay
+        pipeline: deploy-relay-old
         stage: promote-to-pops
 
     stages:


### PR DESCRIPTION
I missed this name change in the last PR. Tested and it fixed the error.

#skip-changelog