### PR TITLE
feat(schema): Increase the maximum length of event tag keys to 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Tag keys in error events and transaction events can now be up to `200` ASCII characters long. Before, tag keys were limited to 32 characters. ([#2453](https://github.com/getsentry/relay/pull/2453))
+
 **Bug Fixes**:
 
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -545,7 +545,7 @@ mod tests {
         let mut event = Annotated::new(Event {
             tags: Annotated::new(Tags(
                 vec![Annotated::new(TagEntry(
-                    Annotated::new("x".repeat(200)),
+                    Annotated::new("x".repeat(300)),
                     Annotated::new("x".repeat(300)),
                 ))]
                 .into(),
@@ -565,7 +565,7 @@ mod tests {
             json,
             r#"[
   [
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx...",
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...",
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..."
   ]
 ]"#

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -123,14 +123,17 @@ impl MaxChars {
             MaxChars::Symbol => 256,
             MaxChars::Path => 256,
             MaxChars::ShortPath => 128,
-            // these are from constants.py or limits imposed by the database
-            MaxChars::Logger => 64,
-            MaxChars::Email => 75,
-            MaxChars::Culprit => 200,
-            MaxChars::TagKey => 32,
-            MaxChars::TagValue => 200,
-            MaxChars::Environment => 64,
-            MaxChars::Distribution => 64,
+            // These limits below were initially derived from Sentry's original implementation in
+            // Python. Before changing any of these limits, check if the values are inserted into
+            // the database by the Sentry processing pipeline, and if there are limits on the
+            // database column.
+            MaxChars::Logger => 64,       // src/sentry/constants.py:???
+            MaxChars::Email => 75,        // src/sentry/constants.py:MAX_EMAIL_FIELD_LENGTH
+            MaxChars::Culprit => 200,     // src/sentry/constants.py:MAX_CULPRIT_LENGTH
+            MaxChars::TagKey => 200,      // src/sentry/constants.py:MAX_TAG_KEY_LENGTH
+            MaxChars::TagValue => 200,    // src/sentry/constants.py:MAX_TAG_VALUE_LENGTH
+            MaxChars::Environment => 64,  // src/sentry/constants.py:ENVIRONMENT_NAME_MAX_LENGTH
+            MaxChars::Distribution => 64, // src/sentry/models/distribution.py
             MaxChars::Soft(len) | MaxChars::Hard(len) => len,
         }
     }


### PR DESCRIPTION
Transaction event tags are being used to store open telemetry attribute names,
which can easily exceed the current limit of 32 characters. There is no
technical reason for that limit, so we can accommodate for longer attribute
names by increasing the tag value length.

See https://github.com/getsentry/sentry/pull/55608