### PR TITLE
ref: inline generated DataCategory constants

### DIFF
--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -1,3 +1,4 @@
+import sys
 from enum import IntEnum
 
 from sentry_relay._lowlevel import lib
@@ -7,17 +8,23 @@ from sentry_relay.utils import decode_str, encode_str
 __all__ = ["DataCategory", "SPAN_STATUS_CODE_TO_NAME", "SPAN_STATUS_NAME_TO_CODE"]
 
 
-def _make_data_categories(ns):
-    prefix = "RELAY_DATA_CATEGORY_"
-
-    for attr in dir(lib):
-        if attr.startswith(prefix):
-            category_name = attr[len(prefix) :]
-            ns[category_name] = getattr(lib, attr)
-
-
 class DataCategory(IntEnum):
-    _make_data_categories(locals())
+    # begin generated
+    DEFAULT = 0
+    ERROR = 1
+    TRANSACTION = 2
+    SECURITY = 3
+    ATTACHMENT = 4
+    SESSION = 5
+    PROFILE = 6
+    REPLAY = 7
+    TRANSACTION_PROCESSED = 8
+    TRANSACTION_INDEXED = 9
+    MONITOR = 10
+    PROFILE_INDEXED = 11
+    SPAN = 12
+    UNKNOWN = -1
+    # end generated
 
     @classmethod
     def parse(cls, name):
@@ -62,6 +69,29 @@ class DataCategory(IntEnum):
         """
         return decode_str(lib.relay_data_category_name(self.value), free=True)
 
+
+def _check_generated():
+    prefix = "RELAY_DATA_CATEGORY_"
+
+    attrs = {}
+    for attr in dir(lib):
+        if attr.startswith(prefix):
+            category_name = attr[len(prefix) :]
+            attrs[category_name] = getattr(lib, attr)
+
+    if attrs != DataCategory.__members__:
+        values = sorted(
+            attrs.items(), key=lambda kv: sys.maxsize if kv[1] == -1 else kv[1]
+        )
+        generated = "".join(f"    {k} = {v}\n" for k, v in values)
+        raise AssertionError(
+            f"DataCategory enum does not match source!\n\n"
+            f"Paste this into `class DataCategory` in py/sentry_relay/consts.py:\n\n"
+            f"{generated}"
+        )
+
+
+_check_generated()
 
 SPAN_STATUS_CODE_TO_NAME = {}
 SPAN_STATUS_NAME_TO_CODE = {}


### PR DESCRIPTION
this allows mypy to type check this enum


this is what it looks like when it fails:

```console
$ python3 -c 'import sentry_relay.consts'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/asottile/workspace/relay/py/sentry_relay/__init__.py", line 22, in <module>
    _import_all()
  File "/Users/asottile/workspace/relay/py/sentry_relay/__init__.py", line 11, in _import_all
    mod = __import__("sentry_relay.%s" % modname, glob, glob, ["__name__"])
  File "/Users/asottile/workspace/relay/py/sentry_relay/consts.py", line 78, in <module>
    _check_generated()
  File "/Users/asottile/workspace/relay/py/sentry_relay/consts.py", line 72, in _check_generated
    raise AssertionError(
AssertionError: DataCategory enum does not match source!

Paste this into `class DataCategory` in pysentry_relay/consts.py:

    DEFAULT = 0
    ERROR = 1
    TRANSACTION = 2
    SECURITY = 3
    ATTACHMENT = 4
    SESSION = 5
    PROFILE = 6
    REPLAY = 7
    TRANSACTION_PROCESSED = 8
    TRANSACTION_INDEXED = 9
    MONITOR = 10
    PROFILE_INDEXED = 11
    SPAN = 12
    UNKNOWN = -1
```

#skip-changelog