### PR TITLE
ref(server): Internal Arc for EnvelopeProccesorService

### DIFF
--- a/relay-general/src/store/normalize/span/tag_extraction.rs
+++ b/relay-general/src/store/normalize/span/tag_extraction.rs
@@ -124,9 +124,9 @@ fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
             .and_then(|r| r.method.value())
             .map(|m| m.to_uppercase());
 
-        if let Some(transaction_method) = transaction_method_from_request
-            .or(http_method_from_transaction_name(transaction_name).map(|m| m.to_uppercase()))
-        {
+        if let Some(transaction_method) = transaction_method_from_request.or_else(|| {
+            http_method_from_transaction_name(transaction_name).map(|m| m.to_uppercase())
+        }) {
             tags.insert(SpanTagKey::TransactionMethod, transaction_method);
         }
     }
@@ -213,7 +213,7 @@ pub(crate) fn extract_tags(span: &Span, config: &Config) -> BTreeMap<SpanTagKey,
             _ => None,
         };
 
-        if let Some(act) = action.clone() {
+        if let Some(act) = action {
             span_tags.insert(SpanTagKey::Action, act);
         }
 
@@ -241,7 +241,7 @@ pub(crate) fn extract_tags(span: &Span, config: &Config) -> BTreeMap<SpanTagKey,
         };
 
         if !span_op.starts_with("db.redis") {
-            if let Some(dom) = domain.clone() {
+            if let Some(dom) = domain {
                 span_tags.insert(SpanTagKey::Domain, dom);
             }
         }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -568,16 +568,7 @@ impl EnvelopeProcessorService {
             geoip_lookup,
         };
 
-        #[cfg(feature = "processing")]
-        {
-            Self {
-                inner: Arc::new(inner),
-            }
-        }
-
-        #[cfg(not(feature = "processing"))]
         Self {
-            config,
             inner: Arc::new(inner),
         }
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -523,10 +523,10 @@ impl FromMessage<RateLimitFlushBuckets> for EnvelopeProcessor {
 #[derive(Clone)]
 pub struct EnvelopeProcessorService {
     config: Arc<Config>,
-    inner: Arc<InnerEnvelopeProcessorService>,
+    inner: Arc<InnerProcessor>,
 }
 
-struct InnerEnvelopeProcessorService {
+struct InnerProcessor {
     envelope_manager: Addr<EnvelopeManager>,
     project_cache: Addr<ProjectCache>,
     outcome_aggregator: Addr<TrackOutcome>,
@@ -546,7 +546,6 @@ impl EnvelopeProcessorService {
         project_cache: Addr<ProjectCache>,
         upstream_relay: Addr<UpstreamRelay>,
     ) -> Self {
-        // TODO(tor): Replace with state enum (`init`, `ready`) and do not process anything while global_config is undefined.
         let geoip_lookup = config.geoip_path().and_then(|p| {
             match GeoIpLookup::open(p).context(ServiceError::GeoIp) {
                 Ok(geoip) => Some(geoip),
@@ -557,7 +556,7 @@ impl EnvelopeProcessorService {
             }
         });
 
-        let inner = InnerEnvelopeProcessorService {
+        let inner = InnerProcessor {
             envelope_manager,
             project_cache,
             outcome_aggregator,
@@ -3166,7 +3165,7 @@ mod tests {
         let (outcome_aggregator, _) = mock_service("outcome_aggregator", (), |&mut (), _| {});
         let (project_cache, _) = mock_service("project_cache", (), |&mut (), _| {});
         let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
-        let inner = InnerEnvelopeProcessorService {
+        let inner = InnerProcessor {
             envelope_manager,
             project_cache,
             outcome_aggregator,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -520,8 +520,13 @@ impl FromMessage<RateLimitFlushBuckets> for EnvelopeProcessor {
 /// Service implementing the [`EnvelopeProcessor`] interface.
 ///
 /// This service handles messages in a worker pool with configurable concurrency.
+#[derive(Clone)]
 pub struct EnvelopeProcessorService {
     config: Arc<Config>,
+    inner: Arc<InnerEnvelopeProcessorService>,
+}
+
+struct InnerEnvelopeProcessorService {
     envelope_manager: Addr<EnvelopeManager>,
     project_cache: Addr<ProjectCache>,
     outcome_aggregator: Addr<TrackOutcome>,
@@ -541,6 +546,7 @@ impl EnvelopeProcessorService {
         project_cache: Addr<ProjectCache>,
         upstream_relay: Addr<UpstreamRelay>,
     ) -> Self {
+        // TODO(tor): Replace with state enum (`init`, `ready`) and do not process anything while global_config is undefined.
         let geoip_lookup = config.geoip_path().and_then(|p| {
             match GeoIpLookup::open(p).context(ServiceError::GeoIp) {
                 Ok(geoip) => Some(geoip),
@@ -551,30 +557,30 @@ impl EnvelopeProcessorService {
             }
         });
 
+        let inner = InnerEnvelopeProcessorService {
+            envelope_manager,
+            project_cache,
+            outcome_aggregator,
+            upstream_relay,
+            geoip_lookup,
+            #[cfg(feature = "processing")]
+            rate_limiter: _redis
+                .map(|pool| RedisRateLimiter::new(pool).max_limit(config.max_rate_limit())),
+        };
+
         #[cfg(feature = "processing")]
         {
-            let rate_limiter =
-                _redis.map(|pool| RedisRateLimiter::new(pool).max_limit(config.max_rate_limit()));
-
             Self {
                 config,
-                rate_limiter,
-                geoip_lookup,
-                envelope_manager,
-                outcome_aggregator,
-                project_cache,
-                upstream_relay,
+                inner: Arc::new(inner),
             }
         }
 
         #[cfg(not(feature = "processing"))]
         Self {
             config,
-            geoip_lookup,
-            envelope_manager,
-            outcome_aggregator,
-            project_cache,
-            upstream_relay,
+            global_config: Arc::new(GlobalConfig::default()),
+            inner: Arc::new(inner),
         }
     }
 
@@ -1044,7 +1050,7 @@ impl EnvelopeProcessorService {
                 }
             };
 
-            self.outcome_aggregator.send(TrackOutcome {
+            self.inner.outcome_aggregator.send(TrackOutcome {
                 // If we get to this point, the unwrap should not be used anymore, since we know by
                 // now that the timestamp can be parsed, but just incase we fallback to UTC current
                 // `DateTime`.
@@ -1935,7 +1941,8 @@ impl EnvelopeProcessorService {
             client_hints: envelope.meta().client_hints().to_owned(),
         };
 
-        let mut store_processor = StoreProcessor::new(store_config, self.geoip_lookup.as_ref());
+        let mut store_processor =
+            StoreProcessor::new(store_config, self.inner.geoip_lookup.as_ref());
         metric!(timer(RelayTimers::EventProcessingProcess), {
             process_value(event, &mut store_processor, ProcessingState::root())
                 .map_err(|_| ProcessingError::InvalidTransaction)?;
@@ -2004,7 +2011,7 @@ impl EnvelopeProcessorService {
 
     #[cfg(feature = "processing")]
     fn enforce_quotas(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
-        let rate_limiter = match self.rate_limiter.as_ref() {
+        let rate_limiter = match self.inner.rate_limiter.as_ref() {
             Some(rate_limiter) => rate_limiter,
             None => return Ok(()),
         };
@@ -2036,7 +2043,8 @@ impl EnvelopeProcessorService {
         });
 
         if limits.is_limited() {
-            self.project_cache
+            self.inner
+                .project_cache
                 .send(UpdateRateLimits::new(scoping.project_key, limits));
         }
 
@@ -2048,7 +2056,7 @@ impl EnvelopeProcessorService {
         enforcement.track_outcomes(
             state.envelope(),
             &state.managed_envelope.scoping(),
-            self.outcome_aggregator.clone(),
+            self.inner.outcome_aggregator.clone(),
         );
 
         Ok(())
@@ -2364,7 +2372,7 @@ impl EnvelopeProcessorService {
                 is_renormalize: false,
                 light_normalize_spans,
                 span_description_rules: state.project_state.config.span_description_rules.as_ref(),
-                geoip_lookup: self.geoip_lookup.as_ref(),
+                geoip_lookup: self.inner.geoip_lookup.as_ref(),
                 enable_trimming: true,
             };
 
@@ -2468,7 +2476,7 @@ impl EnvelopeProcessorService {
 
                         state.extracted_metrics.send_metrics(
                             state.managed_envelope.envelope(),
-                            self.project_cache.clone(),
+                            self.inner.project_cache.clone(),
                         );
 
                         let envelope_response = if state.managed_envelope.envelope().is_empty() {
@@ -2495,7 +2503,7 @@ impl EnvelopeProcessorService {
                         if err.should_keep_metrics() {
                             state.extracted_metrics.send_metrics(
                                 state.managed_envelope.envelope(),
-                                self.project_cache.clone(),
+                                self.inner.project_cache.clone(),
                             );
                         }
 
@@ -2518,7 +2526,7 @@ impl EnvelopeProcessorService {
         match result {
             Ok(response) => {
                 if let Some(managed_envelope) = response.envelope {
-                    self.envelope_manager.send(SubmitEnvelope {
+                    self.inner.envelope_manager.send(SubmitEnvelope {
                         envelope: managed_envelope,
                     })
                 };
@@ -2561,7 +2569,8 @@ impl EnvelopeProcessorService {
                     Metric::parse_all(&payload, timestamp).filter_map(|result| result.ok());
 
                 relay_log::trace!("inserting metrics into project cache");
-                self.project_cache
+                self.inner
+                    .project_cache
                     .send(InsertMetrics::new(public_key, metrics));
             } else if item.ty() == &ItemType::MetricBuckets {
                 match Bucket::parse_all(&payload) {
@@ -2571,7 +2580,8 @@ impl EnvelopeProcessorService {
                         }
 
                         relay_log::trace!("merging metric buckets into project cache");
-                        self.project_cache
+                        self.inner
+                            .project_cache
                             .send(MergeBuckets::new(public_key, buckets));
                     }
                     Err(error) => {
@@ -2603,7 +2613,7 @@ impl EnvelopeProcessorService {
 
         let scoping = *bucket_limiter.scoping();
 
-        if let Some(rate_limiter) = self.rate_limiter.as_ref() {
+        if let Some(rate_limiter) = self.inner.rate_limiter.as_ref() {
             let item_scoping = ItemScoping {
                 category: DataCategory::Transaction,
                 scoping: &scoping,
@@ -2621,13 +2631,14 @@ impl EnvelopeProcessorService {
 
             let was_enforced = bucket_limiter.enforce_limits(
                 rate_limits.as_ref().map_err(|_| ()),
-                self.outcome_aggregator.clone(),
+                self.inner.outcome_aggregator.clone(),
             );
 
             if was_enforced {
                 if let Ok(limits) = rate_limits {
                     // Update the rate limits in the project cache.
-                    self.project_cache
+                    self.inner
+                        .project_cache
                         .send(UpdateRateLimits::new(scoping.project_key, limits));
                 }
             }
@@ -2636,7 +2647,7 @@ impl EnvelopeProcessorService {
         let buckets = bucket_limiter.into_metrics();
         if !buckets.is_empty() {
             // Forward buckets to envelope manager to send them to upstream or kafka:
-            self.envelope_manager.send(SendMetrics {
+            self.inner.envelope_manager.send(SendMetrics {
                 buckets,
                 scoping,
                 partition_key,
@@ -2681,7 +2692,7 @@ impl EnvelopeProcessorService {
             }
             Ok(envelope_body) => {
                 request.envelope_body = envelope_body;
-                self.upstream_relay.send(SendRequest(request));
+                self.inner.upstream_relay.send(SendRequest(request));
             }
         }
     }
@@ -2707,13 +2718,13 @@ impl Service for EnvelopeProcessorService {
         relay_log::info!("starting {thread_count} envelope processing workers");
 
         tokio::spawn(async move {
-            let service = Arc::new(self);
             let semaphore = Arc::new(Semaphore::new(thread_count));
 
             while let (Some(message), Ok(permit)) =
                 tokio::join!(rx.recv(), semaphore.clone().acquire_owned())
             {
-                let service = service.clone();
+                let service = self.clone();
+
                 tokio::task::spawn_blocking(move || {
                     service.handle_message(message);
                     drop(permit);
@@ -3156,15 +3167,19 @@ mod tests {
         let (outcome_aggregator, _) = mock_service("outcome_aggregator", (), |&mut (), _| {});
         let (project_cache, _) = mock_service("project_cache", (), |&mut (), _| {});
         let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
-        EnvelopeProcessorService {
-            config: Arc::new(config),
+        let inner = InnerEnvelopeProcessorService {
             envelope_manager,
-            outcome_aggregator,
             project_cache,
+            outcome_aggregator,
             upstream_relay,
             #[cfg(feature = "processing")]
             rate_limiter: None,
             geoip_lookup: None,
+        };
+
+        EnvelopeProcessorService {
+            config: Arc::new(config),
+            inner: Arc::new(inner),
         }
     }
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -579,7 +579,6 @@ impl EnvelopeProcessorService {
         #[cfg(not(feature = "processing"))]
         Self {
             config,
-            global_config: Arc::new(GlobalConfig::default()),
             inner: Arc::new(inner),
         }
     }


### PR DESCRIPTION
This refactor is needed for #2320, made it a separate PR to make it easier to read the diffs on that branch

We want to make envelopeprocessorservice easily cloneable, so we put most of the data it contains behind an arc. This allows us to remove the outer arc in the spawn_handler, so that we can mutate the service. Which will be needed for global config update.

#skip-changelog