### PR TITLE
Move old pipelines to relay group

### DIFF
--- a/gocd/pipelines/relay-pop.yaml
+++ b/gocd/pipelines/relay-pop.yaml
@@ -7,7 +7,8 @@ pipelines:
     environment_variables:
       GCP_PROJECT: internal-sentry
 
-    group: relay-old
+    group: relay
+    display_order: 100 # Ensure it's last pipeline in UI
     lock_behavior: unlockWhenFinished
 
     materials:

--- a/gocd/pipelines/relay.yaml
+++ b/gocd/pipelines/relay.yaml
@@ -11,7 +11,8 @@ pipelines:
       GKE_CLUSTER_ZONE: b
       GKE_BASTION_ZONE: b
 
-    group: relay-old
+    group: relay
+    display_order: 100 # Ensure it's last pipeline in UI
     lock_behavior: unlockWhenFinished
 
     materials:


### PR DESCRIPTION
I didn't realize that new groups like `relay-old` would not have correct permissions for viewing and operating.

Moving the old pipelines back to relay to address this.

#skip-changelog