### PR TITLE
ref(metrics): Validate transaction timestamps in light normalization

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -126,6 +126,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         received_at: config.received_at,
         max_secs_in_past: config.max_secs_in_past,
         max_secs_in_future: config.max_secs_in_future,
+        transaction_range: None,   // only supported in relay
         measurements_config: None, // only supported in relay
         breakdowns_config: None,   // only supported in relay
         normalize_user_agent: config.normalize_user_agent,

--- a/relay-general/src/store/normalize.rs
+++ b/relay-general/src/store/normalize.rs
@@ -2,13 +2,14 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::mem;
+use std::ops::Range;
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use regex::Regex;
-use relay_common::{is_valid_metric_name, DurationUnit, FractionUnit, MetricUnit};
+use relay_common::{is_valid_metric_name, DurationUnit, FractionUnit, MetricUnit, UnixTimestamp};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
@@ -788,6 +789,7 @@ pub struct LightNormalizationConfig<'a> {
     pub received_at: Option<DateTime<Utc>>,
     pub max_secs_in_past: Option<i64>,
     pub max_secs_in_future: Option<i64>,
+    pub transaction_range: Option<Range<UnixTimestamp>>,
     pub max_name_and_unit_len: Option<usize>,
     pub measurements_config: Option<&'a MeasurementsConfig>,
     pub breakdowns_config: Option<&'a BreakdownsConfig>,
@@ -811,6 +813,7 @@ impl Default for LightNormalizationConfig<'_> {
             received_at: Default::default(),
             max_secs_in_past: Default::default(),
             max_secs_in_future: Default::default(),
+            transaction_range: Default::default(),
             max_name_and_unit_len: Default::default(),
             measurements_config: Default::default(),
             breakdowns_config: Default::default(),
@@ -845,6 +848,7 @@ pub fn light_normalize_event(
             config.transaction_name_config,
             config.enrich_spans,
             config.span_description_rules,
+            config.transaction_range,
         );
         transactions_processor.process_event(event, meta, ProcessingState::root())?;
 

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -548,6 +548,25 @@ mod tests {
     }
 
     #[test]
