### PR TITLE
feat(spans): Collapse list of SQL columns with aliases

### DIFF
--- a/relay-general/src/store/normalize/span/description.rs
+++ b/relay-general/src/store/normalize/span/description.rs
@@ -62,7 +62,7 @@ static SQL_COLLAPSE_PLACEHOLDERS: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Collapse simple lists of columns in select.
-/// For example,
+/// For example:
 ///   SELECT a, b FROM x -> SELECT .. FROM x
 ///   SELECT "a.b" AS a__b, "a.c" AS a__c FROM x -> SELECT .. FROM x
 static SQL_COLLAPSE_SELECT: Lazy<Regex> = Lazy::new(|| {
@@ -707,7 +707,7 @@ mod tests {
 
     span_description_test!(
         span_description_collapse_columns_with_as,
-        // Simple lists of columns will be collapsed
+        // Simple lists of columns will be collapsed.
         r#"SELECT myfield1, "a"."b" AS a__b, another_field as bar FROM table WHERE %s"#,
         "db.sql.query",
         "SELECT .. FROM table WHERE %s"


### PR DESCRIPTION
We already scrubbed list of columns in SQL columns such as

```sql
SELECT a, b, c FROM table
-- becomes
SELECT .. FROM table
```

Also collapse if columns have an alias, e.g.

```sql
SELECT table.a AS table__a, table.b AS table__b, table.c AS table__c FROM table
-- becomes
SELECT .. FROM table
```

#skip-changelog