### PR TITLE
fix(replays): Cap segment_id size to u16

### DIFF
--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -337,7 +337,7 @@ mod tests {
         // Does not fit within a u16.
         let replay_id =
             Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
-        let segment_id: Annotated<u64> = Annotated::new(65536);
+        let segment_id: Annotated<u64> = Annotated::new(u16::MAX + 1 as u64);
         let mut replay = Annotated::new(Replay {
             replay_id,
             segment_id,

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -337,7 +337,7 @@ mod tests {
         // Does not fit within a u16.
         let replay_id =
             Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
-        let segment_id: Annotated<u64> = Annotated::new(u16::MAX + 1 as u64);
+        let segment_id: Annotated<u64> = Annotated::new(u16::MAX as u64 + 1);
         let mut replay = Annotated::new(Replay {
             replay_id,
             segment_id,
@@ -348,7 +348,7 @@ mod tests {
         // Fits within a u16.
         let replay_id =
             Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
-        let segment_id: Annotated<u64> = Annotated::new(65535);
+        let segment_id: Annotated<u64> = Annotated::new(u16::MAX as u64);
         let mut replay = Annotated::new(Replay {
             replay_id,
             segment_id,

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -334,10 +334,9 @@ mod tests {
 
     #[test]
     fn test_validate_u16_segment_id() {
+        // Does not fit within a u16.
         let replay_id =
             Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
-
-        // Does not fit within a u16.
         let segment_id: Annotated<u64> = Annotated::new(65536);
         let mut replay = Annotated::new(Replay {
             replay_id,
@@ -347,6 +346,8 @@ mod tests {
         assert!(validate(replay.value_mut().as_mut().unwrap()).is_err());
 
         // Fits within a u16.
+        let replay_id =
+            Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
         let segment_id: Annotated<u64> = Annotated::new(65535);
         let mut replay = Annotated::new(Replay {
             replay_id,

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -44,6 +44,17 @@ pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing replay_id".to_string()))?;
 
+    let segment_id = replay
+        .segment_id
+        .value()
+        .ok_or_else(|| ReplayError::InvalidPayload("missing segment_id".to_string()))?;
+
+    if segment_id > 65535 {
+        return Err(ReplayError::InvalidPayload(
+            "Segment_id is too large.".to_string(),
+        ));
+    }
+
     Ok(())
 }
 

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -49,7 +49,7 @@ pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing segment_id".to_string()))?;
 
-    if segment_id.to_owned() > 65535 {
+    if segment_id > &65535 {
         return Err(ReplayError::InvalidPayload(
             "segment_id exceeded u16 limit".to_string(),
         ));
@@ -334,9 +334,13 @@ mod tests {
 
     #[test]
     fn test_validate_u16_segment_id() {
+        let replay_id =
+            Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
+
         // Does not fit within a u16.
         let segment_id: Annotated<u64> = Annotated::new(65536);
         let mut replay = Annotated::new(Replay {
+            replay_id,
             segment_id,
             ..Default::default()
         });
@@ -345,6 +349,7 @@ mod tests {
         // Fits within a u16.
         let segment_id: Annotated<u64> = Annotated::new(65535);
         let mut replay = Annotated::new(Replay {
+            replay_id,
             segment_id,
             ..Default::default()
         });

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -337,7 +337,7 @@ mod tests {
         // Does not fit within a u16.
         let segment_id: Annotated<u64> = Annotated::new(65536);
         let mut replay = Annotated::new(Replay {
-            segment_id: segment_id,
+            segment_id,
             ..Default::default()
         });
         assert!(validate(replay.value_mut().as_mut().unwrap()).is_err());
@@ -345,10 +345,10 @@ mod tests {
         // Fits within a u16.
         let segment_id: Annotated<u64> = Annotated::new(65535);
         let mut replay = Annotated::new(Replay {
-            segment_id: segment_id,
+            segment_id,
             ..Default::default()
         });
-        assert!(!validate(replay.value_mut().as_mut().unwrap()).is_err());
+        assert!(validate(replay.value_mut().as_mut().unwrap()).is_ok());
     }
 
     #[test]

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -333,6 +333,25 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_u16_segment_id() {
+        // Does not fit within a u16.
+        let segment_id: Annotated<u64> = Annotated::new(65536);
+        let mut replay = Annotated::new(Replay {
+            segment_id: segment_id,
+            ..Default::default()
+        });
+        assert!(validate(replay.value_mut().as_mut().unwrap()).is_err());
+
+        // Fits within a u16.
+        let segment_id: Annotated<u64> = Annotated::new(65535);
+        let mut replay = Annotated::new(Replay {
+            segment_id: segment_id,
+            ..Default::default()
+        });
+        assert!(!validate(replay.value_mut().as_mut().unwrap()).is_err());
+    }
+
+    #[test]
     fn test_truncated_list_less_than_limit() {
         let mut replay = Annotated::new(Replay {
             urls: Annotated::new(Vec::new()),

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -44,12 +44,12 @@ pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing replay_id".to_string()))?;
 
-    let segment_id = replay
+    let segment_id = *replay
         .segment_id
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing segment_id".to_string()))?;
 
-    if segment_id > &65535 {
+    if segment_id > u16::MAX as u64 {
         return Err(ReplayError::InvalidPayload(
             "segment_id exceeded u16 limit".to_string(),
         ));

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -49,7 +49,7 @@ pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing segment_id".to_string()))?;
 
-    if segment_id > 65535 {
+    if segment_id > &65535 {
         return Err(ReplayError::InvalidPayload(
             "Segment_id is too large.".to_string(),
         ));

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -51,7 +51,7 @@ pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
 
     if segment_id > &65535 {
         return Err(ReplayError::InvalidPayload(
-            "Segment_id is too large.".to_string(),
+            "segment_id exceeded u16 limit".to_string(),
         ));
     }
 

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -49,7 +49,7 @@ pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing segment_id".to_string()))?;
 
-    if segment_id > &65535 {
+    if segment_id.to_owned() > 65535 {
         return Err(ReplayError::InvalidPayload(
             "segment_id exceeded u16 limit".to_string(),
         ));

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -97,7 +97,7 @@ pub struct Replay {
     ///   "segment_id": 10
     /// }
     /// ```
-    pub segment_id: Annotated<u64>,
+    pub segment_id: Annotated<u16>,
 
     /// Timestamp when the event was created.
     ///

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -97,7 +97,7 @@ pub struct Replay {
     ///   "segment_id": 10
     /// }
     /// ```
-    pub segment_id: Annotated<u16>,
+    pub segment_id: Annotated<u64>,
 
     /// Timestamp when the event was created.
     ///


### PR DESCRIPTION
`Annotated<u16>` is not possible so I'm manually checking if the u64 type is within the bounds of a u16.

#skip-changelog