### PR TITLE
ref: Faster case-insensitive comparison

### DIFF
--- a/relay-general/src/pii/config.rs
+++ b/relay-general/src/pii/config.rs
@@ -35,7 +35,7 @@ pub struct LazyPattern {
 
 impl PartialEq for LazyPattern {
     fn eq(&self, other: &Self) -> bool {
-        self.raw.to_lowercase() == other.raw.to_lowercase()
+        self.raw.eq_ignore_ascii_case(&other.raw)
     }
 }
 

--- a/relay-general/src/processor/selector.rs
+++ b/relay-general/src/processor/selector.rs
@@ -126,7 +126,7 @@ impl SelectorPathItem {
             (SelectorPathItem::Key(ref key), _) => state
                 .path()
                 .key()
-                .map(|k| k.to_lowercase() == key.to_lowercase())
+                .map(|k| k.eq_ignore_ascii_case(key))
                 .unwrap_or(false),
         }
     }

--- a/relay-general/src/user_agent.rs
+++ b/relay-general/src/user_agent.rs
@@ -30,7 +30,7 @@ fn get_user_agent_from_headers(headers: &Headers) -> Option<&str> {
     for item in headers.iter() {
         if let Some((ref o_k, ref v)) = item.value() {
             if let Some(k) = o_k.as_str() {
-                if k.to_lowercase() == "user-agent" {
+                if k.eq_ignore_ascii_case("user-agent") {
                     return v.as_str();
                 }
             }


### PR DESCRIPTION
This method avoids extra allocations when comparing two strings. 


#skip-changelog