### PR TITLE
chore(self-hosted): Remove self-hosted e2e action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,34 +440,3 @@ jobs:
         run: |
           echo "Testing against ${RELAY_TEST_IMAGE}"
           make test-relay-integration
-
-  self-hosted-end-to-end:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: build
-
-    # Skip redundant checks for library releases
-    if: "!startsWith(github.ref, 'refs/heads/release-library/')"
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Download Docker Image
-        uses: actions/download-artifact@v3
-        with:
-          name: relay-docker-image
-
-      - name: Import Docker Image
-        run: docker load -i relay-docker-image.tgz
-
-      - name: Run Sentry self-hosted e2e CI
-        # Skip for dependabot or if it's a fork as the image cannot be uploaded to ghcr since this test attempts to pull
-        # the image from ghcr
-        if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
-        uses: getsentry/action-self-hosted-e2e-tests@f45ef07793b2cc805a9a9401819f486da449a90a
-        with:
-          project_name: relay
-          image_url: ghcr.io/getsentry/relay:${{ github.event.pull_request.head.sha || github.sha }}
-          docker_repo: getsentry/relay
-          docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}


### PR DESCRIPTION
Job is flaky, and we've decided instead to run this on a more frequent basis until we can invest more into these tests in self-hosted to reduce CI usage.

#skip-changelog