### PR TITLE
fix(metrics): Validate tag value chars, not bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Interpret `aggregator.max_tag_value_length` as characters instead of bytes. ([#2343](https://github.com/getsentry/relay/pull/2343))
+
 ## 23.7.0
 
 **Bug Fixes**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,6 +3265,7 @@ dependencies = [
 name = "relay-metrics"
 version = "23.7.0"
 dependencies = [
+ "bytecount",
  "criterion",
  "float-ord",
  "fnv",

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         device_class_synthesis_config: false, // only supported in relay
         enrich_spans: false,
         light_normalize_spans: false,
-        max_tag_value_size: usize::MAX,
+        max_tag_value_length: usize::MAX,
         span_description_rules: None,
         geoip_lookup: None, // only supported in relay
     };

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -748,7 +748,7 @@ pub struct LightNormalizationConfig<'a> {
     pub device_class_synthesis_config: bool,
     pub enrich_spans: bool,
     pub light_normalize_spans: bool,
-    pub max_tag_value_size: usize, // TODO: move span related fields into separate config.
+    pub max_tag_value_length: usize, // TODO: move span related fields into separate config.
     pub span_description_rules: Option<&'a Vec<SpanDescriptionRule>>,
     pub geoip_lookup: Option<&'a GeoIpLookup>,
 }
@@ -770,7 +770,7 @@ impl Default for LightNormalizationConfig<'_> {
             device_class_synthesis_config: Default::default(),
             enrich_spans: Default::default(),
             light_normalize_spans: Default::default(),
-            max_tag_value_size: usize::MAX,
+            max_tag_value_length: usize::MAX,
             span_description_rules: Default::default(),
             geoip_lookup: Default::default(),
         }
@@ -794,7 +794,7 @@ pub fn light_normalize_event(
             config.transaction_name_config,
             config.enrich_spans,
             config.span_description_rules,
-            config.max_tag_value_size,
+            config.max_tag_value_length,
         );
         transactions_processor.process_event(event, meta, ProcessingState::root())?;
 

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -10,6 +10,7 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
+bytecount = "0.6.0"
 float-ord = "0.3.1"
 fnv = "1.0.7"
 hash32 = "0.3.1"

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -991,7 +991,7 @@ pub struct AggregatorConfig {
 
     /// The length the tag value is allowed to be.
     ///
-    /// Defaults to `200` bytes.
+    /// Defaults to `200` chars.
     pub max_tag_value_length: usize,
 
     /// Maximum amount of bytes used for metrics aggregation.
@@ -1627,7 +1627,7 @@ impl AggregatorService {
                 relay_log::debug!("Invalid metric tag key");
                 return false;
             }
-            if tag_value.len() > aggregator_config.max_tag_value_length {
+            if bytecount::num_chars(tag_value.as_bytes()) > aggregator_config.max_tag_value_length {
                 relay_log::configure_scope(|scope| {
                     scope.set_extra("bucket.project_key", proj_key.to_owned().into());
                     scope.set_extra("bucket.metric.tag_value", tag_value.to_owned().into());
@@ -3026,6 +3026,25 @@ mod tests {
             AggregatorService::validate_bucket_key(short_metric_long_tag_value, &aggregator_config)
                 .unwrap();
         assert_eq!(validation.tags.len(), 0);
+    }
+
+    #[test]
+    fn test_validate_tag_values_special_chars() {
+        relay_test::setup();
+        let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
+        let aggregator_config = test_config();
+
+        let tag_value = "x".repeat(199) + "ø";
+        assert_eq!(tag_value.chars().count(), 200); // Should be allowed
+        let short_metric = BucketKey {
+            project_key,
+            timestamp: UnixTimestamp::now(),
+            metric_name: "c:transactions/a_short_metric".to_owned(),
+            tags: BTreeMap::from([("foo".into(), tag_value.clone())]),
+        };
+        let validated_bucket =
+            AggregatorService::validate_metric_tags(short_metric, &aggregator_config);
+        assert_eq!(validated_bucket.tags["foo"], tag_value);
     }
 
     #[test]

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2350,7 +2350,7 @@ impl EnvelopeProcessorService {
                 enrich_spans: state
                     .project_state
                     .has_feature(Feature::SpanMetricsExtraction),
-                max_tag_value_size: self.config.aggregator_config().max_tag_value_length,
+                max_tag_value_length: self.config.aggregator_config().max_tag_value_length,
                 is_renormalize: false,
                 light_normalize_spans,
                 span_description_rules: state.project_state.config.span_description_rules.as_ref(),


### PR DESCRIPTION
Currently, the metrics aggregator drops tag values if their number of _bytes_ is above a limit. But other parts of Relay limit the number of _characters_, for example

https://github.com/getsentry/relay/blob/1740a68560b2655d531a0f20f86233c8c93e3d5a/relay-general/src/store/normalize.rs#L526-L528

https://github.com/getsentry/relay/blob/1740a68560b2655d531a0f20f86233c8c93e3d5a/relay-general/src/store/trimming.rs#L267-L273

To better align these limits, and to make sure that values trimmed to 200 chars are actually accepted by the aggregator, validate chars in the metrics aggregator as well.