### PR TITLE
docs(kafka): Add more module docs and fix typos in kafka crate

### DIFF
--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -1,9 +1,9 @@
 //! Configuration primitives to configure the kafka producer and properly set up the connection.
 //!
 //! The configuration can be either;
-//! - [`Primary`] - the main and default kafka Configuration
-//! - [`Secondary`] - used to configure any additional kafka topic
-//! - [`Sharded`] - if we want to configure multiple kafka clusters,
+//! - [`TopicAssignment::Primary`] - the main and default kafka Configuration
+//! - [`TopicAssignment::Secondary`] - used to configure any additional kafka topic
+//! - [`TopicAssignment::Sharded`] - if we want to configure multiple kafka clusters,
 //! we can create a mapping of the range of logical shards to the kafka configuration.
 
 use std::collections::BTreeMap;

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -1,8 +1,8 @@
 //! Configuration primitives to configure the kafka producer and properly set up the connection.
 //!
 //! The configuration can be either;
-//! - [`TopicAssignment::Primary`] - the main and default kafka Configuration
-//! - [`TopicAssignment::Secondary`] - used to configure any additional kafka topic
+//! - [`TopicAssignment::Primary`] - the main and default kafka configuration,
+//! - [`TopicAssignment::Secondary`] - used to configure any additional kafka topic,
 //! - [`TopicAssignment::Sharded`] - if we want to configure multiple kafka clusters,
 //! we can create a mapping of the range of logical shards to the kafka configuration.
 

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -1,3 +1,11 @@
+//! Configuration primitives to configure the kafka producer and properly set up the connection.
+//!
+//! The configuration can be either;
+//! - [`Primary`] - the main and default kafka Configuration
+//! - [`Secondary`] - used to configure any additional kafka topic
+//! - [`Sharded`] - if we want to configure multiple kafka clusters,
+//! we can create a mapping of the range of logical shards to the kafka configuration.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -243,7 +251,7 @@ impl TopicAssignment {
     /// Get the kafka config for the current topic assignment.
     ///
     /// # Errors
-    /// Returns [`ConfigError`] if the configuration for the current topic assignement is invalid.
+    /// Returns [`ConfigError`] if the configuration for the current topic assignment is invalid.
     pub fn kafka_config<'a>(
         &'a self,
         default_config: &'a Vec<KafkaConfigParam>,

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -1,3 +1,11 @@
+//! This module contains the kafka producer related code.
+//!
+//! There are two different producers are supported in Relay right now:
+//! - [`SingleProducer`] - which sends all the messages to the defined kafka [`KafkaTopic`]
+//! - [`ShardedProducer`] - which expects to have at least one shard configured, and depending on
+//! the shard number the different message will be sent to different topic using the configured
+//! producer for the this exact shard.
+
 #[cfg(debug_assertions)]
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
@@ -196,7 +204,7 @@ impl KafkaClient {
     }
 }
 
-/// Helper structure responsable for building the actual [`KafkaClient`].
+/// Helper structure responsible for building the actual [`KafkaClient`].
 #[derive(Default)]
 pub struct KafkaClientBuilder {
     reused_producers: BTreeMap<Option<String>, Arc<ThreadedProducer>>,
@@ -318,7 +326,7 @@ impl fmt::Debug for KafkaClientBuilder {
     }
 }
 
-/// This object containes the Kafka producer variants for single and sharded configurations.
+/// This object contains the Kafka producer variants for single and sharded configurations.
 #[derive(Debug)]
 enum Producer {
     /// Configuration variant for the single kafka producer.

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -1,9 +1,9 @@
 //! This module contains the kafka producer related code.
 //!
-//! There are two different producers are supported in Relay right now:
-//! - [`SingleProducer`] - which sends all the messages to the defined kafka [`KafkaTopic`]
+//! There are two different producers that are supported in Relay right now:
+//! - [`SingleProducer`] - which sends all the messages to the defined kafka [`KafkaTopic`],
 //! - [`ShardedProducer`] - which expects to have at least one shard configured, and depending on
-//! the shard number the different message will be sent to different topic using the configured
+//! the shard number the different messages will be sent to different topics using the configured
 //! producer for the this exact shard.
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
Add more docs into the `relay-kafka` crate and fix some typos. 

#skip-changelog