### PR TITLE
ref(globconfig): Instrument global config service

### DIFF
--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -19,7 +19,6 @@ use relay_system::{Addr, AsyncResponse, FromMessage, Interface, Service};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
-use tokio::time::Instant;
 
 use crate::actors::upstream::{
     RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay, UpstreamRequestError,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -316,7 +316,7 @@ pub enum RelayTimers {
     OutcomeAggregatorFlushTime,
     /// Time in milliseconds spent on parsing, normalizing and scrubbing replay recordings.
     ReplayRecordingProcessing,
-    /// Total time spent to send a request to upstream and handle the response.
+    /// Total time spent to send a request and receive the response from upstream.
     GlobalConfigRequestDuration,
 }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -316,6 +316,8 @@ pub enum RelayTimers {
     OutcomeAggregatorFlushTime,
     /// Time in milliseconds spent on parsing, normalizing and scrubbing replay recordings.
     ReplayRecordingProcessing,
+    /// Total time spent to send a request to upstream and handle the response.
+    GlobalConfigRequestDuration,
 }
 
 impl TimerMetric for RelayTimers {
@@ -349,6 +351,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::TimestampDelay => "requests.timestamp_delay",
             RelayTimers::OutcomeAggregatorFlushTime => "outcomes.aggregator.flush_time",
             RelayTimers::ReplayRecordingProcessing => "replay.recording.process",
+            RelayTimers::GlobalConfigRequestDuration => "global_config.requests.duration",
         }
     }
 }
@@ -541,6 +544,12 @@ pub enum RelayCounters {
     ///  - `sdk`: The name of the Sentry SDK sending the transaction. This tag is only set for
     ///    Sentry's SDKs and defaults to "proprietary".
     OpenTelemetryEvent,
+    /// Number of global config fetches from upstream. Only 2XX responses are
+    /// considered and ignores send errors (e.g. auth or network errors).
+    ///
+    /// This metric is tagged with:
+    ///  - `success`: whether deserializing the global config succeeded.
+    GlobalConfigFetched,
 }
 
 impl CounterMetric for RelayCounters {
@@ -575,6 +584,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
+            RelayCounters::GlobalConfigFetched => "global_config.fetch",
         }
     }
 }


### PR DESCRIPTION
This PR adds two metrics to the service to improve observability:
- Request duration, measuring all upstream request durations.
- Fetch successes, measuring the number of successful responses from the server. This metric ignores send errors, as the goal is to ensure global configs are received ok.

#skip-changelog