### PR TITLE
fix(server): Prevent accidental envelope drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))
 - Fixes the `TraceContext.status` not being defaulted to `unknown` before the new metrics extraction pipeline. ([#2436](https://github.com/getsentry/relay/pull/2436))
 - Support on-demand metrics for alerts and widgets in external Relays. ([#2440](https://github.com/getsentry/relay/pull/2440))
+- Prevent sporadic data loss in `EnvelopeProcessorService`. ([#2454](https://github.com/getsentry/relay/pull/2454))
 
 **Internal**:
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2796,11 +2796,16 @@ impl Service for EnvelopeProcessorService {
             };
 
             loop {
-                let next_msg = async { tokio::join!(rx.recv(), semaphore.clone().acquire_owned()) };
+                let next_msg = async {
+                    let permit_result = semaphore.clone().acquire_owned().await;
+                    // `permit_result` might get dropped when this future is cancelled while awaiting
+                    // `rx.recv()`. This is OK though: No envelope is received so the permit is not
+                    // required.
+                    (rx.recv().await, permit_result)
+                };
 
                 tokio::select! {
                    biased;
-
                     // TODO(iker): deal with the error when the sender of the channel is dropped.
                     _ = subscription.changed() => self.global_config = subscription.borrow().clone(),
                     (Some(message), Ok(permit)) = next_msg => {


### PR DESCRIPTION
Using `join!` in combination with `select!` can result in data loss:

1. `rx.recv()` completes and returns data which is now owned by the `join!` future.
2. 
3. Before `semaphore.acquire_owned()` has a chance to complete, `subscription.changed()` completes. All other futures in the `select!` are cancelled.
4. The `join!` future, which has still not completed and thus owns the data returned by `rx.recv()`, is dropped, together with the data.

Fixes https://github.com/getsentry/team-ingest/issues/210.