### PR TITLE
feat(spans): Detect multiple SQL table names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,7 @@ dependencies = [
  "serde_urlencoded",
  "similar-asserts",
  "smallvec",
+ "sqlparser",
  "thiserror",
  "url",
 ]
@@ -4282,6 +4283,27 @@ dependencies = [
  "itertools",
  "nom",
  "unicode_categories",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ae05a8250b968a3f7db93155a84d68b2e6cea1583949af5ca5b5170c76c075"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fe75cb4a364c7f7ae06c7dbbc8d84bddd85d6cdf9975963c3935bc1991761e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.7.1"
 smallvec = { version = "1.4.0", features = ["serde"] }
+sqlparser = { version = "0.37.0", features = ["visitor"] }
 thiserror = "1.0.38"
 url = "2.1.1"
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -2,7 +2,6 @@
 //! These are then used for metrics extraction.
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
-use std::time::Instant;
 
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -396,7 +396,7 @@ fn sql_table_from_query(query: &str) -> Option<String> {
                     write!(&mut s, ",{name}").ok();
                 }
             }
-            Some(s)
+            (!s.is_empty()).then_some(s)
         }
         Err(e) => {
             relay_log::debug!("Failed to parse SQL: {e}");

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -605,17 +605,14 @@ mod tests {
         let query = r#"SELECT * FROM "a.b" WHERE "x" = 1"#;
         assert_eq!(
             sql_table_from_query(Some("postgresql"), query).unwrap(),
-            "a.b"
+            "b"
         );
     }
 
     #[test]
     fn extract_table_select_nested() {
         let query = r#"SELECT * FROM (SELECT * FROM "a.b") s WHERE "x" = 1"#;
-        assert_eq!(
-            sql_table_from_query(Some("postgresql"), query).unwrap(),
-            "a.b"
-        );
+        assert_eq!(sql_table_from_query(None, query).unwrap(), "b");
     }
 
     #[test]
@@ -668,10 +665,7 @@ LIMIT 1
     #[test]
     fn extract_table_delete() {
         let query = r#"DELETE FROM "a.b" WHERE "x" = 1"#;
-        assert_eq!(
-            sql_table_from_query(Some("postgresql"), query).unwrap(),
-            "a.b"
-        );
+        assert_eq!(sql_table_from_query(None, query).unwrap(), "b");
     }
 
     #[test]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1127,12 +1127,12 @@ def test_limit_custom_measurements(
     "sent_description, expected_description",
     [
         (
-            "SELECT column FROM table WHERE another_col = %s",
-            "SELECT column FROM table WHERE another_col = %s",
+            "SELECT column FROM table1 WHERE another_col = %s",
+            "SELECT column FROM table1 WHERE another_col = %s",
         ),
         (
-            "SELECT column FROM table WHERE another_col = %s AND yet_another_col = something_very_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
-            "SELECT column FROM table WHERE another_col = %s AND yet_another_col = something_very_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*",
+            "SELECT column FROM table1 WHERE another_col = %s AND yet_another_col = something_very_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+            "SELECT column FROM table1 WHERE another_col = %s AND yet_another_col = something_very_longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*",
         ),
     ],
     ids=["Must not truncate short descriptions", "Must truncate long descriptions"],
@@ -1352,6 +1352,7 @@ def test_span_metrics_secondary_aggregator(
                     "span.action": "SELECT",
                     "span.description": "SELECT %s*",
                     "span.category": "db",
+                    "span.domain": "foo",
                     "span.module": "db",
                     "span.op": "db",
                 },


### PR DESCRIPTION
Previously, we extracted the `span.domain` for SQL spans by looking for the first table name we could find, e.g. `SELECT FROM x` or `UPDATE x = ...`. 

With this change the domain becomes a sorted, comma-separated list of table names, for example for

```sql
SELECT * FROM table1 INNER JOIN table2 ON table2_id = table2.id
```

the span domain becomes `table1,table2`.

This allows us to search for all queries that involve a certain table.

**NOTE:** To reliably find all table names involved in a query, this PR introduces a dependency on `sqlparser`. When parsing the SQL query **fails** (for example because the input query is already truncated) we **fall back** to the previous behavior of extracting a a single table name via regex.

ref: [internal issue](https://www.notion.so/sentry/Concatenate-all-table-names-found-in-a-query-together-21872abfe2664dccb00eeffd4b37e1a4?pvs=4)

#skip-changelog 