+    fn test_discards_when_timestamp_out_of_range() {
+        let mut event = new_test_event();
+
+        let processor = &mut TransactionsProcessor::new(
+            TransactionNameConfig::default(),
+            false,
+            None,
+            Some(UnixTimestamp::now()..UnixTimestamp::now()),
+        );
+
+        assert!(matches!(
+            process_value(&mut event, processor, ProcessingState::root()),
+            Err(ProcessingAction::InvalidTransaction(
+                "timestamp is out of the valid range for metrics"
+            ))
+        ));
+    }
+
+    #[test]
     fn test_replace_missing_timestamp() {
         let span = Span {
             start_timestamp: Annotated::new(

--- a/relay-general/src/store/transactions/processor.rs
+++ b/relay-general/src/store/transactions/processor.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
+use std::ops::Range;
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-use relay_common::SpanStatus;
+use relay_common::{SpanStatus, UnixTimestamp};
 
 use super::TransactionNameRule;
 use crate::processor::{ProcessValue, ProcessingState, Processor};
-use crate::protocol::{Event, EventType, Span, Timestamp, TraceContext, TransactionSource};
+use crate::protocol::{Event, EventType, Span, TraceContext, TransactionSource};
 use crate::store::normalize::span::description::scrub_span_description;
 use crate::store::regexes::TRANSACTION_NAME_NORMALIZER_REGEX;
 use crate::store::SpanDescriptionRule;
@@ -20,10 +21,11 @@ pub struct TransactionNameConfig<'r> {
 }
 
 /// Rejects transactions based on required fields.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct TransactionsProcessor<'r> {
     name_config: TransactionNameConfig<'r>,
     span_desc_rules: Vec<SpanDescriptionRule>,
+    timestamp_range: Option<Range<UnixTimestamp>>,
     enrich_spans: bool,
 }
 
@@ -32,6 +34,7 @@ impl<'r> TransactionsProcessor<'r> {
         name_config: TransactionNameConfig<'r>,
         enrich_spans: bool,
         span_description_rules: Option<&Vec<SpanDescriptionRule>>,
+        timestamp_range: Option<Range<UnixTimestamp>>,
     ) -> Self {
         let mut span_desc_rules = if let Some(span_desc_rules) = span_description_rules {
             span_desc_rules.clone()
@@ -46,6 +49,7 @@ impl<'r> TransactionsProcessor<'r> {
         Self {
             name_config,
             span_desc_rules,
+            timestamp_range,
             enrich_spans,
         }
     }
@@ -138,62 +142,67 @@ impl<'r> TransactionsProcessor<'r> {
 
         Ok(())
     }
-}
 
-/// Returns start and end timestamps if they are both set and start <= end.
-pub fn validate_timestamps(
-    transaction_event: &Event,
-) -> Result<(Timestamp, Timestamp), ProcessingAction> {
-    match (
-        transaction_event.start_timestamp.value(),
-        transaction_event.timestamp.value(),
-    ) {
-        (Some(&start), Some(&end)) => {
-            if end < start {
-                return Err(ProcessingAction::InvalidTransaction(
-                    "end timestamp is smaller than start timestamp",
-                ));
+    fn validate_transaction(&self, event: &mut Event) -> ProcessingResult {
+        self.validate_timestamps(event)?;
+
+        let Some(trace_context) = event.context_mut::<TraceContext>() else {
+            return Err(ProcessingAction::InvalidTransaction(
+                "missing valid trace context",
+            ));
+        };
+
+        if trace_context.trace_id.value().is_none() {
+            return Err(ProcessingAction::InvalidTransaction(
+                "trace context is missing trace_id",
+            ));
+        }
+
+        if trace_context.span_id.value().is_none() {
+            return Err(ProcessingAction::InvalidTransaction(
+                "trace context is missing span_id",
+            ));
+        }
+
+        trace_context.op.get_or_insert_with(|| "default".to_owned());
+        Ok(())
+    }
+
+    /// Returns start and end timestamps if they are both set and start <= end.
+    fn validate_timestamps(&self, transaction_event: &Event) -> ProcessingResult {
+        match (
+            transaction_event.start_timestamp.value(),
+            transaction_event.timestamp.value(),
+        ) {
+            (Some(start), Some(end)) => {
+                if end < start {
+                    return Err(ProcessingAction::InvalidTransaction(
+                        "end timestamp is smaller than start timestamp",
+                    ));
+                }
+
+                if let Some(ref range) = self.timestamp_range {
+                    let Some(timestamp) = UnixTimestamp::from_datetime(end.into_inner()) else {
+                        return Err(ProcessingAction::InvalidTransaction("invalid unix timestamp"));
+                    };
+                    if !range.contains(&timestamp) {
+                        return Err(ProcessingAction::InvalidTransaction(
+                            "timestamp is out of the valid range for metrics",
+                        ));
+                    }
+                }
+
+                Ok(())
             }
-            Ok((start, end))
-        }
-        (_, None) => {
-            // This invariant should be already guaranteed for regular error events.
-            Err(ProcessingAction::InvalidTransaction(
+            (_, None) => Err(ProcessingAction::InvalidTransaction(
                 "timestamp hard-required for transaction events",
-            ))
-        }
-        (None, _) => {
+            )),
             // XXX: Maybe copy timestamp over?
-            Err(ProcessingAction::InvalidTransaction(
+            (None, _) => Err(ProcessingAction::InvalidTransaction(
                 "start_timestamp hard-required for transaction events",
-            ))
+            )),
         }
     }
-}
-
-fn validate_transaction(event: &mut Event) -> ProcessingResult {
-    validate_timestamps(event)?;
-
-    let Some(trace_context) = event.context_mut::<TraceContext>() else {
-        return Err(ProcessingAction::InvalidTransaction(
-            "missing valid trace context",
-        ));
-    };
-
-    if trace_context.trace_id.value().is_none() {
-        return Err(ProcessingAction::InvalidTransaction(
-            "trace context is missing trace_id",
-        ));
-    }
-
-    if trace_context.span_id.value().is_none() {
-        return Err(ProcessingAction::InvalidTransaction(
-            "trace context is missing span_id",
-        ));
-    }
-
-    trace_context.op.get_or_insert_with(|| "default".to_owned());
-    Ok(())
 }
 
 /// Span status codes for the Ruby Rack integration that indicate raw URLs being sent as
@@ -404,13 +413,10 @@ impl Processor for TransactionsProcessor<'_> {
 
         set_default_transaction_source(event);
         self.normalize_transaction_name(event)?;
-
-        validate_transaction(event)?;
-
+        self.validate_transaction(event)?;
         end_all_spans(event)?;
 
         event.process_child_values(self, state)?;
-
         Ok(())
     }
 
@@ -1648,6 +1654,7 @@ mod tests {
                 },
                 false,
                 None,
+                None,
             ),
             ProcessingState::root(),
         )
@@ -1712,6 +1719,7 @@ mod tests {
                     rules: rules.as_ref(),
                 },
                 false,
+                None,
                 None,
             ),
             ProcessingState::root(),
@@ -1801,6 +1809,7 @@ mod tests {
                 rules: rules.as_ref(),
             },
             false,
+            None,
             None,
         );
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
@@ -1934,6 +1943,7 @@ mod tests {
                 },
                 false,
                 None,
