### PR TITLE
chore(test): Deflake the actors::spooler::tests::dequeue_waits_for_permits

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1063,7 +1063,6 @@ mod tests {
             key,
             value: empty_managed_envelope(),
         });
-        tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Nothing dequeued yet:
         assert!(rx.try_recv().is_err());
@@ -1078,8 +1077,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // There are enough permits, so get an envelope:
-        let res = rx.try_recv();
-        assert!(res.is_ok(), "{res:?}");
+        let res = rx.recv().await;
+        assert!(res.is_some(), "{res:?}");
         assert_eq!(buffer_guard.available(), 2);
 
         // Simulate a new envelope coming in via a web request:

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1063,6 +1063,7 @@ mod tests {
             key,
             value: empty_managed_envelope(),
         });
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Nothing dequeued yet:
         assert!(rx.try_recv().is_err());

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -1074,8 +1074,6 @@ mod tests {
             sender: tx.clone(),
         });
 
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
         // There are enough permits, so get an envelope:
         let res = rx.recv().await;
         assert!(res.is_some(), "{res:?}");


### PR DESCRIPTION
Let's add timeouts for slow agents to pass and deflake the flaky `actors::spooler::tests::dequeue_waits_for_permits`

#skip-changelog