### PR TITLE
ref(metrics): Move shared tagging to metric extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,6 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "insta",
- "once_cell",
  "relay-auth",
  "relay-common",
  "relay-filter",

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -15,7 +15,6 @@ default = []
 [dependencies]
 anyhow = "1.0.66"
 assert-json-diff = "2.0.2"
-once_cell = "1.13.1"
 relay-auth = { path = "../relay-auth" }
 relay-common = { path = "../relay-common" }
 relay-filter = { path = "../relay-filter" }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -88,11 +88,11 @@ where
     }
 
     for mapping in &config.tags {
-        let mut tags_opt = None;
+        let mut lazy_tags = None;
 
         for metric in &mut metrics {
             if mapping.matches(&metric.name) {
-                let tags = tags_opt.get_or_insert_with(|| extract_tags(instance, &mapping.tags));
+                let tags = lazy_tags.get_or_insert_with(|| extract_tags(instance, &mapping.tags));
                 metric.tags.extend(tags.clone());
             }
         }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -57,7 +57,7 @@ where
         return metrics
     };
 
-    for metric_spec in config.metrics() {
+    for metric_spec in &config.metrics {
         if metric_spec.category != instance.category() {
             continue;
         }
@@ -87,13 +87,24 @@ where
         });
     }
 
+    for mapping in &config.tags {
+        let mut tags_opt = None;
+
+        for metric in &mut metrics {
+            if mapping.matches(&metric.name) {
+                let tags = tags_opt.get_or_insert_with(|| extract_tags(instance, &mapping.tags));
+                metric.tags.extend(tags.clone());
+            }
+        }
+    }
+
     metrics
 }
 
-fn extract_tags(
-    instance: &impl FieldValueProvider,
-    tags: &Vec<TagSpec>,
-) -> BTreeMap<String, String> {
+fn extract_tags<T>(instance: &T, tags: &[TagSpec]) -> BTreeMap<String, String>
+where
+    T: FieldValueProvider,
+{
     let mut map = BTreeMap::new();
 
     for tag_spec in tags {

--- a/relay-server/src/metrics_extraction/spans/mod.rs
+++ b/relay-server/src/metrics_extraction/spans/mod.rs
@@ -8,7 +8,6 @@ use relay_sampling::{EqCondition, RuleCondition};
 use serde_json::Value;
 
 use crate::metrics_extraction::generic::extract_metrics_from;
-
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::statsd::RelayTimers;
 
@@ -17,9 +16,9 @@ use crate::statsd::RelayTimers;
 /// This configuration is temporarily hard-coded here. It will later be moved to project config
 /// and be provided by the upstream.
 static SPAN_EXTRACTION_CONFIG: Lazy<MetricExtractionConfig> = Lazy::new(|| {
-    MetricExtractionConfig::new(
-        // Metrics
-        vec![
+    MetricExtractionConfig {
+        version: MetricExtractionConfig::VERSION,
+        metrics: vec![
             MetricSpec {
                 category: DataCategory::Span,
                 mri: "d:spans/exclusive_time@millisecond".into(),
@@ -40,8 +39,7 @@ static SPAN_EXTRACTION_CONFIG: Lazy<MetricExtractionConfig> = Lazy::new(|| {
                 tags: Default::default(),
             },
         ],
-        // Tags
-        vec![
+        tags: vec![
             TagMapping {
                 metrics: vec![LazyGlob::new("d:spans/exclusive_time*@millisecond".into())],
                 tags: [
@@ -84,7 +82,7 @@ static SPAN_EXTRACTION_CONFIG: Lazy<MetricExtractionConfig> = Lazy::new(|| {
                     .into(),
             },
         ],
-    )
+    }
 });
 
 /// Extracts metrics from the spans of the given transaction.


### PR DESCRIPTION
Instead of inlining shared tag definitions into individual metrics' extraction
configuration, run a single extraction pass after extracting all metrics from a
payload instance.

Follow-up to https://github.com/getsentry/relay/pull/2355
Ref https://github.com/getsentry/team-ingest/issues/142

#skip-changelog