+                None,
             ),
             ProcessingState::root(),
         )
@@ -2001,6 +2011,7 @@ mod tests {
                     rules: rules.as_ref(),
                 },
                 false,
+                None,
                 None,
             ),
             ProcessingState::root(),
@@ -2118,7 +2129,12 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(TransactionNameConfig { rules: &[rule] }, false, None),
+            &mut TransactionsProcessor::new(
+                TransactionNameConfig { rules: &[rule] },
+                false,
+                None,
+                None,
+            ),
             ProcessingState::root(),
         )
         .unwrap();
@@ -2347,6 +2363,7 @@ mod tests {
                 },
                 false,
                 None,
+                None,
             ),
             ProcessingState::root(),
         )
@@ -2392,6 +2409,7 @@ mod tests {
                     }],
                 },
                 false,
+                None,
                 None,
             ),
             ProcessingState::root(),

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -719,8 +719,12 @@ impl FieldValueProvider for Event {
                 .map_or(Value::Null, Value::from),
 
             // Computed fields (see Discover)
-            "duration" => match (self.ty.value(), store::validate_timestamps(self)) {
-                (Some(&EventType::Transaction), Ok((start, end))) => {
+            "duration" => match (
+                self.ty.value(),
+                self.start_timestamp.value(),
+                self.timestamp.value(),
+            ) {
+                (Some(&EventType::Transaction), Some(&start), Some(&end)) if start <= end => {
                     match Number::from_f64(relay_common::chrono_to_positive_millis(end - start)) {
                         Some(num) => Value::Number(num),
                         None => Value::Null,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2096,7 +2096,6 @@ impl EnvelopeProcessorService {
                         .and_then(|dsc| dsc.transaction.as_deref());
 
                     let extractor = TransactionExtractor {
-                        aggregator_config: self.inner.config.aggregator_config(),
                         config: tx_config,
                         generic_tags: config.map(|c| c.tags.as_slice()).unwrap_or_default(),
                         transaction_from_dsc,
@@ -2367,6 +2366,12 @@ impl EnvelopeProcessorService {
                 received_at: Some(state.managed_envelope.received_at()),
                 max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
                 max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
+                transaction_range: Some(
+                    self.inner
+                        .config
+                        .aggregator_config_for(MetricNamespace::Transactions)
+                        .timestamp_range(),
+                ),
                 max_name_and_unit_len: Some(
                     self.inner
                         .config

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -258,7 +258,7 @@ def test_ignore_transactions_filters_are_applied(
 
     now = datetime.datetime.utcnow()
     start_timestamp = now.timestamp()
-    timestamp = (now - datetime.timedelta(minutes=-1)).timestamp()
+    timestamp = (now + datetime.timedelta(minutes=1)).timestamp()
 
     transaction = {
         "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -254,7 +254,7 @@ def test_ignore_transactions_filters_are_applied(
             "isEnabled": is_enabled,
         }
 
-    transactions_consumer = transactions_consumer(timeout=10)
+    transactions_consumer = transactions_consumer(timeout=15)
 
     now = datetime.datetime.utcnow()
     start_timestamp = now.timestamp()

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -254,7 +254,7 @@ def test_ignore_transactions_filters_are_applied(
             "isEnabled": is_enabled,
         }
 
-    transactions_consumer = transactions_consumer(timeout=15)
+    transactions_consumer = transactions_consumer(timeout=10)
 
     now = datetime.datetime.utcnow()
     start_timestamp = now.timestamp()

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -257,8 +257,8 @@ def test_ignore_transactions_filters_are_applied(
     transactions_consumer = transactions_consumer(timeout=10)
 
     now = datetime.datetime.utcnow()
-    start_timestamp = now.timestamp()
-    timestamp = (now + datetime.timedelta(minutes=1)).timestamp()
+    start_timestamp = (now - datetime.timedelta(minutes=1)).timestamp()
+    timestamp = now.timestamp()
 
     transaction = {
         "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",


### PR DESCRIPTION
As opposed to errors, transactions have a valid timestamp range defaulting to
(-5d..+1h). If transactions with an end timestamp outside of this range are
ingested, they are dropped as invalid transactions.

The reason for this check are performance metrics: Sentry metrics cannot be
backdated more than five days, and normalizing the transaction timestamp like
for errors creates strange artifacts in metrics.

However, this check was originally implemented in metric extraction code. In
this PR, it is moved to light normalization, which already performs a series of
validations of transaction events.

#skip-changelog

