### PR TITLE
fix(crons): Avoid responding with a Event ID, 202 instead

### DIFF
--- a/relay-server/src/endpoints/cron.rs
+++ b/relay-server/src/endpoints/cron.rs
@@ -1,4 +1,5 @@
 use axum::extract::{DefaultBodyLimit, FromRequest, Path, Query};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{on, MethodFilter, MethodRouter};
 use relay_common::Uuid;
@@ -7,7 +8,7 @@ use relay_general::protocol::EventId;
 use relay_monitors::{CheckIn, CheckInStatus};
 use serde::Deserialize;
 
-use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
+use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
 use crate::service::ServiceState;
@@ -72,8 +73,9 @@ async fn handle(
         Ok(_) | Err(BadStoreRequest::RateLimited(_)) => (),
         Err(error) => return Err(error),
     };
-    // What do we want to return?
-    Ok(TextResponse(None))
+
+    // Event will be proccessed by Sentry, respond with a 202
+    Ok(StatusCode::ACCEPTED)
 }
 
 pub fn route<B>(config: &Config) -> MethodRouter<ServiceState, B>

--- a/tests/integration/test_crons.py
+++ b/tests/integration/test_crons.py
@@ -43,7 +43,11 @@ def test_crons_endpoint_get_with_processing(
 
     monitor_slug = "my-monitor"
     public_key = relay.get_dsn_public_key(project_id)
-    relay.get(f"/api/{project_id}/cron/{monitor_slug}/{public_key}?status=ok")
+    response = relay.get(
+        f"/api/{project_id}/cron/{monitor_slug}/{public_key}?status=ok"
+    )
+
+    assert response.status_code == 202
 
     check_in, message = monitors_consumer.get_check_in()
     assert message["start_time"] is not None
@@ -68,10 +72,12 @@ def test_crons_endpoint_post_auth_basic_with_processing(
     monitor_slug = "my-monitor"
     public_key = relay.get_dsn_public_key(project_id)
     basic_auth = base64.b64encode((public_key + ":").encode("utf-8")).decode("utf-8")
-    relay.post(
+    response = relay.post(
         f"/api/{project_id}/cron/{monitor_slug}?status=ok",
         headers={"Authorization": "Basic " + basic_auth},
     )
+
+    assert response.status_code == 202
 
     check_in, message = monitors_consumer.get_check_in()
     assert message["start_time"] is not None
@@ -95,9 +101,11 @@ def test_crons_endpoint_embedded_auth_with_processing(
 
     monitor_slug = "my-monitor"
     public_key = relay.get_dsn_public_key(project_id)
-    relay.post(
+    response = relay.post(
         f"/api/{project_id}/cron/{monitor_slug}/{public_key}?status=ok",
     )
+
+    assert response.status_code == 202
 
     check_in, message = monitors_consumer.get_check_in()
     assert message["start_time"] is not None


### PR DESCRIPTION
This is confusing as this is NOT the ID of the check-in, we don't know
what that will be since sentry will process the check-in.

Instead we can respond with a 202 Accepted

> The HyperText Transfer Protocol (HTTP) 202 Accepted response status
> code indicates that the request has been accepted for processing, but
> the processing has not been completed; in fact, processing may not have
> started yet. The request might or might not eventually be acted upon, as
> it might be disallowed when processing actually takes place.

#skip-changelog