### PR TITLE
ref(protocol): Move `FieldValueProvider` to a new `Getter` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,6 +3220,7 @@ dependencies = [
  "relay-jsonschema-derive",
  "relay-protocol",
  "schemars",
+ "sentry-release-parser",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -3462,7 +3463,6 @@ dependencies = [
  "relay-event-schema",
  "relay-log",
  "relay-protocol",
- "sentry-release-parser",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -3956,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c337b2564b136475f056ca1e5c958a58acdc3a6c48a6a02064f749f87acb18"
+checksum = "663a866435288420b8af1ecd0fe5774c4d5f0f584eadb2456303d8ab0f5c8313"
 dependencies = [
  "lazy_static",
  "regex",

--- a/relay-base-schema/src/spans.rs
+++ b/relay-base-schema/src/spans.rs
@@ -121,6 +121,12 @@ impl SpanStatus {
     }
 }
 
+impl AsRef<str> for SpanStatus {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 /// Error parsing a `SpanStatus`.
 #[derive(Clone, Copy, Debug)]
 pub struct ParseSpanStatusError;

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -29,6 +29,6 @@ relay-ffi = { path = "../relay-ffi" }
 relay-pii = { path = "../relay-pii" }
 relay-protocol = { path = "../relay-protocol" }
 relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "1.3.1", features = ["serde"] }
+sentry-release-parser = { version = "1.3.2", features = ["serde"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -213,8 +213,8 @@ pub struct MetricSpec {
     /// A path to the field to extract the metric from.
     ///
     /// This value contains a fully qualified expression pointing at the data field in the payload
-    /// to extract the metric from. It follows the [`Getter`](relay_protocol::Getter) syntax that is
-    /// also used for dynamic sampling.
+    /// to extract the metric from. It follows the `Getter` syntax that is also used for dynamic
+    /// sampling.
     ///
     /// How the value is treated depends on the metric type:
     ///
@@ -289,7 +289,7 @@ pub struct TagSpec {
 
     /// Path to a field containing the tag's value.
     ///
-    /// It follows the [`Getter`](relay_protocol::Getter) syntax to read data from the payload.
+    /// It follows the `Getter` syntax to read data from the payload.
     ///
     /// Mutually exclusive with `value`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -213,9 +213,8 @@ pub struct MetricSpec {
     /// A path to the field to extract the metric from.
     ///
     /// This value contains a fully qualified expression pointing at the data field in the payload
-    /// to extract the metric from. It follows the
-    /// [`FieldValueProvider`](relay_sampling::FieldValueProvider) syntax that is also used for
-    /// dynamic sampling.
+    /// to extract the metric from. It follows the [`Getter`](relay_protocol::Getter) syntax that is
+    /// also used for dynamic sampling.
     ///
     /// How the value is treated depends on the metric type:
     ///
@@ -290,8 +289,7 @@ pub struct TagSpec {
 
     /// Path to a field containing the tag's value.
     ///
-    /// It follows the [`FieldValueProvider`](relay_sampling::FieldValueProvider) syntax to read
-    /// data from the payload.
+    /// It follows the [`Getter`](relay_protocol::Getter) syntax to read data from the payload.
     ///
     /// Mutually exclusive with `value`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -28,7 +28,7 @@ relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
 relay-ua = { path = "../relay-ua" }
-sentry-release-parser = { version = "1.3.1" }
+sentry-release-parser = "1.3.2"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.1"

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -37,7 +37,7 @@ pub use user_agent::*;
 pub use self::clock_drift::*;
 pub use self::geo::*;
 
-pub use sentry_release_parser::{validate_environment, validate_release, Release as ParsedRelease};
+pub use sentry_release_parser::{validate_environment, validate_release};
 
 /// Configuration for the [`StoreProcessor`].
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -28,6 +28,7 @@ schemars = { version = "=0.8.10", features = [
     "uuid1",
     "chrono",
 ], optional = true }
+sentry-release-parser = "1.3.2"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 thiserror = "1.0.38"

--- a/relay-event-schema/src/protocol/contexts/app.rs
+++ b/relay-event-schema/src/protocol/contexts/app.rs
@@ -85,7 +85,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_app_context_roundtrip() {
+    fn test_app_context_roundtrip() {
         let json = r#"{
   "app_start_time": "2018-02-08T22:21:57Z",
   "device_app_hash": "4c793e3776474877ae30618378e9662a",

--- a/relay-event-schema/src/protocol/contexts/browser.rs
+++ b/relay-event-schema/src/protocol/contexts/browser.rs
@@ -56,7 +56,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_browser_context_roundtrip() {
+    fn test_browser_context_roundtrip() {
         let json = r#"{
   "name": "Google Chrome",
   "version": "67.0.3396.99",

--- a/relay-event-schema/src/protocol/contexts/cloud_resource.rs
+++ b/relay-event-schema/src/protocol/contexts/cloud_resource.rs
@@ -97,7 +97,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_cloud_resource_context_roundtrip() {
+    fn test_cloud_resource_context_roundtrip() {
         let json = r#"{
   "cloud.account.id": "499517922981",
   "cloud.provider": "aws",

--- a/relay-event-schema/src/protocol/contexts/otel.rs
+++ b/relay-event-schema/src/protocol/contexts/otel.rs
@@ -64,7 +64,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_otel_context_roundtrip() {
+    fn test_otel_context_roundtrip() {
         let json = r#"{
   "attributes": {
     "app.payment.amount": 394.25,

--- a/relay-event-schema/src/protocol/contexts/profile.rs
+++ b/relay-event-schema/src/protocol/contexts/profile.rs
@@ -51,7 +51,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_trace_context_roundtrip() {
+    fn test_trace_context_roundtrip() {
         let json = r#"{
   "profile_id": "4c79f60c11214eb38604f4ae0781bfb2",
   "type": "profile"
@@ -67,7 +67,7 @@ mod tests {
     }
 
     #[test]
-    pub(crate) fn test_trace_context_normalization() {
+    fn test_trace_context_normalization() {
         let json = r#"{
   "profile_id": "4C79F60C11214EB38604F4AE0781BFB2",
   "type": "profile"

--- a/relay-event-schema/src/protocol/contexts/replay.rs
+++ b/relay-event-schema/src/protocol/contexts/replay.rs
@@ -59,7 +59,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_trace_context_roundtrip() {
+    fn test_trace_context_roundtrip() {
         let json = r#"{
   "replay_id": "4c79f60c11214eb38604f4ae0781bfb2",
   "type": "replay"
@@ -74,7 +74,7 @@ mod tests {
     }
 
     #[test]
-    pub(crate) fn test_replay_context_normalization() {
+    fn test_replay_context_normalization() {
         let json = r#"{
   "replay_id": "4C79F60C11214EB38604F4AE0781BFB2",
   "type": "replay"

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -32,6 +32,12 @@ impl FromValue for TraceId {
     }
 }
 
+impl AsRef<str> for TraceId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// A 16-character hex string as described in the W3C trace context spec.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Empty, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
@@ -56,6 +62,12 @@ impl FromValue for SpanId {
                 Annotated(None, meta)
             }
         }
+    }
+}
+
+impl AsRef<str> for SpanId {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 
@@ -148,7 +160,7 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    pub(crate) fn test_trace_context_roundtrip() {
+    fn test_trace_context_roundtrip() {
         let json = r#"{
   "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
   "span_id": "fa90fdead5f74052",
@@ -186,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    pub(crate) fn test_trace_context_normalization() {
+    fn test_trace_context_normalization() {
         let json = r#"{
   "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
   "span_id": "FA90FDEAD5F74052",

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -18,7 +18,6 @@ relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
-sentry-release-parser = { version = "1.3.1", features = ["serde"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 unicase = "2.6.0"


### PR DESCRIPTION
The `FieldValueProvider` trait was originally introduced to abstract data access
for dynamic sampling rules. Since then, the same rules are being used for
conditional metric tagging and metric extraction.

Since accessing fields in data instances by path is a more generic concern, the
trait is now moved to `relay_protocol` and renamed to `Getter`. It retains its
single `get_value` method, but will be extended by more functionality for arrays
and objects in the near future.

To simplify the implementation of the trait, the `get_value` method now returns
an option. This option is `None` if either the path does not match any known
field, or if the field is an empty option.

To avoid redundant allocations, `get_value` no longer returns an owned
`serde_json::Value`. Instead, there is a new `Val` type: The borrowed variant of
`Value`. For now, the only data actually borrowed are strings, however, there
are stubs to support arrays and objects.

#skip-changelog

