### PR TITLE
instr(spans): Measure span metrics extraction time

### DIFF
--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -11,6 +11,7 @@ use crate::metrics_extraction::spans::types::SpanMetric;
 
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::metrics_extraction::IntoMetric;
+use crate::statsd::RelayTimers;
 
 mod types;
 
@@ -21,7 +22,15 @@ pub(crate) fn extract_span_metrics(
     aggregator_config: &AggregatorConfig,
     event: &Event,
 ) -> Result<Vec<Metric>, ExtractMetricsError> {
-    // TODO(iker): measure the performance of this whole method
+    relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {
+        extract_span_metrics_inner(aggregator_config, event)
+    })
+}
+
+fn extract_span_metrics_inner(
+    aggregator_config: &AggregatorConfig,
+    event: &Event,
+) -> Result<Vec<Metric>, ExtractMetricsError> {
     let mut metrics = Vec::new();
 
     if event.ty.value() != Some(&EventType::Transaction) {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -207,6 +207,8 @@ pub enum RelayTimers {
     EventProcessingPii,
     /// Time spent converting the event from its in-memory reprsentation into a JSON string.
     EventProcessingSerialization,
+    /// Time used to extract span metrics from an event.
+    EventProcessingSpanMetricsExtraction,
     /// Time spent between the start of request handling and processing of the envelope.
     ///
     /// This includes streaming the request body, scheduling overheads, project config fetching,
@@ -329,6 +331,9 @@ impl TimerMetric for RelayTimers {
             #[cfg(feature = "processing")]
             RelayTimers::EventProcessingRateLimiting => "event_processing.rate_limiting",
             RelayTimers::EventProcessingPii => "event_processing.pii",
+            RelayTimers::EventProcessingSpanMetricsExtraction => {
+                "event_processing.span_metrics_extraction"
+            }
             RelayTimers::EventProcessingSerialization => "event_processing.serialization",
             RelayTimers::EnvelopeWaitTime => "event.wait_time",
             RelayTimers::EnvelopeProcessingTime => "event.processing_time",


### PR DESCRIPTION
In preparation of https://github.com/getsentry/relay/pull/2355, measure how much time span metrics extraction currently costs.

#skip-changelog