### PR TITLE
ref(globconfig): Extract subscription mechanism from processor

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -16,9 +16,9 @@ use flate2::Compression;
 use once_cell::sync::OnceCell;
 use relay_profiling::ProfileError;
 use serde_json::Value as SerdeValue;
+use tokio::sync::watch::Receiver;
 use tokio::sync::Semaphore;
 
-use crate::actors::global_config::{GlobalConfigManager, Subscribe};
 use crate::metrics_extraction::transactions::{ExtractedMetrics, TransactionExtractor};
 use crate::service::ServiceError;
 use relay_auth::RelayVersion;
@@ -525,6 +525,7 @@ impl FromMessage<RateLimitFlushBuckets> for EnvelopeProcessor {
 /// This service handles messages in a worker pool with configurable concurrency.
 #[derive(Clone)]
 pub struct EnvelopeProcessorService {
+    global_config_subscription: Receiver<Arc<GlobalConfig>>,
     global_config: Arc<GlobalConfig>,
     inner: Arc<InnerProcessor>,
 }
@@ -533,7 +534,6 @@ struct InnerProcessor {
     config: Arc<Config>,
     envelope_manager: Addr<EnvelopeManager>,
     project_cache: Addr<ProjectCache>,
-    global_config: Addr<GlobalConfigManager>,
     outcome_aggregator: Addr<TrackOutcome>,
     upstream_relay: Addr<UpstreamRelay>,
     #[cfg(feature = "processing")]
@@ -549,8 +549,8 @@ impl EnvelopeProcessorService {
         envelope_manager: Addr<EnvelopeManager>,
         outcome_aggregator: Addr<TrackOutcome>,
         project_cache: Addr<ProjectCache>,
-        global_config: Addr<GlobalConfigManager>,
         upstream_relay: Addr<UpstreamRelay>,
+        global_config_subscription: Receiver<Arc<GlobalConfig>>,
     ) -> Self {
         let geoip_lookup = config.geoip_path().and_then(|p| {
             match GeoIpLookup::open(p).context(ServiceError::GeoIp) {
@@ -569,13 +569,13 @@ impl EnvelopeProcessorService {
             config,
             envelope_manager,
             project_cache,
-            global_config,
             outcome_aggregator,
             upstream_relay,
             geoip_lookup,
         };
 
         Self {
+            global_config_subscription,
             global_config: Arc::default(),
             inner: Arc::new(inner),
         }
@@ -2753,14 +2753,6 @@ impl Service for EnvelopeProcessorService {
         tokio::spawn(async move {
             let semaphore = Arc::new(Semaphore::new(thread_count));
 
-            let Ok(mut subscription) = self.inner.global_config.send(Subscribe).await else {
-                // TODO(iker): we accept this sub-optimal error handling. TBD
-                // the approach to deal with failures on the subscription
-                // mechanism.
-                relay_log::error!("failed to subscribe to GlobalConfigService");
-                return;
-            };
-
             loop {
                 let next_msg = async { tokio::join!(rx.recv(), semaphore.clone().acquire_owned()) };
 
@@ -2768,7 +2760,7 @@ impl Service for EnvelopeProcessorService {
                    biased;
 
                     // TODO(iker): deal with the error when the sender of the channel is dropped.
-                    _ = subscription.changed() => self.global_config = subscription.borrow().clone(),
+                    _ = self.global_config_subscription.changed() => self.global_config = self.global_config_subscription.borrow().clone(),
                     (Some(message), Ok(permit)) = next_msg => {
                         let service = self.clone();
                         tokio::task::spawn_blocking(move || {
@@ -3217,7 +3209,9 @@ mod tests {
         let (outcome_aggregator, _) = mock_service("outcome_aggregator", (), |&mut (), _| {});
         let (project_cache, _) = mock_service("project_cache", (), |&mut (), _| {});
         let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
-        let (global_config, _) = mock_service("global_config", (), |&mut (), _| {});
+        let (_, global_config_subscription) =
+            tokio::sync::watch::channel(Arc::new(GlobalConfig::default()));
+
         let inner = InnerProcessor {
             config: Arc::new(config),
             envelope_manager,
@@ -3227,10 +3221,10 @@ mod tests {
             #[cfg(feature = "processing")]
             rate_limiter: None,
             geoip_lookup: None,
-            global_config,
         };
 
         EnvelopeProcessorService {
+            global_config_subscription,
             global_config: Arc::default(),
             inner: Arc::new(inner),
         }

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -294,7 +294,7 @@ pub fn run(config: Config) -> anyhow::Result<()> {
     // information on all services.
     let service = main_runtime.block_on(async {
         Controller::start(config.shutdown_timeout());
-        let service = ServiceState::start(config.clone())?;
+        let service = ServiceState::start(config.clone()).await?;
         HttpServer::new(config, service.clone())?.start();
         Controller::shutdown_handle().finished().await;
         anyhow::Ok(service)


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/2320. Extract the global config subscription mechanism from the processor to the service initialization.

Currently, the processor subscribes to the global config service by sending a message during its startup, and returning early if this fails finalizing the processor but allowing the rest of the services to continue to work. When subscribing to the global config fails, we're interested in failing as early as possible to actually enforce the dependency on that service. Additionally, we remove any future logic to retry subscribing which is too much complexity. On the other hand, Relay startup can take a bit longer and there's another moving piece that can fail during this time.

Note this is just a solution to the problem described above, and may not be the best. I'm open to ideas and suggestions to iterate on this approach or proceed with a different one.

#skip-changelog