### PR TITLE
ci: only render gocd pipelines if relevant files are changed

### DIFF
--- a/.github/workflows/validate-pipelines.yml
+++ b/.github/workflows/validate-pipelines.yml
@@ -9,20 +9,6 @@ on:
   pull_request:
 
 jobs:
-    render:
-        name: Render GoCD Pipelines with Jsonnet
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
-          - uses: getsentry/action-gocd-jsonnet@v1
-            with:
-              jb-install: true
-              check-for-changes: true
-              convert-to-yaml: true
-              jsonnet-dir: gocd/templates
-              generated-dir: gocd/generated-pipelines
-              render-as-single-file: false
-
     files-changed:
         name: files-changed
         runs-on: ubuntu-latest
@@ -39,6 +25,22 @@ jobs:
                 gocd:
                   - 'gocd/**'
                   - '.github/workflows/validate-pipelines.yml'
+
+    render:
+        if: needs.files-changed.outputs.gocd == 'true'
+        needs: files-changed
+        name: Render GoCD Pipelines with Jsonnet
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
+          - uses: getsentry/action-gocd-jsonnet@v1
+            with:
+              jb-install: true
+              check-for-changes: true
+              convert-to-yaml: true
+              jsonnet-dir: gocd/templates
+              generated-dir: gocd/generated-pipelines
+              render-as-single-file: false
 
     validate:
         if: needs.files-changed.outputs.gocd == 'true'


### PR DESCRIPTION
This saves ~2 minutes every time which would help relieve github free runner queue pressure.

#skip-changelog