### PR TITLE
fix(globalconfig): Shutdown the service on Relay shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))
 - Fixes the `TraceContext.status` not being defaulted to `unknown` before the new metrics extraction pipeline. ([#2436](https://github.com/getsentry/relay/pull/2436))
 - Support on-demand metrics for alerts and widgets in external Relays. ([#2440](https://github.com/getsentry/relay/pull/2440))
+- Shut the global config service down when Relay is shutting down. ([#2445](https://github.com/getsentry/relay/pull/2445))
 
 ## 23.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Fixes the `TraceContext.status` not being defaulted to `unknown` before the new metrics extraction pipeline. ([#2436](https://github.com/getsentry/relay/pull/2436))
 - Support on-demand metrics for alerts and widgets in external Relays. ([#2440](https://github.com/getsentry/relay/pull/2440))
 - Prevent sporadic data loss in `EnvelopeProcessorService`. ([#2454](https://github.com/getsentry/relay/pull/2454))
-- Shut the global config service down when Relay is shutting down. ([#2445](https://github.com/getsentry/relay/pull/2445))
 
 **Internal**:
 

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -98,7 +98,12 @@ symbolic-unreal = { version = "12.1.2", optional = true, default-features = fals
     "serde",
 ] }
 thiserror = "1.0.38"
-tokio = { version = "1.28.0", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1.28.0", features = [
+    "rt-multi-thread",
+    "sync",
+    "macros",
+    "test-util",
+] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.4.0", default-features = false, features = [
     "catch-panic",

--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -85,9 +85,6 @@ impl UpstreamQuery for GetGlobalConfig {
 pub struct Get;
 
 /// The message for receiving a watch that subscribes to the [`GlobalConfigService`].
-///
-/// On Relay shutdown, the sender of the channel is dropped and receiving new
-/// updates errors.
 pub struct Subscribe;
 
 /// An interface to get [`GlobalConfig`]s through [`GlobalConfigService`].

--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -289,7 +289,7 @@ mod tests {
 
     /// Tests whether the service shuts down gracefully when the signal is
     /// received, without requesting more global configs.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_service_shutdown() {
         for mode in &[ShutdownMode::Graceful, ShutdownMode::Immediate] {
             shutdown_service_with_mode(*mode).await;
@@ -306,7 +306,7 @@ mod tests {
         assert!(service.send(Get).await.is_ok());
 
         Controller::shutdown(mode);
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::advance(Duration::from_millis(200)).await;
 
         assert!(service.send(Get).await.is_err());
     }

--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -289,9 +289,9 @@ mod tests {
 
     use crate::actors::global_config::{Get, GlobalConfigService};
 
-    /// Tests whether the service shuts down gracefully when the signal is
-    /// received, without requesting more global configs.
-    #[tokio::test(start_paused = true)]
+    /// Tests that the service can still handle requests after sending a
+    /// shutdown signal.
+    #[tokio::test]
     async fn test_service_shutdown() {
         for mode in &[ShutdownMode::Graceful, ShutdownMode::Immediate] {
             shutdown_service_with_mode(*mode).await;
@@ -308,8 +308,8 @@ mod tests {
         assert!(service.send(Get).await.is_ok());
 
         Controller::shutdown(mode);
-        tokio::time::advance(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
-        assert!(service.send(Get).await.is_err());
+        assert!(service.send(Get).await.is_ok());
     }
 }

--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -85,6 +85,9 @@ impl UpstreamQuery for GetGlobalConfig {
 pub struct Get;
 
 /// The message for receiving a watch that subscribes to the [`GlobalConfigService`].
+///
+/// On Relay shutdown, the sender of the channel is dropped and receiving new
+/// updates errors.
 pub struct Subscribe;
 
 /// An interface to get [`GlobalConfig`]s through [`GlobalConfigService`].

--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -285,11 +285,12 @@ impl Service for GlobalConfigService {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use relay_config::Config;
     use relay_system::{Controller, Service, ShutdownMode};
     use relay_test::mock_service;
-    use std::sync::Arc;
-    use std::time::Duration;
 
     use crate::actors::global_config::{Get, GlobalConfigService};
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2804,6 +2804,11 @@ impl Service for EnvelopeProcessorService {
                    biased;
 
                     update = subscription.changed(), if !shutdown => {
+                        // During Relay shutdown, the global config service
+                        // stops and drops the sender of the subscription,
+                        // causing updates to fail. Not to lose envelopes, the
+                        // processor should continue processing in-flight
+                        // messages before the network access is revoked.
                         match update {
                             Ok(()) => self.global_config = subscription.borrow().clone(),
                             Err(_) => shutdown = true,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2807,11 +2807,6 @@ impl Service for EnvelopeProcessorService {
                 tokio::select! {
                    biased;
 
-                    // During Relay shutdown, the global config service stops
-                    // and drops the sender of the subscription, causing updates
-                    // to fail. Not to lose envelopes, the processor should
-                    // continue processing in-flight messages before the network
-                    // access is revoked.
                     Ok(()) = subscription.changed() => self.global_config = subscription.borrow().clone(),
                     (Some(message), Ok(permit)) = next_msg => {
                         let service = self.clone();

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2795,14 +2795,20 @@ impl Service for EnvelopeProcessorService {
                 return;
             };
 
+            let mut shutdown = false;
+
             loop {
                 let next_msg = async { tokio::join!(rx.recv(), semaphore.clone().acquire_owned()) };
 
                 tokio::select! {
                    biased;
 
-                    // TODO(iker): deal with the error when the sender of the channel is dropped.
-                    _ = subscription.changed() => self.global_config = subscription.borrow().clone(),
+                    update = subscription.changed(), if !shutdown => {
+                        match update {
+                            Ok(()) => self.global_config = subscription.borrow().clone(),
+                            Err(_) => shutdown = true,
+                        };
+                    },
                     (Some(message), Ok(permit)) = next_msg => {
                         let service = self.clone();
                         tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
When Relay gets a `SIGTERM` and network access is disabled for production pods, the global config service continues to request configs from upstream until Relay gets a `SIGINT` or `SIGQUIT`. As a result, the service can't make network requests and emits error metrics, which can be confused with actual errors.

This PR introduces the shutdown control in the service, shutting it down with Relay and avoiding unnecessary network requests and error metrics. Once the global config service has shut down updates from its subscription will fail, so the processor has been updated accordingly to continue processing the remaining envelopes and avoid data loss.

#skip-changelog