### PR TITLE
fix(metrics): Move `TrimmingProcessor` to light normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Trim fields (e.g. `transaction`) before metrics extraction. ([#2342](https://github.com/getsentry/relay/pull/2342))
+
 **Internal**:
 
 - Add capability to configure metrics aggregators per use case. ([#2341](https://github.com/getsentry/relay/pull/2341))

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -137,6 +137,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         max_tag_value_size: usize::MAX,
         span_description_rules: None,
         geoip_lookup: None, // only supported in relay
+        enable_trimming: config.enable_trimming.unwrap_or_default(),
     };
     light_normalize_event(&mut event, light_normalization_config)?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;

--- a/relay-general/src/store/mod.rs
+++ b/relay-general/src/store/mod.rs
@@ -102,7 +102,6 @@ impl<'a> Processor for StoreProcessor<'a> {
     ) -> ProcessingResult {
         let is_renormalize = self.config.is_renormalize.unwrap_or(false);
         let remove_other = self.config.remove_other.unwrap_or(!is_renormalize);
-        let enable_trimming = self.config.enable_trimming.unwrap_or(true);
 
         // Convert legacy data structures to current format
         legacy::LegacyProcessor.process_event(event, meta, state)?;
@@ -120,11 +119,6 @@ impl<'a> Processor for StoreProcessor<'a> {
         if !is_renormalize {
             // Add event errors for top-level keys
             event_error::EmitEventErrors::new().process_event(event, meta, state)?;
-        }
-
-        if enable_trimming {
-            // Trim large strings and databags down
-            trimming::TrimmingProcessor::new().process_event(event, meta, state)?;
         }
 
         Ok(())

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -21,7 +21,8 @@ use crate::protocol::{
     VALID_PLATFORMS,
 };
 use crate::store::{
-    ClockDriftProcessor, GeoIpLookup, SpanDescriptionRule, StoreConfig, TransactionNameConfig,
+    trimming, ClockDriftProcessor, GeoIpLookup, SpanDescriptionRule, StoreConfig,
+    TransactionNameConfig,
 };
 use crate::types::{
     Annotated, Empty, Error, ErrorKind, FromValue, Meta, Object, ProcessingAction,
@@ -751,6 +752,7 @@ pub struct LightNormalizationConfig<'a> {
     pub max_tag_value_size: usize, // TODO: move span related fields into separate config.
     pub span_description_rules: Option<&'a Vec<SpanDescriptionRule>>,
     pub geoip_lookup: Option<&'a GeoIpLookup>,
+    pub enable_trimming: bool,
 }
 
 impl Default for LightNormalizationConfig<'_> {
@@ -773,6 +775,7 @@ impl Default for LightNormalizationConfig<'_> {
             max_tag_value_size: usize::MAX,
             span_description_rules: Default::default(),
             geoip_lookup: Default::default(),
+            enable_trimming: false,
         }
     }
 }
@@ -872,6 +875,15 @@ pub fn light_normalize_event(
                 event,
                 &BTreeSet::from([SpanAttribute::ExclusiveTime]),
             );
+        }
+
+        if config.enable_trimming {
+            // Trim large strings and databags down
+            trimming::TrimmingProcessor::new().process_event(
+                event,
+                meta,
+                ProcessingState::root(),
+            )?;
         }
 
         Ok(())

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2355,6 +2355,7 @@ impl EnvelopeProcessorService {
                 light_normalize_spans,
                 span_description_rules: state.project_state.config.span_description_rules.as_ref(),
                 geoip_lookup: self.geoip_lookup.as_ref(),
+                enable_trimming: true,
             };
 
             metric!(timer(RelayTimers::EventProcessingLightNormalization), {

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1010,7 +1010,8 @@ def test_transaction_name_too_long(
 
     metrics = metrics_consumer.get_metrics()
     for metric, _ in metrics:
-        assert metric["tags"].get("transaction") == expected_transaction_name
+        if metric["name"] != "c:transactions/count_per_root_project@none":
+            assert metric["tags"].get("transaction") == expected_transaction_name
 
 
 @pytest.mark.skip(reason="flake")


### PR DESCRIPTION
Because the `TrimmingProcessor` is not part of light normalization, we extract the untrimmed transaction name from the payload, which then gets dropped by the aggregator.

Solution: Call `TrimmingProcessor` in `light_normalize_event`.

After deploying this, we have to keep an eye on the `event.processing_time` metric.

Fixes https://github.com/getsentry/team-ingest/issues/187