### PR TITLE
Remove manual step for non-us regions

### DIFF
--- a/gocd/generated-pipelines/relay-customer-1.yaml
+++ b/gocd/generated-pipelines/relay-customer-1.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-customer-2.yaml
+++ b/gocd/generated-pipelines/relay-customer-2.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-customer-3.yaml
+++ b/gocd/generated-pipelines/relay-customer-3.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-customer-4.yaml
+++ b/gocd/generated-pipelines/relay-customer-4.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-customer-5.yaml
+++ b/gocd/generated-pipelines/relay-customer-5.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-customer-6.yaml
+++ b/gocd/generated-pipelines/relay-customer-6.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/relay-s4s.yaml
+++ b/gocd/generated-pipelines/relay-s4s.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/templates/libs/relay.libsonnet
+++ b/gocd/templates/libs/relay.libsonnet
@@ -66,26 +66,5 @@ function(region) {
         },
       },
     },
-
-    {
-      'progress-to-pops': {
-        approval: {
-          type: 'manual',
-          allow_only_on_success: true,
-        },
-        jobs: {
-          'progress-to-pops': {
-            timeout: 1200,
-            elastic_profile_id: 'relay',
-            tasks: [
-              gocdtasks.noop,
-            ],
-          },
-        },
-      },
-    },
-  ] + [
-    // Append the relay-pops deployment stages
-    pops.stage(region),
-  ],
+  ] + pops.stages(region),
 }


### PR DESCRIPTION
This change was discussed in the eng ingest slack channel - it removes the manual "promote-to-pops" stage in non-us deployments for relay. Rationale being that the US region has a more complicated pops deployments.

This should make relay deployments easier - 2 manual steps.

#skip-changelog