### PR TITLE
fix(metrics): Honor tag precedence in tag extraction

### DIFF
--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -335,40 +335,6 @@ pub enum TagSource<'a> {
     Unknown,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use similar_asserts::assert_eq;
-
-    #[test]
-    fn parse_tag_spec_value() {
-        let json = r#"{"key":"foo","value":"bar"}"#;
-        let spec: TagSpec = serde_json::from_str(json).unwrap();
-        assert_eq!(spec.source(), TagSource::Literal("bar"));
-    }
-
-    #[test]
-    fn parse_tag_spec_field() {
-        let json = r#"{"key":"foo","field":"bar"}"#;
-        let spec: TagSpec = serde_json::from_str(json).unwrap();
-        assert_eq!(spec.source(), TagSource::Field("bar"));
-    }
-
-    #[test]
-    fn parse_tag_spec_unsupported() {
-        let json = r#"{"key":"foo","somethingNew":"bar"}"#;
-        let spec: TagSpec = serde_json::from_str(json).unwrap();
-        assert_eq!(spec.source(), TagSource::Unknown);
-    }
-
-    #[test]
-    fn parse_tag_mapping() {
-        let json = r#"{"metrics": ["d:spans/*"], "tags": [{"key":"foo","field":"bar"}]}"#;
-        let mapping: TagMapping = serde_json::from_str(json).unwrap();
-        assert!(mapping.metrics[0].compiled().is_match("d:spans/foo"));
-    }
-}
-
 /// Converts the given tagging rules from `conditional_tagging` to the newer metric extraction
 /// config.
 pub fn convert_conditional_tagging(project_config: &mut ProjectConfig) {
@@ -432,5 +398,39 @@ where
                 tags: std::mem::take(&mut self.tags),
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use similar_asserts::assert_eq;
+
+    #[test]
+    fn parse_tag_spec_value() {
+        let json = r#"{"key":"foo","value":"bar"}"#;
+        let spec: TagSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.source(), TagSource::Literal("bar"));
+    }
+
+    #[test]
+    fn parse_tag_spec_field() {
+        let json = r#"{"key":"foo","field":"bar"}"#;
+        let spec: TagSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.source(), TagSource::Field("bar"));
+    }
+
+    #[test]
+    fn parse_tag_spec_unsupported() {
+        let json = r#"{"key":"foo","somethingNew":"bar"}"#;
+        let spec: TagSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.source(), TagSource::Unknown);
+    }
+
+    #[test]
+    fn parse_tag_mapping() {
+        let json = r#"{"metrics": ["d:spans/*"], "tags": [{"key":"foo","field":"bar"}]}"#;
+        let mapping: TagMapping = serde_json::from_str(json).unwrap();
+        assert!(mapping.metrics[0].compiled().is_match("d:spans/foo"));
     }
 }

--- a/relay-general/src/store/transactions/rules.rs
+++ b/relay-general/src/store/transactions/rules.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 
 use chrono::{DateTime, Utc};
 use once_cell::sync::OnceCell;
@@ -10,7 +11,7 @@ use crate::utils::Glob;
 /// Wrapper type around the raw string pattern and the [`crate::utils::Glob`].
 ///
 /// This allows to compile the Glob with internal regexes only then whent they are used.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct LazyGlob {
     raw: String,
     glob: OnceCell<Glob>,
@@ -34,6 +35,12 @@ impl LazyGlob {
                 .capture_question_mark(false)
                 .build()
         })
+    }
+}
+
+impl fmt::Debug for LazyGlob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LazyGlob({:?})", self.raw)
     }
 }
 


### PR DESCRIPTION
Outlier tagging uses a sequence of tagging rules, where the last rules match all
metrics and apply a fallback tag value if none of the previous rules match.

#2388 regressed this, and this PR restores the original behavior.

#skip-changelog
