### PR TITLE
ref(server): Do not cache envelope summary

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1720,6 +1720,10 @@ impl EnvelopeProcessorService {
         };
 
         state.event = event;
+        if let Some(category) = state.event_category() {
+            state.managed_envelope.assume_event(category);
+        }
+
         state.sample_rates = sample_rates;
         state.metrics.bytes_ingested_event = Annotated::new(event_len as u64);
 
@@ -2505,10 +2509,6 @@ impl EnvelopeProcessorService {
             || {
                 match self.process_state(&mut state) {
                     Ok(()) => {
-                        // The envelope could be modified or even emptied during processing, which
-                        // requires recomputation of the context.
-                        state.managed_envelope.update();
-
                         let has_metrics = !state.extracted_metrics.project_metrics.is_empty();
 
                         state.extracted_metrics.send_metrics(

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -354,6 +354,7 @@ impl ProcessEnvelopeState {
     #[cfg(feature = "processing")]
     fn remove_event(&mut self) {
         self.event = Annotated::empty();
+        self.managed_envelope.assume_event(None);
     }
 }
 
@@ -1720,9 +1721,7 @@ impl EnvelopeProcessorService {
         };
 
         state.event = event;
-        if let Some(category) = state.event_category() {
-            state.managed_envelope.assume_event(category);
-        }
+        state.managed_envelope.assume_event(state.event_category());
 
         state.sample_rates = sample_rates;
         state.metrics.bytes_ingested_event = Annotated::new(event_len as u64);

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -782,6 +782,9 @@ impl Project {
 
         let (enforcement, rate_limits) =
             envelope_limiter.enforce(envelope.envelope_mut(), &scoping)?;
+        if enforcement.event_active() {
+            envelope.assume_event(None);
+        }
         enforcement.track_outcomes(envelope.envelope(), &scoping, outcome_aggregator);
 
         let envelope = if envelope.envelope().is_empty() {

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -783,7 +783,6 @@ impl Project {
         let (enforcement, rate_limits) =
             envelope_limiter.enforce(envelope.envelope_mut(), &scoping)?;
         enforcement.track_outcomes(envelope.envelope(), &scoping, outcome_aggregator);
-        envelope.update();
 
         let envelope = if envelope.envelope().is_empty() {
             // Individual rate limits have already been issued above

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -292,8 +292,6 @@ fn queue_envelope(
             state.test_store().clone(),
         )?;
 
-        // Update the old context after successful forking.
-        managed_envelope.update();
         state
             .project_cache()
             .send(ValidateEnvelope::new(event_context));

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -207,13 +207,17 @@ impl ManagedEnvelope {
         self.context.event_category = category;
     }
 
+    /// Gets the value of the `event_metrics_extracted` flag.
+    pub fn event_metrics_extracted(&self) -> bool {
+        self.context.event_metrics_extracted
+    }
+
     /// Record that event metrics have been extracted.
     ///
-    /// This is usually done automatically as part of `EnvelopeContext::new` or `update`. However,
-    /// if the context needs to be updated in-flight without recomputing the entire summary, this
-    /// method can record that metric extraction for the event item has occurred.
-    pub fn set_event_metrics_extracted(&mut self) -> &mut Self {
-        self.context.event_metrics_extracted = true;
+    /// This needs to be represented separately of the event's item header because during
+    /// processing, the event item is removed from the envelope (see `assume_event`).
+    pub fn set_event_metrics_extracted(&mut self, value: bool) -> &mut Self {
+        self.context.event_metrics_extracted = value;
         self
     }
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -203,8 +203,8 @@ impl ManagedEnvelope {
     /// Assume that the envelope contains an event of the given data type.
     ///
     /// This is useful when the actual event item has already been removed for processing.
-    pub fn assume_event(&mut self, category: DataCategory) {
-        self.context.event_category = Some(category);
+    pub fn assume_event(&mut self, category: Option<DataCategory>) {
+        self.context.event_category = category;
     }
 
     /// Record that event metrics have been extracted.
@@ -224,9 +224,6 @@ impl ManagedEnvelope {
     }
 
     /// Records an outcome scoped to this envelope's context.
-    ///
-    /// This managed envelope should be updated using [`update`](Self::update) soon after this
-    /// operation to ensure that subsequent outcomes are consistent.
     fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
         self.outcome_aggregator.send(TrackOutcome {
             timestamp: self.received_at(),
@@ -284,7 +281,7 @@ impl ManagedEnvelope {
             return;
         }
 
-        let summary = self.compute_summary();
+        let summary = dbg!(self.compute_summary());
 
         // Errors are only logged for what we consider failed request handling. In other cases, we
         // "expect" errors and log them as debug level.

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -96,6 +96,7 @@ impl ManagedEnvelope {
         test_store: Addr<TestStore>,
     ) -> Self {
         let meta = &envelope.meta();
+        let summary = EnvelopeSummary::compute(envelope.as_ref(), None);
         let scoping = meta.get_partial_scoping();
         Self {
             envelope,
@@ -103,8 +104,8 @@ impl ManagedEnvelope {
                 scoping,
                 slot,
                 done: false,
-                event_category: None,
-                event_metrics_extracted: false,
+                event_category: summary.event_category,
+                event_metrics_extracted: summary.event_metrics_extracted,
             },
             outcome_aggregator,
             test_store,
@@ -285,7 +286,7 @@ impl ManagedEnvelope {
             return;
         }
 
-        let summary = dbg!(self.compute_summary());
+        let summary = self.compute_summary();
 
         // Errors are only logged for what we consider failed request handling. In other cases, we
         // "expect" errors and log them as debug level.

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -287,7 +287,6 @@ pub struct Enforcement {
 
 impl Enforcement {
     /// Returns `true` if the event should be rate limited.
-    #[cfg(feature = "processing")]
     pub fn event_active(&self) -> bool {
         self.event.is_active()
     }

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -237,7 +237,7 @@ class OutcomesConsumer(ConsumerBase):
     def get_outcome(self):
         outcomes = self.get_outcomes()
         assert len(outcomes) > 0, "No outcomes were consumed"
-        assert len(outcomes) == 1, "More than one outcome was consumed"
+        assert len(outcomes) == 1, outcomes
         return outcomes[0]
 
     def assert_rate_limited(self, reason, key_id=None, categories=None, quantity=None):


### PR DESCRIPTION
We currently keep a cached envelope summary on `ManagedEnvelope`, which is not updated after the event item has been popped from the envelope for processing.

This has the advantage that the summary still "contains" an event while it has been temporarily removed from the envelope, but it causes the problem that we cannot update it _during_ processing without "losing" the event for the purpose of outcome reporting.

This PR attempts to remove all caching of the envelope summary, while still reporting correct outcomes for events.