### PR TITLE
feat(spans): Add event ID to extracted spans

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1191,7 +1191,7 @@ def test_spans(
     project_config = mini_sentry.add_basic_project_config(project_id)
     project_config["config"]["features"] = ["projects:extract-standalone-spans"]
 
-    event = make_transaction({})
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
     event["spans"] = [
         {
             "description": "GET /api/0/organizations/?member=1",
@@ -1207,16 +1207,20 @@ def test_spans(
     relay.send_event(project_id, event)
 
     msg = spans_consumer.get_message()
-    assert msg["type"] == "span"
-    span = msg["span"]
-    assert span == {
-        "description": "GET /api/0/organizations/?member=1",
-        "op": "http",
-        "parent_span_id": "aaaaaaaaaaaaaaaa",
-        "span_id": "bbbbbbbbbbbbbbbb",
-        "start_timestamp": 1000.0,
-        "timestamp": 3000.0,
-        "trace_id": "ff62a8b040f340bda5d830223def1d81",
+    del msg["start_time"]
+    assert msg == {
+        "type": "span",
+        "event_id": "cbf6960622e14a45abc1f03b2055b186",
+        "project_id": 42,
+        "span": {
+            "description": "GET /api/0/organizations/?member=1",
+            "op": "http",
+            "parent_span_id": "aaaaaaaaaaaaaaaa",
+            "span_id": "bbbbbbbbbbbbbbbb",
+            "start_timestamp": 1000.0,
+            "timestamp": 3000.0,
+            "trace_id": "ff62a8b040f340bda5d830223def1d81",
+        },
     }
 
     spans_consumer.assert_empty()


### PR DESCRIPTION
True standalone spans will not have an associated event ID. But because the current spans dataset expects it, add it to the kafka message of spans extracted from transactions for now.

#skip-changelog