### PR TITLE
ref(globconfig): Set empty global config

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -1,7 +1,4 @@
-use relay_general::store::MeasurementsConfig;
 use serde::{Deserialize, Serialize};
-
-use crate::TaggingRule;
 
 /// A dynamic configuration for all Relays passed down from Sentry.
 ///
@@ -9,50 +6,4 @@ use crate::TaggingRule;
 /// [`ProjectConfig`](crate::ProjectConfig)s small.
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
-pub struct GlobalConfig {
-    /// Project configuration for measurements.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    measurements: Option<MeasurementsConfig>,
-    /// Project configuration for rules for applying metrics tags depending on
-    /// the event's content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    metric_conditional_tagging: Option<Vec<TaggingRule>>,
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::GlobalConfig;
-
-    #[test]
-    fn test_global_config_roundtrip() {
-        let json = r#"{
-  "measurements": {
-    "builtinMeasurements": [
-      {
-        "name": "plate.size",
-        "unit": "5"
-      }
-    ],
-    "maxCustomMeasurements": 2
-  },
-  "metricConditionalTagging": [
-    {
-      "condition": {
-        "op": "gt",
-        "name": "food.deliciousness",
-        "value": 8
-      },
-      "targetMetrics": [
-        "tummy.satisfaction"
-      ],
-      "targetTag": "satisfied",
-      "tagValue": "hellyeah"
-    }
-  ]
-}"#;
-
-        let deserialized: GlobalConfig = serde_json::from_str(json).unwrap();
-        let reserialized = serde_json::to_string_pretty(&deserialized).unwrap();
-        assert_eq!(json, reserialized);
-    }
-}
+pub struct GlobalConfig {}


### PR DESCRIPTION
Setting a defined list of keys for the global config requires further consideration of each steps, which currently slows down the iteration velocity. Simplifying this config postpones the considerations for later steps, and should help bring the velocity up again.

### Why is this PR useful?

The global config has two fields: `measurements` and `metric_conditional_tagging`. The latter is going to be removed soon as part of the generic metric extraction initiative so it will never be shipped as part of the global config, thus we're removing it. The former doesn't have this issue, but it adds extra steps that we're not interested in having at this point to try to ship a bit faster.

#skip-changelog