### PR TITLE
ci(gocd): Deploy PoPs automatically

### DIFF
--- a/gocd/generated-pipelines/relay-us.yaml
+++ b/gocd/generated-pipelines/relay-us.yaml
@@ -67,17 +67,6 @@ pipelines:
                         --image="us.gcr.io/sentryio/relay:${GO_REVISION_RELAY_REPO}" \
                         --container-name="relay"
               timeout: 1200
-      - progress-to-pops:
-          approval:
-            allow_only_on_success: true
-            type: manual
-          jobs:
-            progress-to-pops:
-              elastic_profile_id: relay
-              tasks:
-                - exec:
-                    command: true
-              timeout: 1200
       - deploy-pops:
           fetch_materials: true
           jobs:

--- a/gocd/templates/libs/relay-pops.libsonnet
+++ b/gocd/templates/libs/relay-pops.libsonnet
@@ -1,25 +1,6 @@
 local STAGE_NAME = 'deploy-pops';
 local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
 
-local manual_promotion_stage() =
-  {
-    'progress-to-pops': {
-      approval: {
-        type: 'manual',
-        allow_only_on_success: true,
-      },
-      jobs: {
-        'progress-to-pops': {
-          timeout: 1200,
-          elastic_profile_id: 'relay',
-          tasks: [
-            gocdtasks.noop,
-          ],
-        },
-      },
-    },
-  };
-
 // Create a gocd job that will run the deploy-pop script
 local deploy_pop_job(region) =
   {
@@ -89,7 +70,7 @@ local generic_pops_stage(region) =
 {
   stages(region)::
     if region == 'us' then
-      [manual_promotion_stage(), us_pops_stage()]
+      [us_pops_stage()]
     else
       [generic_pops_stage(region)],
 }


### PR DESCRIPTION
With Relay deployments now split across 10 pipelines, the manual approval step
for PoPs has become a frequent friction point and is often forgotten. In favor
of a fully automated rollout pipeline, PoPs should now be deployed
automatically, followed by all regions.

#skip-changelog

