### PR TITLE
ref: Reduce metrics bucket size to 5MB

### DIFF
--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -1144,7 +1144,7 @@ impl Default for AggregatorConfig {
             bucket_interval: 10,
             initial_delay: 30,
             debounce_delay: 10,
-            max_flush_bytes: 50_000_000, // 50 MB
+            max_flush_bytes: 5_000_000, // 5 MB
             flush_partitions: None,
             max_secs_in_past: 5 * 24 * 60 * 60, // 5 days, as for sessions
             max_secs_in_future: 60,             // 1 minute


### PR DESCRIPTION
The maximum bucket size for metrics messages was set to 50MB, which is large for
upstream web requests and larger than the usual maximum message size configured
on our Kafka brokers. As a more sensible default, this PR uses 5MB.

#skip-changelog

