### PR TITLE
feat(spans): Add `SAVEPOINT` and `SET` sql db actions

### DIFF
--- a/relay-general/src/store/normalize/span/tag_extraction.rs
+++ b/relay-general/src/store/normalize/span/tag_extraction.rs
@@ -332,7 +332,7 @@ fn truncate_string(mut string: String, max_bytes: usize) -> String {
 }
 
 const ALLOWED_SQL_ACTION: &str =
-    "SELECT|INSERT|DELETE|UPDATE|SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT";
+    "SELECT|INSERT|DELETE|UPDATE|SET|SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT";
 
 /// Regex with a capture group to extract the database action from a query.
 ///
@@ -585,16 +585,14 @@ mod tests {
                 r#"DELETE FROM "sentry_groupinbox" WHERE "sentry_groupinbox"."id" IN (%s)"#,
                 "DELETE",
             ),
+            (r#"SET search_path TO my_schema, public"#, "SET"),
             (r#"SAVEPOINT %s"#, "SAVEPOINT"),
             (r#"RELEASE SAVEPOINT %s"#, "RELEASE SAVEPOINT"),
             (r#"ROLLBACK TO SAVEPOINT %s"#, "ROLLBACK TO SAVEPOINT"),
         ];
 
-        for (query, expected) in test_cases.iter() {
-            assert_eq!(
-                sql_action_from_query(query.to_owned()).unwrap(),
-                expected.to_owned()
-            )
+        for (query, expected) in test_cases.into_iter() {
+            assert_eq!(sql_action_from_query(query).unwrap(), expected)
         }
     }
 }

--- a/relay-general/src/store/normalize/span/tag_extraction.rs
+++ b/relay-general/src/store/normalize/span/tag_extraction.rs
@@ -331,11 +331,16 @@ fn truncate_string(mut string: String, max_bytes: usize) -> String {
     string
 }
 
+const ALLOWED_SQL_ACTION: &str =
+    "SELECT|INSERT|DELETE|UPDATE|SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT";
+
 /// Regex with a capture group to extract the database action from a query.
 ///
-/// Currently, we're only interested in `SELECT`, `INSERT`, `DELETE` and `UPDATE` statements.
-static SQL_ACTION_EXTRACTOR_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"(?i)(?P<action>(SELECT|INSERT|DELETE|UPDATE))"#).unwrap());
+/// Currently we have an explicit allow-list of database actions considered important
+static SQL_ACTION_EXTRACTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
+    let action_regex: String = format!("(?i)(?P<action>({}))", ALLOWED_SQL_ACTION);
+    Regex::new(&action_regex).unwrap()
+});
 
 fn sql_action_from_query(query: &str) -> Option<&str> {
     extract_captured_substring(query, &SQL_ACTION_EXTRACTOR_REGEX)
@@ -559,5 +564,37 @@ mod tests {
     fn extract_table_update() {
         let query = r#"UPDATE "a" SET "x" = %s, "y" = %s WHERE "z" = %s"#;
         assert_eq!(sql_table_from_query(query).unwrap(), "a");
+    }
+
+    #[test]
+    fn extract_sql_action() {
+        let test_cases = vec![
+            (
+                r#"SELECT "sentry_organization"."id" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s"#,
+                "SELECT",
+            ),
+            (
+                r#"INSERT INTO "sentry_groupseen" ("project_id", "group_id", "user_id", "last_seen") VALUES (%s, %s, %s, %s) RETURNING "sentry_groupseen"."id"#,
+                "INSERT",
+            ),
+            (
+                r#"UPDATE sentry_release SET date_released = %s WHERE id = %s"#,
+                "UPDATE",
+            ),
+            (
+                r#"DELETE FROM "sentry_groupinbox" WHERE "sentry_groupinbox"."id" IN (%s)"#,
+                "DELETE",
+            ),
+            (r#"SAVEPOINT %s"#, "SAVEPOINT"),
+            (r#"RELEASE SAVEPOINT %s"#, "RELEASE SAVEPOINT"),
+            (r#"ROLLBACK TO SAVEPOINT %s"#, "ROLLBACK TO SAVEPOINT"),
+        ];
+
+        for (query, expected) in test_cases.iter() {
+            assert_eq!(
+                sql_action_from_query(query.to_owned()).unwrap(),
+                expected.to_owned()
+            )
+        }
     }
 }

--- a/relay-general/src/store/normalize/span/tag_extraction.rs
+++ b/relay-general/src/store/normalize/span/tag_extraction.rs
@@ -331,15 +331,11 @@ fn truncate_string(mut string: String, max_bytes: usize) -> String {
     string
 }
 
-const ALLOWED_SQL_ACTION: &str =
-    "SELECT|INSERT|DELETE|UPDATE|SET|SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT";
-
 /// Regex with a capture group to extract the database action from a query.
 ///
 /// Currently we have an explicit allow-list of database actions considered important.
 static SQL_ACTION_EXTRACTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
-    let action_regex: String = format!("(?i)(?P<action>({}))", ALLOWED_SQL_ACTION);
-    Regex::new(&action_regex).unwrap()
+    Regex::new(r#"(?i)(?P<action>(SELECT|INSERT|DELETE|UPDATE|SET|SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT))"#).unwrap()
 });
 
 fn sql_action_from_query(query: &str) -> Option<&str> {

--- a/relay-general/src/store/normalize/span/tag_extraction.rs
+++ b/relay-general/src/store/normalize/span/tag_extraction.rs
@@ -336,7 +336,7 @@ const ALLOWED_SQL_ACTION: &str =
 
 /// Regex with a capture group to extract the database action from a query.
 ///
-/// Currently we have an explicit allow-list of database actions considered important
+/// Currently we have an explicit allow-list of database actions considered important.
 static SQL_ACTION_EXTRACTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
     let action_regex: String = format!("(?i)(?P<action>({}))", ALLOWED_SQL_ACTION);
     Regex::new(&action_regex).unwrap()
@@ -591,7 +591,7 @@ mod tests {
             (r#"ROLLBACK TO SAVEPOINT %s"#, "ROLLBACK TO SAVEPOINT"),
         ];
 
-        for (query, expected) in test_cases.into_iter() {
+        for (query, expected) in test_cases {
             assert_eq!(sql_action_from_query(query).unwrap(), expected)
         }
     }

--- a/relay-server/src/metrics_extraction/spans/snapshots/relay_server__metrics_extraction__spans__tests__extract_span_metrics-2.snap
+++ b/relay-server/src/metrics_extraction/spans/snapshots/relay_server__metrics_extraction__spans__tests__extract_span_metrics-2.snap
@@ -772,6 +772,7 @@ expression: metrics
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
+            "span.action": "SAVEPOINT",
             "span.category": "db",
             "span.description": "SAVEPOINT %s",
             "span.group": "3f955cbde39e04b9",
@@ -793,6 +794,7 @@ expression: metrics
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
+            "span.action": "SAVEPOINT",
             "span.category": "db",
             "span.description": "SAVEPOINT %s",
             "span.group": "3f955cbde39e04b9",

--- a/relay-server/src/metrics_extraction/spans/snapshots/relay_server__metrics_extraction__spans__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/spans/snapshots/relay_server__metrics_extraction__spans__tests__extract_span_metrics.snap
@@ -1417,6 +1417,9 @@ expression: event.value().unwrap().spans
             "release": String(
                 "1.2.3",
             ),
+            "span.action": String(
+                "SAVEPOINT",
+            ),
             "span.category": String(
                 "db",
             ),


### PR DESCRIPTION
Add support for parsing `SET`, `SAVEPOINT`, `RELEASE SAVEPOINT`, and `ROLLBACK TO SAVEPOINT` db sql actions.

Adds table test to validate this.

ref https://www.notion.so/sentry/Improve-DB-Module-dropdowns-bb8b9776b7194cdb99ef26273aa452c7?d=f373818634b74aa58e0f00ac68250767#460bfb7733244d43a510edb778192572

#skip-changelog