### PR TITLE
fix(filters): Filter out webkit errors originating in Safari extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))
+
 ## 23.8.0
 
 **Features**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))
+
 ## 0.8.29
 
 - Add rudimentary Mypy setup. ([#2384](https://github.com/getsentry/relay/pull/2384))

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -59,6 +59,7 @@ static EXTENSION_EXC_SOURCES: Lazy<Regex> = Lazy::new(|| {
         ^chrome(-extension)?://|                        # Chrome extensions
         ^moz-extension://|                              # Firefox extensions
         ^safari(-web)?-extension://|                    # Safari extensions
+        webkit-masked-url|                              # Safari extensions
         127\.0\.0\.1:4001/isrunning|                    # Cacaoweb
         webappstoolbarba\.texthelp\.com/|               # Other
         metrics\.itunes\.apple\.com\.edgesuite\.net/|
@@ -217,6 +218,7 @@ mod tests {
             "webappstoolbarba.texthelp.com/",
             "http://metrics.itunes.apple.com.edgesuite.net/itunespreview/itunes/browser:firefo",
             "https://fscr.kaspersky-labs.com/B-9B72-7B7/main.js",
+            "webkit-masked-url:",
         ];
 
         for source_name in &sources {


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/2088 filtered out errors with the title `webkit-masked-url`. However, errors originating from Safari extensions may not have that error title and still be originated in such extensions. This PR filters out these events with sources matching `webkit-masked-url` (it seems the original source is `webkit-masked-url://hidden/`).