### PR TITLE
ref(server): Make glob config receiver in servicestate

### DIFF
--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -17,6 +17,7 @@ use relay_dynamic_config::GlobalConfig;
 use relay_system::{Addr, AsyncResponse, FromMessage, Interface, Service};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
+use tokio::sync::watch::Sender;
 use tokio::sync::{mpsc, watch};
 
 use crate::actors::upstream::{
@@ -143,8 +144,11 @@ pub struct GlobalConfigService {
 
 impl GlobalConfigService {
     /// Creates a new [`GlobalConfigService`].
-    pub fn new(config: Arc<Config>, upstream: Addr<UpstreamRelay>) -> Self {
-        let (global_config_watch, _) = watch::channel(Arc::default());
+    pub fn new(
+        config: Arc<Config>,
+        upstream: Addr<UpstreamRelay>,
+        global_config_watch: Sender<Arc<GlobalConfig>>,
+    ) -> Self {
         let (internal_tx, internal_rx) = mpsc::channel(1);
         Self {
             config,

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -294,7 +294,7 @@ pub fn run(config: Config) -> anyhow::Result<()> {
     // information on all services.
     let service = main_runtime.block_on(async {
         Controller::start(config.shutdown_timeout());
-        let service = ServiceState::start(config.clone()).await?;
+        let service = ServiceState::start(config.clone())?;
         HttpServer::new(config, service.clone())?.start();
         Controller::shutdown_handle().finished().await;
         anyhow::Ok(service)

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -294,7 +294,7 @@ pub fn run(config: Config) -> anyhow::Result<()> {
     // information on all services.
     let service = main_runtime.block_on(async {
         Controller::start(config.shutdown_timeout());
-        let service = ServiceState::start(config.clone())?;
+        let service = ServiceState::start(config.clone()).await?;
         HttpServer::new(config, service.clone())?.start();
         Controller::shutdown_handle().finished().await;
         anyhow::Ok(service)

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -101,7 +101,7 @@ pub struct ServiceState {
 
 impl ServiceState {
     /// Starts all services and returns addresses to all of them.
-    pub async fn start(config: Arc<Config>) -> Result<Self> {
+    pub fn start(config: Arc<Config>) -> Result<Self> {
         let upstream_runtime = create_runtime("upstream-rt", 1);
         let project_runtime = create_runtime("project-rt", 1);
         let aggregator_runtime = create_runtime("aggregator-rt", 1);


### PR DESCRIPTION
Instead of subscribing to the global config service from within envelopeprocessorservice, just make it in the servicestate.  

it should be faster, and we also don't need to handle the case where sending and receiving the subscriber fails. 

