### PR TITLE
fix(on-demand): Fix status extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))
+- Fixes the `TraceContext.status` not being defaulted to `unknown` before the new metrics extraction pipeline. ([#2436](https://github.com/getsentry/relay/pull/2436))
 
 ## 23.8.0
 

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1998,6 +1998,7 @@ mod tests {
     fn test_transaction_status_defaulted_to_unknown() {
         let mut object = Object::new();
         let trace_context = TraceContext {
+            // We assume the status to be null.
             status: Annotated::empty(),
             ..TraceContext::default()
         };

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -788,12 +788,9 @@ fn normalize_user_geoinfo(geoip_lookup: &GeoIpLookup, user: &mut User) {
 
 /// Normalizes incoming contexts for the downstream metric extraction.
 fn normalize_contexts(contexts: &mut Contexts, _: &mut Meta) -> ProcessingResult {
-    for (_, annotated) in &mut contexts.0 {
-        if let Some(ContextInner(context)) = annotated.value_mut() {
-            match context {
-                Context::Trace(context) => normalize_trace_context(context)?,
-                _ => {}
-            }
+    for annotated in &mut contexts.0.values_mut() {
+        if let Some(ContextInner(Context::Trace(context))) = annotated.value_mut() {
+            normalize_trace_context(context)?
         }
     }
 

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -786,6 +786,7 @@ fn normalize_user_geoinfo(geoip_lookup: &GeoIpLookup, user: &mut User) {
     }
 }
 
+/// Normalizes incoming contexts for the downstream metric extraction.
 fn normalize_contexts(contexts: &mut Contexts, _: &mut Meta) -> ProcessingResult {
     for (_, annotated) in &mut contexts.0 {
         if let Some(ContextInner(context)) = annotated.value_mut() {

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -15,10 +15,10 @@ use relay_event_schema::processor::{
     self, MaxChars, ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor,
 };
 use relay_event_schema::protocol::{
-    AsPair, Breadcrumb, ClientSdkInfo, Context, Contexts, DebugImage, DeviceClass, Event, EventId,
-    EventType, Exception, Frame, Headers, IpAddr, Level, LogEntry, Measurement, Measurements,
-    ReplayContext, Request, SpanAttribute, SpanStatus, Stacktrace, Tags, TraceContext, User,
-    VALID_PLATFORMS,
+    AsPair, Breadcrumb, ClientSdkInfo, Context, ContextInner, Contexts, DebugImage, DeviceClass,
+    Event, EventId, EventType, Exception, Frame, Headers, IpAddr, Level, LogEntry, Measurement,
+    Measurements, ReplayContext, Request, SpanAttribute, SpanStatus, Stacktrace, Tags,
+    TraceContext, User, VALID_PLATFORMS,
 };
 use relay_protocol::{
     Annotated, Empty, Error, ErrorKind, FromValue, Meta, Object, Remark, RemarkType, Value,
@@ -786,6 +786,24 @@ fn normalize_user_geoinfo(geoip_lookup: &GeoIpLookup, user: &mut User) {
     }
 }
 
+fn normalize_contexts(contexts: &mut Contexts, _: &mut Meta) -> ProcessingResult {
+    for (_, annotated) in &mut contexts.0 {
+        if let Some(ContextInner(context)) = annotated.value_mut() {
+            match context {
+                Context::Trace(context) => normalize_trace_context(context)?,
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_trace_context(context: &mut TraceContext) -> ProcessingResult {
+    context.status.get_or_insert_with(|| SpanStatus::Unknown);
+    Ok(())
+}
+
 /// Configuration for [`light_normalize_event`].
 #[derive(Clone, Debug)]
 pub struct LightNormalizationConfig<'a> {
@@ -998,6 +1016,9 @@ pub fn light_normalize_event(
             config.max_name_and_unit_len,
         ); // Measurements are part of the metric extraction
         normalize_breakdowns(event, config.breakdowns_config); // Breakdowns are part of the metric extraction too
+
+        // Some contexts need to be normalized before metrics extraction takes place.
+        processor::apply(&mut event.contexts, normalize_contexts)?;
 
         if config.light_normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
             // XXX(iker): span normalization runs in the store processor, but
@@ -1251,19 +1272,6 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         _state: &ProcessingState<'_>,
     ) -> ProcessingResult {
         contexts::normalize_context(context);
-        Ok(())
-    }
-
-    fn process_trace_context(
-        &mut self,
-        context: &mut TraceContext,
-        _meta: &mut Meta,
-        _state: &ProcessingState<'_>,
-    ) -> ProcessingResult {
-        context
-            .status
-            .value_mut()
-            .get_or_insert(SpanStatus::Unknown);
         Ok(())
     }
 
@@ -1984,6 +1992,39 @@ mod tests {
                 )),
             ]))
         );
+    }
+
+    #[test]
+    fn test_transaction_status_defaulted_to_unknown() {
+        let mut object = Object::new();
+        let trace_context = TraceContext {
+            status: Annotated::empty(),
+            ..TraceContext::default()
+        };
+        object.insert(
+            "trace".to_string(),
+            Annotated::new(ContextInner(Context::Trace(Box::new(trace_context)))),
+        );
+
+        let mut event = Annotated::new(Event {
+            contexts: Annotated::new(Contexts(object)),
+            ..Event::default()
+        });
+        let config = StoreConfig {
+            ..StoreConfig::default()
+        };
+        let mut processor = NormalizeProcessor::new(Arc::new(config), None);
+        let config = LightNormalizationConfig::default();
+        light_normalize_event(&mut event, config).unwrap();
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+        let event = event.value().unwrap();
+
+        let event_trace_context = event.context::<TraceContext>().unwrap();
+        assert_eq!(
+            event_trace_context.status,
+            Annotated::new(SpanStatus::Unknown)
+        )
     }
 
     #[test]

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -152,9 +152,9 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
     tags.insert(CommonTag::Platform, platform.to_string());
 
     if let Some(trace_context) = event.context::<TraceContext>() {
-        let status = extract_transaction_status(trace_context);
-
-        tags.insert(CommonTag::TransactionStatus, status.to_string());
+        if let Some(status) = trace_context.status.value() {
+            tags.insert(CommonTag::TransactionStatus, status.to_string());
+        }
 
         if let Some(op) = normalize_utils::extract_transaction_op(trace_context) {
             tags.insert(CommonTag::TransactionOp, op);

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use relay_base_schema::events::EventType;
-use relay_base_schema::spans::SpanStatus;
 use relay_common::time::UnixTimestamp;
 use relay_dynamic_config::{TagMapping, TransactionMetricsConfig};
 use relay_event_normalization::utils as normalize_utils;


### PR DESCRIPTION
This PR fixes the `status` in the `TraceContext` not set to `unknown` for the new metrics extraction pipeline.