### PR TITLE
fix(spans): Use correct limit

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -14,7 +14,7 @@ use relay_common::{Dsn, Uuid};
 use relay_kafka::{
     ConfigError as KafkaConfigError, KafkaConfig, KafkaConfigParam, KafkaTopic, TopicAssignments,
 };
-use relay_metrics::{AggregatorConfig, ScopedAggregatorConfig};
+use relay_metrics::{AggregatorConfig, Condition, Field, MetricNamespace, ScopedAggregatorConfig};
 use relay_redis::RedisConfig;
 use serde::de::{DeserializeOwned, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -1968,6 +1968,17 @@ impl Config {
     /// Returns configuration for non-default metrics [aggregators](relay_metrics::Aggregator).
     pub fn secondary_aggregator_configs(&self) -> &Vec<ScopedAggregatorConfig> {
         &self.values.secondary_aggregators
+    }
+
+    /// Returns aggregator config for a given metrics namespace.
+    pub fn aggregator_config_for(&self, namespace: MetricNamespace) -> &AggregatorConfig {
+        for entry in &self.values.secondary_aggregators {
+            match entry.condition {
+                Condition::Eq(Field::Namespace(ns)) if ns == namespace => return &entry.config,
+                _ => (),
+            }
+        }
+        &self.values.aggregator
     }
 
     /// Return the statically configured Relays.

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -39,7 +39,7 @@ use relay_general::store::{
 };
 use relay_general::types::{Annotated, Array, Empty, FromValue, Object, ProcessingAction, Value};
 use relay_general::user_agent::RawUserAgentInfo;
-use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric};
+use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric, MetricNamespace};
 use relay_quotas::{DataCategory, ReasonCode};
 use relay_redis::RedisPool;
 use relay_replays::recording::RecordingScrubber;
@@ -2350,7 +2350,10 @@ impl EnvelopeProcessorService {
                 enrich_spans: state
                     .project_state
                     .has_feature(Feature::SpanMetricsExtraction),
-                max_tag_value_length: self.config.aggregator_config().max_tag_value_length,
+                max_tag_value_length: self
+                    .config
+                    .aggregator_config_for(MetricNamespace::Spans)
+                    .max_tag_value_length,
                 is_renormalize: false,
                 light_normalize_spans,
                 span_description_rules: state.project_state.config.span_description_rules.as_ref(),

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1283,7 +1283,7 @@ def test_span_metrics_secondary_aggregator(
         },
         "spans": [
             {
-                "description": "this_is_too_long",
+                "description": "SELECT %s FROM foo",
                 "op": "db",
                 "parent_span_id": "8f5a2b8768cafb4e",
                 "span_id": "bd429c44b67a3eb4",
@@ -1315,6 +1315,7 @@ def test_span_metrics_secondary_aggregator(
                         "bucket_interval": 1,
                         "initial_delay": 0,
                         "debounce_delay": 0,
+                        "max_tag_value_length": 10,
                     },
                 }
             ],
@@ -1340,10 +1341,11 @@ def test_span_metrics_secondary_aggregator(
                 "project_id": 42,
                 "retention_days": 90,
                 "tags": {
+                    "span.action": "SELECT",
+                    "span.description": "SELECT %s*",
                     "span.category": "db",
                     "span.module": "db",
                     "span.op": "db",
-                    "transaction": "/organizations/:orgId/performance/:eventSlug/",
                 },
                 "timestamp": int(timestamp.timestamp()),
                 "type": "d",


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/2341:

Now that span metrics can have their own configuration, use the correct one to trim span descriptions.

#skip-changelog