### PR TITLE
feat(metrics): Add support for custom metric ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Fixes the `TraceContext.status` not being defaulted to `unknown` before the new metrics extraction pipeline. ([#2436](https://github.com/getsentry/relay/pull/2436))
 - Support on-demand metrics for alerts and widgets in external Relays. ([#2440](https://github.com/getsentry/relay/pull/2440))
 
+**Internal**:
+
+- Support ingestion of custom metrics when the `organizations:custom-metrics` feature flag is enabled. ([#2443](https://github.com/getsentry/relay/pull/2443))
+
 ## 23.8.0
 
 **Features**:

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -22,6 +22,9 @@ pub enum Feature {
     /// Extract spans from transactions and convert them to standalone spans.
     #[serde(rename = "projects:extract-standalone-spans")]
     ExtractStandaloneSpans,
+    /// Allow ingestion of metrics in the "custom" namespace.
+    #[serde(rename = "organizations:custom-metrics")]
+    CustomMetrics,
 
     /// Deprecated, still forwarded for older downstream Relays.
     #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -39,8 +39,8 @@ pub enum KafkaTopic {
     Sessions,
     /// Any metric that is extracted from sessions.
     MetricsSessions,
-    /// Any metric that is extracted from transactions.
-    MetricsTransactions,
+    /// Generic metrics topic, excluding sessions (release health).
+    MetricsGeneric,
     /// Profiles
     Profiles,
     /// ReplayEvents, breadcrumb + session updates for replays
@@ -66,7 +66,7 @@ impl KafkaTopic {
             OutcomesBilling,
             Sessions,
             MetricsSessions,
-            MetricsTransactions,
+            MetricsGeneric,
             Profiles,
             ReplayEvents,
             ReplayRecordings,
@@ -94,13 +94,13 @@ pub struct TopicAssignments {
     /// Session health topic name.
     pub sessions: TopicAssignment,
     /// Default topic name for all aggregate metrics. Specialized topics for session-based and
-    /// transaction-based metrics can be configured via `metrics_sessions` and
-    /// `metrics_transactions` each.
+    /// generic metrics can be configured via `metrics_sessions` and `metrics_generic` each.
     pub metrics: TopicAssignment,
     /// Topic name for metrics extracted from sessions. Defaults to the assignment of `metrics`.
     pub metrics_sessions: Option<TopicAssignment>,
-    /// Topic name for metrics extracted from transactions. Defaults to the assignment of `metrics`.
-    pub metrics_transactions: TopicAssignment,
+    /// Topic name for all other kinds of metrics. Defaults to the assignment of `metrics`.
+    #[serde(alias = "metrics_transactions")]
+    pub metrics_generic: TopicAssignment,
     /// Stacktrace topic name
     pub profiles: TopicAssignment,
     /// Replay Events topic name.
@@ -125,7 +125,7 @@ impl TopicAssignments {
             KafkaTopic::OutcomesBilling => self.outcomes_billing.as_ref().unwrap_or(&self.outcomes),
             KafkaTopic::Sessions => &self.sessions,
             KafkaTopic::MetricsSessions => self.metrics_sessions.as_ref().unwrap_or(&self.metrics),
-            KafkaTopic::MetricsTransactions => &self.metrics_transactions,
+            KafkaTopic::MetricsGeneric => &self.metrics_generic,
             KafkaTopic::Profiles => &self.profiles,
             KafkaTopic::ReplayEvents => &self.replay_events,
             KafkaTopic::ReplayRecordings => &self.replay_recordings,
@@ -146,7 +146,7 @@ impl Default for TopicAssignments {
             sessions: "ingest-sessions".to_owned().into(),
             metrics: "ingest-metrics".to_owned().into(),
             metrics_sessions: None,
-            metrics_transactions: "ingest-performance-metrics".to_owned().into(),
+            metrics_generic: "ingest-performance-metrics".to_owned().into(),
             profiles: "profiles".to_owned().into(),
             replay_events: "ingest-replay-events".to_owned().into(),
             replay_recordings: "ingest-replay-recordings".to_owned().into(),

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -6,7 +6,10 @@ use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_config::Config;
 use relay_dynamic_config::{Feature, LimitedProjectConfig, ProjectConfig};
 use relay_filter::matches_any_origin;
-use relay_metrics::{Aggregator, Bucket, InsertMetrics, MergeBuckets, Metric, MetricsContainer};
+use relay_metrics::{
+    Aggregator, Bucket, InsertMetrics, MergeBuckets, Metric, MetricNamespace,
+    MetricResourceIdentifier, MetricsContainer,
+};
 use relay_quotas::{Quota, RateLimits, Scoping};
 use relay_statsd::metric;
 use relay_system::{Addr, BroadcastChannel};
@@ -471,26 +474,59 @@ impl Project {
         self.last_updated_at = Instant::now();
     }
 
-    /// Applies cached rate limits to the given metrics or metrics buckets.
+    /// Removes metrics that should not be ingested.
     ///
-    /// This only applies the rate limits currently stored on the project.
+    ///  - Removes metrics from unsupported or disabled use cases.
+    ///  - Applies **cached** rate limits to the given metrics or metrics buckets.
     fn rate_limit_metrics<T: MetricsContainer>(
         &self,
-        metrics: Vec<T>,
+        mut metrics: Vec<T>,
         outcome_aggregator: Addr<TrackOutcome>,
     ) -> Vec<T> {
-        match (&self.state, self.scoping()) {
-            (Some(state), Some(scoping)) => {
-                match MetricsLimiter::create(metrics, &state.config.quotas, scoping) {
-                    Ok(mut limiter) => {
-                        limiter.enforce_limits(Ok(&self.rate_limits), outcome_aggregator);
-                        limiter.into_metrics()
-                    }
-                    Err(metrics) => metrics,
-                }
-            }
-            _ => metrics,
+        self.filter_metrics(&mut metrics);
+        if metrics.is_empty() {
+            return metrics;
         }
+
+        let (Some(state), Some(scoping)) = (&self.state, self.scoping()) else {
+            return metrics;
+        };
+
+        match MetricsLimiter::create(metrics, &state.config.quotas, scoping) {
+            Ok(mut limiter) => {
+                limiter.enforce_limits(Ok(&self.rate_limits), outcome_aggregator);
+                limiter.into_metrics()
+            }
+            Err(metrics) => metrics,
+        }
+    }
+
+    /// Remove metric buckets that are not allowed to be ingested.
+    fn filter_metrics<T: MetricsContainer>(&self, metrics: &mut Vec<T>) {
+        let Some(state) = &self.state else {
+            return;
+        };
+
+        metrics.retain(|metric| {
+            let Ok(mri) = MetricResourceIdentifier::parse(metric.name()) else {
+                relay_log::trace!(mri = metric.name(), "dropping metrics with invalid MRI");
+                return false;
+            };
+
+            let verdict = match mri.namespace {
+                MetricNamespace::Sessions => true,
+                MetricNamespace::Transactions => true,
+                MetricNamespace::Spans => state.has_feature(Feature::SpanMetricsExtraction),
+                MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
+                MetricNamespace::Unsupported => false,
+            };
+
+            if !verdict {
+                relay_log::trace!(mri = metric.name(), "dropping metric in disabled namespace");
+            }
+
+            verdict
+        });
     }
 
     /// Inserts given [buckets](Bucket) into the metrics aggregator.
@@ -507,6 +543,8 @@ impl Project {
             if !buckets.is_empty() {
                 aggregator.send(MergeBuckets::new(self.project_key, buckets));
             }
+        } else {
+            relay_log::debug!("dropping metric buckets, project disabled");
         }
     }
 
@@ -804,7 +842,7 @@ impl Project {
         &mut self,
         services: Services,
         partition_key: Option<u64>,
-        buckets: Vec<Bucket>,
+        mut buckets: Vec<Bucket>,
     ) {
         let Services {
             aggregator,
@@ -840,6 +878,10 @@ impl Project {
         if project_state.check_disabled(config.as_ref()).is_err() {
             return;
         }
+
+        // Re-run feature flag checks since the project might not have been loaded when the buckets
+        // were initially ingested, or feature flags have changed in the meanwhile.
+        self.filter_metrics(&mut buckets);
 
         // Check rate limits if necessary:
         let quotas = project_state.config.quotas.clone();

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -51,7 +51,7 @@ def processing_config(get_topic_name):
                 "outcomes": get_topic_name("outcomes"),
                 "sessions": get_topic_name("sessions"),
                 "metrics": metrics_topic,
-                "metrics_transactions": metrics_topic,
+                "metrics_generic": metrics_topic,
                 "replay_events": get_topic_name("replay_events"),
                 "replay_recordings": get_topic_name("replay_recordings"),
                 "monitors": get_topic_name("monitors"),

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -168,10 +168,11 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     metrics_consumer = metrics_consumer()
 
     project_id = 42
-    mini_sentry.add_full_project_config(project_id)
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = ["organizations:custom-metrics"]
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = "transactions/foo:42|c\ntransactions/bar@second:17|c"
+    metrics_payload = "transactions/foo:42|c\nbar@second:17|c"
     relay.send_metrics(project_id, metrics_payload, timestamp)
 
     metrics = metrics_by_name(metrics_consumer, 2)
@@ -190,14 +191,12 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
         "timestamp": timestamp,
     }
 
-    assert metrics["headers"]["c:transactions/bar@second"] == [
-        ("namespace", b"transactions")
-    ]
-    assert metrics["c:transactions/bar@second"] == {
+    assert metrics["headers"]["c:custom/bar@second"] == [("namespace", b"custom")]
+    assert metrics["c:custom/bar@second"] == {
         "org_id": 1,
         "project_id": project_id,
         "retention_days": 90,
-        "name": "c:transactions/bar@second",
+        "name": "c:custom/bar@second",
         "tags": {},
         "value": 17.0,
         "type": "c",
@@ -218,7 +217,7 @@ def test_metrics_with_sharded_kafka(
         "processing": {
             "secondary_kafka_configs": {"foo": default_config, "baz": default_config},
             "topics": {
-                "metrics_transactions": {
+                "metrics_generic": {
                     "shards": 3,
                     "mapping": {
                         0: {
@@ -1362,3 +1361,21 @@ def test_span_metrics_secondary_aggregator(
             [("namespace", b"spans")],
         ),
     ]
+
+
+def test_custom_metrics_disabled(mini_sentry, relay_with_processing, metrics_consumer):
+    relay = relay_with_processing(options=TEST_CONFIG)
+    metrics_consumer = metrics_consumer()
+
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    # NOTE: "organizations:custom-metrics" missing from features
+
+    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
+    metrics_payload = "transactions/foo:42|c\nbar@second:17|c"
+    relay.send_metrics(project_id, metrics_payload, timestamp)
+
+    metrics = metrics_by_name(metrics_consumer, 1)
+
+    assert "c:transactions/foo@none" in metrics
+    assert "c:custom/bar@second" not in metrics


### PR DESCRIPTION
Adds a feature flag `organizations:custom-metrics` that enables ingestion of
metrics in the "custom" namespace.

Closes https://github.com/getsentry/relay/issues/2441
Ref https://github.com/getsentry/sentry/issues/55451
