### PR TITLE
chore(lint): Fix all beta lint warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["relay", "relay-*", "tools/*"]
 default-members = ["relay"]
+resolver = "2"
 
 [profile.dev]
 # Debug information slows down the build and increases caches in the

--- a/relay-cabi/src/core.rs
+++ b/relay-cabi/src/core.rs
@@ -173,7 +173,7 @@ pub struct RelayBuf {
 impl RelayBuf {
     pub(crate) unsafe fn free(&mut self) {
         if self.owned {
-            Vec::from_raw_parts(self.data as *mut u8, self.len, self.len);
+            Vec::from_raw_parts(self.data, self.len, self.len);
             self.data = ptr::null_mut();
             self.len = 0;
             self.owned = false;

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -210,6 +210,7 @@ pub unsafe extern "C" fn relay_pii_selector_suggestions_from_event(
 /// A test function that always panics.
 #[no_mangle]
 #[relay_ffi::catch_unwind]
+#[allow(clippy::diverging_sub_expression)]
 pub unsafe extern "C" fn relay_test_panic() -> () {
     panic!("this is a test panic")
 }

--- a/relay-common/src/constants.rs
+++ b/relay-common/src/constants.rs
@@ -687,9 +687,6 @@ mod tests {
             "0123456789abcde",
             CustomUnit::parse("0123456789abcde").unwrap().as_str()
         );
-        assert!(matches!(
-            CustomUnit::parse("this_is_a_unit_that_is_too_long"),
-            Err(_)
-        ));
+        assert!(CustomUnit::parse("this_is_a_unit_that_is_too_long").is_err());
     }
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2041,9 +2041,6 @@ cache:
 
     #[test]
     fn test_emit_outcomes_invalid() {
-        assert!(matches!(
-            serde_json::from_str::<EmitOutcomes>("asdf"),
-            Err(_)
-        ));
+        assert!(serde_json::from_str::<EmitOutcomes>("asdf").is_err());
     }
 }

--- a/relay-ffi/tests/test_macro.rs
+++ b/relay-ffi/tests/test_macro.rs
@@ -14,6 +14,7 @@ unsafe fn returns_error() -> i32 {
 }
 
 #[relay_ffi::catch_unwind]
+#[allow(clippy::diverging_sub_expression)]
 unsafe fn panics() {
     panic!("this is fine");
 }

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -51,7 +51,7 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
 
 static EXTENSION_EXC_SOURCES: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?ix)
+        r"(?ix)
         graph\.facebook\.com|                           # Facebook flakiness
         connect\.facebook\.net|                         # Facebook blocked
         eatdifferent\.com\.woopra-ns\.com|              # Woopra flakiness
@@ -63,7 +63,7 @@ static EXTENSION_EXC_SOURCES: Lazy<Regex> = Lazy::new(|| {
         webappstoolbarba\.texthelp\.com/|               # Other
         metrics\.itunes\.apple\.com\.edgesuite\.net/|
         kaspersky-labs\.com                             # Kaspersky Protection browser extension
-    "#,
+    ",
     )
     .expect("Invalid browser extensions filter (Exec Sources) Regex")
 });

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -329,7 +329,7 @@ mod tests {
             },
         };
 
-        insta::assert_json_snapshot!(filters_config, @r###"
+        insta::assert_json_snapshot!(filters_config, @r#"
         {
           "browserExtensions": {
             "isEnabled": true
@@ -373,7 +373,7 @@ mod tests {
             "isEnabled": true
           }
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -9,7 +9,7 @@ use crate::{FilterConfig, FilterStatKey};
 
 static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?ix)
+        r"(?ix)
         Mediapartners-Google|
         AdsBot-Google|
         Googlebot|
@@ -31,16 +31,16 @@ static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
                                     # https://forums.aws.amazon.com/thread.jspa?messageID=932404
                                     # and https://github.com/getsentry/sentry-python/issues/641
         HubSpot\sCrawler            # HubSpot web crawler (web-crawlers@hubspot.com)
-    "#
+    "
     )
     .expect("Invalid web crawlers filter Regex")
 });
 
 static ALLOWED_WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?ix)
+        r"(?ix)
         Slackbot\s1\.\d+             # Slack - see https://api.slack.com/robots
-    "#,
+    ",
     )
     .expect("Invalid allowed web crawlers filter Regex")
 });

