### PR TITLE
feat: add cross-origin-resource-policy response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 23.7.3
+## Unreleased
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 23.7.3
+
+**Features**:
+
+- Add `Cross-Origin-Resource-Policy` HTTP header to responses. ([#2394](https://github.com/getsentry/relay/pull/2394))
+
+
 ## 23.7.2
 
 **Features**:

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -76,7 +76,7 @@ impl Service for HttpServer {
                 HeaderValue::from_static(constants::SERVER),
             ))
             .layer(SetResponseHeaderLayer::overriding(
-                HeaderName::from_static("Cross-Origin-Resource-Policy"),
+                HeaderName::from_static("cross-origin-resource-policy"),
                 HeaderValue::from_static("cross-origin"),
             ))
             .layer(NewSentryLayer::new_from_top())

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::http::{header, HeaderValue};
+use axum::http::{header, HeaderName, HeaderValue};
 use axum::ServiceExt;
 use axum_server::{AddrIncomingConfig, Handle, HttpConfig};
 use relay_config::Config;
@@ -74,6 +74,10 @@ impl Service for HttpServer {
             .layer(SetResponseHeaderLayer::overriding(
                 header::SERVER,
                 HeaderValue::from_static(constants::SERVER),
+            ))
+            .layer(SetResponseHeaderLayer::overriding(
+                HeaderName::from_static("Cross-Origin-Resource-Policy"),
+                HeaderValue::from_static("cross-origin"),
             ))
             .layer(NewSentryLayer::new_from_top())
             .layer(SentryHttpLayer::with_transaction())

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -214,3 +214,23 @@ def test_compression(mini_sentry, relay, content_encoding):
         data=encodings[content_encoding](b'{"message": "hello world"}'),
     )
     response.raise_for_status()
+
+
+@pytest.mark.parametrize(
+    "cross_origin_resource_policy",
+    [
+        "cross-origin",
+    ],
+)
+def test_corp_response_header(mini_sentry, relay, cross_origin_resource_policy):
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+    relay = relay(mini_sentry)
+
+    response = relay.post(
+        "/api/42/store/?sentry_key=%s" % mini_sentry.get_dsn_public_key(project_id),
+    )
+
+    assert (
+        response.headers["cross-origin-resource-policy"] == cross_origin_resource_policy
+    )

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -228,7 +228,7 @@ def test_corp_response_header(mini_sentry, relay, cross_origin_resource_policy):
     relay = relay(mini_sentry)
 
     response = relay.post(
-        "/api/42/store/?sentry_key=%s" % mini_sentry.get_dsn_public_key(project_id),
+        f"/api/42/store/?sentry_key={mini_sentry.get_dsn_public_key(project_id)}",
     )
 
     assert (


### PR DESCRIPTION
Fix for https://github.com/getsentry/sentry/issues/41225. 

Browsers are starting to require the [CORP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy) header it seems. Relay sets `Access-Control-Allow-Origin: *`, but this is not sufficient for those that have stricter headers set:

```
cross-origin-embedder-policy: require-corp
cross-origin-opener-policy: same-origin
```

`tower_http`'s CORS module does not support CORP/COOP/COEP so I just added the static header on the response.