### PR TITLE
ref(crons): Consistently use the name 'monitors'

### DIFF
--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -5,12 +5,12 @@
 
 mod attachments;
 mod common;
-mod cron;
 mod envelope;
 mod events;
 mod forward;
 mod health_check;
 mod minidump;
+mod monitor;
 mod outcomes;
 mod project_configs;
 mod public_keys;
@@ -54,11 +54,11 @@ where
     let store_routes = Router::new()
         // Legacy store path that is missing the project parameter.
         .route("/api/store/", store::route(config))
-        // cron level routes.  These are user facing APIs and as such support trailing slashes.
-        .route("/api/:project_id/cron/:monitor_slug/:sentry_key", cron::route(config))
-        .route("/api/:project_id/cron/:monitor_slug/:sentry_key/", cron::route(config))
-        .route("/api/:project_id/cron/:monitor_slug", cron::route(config))
-        .route("/api/:project_id/cron/:monitor_slug/", cron::route(config))
+        // cron monitor level routes.  These are user facing APIs and as such support trailing slashes.
+        .route("/api/:project_id/cron/:monitor_slug/:sentry_key", monitor::route(config))
+        .route("/api/:project_id/cron/:monitor_slug/:sentry_key/", monitor::route(config))
+        .route("/api/:project_id/cron/:monitor_slug", monitor::route(config))
+        .route("/api/:project_id/cron/:monitor_slug/", monitor::route(config))
 
         .route("/api/:project_id/store/", store::route(config))
         .route("/api/:project_id/envelope/", envelope::route(config))

--- a/relay-server/src/endpoints/monitor.rs
+++ b/relay-server/src/endpoints/monitor.rs
@@ -14,12 +14,12 @@ use crate::extractors::RequestMeta;
 use crate::service::ServiceState;
 
 #[derive(Debug, Deserialize)]
-struct CronPath {
+struct MonitorPath {
     monitor_slug: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct CronQuery {
+struct MonitorQuery {
     status: CheckInStatus,
     check_in_id: Option<Uuid>,
     environment: Option<String>,
@@ -28,15 +28,15 @@ struct CronQuery {
 
 #[derive(Debug, FromRequest)]
 #[from_request(state(ServiceState))]
-struct CronParams {
+struct MonitorParams {
     meta: RequestMeta,
     #[from_request(via(Path))]
-    path: CronPath,
+    path: MonitorPath,
     #[from_request(via(Query))]
-    query: CronQuery,
+    query: MonitorQuery,
 }
 
-impl CronParams {
+impl MonitorParams {
     fn extract_envelope(self) -> Result<Box<Envelope>, BadStoreRequest> {
         let Self { meta, path, query } = self;
 
@@ -64,7 +64,7 @@ impl CronParams {
 
 async fn handle(
     state: ServiceState,
-    params: CronParams,
+    params: MonitorParams,
 ) -> Result<impl IntoResponse, BadStoreRequest> {
     let envelope = params.extract_envelope()?;
 

--- a/tests/integration/test_monitors.py
+++ b/tests/integration/test_monitors.py
@@ -31,7 +31,7 @@ def test_monitors_with_processing(
     }
 
 
-def test_crons_endpoint_get_with_processing(
+def test_monitor_endpoint_get_with_processing(
     mini_sentry, relay_with_processing, monitors_consumer
 ):
     project_id = 42
@@ -59,7 +59,7 @@ def test_crons_endpoint_get_with_processing(
     }
 
 
-def test_crons_endpoint_post_auth_basic_with_processing(
+def test_monitor_endpoint_post_auth_basic_with_processing(
     mini_sentry, relay_with_processing, monitors_consumer
 ):
     project_id = 42
@@ -89,7 +89,7 @@ def test_crons_endpoint_post_auth_basic_with_processing(
     }
 
 
-def test_crons_endpoint_embedded_auth_with_processing(
+def test_monitor_endpoint_embedded_auth_with_processing(
     mini_sentry, relay_with_processing, monitors_consumer
 ):
     project_id = 42


### PR DESCRIPTION
We use monitors internally to refer to the crons product. Let's keep
doing that within relay as well.

#skip-changelog