--- a/relay-general/src/pii/convert.rs
+++ b/relay-general/src/pii/convert.rs
@@ -272,7 +272,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
     #[test]
     fn test_convert_default_pii_config() {
-        insta::assert_json_snapshot!(simple_enabled_pii_config(), @r###"
+        insta::assert_json_snapshot!(simple_enabled_pii_config(), @r#"
         {
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
@@ -287,7 +287,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -297,7 +297,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r###"
+        insta::assert_json_snapshot!(pii_config, @r#"
         {
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
@@ -312,7 +312,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -322,7 +322,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r###"
+        insta::assert_json_snapshot!(pii_config, @r#"
         {
           "rules": {
             "strip-fields": {
@@ -348,7 +348,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -358,7 +358,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r###"
+        insta::assert_json_snapshot!(pii_config, @r#"
         {
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !foobar": [
@@ -373,7 +373,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -385,7 +385,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..Default::default()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r###"
+        insta::assert_json_snapshot!(pii_config, @r#"
         {
           "applications": {
             "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
@@ -396,7 +396,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -824,13 +824,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
-        assert_annotated_snapshot!(data, @r###"
+        assert_annotated_snapshot!(data, @r#"
         {
           "extra": {
             "foo": "1453843029218310"
           }
         }
-        "###);
+        "#);
     }
 
     macro_rules! sanitize_url_test {
@@ -955,13 +955,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(data, @r###"
+        assert_annotated_snapshot!(data, @r#"
         {
           "extra": {
             "foo": 1
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1122,13 +1122,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(data, @r###"
+        assert_annotated_snapshot!(data, @r#"
         {
           "extra": {
             "foobar": "123-45-6789"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1150,13 +1150,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(data, @r###"
+        assert_annotated_snapshot!(data, @r#"
         {
           "extra": {
             "foobar": "xxx"
           }
         }
-        "###);
+        "#);
     }
 
     macro_rules! should_have_mysql_pwd_as_a_default_test {
@@ -1283,7 +1283,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r###"
+        insta::assert_json_snapshot!(pii_config, @r#"
         {
           "rules": {
             "strip-fields": {
@@ -1309,7 +1309,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "###);
+        "#);
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());

--- a/relay-general/src/pii/generate_selectors.rs
+++ b/relay-general/src/pii/generate_selectors.rs
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_full() {
         let mut event = Annotated::<Event>::from_json(
-            r##"
+            r#"
             {
               "message": "hi",
               "exception": {
@@ -210,12 +210,12 @@ mod tests {
                 }
               }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
         let selectors = selector_suggestions_from_value(&mut event);
-        insta::assert_yaml_snapshot!(selectors, @r###"
+        insta::assert_yaml_snapshot!(selectors, @r#"
         ---
         - path: $string
           value: "123"
@@ -253,6 +253,6 @@ mod tests {
           value: ~
         - path: "extra.'My Custom Value'"
           value: "123"
-        "###);
+        "#);
     }
 }

--- a/relay-general/src/pii/processor.rs
+++ b/relay-general/src/pii/processor.rs
@@ -533,7 +533,7 @@ mod tests {
     #[test]
     fn test_basic_stripping() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "rules": {
                     "remove_bad_headers": {
@@ -546,7 +546,7 @@ mod tests {
                     "$object.**": ["remove_bad_headers"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -597,13 +597,13 @@ mod tests {
     #[test]
     fn test_redact_containers() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$object": ["@anything"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn test_redact_custom_pattern() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$string": ["myrule"]
@@ -643,7 +643,7 @@ mod tests {
                     }
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -667,13 +667,13 @@ mod tests {
     #[test]
     fn test_no_field_upsert() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "**": ["@anything:remove"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -697,13 +697,13 @@ mod tests {
     #[test]
     fn test_anything_hash_on_string() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$string": ["@anything:hash"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -727,13 +727,13 @@ mod tests {
     #[test]
     fn test_anything_hash_on_container() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$object": ["@anything:hash"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -757,14 +757,14 @@ mod tests {
     #[test]
     fn test_remove_debugmeta_path() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "debug_meta.images.*.code_file": ["@anything:remove"],
                     "debug_meta.images.*.debug_file": ["@anything:remove"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -806,14 +806,14 @@ mod tests {
     #[test]
     fn test_replace_debugmeta_path() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "debug_meta.images.*.code_file": ["@anything:replace"],
                     "debug_meta.images.*.debug_file": ["@anything:replace"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -855,14 +855,14 @@ mod tests {
     #[test]
     fn test_hash_debugmeta_path() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "debug_meta.images.*.code_file": ["@anything:hash"],
                     "debug_meta.images.*.debug_file": ["@anything:hash"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -904,7 +904,7 @@ mod tests {
     #[test]
     fn test_debugmeta_path_not_addressible_with_wildcard_selector() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$string": ["@anything:remove"],
@@ -913,7 +913,7 @@ mod tests {
                     "(debug_meta.images.**.code_file & $string)": ["@anything:remove"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -955,13 +955,13 @@ mod tests {
     #[test]
     fn test_quoted_keys() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "extra.'special ,./<>?!@#$%^&*())''gärbage'''": ["@anything:remove"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -1033,13 +1033,13 @@ mod tests {
     #[test]
     fn test_ip_address_hashing() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$user.ip_address": ["@ip:hash"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 
@@ -1067,13 +1067,13 @@ mod tests {
     #[test]
     fn test_ip_address_hashing_does_not_overwrite_id() {
         let config = PiiConfig::from_json(
-            r##"
+            r#"
             {
                 "applications": {
                     "$user.ip_address": ["@ip:hash"]
                 }
             }
-            "##,
+            "#,
         )
         .unwrap();
 

--- a/relay-general/src/pii/regexes.rs
+++ b/relay-general/src/pii/regexes.rs
@@ -110,30 +110,30 @@ pub static ANYTHING_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(".*").unwrap())
 
 static IMEI_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
             \b
                 (\d{2}-?
                  \d{6}-?
                  \d{6}-?
                  \d{1,2})
             \b
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static MAC_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
             \b([[:xdigit:]]{2}[:-]){5}[[:xdigit:]]{2}\b
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?ix)
+        r"(?ix)
             \b
             [a-z0-9]{8}-?
             [a-z0-9]{4}-?
@@ -141,31 +141,31 @@ static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
             [a-z0-9]{4}-?
             [a-z0-9]{12}
             \b
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static EMAIL_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
             \b
                 [a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+
                 @
                 [a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*
             \b
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static IBAN_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
             \b
             (AT|AD|AE|AL|AZ|BA|BE|BG|BH|BR|BY|CH|CR|CY|CZ|DE|DK|DO|EE|EG|ES|FI|FO|FR|GB|GE|GI|GL|GR|GT|HR|HU|IE|IL|IQ|IS|IT|JO|KW|KZ|LB|LC|LI|LT|LU|LV|LY|MC|MD|ME|MK|MR|MT|MU|NL|NO|PK|PL|PS|PT|QA|RO|RU|RS|SA|SC|SE|SI|SK|SM|ST|SV|TL|TN|TR|UA|VA|VG|XK|DZ|AO|BJ|BF|BI|CV|CM|CF|TD|KM|CG|CI|DJ|GQ|GA|GW|HN|IR|MG|ML|MA|MZ|NI|NE|SN|TG)\d{2}[a-zA-Z0-9]{11,29}
             \b
-        "#,
+        ",
     )
     .unwrap()
 });
@@ -221,7 +221,7 @@ static CREDITCARD_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 static PATH_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?ix)
+        r"(?ix)
             (?:
                 (?:
                     \b(?:[a-zA-Z]:[\\/])?
@@ -233,14 +233,14 @@ static PATH_REGEX: Lazy<Regex> = Lazy::new(|| {
             (
                 [^/\\]+
             )
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static PEM_KEY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?sx)
+        r"(?sx)
             (?:
                 -----
                 BEGIN[A-Z\ ]+(?:PRIVATE|PUBLIC)\ KEY
@@ -254,32 +254,32 @@ static PEM_KEY_REGEX: Lazy<Regex> = Lazy::new(|| {
                 END[A-Z\ ]+(?:PRIVATE|PUBLIC)\ KEY
                 -----
             )
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static URL_AUTH_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
             \b(?:
                 (?:[a-z0-9+-]+:)?//
                 ([a-zA-Z0-9%_.-]+(?::[a-zA-Z0-9%_.-]+)?)
             )@
-        "#,
+        ",
     )
     .unwrap()
 });
 
 static US_SSN_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
             \b(
                 [0-9]{3}-
                 [0-9]{2}-
                 [0-9]{4}
             )\b
-        "#,
+        ",
     )
     .unwrap()
 });

--- a/relay-general/src/protocol/contexts/browser.rs
+++ b/relay-general/src/protocol/contexts/browser.rs
@@ -170,13 +170,13 @@ mod tests {
         let browser =
             BrowserContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
-        assert_debug_snapshot!(browser, @r###"
+        assert_debug_snapshot!(browser, @r#"
         BrowserContext {
             name: "Google Chrome",
             version: "109",
             other: {},
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -222,13 +222,13 @@ mod tests {
         let browser =
             BrowserContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
-        assert_debug_snapshot!(browser, @r###"
+        assert_debug_snapshot!(browser, @r#"
         BrowserContext {
             name: "weird browser",
             version: "109",
             other: {},
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-general/src/protocol/contexts/os.rs
+++ b/relay-general/src/protocol/contexts/os.rs
@@ -179,7 +179,7 @@ mod tests {
 
         let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
-        insta::assert_debug_snapshot!(os, @r###"
+        insta::assert_debug_snapshot!(os, @r#"
 OsContext {
     name: "macOS",
     version: "13.1.0",
@@ -189,7 +189,7 @@ OsContext {
     raw_description: ~,
     other: {},
 }
-        "###);
+        "#);
     }
 
     #[test]
@@ -250,7 +250,7 @@ OsContext {
 
         let os = OsContext::from_hints_or_ua(&RawUserAgentInfo::from_headers(&headers)).unwrap();
 
-        insta::assert_debug_snapshot!(os, @r###"
+        insta::assert_debug_snapshot!(os, @r#"
 OsContext {
     name: "Mac OS X",
     version: "10.15.6",
@@ -260,7 +260,7 @@ OsContext {
     raw_description: ~,
     other: {},
 }
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-general/src/protocol/security_report.rs
+++ b/relay-general/src/protocol/security_report.rs
@@ -1150,7 +1150,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
 
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "culprit": "style-src cdn.example.com",
           "logentry": {
@@ -1176,7 +1176,7 @@ mod tests {
             "violated_directive": "style-src cdn.example.com"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1191,7 +1191,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
 
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "culprit": "",
           "logentry": {
@@ -1217,7 +1217,7 @@ mod tests {
             "violated_directive": ""
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1235,7 +1235,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
 
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "culprit": "default-src self",
           "logentry": {
@@ -1269,7 +1269,7 @@ mod tests {
             "violated_directive": "default-src self"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1294,7 +1294,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
 
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "culprit": "script-src",
           "logentry": {
@@ -1334,7 +1334,7 @@ mod tests {
             "disposition": "enforce"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1349,7 +1349,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src http://cdn.example.com""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src http://cdn.example.com""#);
     }
 
     #[test]
@@ -1364,7 +1364,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src cdn.example.com""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src cdn.example.com""#);
     }
 
     #[test]
@@ -1379,7 +1379,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src cdn.example.com""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src cdn.example.com""#);
     }
 
     #[test]
@@ -1394,7 +1394,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src https://cdn.example.com""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src https://cdn.example.com""#);
     }
 
     #[test]
@@ -1409,7 +1409,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src 'self'""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src 'self'""#);
     }
 
     #[test]
@@ -1424,7 +1424,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src http://example2.com 'self'""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src http://example2.com 'self'""#);
     }
 
     #[test]
@@ -1439,7 +1439,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r###""style-src example2.com""###);
+        insta::assert_debug_snapshot!(event.culprit, @r#""style-src example2.com""#);
     }
 
     #[test]
@@ -1457,7 +1457,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.tags, @r###"
+        insta::assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -1472,7 +1472,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1488,7 +1488,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'image' from 'google.com'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'image' from 'google.com'""#);
     }
 
     #[test]
@@ -1504,7 +1504,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked inline 'style'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked inline 'style'""#);
     }
 
     #[test]
@@ -1521,7 +1521,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked unsafe inline 'script'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked unsafe inline 'script'""#);
     }
 
     #[test]
@@ -1538,7 +1538,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked unsafe eval() 'script'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked unsafe eval() 'script'""#);
     }
 
     #[test]
@@ -1555,7 +1555,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked unsafe (eval() or inline) 'script'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked unsafe (eval() or inline) 'script'""#);
     }
 
     #[test]
@@ -1571,7 +1571,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'script' from 'data:'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'script' from 'data:'""#);
     }
 
     #[test]
@@ -1587,7 +1587,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'script' from 'data:'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'script' from 'data:'""#);
     }
 
     #[test]
@@ -1603,7 +1603,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'style' from 'fonts.google.com'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'style' from 'fonts.google.com'""#);
     }
 
     #[test]
@@ -1619,7 +1619,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'script' from 'cdn.ajaxapis.com'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'script' from 'cdn.ajaxapis.com'""#);
     }
 
     #[test]
@@ -1635,7 +1635,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'style' from 'notlocalhost:8000'""###);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'style' from 'notlocalhost:8000'""#);
     }
 
     #[test]
@@ -1664,7 +1664,7 @@ mod tests {
 
         let mut event = Event::default();
         ExpectCt::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "culprit": "www.example.com",
           "logentry": {
@@ -1707,7 +1707,7 @@ mod tests {
             "test_report": false
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1739,7 +1739,7 @@ mod tests {
 
         let mut event = Event::default();
         ExpectStaple::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "culprit": "www.example.com",
           "logentry": {
@@ -1781,7 +1781,7 @@ mod tests {
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1799,7 +1799,7 @@ mod tests {
 
         let mut event = Event::default();
         Hpkp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        assert_annotated_snapshot!(Annotated::new(event), @r###"
+        assert_annotated_snapshot!(Annotated::new(event), @r#"
         {
           "logentry": {
             "formatted": "Public key pinning validation failed for 'example.com'"
@@ -1838,7 +1838,7 @@ mod tests {
             ]
           }
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -991,7 +991,7 @@ impl<'a> Processor for NormalizeProcessor<'a> {
     ) -> ProcessingResult {
         if !user.other.is_empty() {
             let data = user.data.value_mut().get_or_insert_with(Object::new);
-            data.extend(std::mem::take(&mut user.other).into_iter());
+            data.extend(std::mem::take(&mut user.other));
         }
 
         user.process_child_values(self, state)?;
@@ -2138,7 +2138,7 @@ mod tests {
             ".event_id" => "[event-id]",
             ".received" => "[received]",
             ".timestamp" => "[timestamp]"
-        }, @r###"
+        }, @r#"
         {
           "event_id": "[event-id]",
           "level": "error",
@@ -2154,12 +2154,12 @@ mod tests {
             "id": "legacy:1234-12-12",
           },
         }
-        "###);
+        "#);
     }
 
     #[test]
     fn test_logentry_error() {
-        let json = r###"
+        let json = r#"
 {
     "event_id": "74ad1301f4df489ead37d757295442b1",
     "timestamp": 1668148328.308933,
@@ -2173,7 +2173,7 @@ mod tests {
         "formatted": 42
     }
 }
-"###;
+"#;
         let mut event = Annotated::from_json(json).unwrap();
 
         let mut processor = NormalizeProcessor::default();
@@ -2181,7 +2181,7 @@ mod tests {
         light_normalize_event(&mut event, config).unwrap();
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&event), {".received" => "[received]"}, @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&event), {".received" => "[received]"}, @r#"
         {
           "event_id": "74ad1301f4df489ead37d757295442b1",
           "level": "error",
@@ -2212,7 +2212,7 @@ mod tests {
               }
             }
           }
-        }"###)
+        }"#)
     }
 
     #[test]
@@ -2246,7 +2246,7 @@ mod tests {
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
         ".event_id" => "[event-id]",
-    }, @r###"
+    }, @r#"
     {
       "event_id": "[event-id]",
       "level": "error",
@@ -2271,7 +2271,7 @@ mod tests {
         },
       },
     }
-    "###);
+    "#);
     }
 
     #[test]
@@ -2305,7 +2305,7 @@ mod tests {
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
         ".event_id" => "[event-id]",
-    }, @r###"
+    }, @r#"
     {
       "event_id": "[event-id]",
       "level": "error",
@@ -2330,7 +2330,7 @@ mod tests {
         },
       },
     }
-    "###);
+    "#);
     }
 
     #[test]
@@ -2511,7 +2511,7 @@ mod tests {
 
         normalize_measurements(&mut event, None, None);
 
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r#"
         {
           "type": "transaction",
           "timestamp": 1619420405.0,
@@ -2547,7 +2547,7 @@ mod tests {
             },
           },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -2581,7 +2581,7 @@ mod tests {
         normalize_measurements(&mut event, Some(&config), None);
 
         // Only two custom measurements are retained, in alphabetic order (1 and 2)
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r#"
         {
           "type": "transaction",
           "timestamp": 1619420405.0,
@@ -2621,7 +2621,7 @@ mod tests {
             },
           },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -2693,16 +2693,16 @@ mod tests {
     #[test]
     fn test_normalize_units() {
         let mut measurements = Annotated::<Measurements>::from_json(
-            r###"{
+            r#"{
                 "fcp": {"value": 1.1},
                 "stall_count": {"value": 3.3},
                 "foo": {"value": 8.8}
-            }"###,
+            }"#,
         )
         .unwrap()
         .into_value()
         .unwrap();
-        insta::assert_debug_snapshot!(measurements, @r###"
+        insta::assert_debug_snapshot!(measurements, @r#"
         Measurements(
             {
                 "fcp": Measurement {
@@ -2719,9 +2719,9 @@ mod tests {
                 },
             },
         )
-        "###);
+        "#);
         normalize_units(&mut measurements);
-        insta::assert_debug_snapshot!(measurements, @r###"
+        insta::assert_debug_snapshot!(measurements, @r#"
         Measurements(
             {
                 "fcp": Measurement {
@@ -2740,13 +2740,13 @@ mod tests {
                 },
             },
         )
-        "###);
+        "#);
     }
 
     #[test]
     fn test_light_normalize_validates_spans() {
         let event = Annotated::<Event>::from_json(
-            r###"
+            r#"
             {
                 "type": "transaction",
                 "transaction": "/",
@@ -2762,7 +2762,7 @@ mod tests {
                 },
                 "spans": []
             }
-            "###,
+            "#,
         )
         .unwrap();
 
@@ -2806,12 +2806,12 @@ mod tests {
     #[test]
     fn test_light_normalization_respects_is_renormalize() {
         let mut event = Annotated::<Event>::from_json(
-            r###"
+            r#"
             {
                 "type": "default",
                 "tags": [["environment", "some_environment"]]
             }
-            "###,
+            "#,
         )
         .unwrap();
 
@@ -2825,7 +2825,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        assert_debug_snapshot!(event.value().unwrap().tags, @r###"
+        assert_debug_snapshot!(event.value().unwrap().tags, @r#"
         Tags(
             PairList(
                 [
@@ -2836,7 +2836,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -2918,7 +2918,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r###"
+        assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -2929,7 +2929,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -2947,7 +2947,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r###"
+        assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -2958,7 +2958,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -2976,7 +2976,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r###"
+        assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -2987,7 +2987,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3007,7 +3007,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r###"
+        assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -3018,7 +3018,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3038,7 +3038,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r###"
+        assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -3049,7 +3049,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3069,7 +3069,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r###"
+        assert_debug_snapshot!(event.tags, @r#"
         Tags(
             PairList(
                 [
@@ -3080,7 +3080,7 @@ mod tests {
                 ],
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-general/src/store/normalize/contexts.rs
+++ b/relay-general/src/store/normalize/contexts.rs
@@ -6,36 +6,36 @@ use crate::types::{Annotated, Empty, Value};
 
 /// Environment.OSVersion (GetVersionEx) or RuntimeInformation.OSDescription on Windows
 static OS_WINDOWS_REGEX1: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^(Microsoft )?Windows (NT )?(?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$"#)
+    Regex::new(r"^(Microsoft )?Windows (NT )?(?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$")
         .unwrap()
 });
 static OS_WINDOWS_REGEX2: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^Windows\s+\d+\s+\((?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$"#).unwrap()
+    Regex::new(r"^Windows\s+\d+\s+\((?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$").unwrap()
 });
 
 static OS_ANDROID_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^Android (OS )?(?P<version>\d+(\.\d+){0,2}) / API-(?P<api>(\d+))"#).unwrap()
+    Regex::new(r"^Android (OS )?(?P<version>\d+(\.\d+){0,2}) / API-(?P<api>(\d+))").unwrap()
 });
 
 /// Format sent by Unreal Engine on macOS
 static OS_MACOS_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$"#).unwrap()
+    Regex::new(r"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$").unwrap()
 });
 
 /// Specific regex to parse Linux distros
 static OS_LINUX_DISTRO_UNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^Linux (?P<kernel_version>\d+\.\d+(\.\d+(\.[1-9]+)?)?) (?P<name>[a-zA-Z]+) (?P<version>\d+(\.\d+){0,2})"#).unwrap()
+    Regex::new(r"^Linux (?P<kernel_version>\d+\.\d+(\.\d+(\.[1-9]+)?)?) (?P<name>[a-zA-Z]+) (?P<version>\d+(\.\d+){0,2})").unwrap()
 });
 
 /// Environment.OSVersion or RuntimeInformation.OSDescription (uname) on Mono and CoreCLR on
 /// macOS, iOS, Linux, etc.
 static OS_UNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^(?P<name>[a-zA-Z]+) (?P<kernel_version>\d+\.\d+(\.\d+(\.[1-9]+)?)?)"#).unwrap()
+    Regex::new(r"^(?P<name>[a-zA-Z]+) (?P<kernel_version>\d+\.\d+(\.\d+(\.[1-9]+)?)?)").unwrap()
 });
 
 /// Mono 5.4, .NET Core 2.0
 static RUNTIME_DOTNET_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"^(?P<name>.*) (?P<version>\d+\.\d+(\.\d+){0,2}).*$"#).unwrap());
+    Lazy::new(|| Regex::new(r"^(?P<name>.*) (?P<version>\d+\.\d+(\.\d+){0,2}).*$").unwrap());
 
 fn normalize_runtime_context(runtime: &mut RuntimeContext) {
     if runtime.name.value().is_empty() && runtime.version.value().is_empty() {

--- a/relay-general/src/store/normalize/mechanism.rs
+++ b/relay-general/src/store/normalize/mechanism.rs
@@ -990,12 +990,12 @@ mod tests {
         };
 
         normalize_mechanism(&mut good_mechanism, None).unwrap();
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(good_mechanism)), @r###"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(good_mechanism)), @r#"
         {
           "type": "generic",
           "help_link": "https://example.com/",
         }
-        "###);
+        "#);
 
         let mut bad_mechanism = Mechanism {
             ty: Annotated::new("generic".to_string()),
@@ -1004,7 +1004,7 @@ mod tests {
         };
 
         normalize_mechanism(&mut bad_mechanism, None).unwrap();
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(bad_mechanism)), @r###"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(bad_mechanism)), @r#"
         {
           "type": "generic",
           "help_link": (),
@@ -1024,6 +1024,6 @@ mod tests {
             },
           },
         }
-        "###);
+        "#);
     }
 }

--- a/relay-general/src/store/normalize/span/description.rs
+++ b/relay-general/src/store/normalize/span/description.rs
@@ -54,16 +54,16 @@ static SQL_COLLAPSE_ENTITIES: Lazy<Regex> =
 /// This can be used as a second pass after [`SQL_NORMALIZER_REGEX`].
 static SQL_COLLAPSE_PLACEHOLDERS: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?xi)
+        r"(?xi)
         (?P<pre>(?:VALUES|IN) \s+\() (?P<values> ( %s ( \)\s*,\s*\(\s*%s | \s*,\s*%s )* )) (?P<post>\s*\)?)
-        "#,
+        ",
     )
     .unwrap()
 });
 
 /// Collapse simple lists of columns in select.
 static SQL_COLLAPSE_SELECT: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)(?P<select>SELECT(\s+(DISTINCT|ALL))?)\s+(?P<columns>(\w+(?:\s*,\s*\w+)+))\s+(?<from>FROM|$)"#)
+    Regex::new(r"(?i)(?P<select>SELECT(\s+(DISTINCT|ALL))?)\s+(?P<columns>(\w+(?:\s*,\s*\w+)+))\s+(?<from>FROM|$)")
         .unwrap()
 });
 
@@ -71,8 +71,7 @@ static SQL_COLLAPSE_SELECT: Lazy<Regex> = Lazy::new(|| {
 ///
 /// Looks for `?`, `$1` or `%s` identifiers, commonly used identifiers in
 /// Python, Ruby on Rails and PHP platforms.
-static SQL_ALREADY_NORMALIZED_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"/\?|\$1|%s"#).unwrap());
+static SQL_ALREADY_NORMALIZED_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"/\?|\$1|%s").unwrap());
 
 /// Attempts to replace identifiers in the span description with placeholders.
 ///
@@ -531,14 +530,14 @@ mod tests {
 
     span_description_test!(
         span_description_scrub_single_quoted_string_finished,
-        r#"SELECT * FROM table WHERE quote = 'it\\'s a string'"#,
+        r"SELECT * FROM table WHERE quote = 'it\\'s a string'",
         "db.sql.query",
         "SELECT * FROM table WHERE quote = %s"
     );
 
     span_description_test!(
         span_description_scrub_single_quoted_string_unfinished,
-        r#"SELECT * FROM table WHERE quote = 'it\\'s a string"#,
+        r"SELECT * FROM table WHERE quote = 'it\\'s a string",
         "db.sql.query",
         "SELECT * FROM table WHERE quote = %s"
     );

--- a/relay-general/src/store/normalize/span/tag_extraction.rs
+++ b/relay-general/src/store/normalize/span/tag_extraction.rs
@@ -93,7 +93,7 @@ pub(crate) fn extract_span_tags(event: &mut Event, config: &Config) {
             shared_tags
                 .clone()
                 .into_iter()
-                .chain(tags.into_iter())
+                .chain(tags)
                 .map(|(k, v)| (k.to_string(), Annotated::new(v.into()))),
         );
     }
@@ -332,7 +332,7 @@ fn sql_table_from_query(query: &str) -> Option<&str> {
 
 /// Regex with a capture group to extract the HTTP method from a string.
 pub static HTTP_METHOD_EXTRACTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)^(?P<method>(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH))\b"#)
+    Regex::new(r"(?i)^(?P<method>(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH))\b")
         .unwrap()
 });
 

--- a/relay-general/src/store/normalize/user_agent.rs
+++ b/relay-general/src/store/normalize/user_agent.rs
@@ -150,7 +150,7 @@ mod tests {
 
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "browser": {
             "name": "Chrome Mobile",
@@ -158,7 +158,7 @@ mod tests {
             "type": "browser"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -167,7 +167,7 @@ mod tests {
 
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "client_os": {
             "name": "Windows",
@@ -175,7 +175,7 @@ mod tests {
             "type": "os"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -183,7 +183,7 @@ mod tests {
         let ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) - (-)";
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "browser": {
             "name": "Mobile Safari UI/WKWebView",
@@ -201,7 +201,7 @@ mod tests {
             "type": "device"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -209,7 +209,7 @@ mod tests {
         let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) - (-)";
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "client_os": {
             "name": "Mac OS X",
@@ -223,7 +223,7 @@ mod tests {
             "type": "device"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
 
         let mut event = testutils::get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "device": {
             "family": "Samsung Galaxy Nexus",
@@ -241,14 +241,14 @@ mod tests {
             "type": "device"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
     fn test_all_contexts() {
         let mut event = testutils::get_event_with_user_agent(GOOD_UA);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "browser": {
             "name": "Chrome Mobile",
@@ -267,7 +267,7 @@ mod tests {
             "type": "device"
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -294,7 +294,7 @@ mod tests {
         event.contexts = Annotated::new(contexts);
 
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r###"
+        assert_annotated_snapshot!(event.contexts, @r#"
         {
           "browser": {
             "name": "BR_FAMILY",
@@ -318,6 +318,6 @@ mod tests {
             "type": "os"
           }
         }
-        "###);
+        "#);
     }
 }

--- a/relay-general/src/store/regexes.rs
+++ b/relay-general/src/store/regexes.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 /// <https://github.com/getsentry/sentry/blob/6ba59023a78bfe033e48ea4e035b64710a905c6b/src/sentry/grouping/strategies/message.py#L16-L97>
 pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?x)
+        r"(?x)
     (?P<uuid>[^/\\]*
         \b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b
     [^/\\]*) |
@@ -46,14 +46,14 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     (?:^|[/\\])
     (?P<int>
         (:?[^%/\\]|%[0-9a-fA-F]{2})*\d{2,}
-    [^/\\]*)"#,
+    [^/\\]*)",
     )
     .unwrap()
 });
 
 /// Captures initial all-caps words as redis command, the rest as arguments.
 pub static REDIS_COMMAND_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"\s*(?P<command>[A-Z]+(\s+[A-Z]+)*\b)(?P<args>.+)?"#).unwrap());
+    Lazy::new(|| Regex::new(r"\s*(?P<command>[A-Z]+(\s+[A-Z]+)*\b)(?P<args>.+)?").unwrap());
 
 /// Regex with multiple capture groups for resource tokens we should scrub.
 ///
@@ -65,7 +65,7 @@ pub static REDIS_COMMAND_REGEX: Lazy<Regex> =
 /// <https://github.com/getsentry/sentry/blob/de5949a9a313d7ef0bf0685f84fe6e981ac38558/src/sentry/utils/performance_issues/base.py#L292-L306>
 pub static RESOURCE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"(?xi)
+        r"(?xi)
         # UUIDs.
         (?P<uuid>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}) |
         # Chunks and chunk numbers.
@@ -78,7 +78,7 @@ pub static RESOURCE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
         (?P<large_hash>[a-f0-9]{16,64}) |
         # Only numbers (for file names that are just numbers).
         (?P<only_numbers>/[0-9]+(\.[a-z0-9]{2,6})$)
-        "#,
+        ",
     )
     .unwrap()
 });

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -112,8 +112,7 @@ impl<'r> TransactionsProcessor<'r> {
         matches!(
             source,
             Some(&TransactionSource::Url | &TransactionSource::Sanitized)
-        ) || (matches!(source, None)
-            && event.transaction.value().map_or(false, |t| t.contains('/')))
+        ) || (source.is_none() && event.transaction.value().map_or(false, |t| t.contains('/')))
     }
 
     fn normalize_transaction_name(&self, event: &mut Event) -> ProcessingResult {
@@ -777,7 +776,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/",
@@ -796,7 +795,7 @@ mod tests {
           },
           "spans": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -878,7 +877,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/",
@@ -897,7 +896,7 @@ mod tests {
           },
           "spans": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1100,7 +1099,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/",
@@ -1127,13 +1126,13 @@ mod tests {
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[test]
     fn test_default_transaction_source_unknown() {
         let mut event = Annotated::<Event>::from_json(
-            r###"
+            r#"
             {
                 "type": "transaction",
                 "transaction": "/",
@@ -1152,7 +1151,7 @@ mod tests {
                 },
                 "spans": []
             }
-            "###,
+            "#,
         )
         .unwrap();
 
@@ -1185,7 +1184,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/",
@@ -1212,7 +1211,7 @@ mod tests {
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1233,7 +1232,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "<unlabeled transaction>",
@@ -1260,7 +1259,7 @@ mod tests {
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1281,7 +1280,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "<unlabeled transaction>",
@@ -1308,7 +1307,7 @@ mod tests {
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1393,7 +1392,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/*/user/*/0",
@@ -1440,7 +1439,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     /// When no identifiers are scrubbed, we should not set an original value in _meta.
@@ -1511,7 +1510,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/*/user/*/0",
@@ -1552,7 +1551,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1587,7 +1586,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/bar/user/john/0",
@@ -1607,7 +1606,7 @@ mod tests {
           },
           "spans": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1669,7 +1668,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
          {
            "type": "transaction",
            "transaction": "/foo/*/user/*/0/",
@@ -1714,7 +1713,7 @@ mod tests {
              }
            }
          }
-         "###);
+         "#);
 
         let mut event = Annotated::<Event>::from_json(json).unwrap();
 
@@ -1735,7 +1734,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/*/user/*/0/",
@@ -1780,7 +1779,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1823,7 +1822,7 @@ mod tests {
         );
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/*/user/*/0/",
@@ -1861,13 +1860,13 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
 
         // Process again:
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         // _meta entry is unchanged, because only updated when "transaction" changed:
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/*/user/*/0/",
@@ -1905,7 +1904,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1958,7 +1957,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0",
@@ -1978,7 +1977,7 @@ mod tests {
           },
           "spans": []
         }
-        "###);
+        "#);
     }
 
     fn run_with_unknown_source(sdk: &str) -> Annotated<Event> {
@@ -2033,7 +2032,7 @@ mod tests {
     fn test_normalize_legacy_javascript() {
         // Javascript without source annotation gets sanitized.
         let event = run_with_unknown_source("sentry.javascript.browser");
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/user/*/blog/",
@@ -2069,7 +2068,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -2077,7 +2076,7 @@ mod tests {
         // Python without source annotation does not get sanitized, because we assume it to be
         // low cardinality.
         let event = run_with_unknown_source("sentry.python");
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
         {
           "type": "transaction",
           "transaction": "/user/jane/blog/",
@@ -2100,7 +2099,7 @@ mod tests {
           },
           "spans": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -2148,7 +2147,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r###"
+        assert_annotated_snapshot!(event, @r#"
          {
            "type": "transaction",
            "transaction": "/foo/*/user",
@@ -2187,7 +2186,7 @@ mod tests {
              }
            }
          }
-         "###);
+         "#);
     }
 
     #[test]
@@ -2325,8 +2324,8 @@ mod tests {
     );
     transaction_name_test!(
         test_transaction_name_normalize_windows_path,
-        r#"C:\\\\Program Files\\1234\\Files"#,
-        r#"C:\\Program Files\*\Files"#
+        r"C:\\\\Program Files\\1234\\Files",
+        r"C:\\Program Files\*\Files"
     );
     transaction_name_test!(test_transaction_name_skip_replace_all, "12345", "12345");
     transaction_name_test!(

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_rule_format() {
-        let json = r###"
+        let json = r#"
         {
           "pattern": "/auth/login/*/**",
           "expiry": "2022-11-30T00:00:00.000000Z",
@@ -228,7 +228,7 @@ mod tests {
             "substitution": ":id"
           }
         }
-        "###;
+        "#;
 
         let rule: TransactionNameRule = serde_json::from_str(json).unwrap();
 
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_rule_format_defaults() {
-        let json = r###"
+        let json = r#"
         {
           "pattern": "/auth/login/*/**",
           "expiry": "2022-11-30T00:00:00.000000Z",
@@ -254,7 +254,7 @@ mod tests {
             "method": "replace"
           }
         }
-        "###;
+        "#;
 
         let rule: TransactionNameRule = serde_json::from_str(json).unwrap();
 
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_rule_format_unsupported_reduction() {
-        let json = r###"
+        let json = r#"
         {
           "pattern": "/auth/login/*/**",
           "expiry": "2022-11-30T00:00:00.000000Z",
@@ -280,7 +280,7 @@ mod tests {
             "method": "update"
           }
         }
-        "###;
+        "#;
 
         let rule: TransactionNameRule = serde_json::from_str(json).unwrap();
         let result = rule.apply("/auth/login/test/");
@@ -290,14 +290,14 @@ mod tests {
 
     #[test]
     fn test_rule_format_roundtrip() {
-        let json = r###"{
+        let json = r#"{
   "pattern": "/auth/login/*/**",
   "expiry": "2022-11-30T00:00:00Z",
   "redaction": {
     "method": "replace",
     "substitution": ":id"
   }
-}"###;
+}"#;
 
         let rule: TransactionNameRule = serde_json::from_str(json).unwrap();
         let rule_json = serde_json::to_string_pretty(&rule).unwrap();

--- a/relay-general/src/types/meta.rs
+++ b/relay-general/src/types/meta.rs
@@ -592,8 +592,8 @@ impl Meta {
         if let Some(other_inner) = other.0 {
             let other_inner = *other_inner;
             let inner = self.upsert();
-            inner.remarks.extend(other_inner.remarks.into_iter());
-            inner.errors.extend(other_inner.errors.into_iter());
+            inner.remarks.extend(other_inner.remarks);
+            inner.errors.extend(other_inner.errors);
             if inner.original_length.is_none() {
                 inner.original_length = other_inner.original_length;
             }

--- a/relay-general/src/utils.rs
+++ b/relay-general/src/utils.rs
@@ -66,7 +66,7 @@ impl<'g> GlobBuilder<'g> {
         pattern.push('^');
 
         static GLOB_RE: OnceCell<Regex> = OnceCell::new();
-        let regex = GLOB_RE.get_or_init(|| Regex::new(r#"\\\?|\\\*\\\*|\\\*|\?|\*\*|\*"#).unwrap());
+        let regex = GLOB_RE.get_or_init(|| Regex::new(r"\\\?|\\\*\\\*|\\\*|\?|\*\*|\*").unwrap());
 
         for m in regex.find_iter(self.value) {
             pattern.push_str(&regex::escape(&self.value[last..m.start()]));

--- a/relay-general/tests/test_fixtures.rs
+++ b/relay-general/tests/test_fixtures.rs
@@ -10,7 +10,7 @@ use relay_general::types::{Annotated, SerializableAnnotated};
 
 fn pii_config() -> PiiConfig {
     PiiConfig::from_json(
-        r##"{
+        r#"{
           "rules": {
             "removeOkDetectToken": {
               "type": "pattern",
@@ -50,7 +50,7 @@ fn pii_config() -> PiiConfig {
             "exception.values.*.stacktrace.frames.*.abs_path": ["@userpath:replace"],
             "breadcrumbs.values.*.message": ["@userpath:replace"]
           }
-        }"##,
+        }"#,
     )
     .unwrap()
 }

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -5,7 +5,7 @@ description = "Kafka related functionality for Relay"
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"
 version = "23.7.1"
-edition = "2018"
+edition = "2021"
 license-file = "../LICENSE"
 publish = false
 

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_kafka_config() {
-        let yaml = r###"
+        let yaml = r#"
 events: "ingest-events-kafka-topic"
 profiles:
     name: "ingest-profiles"
@@ -329,7 +329,7 @@ metrics:
       45000:
           name: "ingest-metrics-3"
           config: "metrics_3"
-"###;
+"#;
 
         let def_config = vec![KafkaConfigParam {
             name: "test".to_string(),

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -2271,7 +2271,7 @@ mod tests {
         ]"#;
 
         let buckets = Bucket::parse_all(json.as_bytes()).unwrap();
-        insta::assert_debug_snapshot!(buckets, @r###"
+        insta::assert_debug_snapshot!(buckets, @r#"
         [
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
@@ -2290,7 +2290,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -2306,7 +2306,7 @@ mod tests {
         ]"#;
 
         let buckets = Bucket::parse_all(json.as_bytes()).unwrap();
-        insta::assert_debug_snapshot!(buckets, @r###"
+        insta::assert_debug_snapshot!(buckets, @r#"
         [
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
@@ -2318,7 +2318,7 @@ mod tests {
                 tags: {},
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -2538,7 +2538,7 @@ mod tests {
             .map(|(k, e)| (k, &e.value)) // skip flush times, they are different every time
             .collect();
 
-        insta::assert_debug_snapshot!(buckets, @r###"
+        insta::assert_debug_snapshot!(buckets, @r#"
         [
             (
                 BucketKey {
@@ -2552,7 +2552,7 @@ mod tests {
                 ),
             ),
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -2583,7 +2583,7 @@ mod tests {
             .collect();
 
         buckets.sort_by(|a, b| a.0.timestamp.cmp(&b.0.timestamp));
-        insta::assert_debug_snapshot!(buckets, @r###"
+        insta::assert_debug_snapshot!(buckets, @r#"
         [
             (
                 BucketKey {
@@ -2608,7 +2608,7 @@ mod tests {
                 ),
             ),
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -2638,23 +2638,23 @@ mod tests {
         let project_key2 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
         let project_key3 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fef").unwrap();
         let mut cost_tracker = CostTracker::default();
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 0,
             cost_per_project_key: {},
         }
-        "###);
+        "#);
         cost_tracker.add_cost(project_key1, 100);
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 100,
             cost_per_project_key: {
                 ProjectKey("a94ae32be2584e0bbd7a4cbb95971fed"): 100,
             },
         }
-        "###);
+        "#);
         cost_tracker.add_cost(project_key2, 200);
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 300,
             cost_per_project_key: {
@@ -2662,10 +2662,10 @@ mod tests {
                 ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 200,
             },
         }
-        "###);
+        "#);
         // Unknown project: Will log error, but not crash
         cost_tracker.subtract_cost(project_key3, 666);
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 300,
             cost_per_project_key: {
@@ -2673,33 +2673,33 @@ mod tests {
                 ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 200,
             },
         }
-        "###);
+        "#);
         // Subtract too much: Will log error, but not crash
         cost_tracker.subtract_cost(project_key1, 666);
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 200,
             cost_per_project_key: {
                 ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 200,
             },
         }
-        "###);
+        "#);
         cost_tracker.subtract_cost(project_key2, 20);
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 180,
             cost_per_project_key: {
                 ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 180,
             },
         }
-        "###);
+        "#);
         cost_tracker.subtract_cost(project_key2, 180);
-        insta::assert_debug_snapshot!(cost_tracker, @r###"
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
         CostTracker {
             total_cost: 0,
             cost_per_project_key: {},
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -3199,12 +3199,12 @@ mod tests {
     #[test]
     fn test_bucket_partitioning_dummy() {
         let output = run_test_bucket_partitioning(None);
-        insta::assert_debug_snapshot!(output, @r###"
+        insta::assert_debug_snapshot!(output, @r#"
         [
             "metrics.buckets.per_batch:2|h|#aggregator:default",
             "metrics.buckets.batches_per_partition:1|h|#aggregator:default",
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -3213,21 +3213,21 @@ mod tests {
         // Because buckets are stored in a HashMap, we do not know in what order the buckets will
         // be processed, so we need to convert them to a set:
         let (partition_keys, tail) = output.split_at(2);
-        insta::assert_debug_snapshot!(BTreeSet::from_iter(partition_keys), @r###"
+        insta::assert_debug_snapshot!(BTreeSet::from_iter(partition_keys), @r#"
         {
             "metrics.buckets.partition_keys:59|h|#aggregator:default",
             "metrics.buckets.partition_keys:62|h|#aggregator:default",
         }
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(tail, @r###"
+        insta::assert_debug_snapshot!(tail, @r#"
         [
             "metrics.buckets.per_batch:1|h|#aggregator:default",
             "metrics.buckets.batches_per_partition:1|h|#aggregator:default",
             "metrics.buckets.per_batch:1|h|#aggregator:default",
             "metrics.buckets.batches_per_partition:1|h|#aggregator:default",
         ]
-        "###);
+        "#);
     }
 
     fn test_capped_iter_completeness(max_flush_bytes: usize, expected_elements: usize) {

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -681,7 +681,7 @@ mod tests {
         let s = "transactions/foo:42|c";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric, @r###"
+        insta::assert_debug_snapshot!(metric, @r#"
         Metric {
             name: "c:transactions/foo@none",
             value: Counter(
@@ -690,7 +690,7 @@ mod tests {
             timestamp: UnixTimestamp(4711),
             tags: {},
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -698,7 +698,7 @@ mod tests {
         let s = "transactions/foo:17.5|d";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric, @r###"
+        insta::assert_debug_snapshot!(metric, @r#"
         Metric {
             name: "d:transactions/foo@none",
             value: Distribution(
@@ -707,7 +707,7 @@ mod tests {
             timestamp: UnixTimestamp(4711),
             tags: {},
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -723,7 +723,7 @@ mod tests {
         let s = "transactions/foo:e2546e4c-ecd0-43ad-ae27-87960e57a658|s";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric, @r###"
+        insta::assert_debug_snapshot!(metric, @r#"
         Metric {
             name: "s:transactions/foo@none",
             value: Set(
@@ -732,7 +732,7 @@ mod tests {
             timestamp: UnixTimestamp(4711),
             tags: {},
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -740,7 +740,7 @@ mod tests {
         let s = "transactions/foo:42|g";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric, @r###"
+        insta::assert_debug_snapshot!(metric, @r#"
         Metric {
             name: "g:transactions/foo@none",
             value: Gauge(
@@ -749,7 +749,7 @@ mod tests {
             timestamp: UnixTimestamp(4711),
             tags: {},
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -775,12 +775,12 @@ mod tests {
         let s = "transactions/foo:17.5|d|#foo,bar:baz";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Metric::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric.tags, @r###"
+        insta::assert_debug_snapshot!(metric.tags, @r#"
         {
             "bar": "baz",
             "foo": "",
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -821,7 +821,7 @@ mod tests {
 }"#;
 
         let metric = serde_json::from_str::<Metric>(json).unwrap();
-        insta::assert_debug_snapshot!(metric, @r###"
+        insta::assert_debug_snapshot!(metric, @r#"
         Metric {
             name: "foo",
             value: Counter(
@@ -833,7 +833,7 @@ mod tests {
                 "full": "value",
             },
         }
-        "###);
+        "#);
 
         let string = serde_json::to_string_pretty(&metric).unwrap();
         assert_eq!(string, json);
@@ -850,7 +850,7 @@ mod tests {
         }"#;
 
         let metric = serde_json::from_str::<Metric>(json).unwrap();
-        insta::assert_debug_snapshot!(metric, @r###"
+        insta::assert_debug_snapshot!(metric, @r#"
         Metric {
             name: "foo",
             value: Counter(
@@ -859,7 +859,7 @@ mod tests {
             timestamp: UnixTimestamp(4711),
             tags: {},
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-profiling/src/extract_from_transaction.rs
+++ b/relay-profiling/src/extract_from_transaction.rs
@@ -127,7 +127,7 @@ mod tests {
         );
 
         let metadata = extract_transaction_metadata(&event.0.unwrap());
-        insta::assert_debug_snapshot!(metadata, @r###"
+        insta::assert_debug_snapshot!(metadata, @r#"
         {
             "app.identifier": "io.sentry.myexample",
             "dist": "mydist",
@@ -140,6 +140,6 @@ mod tests {
             "transaction.start": "2011-05-02T17:40:36.000000000+00:00",
             "transaction.status": "ok",
         }
-        "###);
+        "#);
     }
 }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -328,7 +328,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: None,
           categories: [],
@@ -336,7 +336,7 @@ mod tests {
           limit: Some(0),
           reasonCode: Some(ReasonCode("not_yet")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -349,7 +349,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: None,
           categories: [
@@ -359,7 +359,7 @@ mod tests {
           limit: Some(0),
           reasonCode: Some(ReasonCode("not_yet")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -373,7 +373,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("o"),
           categories: [],
@@ -382,7 +382,7 @@ mod tests {
           window: Some(42),
           reasonCode: Some(ReasonCode("not_so_fast")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -398,7 +398,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("p"),
           categories: [],
@@ -408,7 +408,7 @@ mod tests {
           window: Some(42),
           reasonCode: Some(ReasonCode("not_so_fast")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -424,7 +424,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("p"),
           categories: [],
@@ -434,7 +434,7 @@ mod tests {
           window: Some(42),
           reasonCode: Some(ReasonCode("not_so_fast")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -450,7 +450,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("k"),
           categories: [],
@@ -460,7 +460,7 @@ mod tests {
           window: Some(42),
           reasonCode: Some(ReasonCode("not_so_fast")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -477,7 +477,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("f"),
           categories: [
@@ -489,7 +489,7 @@ mod tests {
           window: Some(42),
           reasonCode: Some(ReasonCode("not_so_fast")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -501,7 +501,7 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("o"),
           categories: [],
@@ -509,7 +509,7 @@ mod tests {
           limit: None,
           window: Some(42),
         )
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -533,7 +533,7 @@ mod tests {
             retry_after: RetryAfter::from_secs(10),
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -547,7 +547,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -569,7 +569,7 @@ mod tests {
             retry_after: RetryAfter::from_secs(1),
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -583,7 +583,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -613,7 +613,7 @@ mod tests {
             retry_after: RetryAfter::from_secs(1),
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -642,7 +642,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -665,7 +665,7 @@ mod tests {
         });
 
         let rate_limit = rate_limits.longest().unwrap();
-        insta::assert_ron_snapshot!(rate_limit, @r###"
+        insta::assert_ron_snapshot!(rate_limit, @r#"
         RateLimit(
           categories: [
             transaction,
@@ -674,7 +674,7 @@ mod tests {
           reason_code: Some(ReasonCode("second")),
           retry_after: RetryAfter(10),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -703,7 +703,7 @@ mod tests {
         rate_limits.clean_expired();
 
         // Check that the expired limit has been removed
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -716,7 +716,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -750,7 +750,7 @@ mod tests {
         });
 
         // Check that the error limit is applied
-        insta::assert_ron_snapshot!(applied_limits, @r###"
+        insta::assert_ron_snapshot!(applied_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -763,7 +763,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -808,7 +808,7 @@ mod tests {
 
         let applied_limits = rate_limits.check_with_quotas(quotas, item_scoping);
 
-        insta::assert_ron_snapshot!(applied_limits, @r###"
+        insta::assert_ron_snapshot!(applied_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -821,7 +821,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -852,7 +852,7 @@ mod tests {
 
         rate_limits1.merge(rate_limits2);
 
-        insta::assert_ron_snapshot!(rate_limits1, @r###"
+        insta::assert_ron_snapshot!(rate_limits1, @r#"
         RateLimits(
           limits: [
             RateLimit(
@@ -873,6 +873,6 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 }

--- a/relay-redis/src/config.rs
+++ b/relay-redis/src/config.rs
@@ -61,10 +61,10 @@ mod tests {
 
     #[test]
     fn test_redis_single_opts() {
-        let yaml = r###"
+        let yaml = r#"
 server: "redis://127.0.0.1:6379"
 max_connections: 42
-"###;
+"#;
 
         let config: RedisConfig = serde_yaml::from_str(yaml)
             .expect("Parsed processing redis config: single with options");
@@ -80,9 +80,9 @@ max_connections: 42
 
     #[test]
     fn test_redis_single_opts_default() {
-        let yaml = r###"
+        let yaml = r#"
 server: "redis://127.0.0.1:6379"
-"###;
+"#;
 
         let config: RedisConfig = serde_yaml::from_str(yaml)
             .expect("Parsed processing redis config: single with options");
@@ -100,9 +100,9 @@ server: "redis://127.0.0.1:6379"
     // when the single `redis://...` address is provided.
     #[test]
     fn test_redis_single() {
-        let yaml = r###"
+        let yaml = r#"
 "redis://127.0.0.1:6379"
-"###;
+"#;
 
         let config: RedisConfig = serde_yaml::from_str(yaml)
             .expect("Parsed processing redis config: single with options");

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -2330,7 +2330,7 @@ mod tests {
         let rules: Result<Vec<RuleCondition>, _> = serde_json::from_str(serialized_rules);
         assert!(rules.is_ok());
         let rules = rules.unwrap();
-        insta::assert_ron_snapshot!(rules, @r###"
+        insta::assert_ron_snapshot!(rules, @r#"
             [
               EqCondition(
                 op: "eq",
@@ -2393,7 +2393,7 @@ mod tests {
                   ),
                 ],
               ),
-            ]"###);
+            ]"#);
     }
 
     #[test]
@@ -2736,13 +2736,13 @@ mod tests {
             Ok(MatchedRuleIds(vec![RuleId(123)]))
         );
 
-        assert!(matches!(MatchedRuleIds::from_string(""), Err(_)));
+        assert!(MatchedRuleIds::from_string("").is_err());
 
-        assert!(matches!(MatchedRuleIds::from_string(","), Err(_)));
+        assert!(MatchedRuleIds::from_string(",").is_err());
 
-        assert!(matches!(MatchedRuleIds::from_string("123.456"), Err(_)));
+        assert!(MatchedRuleIds::from_string("123.456").is_err());
 
-        assert!(matches!(MatchedRuleIds::from_string("a,b"), Err(_)));
+        assert!(MatchedRuleIds::from_string("a,b").is_err());
     }
 
     #[test]
@@ -3149,7 +3149,7 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r###"
+        insta::assert_ron_snapshot!(dsc, @r#"
         {
           "trace_id": "00000000-0000-0000-0000-000000000000",
           "public_key": "abd0f232775f45feab79864e580d160b",
@@ -3159,7 +3159,7 @@ mod tests {
           "user_id": "hello",
           "replay_id": None,
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -3173,7 +3173,7 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r###"
+        insta::assert_ron_snapshot!(dsc, @r#"
         {
           "trace_id": "00000000-0000-0000-0000-000000000000",
           "public_key": "abd0f232775f45feab79864e580d160b",
@@ -3184,7 +3184,7 @@ mod tests {
           "user_id": "hello",
           "replay_id": None,
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -3198,7 +3198,7 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r###"
+        insta::assert_ron_snapshot!(dsc, @r#"
         {
           "trace_id": "00000000-0000-0000-0000-000000000000",
           "public_key": "abd0f232775f45feab79864e580d160b",
@@ -3209,7 +3209,7 @@ mod tests {
           "user_id": "hello",
           "replay_id": None,
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -3263,7 +3263,7 @@ mod tests {
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
         let dsc_as_json = serde_json::to_string_pretty(&dsc).unwrap();
-        let expected_json = r###"{
+        let expected_json = r#"{
   "trace_id": "00000000-0000-0000-0000-000000000000",
   "public_key": "abd0f232775f45feab79864e580d160b",
   "release": null,
@@ -3272,7 +3272,7 @@ mod tests {
   "user_id": "hello",
   "replay_id": null,
   "sampled": true
-}"###;
+}"#;
 
         assert_eq!(dsc_as_json, expected_json);
     }
@@ -3289,7 +3289,7 @@ mod tests {
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
         let dsc_as_json = serde_json::to_string_pretty(&dsc).unwrap();
-        let expected_json = r###"{
+        let expected_json = r#"{
   "trace_id": "00000000-0000-0000-0000-000000000000",
   "public_key": "abd0f232775f45feab79864e580d160b",
   "release": null,
@@ -3298,7 +3298,7 @@ mod tests {
   "user_id": "hello",
   "replay_id": null,
   "sampled": false
-}"###;
+}"#;
 
         assert_eq!(dsc_as_json, expected_json);
     }
@@ -3315,7 +3315,7 @@ mod tests {
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
         let dsc_as_json = serde_json::to_string_pretty(&dsc).unwrap();
-        let expected_json = r###"{
+        let expected_json = r#"{
   "trace_id": "00000000-0000-0000-0000-000000000000",
   "public_key": "abd0f232775f45feab79864e580d160b",
   "release": null,
@@ -3323,7 +3323,7 @@ mod tests {
   "transaction": null,
   "user_id": "hello",
   "replay_id": null
-}"###;
+}"#;
 
         assert_eq!(dsc_as_json, expected_json);
     }
@@ -3340,7 +3340,7 @@ mod tests {
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
         let dsc_as_json = serde_json::to_string_pretty(&dsc).unwrap();
-        let expected_json = r###"{
+        let expected_json = r#"{
   "trace_id": "00000000-0000-0000-0000-000000000000",
   "public_key": "abd0f232775f45feab79864e580d160b",
   "release": null,
@@ -3348,7 +3348,7 @@ mod tests {
   "transaction": null,
   "user_id": "hello",
   "replay_id": null
-}"###;
+}"#;
 
         assert_eq!(dsc_as_json, expected_json);
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3183,7 +3183,7 @@ mod tests {
 
         envelope.add_item({
             let mut item = Item::new(ItemType::UserReport);
-            item.set_payload(ContentType::Json, r###"{"foo": "bar"}"###);
+            item.set_payload(ContentType::Json, r#"{"foo": "bar"}"#);
             item
         });
 
@@ -3394,7 +3394,7 @@ mod tests {
                 let mut item = Item::new(ItemType::Event);
                 item.set_payload(
                     ContentType::Json,
-                    r###"
+                    r#"
                     {
                         "request": {
                             "headers": [
@@ -3402,7 +3402,7 @@ mod tests {
                             ]
                         }
                     }
-                "###,
+                "#,
                 );
                 item
             });
@@ -3415,13 +3415,13 @@ mod tests {
 
         // Make sure to mask any IP-like looking data
         let pii_config = PiiConfig::from_json(
-            r##"
+            r#"
                 {
                     "applications": {
                         "**": ["@ip:mask"]
                     }
                 }
-                "##,
+                "#,
         )
         .unwrap();
 
@@ -3492,13 +3492,13 @@ mod tests {
             let mut item = Item::new(ItemType::ClientReport);
             item.set_payload(
                 ContentType::Json,
-                r###"
+                r#"
                     {
                         "discarded_events": [
                             ["queue_full", "error", 42]
                         ]
                     }
-                "###,
+                "#,
             );
             item
         });
@@ -3540,13 +3540,13 @@ mod tests {
             let mut item = Item::new(ItemType::ClientReport);
             item.set_payload(
                 ContentType::Json,
-                r###"
+                r#"
                     {
                         "discarded_events": [
                             ["queue_full", "error", 42]
                         ]
                     }
-                "###,
+                "#,
             );
             item
         });
@@ -3596,13 +3596,13 @@ mod tests {
             let mut item = Item::new(ItemType::ClientReport);
             item.set_payload(
                 ContentType::Json,
-                r###"
+                r#"
                     {
                         "discarded_events": [
                             ["queue_full", "error", 42]
                         ]
                     }
-                "###,
+                "#,
             );
             item
         });
@@ -3653,20 +3653,11 @@ mod tests {
 
     #[test]
     fn test_from_outcome_type_sampled() {
-        assert!(matches!(
-            outcome_from_parts(ClientReportField::FilteredSampling, "adsf"),
-            Err(_)
-        ));
+        assert!(outcome_from_parts(ClientReportField::FilteredSampling, "adsf").is_err());
 
-        assert!(matches!(
-            outcome_from_parts(ClientReportField::FilteredSampling, "Sampled:"),
-            Err(_)
-        ));
+        assert!(outcome_from_parts(ClientReportField::FilteredSampling, "Sampled:").is_err());
 
-        assert!(matches!(
-            outcome_from_parts(ClientReportField::FilteredSampling, "Sampled:foo"),
-            Err(_)
-        ));
+        assert!(outcome_from_parts(ClientReportField::FilteredSampling, "Sampled:foo").is_err());
 
         assert!(matches!(
             outcome_from_parts(ClientReportField::FilteredSampling, "Sampled:"),
@@ -3703,10 +3694,7 @@ mod tests {
             outcome_from_parts(ClientReportField::Filtered, "error-message"),
             Ok(Outcome::Filtered(FilterStatKey::ErrorMessage))
         ));
-        assert!(matches!(
-            outcome_from_parts(ClientReportField::Filtered, "adsf"),
-            Err(_)
-        ));
+        assert!(outcome_from_parts(ClientReportField::Filtered, "adsf").is_err());
     }
 
     #[test]
@@ -3731,7 +3719,7 @@ mod tests {
 
     fn capture_test_event(transaction_name: &str, source: TransactionSource) -> Vec<String> {
         let mut event = Annotated::<Event>::from_json(
-            r###"
+            r#"
             {
                 "type": "transaction",
                 "transaction": "/foo/",
@@ -3749,7 +3737,7 @@ mod tests {
                     "source": "url"
                 }
             }
-            "###,
+            "#,
         )
         .unwrap();
         let e = event.value_mut().as_mut().unwrap();
@@ -3785,51 +3773,51 @@ mod tests {
     #[test]
     fn test_log_transaction_metrics_none() {
         let captures = capture_test_event("/nothing", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r###"
+        insta::assert_debug_snapshot!(captures, @r#"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:sanitized,is_404:false",
         ]
-        "###);
+        "#);
     }
 
     #[test]
     fn test_log_transaction_metrics_rule() {
         let captures = capture_test_event("/foo/john/denver", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r###"
+        insta::assert_debug_snapshot!(captures, @r#"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:rule,source_out:sanitized,is_404:false",
         ]
-        "###);
+        "#);
     }
 
     #[test]
     fn test_log_transaction_metrics_pattern() {
         let captures = capture_test_event("/something/12345", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r###"
+        insta::assert_debug_snapshot!(captures, @r#"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:sanitized,is_404:false",
         ]
-        "###);
+        "#);
     }
 
     #[test]
     fn test_log_transaction_metrics_both() {
         let captures = capture_test_event("/foo/john/12345", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r###"
+        insta::assert_debug_snapshot!(captures, @r#"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:both,source_out:sanitized,is_404:false",
         ]
-        "###);
+        "#);
     }
 
     #[test]
     fn test_log_transaction_metrics_no_match() {
         let captures = capture_test_event("/foo/john/12345", TransactionSource::Route);
-        insta::assert_debug_snapshot!(captures, @r###"
+        insta::assert_debug_snapshot!(captures, @r#"
         [
             "event.transaction_name_changes:1|c|#source_in:route,changes:none,source_out:route,is_404:false",
         ]
-        "###);
+        "#);
     }
 
     /// This is a stand-in test to assert panicking behavior for spawn_blocking.
@@ -3901,7 +3889,7 @@ mod tests {
     #[test]
     fn test_geo_in_light_normalize() {
         let mut event = Annotated::<Event>::from_json(
-            r###"
+            r#"
             {
                 "type": "transaction",
                 "transaction": "/foo/",
@@ -3922,7 +3910,7 @@ mod tests {
                     "ip_address": "2.125.160.216"
                 }
             }
-            "###,
+            "#,
         )
         .unwrap();
 

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -257,6 +257,10 @@ impl UpstreamProjectSourceService {
         let nocache_batches = channels.nocache_channels.into_iter().chunks(batch_size);
 
         let mut requests = vec![];
+        // The `nocache_batches.into_iter()` still must be called here, since compiler produces the
+        // error: `that nocache_batches is not an iterator`.
+        // Since `IntoChunks` is not an iterator itself but only implements `IntoIterator` trait.
+        #[allow(clippy::useless_conversion)]
         for channels_batch in cache_batches.into_iter().chain(nocache_batches.into_iter()) {
             let mut channels_batch: ProjectStateChannels = channels_batch.collect();
             for channel in channels_batch.values_mut() {

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1164,7 +1164,7 @@ mod tests {
             .filter(|name| name.contains("buffer."))
             .collect();
 
-        assert_debug_snapshot!(captures, @r###"
+        assert_debug_snapshot!(captures, @r#"
         [
             "buffer.envelopes_mem:2000|h",
             "buffer.envelopes_mem_count:1|g",
@@ -1185,6 +1185,6 @@ mod tests {
             "buffer.dequeue_attempts:1|h",
             "buffer.reads:1|c",
         ]
-        "###);
+        "#);
     }
 }

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -139,7 +139,7 @@ impl UpstreamRequestError {
     fn is_network_error(&self) -> bool {
         match self {
             Self::SendFailed(_) => true,
-            Self::ResponseError(code, _) => matches!(code.as_u16(), 502 | 503 | 504),
+            Self::ResponseError(code, _) => matches!(code.as_u16(), 502..=504),
             Self::Http(http) => http.is_network_error(),
             _ => false,
         }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1624,8 +1624,8 @@ mod tests {
         envelope.serialize(&mut buffer).unwrap();
 
         let stringified = String::from_utf8_lossy(&buffer);
-        insta::assert_snapshot!(stringified, @r###"{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","client":"sentry/client","version":7,"origin":"http://origin/","remote_addr":"192.168.0.1","user_agent":"sentry/agent"}
-"###);
+        insta::assert_snapshot!(stringified, @r#"{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","client":"sentry/client","version":7,"origin":"http://origin/","remote_addr":"192.168.0.1","user_agent":"sentry/agent"}
+"#);
     }
 
     #[test]
@@ -1649,14 +1649,14 @@ mod tests {
         envelope.serialize(&mut buffer).unwrap();
 
         let stringified = String::from_utf8_lossy(&buffer);
-        insta::assert_snapshot!(stringified, @r###"
+        insta::assert_snapshot!(stringified, @r#"
         {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","client":"sentry/client","version":7,"origin":"http://origin/","remote_addr":"192.168.0.1","user_agent":"sentry/agent"}
         {"type":"event","length":41,"content_type":"application/json"}
         {"message":"hello world","level":"error"}
         {"type":"attachment","length":7,"content_type":"text/plain","filename":"application.log"}
         Hello
 
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-server/src/metrics_extraction/conditional_tagging.rs
+++ b/relay-server/src/metrics_extraction/conditional_tagging.rs
@@ -102,7 +102,7 @@ mod tests {
 
         run_conditional_tagging(event.value().unwrap(), &tagging_config, &mut metrics);
 
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 name: "d:transactions/measurements.lcp@millisecond",
@@ -123,7 +123,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -126,7 +126,7 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_event_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 name: "c:transactions/counter@none",
@@ -137,7 +137,7 @@ mod tests {
                 tags: {},
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -162,7 +162,7 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_event_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 name: "d:transactions/duration@none",
@@ -173,7 +173,7 @@ mod tests {
                 tags: {},
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_event_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 name: "s:transactions/users@none",
@@ -211,7 +211,7 @@ mod tests {
                 tags: {},
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -250,7 +250,7 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_event_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 name: "c:transactions/counter@none",
@@ -265,6 +265,6 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 }

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -473,7 +473,7 @@ mod tests {
             );
         }
 
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 name: "c:sessions/session@none",
@@ -567,6 +567,6 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 }

--- a/relay-server/src/metrics_extraction/spans/types.rs
+++ b/relay-server/src/metrics_extraction/spans/types.rs
@@ -76,7 +76,7 @@ mod tests {
         };
         let converted = metric.into_metric(timestamp);
 
-        insta::assert_debug_snapshot!(converted, @r###"
+        insta::assert_debug_snapshot!(converted, @r#"
         Metric {
             name: "d:spans/exclusive_time@millisecond",
             value: Distribution(
@@ -87,6 +87,6 @@ mod tests {
                 "release": "1.2.3",
             },
         }
-        "###);
+        "#);
     }
 }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -535,7 +535,7 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(event.value().unwrap().spans, @r###"
+        insta::assert_debug_snapshot!(event.value().unwrap().spans, @r#"
         [
             Span {
                 timestamp: Timestamp(
@@ -563,9 +563,9 @@ mod tests {
                 other: {},
             },
         ]
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
         [
             Metric {
                 name: "d:transactions/measurements.foo@none",
@@ -674,7 +674,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -716,7 +716,7 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
         [
             Metric {
                 name: "d:transactions/measurements.fcp@millisecond",
@@ -768,7 +768,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -807,7 +807,7 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
         [
             Metric {
                 name: "d:transactions/measurements.fcp@second",
@@ -848,7 +848,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -952,7 +952,7 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
         [
             Metric {
                 name: "d:transactions/measurements.a_custom1@none",
@@ -1004,7 +1004,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -1235,7 +1235,7 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.sampling_metrics, @r###"
+        insta::assert_debug_snapshot!(extracted.sampling_metrics, @r#"
         [
             Metric {
                 name: "c:transactions/count_per_root_project@none",
@@ -1249,7 +1249,7 @@ mod tests {
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -1502,7 +1502,7 @@ mod tests {
             .map(|m| m.name)
             .collect();
 
-        insta::assert_debug_snapshot!(metrics_names, @r###"
+        insta::assert_debug_snapshot!(metrics_names, @r#"
         [
             "d:transactions/measurements.frames_frozen@none",
             "d:transactions/measurements.frames_frozen_rate@ratio",
@@ -1513,7 +1513,7 @@ mod tests {
             "d:transactions/measurements.stall_total_time@millisecond",
             "d:transactions/duration@millisecond",
         ]
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -355,10 +355,10 @@ mod tests {
         let dsc = mocked_simple_dynamic_sampling_context(Some(1.0), Some("3.0"), None, None, None);
 
         let result = is_trace_fully_sampled(true, Some(&project_state), Some(&dsc));
-        matches!(result, None);
+        assert!(result.is_none());
 
         // We test with missing dsc and project config.
         let result = is_trace_fully_sampled(true, None, None);
-        matches!(result, None);
+        assert!(result.is_none())
     }
 }

--- a/relay-server/src/utils/param_parser.rs
+++ b/relay-server/src/utils/param_parser.rs
@@ -168,7 +168,7 @@ mod tests {
 
         update_nested_value(&mut val, &["x", "y", "z"], "xx");
 
-        insta::assert_json_snapshot!(val, @r###"
+        insta::assert_json_snapshot!(val, @r#"
        ⋮{
        ⋮  "x": {
        ⋮    "y": {
@@ -176,12 +176,12 @@ mod tests {
        ⋮    }
        ⋮  }
        ⋮}
-        "###);
+        "#);
 
         update_nested_value(&mut val, &["x", "y", "k"], "kk");
         update_nested_value(&mut val, &["w", ""], "w");
         update_nested_value(&mut val, &["z1"], "val1");
-        insta::assert_json_snapshot!(val, @r###"
+        insta::assert_json_snapshot!(val, @r#"
        ⋮{
        ⋮  "w": {
        ⋮    "": "w"
@@ -194,7 +194,7 @@ mod tests {
        ⋮  },
        ⋮  "z1": "val1"
        ⋮}
-        "###);
+        "#);
     }
 
     #[test]
@@ -218,7 +218,7 @@ mod tests {
         });
 
         merge_values(&mut original, modified);
-        insta::assert_json_snapshot!(original, @r###"
+        insta::assert_json_snapshot!(original, @r#"
        ⋮{
        ⋮  "k1": "v1",
        ⋮  "k2": {
@@ -233,7 +233,7 @@ mod tests {
        ⋮  ],
        ⋮  "k6": "v6"
        ⋮}
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -317,7 +317,7 @@ mod tests {
     use super::*;
 
     fn get_context() -> Unreal4Context {
-        let raw_context = br##"<?xml version="1.0" encoding="UTF-8"?>
+        let raw_context = br#"<?xml version="1.0" encoding="UTF-8"?>
 <FGenericCrashContext>
 	<RuntimeProperties>
 		<UserName>bruno</UserName>
@@ -343,7 +343,7 @@ mod tests {
 		<PlatformCallbackResult>0</PlatformCallbackResult>
 	</PlatformProperties>
 </FGenericCrashContext>
-"##;
+"#;
 
         Unreal4Context::parse(raw_context).unwrap()
     }
@@ -386,11 +386,11 @@ mod tests {
 
     #[test]
     fn test_merge_unreal_logs() {
-        let logs = br##"Log file open, 10/29/18 17:56:37
+        let logs = br#"Log file open, 10/29/18 17:56:37
 [2018.10.29-16.56.38:332][  0]LogGameplayTags: Display: UGameplayTagsManager::DoneAddingNativeTags. DelegateIsBound: 0
 [2018.10.29-16.56.39:332][  0]LogStats: UGameplayTagsManager::ConstructGameplayTagTree: ImportINI prefixes -  0.000 s
 [2018.10.29-16.56.40:332][  0]LogStats: UGameplayTagsManager::ConstructGameplayTagTree: Construct from data asset -  0.000 s
-[2018.10.29-16.56.41:332][  0]LogStats: UGameplayTagsManager::ConstructGameplayTagTree: ImportINI -  0.000 s"##;
+[2018.10.29-16.56.41:332][  0]LogStats: UGameplayTagsManager::ConstructGameplayTagTree: ImportINI -  0.000 s"#;
 
         let mut event = Event::default();
         merge_unreal_logs(&mut event, logs).ok();

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.1.4", features = ["derive"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_yaml = "0.9.17"
-syn = "1.0.39"
+syn = { version = "1.0.39", features = ["full"] }
 
 [dev-dependencies]
 insta = "1.19.0"

--- a/tools/document-metrics/src/main.rs
+++ b/tools/document-metrics/src/main.rs
@@ -303,7 +303,7 @@ mod tests {
         "#;
 
         let metrics = parse_metrics(source)?;
-        insta::assert_debug_snapshot!(metrics, @r###"
+        insta::assert_debug_snapshot!(metrics, @r#"
         [
             Metric {
                 ty: Set,
@@ -320,7 +320,7 @@ mod tests {
                 features: [],
             },
         ]
-        "###);
+        "#);
 
         Ok(())
     }


### PR DESCRIPTION
Using combination of `cargo fix` and some of the manual changes, to make sure `Relay` can be compiled with `stable` and `beta` toolsets.

#skip-changelog