### PR TITLE
docs(spooler): Add module level documentation

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1,3 +1,30 @@
+//! This module contains the [`BufferService`], which responsible for spooling of the incoming
+//! envelopes, either in memory or on persistent storage.
+//!
+//! The main entry point for the [`BufferService`] is the [`Buffer`] interface. Which currently
+//! supports:
+//! - [`Enqueue`] - enqueueing message into the backend storage
+//! - [`DequeueMany`] - dequeueing all the requested [`QueueKey`] keys
+//! - [`RemoveMany`] - Removing and dropping the requested [`QueueKey`] keys.
+//! - [`Health`] - checking the health of the [`BufferService`]
+//!
+//! To make sure the [`BufferService`] is fast the responsive, especially in the normal working
+//! conditions, it keeps the internal [`BufferState`] state, which defines where the spooling will
+//! be happening.
+//!
+//! The initial state is always [`InMemory`], and if the Relay can properly fetch all the
+//! [`crate::project::ProjectState`] it continue to use the memory as temporary spool.
+//!
+//! In case of an incident when the in-memory spool gets full (see, `spool.envelopes.max_memory_size` config option)
+//! or if the processing pipeline gets too many messages in-flight, the internal state will be
+//! switched to [`OnDisk`] and we will continue spooling all the incoming envelopes onto the disk.
+//! This will happen also only when the disk spool is configured.
+//!
+//! The state can be changed to [`InMemory`] again only if all the on-disk spoolled envelopes are
+//! read out again and disk is empty.
+//!
+//! Current on-disk spool implementation uses Sqlite as a storage.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::path::PathBuf;

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -13,7 +13,7 @@
 //! be happening.
 //!
 //! The initial state is always [`InMemory`], and if the Relay can properly fetch all the
-//! [`crate::project::ProjectState`] it continue to use the memory as temporary spool.
+//! [`crate::actors::project::ProjectState`] it continue to use the memory as temporary spool.
 //!
 //! In case of an incident when the in-memory spool gets full (see, `spool.envelopes.max_memory_size` config option)
 //! or if the processing pipeline gets too many messages in-flight, the internal state will be

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1,11 +1,11 @@
-//! This module contains the [`BufferService`], which responsible for spooling of the incoming
-//! envelopes, either in memory or on persistent storage.
+//! This module contains the [`BufferService`], which is responsible for spooling of the incoming
+//! envelopes, either to in-memory or to persistent storage.
 //!
-//! The main entry point for the [`BufferService`] is the [`Buffer`] interface. Which currently
+//! The main entry point for the [`BufferService`] is the [`Buffer`] interface, which currently
 //! supports:
-//! - [`Enqueue`] - enqueueing message into the backend storage
+//! - [`Enqueue`] - enqueueing a message into the backend storage
 //! - [`DequeueMany`] - dequeueing all the requested [`QueueKey`] keys
-//! - [`RemoveMany`] - Removing and dropping the requested [`QueueKey`] keys.
+//! - [`RemoveMany`] - removing and dropping the requested [`QueueKey`] keys.
 //! - [`Health`] - checking the health of the [`BufferService`]
 //!
 //! To make sure the [`BufferService`] is fast the responsive, especially in the normal working
@@ -13,17 +13,21 @@
 //! be happening.
 //!
 //! The initial state is always [`InMemory`], and if the Relay can properly fetch all the
-//! [`crate::actors::project::ProjectState`] it continue to use the memory as temporary spool.
+//! [`crate::actors::project::ProjectState`] it continues to use the memory as temporary spool.
+//!
+//! Keeping the envelopes in memory as long as we can, we ensure the fast unspool operations and
+//! fast processing times.
 //!
 //! In case of an incident when the in-memory spool gets full (see, `spool.envelopes.max_memory_size` config option)
-//! or if the processing pipeline gets too many messages in-flight, the internal state will be
-//! switched to [`OnDisk`] and we will continue spooling all the incoming envelopes onto the disk.
+//! or if the processing pipeline gets too many messages in-flight, configured by
+//! `cache.envelope_buffer_size` and once it reaches 80% of the defined amount, the internal state will be
+//! switched to [`OnDisk`] and service will continue spooling all the incoming envelopes onto the disk.
 //! This will happen also only when the disk spool is configured.
 //!
-//! The state can be changed to [`InMemory`] again only if all the on-disk spoolled envelopes are
-//! read out again and disk is empty.
+//! The state can be changed to [`InMemory`] again only if all the on-disk spooled envelopes are
+//! read out again and the disk is empty.
 //!
-//! Current on-disk spool implementation uses Sqlite as a storage.
+//! Current on-disk spool implementation uses SQLite as a storage.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;

--- a/relay-server/src/actors/spooler/sql.rs
+++ b/relay-server/src/actors/spooler/sql.rs
@@ -1,3 +1,6 @@
+//! This module contains the helper functions wrapping pthe SQL queris which will be run against
+//! the on-disk spool (currently backed by Sqlite).
+
 use futures::stream::{Stream, StreamExt};
 use sqlx::query::Query;
 use sqlx::sqlite::SqliteArguments;

--- a/relay-server/src/actors/spooler/sql.rs
+++ b/relay-server/src/actors/spooler/sql.rs
@@ -1,5 +1,5 @@
-//! This module contains the helper functions wrapping pthe SQL queris which will be run against
-//! the on-disk spool (currently backed by Sqlite).
+//! This module contains the helper functions wrapping the SQL queries which will be run against
+//! the on-disk spool (currently backed by SQLite).
 
 use futures::stream::{Stream, StreamExt};
 use sqlx::query::Query;


### PR DESCRIPTION
This adds module levels docs to `spooler` module and `spooler/sql` module. 

#skip-changelog