### PR TITLE
fix(server): Allow partial update of envelope summary during processing

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2364,8 +2364,10 @@ impl EnvelopeProcessorService {
                         ItemAction::Drop(outcome.clone())
                     }
                 });
+                state.managed_envelope.update_freeze_event();
                 if state.managed_envelope.envelope().is_empty() {
-                    // Just for bookkeeping.
+                    // Call reject to make sure that outcomes are generated for the transaction event,
+                    // which has already been removed from the envelope for processing.
                     state.managed_envelope.reject(outcome);
                 }
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -181,6 +181,21 @@ impl ManagedEnvelope {
         self
     }
 
+    /// Update the context with envelope information, leaving event information untouched.
+    ///
+    /// This is useful when the event has already been removed from the envelope for processing,
+    /// but we still want outcomes to be generated for the event.
+    pub fn update_freeze_event(&mut self) -> &mut Self {
+        let event_category = self.context.summary.event_category;
+        let event_metrics_extracted = self.context.summary.event_metrics_extracted;
+
+        self.context.summary = EnvelopeSummary::compute(self.envelope());
+
+        self.context.summary.event_category = event_category;
+        self.context.summary.event_metrics_extracted = event_metrics_extracted;
+        self
+    }
+
     /// Retains or drops items based on the [`ItemAction`].
     ///
     ///


### PR DESCRIPTION
Updating the envelope summary during envelope processing is currently a no-go, because recomputing the summary will miss the event item, which is taken from the envelope before processing.

https://github.com/getsentry/relay/pull/2380 contains an attempt to remove caching of the envelope summary entirely. As a quick fix, this PR provides a partial update function.

#skip-changelog