### PR TITLE
feat(monitors): Support sending monitor check-ins as JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `view_names` to `AppContext` ([#2344](https://github.com/getsentry/relay/pull/2344))
 - Tag keys in error events and transaction events can now be up to `200` ASCII characters long. Before, tag keys were limited to 32 characters. ([#2453](https://github.com/getsentry/relay/pull/2453))
+- The Crons monitor check-in APIs have learned to accept JSON via POST. This allows for monitor upserts by specifying the `monitor_config` in the JSON body. ([#2448](https://github.com/getsentry/relay/pull/2448))
 
 **Bug Fixes**:
 

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -129,6 +129,7 @@ pub struct CheckIn {
     pub check_in_id: Uuid,
 
     /// Identifier of the monitor for this check-in.
+    #[serde(default)]
     pub monitor_slug: String,
 
     /// Status of this check-in. Defaults to `"unknown"`.


### PR DESCRIPTION
Implements https://github.com/getsentry/relay/issues/2334 + https://github.com/getsentry/relay/issues/2333

---

Thank you very much @jan-auer for pairing with me on this!