### PR TITLE
build: Move common dependencies to workspace.dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,7 +3493,6 @@ dependencies = [
  "minidump",
  "multer",
  "once_cell",
- "parking_lot",
  "regex",
  "relay-auth",
  "relay-aws-extension",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,6 @@ checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1419,7 +1418,6 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,12 +3027,12 @@ dependencies = [
  "dialoguer",
  "hostname",
  "once_cell",
- "relay-common",
  "relay-config",
  "relay-log",
  "relay-server",
  "relay-statsd",
  "tikv-jemallocator",
+ "uuid",
 ]
 
 [[package]]
@@ -3049,6 +3049,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -3096,6 +3097,7 @@ dependencies = [
  "sentry-release-parser",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3111,7 +3113,6 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_test",
- "uuid",
 ]
 
 [[package]]
@@ -3132,6 +3133,7 @@ dependencies = [
  "serde_yaml 0.9.17",
  "thiserror",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3201,6 +3203,7 @@ dependencies = [
  "sqlparser",
  "thiserror",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3225,6 +3228,7 @@ dependencies = [
  "similar-asserts",
  "thiserror",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3331,11 +3335,11 @@ version = "23.8.0"
 dependencies = [
  "once_cell",
  "regex",
- "relay-common",
  "serde",
  "serde_json",
  "similar-asserts",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -3385,13 +3389,13 @@ name = "relay-protocol"
 version = "23.8.0"
 dependencies = [
  "num-traits",
- "relay-common",
  "relay-protocol-derive",
  "schemars",
  "serde",
  "serde_json",
  "similar-asserts",
  "smallvec",
+ "uuid",
 ]
 
 [[package]]
@@ -3466,6 +3470,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "unicase",
+ "uuid",
 ]
 
 [[package]]
@@ -3530,6 +3535,7 @@ dependencies = [
  "tower",
  "tower-http",
  "url",
+ "uuid",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
 ] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 itertools = "0.10.5"
+once_cell = "1.13.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
 similar-asserts = "1.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ smallvec = { version = "1.10.0", features = ["serde"] }
 thiserror = "1.0.38"
 tokio = { version = "1.28.0", features = ["macros", "sync", "tracing"] }
 url = "2.1.1"
+uuid = { version = "1.3.0", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "serde",
 ] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
+itertools = "0.10.5"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
 similar-asserts = "1.4.2"
+smallvec = { version = "1.10.0", features = ["serde"] }
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",
 ] }
+clap = { version = "4.1.4" }
 criterion = "0.5"
 futures = { version = "0.3", default-features = false }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ debug = false
 # In release, however, we do want full debug information to report
 # panic and error stack traces to Sentry.
 debug = true
+
+[workspace.dependencies]
+chrono = { version = "0.4.24", default-features = false, features = [
+    "std",
+    "serde",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",
 ] }
+insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ chrono = { version = "0.4.24", default-features = false, features = [
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
+similar-asserts = "1.4.2"
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",
 ] }
+futures = { version = "0.3", default-features = false }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 itertools = "0.10.5"
 once_cell = "1.13.1"
@@ -28,3 +29,4 @@ serde_json = "1.0.93"
 similar-asserts = "1.4.2"
 smallvec = { version = "1.10.0", features = ["serde"] }
 thiserror = "1.0.38"
+tokio = { version = "1.28.0", features = ["macros", "sync", "tracing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",
 ] }
+thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.13.1"
 regex = "1.9.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
+serde_yaml = "0.9.17"
 schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }
 similar-asserts = "1.4.2"
 smallvec = { version = "1.10.0", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ debug = false
 debug = true
 
 [workspace.dependencies]
+anyhow = "1.0.66"
 chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",
 ] }
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = "1.0.93"
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
     "std",
     "serde",
 ] }
+criterion = "0.5"
 futures = { version = "0.3", default-features = false }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 itertools = "0.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ once_cell = "1.13.1"
 regex = "1.9.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
+schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }
 similar-asserts = "1.4.2"
 smallvec = { version = "1.10.0", features = ["serde"] }
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ similar-asserts = "1.4.2"
 smallvec = { version = "1.10.0", features = ["serde"] }
 thiserror = "1.0.38"
 tokio = { version = "1.28.0", features = ["macros", "sync", "tracing"] }
+url = "2.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 itertools = "0.10.5"
 once_cell = "1.13.1"
+regex = "1.9.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
 similar-asserts = "1.4.2"

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -11,10 +11,7 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "0.4.24", default-features = false, features = [
-    "std",
-    "serde",
-] }
+chrono = { workspace = true }
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 thiserror = "1.0.38"
 hmac = "0.12.1"

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 chrono = { workspace = true }
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 hmac = "0.12.1"
 rand = "0.8.5"
 relay-common = { path = "../relay-common" }

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -12,12 +12,13 @@ build = "build.rs"
 
 [dependencies]
 chrono = { workspace = true }
+data-encoding = "2.3.3"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
-thiserror = { workspace = true }
 hmac = "0.12.1"
 rand = "0.8.5"
 relay-common = { path = "../relay-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
-data-encoding = "2.3.3"
+thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = { workspace = true }
 hmac = "0.12.1"
 rand = "0.8.5"
 relay-common = { path = "../relay-common" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 sha2 = "0.10.6"
 data-encoding = "2.3.3"

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -11,7 +11,10 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "0.4.24", default-features = false, features = ["std", "serde"] }
+chrono = { version = "0.4.24", default-features = false, features = [
+    "std",
+    "serde",
+] }
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 thiserror = "1.0.38"
 hmac = "0.12.1"

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -32,10 +32,10 @@ use hmac::{Hmac, Mac};
 use rand::rngs::OsRng;
 use rand::{thread_rng, RngCore};
 use relay_common::time::UnixTimestamp;
-use relay_common::uuid::Uuid;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::Sha512;
+use uuid::Uuid;
 
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
 

--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 relay-log = { path = "../relay-log" }
 relay-system = { path = "../relay-system" }
 reqwest = { version = "0.11.1", features = ["json"] }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { version = "1.28.0" }

--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -15,4 +15,4 @@ relay-system = { path = "../relay-system" }
 reqwest = { version = "0.11.1", features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1.28.0" }
+tokio = { workspace = true }

--- a/relay-base-schema/Cargo.toml
+++ b/relay-base-schema/Cargo.toml
@@ -16,7 +16,7 @@ schemars = { version = "0.8.0", features = [
     "uuid1",
     "chrono",
 ], optional = true }
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }
 
 [features]
 default = []

--- a/relay-base-schema/Cargo.toml
+++ b/relay-base-schema/Cargo.toml
@@ -12,10 +12,7 @@ publish = false
 [dependencies]
 relay-common = { path = "../relay-common" }
 relay-protocol = { path = "../relay-protocol" }
-schemars = { version = "0.8.0", features = [
-    "uuid1",
-    "chrono",
-], optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 
 [features]

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true, features = ["backtrace"] }
 chrono = { workspace = true }
 json-forensics = { version = "0.1.1" }
 lru = "0.9.0"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 regex = "1.9.1"
 relay-auth = { path = "../relay-auth" }
 relay-base-schema = { path = "../relay-base-schema" }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -32,3 +32,4 @@ relay-sampling = { path = "../relay-sampling" }
 sentry-release-parser = { version = "1.3.2", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { workspace = true }
 json-forensics = { version = "0.1.1" }
 lru = "0.9.0"
 once_cell = { workspace = true }
-regex = "1.9.1"
+regex = { workspace = true }
 relay-auth = { path = "../relay-auth" }
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -30,5 +30,5 @@ relay-pii = { path = "../relay-pii" }
 relay-protocol = { path = "../relay-protocol" }
 relay-sampling = { path = "../relay-sampling" }
 sentry-release-parser = { version = "1.3.2", features = ["serde"] }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-chrono = { version = "0.4.24", default-features = false, features = ["std"] }
+chrono = { workspace = true }
 json-forensics = { version = "0.1.1" }
 lru = "0.9.0"
 once_cell = "1.13.1"

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = { version = "1.0.66", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 chrono = { workspace = true }
 json-forensics = { version = "0.1.1" }
 lru = "0.9.0"

--- a/relay-cabi/src/core.rs
+++ b/relay-cabi/src/core.rs
@@ -2,7 +2,7 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::{mem, ptr, slice, str};
 
-use relay_common::uuid::Uuid;
+use uuid::Uuid;
 
 /// A length-prefixed UTF-8 string.
 ///

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4.24", default-features = false, features = ["std"] }
+chrono = { workspace = true }
 globset = "0.4.5"
 lru = "0.9.0"
 once_cell = "1.13.1"

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -15,7 +15,7 @@ globset = "0.4.5"
 lru = "0.9.0"
 once_cell = { workspace = true }
 parking_lot = "0.12.1"
-regex = "1.9.1"
+regex = { workspace = true }
 sentry-types = "0.31.3"
 serde = { workspace = true }
 uuid = { version = "1.3.0", features = ["serde", "v4", "v5"] }

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -18,7 +18,6 @@ parking_lot = "0.12.1"
 regex = { workspace = true }
 sentry-types = "0.31.3"
 serde = { workspace = true }
-uuid = { version = "1.3.0", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
 serde_test = "1.0.125"

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.13.1"
 parking_lot = "0.12.1"
 regex = "1.9.1"
 sentry-types = "0.31.3"
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }
 uuid = { version = "1.3.0", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 chrono = { workspace = true }
 globset = "0.4.5"
 lru = "0.9.0"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 parking_lot = "0.12.1"
 regex = "1.9.1"
 sentry-types = "0.31.3"

--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -14,6 +14,3 @@ pub mod glob3;
 pub mod time;
 
 pub use sentry_types::{Auth, Dsn, ParseAuthError, ParseDsnError, Scheme};
-
-#[doc(inline)]
-pub use uuid;

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 processing = []
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 human-size = "0.4.1"
 num_cpus = "1.13.0"
 relay-auth = { path = "../relay-auth" }

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -26,5 +26,5 @@ relay-redis = { path = "../relay-redis" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_yaml = "0.9.17"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 url = "2.1.1"

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -27,4 +27,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9.17"
 thiserror = { workspace = true }
-url = "2.1.1"
+url = { workspace = true }

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -23,8 +23,8 @@ relay-kafka = { path = "../relay-kafka" }
 relay-log = { path = "../relay-log", features = ["init"] }
 relay-metrics = { path = "../relay-metrics" }
 relay-redis = { path = "../relay-redis" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9.17"
 thiserror = { workspace = true }
 url = "2.1.1"

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -25,6 +25,6 @@ relay-metrics = { path = "../relay-metrics" }
 relay-redis = { path = "../relay-redis" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = "0.9.17"
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -10,7 +10,6 @@ use std::{env, fmt, fs, io};
 
 use anyhow::Context;
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
-use relay_common::uuid::Uuid;
 use relay_common::Dsn;
 use relay_kafka::{
     ConfigError as KafkaConfigError, KafkaConfig, KafkaConfigParam, KafkaTopic, TopicAssignments,
@@ -19,6 +18,7 @@ use relay_metrics::{AggregatorConfig, Condition, Field, MetricNamespace, ScopedA
 use relay_redis::RedisConfig;
 use serde::de::{DeserializeOwned, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
 
 use crate::byte_size::ByteSize;
 use crate::upstream::UpstreamDescriptor;

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 default = []
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 assert-json-diff = "2.0.2"
 relay-auth = { path = "../relay-auth" }
 relay-base-schema = { path = "../relay-base-schema" }

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -28,5 +28,5 @@ serde_json = { workspace = true }
 smallvec = "1.10.0"
 
 [dev-dependencies]
-insta = "1.31.0"
+insta = { workspace = true }
 similar-asserts = "1.4.2"

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -25,7 +25,7 @@ relay-quotas = { path = "../relay-quotas" }
 relay-sampling = { path = "../relay-sampling" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-smallvec = "1.10.0"
+smallvec = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -23,8 +23,8 @@ relay-event-normalization = { path = "../relay-event-normalization" }
 relay-pii = { path = "../relay-pii" }
 relay-quotas = { path = "../relay-quotas" }
 relay-sampling = { path = "../relay-sampling" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 smallvec = "1.10.0"
 
 [dev-dependencies]

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -29,4 +29,4 @@ smallvec = "1.10.0"
 
 [dev-dependencies]
 insta = { workspace = true }
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = { workspace = true }
 url = "2.1.1"
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["json", "redactions", "ron", "yaml"] }
+insta = { workspace = true }
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
 similar-asserts = "1.4.2"
 

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -17,7 +17,7 @@ itertools = { workspace = true }
 maxminddb = "0.23.0"
 md5 = "0.7.0"
 once_cell = { workspace = true }
-regex = "1.9.1"
+regex = { workspace = true }
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -36,7 +36,7 @@ url = "2.1.1"
 [dev-dependencies]
 insta = { workspace = true }
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }
 
 [features]
 default = ["mmap"]

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -31,7 +31,7 @@ serde_urlencoded = "0.7.1"
 smallvec = { workspace = true }
 sqlparser = { version = "0.37.0", features = ["visitor"] }
 thiserror = { workspace = true }
-url = "2.1.1"
+url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -32,6 +32,7 @@ smallvec = { workspace = true }
 sqlparser = { version = "0.37.0", features = ["visitor"] }
 thiserror = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -25,8 +25,8 @@ relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
 relay-ua = { path = "../relay-ua" }
 sentry-release-parser = "1.3.2"
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_urlencoded = "0.7.1"
 smallvec = { version = "1.4.0", features = ["serde"] }
 sqlparser = { version = "0.37.0", features = ["visitor"] }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -16,7 +16,7 @@ dynfmt = { version = "0.1.4", features = ["python", "curly"] }
 itertools = { workspace = true }
 maxminddb = "0.23.0"
 md5 = "0.7.0"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 regex = "1.9.1"
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.55"
 serde_urlencoded = "0.7.1"
 smallvec = { version = "1.4.0", features = ["serde"] }
 sqlparser = { version = "0.37.0", features = ["visitor"] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 url = "2.1.1"
 
 [dev-dependencies]

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -11,11 +11,7 @@ publish = false
 
 [dependencies]
 bytecount = "0.6.0"
-chrono = { version = "0.4.24", default-features = false, features = [
-    "clock",
-    "std",
-    "serde",
-] }
+chrono = { workspace = true, features = ["clock"] }
 dynfmt = { version = "0.1.4", features = ["python", "curly"] }
 itertools = "0.10.5"
 maxminddb = "0.23.0"

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 bytecount = "0.6.0"
 chrono = { workspace = true, features = ["clock"] }
 dynfmt = { version = "0.1.4", features = ["python", "curly"] }
-itertools = "0.10.5"
+itertools = { workspace = true }
 maxminddb = "0.23.0"
 md5 = "0.7.0"
 once_cell = "1.13.1"
@@ -28,7 +28,7 @@ sentry-release-parser = "1.3.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7.1"
-smallvec = { version = "1.4.0", features = ["serde"] }
+smallvec = { workspace = true }
 sqlparser = { version = "0.37.0", features = ["visitor"] }
 thiserror = { workspace = true }
 url = "2.1.1"

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -10,12 +10,12 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use relay_common::uuid::Uuid;
 use relay_event_schema::processor::{ProcessingResult, ProcessingState, Processor};
 use relay_event_schema::protocol::{Event, IpAddr, SpanAttribute};
 use relay_protocol::Meta;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use uuid::Uuid;
 
 mod clock_drift;
 mod event_error;

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1394,7 +1394,6 @@ mod tests {
 
     use chrono::TimeZone;
     use insta::assert_debug_snapshot;
-    use relay_common::uuid::Uuid;
     use relay_event_schema::processor::process_value;
     use relay_event_schema::protocol::{
         Csp, DebugMeta, DeviceContext, Frame, Geo, LenientString, LogEntry, PairList,
@@ -1405,6 +1404,7 @@ mod tests {
     };
     use serde_json::json;
     use similar_asserts::assert_eq;
+    use uuid::Uuid;
 
     use crate::user_agent::ClientHints;
 

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -25,7 +25,7 @@ sentry-release-parser = "1.3.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-url = "2.1.1"
+url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -20,10 +20,7 @@ relay-base-schema = { path = "../relay-base-schema" }
 relay-event-derive = { path = "../relay-event-derive" }
 relay-jsonschema-derive = { path = "../relay-jsonschema-derive", optional = true }
 relay-protocol = { path = "../relay-protocol", features = ["derive"] }
-schemars = { version = "=0.8.10", features = [
-    "uuid1",
-    "chrono",
-], optional = true }
+schemars = { workspace = true, optional = true }
 sentry-release-parser = "1.3.2"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = { workspace = true }
 url = "2.1.1"
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["json", "redactions", "ron", "yaml"] }
+insta = { workspace = true }
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
 similar-asserts = "1.4.2"
 

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -11,11 +11,7 @@ publish = false
 
 [dependencies]
 bytecount = "0.6.0"
-chrono = { version = "0.4.24", default-features = false, features = [
-    "clock",
-    "std",
-    "serde",
-] }
+chrono = { workspace = true, features = ["clock"] }
 cookie = { version = "0.17.0", features = ["percent-encode"] }
 debugid = { version = "0.8.0", features = ["serde"] }
 enumset = "1.0.4"

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -27,7 +27,7 @@ schemars = { version = "=0.8.10", features = [
 sentry-release-parser = "1.3.2"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 url = "2.1.1"
 
 [dev-dependencies]

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -25,8 +25,8 @@ schemars = { version = "=0.8.10", features = [
     "chrono",
 ], optional = true }
 sentry-release-parser = "1.3.2"
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 url = "2.1.1"
 

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -33,7 +33,7 @@ url = "2.1.1"
 [dev-dependencies]
 insta = { workspace = true }
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }
 
 [features]
 jsonschema = [

--- a/relay-event-schema/src/processor/impls.rs
+++ b/relay-event-schema/src/processor/impls.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use enumset::EnumSet;
-use relay_common::uuid::Uuid;
 use relay_protocol::{Annotated, Array, Meta, Object, Value};
+use uuid::Uuid;
 
 use crate::processor::{
     process_value, ProcessValue, ProcessingResult, ProcessingState, Processor, ValueType,

--- a/relay-event-schema/src/protocol/debugmeta.rs
+++ b/relay-event-schema/src/protocol/debugmeta.rs
@@ -3,7 +3,6 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
 use enumset::EnumSet;
-use relay_common::uuid::Uuid;
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;
 use relay_protocol::{
@@ -12,6 +11,7 @@ use relay_protocol::{
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::processor::{ProcessValue, ProcessingResult, ProcessingState, Processor, ValueType};
 use crate::protocol::Addr;

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -2,13 +2,13 @@ use std::fmt;
 use std::str::FromStr;
 
 use relay_common::time;
-use relay_common::uuid::Uuid;
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;
 use relay_protocol::{Annotated, Array, Empty, FromValue, Getter, IntoValue, Object, Val, Value};
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema};
 use sentry_release_parser::Release as ParsedRelease;
+use uuid::Uuid;
 
 use crate::processor::ProcessValue;
 use crate::protocol::{

--- a/relay-event-schema/src/protocol/session.rs
+++ b/relay-event-schema/src/protocol/session.rs
@@ -2,8 +2,8 @@ use std::fmt::{self, Display};
 use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
-use relay_common::uuid::Uuid;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::protocol::utils::null_to_default;
 use crate::protocol::IpAddr;

--- a/relay-ffi/Cargo.toml
+++ b/relay-ffi/Cargo.toml
@@ -10,5 +10,5 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 relay-ffi-macros = { path = "../relay-ffi-macros" }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 ipnetwork = "0.20.0"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 regex = "1.9.1"
 relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -21,5 +21,5 @@ serde = { workspace = true }
 url = "2.1.1"
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["json"] }
+insta = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -17,9 +17,9 @@ relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }
 relay-ua = { path = "../relay-ua" }
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }
 url = "2.1.1"
 
 [dev-dependencies]
 insta = { version = "1.31.0", features = ["json"] }
-serde_json = "1.0.55"
+serde_json = { workspace = true }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -18,7 +18,7 @@ relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }
 relay-ua = { path = "../relay-ua" }
 serde = { workspace = true }
-url = "2.1.1"
+url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 ipnetwork = "0.20.0"
 once_cell = { workspace = true }
-regex = "1.9.1"
+regex = { workspace = true }
 relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -22,7 +22,7 @@ sentry-kafka-schemas = { version = "0.1.12", default_features = false, optional 
 jsonschema = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
-serde_yaml = "0.9.17"
+serde_yaml = { workspace = true }
 
 [features]
 default = []

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -15,8 +15,8 @@ rdkafka-sys = { version = "4.3.0", optional = true }
 relay-log = { path = "../relay-log", optional = true }
 relay-statsd = { path = "../relay-statsd", optional = true }
 rmp-serde = { version = "1.1.1", optional = true }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = { version = "1.0.55", optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 sentry-kafka-schemas = { version = "0.1.12", default_features = false }
 jsonschema = { version = "0.17.0", optional = true }

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -18,7 +18,7 @@ rmp-serde = { version = "1.1.1", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
-sentry-kafka-schemas = { version = "0.1.12", default_features = false }
+sentry-kafka-schemas = { version = "0.1.12", default_features = false, optional = true }
 jsonschema = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
@@ -26,7 +26,7 @@ serde_yaml = "0.9.17"
 
 [features]
 default = []
-schemas = ["dep:jsonschema"]
+schemas = ["dep:jsonschema", "dep:sentry-kafka-schemas"]
 producer = [
   "dep:rdkafka",
   "dep:relay-log",

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -17,7 +17,7 @@ relay-statsd = { path = "../relay-statsd", optional = true }
 rmp-serde = { version = "1.1.1", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = { version = "1.0.55", optional = true }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 sentry-kafka-schemas = { version = "0.1.12", default_features = false }
 jsonschema = { version = "0.17.0", optional = true }
 

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -11,21 +11,31 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "0.4.24", optional = true, default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4.24", optional = true, default-features = false, features = [
+    "clock",
+    "std",
+    "serde",
+] }
 console = { version = "0.15.5", optional = true }
 relay-crash = { path = "../relay-crash", optional = true }
-sentry = { version = "0.31.3", features = ["debug-images", "tower-axum-matched-path", "tracing"], optional = true }
+sentry = { version = "0.31.3", features = [
+    "debug-images",
+    "tower-axum-matched-path",
+    "tracing",
+], optional = true }
 sentry-core = { version = "0.31.3" }
 serde = { version = "1.0.114", features = ["derive"], optional = true }
 serde_json = { version = "1.0.55", optional = true }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json", "time"], optional = true }
+tracing-subscriber = { version = "0.3.17", features = [
+    "env-filter",
+    "json",
+    "time",
+], optional = true }
 
 [features]
 default = []
-test = [
-    "dep:tracing-subscriber",
-]
+test = ["dep:tracing-subscriber"]
 init = [
     "dep:chrono",
     "dep:console",
@@ -34,10 +44,5 @@ init = [
     "dep:serde_json",
     "dep:tracing-subscriber",
 ]
-crash-handler = [
-    "init",
-    "dep:relay-crash",
-]
-sentry = [
-    "dep:sentry",
-]
+crash-handler = ["init", "dep:relay-crash"]
+sentry = ["dep:sentry"]

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -20,8 +20,8 @@ sentry = { version = "0.31.3", features = [
     "tracing",
 ], optional = true }
 sentry-core = { version = "0.31.3" }
-serde = { version = "1.0.114", features = ["derive"], optional = true }
-serde_json = { version = "1.0.55", optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -11,11 +11,7 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "0.4.24", optional = true, default-features = false, features = [
-    "clock",
-    "std",
-    "serde",
-] }
+chrono = { workspace = true, features = ["clock"], optional = true }
 console = { version = "0.15.5", optional = true }
 relay-crash = { path = "../relay-crash", optional = true }
 sentry = { version = "0.31.3", features = [

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -23,14 +23,14 @@ relay-system = { path = "../relay-system" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { version = "1.28.0", features = ["macros", "time"] }
+tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 criterion = "0.5"
 insta = { workspace = true }
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }
-tokio = { version = "1.28.0", features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "aggregator"

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.28.0", features = ["macros", "time"] }
 
 [dev-dependencies]
 criterion = "0.5"
-insta = "1.31.0"
+insta = { workspace = true }
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }
 tokio = { version = "1.28.0", features = ["test-util"] }

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { workspace = true }
 insta = { workspace = true }
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -22,7 +22,7 @@ relay-statsd = { path = "../relay-statsd" }
 relay-system = { path = "../relay-system" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tokio = { version = "1.28.0", features = ["macros", "time"] }
 
 [dev-dependencies]

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -20,8 +20,8 @@ relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
 relay-system = { path = "../relay-system" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1.28.0", features = ["macros", "time"] }
 

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -14,7 +14,7 @@ bytecount = "0.6.0"
 float-ord = "0.3.1"
 fnv = "1.0.7"
 hash32 = "0.3.1"
-itertools = "0.10.5"
+itertools = { workspace = true }
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log" }

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 
 [dependencies]
 relay-common = { path = "../relay-common" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 regex = "1.9.1"
 once_cell = "1.13.1"
 thiserror = { workspace = true }

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -14,7 +14,7 @@ relay-common = { path = "../relay-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1.9.1"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -10,12 +10,12 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-relay-common = { path = "../relay-common" }
+once_cell = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-regex = { workspace = true }
-once_cell = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 similar-asserts = { workspace = true }

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -18,4 +18,4 @@ once_cell = "1.13.1"
 thiserror = { workspace = true }
 
 [dev-dependencies]
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 relay-common = { path = "../relay-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-regex = "1.9.1"
+regex = { workspace = true }
 once_cell = { workspace = true }
 thiserror = { workspace = true }
 

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 regex = "1.9.1"
 once_cell = "1.13.1"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 similar-asserts = "1.4.2"

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -16,8 +16,8 @@
 )]
 #![warn(missing_docs)]
 
-use relay_common::uuid::Uuid;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// Maximum length of monitor slugs.
 const SLUG_LENGTH: usize = 50;

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 hmac = "0.12.1"
 minidump = "0.15.2"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 pest = "2.1.3"
 pest_derive = "2.1.0"
 regex = "1.9.1"

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -23,7 +23,7 @@ relay-protocol = { path = "../relay-protocol" }
 serde = { version = "1.0.114", features = ["derive"] }
 sha1 = "0.10.5"
 smallvec = { version = "1.4.0", features = ["serde"] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 utf16string = "0.2.0"
 
 [dev-dependencies]

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -20,7 +20,7 @@ relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }
 sha1 = "0.10.5"
 smallvec = { version = "1.4.0", features = ["serde"] }
 thiserror = { workspace = true }
@@ -31,7 +31,7 @@ insta = { version = "1.31.0", features = ["json", "redactions", "ron", "yaml"] }
 itertools = "0.10.5"
 pretty-hex = "0.3.0"
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
-serde_json = "1.0.55"
+serde_json = { workspace = true }
 similar-asserts = "1.4.2"
 
 [features]

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = { workspace = true }
 utf16string = "0.2.0"
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["json", "redactions", "ron", "yaml"] }
+insta = { workspace = true }
 itertools = "0.10.5"
 pretty-hex = "0.3.0"
 relay-protocol = { path = "../relay-protocol", features = ["test"] }

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -22,13 +22,13 @@ relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
 serde = { workspace = true }
 sha1 = "0.10.5"
-smallvec = { version = "1.4.0", features = ["serde"] }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 utf16string = "0.2.0"
 
 [dev-dependencies]
 insta = { workspace = true }
-itertools = "0.10.5"
+itertools = { workspace = true }
 pretty-hex = "0.3.0"
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
 serde_json = { workspace = true }

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -15,7 +15,7 @@ minidump = "0.15.2"
 once_cell = { workspace = true }
 pest = "2.1.3"
 pest_derive = "2.1.0"
-regex = "1.9.1"
+regex = { workspace = true }
 relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -32,7 +32,7 @@ itertools = "0.10.5"
 pretty-hex = "0.3.0"
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
 serde_json = { workspace = true }
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }
 
 [features]
 default = []

--- a/relay-pii/src/generate_selectors.rs
+++ b/relay-pii/src/generate_selectors.rs
@@ -158,10 +158,7 @@ mod tests {
             Annotated::<Event>::from_json(r#"{"logentry": {"message": "hi"}}"#).unwrap();
 
         let selectors = selector_suggestions_from_value(&mut event);
-        insta::assert_yaml_snapshot!(selectors, @r###"
-        ---
-        []
-        "###);
+        assert!(selectors.is_empty());
     }
 
     #[test]
@@ -216,44 +213,81 @@ mod tests {
         .unwrap();
 
         let selectors = selector_suggestions_from_value(&mut event);
-        insta::assert_yaml_snapshot!(selectors, @r#"
-        ---
-        - path: $string
-          value: "123"
-        - path: $string
-          value: Divided by zero
-        - path: $string
-          value: Something failed
-        - path: $string
-          value: bar
-        - path: $string
-          value: hi
-        - path: $string
-          value: not really
-        - path: $error.value
-          value: Divided by zero
-        - path: $error.value
-          value: Something failed
-        - path: $frame.abs_path
-          value: foo/bar/baz
-        - path: $frame.filename
-          value: baz
-        - path: $frame.vars
-          value: ~
-        - path: $frame.vars.bam
-          value: bar
-        - path: $frame.vars.foo
-          value: bar
-        - path: $http.headers
-          value: ~
-        - path: $http.headers.Authorization
-          value: not really
-        - path: $message
-          value: hi
-        - path: extra
-          value: ~
-        - path: "extra.'My Custom Value'"
-          value: "123"
-        "#);
+        insta::assert_json_snapshot!(selectors, @r###"
+        [
+          {
+            "path": "$string",
+            "value": "123"
+          },
+          {
+            "path": "$string",
+            "value": "Divided by zero"
+          },
+          {
+            "path": "$string",
+            "value": "Something failed"
+          },
+          {
+            "path": "$string",
+            "value": "bar"
+          },
+          {
+            "path": "$string",
+            "value": "hi"
+          },
+          {
+            "path": "$string",
+            "value": "not really"
+          },
+          {
+            "path": "$error.value",
+            "value": "Divided by zero"
+          },
+          {
+            "path": "$error.value",
+            "value": "Something failed"
+          },
+          {
+            "path": "$frame.abs_path",
+            "value": "foo/bar/baz"
+          },
+          {
+            "path": "$frame.filename",
+            "value": "baz"
+          },
+          {
+            "path": "$frame.vars",
+            "value": null
+          },
+          {
+            "path": "$frame.vars.bam",
+            "value": "bar"
+          },
+          {
+            "path": "$frame.vars.foo",
+            "value": "bar"
+          },
+          {
+            "path": "$http.headers",
+            "value": null
+          },
+          {
+            "path": "$http.headers.Authorization",
+            "value": "not really"
+          },
+          {
+            "path": "$message",
+            "value": "hi"
+          },
+          {
+            "path": "extra",
+            "value": null
+          },
+          {
+            "path": "extra.'My Custom Value'",
+            "value": "123"
+          }
+        ]
+        "###);
     }
 }

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -17,7 +17,7 @@ relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_test = "1.0.125"

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -11,10 +11,7 @@ publish = false
 
 [dependencies]
 android_trace_log = { version = "0.2.0", features = ["serde"] }
-chrono = { version = "0.4.24", default-features = false, features = [
-    "std",
-    "serde",
-] }
+chrono = { workspace = true }
 data-encoding = "2.3.3"
 relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -20,5 +20,5 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 serde_test = "1.0.125"
-insta = "1.31.0"

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 data-encoding = "2.3.3"
 relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 num-traits = "0.2.12"
 relay-common = { path = "../relay-common" }
 relay-protocol-derive = { path = "../relay-protocol-derive", optional = true }
-schemars = { version = "=0.8.10", optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -14,8 +14,8 @@ num-traits = "0.2.12"
 relay-common = { path = "../relay-common" }
 relay-protocol-derive = { path = "../relay-protocol-derive", optional = true }
 schemars = { version = "=0.8.10", optional = true }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 smallvec = { version = "1.4.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 smallvec = { version = "1.4.0", features = ["serde"] }
 
 [dev-dependencies]
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }
 
 [features]
 default = []

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -11,12 +11,12 @@ publish = false
 
 [dependencies]
 num-traits = "0.2.12"
-relay-common = { path = "../relay-common" }
 relay-protocol-derive = { path = "../relay-protocol-derive", optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 similar-asserts = { workspace = true }

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -16,7 +16,7 @@ relay-protocol-derive = { path = "../relay-protocol-derive", optional = true }
 schemars = { version = "=0.8.10", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-smallvec = { version = "1.4.0", features = ["serde"] }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 similar-asserts = { workspace = true }

--- a/relay-protocol/src/impls.rs
+++ b/relay-protocol/src/impls.rs
@@ -1,6 +1,6 @@
-use relay_common::uuid::Uuid;
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
+use uuid::Uuid;
 
 use crate::annotated::{Annotated, MetaMap, MetaTree};
 use crate::macros::derive_string_meta_structure;

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 use std::{fmt, str};
 
-use relay_common::uuid::Uuid;
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::de::{Deserialize, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+use uuid::Uuid;
 
 use crate::annotated::Annotated;
 use crate::meta::Meta;

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -19,7 +19,7 @@ relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log", optional = true }
 relay-redis = { path = "../relay-redis", optional = true }
 serde = { workspace = true }
-smallvec = { version = "1.4.0", features = ["serde"] }
+smallvec = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -20,7 +20,7 @@ relay-log = { path = "../relay-log", optional = true }
 relay-redis = { path = "../relay-redis", optional = true }
 serde = { version = "1.0.114", features = ["derive"] }
 smallvec = { version = "1.4.0", features = ["serde"] }
-thiserror = { version = "1.0.38", optional = true }
+thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { version = "1.31.0", features = ["ron"] }

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -23,5 +23,5 @@ smallvec = { version = "1.4.0", features = ["serde"] }
 thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["ron"] }
+insta = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -18,10 +18,10 @@ relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log", optional = true }
 relay-redis = { path = "../relay-redis", optional = true }
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }
 smallvec = { version = "1.4.0", features = ["serde"] }
 thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { version = "1.31.0", features = ["ron"] }
-serde_json = "1.0.55"
+serde_json = { workspace = true }

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -17,7 +17,7 @@ redis = { version = "0.23.1", optional = true, features = [
     "tls-native-tls",
     "keep-alive",
 ] }
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { workspace = true }
 thiserror = { workspace = true }
 
 [features]

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -18,7 +18,7 @@ redis = { version = "0.23.1", optional = true, features = [
     "keep-alive",
 ] }
 serde = { version = "1.0.114", features = ["derive"] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 
 [features]
 default = []

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -11,7 +11,12 @@ publish = false
 
 [dependencies]
 r2d2 = { version = "0.8.10", optional = true }
-redis = { version = "0.23.1", optional = true, features = ["cluster", "r2d2", "tls-native-tls", "keep-alive"] }
+redis = { version = "0.23.1", optional = true, features = [
+    "cluster",
+    "r2d2",
+    "tls-native-tls",
+    "keep-alive",
+] }
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.38"
 

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -25,4 +25,4 @@ default = []
 impl = ["dep:r2d2", "dep:redis"]
 
 [dev-dependencies]
-serde_yaml = "0.9.17"
+serde_yaml = { workspace = true }

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -24,7 +24,7 @@ serde-transcode = "1.1.1"
 [dev-dependencies]
 assert-json-diff = "2.0.2"
 criterion = "0.5"
-insta = { version = "1.31.0", features = ["ron"] }
+insta = { workspace = true }
 
 [[bench]]
 name = "benchmarks"

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -17,8 +17,8 @@ relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-pii = { path = "../relay-pii" }
 relay-protocol = { path = "../relay-protocol" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = { version = "1.0.55", features = ["raw_value"] }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 serde-transcode = "1.1.1"
 
 [dev-dependencies]

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 flate2 = "1.0.19"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -23,7 +23,7 @@ serde-transcode = "1.1.1"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"
-criterion = "0.5"
+criterion = { workspace = true }
 insta = { workspace = true }
 
 [[bench]]

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -21,6 +21,7 @@ relay-protocol = { path = "../relay-protocol" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 unicase = "2.6.0"
+uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4.24", default-features = false, features = ["std"] }
+chrono = { workspace = true }
 rand = "0.8.5"
 rand_pcg = "0.3.1"
 relay-base-schema = { path = "../relay-base-schema" }

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -18,8 +18,8 @@ relay-common = { path = "../relay-common" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 unicase = "2.6.0"
 
 [dev-dependencies]

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -24,4 +24,4 @@ unicase = "2.6.0"
 
 [dev-dependencies]
 insta = { workspace = true }
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = { workspace = true }
 unicase = "2.6.0"
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["ron"] }
+insta = { workspace = true }
 similar-asserts = "1.4.2"

--- a/relay-sampling/src/dsc.rs
+++ b/relay-sampling/src/dsc.rs
@@ -12,11 +12,11 @@ use std::fmt;
 
 use relay_base_schema::events::EventType;
 use relay_base_schema::project::ProjectKey;
-use relay_common::uuid::Uuid;
 use relay_event_schema::protocol::{Event, TraceContext};
 use relay_protocol::{Getter, Val};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use uuid::Uuid;
 
 /// DynamicSamplingContext created by the first Sentry SDK in the call chain.
 ///

--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -8,9 +8,9 @@ use rand::distributions::Uniform;
 use rand::Rng;
 use rand_pcg::Pcg32;
 use relay_base_schema::events::EventType;
-use relay_common::uuid::Uuid;
 use relay_event_schema::protocol::Event;
 use serde::Serialize;
+use uuid::Uuid;
 
 use crate::config::{
     DecayingFunction, RuleId, RuleType, SamplingConfig, SamplingMode, SamplingRule, SamplingValue,

--- a/relay-sampling/src/lib.rs
+++ b/relay-sampling/src/lib.rs
@@ -90,9 +90,9 @@ mod tests {
     use relay_base_schema::events::EventType;
     use relay_base_schema::project::ProjectKey;
     use relay_common::glob3::GlobPatterns;
-    use relay_common::uuid::Uuid;
     use serde_json::Value;
     use similar_asserts::assert_eq;
+    use uuid::Uuid;
 
     use relay_event_schema::protocol::{
         Event, EventId, Exception, Headers, IpAddr, JsonLenientString, LenientString, LogEntry,

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -25,7 +25,7 @@ processing = [
 ]
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 axum = { version = "0.6.15", features = [
     "headers",
     "macros",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -38,11 +38,7 @@ backoff = "0.4.0"
 brotli = "3.3.4"
 bytecount = "0.6.0"
 bytes = { version = "1.4.0" }
-chrono = { version = "0.4.24", default-features = false, features = [
-    "clock",
-    "std",
-    "serde",
-] }
+chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"
 futures = "0.3"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -43,7 +43,7 @@ data-encoding = "2.3.3"
 flate2 = "1.0.19"
 futures = "0.3"
 hashbrown = "0.13.2"
-itertools = "0.10.5"
+itertools = { workspace = true }
 json-forensics = { version = "0.1.1" }
 mime = "0.3.16"
 minidump = { version = "0.15.2", optional = true }
@@ -82,7 +82,7 @@ reqwest = { version = "0.11.1", features = [
 rmp-serde = "1.1.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
-smallvec = { version = "1.4.0", features = ["serde"] }
+smallvec = { workspace = true }
 sqlx = { version = "0.7.0", features = [
     "macros",
     "migrate",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -49,7 +49,7 @@ mime = "0.3.16"
 minidump = { version = "0.15.2", optional = true }
 multer = "2.0.4"
 once_cell = { workspace = true }
-regex = "1.9.1"
+regex = { workspace = true }
 relay-auth = { path = "../relay-auth" }
 relay-aws-extension = { path = "../relay-aws-extension" }
 relay-base-schema = { path = "../relay-base-schema" }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -104,7 +104,7 @@ tower-http = { version = "0.4.0", default-features = false, features = [
     "set-header",
     "trace",
 ] }
-url = { version = "2.1.1", features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
 zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -49,7 +49,6 @@ mime = "0.3.16"
 minidump = { version = "0.15.2", optional = true }
 multer = "2.0.4"
 once_cell = { workspace = true }
-parking_lot = "0.12.1"
 regex = "1.9.1"
 relay-auth = { path = "../relay-auth" }
 relay-aws-extension = { path = "../relay-aws-extension" }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -48,7 +48,7 @@ json-forensics = { version = "0.1.1" }
 mime = "0.3.16"
 minidump = { version = "0.15.2", optional = true }
 multer = "2.0.4"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 parking_lot = "0.12.1"
 regex = "1.9.1"
 relay-auth = { path = "../relay-auth" }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -115,5 +115,5 @@ relay-event-schema = { path = "../relay-event-schema", features = [
 ] }
 relay-protocol = { path = "../relay-protocol", features = ["test"] }
 relay-test = { path = "../relay-test" }
-similar-asserts = "1.4.2"
+similar-asserts = { workspace = true }
 tempfile = "3.5.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -80,8 +80,8 @@ reqwest = { version = "0.11.1", features = [
     "native-tls-vendored",
 ] }
 rmp-serde = "1.1.1"
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 smallvec = { version = "1.4.0", features = ["serde"] }
 sqlx = { version = "0.7.0", features = [
     "macros",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -109,7 +109,7 @@ url = { version = "2.1.1", features = ["serde"] }
 zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["json", "yaml"] }
+insta = { workspace = true }
 relay-event-schema = { path = "../relay-event-schema", features = [
     "jsonschema",
 ] }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -41,7 +41,7 @@ bytes = { version = "1.4.0" }
 chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"
-futures = "0.3"
+futures = { workspace = true }
 hashbrown = "0.13.2"
 itertools = { workspace = true }
 json-forensics = { version = "0.1.1" }
@@ -93,7 +93,7 @@ symbolic-unreal = { version = "12.1.2", optional = true, default-features = fals
     "serde",
 ] }
 thiserror = { workspace = true }
-tokio = { version = "1.28.0", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.4.0", default-features = false, features = [
     "catch-panic",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -93,7 +93,7 @@ symbolic-common = { version = "12.1.2", optional = true, default-features = fals
 symbolic-unreal = { version = "12.1.2", optional = true, default-features = false, features = [
     "serde",
 ] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tokio = { version = "1.28.0", features = ["rt-multi-thread", "sync", "macros"] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.4.0", default-features = false, features = [

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -105,6 +105,7 @@ tower-http = { version = "0.4.0", default-features = false, features = [
     "trace",
 ] }
 url = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["v5"] }
 zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2827,19 +2827,18 @@ mod tests {
     use std::str::FromStr;
 
     use chrono::{DateTime, TimeZone, Utc};
+    use relay_base_schema::metrics::{DurationUnit, MetricUnit};
     use relay_common::glob2::LazyGlob;
+    use relay_event_normalization::{MeasurementsConfig, RedactionRule, TransactionNameRule};
+    use relay_event_schema::protocol::{EventId, TransactionSource};
+    use relay_pii::DataScrubbingConfig;
     use relay_sampling::condition::RuleCondition;
     use relay_sampling::config::{
         RuleId, RuleType, SamplingConfig, SamplingMode, SamplingRule, SamplingValue,
     };
-    use similar_asserts::assert_eq;
-
-    use relay_base_schema::metrics::{DurationUnit, MetricUnit};
-    use relay_common::uuid::Uuid;
-    use relay_event_normalization::{MeasurementsConfig, RedactionRule, TransactionNameRule};
-    use relay_event_schema::protocol::{EventId, TransactionSource};
-    use relay_pii::DataScrubbingConfig;
     use relay_test::mock_service;
+    use similar_asserts::assert_eq;
+    use uuid::Uuid;
 
     use crate::actors::test_store::TestStore;
     use crate::extractors::RequestMeta;

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2796,7 +2796,10 @@ impl Service for EnvelopeProcessorService {
             };
 
             loop {
-                let next_msg = async { tokio::join!(rx.recv(), semaphore.clone().acquire_owned()) };
+                let next_msg = async {
+                    let permit_result = semaphore.clone().acquire_owned().await;
+                    (rx.recv().await, permit_result)
+                };
 
                 tokio::select! {
                    biased;

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -939,8 +939,8 @@ impl FetchOptionalProjectState {
 mod tests {
     use std::time::Duration;
 
-    use relay_common::uuid::Uuid;
     use relay_test::mock_service;
+    use uuid::Uuid;
 
     use crate::testutils::empty_envelope;
 

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -948,8 +948,8 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use insta::assert_debug_snapshot;
-    use relay_common::uuid::Uuid;
     use relay_test::mock_service;
+    use uuid::Uuid;
 
     use crate::testutils::empty_envelope;
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -9,7 +9,6 @@ use bytes::Bytes;
 use once_cell::sync::OnceCell;
 use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
-use relay_common::uuid::Uuid;
 use relay_config::Config;
 use relay_event_schema::protocol::{
     self, EventId, SessionAggregates, SessionStatus, SessionUpdate,
@@ -21,6 +20,7 @@ use relay_statsd::metric;
 use relay_system::{AsyncResponse, FromMessage, Interface, Sender, Service};
 use serde::ser::Error;
 use serde::Serialize;
+use uuid::Uuid;
 
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::service::ServiceError;

--- a/relay-server/src/endpoints/monitor.rs
+++ b/relay-server/src/endpoints/monitor.rs
@@ -2,11 +2,11 @@ use axum::extract::{DefaultBodyLimit, FromRequest, Path, Query};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{on, MethodFilter, MethodRouter};
-use relay_common::uuid::Uuid;
 use relay_config::Config;
 use relay_event_schema::protocol::EventId;
 use relay_monitors::{CheckIn, CheckInStatus};
 use serde::Deserialize;
+use uuid::Uuid;
 
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{ContentType, Envelope, Item, ItemType};

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -1,9 +1,9 @@
 use relay_common::time::UnixTimestamp;
-use relay_common::uuid::Uuid;
 use relay_event_schema::protocol::{
     AbnormalMechanism, SessionAttributes, SessionErrored, SessionLike, SessionStatus,
 };
 use relay_metrics::Metric;
+use uuid::Uuid;
 
 use crate::metrics_extraction::sessions::types::{
     CommonTags, SessionMetric, SessionSessionTags, SessionUserTags,

--- a/relay-server/src/metrics_extraction/sessions/types.rs
+++ b/relay-server/src/metrics_extraction/sessions/types.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 use std::fmt::{self, Display};
 
 use relay_common::time::UnixTimestamp;
-use relay_common::uuid::Uuid;
 use relay_event_schema::protocol::SessionStatus;
 use relay_metrics::{CounterType, Metric, MetricNamespace, MetricUnit, MetricValue};
+use uuid::Uuid;
 
 use crate::metrics_extraction::IntoMetric;
 

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -42,7 +42,7 @@ pub fn project_state_with_config(sampling_config: SamplingConfig) -> ProjectStat
 
 pub fn create_sampling_context(sample_rate: Option<f64>) -> DynamicSamplingContext {
     DynamicSamplingContext {
-        trace_id: relay_common::uuid::Uuid::new_v4(),
+        trace_id: uuid::Uuid::new_v4(),
         public_key: "12345678901234567890123456789012".parse().unwrap(),
         release: None,
         environment: None,

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -152,7 +152,6 @@ pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
 #[cfg(test)]
 mod tests {
     use relay_base_schema::events::EventType;
-    use relay_common::uuid::Uuid;
     use relay_event_schema::protocol::{EventId, LenientString};
     use relay_protocol::Annotated;
     use relay_sampling::condition::{EqCondOptions, EqCondition, RuleCondition};
@@ -160,6 +159,7 @@ mod tests {
         RuleId, RuleType, SamplingConfig, SamplingMode, SamplingRule, SamplingValue,
     };
     use similar_asserts::assert_eq;
+    use uuid::Uuid;
 
     use super::*;
     use crate::testutils::project_state_with_config;

--- a/relay-server/tests/snapshots/test_fixtures__android__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__android__pii_stripping.snap
@@ -1,522 +1,739 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: ae3a2cc6e08741c5b09946c65c022469
-level: error
-type: error
-culprit: io.sentry.sample.MainActivity in lambda$onCreate$2
-logger: ""
-platform: java
-timestamp: "[timestamp]"
-received: "[received]"
-release: io.sentry.sample-1.0
-dist: "1"
-contexts:
-  app:
-    app_identifier: io.sentry.sample
-    app_version: "1.0"
-    app_build: "1"
-    type: app
-  device:
-    name: Emulator
-    family: Android
-    model: Android SDK built for x86
-    model_id: NYC
-    arch: x86
-    battery_level: 100
-    orientation: portrait
-    manufacturer: Google
-    brand: google
-    screen_resolution: ~
-    screen_density: ~
-    screen_dpi: ~
-    online: true
-    charging: true
-    low_memory: false
-    simulator: true
-    memory_size: ~
-    free_memory: 658702336
-    storage_size: 817143808
-    free_storage: 508784640
-    external_storage_size: 534761472
-    external_free_storage: 534702080
-    boot_time: ~
-    timezone: ~
-    archs:
-      - x86
-    screen_height_pixels: ~
-    screen_width_pixels: ~
-    type: device
-  os:
-    name: Android
-    version: 7.1.1
-    build: sdk_google_phone_x86-userdebug 7.1.1 NYC 5464897 test-keys
-    kernel_version: "Linux version 3.10.0+ (bjoernj@bjoernj.mtv.corp.google.com) (gcc version 4.9.x 20150123 (prerelease) (GCC) ) #256 SMP PREEMPT Fri May 19 11:58:12 PDT 2017"
-    rooted: true
-    type: os
-exception:
-  values:
-    - type: Exception
-      value: "java.lang.Exception: java.lang.Exception: Some exception."
-      module: java.lang
-      stacktrace:
-        frames:
-          - function: main
-            module: com.android.internal.os.ZygoteInit
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 776
-            in_app: false
-          - function: run
-            module: com.android.internal.os.ZygoteInit$MethodAndArgsCaller
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 886
-            in_app: false
-          - function: invoke
-            module: java.lang.reflect.Method
-            filename: Method.java
-            abs_path: Method.java
-            in_app: false
-          - function: main
-            module: android.app.ActivityThread
-            filename: ActivityThread.java
-            abs_path: ActivityThread.java
-            lineno: 6119
-            in_app: false
-          - function: loop
-            module: android.os.Looper
-            filename: Looper.java
-            abs_path: Looper.java
-            lineno: 154
-            in_app: false
-          - function: dispatchMessage
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 95
-            in_app: false
-          - function: handleCallback
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 751
-            in_app: false
-          - function: run
-            module: android.view.View$PerformClick
-            filename: View.java
-            abs_path: View.java
-            lineno: 22429
-            in_app: false
-          - function: performClick
-            module: android.view.View
-            filename: View.java
-            abs_path: View.java
-            lineno: 5637
-            in_app: false
-          - function: onClick
-            module: io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI
-            filename: lambda
-            abs_path: lambda
-            in_app: true
-          - function: lambda$onCreate$2
-            module: io.sentry.sample.MainActivity
-            filename: MainActivity.java
-            abs_path: MainActivity.java
-            lineno: 36
-            in_app: true
-    - type: Exception
-      value: "java.lang.Exception: Some exception."
-      module: java.lang
-      stacktrace:
-        frames:
-          - function: main
-            module: com.android.internal.os.ZygoteInit
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 776
-            in_app: false
-          - function: run
-            module: com.android.internal.os.ZygoteInit$MethodAndArgsCaller
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 886
-            in_app: false
-          - function: invoke
-            module: java.lang.reflect.Method
-            filename: Method.java
-            abs_path: Method.java
-            in_app: false
-          - function: main
-            module: android.app.ActivityThread
-            filename: ActivityThread.java
-            abs_path: ActivityThread.java
-            lineno: 6119
-            in_app: false
-          - function: loop
-            module: android.os.Looper
-            filename: Looper.java
-            abs_path: Looper.java
-            lineno: 154
-            in_app: false
-          - function: dispatchMessage
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 95
-            in_app: false
-          - function: handleCallback
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 751
-            in_app: false
-          - function: run
-            module: android.view.View$PerformClick
-            filename: View.java
-            abs_path: View.java
-            lineno: 22429
-            in_app: false
-          - function: performClick
-            module: android.view.View
-            filename: View.java
-            abs_path: View.java
-            lineno: 5637
-            in_app: false
-          - function: onClick
-            module: io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI
-            filename: lambda
-            abs_path: lambda
-            in_app: true
-          - function: lambda$onCreate$2
-            module: io.sentry.sample.MainActivity
-            filename: MainActivity.java
-            abs_path: MainActivity.java
-            lineno: 36
-            in_app: true
-    - type: Exception
-      value: Some exception.
-      module: java.lang
-      stacktrace:
-        frames:
-          - function: main
-            module: com.android.internal.os.ZygoteInit
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 776
-            in_app: false
-          - function: run
-            module: com.android.internal.os.ZygoteInit$MethodAndArgsCaller
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 886
-            in_app: false
-          - function: invoke
-            module: java.lang.reflect.Method
-            filename: Method.java
-            abs_path: Method.java
-            in_app: false
-          - function: main
-            module: android.app.ActivityThread
-            filename: ActivityThread.java
-            abs_path: ActivityThread.java
-            lineno: 6119
-            in_app: false
-          - function: loop
-            module: android.os.Looper
-            filename: Looper.java
-            abs_path: Looper.java
-            lineno: 154
-            in_app: false
-          - function: dispatchMessage
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 95
-            in_app: false
-          - function: handleCallback
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 751
-            in_app: false
-          - function: run
-            module: android.view.View$PerformClick
-            filename: View.java
-            abs_path: View.java
-            lineno: 22429
-            in_app: false
-          - function: performClick
-            module: android.view.View
-            filename: View.java
-            abs_path: View.java
-            lineno: 5637
-            in_app: false
-          - function: onClick
-            module: io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI
-            filename: lambda
-            abs_path: lambda
-            in_app: true
-          - function: lambda$onCreate$2
-            module: io.sentry.sample.MainActivity
-            filename: MainActivity.java
-            abs_path: MainActivity.java
-            lineno: 36
-            in_app: true
-threads:
-  values:
-    - id: 444
-      name: "|ANR-WatchDog|"
-      stacktrace:
-        frames:
-          - function: run
-            module: io.sentry.android.core.ANRWatchDog
-            filename: ANRWatchDog.java
-            abs_path: ANRWatchDog.java
-            lineno: 66
-            in_app: false
-          - function: sleep
-            module: java.lang.Thread
-            filename: Thread.java
-            abs_path: Thread.java
-            lineno: 313
-            in_app: false
-          - function: sleep
-            module: java.lang.Thread
-            filename: Thread.java
-            abs_path: Thread.java
-            lineno: 371
-            in_app: false
-          - function: sleep
-            module: java.lang.Thread
-            filename: Thread.java
-            abs_path: Thread.java
-            in_app: false
-      crashed: false
-    - id: 437
-      name: HeapTaskDaemon
-      stacktrace:
-        frames:
-          - function: run
-            module: java.lang.Thread
-            filename: Thread.java
-            abs_path: Thread.java
-            lineno: 761
-            in_app: false
-          - function: run
-            module: java.lang.Daemons$HeapTaskDaemon
-            filename: Daemons.java
-            abs_path: Daemons.java
-            lineno: 433
-            in_app: false
-          - function: runHeapTasks
-            module: dalvik.system.VMRuntime
-            filename: VMRuntime.java
-            abs_path: VMRuntime.java
-            in_app: false
-      crashed: false
-    - id: 1
-      name: main
-      stacktrace:
-        frames:
-          - function: main
-            module: com.android.internal.os.ZygoteInit
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 776
-            in_app: false
-          - function: run
-            module: com.android.internal.os.ZygoteInit$MethodAndArgsCaller
-            filename: ZygoteInit.java
-            abs_path: ZygoteInit.java
-            lineno: 886
-            in_app: false
-          - function: invoke
-            module: java.lang.reflect.Method
-            filename: Method.java
-            abs_path: Method.java
-            in_app: false
-          - function: main
-            module: android.app.ActivityThread
-            filename: ActivityThread.java
-            abs_path: ActivityThread.java
-            lineno: 6119
-            in_app: false
-          - function: loop
-            module: android.os.Looper
-            filename: Looper.java
-            abs_path: Looper.java
-            lineno: 154
-            in_app: false
-          - function: dispatchMessage
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 95
-            in_app: false
-          - function: handleCallback
-            module: android.os.Handler
-            filename: Handler.java
-            abs_path: Handler.java
-            lineno: 751
-            in_app: false
-          - function: run
-            module: android.view.View$PerformClick
-            filename: View.java
-            abs_path: View.java
-            lineno: 22429
-            in_app: false
-          - function: performClick
-            module: android.view.View
-            filename: View.java
-            abs_path: View.java
-            lineno: 5637
-            in_app: false
-          - function: onClick
-            module: io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI
-            filename: lambda
-            abs_path: lambda
-            in_app: true
-          - function: lambda$onCreate$2
-            module: io.sentry.sample.MainActivity
-            filename: MainActivity.java
-            abs_path: MainActivity.java
-            lineno: 36
-            in_app: true
-          - function: captureException
-            module: io.sentry.core.Sentry
-            filename: Sentry.java
-            abs_path: Sentry.java
-            lineno: 94
-            in_app: false
-          - function: captureException
-            module: io.sentry.core.IHub
-            filename: IHub.java
-            abs_path: IHub.java
-            lineno: 28
-            in_app: false
-          - function: captureException
-            module: io.sentry.core.Hub
-            filename: Hub.java
-            abs_path: Hub.java
-            lineno: 155
-            in_app: false
-          - function: captureException
-            module: io.sentry.core.ISentryClient
-            filename: ISentryClient.java
-            abs_path: ISentryClient.java
-            lineno: 49
-            in_app: false
-          - function: captureEvent
-            module: io.sentry.core.SentryClient
-            filename: SentryClient.java
-            abs_path: SentryClient.java
-            lineno: 80
-            in_app: false
-          - function: process
-            module: io.sentry.core.MainEventProcessor
-            filename: MainEventProcessor.java
-            abs_path: MainEventProcessor.java
-            lineno: 51
-            in_app: false
-          - function: processNonCachedEvent
-            module: io.sentry.core.MainEventProcessor
-            filename: MainEventProcessor.java
-            abs_path: MainEventProcessor.java
-            lineno: 72
-            in_app: false
-          - function: getCurrentThreads
-            module: io.sentry.core.SentryThreadFactory
-            filename: SentryThreadFactory.java
-            abs_path: SentryThreadFactory.java
-            lineno: 23
-            in_app: false
-          - function: getCurrentThreads
-            module: io.sentry.core.SentryThreadFactory
-            filename: SentryThreadFactory.java
-            abs_path: SentryThreadFactory.java
-            lineno: 35
-            in_app: false
-          - function: getStackTrace
-            module: java.lang.Thread
-            filename: Thread.java
-            abs_path: Thread.java
-            lineno: 1566
-            in_app: false
-          - function: getThreadStackTrace
-            module: dalvik.system.VMStack
-            filename: VMStack.java
-            abs_path: VMStack.java
-            in_app: false
-      crashed: true
-    - id: 443
-      name: FileObserver
-      stacktrace:
-        frames:
-          - function: run
-            module: android.os.FileObserver$ObserverThread
-            filename: FileObserver.java
-            abs_path: FileObserver.java
-            lineno: 86
-            in_app: false
-          - function: observe
-            module: android.os.FileObserver$ObserverThread
-            filename: FileObserver.java
-            abs_path: FileObserver.java
-            in_app: false
-      crashed: false
-sdk:
-  name: sentry.java.android
-  version: 2.0.0-beta01
-  packages:
-    - name: sentry-core
-      version: 2.0.0-beta01
-    - name: sentry-android-core
-      version: 2.0.0-beta01
-    - name: sentry-android-ndk
-      version: 2.0.0-beta01
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      screen_density:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      screen_dpi:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      screen_height_pixels:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      screen_resolution:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      screen_width_pixels:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      timezone:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-
+{
+  "event_id": "ae3a2cc6e08741c5b09946c65c022469",
+  "level": "error",
+  "type": "error",
+  "culprit": "io.sentry.sample.MainActivity in lambda$onCreate$2",
+  "logger": "",
+  "platform": "java",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "io.sentry.sample-1.0",
+  "dist": "1",
+  "contexts": {
+    "app": {
+      "app_identifier": "io.sentry.sample",
+      "app_version": "1.0",
+      "app_build": "1",
+      "type": "app"
+    },
+    "device": {
+      "name": "Emulator",
+      "family": "Android",
+      "model": "Android SDK built for x86",
+      "model_id": "NYC",
+      "arch": "x86",
+      "battery_level": 100.0,
+      "orientation": "portrait",
+      "manufacturer": "Google",
+      "brand": "google",
+      "screen_resolution": null,
+      "screen_density": null,
+      "screen_dpi": null,
+      "online": true,
+      "charging": true,
+      "low_memory": false,
+      "simulator": true,
+      "memory_size": null,
+      "free_memory": 658702336,
+      "storage_size": 817143808,
+      "free_storage": 508784640,
+      "external_storage_size": 534761472,
+      "external_free_storage": 534702080,
+      "boot_time": null,
+      "timezone": null,
+      "archs": [
+        "x86"
+      ],
+      "screen_height_pixels": null,
+      "screen_width_pixels": null,
+      "type": "device"
+    },
+    "os": {
+      "name": "Android",
+      "version": "7.1.1",
+      "build": "sdk_google_phone_x86-userdebug 7.1.1 NYC 5464897 test-keys",
+      "kernel_version": "Linux version 3.10.0+ (bjoernj@bjoernj.mtv.corp.google.com) (gcc version 4.9.x 20150123 (prerelease) (GCC) ) #256 SMP PREEMPT Fri May 19 11:58:12 PDT 2017",
+      "rooted": true,
+      "type": "os"
+    }
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "java.lang.Exception: java.lang.Exception: Some exception.",
+        "module": "java.lang",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "module": "com.android.internal.os.ZygoteInit",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 776,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "com.android.internal.os.ZygoteInit$MethodAndArgsCaller",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 886,
+              "in_app": false
+            },
+            {
+              "function": "invoke",
+              "module": "java.lang.reflect.Method",
+              "filename": "Method.java",
+              "abs_path": "Method.java",
+              "in_app": false
+            },
+            {
+              "function": "main",
+              "module": "android.app.ActivityThread",
+              "filename": "ActivityThread.java",
+              "abs_path": "ActivityThread.java",
+              "lineno": 6119,
+              "in_app": false
+            },
+            {
+              "function": "loop",
+              "module": "android.os.Looper",
+              "filename": "Looper.java",
+              "abs_path": "Looper.java",
+              "lineno": 154,
+              "in_app": false
+            },
+            {
+              "function": "dispatchMessage",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 95,
+              "in_app": false
+            },
+            {
+              "function": "handleCallback",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 751,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "android.view.View$PerformClick",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 22429,
+              "in_app": false
+            },
+            {
+              "function": "performClick",
+              "module": "android.view.View",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 5637,
+              "in_app": false
+            },
+            {
+              "function": "onClick",
+              "module": "io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI",
+              "filename": "lambda",
+              "abs_path": "lambda",
+              "in_app": true
+            },
+            {
+              "function": "lambda$onCreate$2",
+              "module": "io.sentry.sample.MainActivity",
+              "filename": "MainActivity.java",
+              "abs_path": "MainActivity.java",
+              "lineno": 36,
+              "in_app": true
+            }
+          ]
+        }
+      },
+      {
+        "type": "Exception",
+        "value": "java.lang.Exception: Some exception.",
+        "module": "java.lang",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "module": "com.android.internal.os.ZygoteInit",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 776,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "com.android.internal.os.ZygoteInit$MethodAndArgsCaller",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 886,
+              "in_app": false
+            },
+            {
+              "function": "invoke",
+              "module": "java.lang.reflect.Method",
+              "filename": "Method.java",
+              "abs_path": "Method.java",
+              "in_app": false
+            },
+            {
+              "function": "main",
+              "module": "android.app.ActivityThread",
+              "filename": "ActivityThread.java",
+              "abs_path": "ActivityThread.java",
+              "lineno": 6119,
+              "in_app": false
+            },
+            {
+              "function": "loop",
+              "module": "android.os.Looper",
+              "filename": "Looper.java",
+              "abs_path": "Looper.java",
+              "lineno": 154,
+              "in_app": false
+            },
+            {
+              "function": "dispatchMessage",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 95,
+              "in_app": false
+            },
+            {
+              "function": "handleCallback",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 751,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "android.view.View$PerformClick",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 22429,
+              "in_app": false
+            },
+            {
+              "function": "performClick",
+              "module": "android.view.View",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 5637,
+              "in_app": false
+            },
+            {
+              "function": "onClick",
+              "module": "io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI",
+              "filename": "lambda",
+              "abs_path": "lambda",
+              "in_app": true
+            },
+            {
+              "function": "lambda$onCreate$2",
+              "module": "io.sentry.sample.MainActivity",
+              "filename": "MainActivity.java",
+              "abs_path": "MainActivity.java",
+              "lineno": 36,
+              "in_app": true
+            }
+          ]
+        }
+      },
+      {
+        "type": "Exception",
+        "value": "Some exception.",
+        "module": "java.lang",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "module": "com.android.internal.os.ZygoteInit",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 776,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "com.android.internal.os.ZygoteInit$MethodAndArgsCaller",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 886,
+              "in_app": false
+            },
+            {
+              "function": "invoke",
+              "module": "java.lang.reflect.Method",
+              "filename": "Method.java",
+              "abs_path": "Method.java",
+              "in_app": false
+            },
+            {
+              "function": "main",
+              "module": "android.app.ActivityThread",
+              "filename": "ActivityThread.java",
+              "abs_path": "ActivityThread.java",
+              "lineno": 6119,
+              "in_app": false
+            },
+            {
+              "function": "loop",
+              "module": "android.os.Looper",
+              "filename": "Looper.java",
+              "abs_path": "Looper.java",
+              "lineno": 154,
+              "in_app": false
+            },
+            {
+              "function": "dispatchMessage",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 95,
+              "in_app": false
+            },
+            {
+              "function": "handleCallback",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 751,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "android.view.View$PerformClick",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 22429,
+              "in_app": false
+            },
+            {
+              "function": "performClick",
+              "module": "android.view.View",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 5637,
+              "in_app": false
+            },
+            {
+              "function": "onClick",
+              "module": "io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI",
+              "filename": "lambda",
+              "abs_path": "lambda",
+              "in_app": true
+            },
+            {
+              "function": "lambda$onCreate$2",
+              "module": "io.sentry.sample.MainActivity",
+              "filename": "MainActivity.java",
+              "abs_path": "MainActivity.java",
+              "lineno": 36,
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "threads": {
+    "values": [
+      {
+        "id": 444,
+        "name": "|ANR-WatchDog|",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "run",
+              "module": "io.sentry.android.core.ANRWatchDog",
+              "filename": "ANRWatchDog.java",
+              "abs_path": "ANRWatchDog.java",
+              "lineno": 66,
+              "in_app": false
+            },
+            {
+              "function": "sleep",
+              "module": "java.lang.Thread",
+              "filename": "Thread.java",
+              "abs_path": "Thread.java",
+              "lineno": 313,
+              "in_app": false
+            },
+            {
+              "function": "sleep",
+              "module": "java.lang.Thread",
+              "filename": "Thread.java",
+              "abs_path": "Thread.java",
+              "lineno": 371,
+              "in_app": false
+            },
+            {
+              "function": "sleep",
+              "module": "java.lang.Thread",
+              "filename": "Thread.java",
+              "abs_path": "Thread.java",
+              "in_app": false
+            }
+          ]
+        },
+        "crashed": false
+      },
+      {
+        "id": 437,
+        "name": "HeapTaskDaemon",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "run",
+              "module": "java.lang.Thread",
+              "filename": "Thread.java",
+              "abs_path": "Thread.java",
+              "lineno": 761,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "java.lang.Daemons$HeapTaskDaemon",
+              "filename": "Daemons.java",
+              "abs_path": "Daemons.java",
+              "lineno": 433,
+              "in_app": false
+            },
+            {
+              "function": "runHeapTasks",
+              "module": "dalvik.system.VMRuntime",
+              "filename": "VMRuntime.java",
+              "abs_path": "VMRuntime.java",
+              "in_app": false
+            }
+          ]
+        },
+        "crashed": false
+      },
+      {
+        "id": 1,
+        "name": "main",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "module": "com.android.internal.os.ZygoteInit",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 776,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "com.android.internal.os.ZygoteInit$MethodAndArgsCaller",
+              "filename": "ZygoteInit.java",
+              "abs_path": "ZygoteInit.java",
+              "lineno": 886,
+              "in_app": false
+            },
+            {
+              "function": "invoke",
+              "module": "java.lang.reflect.Method",
+              "filename": "Method.java",
+              "abs_path": "Method.java",
+              "in_app": false
+            },
+            {
+              "function": "main",
+              "module": "android.app.ActivityThread",
+              "filename": "ActivityThread.java",
+              "abs_path": "ActivityThread.java",
+              "lineno": 6119,
+              "in_app": false
+            },
+            {
+              "function": "loop",
+              "module": "android.os.Looper",
+              "filename": "Looper.java",
+              "abs_path": "Looper.java",
+              "lineno": 154,
+              "in_app": false
+            },
+            {
+              "function": "dispatchMessage",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 95,
+              "in_app": false
+            },
+            {
+              "function": "handleCallback",
+              "module": "android.os.Handler",
+              "filename": "Handler.java",
+              "abs_path": "Handler.java",
+              "lineno": 751,
+              "in_app": false
+            },
+            {
+              "function": "run",
+              "module": "android.view.View$PerformClick",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 22429,
+              "in_app": false
+            },
+            {
+              "function": "performClick",
+              "module": "android.view.View",
+              "filename": "View.java",
+              "abs_path": "View.java",
+              "lineno": 5637,
+              "in_app": false
+            },
+            {
+              "function": "onClick",
+              "module": "io.sentry.sample.-$$Lambda$MainActivity$tVGPRGxxb8SivUa5SKhzp6BuXOI",
+              "filename": "lambda",
+              "abs_path": "lambda",
+              "in_app": true
+            },
+            {
+              "function": "lambda$onCreate$2",
+              "module": "io.sentry.sample.MainActivity",
+              "filename": "MainActivity.java",
+              "abs_path": "MainActivity.java",
+              "lineno": 36,
+              "in_app": true
+            },
+            {
+              "function": "captureException",
+              "module": "io.sentry.core.Sentry",
+              "filename": "Sentry.java",
+              "abs_path": "Sentry.java",
+              "lineno": 94,
+              "in_app": false
+            },
+            {
+              "function": "captureException",
+              "module": "io.sentry.core.IHub",
+              "filename": "IHub.java",
+              "abs_path": "IHub.java",
+              "lineno": 28,
+              "in_app": false
+            },
+            {
+              "function": "captureException",
+              "module": "io.sentry.core.Hub",
+              "filename": "Hub.java",
+              "abs_path": "Hub.java",
+              "lineno": 155,
+              "in_app": false
+            },
+            {
+              "function": "captureException",
+              "module": "io.sentry.core.ISentryClient",
+              "filename": "ISentryClient.java",
+              "abs_path": "ISentryClient.java",
+              "lineno": 49,
+              "in_app": false
+            },
+            {
+              "function": "captureEvent",
+              "module": "io.sentry.core.SentryClient",
+              "filename": "SentryClient.java",
+              "abs_path": "SentryClient.java",
+              "lineno": 80,
+              "in_app": false
+            },
+            {
+              "function": "process",
+              "module": "io.sentry.core.MainEventProcessor",
+              "filename": "MainEventProcessor.java",
+              "abs_path": "MainEventProcessor.java",
+              "lineno": 51,
+              "in_app": false
+            },
+            {
+              "function": "processNonCachedEvent",
+              "module": "io.sentry.core.MainEventProcessor",
+              "filename": "MainEventProcessor.java",
+              "abs_path": "MainEventProcessor.java",
+              "lineno": 72,
+              "in_app": false
+            },
+            {
+              "function": "getCurrentThreads",
+              "module": "io.sentry.core.SentryThreadFactory",
+              "filename": "SentryThreadFactory.java",
+              "abs_path": "SentryThreadFactory.java",
+              "lineno": 23,
+              "in_app": false
+            },
+            {
+              "function": "getCurrentThreads",
+              "module": "io.sentry.core.SentryThreadFactory",
+              "filename": "SentryThreadFactory.java",
+              "abs_path": "SentryThreadFactory.java",
+              "lineno": 35,
+              "in_app": false
+            },
+            {
+              "function": "getStackTrace",
+              "module": "java.lang.Thread",
+              "filename": "Thread.java",
+              "abs_path": "Thread.java",
+              "lineno": 1566,
+              "in_app": false
+            },
+            {
+              "function": "getThreadStackTrace",
+              "module": "dalvik.system.VMStack",
+              "filename": "VMStack.java",
+              "abs_path": "VMStack.java",
+              "in_app": false
+            }
+          ]
+        },
+        "crashed": true
+      },
+      {
+        "id": 443,
+        "name": "FileObserver",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "run",
+              "module": "android.os.FileObserver$ObserverThread",
+              "filename": "FileObserver.java",
+              "abs_path": "FileObserver.java",
+              "lineno": 86,
+              "in_app": false
+            },
+            {
+              "function": "observe",
+              "module": "android.os.FileObserver$ObserverThread",
+              "filename": "FileObserver.java",
+              "abs_path": "FileObserver.java",
+              "in_app": false
+            }
+          ]
+        },
+        "crashed": false
+      }
+    ]
+  },
+  "sdk": {
+    "name": "sentry.java.android",
+    "version": "2.0.0-beta01",
+    "packages": [
+      {
+        "name": "sentry-core",
+        "version": "2.0.0-beta01"
+      },
+      {
+        "name": "sentry-android-core",
+        "version": "2.0.0-beta01"
+      },
+      {
+        "name": "sentry-android-ndk",
+        "version": "2.0.0-beta01"
+      }
+    ]
+  },
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "screen_density": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "screen_dpi": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "screen_height_pixels": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "screen_resolution": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "screen_width_pixels": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "timezone": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__cocoa__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__cocoa__pii_stripping.snap
@@ -1,1721 +1,2300 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 498b1ef84dd242d4b265fcc39c42f744
-level: fatal
-type: error
-transaction: sentry_ios_cocoapods.ViewController
-logger: ""
-platform: cocoa
-timestamp: "[timestamp]"
-received: "[received]"
-release: io.sentry.sentry-ios-cocoapods-1.0
-dist: "1"
-user:
-  id: "1234"
-  email: 08C2CF67C31871F7BAD220E0702F5C61461C822B
-contexts:
-  app:
-    app_start_time: "2018-07-24T14:36:26Z"
-    device_app_hash: a4f467651d38bc28f815a2cfd5f73748a6cb8853
-    build_type: simulator
-    app_identifier: io.sentry.sentry-ios-cocoapods
-    app_name: sentry-ios-cocoapods
-    app_version: "1.0"
-    app_build: "1"
-    executable_path: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods
-    type: app
-  device:
-    family: iOS
-    model: "iPhone10,5"
-    model_id: simulator
-    arch: x86
-    memory_size: ~
-    free_memory: 170725376
-    usable_memory: 14726877184
-    storage_size: 250030215168
-    boot_time: ~
-    type: device
-  os:
-    name: iOS
-    version: "11.4"
-    build: 17F77
-    kernel_version: "Darwin Kernel Version 17.6.0: Tue May  8 15:22:16 PDT 2018; root:xnu-4570.61.1~1/RELEASE_X86_64"
-    rooted: false
-    type: os
-breadcrumbs:
-  values:
-    - timestamp: 1532442982
-      type: debug
-      category: started
-      level: info
-      message: Breadcrumb Tracking
-    - timestamp: 1532442982
-      type: navigation
-      category: UIViewController
-      level: info
-      message: viewDidAppear
-      data:
-        controller: sentry_ios_cocoapods.ViewController
-    - timestamp: 1532442986
-      type: debug
-      category: started
-      level: info
-      message: Breadcrumb Tracking
-    - timestamp: 1532442986
-      type: navigation
-      category: UIViewController
-      level: info
-      message: viewDidAppear
-      data:
-        controller: sentry_ios_cocoapods.ViewController
-    - timestamp: 1532442987
-      type: user
-      category: touch
-      level: info
-      message: "causeCrash:"
-      data:
-        view: "<UIButton: 0x7f8c0fb0a320; frame = (186.667 415.667; 41 30); opaque = NO; autoresize = RM+BM; layer = <CALayer: 0x60800002e6c0>>"
-    - timestamp: 1532442988
-      type: debug
-      category: started
-      level: info
-      message: Breadcrumb Tracking
-exception:
-  values:
-    - type: EXC_BAD_ACCESS
-      value: "causeCrash: > crash >\nAttempted to dereference null pointer."
-      stacktrace:
-        frames:
-          - function: start
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib
-            image_addr: "0x102c91000"
-            instruction_addr: "0x102c92955"
-            symbol_addr: "0x102c92954"
-          - function: main
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods
-            image_addr: "0x100af2000"
-            instruction_addr: "0x100af5a67"
-            symbol_addr: "0x100af5a30"
-          - function: UIApplicationMain
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x10386a057"
-            symbol_addr: "0x103869fb8"
-          - function: GSEventRunModal
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
-            image_addr: "0x1077fd000"
-            instruction_addr: "0x107809a73"
-            symbol_addr: "0x107809a35"
-          - function: CFRunLoopRunSpecific
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x10262c30b"
-            symbol_addr: "0x10262c090"
-          - function: __CFRunLoopRun
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x10262ca6f"
-            symbol_addr: "0x10262c580"
-          - function: __CFRunLoopDoSources0
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x10262d4af"
-            symbol_addr: "0x10262d3a0"
-          - function: __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x102648bb1"
-            symbol_addr: "0x102648ba0"
-          - function: __handleEventQueueInternal
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1041c92c4"
-            symbol_addr: "0x1041c7b87"
-          - function: __dispatchPreprocessedEventFromEventQueue
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1041c66af"
-            symbol_addr: "0x1041c5bc3"
-          - function: "-[UIApplication sendEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x103885310"
-            symbol_addr: "0x1038851b0"
-          - function: "-[UIWindow sendEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1038e17c1"
-            symbol_addr: "0x1038e07cb"
-          - function: "-[UIWindow _sendTouchesForEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1038e00bf"
-            symbol_addr: "0x1038df616"
-          - function: "-[UIControl touchesEnded:withEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1039e5a09"
-            symbol_addr: "0x1039e57c5"
-          - function: "-[UIControl _sendActionsForEvents:withEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1039e6ac1"
-            symbol_addr: "0x1039e68ff"
-          - function: "-[UIControl sendAction:to:forEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1039e67a4"
-            symbol_addr: "0x1039e6761"
-          - function: "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry
-            image_addr: "0x100b89000"
-            instruction_addr: "0x100b8e91a"
-            symbol_addr: "0x100b8e340"
-          - function: "-[UIApplication sendAction:to:from:forEvent:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x10386b3e8"
-            symbol_addr: "0x10386b395"
-          - function: _T020sentry_ios_cocoapods14ViewControllerC10causeCrashyypFTo
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods
-            image_addr: "0x100af2000"
-            instruction_addr: "0x100af45ec"
-            symbol_addr: "0x100af45a0"
-          - function: _T020sentry_ios_cocoapods14ViewControllerC10causeCrashyypF
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods
-            image_addr: "0x100af2000"
-            instruction_addr: "0x100af4580"
-            symbol_addr: "0x100af44f0"
-          - function: "-[SentryClient crash]"
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry
-            image_addr: "0x100b89000"
-            instruction_addr: "0x100b927c8"
-            symbol_addr: "0x100b927b0"
-        registers:
-          cs: "0x2b"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x5f7f01005f4600"
-          r11: "0x100b927b0"
-          r12: "0x100af622a"
-          r13: "0x100bf9460"
-          r14: "0x60c000114130"
-          r15: "0x7f8c0fb0a320"
-          r8: "0x1f"
-          r9: "0x608000117340"
-          rax: "0x7ffeef10a590"
-          rbp: "0x7ffeef10a550"
-          rbx: "0x7f8c0d703d20"
-          rcx: "0x7ffeef10a590"
-          rdi: "0x608000117340"
-          rdx: "0x303"
-          rflags: "0x10246"
-          rip: "0x100b927c8"
-          rsi: "0x0"
-          rsp: "0x7ffeef10a550"
-      thread_id: 0
-      mechanism:
-        type: mach
-        handled: false
-        meta:
-          signal:
-            number: 10
-            code: 0
-            name: SIGBUS
-            code_name: BUS_NOOP
-          mach_exception:
-            exception: 1
-            code: 0
-            subcode: 8
-            name: EXC_BAD_ACCESS
-threads:
-  values:
-    - id: 0
-      crashed: true
-      current: false
-    - id: 1
-      stacktrace:
-        frames:
-          - function: start_wqthread
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbe9"
-            symbol_addr: "0x10313fbdc"
-          - function: __workq_kernreturn
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310a292"
-            symbol_addr: "0x10310a288"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x0"
-          r11: "0x246"
-          r12: "0x0"
-          r13: "0x70000d9916c0"
-          r14: "0x0"
-          r15: "0x70000d9916e0"
-          r8: "0x10"
-          r9: "0x0"
-          rax: "0x2000170"
-          rbp: "0x70000d991720"
-          rbx: "0x70000d9916f4"
-          rcx: "0x70000d9916b8"
-          rdi: "0x40"
-          rdx: "0x0"
-          rflags: "0x246"
-          rip: "0x10310a292"
-          rsi: "0x70000d991b80"
-          rsp: "0x70000d9916b8"
-      crashed: false
-      current: false
-    - id: 2
-      stacktrace:
-        frames:
-          - function: start_wqthread
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbe9"
-            symbol_addr: "0x10313fbdc"
-          - function: __workq_kernreturn
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310a292"
-            symbol_addr: "0x10310a288"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x0"
-          r11: "0x246"
-          r12: "0x0"
-          r13: "0x70000da149d0"
-          r14: "0x0"
-          r15: "0x70000da149f0"
-          r8: "0x0"
-          r9: "0x990b"
-          rax: "0x2000170"
-          rbp: "0x70000da14a30"
-          rbx: "0x70000da14a04"
-          rcx: "0x70000da149c8"
-          rdi: "0x40"
-          rdx: "0x1"
-          rflags: "0x246"
-          rip: "0x10310a292"
-          rsi: "0x70000da14b80"
-          rsp: "0x70000da149c8"
-      crashed: false
-      current: false
-    - id: 3
-      stacktrace:
-        frames:
-          - function: start_wqthread
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbe9"
-            symbol_addr: "0x10313fbdc"
-          - function: __workq_kernreturn
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310a292"
-            symbol_addr: "0x10310a288"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x0"
-          r11: "0x246"
-          r12: "0x0"
-          r13: "0x70021"
-          r14: "0x0"
-          r15: "0x7"
-          r8: "0x1f"
-          r9: "0x60800005d190"
-          rax: "0x2000170"
-          rbp: "0x70000da97f50"
-          rbx: "0x70000da98000"
-          rcx: "0x70000da97ee8"
-          rdi: "0x4"
-          rdx: "0x0"
-          rflags: "0x246"
-          rip: "0x10310a292"
-          rsi: "0x0"
-          rsp: "0x70000da97ee8"
-      crashed: false
-      current: false
-    - id: 4
-      stacktrace:
-        frames:
-          - function: start_wqthread
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbe9"
-            symbol_addr: "0x10313fbdc"
-          - function: __workq_kernreturn
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310a292"
-            symbol_addr: "0x10310a288"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x0"
-          r11: "0x246"
-          r12: "0x0"
-          r13: "0x70000db1a9f0"
-          r14: "0x0"
-          r15: "0x70000db1aa10"
-          r8: "0x10"
-          r9: "0x0"
-          rax: "0x2000170"
-          rbp: "0x70000db1aa50"
-          rbx: "0x70000db1aa24"
-          rcx: "0x70000db1a9e8"
-          rdi: "0x40"
-          rdx: "0x0"
-          rflags: "0x246"
-          rip: "0x10310a292"
-          rsi: "0x70000db1ab80"
-          rsp: "0x70000db1a9e8"
-      crashed: false
-      current: false
-    - id: 5
-      stacktrace:
-        frames:
-          - function: start_wqthread
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbe9"
-            symbol_addr: "0x10313fbdc"
-          - function: __workq_kernreturn
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310a292"
-            symbol_addr: "0x10310a288"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x0"
-          r11: "0x246"
-          r12: "0x0"
-          r13: "0x70019"
-          r14: "0x0"
-          r15: "0x5"
-          r8: "0x3f"
-          r9: "0x60800005d910"
-          rax: "0x2000170"
-          rbp: "0x70000db9df50"
-          rbx: "0x70000db9e000"
-          rcx: "0x70000db9dee8"
-          rdi: "0x4"
-          rdx: "0x0"
-          rflags: "0x246"
-          rip: "0x10310a292"
-          rsi: "0x0"
-          rsp: "0x70000db9dee8"
-      crashed: false
-      current: false
-    - id: 6
-      name: com.apple.uikit.eventfetch-thread
-      stacktrace:
-        frames:
-          - function: thread_start
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbf9"
-            symbol_addr: "0x10313fbec"
-          - function: _pthread_start
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10314050d"
-            symbol_addr: "0x103140394"
-          - function: _pthread_body
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x103140661"
-            symbol_addr: "0x10314050d"
-          - function: __NSThread__start__
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation
-            image_addr: "0x100c51000"
-            instruction_addr: "0x100c7f3b3"
-            symbol_addr: "0x100c7eeee"
-          - function: "-[UIEventFetcher threadMain]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-            image_addr: "0x103840000"
-            instruction_addr: "0x1044c0ce4"
-            symbol_addr: "0x1044c0c6e"
-          - function: "-[NSRunLoop(NSRunLoop) runUntilDate:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation
-            image_addr: "0x100c51000"
-            instruction_addr: "0x100cee6bf"
-            symbol_addr: "0x100cee630"
-          - function: "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation
-            image_addr: "0x100c51000"
-            instruction_addr: "0x100c71b4a"
-            symbol_addr: "0x100c71a38"
-          - function: CFRunLoopRunSpecific
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x10262c30b"
-            symbol_addr: "0x10262c090"
-          - function: __CFRunLoopRun
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x10262cc19"
-            symbol_addr: "0x10262c580"
-          - function: __CFRunLoopServiceMachPort
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-            image_addr: "0x1025ad000"
-            instruction_addr: "0x10262d7d5"
-            symbol_addr: "0x10262d6f0"
-          - function: mach_msg_trap
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310020a"
-            symbol_addr: "0x103100200"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0xc00"
-          r11: "0x206"
-          r12: "0xc00"
-          r13: "0x7000806"
-          r14: "0x70000dc1fe20"
-          r15: "0xffffffff"
-          r8: "0x1b03"
-          r9: "0xffffffff"
-          rax: "0x100001f"
-          rbp: "0x70000dc1fcf0"
-          rbx: "0x7000806"
-          rcx: "0x70000dc1fc98"
-          rdi: "0x70000dc1fe20"
-          rdx: "0x0"
-          rflags: "0x206"
-          rip: "0x10310020a"
-          rsi: "0x7000806"
-          rsp: "0x70000dc1fc98"
-      crashed: false
-      current: false
-    - id: 7
-      stacktrace:
-        frames:
-          - function: thread_start
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbf9"
-            symbol_addr: "0x10313fbec"
-          - function: _pthread_start
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10314050d"
-            symbol_addr: "0x103140394"
-          - function: _pthread_body
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x103140661"
-            symbol_addr: "0x10314050d"
-          - function: monitorCachedData
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry
-            image_addr: "0x100b89000"
-            instruction_addr: "0x100b98831"
-            symbol_addr: "0x100b987d0"
-          - function: sleep
-            package: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib
-            image_addr: "0x102d09000"
-            instruction_addr: "0x102d83d3e"
-            symbol_addr: "0x102d83d15"
-          - function: __semwait_signal
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x103109d8a"
-            symbol_addr: "0x103109d80"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x1"
-          r11: "0x246"
-          r12: "0x100b987d0"
-          r13: "0x0"
-          r14: "0x70000dca3ea8"
-          r15: "0x70000dca3e98"
-          r8: "0x1"
-          r9: "0x0"
-          rax: "0x200014e"
-          rbp: "0x70000dca3e80"
-          rbx: "0x0"
-          rcx: "0x70000dca3e48"
-          rdi: "0x1403"
-          rdx: "0x1"
-          rflags: "0x246"
-          rip: "0x103109d8a"
-          rsi: "0x0"
-          rsp: "0x70000dca3e48"
-      crashed: false
-      current: false
-    - id: 8
-      stacktrace:
-        frames:
-          - function: thread_start
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10313fbf9"
-            symbol_addr: "0x10313fbec"
-          - function: _pthread_start
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x10314050d"
-            symbol_addr: "0x103140394"
-          - function: _pthread_body
-            package: /usr/lib/system/libsystem_pthread.dylib
-            image_addr: "0x10313d000"
-            instruction_addr: "0x103140661"
-            symbol_addr: "0x10314050d"
-          - function: handleExceptions
-            package: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry
-            image_addr: "0x100b89000"
-            instruction_addr: "0x100badb11"
-            symbol_addr: "0x100bad9f0"
-          - function: mach_msg_trap
-            package: /usr/lib/system/libsystem_kernel.dylib
-            image_addr: "0x1030ed000"
-            instruction_addr: "0x10310020a"
-            symbol_addr: "0x103100200"
-        registers:
-          cs: "0x7"
-          fs: "0x0"
-          gs: "0x0"
-          r10: "0x248"
-          r11: "0x202"
-          r12: "0x248"
-          r13: "0x2"
-          r14: "0x70000dd26ca0"
-          r15: "0x0"
-          r8: "0x9e03"
-          r9: "0x0"
-          rax: "0x100001f"
-          rbp: "0x70000dd26bd0"
-          rbx: "0x2"
-          rcx: "0x70000dd26b78"
-          rdi: "0x70000dd26ca0"
-          rdx: "0x0"
-          rflags: "0x202"
-          rip: "0x10310020a"
-          rsi: "0x2"
-          rsp: "0x70000dd26b78"
-      crashed: false
-      current: false
-    - id: 9
-      stacktrace:
-        frames: ~
-      crashed: false
-      current: true
-tags:
-  - - a
-    - b
-extra:
-  c: d
-debug_meta:
-  images:
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/dyld_sim
-      debug_id: a356f82b-146b-353d-9fc1-250800b6b67c
-      image_addr: "0x100b06000"
-      image_size: 212992
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods
-      debug_id: a42410ed-51f4-3cb8-90bf-acfc063fff54
-      image_addr: "0x100af2000"
-      image_size: 24576
-      image_vmaddr: "0x100000000"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry
-      debug_id: 0a60a189-2ba3-3c17-a865-3f92639d9deb
-      image_addr: "0x100b89000"
-      image_size: 397312
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation
-      debug_id: a00c3fcc-12cc-3076-afbb-bfc6f24741a8
-      image_addr: "0x100c51000"
-      image_size: 3178496
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libobjc.A.dylib
-      debug_id: f2a3c04b-b58a-3336-8226-07eb955662e8
-      image_addr: "0x101271000"
-      image_size: 7008256
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libSystem.dylib
-      debug_id: 8107447d-2e17-3dd6-b0fd-7d8f13db52e8
-      image_addr: "0x101ae0000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit
-      debug_id: 43b826c4-9e66-3533-b688-8873f5c738e5
-      image_addr: "0x103840000"
-      image_size: 18366464
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCore.dylib
-      debug_id: 92c23e3b-8829-3c25-b352-affc4d587080
-      image_addr: "0x101ae8000"
-      image_size: 3493888
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCoreFoundation.dylib
-      debug_id: 00f0f489-b4d0-36b3-b5f4-6e0b967faa3a
-      image_addr: "0x1020e9000"
-      image_size: 16384
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCoreGraphics.dylib
-      debug_id: 9ca6cea8-0a3c-3391-ac6f-33403ed2ab90
-      image_addr: "0x1020f1000"
-      image_size: 73728
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCoreImage.dylib
-      debug_id: 0f9bc395-c472-3094-9675-1fa4beec27d4
-      image_addr: "0x10211e000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftDarwin.dylib
-      debug_id: 53af9ec1-48ff-3e77-8a01-7df99564aee9
-      image_addr: "0x102128000"
-      image_size: 32768
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftDispatch.dylib
-      debug_id: de441136-70b2-3c95-a63f-8474975e98e7
-      image_addr: "0x10213e000"
-      image_size: 110592
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftFoundation.dylib
-      debug_id: c3ab0fe7-1e2d-3f4f-a09a-4aff317a359e
-      image_addr: "0x102189000"
-      image_size: 1515520
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftMetal.dylib
-      debug_id: c1d44eac-9f90-3894-9b28-6030ac665a69
-      image_addr: "0x102440000"
-      image_size: 28672
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftObjectiveC.dylib
-      debug_id: 619a0a7c-70c0-302d-ad7e-b4a44477c11a
-      image_addr: "0x10244e000"
-      image_size: 28672
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftQuartzCore.dylib
-      debug_id: 4e4a6981-3a15-3552-95d2-ee8d9e65a39c
-      image_addr: "0x10245d000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftSwiftOnoneSupport.dylib
-      debug_id: e1eaf4ce-75bf-34fe-9183-c57fb3655ff5
-      image_addr: "0x102468000"
-      image_size: 229376
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftUIKit.dylib
-      debug_id: 0a7e2055-d0a6-3582-83e6-fd24b9b170e7
-      image_addr: "0x1024da000"
-      image_size: 61440
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++.1.dylib
-      debug_id: 5c5e99f8-3e0f-3024-b6e3-3c87bf6d091b
-      image_addr: "0x1024fa000"
-      image_size: 319488
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libz.1.dylib
-      debug_id: 85d4504d-b0e8-332c-8ccb-d7b7ededae37
-      image_addr: "0x102595000"
-      image_size: 77824
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-      debug_id: 89a74ba0-442c-3a88-8ca4-3d201e33a4c2
-      image_addr: "0x1025ad000"
-      image_size: 3678208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++abi.dylib
-      debug_id: 09803d55-2cf0-3cb3-bafa-44a07f736424
-      image_addr: "0x102af9000"
-      image_size: 159744
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcache.dylib
-      debug_id: c7fb7be9-b2a7-3996-abc9-14b3919ff5c4
-      image_addr: "0x102b30000"
-      image_size: 20480
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcommonCrypto.dylib
-      debug_id: e4679a53-b963-38ef-a107-5c503d03d803
-      image_addr: "0x102b3a000"
-      image_size: 45056
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcompiler_rt.dylib
-      debug_id: 64cc3933-a0e0-3218-a5b0-6bc5de9fa558
-      image_addr: "0x102b53000"
-      image_size: 32768
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcopyfile.dylib
-      debug_id: 36a31cb2-f650-3e99-b5fe-123be1438e60
-      image_addr: "0x102b64000"
-      image_size: 40960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcorecrypto.dylib
-      debug_id: 834753ba-07bb-35e1-8b24-1d97e8bfbeba
-      image_addr: "0x102b75000"
-      image_size: 552960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdispatch.dylib
-      debug_id: db8ef273-7794-33d5-90bc-ef6b75b5d38c
-      image_addr: "0x102c1a000"
-      image_size: 225280
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib
-      debug_id: 7743b27f-094f-3ec9-a9dd-14df89d6369f
-      image_addr: "0x102c91000"
-      image_size: 110592
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/liblaunch.dylib
-      debug_id: 08a3db9e-9bcb-3448-bc4e-cc3bd860ac2a
-      image_addr: "0x102cc5000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libmacho.dylib
-      debug_id: 5b5e3511-f5d2-375d-b57c-4d063ce23d0c
-      image_addr: "0x102ccc000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libremovefile.dylib
-      debug_id: 73e9d285-86d9-3463-ad8a-5ec99d3e49b6
-      image_addr: "0x102cd8000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_asl.dylib
-      debug_id: 984be404-07e5-3403-a02b-c2aa21b84fc5
-      image_addr: "0x102cdf000"
-      image_size: 94208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_blocks.dylib
-      debug_id: cb6a9572-2087-3e1f-a242-c6391ffd0698
-      image_addr: "0x102d04000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib
-      debug_id: cfb83b0b-0bfa-3482-92b4-b0c5c2bf24bb
-      image_addr: "0x102d09000"
-      image_size: 540672
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_configuration.dylib
-      debug_id: 7aeb76ec-4f3b-3a5a-a904-afe999f40901
-      image_addr: "0x102db8000"
-      image_size: 16384
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_containermanager.dylib
-      debug_id: f32f9759-4ad2-3227-8a71-1b9938180292
-      image_addr: "0x102dc2000"
-      image_size: 20480
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_coreservices.dylib
-      debug_id: 899320b3-97a7-3a2d-ae6b-11d39d9ca6ea
-      image_addr: "0x102dce000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_darwin.dylib
-      debug_id: 111993ae-367b-3815-9191-2611f3a3c6f3
-      image_addr: "0x102dd5000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_dnssd.dylib
-      debug_id: 6b5f9585-dab8-3794-8ca0-ba176a1923d3
-      image_addr: "0x102ddc000"
-      image_size: 28672
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_info.dylib
-      debug_id: 96bf24a5-a445-312e-944c-953b16ac376f
-      image_addr: "0x102de9000"
-      image_size: 258048
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_m.dylib
-      debug_id: 73c587bb-2774-3498-b763-69c88b182532
-      image_addr: "0x102e3d000"
-      image_size: 299008
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_malloc.dylib
-      debug_id: 01bf1025-1c09-32d1-8075-7768f5a3a47d
-      image_addr: "0x102e93000"
-      image_size: 122880
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_network.dylib
-      debug_id: 9382dffe-4042-34d2-952d-debbd7cf8ff1
-      image_addr: "0x102ebf000"
-      image_size: 856064
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_notify.dylib
-      debug_id: 04b20fc0-4eae-3a21-8695-43d189f92259
-      image_addr: "0x102fd7000"
-      image_size: 40960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sandbox.dylib
-      debug_id: 8db66720-d558-3eb4-ae26-46dd98de3ef6
-      image_addr: "0x102fe9000"
-      image_size: 16384
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_kernel.dylib
-      debug_id: c456329d-6701-3b48-8cdf-bf8467ed501e
-      image_addr: "0x102ff3000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_platform.dylib
-      debug_id: 3ca0cfd4-2965-32b0-af67-7948b9a512dd
-      image_addr: "0x102ffc000"
-      image_size: 12288
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_pthread.dylib
-      debug_id: 85d62046-30cb-34c2-9f50-cdb39e9ea7dc
-      image_addr: "0x103004000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_trace.dylib
-      debug_id: 004f5e16-5889-33d5-a54f-df649f91815a
-      image_addr: "0x10300a000"
-      image_size: 81920
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libunwind.dylib
-      debug_id: 7de3fd88-357b-3535-a00c-3ad23438f231
-      image_addr: "0x10302e000"
-      image_size: 28672
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libxpc.dylib
-      debug_id: c070aa3b-6f2b-3d85-887c-5a00fae39163
-      image_addr: "0x10303b000"
-      image_size: 180224
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_pthread_host.dylib
-      debug_id: cc81462a-9a6c-3b9e-9432-497564a74d2a
-      image_addr: "0x10308e000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/closure/libclosured.dylib
-      debug_id: 57245ea6-791d-3aab-9a54-8891ae1e57ab
-      image_addr: "0x103093000"
-      image_size: 208896
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_platform_host.dylib
-      debug_id: d26c8812-4795-3ab8-88aa-e8ca9e18ee29
-      image_addr: "0x1030e1000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_kernel_host.dylib
-      debug_id: 1dd26c10-f171-3cb1-883f-24a263cdd3c6
-      image_addr: "0x1030e7000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /usr/lib/system/libsystem_kernel.dylib
-      debug_id: d7f2010a-ea32-3f62-90de-85e3c5cc3065
-      image_addr: "0x1030ed000"
-      image_size: 159744
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /usr/lib/system/libsystem_platform.dylib
-      debug_id: 6355ee2d-5456-3ca8-a227-b96e8f1e2af8
-      image_addr: "0x10312d000"
-      image_size: 32768
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /usr/lib/system/libsystem_pthread.dylib
-      debug_id: 0e51ccba-91f2-34e1-bf2a-feefd3d321e4
-      image_addr: "0x10313d000"
-      image_size: 49152
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/MobileCoreServices.framework/MobileCoreServices
-      debug_id: 2cb6a685-3abd-397b-be8c-c215eb1a8dba
-      image_addr: "0x103155000"
-      image_size: 1294336
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libarchive.2.dylib
-      debug_id: bcc36594-0971-3cfd-a904-3ee00de4cfa8
-      image_addr: "0x103390000"
-      image_size: 176128
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libicucore.A.dylib
-      debug_id: 3e7934c4-9ae6-37f3-87fa-ae22ceff82b8
-      image_addr: "0x1033c8000"
-      image_size: 2232320
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libxml2.2.dylib
-      debug_id: baf5b2d7-f616-3f51-b065-8e826a6b6c9f
-      image_addr: "0x105a00000"
-      image_size: 937984
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CFNetwork.framework/CFNetwork
-      debug_id: 92c425d8-fed3-30ba-9f9c-c79c57530f8c
-      image_addr: "0x105b2a000"
-      image_size: 3805184
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration
-      debug_id: a787da85-bb43-3669-b965-9171a9fa0084
-      image_addr: "0x1036cf000"
-      image_size: 397312
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
-      debug_id: 4948e268-e78f-35b4-a641-b516e1f41a34
-      image_addr: "0x106290000"
-      image_size: 442368
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libCRFSuite.dylib
-      debug_id: e7bb1a6f-7503-3485-8f8b-e204dd280070
-      image_addr: "0x10633f000"
-      image_size: 204800
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/liblangid.dylib
-      debug_id: eb66cb86-e39d-3f86-a556-f97554f3d7de
-      image_addr: "0x103768000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libMobileGestalt.dylib
-      debug_id: 73e93331-3e72-36fa-bc0c-eca06e15dbe7
-      image_addr: "0x106387000"
-      image_size: 102400
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libbsm.0.dylib
-      debug_id: 8c63b2fd-e6b7-3614-90a3-e8d5f18f604a
-      image_addr: "0x10376f000"
-      image_size: 69632
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Security.framework/Security
-      debug_id: 371e74a4-bfd0-3dd6-9b3e-b4bcfb54e2c8
-      image_addr: "0x1063e7000"
-      image_size: 1024000
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libsqlite3.dylib
-      debug_id: ad71d820-f713-3c53-8956-2c63b92c1edd
-      image_addr: "0x1065c1000"
-      image_size: 1548288
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcoretls.dylib
-      debug_id: ccd0954e-af64-3f84-9b0c-f100813c43ad
-      image_addr: "0x10676c000"
-      image_size: 94208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcoretls_cfhelpers.dylib
-      debug_id: b45e9ae6-35cb-302d-8dc6-4f99db1f35a4
-      image_addr: "0x10378a000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libnetwork.dylib
-      debug_id: 32e5990d-9650-33cd-a9c2-0d3a589226f4
-      image_addr: "0x106790000"
-      image_size: 1458176
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libapple_nghttp2.dylib
-      debug_id: ee559726-7fc5-3dcf-9972-3dec3d24818d
-      image_addr: "0x106963000"
-      image_size: 94208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libboringssl.dylib
-      debug_id: c3e1afab-67c7-313f-84f4-cc23315ebfe5
-      image_addr: "0x106987000"
-      image_size: 749568
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libusrtcp.dylib
-      debug_id: 0bece6cd-a940-31e9-b325-0111f1819f9b
-      image_addr: "0x106ac3000"
-      image_size: 380928
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libapple_crypto.dylib
-      debug_id: fac182bd-0168-34fc-8315-f020aab2d524
-      image_addr: "0x103792000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libbz2.1.0.dylib
-      debug_id: 2460323f-bbef-3699-95bc-54a86b4dc0fe
-      image_addr: "0x106b31000"
-      image_size: 57344
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/liblzma.5.dylib
-      debug_id: 53e854a1-8f4a-3f14-b4f7-a8ef3ee43e91
-      image_addr: "0x106b44000"
-      image_size: 102400
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/Frameworks/DocumentManager.framework/DocumentManager
-      debug_id: 564e2ffa-43ae-3a58-afd4-31e270ec3475
-      image_addr: "0x106b65000"
-      image_size: 356352
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/FileProvider.framework/FileProvider
-      debug_id: 85a6a3c4-72a8-3b35-a9a6-4278dc5e56ad
-      image_addr: "0x106c15000"
-      image_size: 610304
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UIFoundation.framework/UIFoundation
-      debug_id: b3527499-ee4d-3fdc-b152-b1551e6639fe
-      image_addr: "0x106d2f000"
-      image_size: 991232
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AggregateDictionary.framework/AggregateDictionary
-      debug_id: 6e11cfeb-f786-3402-b6eb-d6e97badfe18
-      image_addr: "0x106eca000"
-      image_size: 20480
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UserNotifications.framework/UserNotifications
-      debug_id: 20623b1b-d5d7-37b8-bef8-91afd7afc536
-      image_addr: "0x106ed7000"
-      image_size: 176128
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices
-      debug_id: 56d5662e-de3a-3d5a-8801-af47e8378f2e
-      image_addr: "0x106f34000"
-      image_size: 376832
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard
-      debug_id: 88c7bba8-1e64-32a9-b48f-66bf3cedb184
-      image_addr: "0x107015000"
-      image_size: 397312
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreUI.framework/CoreUI
-      debug_id: 5505e019-f956-3e63-bec5-a2802b4c3ae8
-      image_addr: "0x1070f2000"
-      image_size: 827392
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/OpenGLES
-      debug_id: b8d9f8f0-1b8f-3d2f-b701-033766745f1b
-      image_addr: "0x107308000"
-      image_size: 53248
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/MobileAsset.framework/MobileAsset
-      debug_id: f6322ef6-997b-3906-90df-ebd0dde5f5d2
-      image_addr: "0x107322000"
-      image_size: 98304
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices
-      debug_id: 2590a752-29cd-3a85-b157-e6767ac083b7
-      image_addr: "0x107355000"
-      image_size: 204800
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreImage.framework/CoreImage
-      debug_id: ed2db79a-efd7-388f-b987-35bde69637f2
-      image_addr: "0x1073cb000"
-      image_size: 2551808
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
-      debug_id: ee602b3e-9730-391a-acdf-80aeeb3c6971
-      image_addr: "0x1077fd000"
-      image_size: 86016
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics
-      debug_id: 3cf1c89f-021c-3c50-8660-bb13cbe9c05a
-      image_addr: "0x10782d000"
-      image_size: 6299648
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/ImageIO.framework/ImageIO
-      debug_id: 1b8a8f42-9d78-3785-a689-eccd4d51a85f
-      image_addr: "0x107f42000"
-      image_size: 5337088
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/QuartzCore.framework/QuartzCore
-      debug_id: 40a28db3-812e-3ee7-870b-dd53fcf43964
-      image_addr: "0x10857c000"
-      image_size: 1806336
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SpringBoardServices.framework/SpringBoardServices
-      debug_id: 46074880-7c9d-3fcd-ad1a-67d04aaa7f61
-      image_addr: "0x10881d000"
-      image_size: 241664
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport
-      debug_id: c01bb93a-891c-3aa8-8f54-1bf65e7f30f4
-      image_addr: "0x1088ac000"
-      image_size: 274432
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreText.framework/CoreText
-      debug_id: 64b538c9-4b73-37d1-917a-4b8af9062751
-      image_addr: "0x108935000"
-      image_size: 1404928
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/TextInput.framework/TextInput
-      debug_id: cacc8683-e618-31c8-84de-15929f3268a8
-      image_addr: "0x108b60000"
-      image_size: 360448
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WebKitLegacy.framework/WebKitLegacy
-      debug_id: d4957e39-bc32-33eb-b1dd-67e4fc71755b
-      image_addr: "0x108c40000"
-      image_size: 1589248
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libAccessibility.dylib
-      debug_id: 0a1df097-46bb-3a1d-8154-8807bae18a55
-      image_addr: "0x108f2c000"
-      image_size: 81920
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Accelerate
-      debug_id: d1ecfb48-90b4-3665-999f-03b22ad35a42
-      image_addr: "0x103796000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PhysicsKit.framework/PhysicsKit
-      debug_id: 2d7992d8-0b8b-328c-9101-0819cbc052a2
-      image_addr: "0x108f66000"
-      image_size: 339968
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/Network.framework/Network
-      debug_id: b7244df3-a73d-3537-b064-425d488e3669
-      image_addr: "0x108fec000"
-      image_size: 606208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/MobileIcons.framework/MobileIcons
-      debug_id: e96558d8-34ae-3c7b-b553-b923a78cecac
-      image_addr: "0x1090e6000"
-      image_size: 40960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DocumentManagerCore.framework/DocumentManagerCore
-      debug_id: 27181094-155d-39b2-8b8d-a9d195e14726
-      image_addr: "0x1090fc000"
-      image_size: 77824
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PlugInKit.framework/PlugInKit
-      debug_id: f1c5285a-8e88-35d3-9c3f-972c6332633a
-      image_addr: "0x109126000"
-      image_size: 143360
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreVideo.framework/CoreVideo
-      debug_id: 135c2dc9-7a30-3080-babf-6f23fc38d381
-      image_addr: "0x10916e000"
-      image_size: 126976
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/vImage
-      debug_id: 4bb6b0b2-4c40-3dd0-ae47-99c26918c861
-      image_addr: "0x1091a8000"
-      image_size: 7856128
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/vecLib
-      debug_id: 93690aa9-fa28-3cef-8b3e-490cd2fc624b
-      image_addr: "0x10379a000"
-      image_size: 4096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libvDSP.dylib
-      debug_id: e233ecf4-ff51-3ffa-a4f3-f0a79fdab073
-      image_addr: "0x1099bd000"
-      image_size: 1540096
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libLAPACK.dylib
-      debug_id: b0760cbf-1efb-3e50-9158-61486066bb25
-      image_addr: "0x109b48000"
-      image_size: 3928064
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libBLAS.dylib
-      debug_id: ccb04ddb-271b-37dc-9ed8-3b7de2c92d1f
-      image_addr: "0x109f56000"
-      image_size: 1716224
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libvMisc.dylib
-      debug_id: 89317eca-178a-33a6-9414-f088027aeb55
-      image_addr: "0x10a11e000"
-      image_size: 630784
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libLinearAlgebra.dylib
-      debug_id: 779fac1b-9f58-30b7-b634-90ffb8a3bbc2
-      image_addr: "0x10a1c9000"
-      image_size: 90112
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libSparse.dylib
-      debug_id: f4b67424-b162-30e9-b631-b6c6dcb13518
-      image_addr: "0x10a1e8000"
-      image_size: 442368
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libSparseBLAS.dylib
-      debug_id: 70ee3e93-d461-379c-99c4-e5452f836a24
-      image_addr: "0x10a26d000"
-      image_size: 77824
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libQuadrature.dylib
-      debug_id: 57390fb3-49f7-3226-9852-62c702199795
-      image_addr: "0x10a288000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libBNNS.dylib
-      debug_id: 8ff94ca4-ee6f-377c-ae9d-c5685d93d91f
-      image_addr: "0x10a292000"
-      image_size: 229376
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcompression.dylib
-      debug_id: f6b2336f-85ae-3273-a0a3-b78d8c3ced39
-      image_addr: "0x10a2d4000"
-      image_size: 98304
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/FontServices
-      debug_id: d2fbb5da-3249-3f52-a3a3-1bf2b8bec350
-      image_addr: "0x10a2f4000"
-      image_size: 8192
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
-      debug_id: 90e9ee62-990a-3bcf-94ec-581a2154cf64
-      image_addr: "0x10a2fb000"
-      image_size: 1097728
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Metal.framework/Metal
-      debug_id: a3e27d9b-a720-3799-a0fd-d80c0bd858f8
-      image_addr: "0x10a4e0000"
-      image_size: 532480
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AppleJPEG.framework/AppleJPEG
-      debug_id: 4a7a020a-d6d4-322c-981d-1af73e9b109e
-      image_addr: "0x10a645000"
-      image_size: 299008
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libCoreFSCache.dylib
-      debug_id: bc6533bb-3f40-3eee-b7f8-fab586b68b61
-      image_addr: "0x10a69d000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ColorSync.framework/ColorSync
-      debug_id: 823de8e2-3ca6-3096-bf03-d49feb3e3974
-      image_addr: "0x10a6a8000"
-      image_size: 548864
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libGFXShared.dylib
-      debug_id: 8bedc9be-133c-3681-b10f-19a44828b5c1
-      image_addr: "0x10a75f000"
-      image_size: 40960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libGLImage.dylib
-      debug_id: 80b69f02-8df2-3f67-b85d-7c81071338dc
-      image_addr: "0x10a771000"
-      image_size: 274432
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libCVMSPluginSupport.dylib
-      debug_id: c787d7ad-1886-31d6-8b5c-d4cc8270a790
-      image_addr: "0x10a7bf000"
-      image_size: 12288
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libCoreVMClient.dylib
-      debug_id: 3ce8485d-64f9-38d0-9f55-a111b7ea8189
-      image_addr: "0x10a7c8000"
-      image_size: 36864
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework//libLLVMContainer.dylib
-      debug_id: 83a809d9-af93-350b-9eb0-1f80e9ad1212
-      image_addr: "0x10a7d9000"
-      image_size: 13275136
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ProtocolBuffer.framework/ProtocolBuffer
-      debug_id: 0535baf2-66bd-3849-86dc-7d2b33c60527
-      image_addr: "0x10b823000"
-      image_size: 126976
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CorePhoneNumbers.framework/CorePhoneNumbers
-      debug_id: 3936b548-6500-38f1-a3e7-3b3ca44aeccd
-      image_addr: "0x10b863000"
-      image_size: 36864
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/TextureIO.framework/TextureIO
-      debug_id: a35af06f-ddd3-3aa7-afd3-c906632020b1
-      image_addr: "0x10b875000"
-      image_size: 839680
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libate.dylib
-      debug_id: a157691a-9409-33af-a3e9-f1c6b2432df7
-      image_addr: "0x10b96c000"
-      image_size: 1048576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FaceCore.framework/FaceCore
-      debug_id: db86f332-9f42-3da0-a332-0db09f1d6ee3
-      image_addr: "0x10ba80000"
-      image_size: 4354048
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libFosl_dynamic.dylib
-      debug_id: cc06c87c-d14f-3b8e-a9b7-1eb902eb37d1
-      image_addr: "0x10c0ce000"
-      image_size: 1875968
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreMedia.framework/CoreMedia
-      debug_id: 046ca873-6df3-3f92-a8d6-fbf7aa31b5c3
-      image_addr: "0x10c2ea000"
-      image_size: 643072
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/VideoToolbox.framework/VideoToolbox
-      debug_id: 1d8fdae3-3092-369c-b0e9-9333778bb794
-      image_addr: "0x10c42e000"
-      image_size: 3112960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SimulatorClient.framework/SimulatorClient
-      debug_id: e0025bc3-188f-34b8-861d-61dc2398b6a9
-      image_addr: "0x10c7c0000"
-      image_size: 16384
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreAudio.framework/CoreAudio
-      debug_id: 5c9ceb71-c095-3ac0-932a-00ae8b5d10ec
-      image_addr: "0x10c7c9000"
-      image_size: 565248
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AppleSauce.framework/AppleSauce
-      debug_id: 2ec28941-a45f-3ac5-95c8-55e7401d1c68
-      image_addr: "0x10c883000"
-      image_size: 167936
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ManagedConfiguration.framework/ManagedConfiguration
-      debug_id: bd390f61-c63a-316a-bf6c-527cd7ac11c5
-      image_addr: "0x10c8b8000"
-      image_size: 1060864
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accounts.framework/Accounts
-      debug_id: 9405ecc3-f02b-32ad-90a5-2bbc32512586
-      image_addr: "0x10cac0000"
-      image_size: 356352
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PersistentConnection.framework/PersistentConnection
-      debug_id: cd5c2c68-916e-36ee-b8b6-e02fb23a8e55
-      image_addr: "0x10cb6e000"
-      image_size: 176128
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DataMigration.framework/DataMigration
-      debug_id: c2277c44-5c37-37d2-8f2c-7d440244aef9
-      image_addr: "0x10cbc6000"
-      image_size: 36864
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreTelephony.framework/CoreTelephony
-      debug_id: b6efd824-477a-3862-b830-bc7547f5203a
-      image_addr: "0x10cbdc000"
-      image_size: 598016
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices
-      debug_id: ec5a6474-4e00-3e99-bdd0-3f5d1017af53
-      image_addr: "0x10ccf1000"
-      image_size: 94208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreData.framework/CoreData
-      debug_id: de294808-6981-31a8-be57-9e02916812cc
-      image_addr: "0x10cd2e000"
-      image_size: 3403776
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CommonUtilities.framework/CommonUtilities
-      debug_id: 97fba9be-c7d5-3e2b-b067-435630dbfa34
-      image_addr: "0x10d27b000"
-      image_size: 90112
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcupolicy.dylib
-      debug_id: e2a2232b-8875-33e8-96a5-e974bc36d537
-      image_addr: "0x10d2a7000"
-      image_size: 32768
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libTelephonyUtilDynamic.dylib
-      debug_id: f5e7a693-fa13-3900-9624-2fbf1d22b8c9
-      image_addr: "0x10d2b9000"
-      image_size: 245760
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/StreamingZip.framework/StreamingZip
-      debug_id: 571aaad0-f7b7-3a7c-b1ca-39e390d1c86d
-      image_addr: "0x10d340000"
-      image_size: 159744
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore
-      debug_id: 7ac56c8c-5423-3a0d-85bf-6c4259631a21
-      image_addr: "0x10d384000"
-      image_size: 10702848
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WebCore.framework/WebCore
-      debug_id: 3942e6eb-75b2-3633-b1cc-8cca5b14b6a1
-      image_addr: "0x10e074000"
-      image_size: 25214976
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WebCore.framework/Frameworks/libwebrtc.dylib
-      debug_id: 7c152773-f29f-3103-b2e0-2b75ef5fdd23
-      image_addr: "0x1106b1000"
-      image_size: 5894144
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/AudioToolbox.framework/AudioToolbox
-      debug_id: 398f11ef-74d5-30e2-b982-5011a0445044
-      image_addr: "0x110e67000"
-      image_size: 4554752
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libAudioStatistics.dylib
-      debug_id: c28dc050-88cb-3b4d-8321-b12fbb2df34c
-      image_addr: "0x1114a6000"
-      image_size: 45056
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WirelessDiagnostics.framework/WirelessDiagnostics
-      debug_id: e8853a59-84d0-3e36-82f0-e9e39f5d338b
-      image_addr: "0x1114bd000"
-      image_size: 278528
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/RTCReporting.framework/RTCReporting
-      debug_id: b06bd3ce-4fc6-3fbf-8ffa-528e61d4042f
-      image_addr: "0x111533000"
-      image_size: 36864
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/TCC.framework/TCC
-      debug_id: 7c485ad6-c00b-348c-8338-3c4520ac477a
-      image_addr: "0x11154a000"
-      image_size: 28672
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libAWDSupportFramework.dylib
-      debug_id: bdad7136-805f-3875-b17d-1e8ea8562f21
-      image_addr: "0x11155c000"
-      image_size: 987136
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libprotobuf-lite.dylib
-      debug_id: 0ab656df-4f5b-3d31-ade8-c7f21a9e1908
-      image_addr: "0x11176f000"
-      image_size: 73728
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics
-      debug_id: 625da12d-3bfd-34cd-866e-50cb7319ae72
-      image_addr: "0x111798000"
-      image_size: 184320
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libprotobuf.dylib
-      debug_id: ae118836-7217-3fe7-b587-c0b38f475e1c
-      image_addr: "0x1117ee000"
-      image_size: 401408
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/MediaAccessibility.framework/MediaAccessibility
-      debug_id: d945a756-a7a4-3873-859e-d03b222ca8fc
-      image_addr: "0x1118a7000"
-      image_size: 45056
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftos.dylib
-      debug_id: f1418fa3-2b3d-3e9e-949e-e4f7d949bec8
-      image_addr: "0x1118c3000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libMobileGestaltExtensions.dylib
-      debug_id: e59792e5-b59d-3f38-9f7e-23a430743e5f
-      image_addr: "0x11376b000"
-      image_size: 40960
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/Libraries/libCGInterfaces.dylib
-      debug_id: 0eaf93d8-df5c-35c5-ae09-9952ddd7e908
-      image_addr: "0x113795000"
-      image_size: 94208
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/libGSFontCache.dylib
-      debug_id: b2bd1945-1691-385b-93b9-6e981156bcd6
-      image_addr: "0x1137c1000"
-      image_size: 73728
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ConstantClasses.framework/ConstantClasses
-      debug_id: 6d6c2054-3c39-3dc9-8a79-c7f70c8c358f
-      image_addr: "0x113a91000"
-      image_size: 24576
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/libTrueTypeScaler.dylib
-      debug_id: 9b6edafe-30e4-3420-9a3c-f5bc39902fa2
-      image_addr: "0x113da2000"
-      image_size: 208896
-      image_vmaddr: "0x0"
-      type: macho
-    - code_file: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UserManagement.framework/UserManagement
-      debug_id: 7aa6ada1-9c31-34e2-829d-cc2f30dc4228
-      image_addr: "0x113e06000"
-      image_size: 81920
-      image_vmaddr: "0x0"
-      type: macho
-sdk:
-  name: sentry-cocoa
-  version: 4.0.1
-errors:
-  - type: invalid_data
-    name: threads.values.9.stacktrace.frames
-    reason: expected a non-empty value
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-  threads:
-    values:
-      "9":
-        stacktrace:
-          frames:
-            "":
-              err:
-                - - invalid_data
-                  - reason: expected a non-empty value
-  user:
-    email:
-      "":
-        rem:
-          - - "@anything:hash"
-            - p
-            - 0
-            - 40
-        len: 15
-
+{
+  "event_id": "498b1ef84dd242d4b265fcc39c42f744",
+  "level": "fatal",
+  "type": "error",
+  "transaction": "sentry_ios_cocoapods.ViewController",
+  "logger": "",
+  "platform": "cocoa",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "io.sentry.sentry-ios-cocoapods-1.0",
+  "dist": "1",
+  "user": {
+    "id": "1234",
+    "email": "08C2CF67C31871F7BAD220E0702F5C61461C822B"
+  },
+  "contexts": {
+    "app": {
+      "app_start_time": "2018-07-24T14:36:26Z",
+      "device_app_hash": "a4f467651d38bc28f815a2cfd5f73748a6cb8853",
+      "build_type": "simulator",
+      "app_identifier": "io.sentry.sentry-ios-cocoapods",
+      "app_name": "sentry-ios-cocoapods",
+      "app_version": "1.0",
+      "app_build": "1",
+      "executable_path": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods",
+      "type": "app"
+    },
+    "device": {
+      "family": "iOS",
+      "model": "iPhone10,5",
+      "model_id": "simulator",
+      "arch": "x86",
+      "memory_size": null,
+      "free_memory": 170725376,
+      "usable_memory": 14726877184,
+      "storage_size": 250030215168,
+      "boot_time": null,
+      "type": "device"
+    },
+    "os": {
+      "name": "iOS",
+      "version": "11.4",
+      "build": "17F77",
+      "kernel_version": "Darwin Kernel Version 17.6.0: Tue May  8 15:22:16 PDT 2018; root:xnu-4570.61.1~1/RELEASE_X86_64",
+      "rooted": false,
+      "type": "os"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1532442982.0,
+        "type": "debug",
+        "category": "started",
+        "level": "info",
+        "message": "Breadcrumb Tracking"
+      },
+      {
+        "timestamp": 1532442982.0,
+        "type": "navigation",
+        "category": "UIViewController",
+        "level": "info",
+        "message": "viewDidAppear",
+        "data": {
+          "controller": "sentry_ios_cocoapods.ViewController"
+        }
+      },
+      {
+        "timestamp": 1532442986.0,
+        "type": "debug",
+        "category": "started",
+        "level": "info",
+        "message": "Breadcrumb Tracking"
+      },
+      {
+        "timestamp": 1532442986.0,
+        "type": "navigation",
+        "category": "UIViewController",
+        "level": "info",
+        "message": "viewDidAppear",
+        "data": {
+          "controller": "sentry_ios_cocoapods.ViewController"
+        }
+      },
+      {
+        "timestamp": 1532442987.0,
+        "type": "user",
+        "category": "touch",
+        "level": "info",
+        "message": "causeCrash:",
+        "data": {
+          "view": "<UIButton: 0x7f8c0fb0a320; frame = (186.667 415.667; 41 30); opaque = NO; autoresize = RM+BM; layer = <CALayer: 0x60800002e6c0>>"
+        }
+      },
+      {
+        "timestamp": 1532442988.0,
+        "type": "debug",
+        "category": "started",
+        "level": "info",
+        "message": "Breadcrumb Tracking"
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "EXC_BAD_ACCESS",
+        "value": "causeCrash: > crash >\nAttempted to dereference null pointer.",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib",
+              "image_addr": "0x102c91000",
+              "instruction_addr": "0x102c92955",
+              "symbol_addr": "0x102c92954"
+            },
+            {
+              "function": "main",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods",
+              "image_addr": "0x100af2000",
+              "instruction_addr": "0x100af5a67",
+              "symbol_addr": "0x100af5a30"
+            },
+            {
+              "function": "UIApplicationMain",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x10386a057",
+              "symbol_addr": "0x103869fb8"
+            },
+            {
+              "function": "GSEventRunModal",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices",
+              "image_addr": "0x1077fd000",
+              "instruction_addr": "0x107809a73",
+              "symbol_addr": "0x107809a35"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x10262c30b",
+              "symbol_addr": "0x10262c090"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x10262ca6f",
+              "symbol_addr": "0x10262c580"
+            },
+            {
+              "function": "__CFRunLoopDoSources0",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x10262d4af",
+              "symbol_addr": "0x10262d3a0"
+            },
+            {
+              "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x102648bb1",
+              "symbol_addr": "0x102648ba0"
+            },
+            {
+              "function": "__handleEventQueueInternal",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1041c92c4",
+              "symbol_addr": "0x1041c7b87"
+            },
+            {
+              "function": "__dispatchPreprocessedEventFromEventQueue",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1041c66af",
+              "symbol_addr": "0x1041c5bc3"
+            },
+            {
+              "function": "-[UIApplication sendEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x103885310",
+              "symbol_addr": "0x1038851b0"
+            },
+            {
+              "function": "-[UIWindow sendEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1038e17c1",
+              "symbol_addr": "0x1038e07cb"
+            },
+            {
+              "function": "-[UIWindow _sendTouchesForEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1038e00bf",
+              "symbol_addr": "0x1038df616"
+            },
+            {
+              "function": "-[UIControl touchesEnded:withEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1039e5a09",
+              "symbol_addr": "0x1039e57c5"
+            },
+            {
+              "function": "-[UIControl _sendActionsForEvents:withEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1039e6ac1",
+              "symbol_addr": "0x1039e68ff"
+            },
+            {
+              "function": "-[UIControl sendAction:to:forEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1039e67a4",
+              "symbol_addr": "0x1039e6761"
+            },
+            {
+              "function": "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x100b89000",
+              "instruction_addr": "0x100b8e91a",
+              "symbol_addr": "0x100b8e340"
+            },
+            {
+              "function": "-[UIApplication sendAction:to:from:forEvent:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x10386b3e8",
+              "symbol_addr": "0x10386b395"
+            },
+            {
+              "function": "_T020sentry_ios_cocoapods14ViewControllerC10causeCrashyypFTo",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods",
+              "image_addr": "0x100af2000",
+              "instruction_addr": "0x100af45ec",
+              "symbol_addr": "0x100af45a0"
+            },
+            {
+              "function": "_T020sentry_ios_cocoapods14ViewControllerC10causeCrashyypF",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods",
+              "image_addr": "0x100af2000",
+              "instruction_addr": "0x100af4580",
+              "symbol_addr": "0x100af44f0"
+            },
+            {
+              "function": "-[SentryClient crash]",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x100b89000",
+              "instruction_addr": "0x100b927c8",
+              "symbol_addr": "0x100b927b0"
+            }
+          ],
+          "registers": {
+            "cs": "0x2b",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x5f7f01005f4600",
+            "r11": "0x100b927b0",
+            "r12": "0x100af622a",
+            "r13": "0x100bf9460",
+            "r14": "0x60c000114130",
+            "r15": "0x7f8c0fb0a320",
+            "r8": "0x1f",
+            "r9": "0x608000117340",
+            "rax": "0x7ffeef10a590",
+            "rbp": "0x7ffeef10a550",
+            "rbx": "0x7f8c0d703d20",
+            "rcx": "0x7ffeef10a590",
+            "rdi": "0x608000117340",
+            "rdx": "0x303",
+            "rflags": "0x10246",
+            "rip": "0x100b927c8",
+            "rsi": "0x0",
+            "rsp": "0x7ffeef10a550"
+          }
+        },
+        "thread_id": 0,
+        "mechanism": {
+          "type": "mach",
+          "handled": false,
+          "meta": {
+            "signal": {
+              "number": 10,
+              "code": 0,
+              "name": "SIGBUS",
+              "code_name": "BUS_NOOP"
+            },
+            "mach_exception": {
+              "exception": 1,
+              "code": 0,
+              "subcode": 8,
+              "name": "EXC_BAD_ACCESS"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "threads": {
+    "values": [
+      {
+        "id": 0,
+        "crashed": true,
+        "current": false
+      },
+      {
+        "id": 1,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbe9",
+              "symbol_addr": "0x10313fbdc"
+            },
+            {
+              "function": "__workq_kernreturn",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310a292",
+              "symbol_addr": "0x10310a288"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x0",
+            "r11": "0x246",
+            "r12": "0x0",
+            "r13": "0x70000d9916c0",
+            "r14": "0x0",
+            "r15": "0x70000d9916e0",
+            "r8": "0x10",
+            "r9": "0x0",
+            "rax": "0x2000170",
+            "rbp": "0x70000d991720",
+            "rbx": "0x70000d9916f4",
+            "rcx": "0x70000d9916b8",
+            "rdi": "0x40",
+            "rdx": "0x0",
+            "rflags": "0x246",
+            "rip": "0x10310a292",
+            "rsi": "0x70000d991b80",
+            "rsp": "0x70000d9916b8"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 2,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbe9",
+              "symbol_addr": "0x10313fbdc"
+            },
+            {
+              "function": "__workq_kernreturn",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310a292",
+              "symbol_addr": "0x10310a288"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x0",
+            "r11": "0x246",
+            "r12": "0x0",
+            "r13": "0x70000da149d0",
+            "r14": "0x0",
+            "r15": "0x70000da149f0",
+            "r8": "0x0",
+            "r9": "0x990b",
+            "rax": "0x2000170",
+            "rbp": "0x70000da14a30",
+            "rbx": "0x70000da14a04",
+            "rcx": "0x70000da149c8",
+            "rdi": "0x40",
+            "rdx": "0x1",
+            "rflags": "0x246",
+            "rip": "0x10310a292",
+            "rsi": "0x70000da14b80",
+            "rsp": "0x70000da149c8"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 3,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbe9",
+              "symbol_addr": "0x10313fbdc"
+            },
+            {
+              "function": "__workq_kernreturn",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310a292",
+              "symbol_addr": "0x10310a288"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x0",
+            "r11": "0x246",
+            "r12": "0x0",
+            "r13": "0x70021",
+            "r14": "0x0",
+            "r15": "0x7",
+            "r8": "0x1f",
+            "r9": "0x60800005d190",
+            "rax": "0x2000170",
+            "rbp": "0x70000da97f50",
+            "rbx": "0x70000da98000",
+            "rcx": "0x70000da97ee8",
+            "rdi": "0x4",
+            "rdx": "0x0",
+            "rflags": "0x246",
+            "rip": "0x10310a292",
+            "rsi": "0x0",
+            "rsp": "0x70000da97ee8"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 4,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbe9",
+              "symbol_addr": "0x10313fbdc"
+            },
+            {
+              "function": "__workq_kernreturn",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310a292",
+              "symbol_addr": "0x10310a288"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x0",
+            "r11": "0x246",
+            "r12": "0x0",
+            "r13": "0x70000db1a9f0",
+            "r14": "0x0",
+            "r15": "0x70000db1aa10",
+            "r8": "0x10",
+            "r9": "0x0",
+            "rax": "0x2000170",
+            "rbp": "0x70000db1aa50",
+            "rbx": "0x70000db1aa24",
+            "rcx": "0x70000db1a9e8",
+            "rdi": "0x40",
+            "rdx": "0x0",
+            "rflags": "0x246",
+            "rip": "0x10310a292",
+            "rsi": "0x70000db1ab80",
+            "rsp": "0x70000db1a9e8"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 5,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbe9",
+              "symbol_addr": "0x10313fbdc"
+            },
+            {
+              "function": "__workq_kernreturn",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310a292",
+              "symbol_addr": "0x10310a288"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x0",
+            "r11": "0x246",
+            "r12": "0x0",
+            "r13": "0x70019",
+            "r14": "0x0",
+            "r15": "0x5",
+            "r8": "0x3f",
+            "r9": "0x60800005d910",
+            "rax": "0x2000170",
+            "rbp": "0x70000db9df50",
+            "rbx": "0x70000db9e000",
+            "rcx": "0x70000db9dee8",
+            "rdi": "0x4",
+            "rdx": "0x0",
+            "rflags": "0x246",
+            "rip": "0x10310a292",
+            "rsi": "0x0",
+            "rsp": "0x70000db9dee8"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 6,
+        "name": "com.apple.uikit.eventfetch-thread",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "thread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbf9",
+              "symbol_addr": "0x10313fbec"
+            },
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10314050d",
+              "symbol_addr": "0x103140394"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x103140661",
+              "symbol_addr": "0x10314050d"
+            },
+            {
+              "function": "__NSThread__start__",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x100c51000",
+              "instruction_addr": "0x100c7f3b3",
+              "symbol_addr": "0x100c7eeee"
+            },
+            {
+              "function": "-[UIEventFetcher threadMain]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+              "image_addr": "0x103840000",
+              "instruction_addr": "0x1044c0ce4",
+              "symbol_addr": "0x1044c0c6e"
+            },
+            {
+              "function": "-[NSRunLoop(NSRunLoop) runUntilDate:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x100c51000",
+              "instruction_addr": "0x100cee6bf",
+              "symbol_addr": "0x100cee630"
+            },
+            {
+              "function": "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x100c51000",
+              "instruction_addr": "0x100c71b4a",
+              "symbol_addr": "0x100c71a38"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x10262c30b",
+              "symbol_addr": "0x10262c090"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x10262cc19",
+              "symbol_addr": "0x10262c580"
+            },
+            {
+              "function": "__CFRunLoopServiceMachPort",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x1025ad000",
+              "instruction_addr": "0x10262d7d5",
+              "symbol_addr": "0x10262d6f0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310020a",
+              "symbol_addr": "0x103100200"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0xc00",
+            "r11": "0x206",
+            "r12": "0xc00",
+            "r13": "0x7000806",
+            "r14": "0x70000dc1fe20",
+            "r15": "0xffffffff",
+            "r8": "0x1b03",
+            "r9": "0xffffffff",
+            "rax": "0x100001f",
+            "rbp": "0x70000dc1fcf0",
+            "rbx": "0x7000806",
+            "rcx": "0x70000dc1fc98",
+            "rdi": "0x70000dc1fe20",
+            "rdx": "0x0",
+            "rflags": "0x206",
+            "rip": "0x10310020a",
+            "rsi": "0x7000806",
+            "rsp": "0x70000dc1fc98"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 7,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "thread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbf9",
+              "symbol_addr": "0x10313fbec"
+            },
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10314050d",
+              "symbol_addr": "0x103140394"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x103140661",
+              "symbol_addr": "0x10314050d"
+            },
+            {
+              "function": "monitorCachedData",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x100b89000",
+              "instruction_addr": "0x100b98831",
+              "symbol_addr": "0x100b987d0"
+            },
+            {
+              "function": "sleep",
+              "package": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x102d09000",
+              "instruction_addr": "0x102d83d3e",
+              "symbol_addr": "0x102d83d15"
+            },
+            {
+              "function": "__semwait_signal",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x103109d8a",
+              "symbol_addr": "0x103109d80"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x1",
+            "r11": "0x246",
+            "r12": "0x100b987d0",
+            "r13": "0x0",
+            "r14": "0x70000dca3ea8",
+            "r15": "0x70000dca3e98",
+            "r8": "0x1",
+            "r9": "0x0",
+            "rax": "0x200014e",
+            "rbp": "0x70000dca3e80",
+            "rbx": "0x0",
+            "rcx": "0x70000dca3e48",
+            "rdi": "0x1403",
+            "rdx": "0x1",
+            "rflags": "0x246",
+            "rip": "0x103109d8a",
+            "rsi": "0x0",
+            "rsp": "0x70000dca3e48"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 8,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "thread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10313fbf9",
+              "symbol_addr": "0x10313fbec"
+            },
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x10314050d",
+              "symbol_addr": "0x103140394"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x10313d000",
+              "instruction_addr": "0x103140661",
+              "symbol_addr": "0x10314050d"
+            },
+            {
+              "function": "handleExceptions",
+              "package": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x100b89000",
+              "instruction_addr": "0x100badb11",
+              "symbol_addr": "0x100bad9f0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x1030ed000",
+              "instruction_addr": "0x10310020a",
+              "symbol_addr": "0x103100200"
+            }
+          ],
+          "registers": {
+            "cs": "0x7",
+            "fs": "0x0",
+            "gs": "0x0",
+            "r10": "0x248",
+            "r11": "0x202",
+            "r12": "0x248",
+            "r13": "0x2",
+            "r14": "0x70000dd26ca0",
+            "r15": "0x0",
+            "r8": "0x9e03",
+            "r9": "0x0",
+            "rax": "0x100001f",
+            "rbp": "0x70000dd26bd0",
+            "rbx": "0x2",
+            "rcx": "0x70000dd26b78",
+            "rdi": "0x70000dd26ca0",
+            "rdx": "0x0",
+            "rflags": "0x202",
+            "rip": "0x10310020a",
+            "rsi": "0x2",
+            "rsp": "0x70000dd26b78"
+          }
+        },
+        "crashed": false,
+        "current": false
+      },
+      {
+        "id": 9,
+        "stacktrace": {
+          "frames": null
+        },
+        "crashed": false,
+        "current": true
+      }
+    ]
+  },
+  "tags": [
+    [
+      "a",
+      "b"
+    ]
+  ],
+  "extra": {
+    "c": "d"
+  },
+  "debug_meta": {
+    "images": [
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/dyld_sim",
+        "debug_id": "a356f82b-146b-353d-9fc1-250800b6b67c",
+        "image_addr": "0x100b06000",
+        "image_size": 212992,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/sentry-ios-cocoapods",
+        "debug_id": "a42410ed-51f4-3cb8-90bf-acfc063fff54",
+        "image_addr": "0x100af2000",
+        "image_size": 24576,
+        "image_vmaddr": "0x100000000",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/Sentry.framework/Sentry",
+        "debug_id": "0a60a189-2ba3-3c17-a865-3f92639d9deb",
+        "image_addr": "0x100b89000",
+        "image_size": 397312,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Foundation",
+        "debug_id": "a00c3fcc-12cc-3076-afbb-bfc6f24741a8",
+        "image_addr": "0x100c51000",
+        "image_size": 3178496,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libobjc.A.dylib",
+        "debug_id": "f2a3c04b-b58a-3336-8226-07eb955662e8",
+        "image_addr": "0x101271000",
+        "image_size": 7008256,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libSystem.dylib",
+        "debug_id": "8107447d-2e17-3dd6-b0fd-7d8f13db52e8",
+        "image_addr": "0x101ae0000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit",
+        "debug_id": "43b826c4-9e66-3533-b688-8873f5c738e5",
+        "image_addr": "0x103840000",
+        "image_size": 18366464,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCore.dylib",
+        "debug_id": "92c23e3b-8829-3c25-b352-affc4d587080",
+        "image_addr": "0x101ae8000",
+        "image_size": 3493888,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCoreFoundation.dylib",
+        "debug_id": "00f0f489-b4d0-36b3-b5f4-6e0b967faa3a",
+        "image_addr": "0x1020e9000",
+        "image_size": 16384,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCoreGraphics.dylib",
+        "debug_id": "9ca6cea8-0a3c-3391-ac6f-33403ed2ab90",
+        "image_addr": "0x1020f1000",
+        "image_size": 73728,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftCoreImage.dylib",
+        "debug_id": "0f9bc395-c472-3094-9675-1fa4beec27d4",
+        "image_addr": "0x10211e000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftDarwin.dylib",
+        "debug_id": "53af9ec1-48ff-3e77-8a01-7df99564aee9",
+        "image_addr": "0x102128000",
+        "image_size": 32768,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftDispatch.dylib",
+        "debug_id": "de441136-70b2-3c95-a63f-8474975e98e7",
+        "image_addr": "0x10213e000",
+        "image_size": 110592,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftFoundation.dylib",
+        "debug_id": "c3ab0fe7-1e2d-3f4f-a09a-4aff317a359e",
+        "image_addr": "0x102189000",
+        "image_size": 1515520,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftMetal.dylib",
+        "debug_id": "c1d44eac-9f90-3894-9b28-6030ac665a69",
+        "image_addr": "0x102440000",
+        "image_size": 28672,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftObjectiveC.dylib",
+        "debug_id": "619a0a7c-70c0-302d-ad7e-b4a44477c11a",
+        "image_addr": "0x10244e000",
+        "image_size": 28672,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftQuartzCore.dylib",
+        "debug_id": "4e4a6981-3a15-3552-95d2-ee8d9e65a39c",
+        "image_addr": "0x10245d000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftSwiftOnoneSupport.dylib",
+        "debug_id": "e1eaf4ce-75bf-34fe-9183-c57fb3655ff5",
+        "image_addr": "0x102468000",
+        "image_size": 229376,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftUIKit.dylib",
+        "debug_id": "0a7e2055-d0a6-3582-83e6-fd24b9b170e7",
+        "image_addr": "0x1024da000",
+        "image_size": 61440,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++.1.dylib",
+        "debug_id": "5c5e99f8-3e0f-3024-b6e3-3c87bf6d091b",
+        "image_addr": "0x1024fa000",
+        "image_size": 319488,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libz.1.dylib",
+        "debug_id": "85d4504d-b0e8-332c-8ccb-d7b7ededae37",
+        "image_addr": "0x102595000",
+        "image_size": 77824,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+        "debug_id": "89a74ba0-442c-3a88-8ca4-3d201e33a4c2",
+        "image_addr": "0x1025ad000",
+        "image_size": 3678208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libc++abi.dylib",
+        "debug_id": "09803d55-2cf0-3cb3-bafa-44a07f736424",
+        "image_addr": "0x102af9000",
+        "image_size": 159744,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcache.dylib",
+        "debug_id": "c7fb7be9-b2a7-3996-abc9-14b3919ff5c4",
+        "image_addr": "0x102b30000",
+        "image_size": 20480,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcommonCrypto.dylib",
+        "debug_id": "e4679a53-b963-38ef-a107-5c503d03d803",
+        "image_addr": "0x102b3a000",
+        "image_size": 45056,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcompiler_rt.dylib",
+        "debug_id": "64cc3933-a0e0-3218-a5b0-6bc5de9fa558",
+        "image_addr": "0x102b53000",
+        "image_size": 32768,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcopyfile.dylib",
+        "debug_id": "36a31cb2-f650-3e99-b5fe-123be1438e60",
+        "image_addr": "0x102b64000",
+        "image_size": 40960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libcorecrypto.dylib",
+        "debug_id": "834753ba-07bb-35e1-8b24-1d97e8bfbeba",
+        "image_addr": "0x102b75000",
+        "image_size": 552960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdispatch.dylib",
+        "debug_id": "db8ef273-7794-33d5-90bc-ef6b75b5d38c",
+        "image_addr": "0x102c1a000",
+        "image_size": 225280,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libdyld.dylib",
+        "debug_id": "7743b27f-094f-3ec9-a9dd-14df89d6369f",
+        "image_addr": "0x102c91000",
+        "image_size": 110592,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/liblaunch.dylib",
+        "debug_id": "08a3db9e-9bcb-3448-bc4e-cc3bd860ac2a",
+        "image_addr": "0x102cc5000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libmacho.dylib",
+        "debug_id": "5b5e3511-f5d2-375d-b57c-4d063ce23d0c",
+        "image_addr": "0x102ccc000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libremovefile.dylib",
+        "debug_id": "73e9d285-86d9-3463-ad8a-5ec99d3e49b6",
+        "image_addr": "0x102cd8000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_asl.dylib",
+        "debug_id": "984be404-07e5-3403-a02b-c2aa21b84fc5",
+        "image_addr": "0x102cdf000",
+        "image_size": 94208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_blocks.dylib",
+        "debug_id": "cb6a9572-2087-3e1f-a242-c6391ffd0698",
+        "image_addr": "0x102d04000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_c.dylib",
+        "debug_id": "cfb83b0b-0bfa-3482-92b4-b0c5c2bf24bb",
+        "image_addr": "0x102d09000",
+        "image_size": 540672,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_configuration.dylib",
+        "debug_id": "7aeb76ec-4f3b-3a5a-a904-afe999f40901",
+        "image_addr": "0x102db8000",
+        "image_size": 16384,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_containermanager.dylib",
+        "debug_id": "f32f9759-4ad2-3227-8a71-1b9938180292",
+        "image_addr": "0x102dc2000",
+        "image_size": 20480,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_coreservices.dylib",
+        "debug_id": "899320b3-97a7-3a2d-ae6b-11d39d9ca6ea",
+        "image_addr": "0x102dce000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_darwin.dylib",
+        "debug_id": "111993ae-367b-3815-9191-2611f3a3c6f3",
+        "image_addr": "0x102dd5000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_dnssd.dylib",
+        "debug_id": "6b5f9585-dab8-3794-8ca0-ba176a1923d3",
+        "image_addr": "0x102ddc000",
+        "image_size": 28672,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_info.dylib",
+        "debug_id": "96bf24a5-a445-312e-944c-953b16ac376f",
+        "image_addr": "0x102de9000",
+        "image_size": 258048,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_m.dylib",
+        "debug_id": "73c587bb-2774-3498-b763-69c88b182532",
+        "image_addr": "0x102e3d000",
+        "image_size": 299008,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_malloc.dylib",
+        "debug_id": "01bf1025-1c09-32d1-8075-7768f5a3a47d",
+        "image_addr": "0x102e93000",
+        "image_size": 122880,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_network.dylib",
+        "debug_id": "9382dffe-4042-34d2-952d-debbd7cf8ff1",
+        "image_addr": "0x102ebf000",
+        "image_size": 856064,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_notify.dylib",
+        "debug_id": "04b20fc0-4eae-3a21-8695-43d189f92259",
+        "image_addr": "0x102fd7000",
+        "image_size": 40960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sandbox.dylib",
+        "debug_id": "8db66720-d558-3eb4-ae26-46dd98de3ef6",
+        "image_addr": "0x102fe9000",
+        "image_size": 16384,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_kernel.dylib",
+        "debug_id": "c456329d-6701-3b48-8cdf-bf8467ed501e",
+        "image_addr": "0x102ff3000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_platform.dylib",
+        "debug_id": "3ca0cfd4-2965-32b0-af67-7948b9a512dd",
+        "image_addr": "0x102ffc000",
+        "image_size": 12288,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_pthread.dylib",
+        "debug_id": "85d62046-30cb-34c2-9f50-cdb39e9ea7dc",
+        "image_addr": "0x103004000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_trace.dylib",
+        "debug_id": "004f5e16-5889-33d5-a54f-df649f91815a",
+        "image_addr": "0x10300a000",
+        "image_size": 81920,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libunwind.dylib",
+        "debug_id": "7de3fd88-357b-3535-a00c-3ad23438f231",
+        "image_addr": "0x10302e000",
+        "image_size": 28672,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libxpc.dylib",
+        "debug_id": "c070aa3b-6f2b-3d85-887c-5a00fae39163",
+        "image_addr": "0x10303b000",
+        "image_size": 180224,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_pthread_host.dylib",
+        "debug_id": "cc81462a-9a6c-3b9e-9432-497564a74d2a",
+        "image_addr": "0x10308e000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/closure/libclosured.dylib",
+        "debug_id": "57245ea6-791d-3aab-9a54-8891ae1e57ab",
+        "image_addr": "0x103093000",
+        "image_size": 208896,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_platform_host.dylib",
+        "debug_id": "d26c8812-4795-3ab8-88aa-e8ca9e18ee29",
+        "image_addr": "0x1030e1000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/system/libsystem_sim_kernel_host.dylib",
+        "debug_id": "1dd26c10-f171-3cb1-883f-24a263cdd3c6",
+        "image_addr": "0x1030e7000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/usr/lib/system/libsystem_kernel.dylib",
+        "debug_id": "d7f2010a-ea32-3f62-90de-85e3c5cc3065",
+        "image_addr": "0x1030ed000",
+        "image_size": 159744,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/usr/lib/system/libsystem_platform.dylib",
+        "debug_id": "6355ee2d-5456-3ca8-a227-b96e8f1e2af8",
+        "image_addr": "0x10312d000",
+        "image_size": 32768,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/usr/lib/system/libsystem_pthread.dylib",
+        "debug_id": "0e51ccba-91f2-34e1-bf2a-feefd3d321e4",
+        "image_addr": "0x10313d000",
+        "image_size": 49152,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/MobileCoreServices.framework/MobileCoreServices",
+        "debug_id": "2cb6a685-3abd-397b-be8c-c215eb1a8dba",
+        "image_addr": "0x103155000",
+        "image_size": 1294336,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libarchive.2.dylib",
+        "debug_id": "bcc36594-0971-3cfd-a904-3ee00de4cfa8",
+        "image_addr": "0x103390000",
+        "image_size": 176128,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libicucore.A.dylib",
+        "debug_id": "3e7934c4-9ae6-37f3-87fa-ae22ceff82b8",
+        "image_addr": "0x1033c8000",
+        "image_size": 2232320,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libxml2.2.dylib",
+        "debug_id": "baf5b2d7-f616-3f51-b065-8e826a6b6c9f",
+        "image_addr": "0x105a00000",
+        "image_size": 937984,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+        "debug_id": "92c425d8-fed3-30ba-9f9c-c79c57530f8c",
+        "image_addr": "0x105b2a000",
+        "image_size": 3805184,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration",
+        "debug_id": "a787da85-bb43-3669-b965-9171a9fa0084",
+        "image_addr": "0x1036cf000",
+        "image_size": 397312,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+        "debug_id": "4948e268-e78f-35b4-a641-b516e1f41a34",
+        "image_addr": "0x106290000",
+        "image_size": 442368,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libCRFSuite.dylib",
+        "debug_id": "e7bb1a6f-7503-3485-8f8b-e204dd280070",
+        "image_addr": "0x10633f000",
+        "image_size": 204800,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/liblangid.dylib",
+        "debug_id": "eb66cb86-e39d-3f86-a556-f97554f3d7de",
+        "image_addr": "0x103768000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libMobileGestalt.dylib",
+        "debug_id": "73e93331-3e72-36fa-bc0c-eca06e15dbe7",
+        "image_addr": "0x106387000",
+        "image_size": 102400,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libbsm.0.dylib",
+        "debug_id": "8c63b2fd-e6b7-3614-90a3-e8d5f18f604a",
+        "image_addr": "0x10376f000",
+        "image_size": 69632,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Security.framework/Security",
+        "debug_id": "371e74a4-bfd0-3dd6-9b3e-b4bcfb54e2c8",
+        "image_addr": "0x1063e7000",
+        "image_size": 1024000,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libsqlite3.dylib",
+        "debug_id": "ad71d820-f713-3c53-8956-2c63b92c1edd",
+        "image_addr": "0x1065c1000",
+        "image_size": 1548288,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcoretls.dylib",
+        "debug_id": "ccd0954e-af64-3f84-9b0c-f100813c43ad",
+        "image_addr": "0x10676c000",
+        "image_size": 94208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcoretls_cfhelpers.dylib",
+        "debug_id": "b45e9ae6-35cb-302d-8dc6-4f99db1f35a4",
+        "image_addr": "0x10378a000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libnetwork.dylib",
+        "debug_id": "32e5990d-9650-33cd-a9c2-0d3a589226f4",
+        "image_addr": "0x106790000",
+        "image_size": 1458176,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libapple_nghttp2.dylib",
+        "debug_id": "ee559726-7fc5-3dcf-9972-3dec3d24818d",
+        "image_addr": "0x106963000",
+        "image_size": 94208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libboringssl.dylib",
+        "debug_id": "c3e1afab-67c7-313f-84f4-cc23315ebfe5",
+        "image_addr": "0x106987000",
+        "image_size": 749568,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libusrtcp.dylib",
+        "debug_id": "0bece6cd-a940-31e9-b325-0111f1819f9b",
+        "image_addr": "0x106ac3000",
+        "image_size": 380928,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libapple_crypto.dylib",
+        "debug_id": "fac182bd-0168-34fc-8315-f020aab2d524",
+        "image_addr": "0x103792000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libbz2.1.0.dylib",
+        "debug_id": "2460323f-bbef-3699-95bc-54a86b4dc0fe",
+        "image_addr": "0x106b31000",
+        "image_size": 57344,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/liblzma.5.dylib",
+        "debug_id": "53e854a1-8f4a-3f14-b4f7-a8ef3ee43e91",
+        "image_addr": "0x106b44000",
+        "image_size": 102400,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/Frameworks/DocumentManager.framework/DocumentManager",
+        "debug_id": "564e2ffa-43ae-3a58-afd4-31e270ec3475",
+        "image_addr": "0x106b65000",
+        "image_size": 356352,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/FileProvider.framework/FileProvider",
+        "debug_id": "85a6a3c4-72a8-3b35-a9a6-4278dc5e56ad",
+        "image_addr": "0x106c15000",
+        "image_size": 610304,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UIFoundation.framework/UIFoundation",
+        "debug_id": "b3527499-ee4d-3fdc-b152-b1551e6639fe",
+        "image_addr": "0x106d2f000",
+        "image_size": 991232,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AggregateDictionary.framework/AggregateDictionary",
+        "debug_id": "6e11cfeb-f786-3402-b6eb-d6e97badfe18",
+        "image_addr": "0x106eca000",
+        "image_size": 20480,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UserNotifications.framework/UserNotifications",
+        "debug_id": "20623b1b-d5d7-37b8-bef8-91afd7afc536",
+        "image_addr": "0x106ed7000",
+        "image_size": 176128,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices",
+        "debug_id": "56d5662e-de3a-3d5a-8801-af47e8378f2e",
+        "image_addr": "0x106f34000",
+        "image_size": 376832,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard",
+        "debug_id": "88c7bba8-1e64-32a9-b48f-66bf3cedb184",
+        "image_addr": "0x107015000",
+        "image_size": 397312,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreUI.framework/CoreUI",
+        "debug_id": "5505e019-f956-3e63-bec5-a2802b4c3ae8",
+        "image_addr": "0x1070f2000",
+        "image_size": 827392,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/OpenGLES",
+        "debug_id": "b8d9f8f0-1b8f-3d2f-b701-033766745f1b",
+        "image_addr": "0x107308000",
+        "image_size": 53248,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/MobileAsset.framework/MobileAsset",
+        "debug_id": "f6322ef6-997b-3906-90df-ebd0dde5f5d2",
+        "image_addr": "0x107322000",
+        "image_size": 98304,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices",
+        "debug_id": "2590a752-29cd-3a85-b157-e6767ac083b7",
+        "image_addr": "0x107355000",
+        "image_size": 204800,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreImage.framework/CoreImage",
+        "debug_id": "ed2db79a-efd7-388f-b987-35bde69637f2",
+        "image_addr": "0x1073cb000",
+        "image_size": 2551808,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices",
+        "debug_id": "ee602b3e-9730-391a-acdf-80aeeb3c6971",
+        "image_addr": "0x1077fd000",
+        "image_size": 86016,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+        "debug_id": "3cf1c89f-021c-3c50-8660-bb13cbe9c05a",
+        "image_addr": "0x10782d000",
+        "image_size": 6299648,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/ImageIO.framework/ImageIO",
+        "debug_id": "1b8a8f42-9d78-3785-a689-eccd4d51a85f",
+        "image_addr": "0x107f42000",
+        "image_size": 5337088,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/QuartzCore.framework/QuartzCore",
+        "debug_id": "40a28db3-812e-3ee7-870b-dd53fcf43964",
+        "image_addr": "0x10857c000",
+        "image_size": 1806336,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SpringBoardServices.framework/SpringBoardServices",
+        "debug_id": "46074880-7c9d-3fcd-ad1a-67d04aaa7f61",
+        "image_addr": "0x10881d000",
+        "image_size": 241664,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport",
+        "debug_id": "c01bb93a-891c-3aa8-8f54-1bf65e7f30f4",
+        "image_addr": "0x1088ac000",
+        "image_size": 274432,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreText.framework/CoreText",
+        "debug_id": "64b538c9-4b73-37d1-917a-4b8af9062751",
+        "image_addr": "0x108935000",
+        "image_size": 1404928,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/TextInput.framework/TextInput",
+        "debug_id": "cacc8683-e618-31c8-84de-15929f3268a8",
+        "image_addr": "0x108b60000",
+        "image_size": 360448,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WebKitLegacy.framework/WebKitLegacy",
+        "debug_id": "d4957e39-bc32-33eb-b1dd-67e4fc71755b",
+        "image_addr": "0x108c40000",
+        "image_size": 1589248,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libAccessibility.dylib",
+        "debug_id": "0a1df097-46bb-3a1d-8154-8807bae18a55",
+        "image_addr": "0x108f2c000",
+        "image_size": 81920,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Accelerate",
+        "debug_id": "d1ecfb48-90b4-3665-999f-03b22ad35a42",
+        "image_addr": "0x103796000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PhysicsKit.framework/PhysicsKit",
+        "debug_id": "2d7992d8-0b8b-328c-9101-0819cbc052a2",
+        "image_addr": "0x108f66000",
+        "image_size": 339968,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/Network.framework/Network",
+        "debug_id": "b7244df3-a73d-3537-b064-425d488e3669",
+        "image_addr": "0x108fec000",
+        "image_size": 606208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/MobileIcons.framework/MobileIcons",
+        "debug_id": "e96558d8-34ae-3c7b-b553-b923a78cecac",
+        "image_addr": "0x1090e6000",
+        "image_size": 40960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DocumentManagerCore.framework/DocumentManagerCore",
+        "debug_id": "27181094-155d-39b2-8b8d-a9d195e14726",
+        "image_addr": "0x1090fc000",
+        "image_size": 77824,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PlugInKit.framework/PlugInKit",
+        "debug_id": "f1c5285a-8e88-35d3-9c3f-972c6332633a",
+        "image_addr": "0x109126000",
+        "image_size": 143360,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreVideo.framework/CoreVideo",
+        "debug_id": "135c2dc9-7a30-3080-babf-6f23fc38d381",
+        "image_addr": "0x10916e000",
+        "image_size": 126976,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/vImage",
+        "debug_id": "4bb6b0b2-4c40-3dd0-ae47-99c26918c861",
+        "image_addr": "0x1091a8000",
+        "image_size": 7856128,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/vecLib",
+        "debug_id": "93690aa9-fa28-3cef-8b3e-490cd2fc624b",
+        "image_addr": "0x10379a000",
+        "image_size": 4096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libvDSP.dylib",
+        "debug_id": "e233ecf4-ff51-3ffa-a4f3-f0a79fdab073",
+        "image_addr": "0x1099bd000",
+        "image_size": 1540096,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libLAPACK.dylib",
+        "debug_id": "b0760cbf-1efb-3e50-9158-61486066bb25",
+        "image_addr": "0x109b48000",
+        "image_size": 3928064,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libBLAS.dylib",
+        "debug_id": "ccb04ddb-271b-37dc-9ed8-3b7de2c92d1f",
+        "image_addr": "0x109f56000",
+        "image_size": 1716224,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libvMisc.dylib",
+        "debug_id": "89317eca-178a-33a6-9414-f088027aeb55",
+        "image_addr": "0x10a11e000",
+        "image_size": 630784,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libLinearAlgebra.dylib",
+        "debug_id": "779fac1b-9f58-30b7-b634-90ffb8a3bbc2",
+        "image_addr": "0x10a1c9000",
+        "image_size": 90112,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libSparse.dylib",
+        "debug_id": "f4b67424-b162-30e9-b631-b6c6dcb13518",
+        "image_addr": "0x10a1e8000",
+        "image_size": 442368,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libSparseBLAS.dylib",
+        "debug_id": "70ee3e93-d461-379c-99c4-e5452f836a24",
+        "image_addr": "0x10a26d000",
+        "image_size": 77824,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libQuadrature.dylib",
+        "debug_id": "57390fb3-49f7-3226-9852-62c702199795",
+        "image_addr": "0x10a288000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libBNNS.dylib",
+        "debug_id": "8ff94ca4-ee6f-377c-ae9d-c5685d93d91f",
+        "image_addr": "0x10a292000",
+        "image_size": 229376,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcompression.dylib",
+        "debug_id": "f6b2336f-85ae-3273-a0a3-b78d8c3ced39",
+        "image_addr": "0x10a2d4000",
+        "image_size": 98304,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/FontServices",
+        "debug_id": "d2fbb5da-3249-3f52-a3a3-1bf2b8bec350",
+        "image_addr": "0x10a2f4000",
+        "image_size": 8192,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib",
+        "debug_id": "90e9ee62-990a-3bcf-94ec-581a2154cf64",
+        "image_addr": "0x10a2fb000",
+        "image_size": 1097728,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Metal.framework/Metal",
+        "debug_id": "a3e27d9b-a720-3799-a0fd-d80c0bd858f8",
+        "image_addr": "0x10a4e0000",
+        "image_size": 532480,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AppleJPEG.framework/AppleJPEG",
+        "debug_id": "4a7a020a-d6d4-322c-981d-1af73e9b109e",
+        "image_addr": "0x10a645000",
+        "image_size": 299008,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libCoreFSCache.dylib",
+        "debug_id": "bc6533bb-3f40-3eee-b7f8-fab586b68b61",
+        "image_addr": "0x10a69d000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ColorSync.framework/ColorSync",
+        "debug_id": "823de8e2-3ca6-3096-bf03-d49feb3e3974",
+        "image_addr": "0x10a6a8000",
+        "image_size": 548864,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libGFXShared.dylib",
+        "debug_id": "8bedc9be-133c-3681-b10f-19a44828b5c1",
+        "image_addr": "0x10a75f000",
+        "image_size": 40960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libGLImage.dylib",
+        "debug_id": "80b69f02-8df2-3f67-b85d-7c81071338dc",
+        "image_addr": "0x10a771000",
+        "image_size": 274432,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libCVMSPluginSupport.dylib",
+        "debug_id": "c787d7ad-1886-31d6-8b5c-d4cc8270a790",
+        "image_addr": "0x10a7bf000",
+        "image_size": 12288,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework/libCoreVMClient.dylib",
+        "debug_id": "3ce8485d-64f9-38d0-9f55-a111b7ea8189",
+        "image_addr": "0x10a7c8000",
+        "image_size": 36864,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/OpenGLES.framework//libLLVMContainer.dylib",
+        "debug_id": "83a809d9-af93-350b-9eb0-1f80e9ad1212",
+        "image_addr": "0x10a7d9000",
+        "image_size": 13275136,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ProtocolBuffer.framework/ProtocolBuffer",
+        "debug_id": "0535baf2-66bd-3849-86dc-7d2b33c60527",
+        "image_addr": "0x10b823000",
+        "image_size": 126976,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CorePhoneNumbers.framework/CorePhoneNumbers",
+        "debug_id": "3936b548-6500-38f1-a3e7-3b3ca44aeccd",
+        "image_addr": "0x10b863000",
+        "image_size": 36864,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/TextureIO.framework/TextureIO",
+        "debug_id": "a35af06f-ddd3-3aa7-afd3-c906632020b1",
+        "image_addr": "0x10b875000",
+        "image_size": 839680,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libate.dylib",
+        "debug_id": "a157691a-9409-33af-a3e9-f1c6b2432df7",
+        "image_addr": "0x10b96c000",
+        "image_size": 1048576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FaceCore.framework/FaceCore",
+        "debug_id": "db86f332-9f42-3da0-a332-0db09f1d6ee3",
+        "image_addr": "0x10ba80000",
+        "image_size": 4354048,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libFosl_dynamic.dylib",
+        "debug_id": "cc06c87c-d14f-3b8e-a9b7-1eb902eb37d1",
+        "image_addr": "0x10c0ce000",
+        "image_size": 1875968,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreMedia.framework/CoreMedia",
+        "debug_id": "046ca873-6df3-3f92-a8d6-fbf7aa31b5c3",
+        "image_addr": "0x10c2ea000",
+        "image_size": 643072,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/VideoToolbox.framework/VideoToolbox",
+        "debug_id": "1d8fdae3-3092-369c-b0e9-9333778bb794",
+        "image_addr": "0x10c42e000",
+        "image_size": 3112960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/SimulatorClient.framework/SimulatorClient",
+        "debug_id": "e0025bc3-188f-34b8-861d-61dc2398b6a9",
+        "image_addr": "0x10c7c0000",
+        "image_size": 16384,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreAudio.framework/CoreAudio",
+        "debug_id": "5c9ceb71-c095-3ac0-932a-00ae8b5d10ec",
+        "image_addr": "0x10c7c9000",
+        "image_size": 565248,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AppleSauce.framework/AppleSauce",
+        "debug_id": "2ec28941-a45f-3ac5-95c8-55e7401d1c68",
+        "image_addr": "0x10c883000",
+        "image_size": 167936,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ManagedConfiguration.framework/ManagedConfiguration",
+        "debug_id": "bd390f61-c63a-316a-bf6c-527cd7ac11c5",
+        "image_addr": "0x10c8b8000",
+        "image_size": 1060864,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accounts.framework/Accounts",
+        "debug_id": "9405ecc3-f02b-32ad-90a5-2bbc32512586",
+        "image_addr": "0x10cac0000",
+        "image_size": 356352,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/PersistentConnection.framework/PersistentConnection",
+        "debug_id": "cd5c2c68-916e-36ee-b8b6-e02fb23a8e55",
+        "image_addr": "0x10cb6e000",
+        "image_size": 176128,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DataMigration.framework/DataMigration",
+        "debug_id": "c2277c44-5c37-37d2-8f2c-7d440244aef9",
+        "image_addr": "0x10cbc6000",
+        "image_size": 36864,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreTelephony.framework/CoreTelephony",
+        "debug_id": "b6efd824-477a-3862-b830-bc7547f5203a",
+        "image_addr": "0x10cbdc000",
+        "image_size": 598016,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices",
+        "debug_id": "ec5a6474-4e00-3e99-bdd0-3f5d1017af53",
+        "image_addr": "0x10ccf1000",
+        "image_size": 94208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreData.framework/CoreData",
+        "debug_id": "de294808-6981-31a8-be57-9e02916812cc",
+        "image_addr": "0x10cd2e000",
+        "image_size": 3403776,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CommonUtilities.framework/CommonUtilities",
+        "debug_id": "97fba9be-c7d5-3e2b-b067-435630dbfa34",
+        "image_addr": "0x10d27b000",
+        "image_size": 90112,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libcupolicy.dylib",
+        "debug_id": "e2a2232b-8875-33e8-96a5-e974bc36d537",
+        "image_addr": "0x10d2a7000",
+        "image_size": 32768,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libTelephonyUtilDynamic.dylib",
+        "debug_id": "f5e7a693-fa13-3900-9624-2fbf1d22b8c9",
+        "image_addr": "0x10d2b9000",
+        "image_size": 245760,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/StreamingZip.framework/StreamingZip",
+        "debug_id": "571aaad0-f7b7-3a7c-b1ca-39e390d1c86d",
+        "image_addr": "0x10d340000",
+        "image_size": 159744,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+        "debug_id": "7ac56c8c-5423-3a0d-85bf-6c4259631a21",
+        "image_addr": "0x10d384000",
+        "image_size": 10702848,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WebCore.framework/WebCore",
+        "debug_id": "3942e6eb-75b2-3633-b1cc-8cca5b14b6a1",
+        "image_addr": "0x10e074000",
+        "image_size": 25214976,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WebCore.framework/Frameworks/libwebrtc.dylib",
+        "debug_id": "7c152773-f29f-3103-b2e0-2b75ef5fdd23",
+        "image_addr": "0x1106b1000",
+        "image_size": 5894144,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/AudioToolbox.framework/AudioToolbox",
+        "debug_id": "398f11ef-74d5-30e2-b982-5011a0445044",
+        "image_addr": "0x110e67000",
+        "image_size": 4554752,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libAudioStatistics.dylib",
+        "debug_id": "c28dc050-88cb-3b4d-8321-b12fbb2df34c",
+        "image_addr": "0x1114a6000",
+        "image_size": 45056,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/WirelessDiagnostics.framework/WirelessDiagnostics",
+        "debug_id": "e8853a59-84d0-3e36-82f0-e9e39f5d338b",
+        "image_addr": "0x1114bd000",
+        "image_size": 278528,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/RTCReporting.framework/RTCReporting",
+        "debug_id": "b06bd3ce-4fc6-3fbf-8ffa-528e61d4042f",
+        "image_addr": "0x111533000",
+        "image_size": 36864,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/TCC.framework/TCC",
+        "debug_id": "7c485ad6-c00b-348c-8338-3c4520ac477a",
+        "image_addr": "0x11154a000",
+        "image_size": 28672,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libAWDSupportFramework.dylib",
+        "debug_id": "bdad7136-805f-3875-b17d-1e8ea8562f21",
+        "image_addr": "0x11155c000",
+        "image_size": 987136,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libprotobuf-lite.dylib",
+        "debug_id": "0ab656df-4f5b-3d31-ade8-c7f21a9e1908",
+        "image_addr": "0x11176f000",
+        "image_size": 73728,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics",
+        "debug_id": "625da12d-3bfd-34cd-866e-50cb7319ae72",
+        "image_addr": "0x111798000",
+        "image_size": 184320,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libprotobuf.dylib",
+        "debug_id": "ae118836-7217-3fe7-b587-c0b38f475e1c",
+        "image_addr": "0x1117ee000",
+        "image_size": 401408,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/MediaAccessibility.framework/MediaAccessibility",
+        "debug_id": "d945a756-a7a4-3873-859e-d03b222ca8fc",
+        "image_addr": "0x1118a7000",
+        "image_size": 45056,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Users/haza/Library/Developer/CoreSimulator/Devices/39AA02D4-5472-4955-B38E-D5E107B8426D/data/Containers/Bundle/Application/E22C2ECA-17F9-4530-9540-1B06DDAD9147/sentry-ios-cocoapods.app/Frameworks/libswiftos.dylib",
+        "debug_id": "f1418fa3-2b3d-3e9e-949e-e4f7d949bec8",
+        "image_addr": "0x1118c3000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libMobileGestaltExtensions.dylib",
+        "debug_id": "e59792e5-b59d-3f38-9f7e-23a430743e5f",
+        "image_addr": "0x11376b000",
+        "image_size": 40960,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/Libraries/libCGInterfaces.dylib",
+        "debug_id": "0eaf93d8-df5c-35c5-ae09-9952ddd7e908",
+        "image_addr": "0x113795000",
+        "image_size": 94208,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/libGSFontCache.dylib",
+        "debug_id": "b2bd1945-1691-385b-93b9-6e981156bcd6",
+        "image_addr": "0x1137c1000",
+        "image_size": 73728,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/ConstantClasses.framework/ConstantClasses",
+        "debug_id": "6d6c2054-3c39-3dc9-8a79-c7f70c8c358f",
+        "image_addr": "0x113a91000",
+        "image_size": 24576,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/FontServices.framework/libTrueTypeScaler.dylib",
+        "debug_id": "9b6edafe-30e4-3420-9a3c-f5bc39902fa2",
+        "image_addr": "0x113da2000",
+        "image_size": 208896,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      },
+      {
+        "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UserManagement.framework/UserManagement",
+        "debug_id": "7aa6ada1-9c31-34e2-829d-cc2f30dc4228",
+        "image_addr": "0x113e06000",
+        "image_size": 81920,
+        "image_vmaddr": "0x0",
+        "type": "macho"
+      }
+    ]
+  },
+  "sdk": {
+    "name": "sentry-cocoa",
+    "version": "4.0.1"
+  },
+  "errors": [
+    {
+      "type": "invalid_data",
+      "name": "threads.values.9.stacktrace.frames",
+      "reason": "expected a non-empty value"
+    }
+  ],
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "threads": {
+      "values": {
+        "9": {
+          "stacktrace": {
+            "frames": {
+              "": {
+                "err": [
+                  [
+                    "invalid_data",
+                    {
+                      "reason": "expected a non-empty value"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "user": {
+      "email": {
+        "": {
+          "rem": [
+            [
+              "@anything:hash",
+              "p",
+              0,
+              40
+            ]
+          ],
+          "len": 15
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__cordova__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__cordova__pii_stripping.snap
@@ -1,234 +1,322 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: ae3a2cc6e08741c5b09946c65c022469
-level: fatal
-type: error
-transaction: main at EventEmitter.ipcMain.on
-logentry:
-  formatted: "Error: Error triggered in main processes"
-logger: ""
-platform: other
-timestamp: "[timestamp]"
-received: "[received]"
-release: sentry-electron-test@2.0.2
-environment: development
-user:
-  ip_address: ~
-contexts:
-  app:
-    app_name: Sentry Crash Test
-    app_version: 2.0.2
-    type: app
-  chrome:
-    name: Chrome
-    version: 61.0.3163.100
-    type: runtime
-  device:
-    arch: x64
-    type: device
-  node:
-    name: Node
-    version: 8.9.3
-    type: runtime
-  os:
-    name: Mac OS X
-    version: 10.13.6
-    build: 17G65
-    kernel_version: 17.7.0
-    type: os
-  runtime:
-    name: Electron
-    version: 2.0.2
-    type: runtime
-breadcrumbs:
-  values:
-    - timestamp: 1532692006.665
-      type: ui
-      category: electron
-      level: info
-      message: app.will-finish-launching
-    - timestamp: 1532692006.715
-      type: ui
-      category: electron
-      level: info
-      message: app.ready
-    - timestamp: 1532692006.734
-      type: ui
-      category: electron
-      level: info
-      message: app.session-created
-    - timestamp: 1532692006.754
-      type: ui
-      category: electron
-      level: info
-      message: app.web-contents-created
-    - timestamp: 1532692006.796
-      type: ui
-      category: electron
-      level: info
-      message: app.browser-window-created
-    - timestamp: 1532692006.918
-      type: ui
-      category: electron
-      level: info
-      message: app.browser-window-focus
-    - timestamp: 1532692007.165
-      type: ui
-      category: electron
-      level: info
-      message: "WebContents[1].dom-ready"
-    - timestamp: 1532692011.34
-      type: default
-      category: ui.click
-      level: info
-      message: body > div.main > div.group > a.crash
-exception:
-  values:
-    - type: Error
-      value: Error triggered in main processes
-      stacktrace:
-        frames:
-          - function: "WebContents.emitter.emit.args [as emit]"
-            module: backend
-            filename: "/Users/[user]/Projects/sentry-electron/dist/main/backend.js"
-            abs_path: "/Users/[user]/Projects/sentry-electron/dist/main/backend.js"
-            lineno: 278
-            colno: 20
-            pre_context:
-              - "                    category: 'electron',"
-              - "                    message: `${category}.${event}`,"
-              - "                    timestamp: new Date().getTime() / 1000,"
-              - "                    type: 'ui',"
-              - "                };"
-              - "                minimal_1.addBreadcrumb(breadcrumb);"
-              - "            }"
-            context_line: "            return emit(event, ...args);"
-            post_context:
-              - "        };"
-              - "    }"
-              - "    /** Loads new native crashes from disk and sends them to Sentry. */"
-              - "    sendNativeCrashes(extra) {"
-              - "        return __awaiter(this, void 0, void 0, function* () {"
-              - "            // Whenever we are called, assume that the crashes we are going to load down"
-              - "            // below have occurred recently. This means, we can use the same event data"
-            in_app: false
-          - function: WebContents.emit
-            module: events
-            filename: events.js
-            abs_path: events.js
-            lineno: 214
-            colno: 7
-            in_app: false
-          - function: emitTwo
-            module: events
-            filename: events.js
-            abs_path: events.js
-            lineno: 126
-            colno: 13
-            in_app: false
-          - function: WebContents.<anonymous>
-            module: "electron.dist.Electron.app.Contents.Resources.electron.asar.browser.api:web-contents"
-            filename: "app:///node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/browser/api/web-contents.js"
-            abs_path: "app:///node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/browser/api/web-contents.js"
-            lineno: 286
-            colno: 13
-            pre_context:
-              - ""
-              - "  // Every remote callback from renderer process would add a listenter to the"
-              - "  // render-view-deleted event, so ignore the listenters warning."
-              - "  this.setMaxListeners(0)"
-              - ""
-              - "  // Dispatch IPC messages to the ipc module."
-              - "  this.on('ipc-message', function (event, [channel, ...args]) {"
-            context_line: "    ipcMain.emit(channel, event, ...args)"
-            post_context:
-              - "  })"
-              - "  this.on('ipc-message-sync', function (event, [channel, ...args]) {"
-              - "    Object.defineProperty(event, 'returnValue', {"
-              - "      set: function (value) {"
-              - "        return event.sendReply(JSON.stringify(value))"
-              - "      },"
-              - "      get: function () {}"
-            in_app: false
-          - function: EventEmitter.emit
-            module: events
-            filename: events.js
-            abs_path: events.js
-            lineno: 211
-            colno: 7
-            in_app: false
-          - function: emitOne
-            module: events
-            filename: events.js
-            abs_path: events.js
-            lineno: 116
-            colno: 13
-            in_app: false
-          - function: EventEmitter.ipcMain.on
-            module: main
-            filename: "app:///main.js"
-            abs_path: "app:///main.js"
-            lineno: 38
-            colno: 9
-            pre_context:
-              - ""
-              - "app.on('window-all-closed', () => app.quit());"
-              - ""
-              - // The IPC handlers below trigger errors in the here (main process) when
-              - // the user clicks on corresponding buttons in the UI (renderer).
-              - "ipcMain.on('demo.error', () => {"
-              - "  console.log('Error triggered in main processes');"
-            context_line: "  throw new Error('Error triggered in main processes');"
-            post_context:
-              - "});"
-              - ""
-              - "ipcMain.on('demo.crash', () => {"
-              - "  console.log('process.crash()');"
-              - "  process.crash();"
-              - "});"
-              - ""
-            in_app: true
-tags:
-  - - event_type
-    - javascript
-extra:
-  crashed_process: browser
-sdk:
-  name: sentry.javascript.electron
-  version: 0.8.0
-  packages:
-    - name: "npm:@sentry/node"
-      version: 4.0.0-beta.11
-    - name: "npm:@sentry/node"
-      version: 0.8.0
-_meta:
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 46
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 46
-  user:
-    ip_address:
-      "":
-        rem:
-          - - "@anything:remove"
-            - x
+{
+  "event_id": "ae3a2cc6e08741c5b09946c65c022469",
+  "level": "fatal",
+  "type": "error",
+  "transaction": "main at EventEmitter.ipcMain.on",
+  "logentry": {
+    "formatted": "Error: Error triggered in main processes"
+  },
+  "logger": "",
+  "platform": "other",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "sentry-electron-test@2.0.2",
+  "environment": "development",
+  "user": {
+    "ip_address": null
+  },
+  "contexts": {
+    "app": {
+      "app_name": "Sentry Crash Test",
+      "app_version": "2.0.2",
+      "type": "app"
+    },
+    "chrome": {
+      "name": "Chrome",
+      "version": "61.0.3163.100",
+      "type": "runtime"
+    },
+    "device": {
+      "arch": "x64",
+      "type": "device"
+    },
+    "node": {
+      "name": "Node",
+      "version": "8.9.3",
+      "type": "runtime"
+    },
+    "os": {
+      "name": "Mac OS X",
+      "version": "10.13.6",
+      "build": "17G65",
+      "kernel_version": "17.7.0",
+      "type": "os"
+    },
+    "runtime": {
+      "name": "Electron",
+      "version": "2.0.2",
+      "type": "runtime"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1532692006.665,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "app.will-finish-launching"
+      },
+      {
+        "timestamp": 1532692006.715,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "app.ready"
+      },
+      {
+        "timestamp": 1532692006.734,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "app.session-created"
+      },
+      {
+        "timestamp": 1532692006.754,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "app.web-contents-created"
+      },
+      {
+        "timestamp": 1532692006.796,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "app.browser-window-created"
+      },
+      {
+        "timestamp": 1532692006.918,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "app.browser-window-focus"
+      },
+      {
+        "timestamp": 1532692007.165,
+        "type": "ui",
+        "category": "electron",
+        "level": "info",
+        "message": "WebContents[1].dom-ready"
+      },
+      {
+        "timestamp": 1532692011.34,
+        "type": "default",
+        "category": "ui.click",
+        "level": "info",
+        "message": "body > div.main > div.group > a.crash"
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "Error triggered in main processes",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "WebContents.emitter.emit.args [as emit]",
+              "module": "backend",
+              "filename": "/Users/[user]/Projects/sentry-electron/dist/main/backend.js",
+              "abs_path": "/Users/[user]/Projects/sentry-electron/dist/main/backend.js",
+              "lineno": 278,
+              "colno": 20,
+              "pre_context": [
+                "                    category: 'electron',",
+                "                    message: `${category}.${event}`,",
+                "                    timestamp: new Date().getTime() / 1000,",
+                "                    type: 'ui',",
+                "                };",
+                "                minimal_1.addBreadcrumb(breadcrumb);",
+                "            }"
+              ],
+              "context_line": "            return emit(event, ...args);",
+              "post_context": [
+                "        };",
+                "    }",
+                "    /** Loads new native crashes from disk and sends them to Sentry. */",
+                "    sendNativeCrashes(extra) {",
+                "        return __awaiter(this, void 0, void 0, function* () {",
+                "            // Whenever we are called, assume that the crashes we are going to load down",
+                "            // below have occurred recently. This means, we can use the same event data"
+              ],
+              "in_app": false
+            },
+            {
+              "function": "WebContents.emit",
+              "module": "events",
+              "filename": "events.js",
+              "abs_path": "events.js",
+              "lineno": 214,
+              "colno": 7,
+              "in_app": false
+            },
+            {
+              "function": "emitTwo",
+              "module": "events",
+              "filename": "events.js",
+              "abs_path": "events.js",
+              "lineno": 126,
+              "colno": 13,
+              "in_app": false
+            },
+            {
+              "function": "WebContents.<anonymous>",
+              "module": "electron.dist.Electron.app.Contents.Resources.electron.asar.browser.api:web-contents",
+              "filename": "app:///node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/browser/api/web-contents.js",
+              "abs_path": "app:///node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/browser/api/web-contents.js",
+              "lineno": 286,
+              "colno": 13,
+              "pre_context": [
+                "",
+                "  // Every remote callback from renderer process would add a listenter to the",
+                "  // render-view-deleted event, so ignore the listenters warning.",
+                "  this.setMaxListeners(0)",
+                "",
+                "  // Dispatch IPC messages to the ipc module.",
+                "  this.on('ipc-message', function (event, [channel, ...args]) {"
+              ],
+              "context_line": "    ipcMain.emit(channel, event, ...args)",
+              "post_context": [
+                "  })",
+                "  this.on('ipc-message-sync', function (event, [channel, ...args]) {",
+                "    Object.defineProperty(event, 'returnValue', {",
+                "      set: function (value) {",
+                "        return event.sendReply(JSON.stringify(value))",
+                "      },",
+                "      get: function () {}"
+              ],
+              "in_app": false
+            },
+            {
+              "function": "EventEmitter.emit",
+              "module": "events",
+              "filename": "events.js",
+              "abs_path": "events.js",
+              "lineno": 211,
+              "colno": 7,
+              "in_app": false
+            },
+            {
+              "function": "emitOne",
+              "module": "events",
+              "filename": "events.js",
+              "abs_path": "events.js",
+              "lineno": 116,
+              "colno": 13,
+              "in_app": false
+            },
+            {
+              "function": "EventEmitter.ipcMain.on",
+              "module": "main",
+              "filename": "app:///main.js",
+              "abs_path": "app:///main.js",
+              "lineno": 38,
+              "colno": 9,
+              "pre_context": [
+                "",
+                "app.on('window-all-closed', () => app.quit());",
+                "",
+                "// The IPC handlers below trigger errors in the here (main process) when",
+                "// the user clicks on corresponding buttons in the UI (renderer).",
+                "ipcMain.on('demo.error', () => {",
+                "  console.log('Error triggered in main processes');"
+              ],
+              "context_line": "  throw new Error('Error triggered in main processes');",
+              "post_context": [
+                "});",
+                "",
+                "ipcMain.on('demo.crash', () => {",
+                "  console.log('process.crash()');",
+                "  process.crash();",
+                "});",
+                ""
+              ],
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "event_type",
+      "javascript"
+    ]
+  ],
+  "extra": {
+    "crashed_process": "browser"
+  },
+  "sdk": {
+    "name": "sentry.javascript.electron",
+    "version": "0.8.0",
+    "packages": [
+      {
+        "name": "npm:@sentry/node",
+        "version": "4.0.0-beta.11"
+      },
+      {
+        "name": "npm:@sentry/node",
+        "version": "0.8.0"
+      }
+    ]
+  },
+  "_meta": {
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 46
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 46
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "user": {
+      "ip_address": {
+        "": {
+          "rem": [
+            [
+              "@anything:remove",
+              "x"
+            ]
+          ]
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -1,815 +1,1161 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 04e03764d7024caab8736daeefbb9bee
-level: error
-type: error
-logger: ""
-modules:
-  Microsoft.AI.DependencyCollector: 2.4.1.0
-  Microsoft.ApplicationInsights: 2.4.0.0
-  Microsoft.ApplicationInsights.AspNetCore: 2.1.1.0
-  Microsoft.AspNetCore: 2.0.3.0
-  Microsoft.AspNetCore.Antiforgery: 2.0.3.0
-  Microsoft.AspNetCore.ApplicationInsights.HostingStartup: 2.0.3.0
-  Microsoft.AspNetCore.Authentication.Abstractions: 2.0.3.0
-  Microsoft.AspNetCore.Authentication.Core: 2.0.3.0
-  Microsoft.AspNetCore.Authorization: 2.0.4.0
-  Microsoft.AspNetCore.Authorization.Policy: 2.0.4.0
-  Microsoft.AspNetCore.Cors: 2.0.3.0
-  Microsoft.AspNetCore.Cryptography.Internal: 2.0.3.0
-  Microsoft.AspNetCore.DataProtection: 2.0.3.0
-  Microsoft.AspNetCore.DataProtection.Abstractions: 2.0.3.0
-  Microsoft.AspNetCore.Diagnostics: 2.0.3.0
-  Microsoft.AspNetCore.Diagnostics.Abstractions: 2.1.0.0
-  Microsoft.AspNetCore.Hosting: 2.1.0.0
-  Microsoft.AspNetCore.Hosting.Abstractions: 2.1.0.0
-  Microsoft.AspNetCore.Hosting.Server.Abstractions: 2.1.0.0
-  Microsoft.AspNetCore.Html.Abstractions: 2.0.2.0
-  Microsoft.AspNetCore.Http: 2.1.0.0
-  Microsoft.AspNetCore.Http.Abstractions: 2.1.0.0
-  Microsoft.AspNetCore.Http.Extensions: 2.1.0.0
-  Microsoft.AspNetCore.Http.Features: 2.1.0.0
-  Microsoft.AspNetCore.HttpOverrides: 2.0.3.0
-  Microsoft.AspNetCore.JsonPatch: 2.0.0.0
-  Microsoft.AspNetCore.Mvc: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.Abstractions: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.ApiExplorer: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.Core: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.Cors: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.DataAnnotations: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.Formatters.Json: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.Razor: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.Razor.Extensions: 2.0.3.0
-  Microsoft.AspNetCore.Mvc.RazorPages: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.TagHelpers: 2.0.4.0
-  Microsoft.AspNetCore.Mvc.ViewFeatures: 2.0.4.0
-  Microsoft.AspNetCore.Razor: 2.0.3.0
-  Microsoft.AspNetCore.Razor.Language: 2.0.3.0
-  Microsoft.AspNetCore.Razor.Runtime: 2.0.3.0
-  Microsoft.AspNetCore.Routing: 2.0.3.0
-  Microsoft.AspNetCore.Routing.Abstractions: 2.0.3.0
-  Microsoft.AspNetCore.Server.IISIntegration: 2.0.3.0
-  Microsoft.AspNetCore.Server.Kestrel: 2.0.3.0
-  Microsoft.AspNetCore.Server.Kestrel.Core: 2.0.3.0
-  Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions: 2.0.3.0
-  Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv: 2.0.3.0
-  Microsoft.AspNetCore.SpaServices: 2.0.4.0
-  Microsoft.AspNetCore.StaticFiles: 2.0.3.0
-  Microsoft.AspNetCore.WebUtilities: 2.1.0.0
-  Microsoft.CodeAnalysis: 2.3.0.0
-  Microsoft.CodeAnalysis.CSharp: 2.3.0.0
-  Microsoft.CodeAnalysis.Razor: 2.0.3.0
-  Microsoft.DotNet.PlatformAbstractions: 2.0.3.0
-  Microsoft.Extensions.Caching.Abstractions: 2.0.2.0
-  Microsoft.Extensions.Caching.Memory: 2.0.2.0
-  Microsoft.Extensions.Configuration: 2.1.0.0
-  Microsoft.Extensions.Configuration.Abstractions: 2.1.0.0
-  Microsoft.Extensions.Configuration.Binder: 2.1.0.0
-  Microsoft.Extensions.Configuration.CommandLine: 2.0.2.0
-  Microsoft.Extensions.Configuration.EnvironmentVariables: 2.1.0.0
-  Microsoft.Extensions.Configuration.FileExtensions: 2.1.0.0
-  Microsoft.Extensions.Configuration.Json: 2.0.2.0
-  Microsoft.Extensions.DependencyInjection: 2.1.0.0
-  Microsoft.Extensions.DependencyInjection.Abstractions: 2.1.0.0
-  Microsoft.Extensions.DependencyModel: 2.0.3.0
-  Microsoft.Extensions.DiagnosticAdapter: 2.0.1.0
-  Microsoft.Extensions.FileProviders.Abstractions: 2.1.0.0
-  Microsoft.Extensions.FileProviders.Physical: 2.1.0.0
-  Microsoft.Extensions.FileSystemGlobbing: 2.1.0.0
-  Microsoft.Extensions.Hosting.Abstractions: 2.1.0.0
-  Microsoft.Extensions.Localization.Abstractions: 2.0.3.0
-  Microsoft.Extensions.Logging: 2.1.0.0
-  Microsoft.Extensions.Logging.Abstractions: 2.1.0.0
-  Microsoft.Extensions.Logging.Configuration: 2.0.2.0
-  Microsoft.Extensions.Logging.Console: 2.0.2.0
-  Microsoft.Extensions.Logging.Debug: 2.0.2.0
-  Microsoft.Extensions.ObjectPool: 2.1.0.0
-  Microsoft.Extensions.Options: 2.1.0.0
-  Microsoft.Extensions.Options.ConfigurationExtensions: 2.0.2.0
-  Microsoft.Extensions.Primitives: 2.1.0.0
-  Microsoft.Extensions.WebEncoders: 2.0.2.0
-  Microsoft.Net.Http.Headers: 2.1.0.0
-  Microsoft.VisualStudio.Web.BrowserLink: 2.0.3.0
-  Microsoft.Win32.Registry: 4.1.0.0
-  Newtonsoft.Json: 11.0.0.0
-  Sentry: 0.0.1.0
-  Sentry.AspNetCore: 0.0.1.0
-  Sentry.Extensions.Logging: 0.0.1.0
-  Sentry.PlatformAbstractions: 1.0.0.0
-  Sentry.Samples.AspNetCore.Mvc: 1.0.0.0
-  System.AppContext: 4.2.0.0
-  System.Buffers: 4.0.2.0
-  System.Collections: 4.1.0.0
-  System.Collections.Concurrent: 4.0.14.0
-  System.Collections.Immutable: 1.2.3.0
-  System.Collections.Specialized: 4.1.0.0
-  System.ComponentModel: 4.0.3.0
-  System.ComponentModel.Annotations: 4.2.0.0
-  System.ComponentModel.Primitives: 4.2.0.0
-  System.ComponentModel.TypeConverter: 4.2.0.0
-  System.Console: 4.1.0.0
-  System.Data.Common: 4.2.0.0
-  System.Diagnostics.Debug: 4.1.0.0
-  System.Diagnostics.DiagnosticSource: 4.0.3.0
-  System.Diagnostics.StackTrace: 4.1.0.0
-  System.Diagnostics.Tools: 4.1.0.0
-  System.Diagnostics.TraceSource: 4.1.0.0
-  System.Diagnostics.Tracing: 4.2.0.0
-  System.Drawing.Primitives: 4.1.0.0
-  System.Globalization: 4.1.0.0
-  System.IO: 4.2.0.0
-  System.IO.FileSystem: 4.1.0.0
-  System.IO.FileSystem.Primitives: 4.1.0.0
-  System.IO.FileSystem.Watcher: 4.1.0.0
-  System.Linq: 4.2.0.0
-  System.Linq.Expressions: 4.2.0.0
-  System.Net.Http: 4.2.0.0
-  System.Net.NameResolution: 4.1.0.0
-  System.Net.Primitives: 4.1.0.0
-  System.Numerics.Vectors: 4.1.3.0
-  System.ObjectModel: 4.1.0.0
-  System.Private.CoreLib: 4.0.0.0
-  System.Private.Uri: 4.0.4.0
-  System.Private.Xml: 4.0.0.0
-  System.Private.Xml.Linq: 4.0.0.0
-  System.Reflection: 4.2.0.0
-  System.Reflection.Emit: 4.1.0.0
-  System.Reflection.Emit.ILGeneration: 4.0.3.0
-  System.Reflection.Emit.Lightweight: 4.0.3.0
-  System.Reflection.Extensions: 4.1.0.0
-  System.Reflection.Metadata: 1.4.3.0
-  System.Reflection.Primitives: 4.1.0.0
-  System.Resources.ResourceManager: 4.1.0.0
-  System.Runtime: 4.2.0.0
-  System.Runtime.CompilerServices.Unsafe: 4.0.4.0
-  System.Runtime.Extensions: 4.2.0.0
-  System.Runtime.InteropServices: 4.2.0.0
-  System.Runtime.InteropServices.RuntimeInformation: 4.0.2.0
-  System.Runtime.Numerics: 4.1.0.0
-  System.Runtime.Serialization.Formatters: 4.0.2.0
-  System.Security.Claims: 4.1.0.0
-  System.Security.Cryptography.Algorithms: 4.3.0.0
-  System.Security.Cryptography.Primitives: 4.1.0.0
-  System.Security.Cryptography.X509Certificates: 4.2.0.0
-  System.Security.Principal: 4.1.0.0
-  System.Text.Encoding: 4.1.0.0
-  System.Text.Encoding.Extensions: 4.1.0.0
-  System.Text.Encodings.Web: 4.0.3.0
-  System.Text.RegularExpressions: 4.2.0.0
-  System.Threading: 4.1.0.0
-  System.Threading.Overlapped: 4.1.0.0
-  System.Threading.Tasks: 4.1.0.0
-  System.Threading.Tasks.Parallel: 4.0.3.0
-  System.Threading.Thread: 4.1.0.0
-  System.Threading.ThreadPool: 4.1.0.0
-  System.Threading.Timer: 4.1.0.0
-  System.ValueTuple: 4.0.2.0
-  System.Xml.XDocument: 4.1.0.0
-  b3kd5uzy.5ut: 0.0.0.0
-  cvrsljbk.gm1: 0.0.0.0
-  fwwefxr0.3z0: 0.0.0.0
-  nbxk3h5b.orp: 0.0.0.0
-  netstandard: 2.0.0.0
-platform: csharp
-timestamp: "[timestamp]"
-received: "[received]"
-release: e386dfd
-environment: Production
-user:
-  ip_address: ~
-request:
-  url: /Home/PostIndex
-  method: POST
-  data:
-    a: b
-    c:
-      - d: e
-        f: g
-  cookies:
-    - - ".AspNetCore.Antiforgery._2NlYY4B078"
-      - CfDJ8ChafIEN-7pHv152tZrpaC_lvW7hdfN_EdO5t5Zh63rpzWqqsA5O2nEyfM5KDfb0QyrEiEK_I3phDQyTPdGKKImqEXWHWHjLJyUU8VRQNNsFvKgwyLiiOc1mDPNxlDbsXhWV44nuF4SzFe9gy9mm_g0
-    - - wcsid
-      - "[Filtered]"
-    - - hblid
-      - "[Filtered]"
-    - - _okdetect
-      - "{[ok detect token],\"proto\":\"http:\",\"host\":\"localhost:4040\"}"
-    - - olfsk
-      - olfsk36178984508065715
-    - - _okbk
-      - "cd4=true,vi5=0,vi4=1532343436427,vi3=active,vi2=false,vi1=false,cd8=chat,cd6=0,cd5=away,cd3=false,cd2=0,cd1=0,"
-    - - _ok
-      - 1700-237-10-3483
-    - - _oklv
-      - "1532343437829,9BYRwrV1RfdG7uxS3m39N0NXoA7d3ajb"
-  headers:
-    - - Accept
-      - "application/json, text/javascript, */*; q=0.01"
-    - - Accept-Encoding
-      - "gzip, deflate, br"
-    - - Accept-Language
-      - "en-US,en;q=0.9,de-AT;q=0.8,de;q=0.7,cs-CZ;q=0.6,cs;q=0.5,pt-BR;q=0.4,pt;q=0.3,es-AR;q=0.2,es;q=0.1"
-    - - Connection
-      - Keep-Alive
-    - - Content-Length
-      - "65"
-    - - Content-Type
-      - application/json; charset=UTF-8
-    - - Host
-      - "localhost:62919"
-    - - MS-ASPNETCORE-TOKEN
-      - "[Filtered]"
-    - - Origin
-      - "http://localhost:62919"
-    - - Referer
-      - "http://localhost:62919/"
-    - - User-Agent
-      - "[Filtered]"
-    - - X-Original-For
-      - "127.0.0.1:50788"
-    - - X-Original-Proto
-      - http
-    - - X-Requested-With
-      - XMLHttpRequest
-  env:
-    DOCUMENT_ROOT: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\wwwroot"
-    REMOTE_ADDR: "::1"
-    SERVER_NAME: TAMPERE
-    SERVER_PORT: "15446"
-    SERVER_SOFTWARE: Kestrel
-  inferred_content_type: application/json
-contexts:
-  server-os:
-    name: Windows
-    version: "10"
-    build: "17134"
-    raw_description: "Microsoft Windows 10.0.17134 "
-    type: os
-  server-runtime:
-    name: ".NET Core"
-    version: 2.0.7
-    raw_description: ".NET Core 4.6.26328.01"
-    type: runtime
-breadcrumbs:
-  values:
-    - timestamp: 1532343407
-      type: default
-      category: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager
-      level: info
-      message: "User profile is available. Using 'C:\\Users\\[user]\\AppData\\Local\\ASP.NET\\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest."
-    - timestamp: 1532343443
-      type: default
-      category: Microsoft.AspNetCore.Hosting.Internal.WebHost
-      level: info
-      message: "Request starting HTTP/1.1 POST http://localhost:62919/Home/[user]/json; charset=UTF-8 65"
-      data:
-        eventId: "1"
-    - timestamp: 1532343443
-      type: default
-      category: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-      level: info
-      message: Executing action method Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.PostIndex (Sentry.Samples.AspNetCore.Mvc) with arguments () - ModelState is Valid
-      data:
-        eventId: "1"
-    - timestamp: 1532343443
-      type: default
-      category: Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController
-      level: warning
-      message: Param is null!
-    - timestamp: 1532343443
-      type: default
-      category: Sentry.Samples.AspNetCore.Mvc.GameService
-      level: info
-      message: Fetching dungeons and mana level in parallel.
-    - timestamp: 1532343443
-      type: default
-      category: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-      level: info
-      message: Executed action Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.PostIndex (Sentry.Samples.AspNetCore.Mvc) in 43.7868ms
-      data:
-        eventId: "2"
-    - timestamp: 1532343443
-      type: default
-      category: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-      level: info
-      message: Executing action method Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.Error (Sentry.Samples.AspNetCore.Mvc) with arguments ((null)) - ModelState is Valid
-      data:
-        eventId: "1"
-    - timestamp: 1532343443
-      type: default
-      category: Microsoft.AspNetCore.Mvc.ViewFeatures.Internal.ViewResultExecutor
-      level: info
-      message: "Executing ViewResult, running view at path /Views/Shared/Error.cshtml."
-      data:
-        eventId: "1"
-    - timestamp: 1532343443
-      type: default
-      category: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-      level: info
-      message: Executed action Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.Error (Sentry.Samples.AspNetCore.Mvc) in 146.9482ms
-      data:
-        eventId: "2"
-exception:
-  values:
-    - type: System.Net.Http.HttpRequestException
-      value: Failed to fetch available Dungeons
-      module: "System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-      stacktrace:
-        frames:
-          - function: FetchNextPhaseDataAsync
-            module: Sentry.Samples.AspNetCore.Mvc.GameService
-            package: "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0"
-            filename: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            abs_path: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            lineno: 25
-            colno: 17
-            context_line: Void MoveNext()
-            in_app: true
-          - function: GetResult
-            module: "System.Runtime.CompilerServices.TaskAwaiter`1"
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: TResult GetResult()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: ExecuteWithThreadLocal
-            module: System.Threading.Tasks.Task
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef)
-            in_app: false
-          - function: Run
-            module: System.Threading.ExecutionContext
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: "Void Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)"
-            in_app: false
-          - function: InnerInvoke
-            module: "System.Threading.Tasks.Task`1"
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void InnerInvoke()
-            in_app: false
-          - function: "FetchNextPhaseDataAsync { <lambda> }"
-            module: Sentry.Samples.AspNetCore.Mvc.GameService+<>c
-            package: "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0"
-            filename: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            abs_path: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            lineno: 19
-            colno: 64
-            context_line: Int32 <FetchNextPhaseDataAsync>b__2_0()
-            in_app: true
-      thread_id: 25
-    - type: System.Data.DataException
-      value: "Invalid Mana level: -10"
-      module: "System.Data.Common, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-      stacktrace:
-        frames:
-          - function: ExecuteWithThreadLocal
-            module: System.Threading.Tasks.Task
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef)
-            in_app: false
-          - function: Run
-            module: System.Threading.ExecutionContext
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: "Void Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)"
-            in_app: false
-          - function: InnerInvoke
-            module: "System.Threading.Tasks.Task`1"
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void InnerInvoke()
-            in_app: false
-          - function: "FetchNextPhaseDataAsync { <lambda> }"
-            module: Sentry.Samples.AspNetCore.Mvc.GameService+<>c
-            package: "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0"
-            filename: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            abs_path: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            lineno: 20
-            colno: 60
-            context_line: Int32 <FetchNextPhaseDataAsync>b__2_1()
-            in_app: true
-      thread_id: 25
-    - type: System.AggregateException
-      value: "One or more errors occurred. (Failed to fetch available Dungeons) (Invalid Mana level: -10)"
-      module: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-      stacktrace:
-        frames:
-          - function: PostIndex
-            module: Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController
-            package: "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0"
-            filename: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs"
-            abs_path: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs"
-            lineno: 38
-            colno: 17
-            context_line: Void MoveNext()
-            in_app: true
-          - function: GetResult
-            module: "System.Runtime.CompilerServices.TaskAwaiter`1"
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: TResult GetResult()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: FetchNextPhaseDataAsync
-            module: Sentry.Samples.AspNetCore.Mvc.GameService
-            package: "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0"
-            filename: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            abs_path: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs"
-            lineno: 31
-            colno: 17
-            context_line: Void MoveNext()
-            in_app: true
-      thread_id: 25
-    - type: System.InvalidOperationException
-      value: Bad POST! See Inner exception for details.
-      module: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-      stacktrace:
-        frames:
-          - function: Invoke
-            module: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware
-            package: "Microsoft.AspNetCore.Diagnostics, Version=2.0.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: Invoke
-            module: Microsoft.AspNetCore.Builder.RouterMiddleware
-            package: "Microsoft.AspNetCore.Routing, Version=2.0.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: InvokeAsync
-            module: Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: InvokeFilterPipelineAsync
-            module: Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: Next
-            module: Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: "System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)"
-            in_app: false
-          - function: Rethrow
-            module: Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: InvokeNextResourceFilter
-            module: Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: InvokeInnerFilterAsync
-            module: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: Next
-            module: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: "System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)"
-            in_app: false
-          - function: Rethrow
-            module: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: InvokeNextActionFilterAsync
-            module: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: InvokeActionMethodAsync
-            module: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker
-            package: "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60"
-            context_line: Void MoveNext()
-            in_app: false
-          - function: HandleNonSuccessAndDebuggerNotification
-            module: System.Runtime.CompilerServices.TaskAwaiter
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-            in_app: false
-          - function: Throw
-            module: System.Runtime.ExceptionServices.ExceptionDispatchInfo
-            package: "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"
-            context_line: Void Throw()
-            in_app: false
-          - function: PostIndex
-            module: Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController
-            package: "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0"
-            filename: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs"
-            abs_path: "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs"
-            lineno: 53
-            colno: 17
-            context_line: Void MoveNext()
-            in_app: true
-      thread_id: 25
-tags:
-  - - RequestId
-    - ~
-extra:
-  "Response:HasStarted": true
-  "System.AggregateException.Data[inventory]":
-    BigPotion: 0
-    CheeseWheels: 512
-    SmallPotion: 3
-  "System.Data.DataException.Data[inventory]":
-    BigPotion: 0
-    CheeseWheels: 512
-    SmallPotion: 3
-  "System.InvalidOperationException.Data[inventory]":
-    BigPotion: 0
-    CheeseWheels: 512
-    SmallPotion: 3
-  "System.Net.Http.HttpRequestException.Data[inventory]":
-    BigPotion: 0
-    CheeseWheels: 512
-    SmallPotion: 3
-sdk:
-  name: Sentry.AspNetCore
-  version: 0.0.1-preview3
-_meta:
-  breadcrumbs:
-    values:
-      "0":
-        message:
-          "":
-            rem:
-              - - "@userpath:replace"
-                - s
-                - 43
-                - 49
-            len: 152
-      "1":
-        message:
-          "":
-            rem:
-              - - "@userpath:replace"
-                - s
-                - 59
-                - 65
-            len: 103
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-            "7":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-      "1":
-        stacktrace:
-          frames:
-            "3":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-      "2":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 82
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 82
-            "4":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 70
-      "3":
-        stacktrace:
-          frames:
-            "26":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 82
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 9
-                      - 15
-                  len: 82
-  request:
-    cookies:
-      "1":
-        "1":
-          "":
-            rem:
-              - - "@anything:replace"
-                - s
-                - 0
-                - 10
-            len: 32
-      "2":
-        "1":
-          "":
-            rem:
-              - - "@anything:replace"
-                - s
-                - 0
-                - 10
-            len: 32
-      "3":
-        "1":
-          "":
-            rem:
-              - - removeOkDetectToken
-                - s
-                - 1
-                - 18
-            len: 66
-    env:
-      DOCUMENT_ROOT:
-        "":
-          rem:
-            - - "@userpath:replace"
-              - s
-              - 9
-              - 15
-          len: 78
-    headers:
-      "10":
-        "1":
-          "":
-            rem:
-              - - "@anything:replace"
-                - s
-                - 0
-                - 10
-            len: 114
-      "7":
-        "1":
-          "":
-            rem:
-              - - "@anything:replace"
-                - s
-                - 0
-                - 10
-            len: 36
-  tags:
-    "0":
-      "1":
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-  user:
-    ip_address:
-      "":
-        rem:
-          - - "@anything:remove"
-            - x
-
+{
+  "event_id": "04e03764d7024caab8736daeefbb9bee",
+  "level": "error",
+  "type": "error",
+  "logger": "",
+  "modules": {
+    "Microsoft.AI.DependencyCollector": "2.4.1.0",
+    "Microsoft.ApplicationInsights": "2.4.0.0",
+    "Microsoft.ApplicationInsights.AspNetCore": "2.1.1.0",
+    "Microsoft.AspNetCore": "2.0.3.0",
+    "Microsoft.AspNetCore.Antiforgery": "2.0.3.0",
+    "Microsoft.AspNetCore.ApplicationInsights.HostingStartup": "2.0.3.0",
+    "Microsoft.AspNetCore.Authentication.Abstractions": "2.0.3.0",
+    "Microsoft.AspNetCore.Authentication.Core": "2.0.3.0",
+    "Microsoft.AspNetCore.Authorization": "2.0.4.0",
+    "Microsoft.AspNetCore.Authorization.Policy": "2.0.4.0",
+    "Microsoft.AspNetCore.Cors": "2.0.3.0",
+    "Microsoft.AspNetCore.Cryptography.Internal": "2.0.3.0",
+    "Microsoft.AspNetCore.DataProtection": "2.0.3.0",
+    "Microsoft.AspNetCore.DataProtection.Abstractions": "2.0.3.0",
+    "Microsoft.AspNetCore.Diagnostics": "2.0.3.0",
+    "Microsoft.AspNetCore.Diagnostics.Abstractions": "2.1.0.0",
+    "Microsoft.AspNetCore.Hosting": "2.1.0.0",
+    "Microsoft.AspNetCore.Hosting.Abstractions": "2.1.0.0",
+    "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.1.0.0",
+    "Microsoft.AspNetCore.Html.Abstractions": "2.0.2.0",
+    "Microsoft.AspNetCore.Http": "2.1.0.0",
+    "Microsoft.AspNetCore.Http.Abstractions": "2.1.0.0",
+    "Microsoft.AspNetCore.Http.Extensions": "2.1.0.0",
+    "Microsoft.AspNetCore.Http.Features": "2.1.0.0",
+    "Microsoft.AspNetCore.HttpOverrides": "2.0.3.0",
+    "Microsoft.AspNetCore.JsonPatch": "2.0.0.0",
+    "Microsoft.AspNetCore.Mvc": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.Abstractions": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.ApiExplorer": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.Core": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.Cors": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.DataAnnotations": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.Razor": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.Razor.Extensions": "2.0.3.0",
+    "Microsoft.AspNetCore.Mvc.RazorPages": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "2.0.4.0",
+    "Microsoft.AspNetCore.Mvc.ViewFeatures": "2.0.4.0",
+    "Microsoft.AspNetCore.Razor": "2.0.3.0",
+    "Microsoft.AspNetCore.Razor.Language": "2.0.3.0",
+    "Microsoft.AspNetCore.Razor.Runtime": "2.0.3.0",
+    "Microsoft.AspNetCore.Routing": "2.0.3.0",
+    "Microsoft.AspNetCore.Routing.Abstractions": "2.0.3.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "2.0.3.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "2.0.3.0",
+    "Microsoft.AspNetCore.Server.Kestrel.Core": "2.0.3.0",
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.0.3.0",
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv": "2.0.3.0",
+    "Microsoft.AspNetCore.SpaServices": "2.0.4.0",
+    "Microsoft.AspNetCore.StaticFiles": "2.0.3.0",
+    "Microsoft.AspNetCore.WebUtilities": "2.1.0.0",
+    "Microsoft.CodeAnalysis": "2.3.0.0",
+    "Microsoft.CodeAnalysis.CSharp": "2.3.0.0",
+    "Microsoft.CodeAnalysis.Razor": "2.0.3.0",
+    "Microsoft.DotNet.PlatformAbstractions": "2.0.3.0",
+    "Microsoft.Extensions.Caching.Abstractions": "2.0.2.0",
+    "Microsoft.Extensions.Caching.Memory": "2.0.2.0",
+    "Microsoft.Extensions.Configuration": "2.1.0.0",
+    "Microsoft.Extensions.Configuration.Abstractions": "2.1.0.0",
+    "Microsoft.Extensions.Configuration.Binder": "2.1.0.0",
+    "Microsoft.Extensions.Configuration.CommandLine": "2.0.2.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.0.0",
+    "Microsoft.Extensions.Configuration.FileExtensions": "2.1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "2.0.2.0",
+    "Microsoft.Extensions.DependencyInjection": "2.1.0.0",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0.0",
+    "Microsoft.Extensions.DependencyModel": "2.0.3.0",
+    "Microsoft.Extensions.DiagnosticAdapter": "2.0.1.0",
+    "Microsoft.Extensions.FileProviders.Abstractions": "2.1.0.0",
+    "Microsoft.Extensions.FileProviders.Physical": "2.1.0.0",
+    "Microsoft.Extensions.FileSystemGlobbing": "2.1.0.0",
+    "Microsoft.Extensions.Hosting.Abstractions": "2.1.0.0",
+    "Microsoft.Extensions.Localization.Abstractions": "2.0.3.0",
+    "Microsoft.Extensions.Logging": "2.1.0.0",
+    "Microsoft.Extensions.Logging.Abstractions": "2.1.0.0",
+    "Microsoft.Extensions.Logging.Configuration": "2.0.2.0",
+    "Microsoft.Extensions.Logging.Console": "2.0.2.0",
+    "Microsoft.Extensions.Logging.Debug": "2.0.2.0",
+    "Microsoft.Extensions.ObjectPool": "2.1.0.0",
+    "Microsoft.Extensions.Options": "2.1.0.0",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.2.0",
+    "Microsoft.Extensions.Primitives": "2.1.0.0",
+    "Microsoft.Extensions.WebEncoders": "2.0.2.0",
+    "Microsoft.Net.Http.Headers": "2.1.0.0",
+    "Microsoft.VisualStudio.Web.BrowserLink": "2.0.3.0",
+    "Microsoft.Win32.Registry": "4.1.0.0",
+    "Newtonsoft.Json": "11.0.0.0",
+    "Sentry": "0.0.1.0",
+    "Sentry.AspNetCore": "0.0.1.0",
+    "Sentry.Extensions.Logging": "0.0.1.0",
+    "Sentry.PlatformAbstractions": "1.0.0.0",
+    "Sentry.Samples.AspNetCore.Mvc": "1.0.0.0",
+    "System.AppContext": "4.2.0.0",
+    "System.Buffers": "4.0.2.0",
+    "System.Collections": "4.1.0.0",
+    "System.Collections.Concurrent": "4.0.14.0",
+    "System.Collections.Immutable": "1.2.3.0",
+    "System.Collections.Specialized": "4.1.0.0",
+    "System.ComponentModel": "4.0.3.0",
+    "System.ComponentModel.Annotations": "4.2.0.0",
+    "System.ComponentModel.Primitives": "4.2.0.0",
+    "System.ComponentModel.TypeConverter": "4.2.0.0",
+    "System.Console": "4.1.0.0",
+    "System.Data.Common": "4.2.0.0",
+    "System.Diagnostics.Debug": "4.1.0.0",
+    "System.Diagnostics.DiagnosticSource": "4.0.3.0",
+    "System.Diagnostics.StackTrace": "4.1.0.0",
+    "System.Diagnostics.Tools": "4.1.0.0",
+    "System.Diagnostics.TraceSource": "4.1.0.0",
+    "System.Diagnostics.Tracing": "4.2.0.0",
+    "System.Drawing.Primitives": "4.1.0.0",
+    "System.Globalization": "4.1.0.0",
+    "System.IO": "4.2.0.0",
+    "System.IO.FileSystem": "4.1.0.0",
+    "System.IO.FileSystem.Primitives": "4.1.0.0",
+    "System.IO.FileSystem.Watcher": "4.1.0.0",
+    "System.Linq": "4.2.0.0",
+    "System.Linq.Expressions": "4.2.0.0",
+    "System.Net.Http": "4.2.0.0",
+    "System.Net.NameResolution": "4.1.0.0",
+    "System.Net.Primitives": "4.1.0.0",
+    "System.Numerics.Vectors": "4.1.3.0",
+    "System.ObjectModel": "4.1.0.0",
+    "System.Private.CoreLib": "4.0.0.0",
+    "System.Private.Uri": "4.0.4.0",
+    "System.Private.Xml": "4.0.0.0",
+    "System.Private.Xml.Linq": "4.0.0.0",
+    "System.Reflection": "4.2.0.0",
+    "System.Reflection.Emit": "4.1.0.0",
+    "System.Reflection.Emit.ILGeneration": "4.0.3.0",
+    "System.Reflection.Emit.Lightweight": "4.0.3.0",
+    "System.Reflection.Extensions": "4.1.0.0",
+    "System.Reflection.Metadata": "1.4.3.0",
+    "System.Reflection.Primitives": "4.1.0.0",
+    "System.Resources.ResourceManager": "4.1.0.0",
+    "System.Runtime": "4.2.0.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.0.4.0",
+    "System.Runtime.Extensions": "4.2.0.0",
+    "System.Runtime.InteropServices": "4.2.0.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.2.0",
+    "System.Runtime.Numerics": "4.1.0.0",
+    "System.Runtime.Serialization.Formatters": "4.0.2.0",
+    "System.Security.Claims": "4.1.0.0",
+    "System.Security.Cryptography.Algorithms": "4.3.0.0",
+    "System.Security.Cryptography.Primitives": "4.1.0.0",
+    "System.Security.Cryptography.X509Certificates": "4.2.0.0",
+    "System.Security.Principal": "4.1.0.0",
+    "System.Text.Encoding": "4.1.0.0",
+    "System.Text.Encoding.Extensions": "4.1.0.0",
+    "System.Text.Encodings.Web": "4.0.3.0",
+    "System.Text.RegularExpressions": "4.2.0.0",
+    "System.Threading": "4.1.0.0",
+    "System.Threading.Overlapped": "4.1.0.0",
+    "System.Threading.Tasks": "4.1.0.0",
+    "System.Threading.Tasks.Parallel": "4.0.3.0",
+    "System.Threading.Thread": "4.1.0.0",
+    "System.Threading.ThreadPool": "4.1.0.0",
+    "System.Threading.Timer": "4.1.0.0",
+    "System.ValueTuple": "4.0.2.0",
+    "System.Xml.XDocument": "4.1.0.0",
+    "b3kd5uzy.5ut": "0.0.0.0",
+    "cvrsljbk.gm1": "0.0.0.0",
+    "fwwefxr0.3z0": "0.0.0.0",
+    "nbxk3h5b.orp": "0.0.0.0",
+    "netstandard": "2.0.0.0"
+  },
+  "platform": "csharp",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "e386dfd",
+  "environment": "Production",
+  "user": {
+    "ip_address": null
+  },
+  "request": {
+    "url": "/Home/PostIndex",
+    "method": "POST",
+    "data": {
+      "a": "b",
+      "c": [
+        {
+          "d": "e",
+          "f": "g"
+        }
+      ]
+    },
+    "cookies": [
+      [
+        ".AspNetCore.Antiforgery._2NlYY4B078",
+        "CfDJ8ChafIEN-7pHv152tZrpaC_lvW7hdfN_EdO5t5Zh63rpzWqqsA5O2nEyfM5KDfb0QyrEiEK_I3phDQyTPdGKKImqEXWHWHjLJyUU8VRQNNsFvKgwyLiiOc1mDPNxlDbsXhWV44nuF4SzFe9gy9mm_g0"
+      ],
+      [
+        "wcsid",
+        "[Filtered]"
+      ],
+      [
+        "hblid",
+        "[Filtered]"
+      ],
+      [
+        "_okdetect",
+        "{[ok detect token],\"proto\":\"http:\",\"host\":\"localhost:4040\"}"
+      ],
+      [
+        "olfsk",
+        "olfsk36178984508065715"
+      ],
+      [
+        "_okbk",
+        "cd4=true,vi5=0,vi4=1532343436427,vi3=active,vi2=false,vi1=false,cd8=chat,cd6=0,cd5=away,cd3=false,cd2=0,cd1=0,"
+      ],
+      [
+        "_ok",
+        "1700-237-10-3483"
+      ],
+      [
+        "_oklv",
+        "1532343437829,9BYRwrV1RfdG7uxS3m39N0NXoA7d3ajb"
+      ]
+    ],
+    "headers": [
+      [
+        "Accept",
+        "application/json, text/javascript, */*; q=0.01"
+      ],
+      [
+        "Accept-Encoding",
+        "gzip, deflate, br"
+      ],
+      [
+        "Accept-Language",
+        "en-US,en;q=0.9,de-AT;q=0.8,de;q=0.7,cs-CZ;q=0.6,cs;q=0.5,pt-BR;q=0.4,pt;q=0.3,es-AR;q=0.2,es;q=0.1"
+      ],
+      [
+        "Connection",
+        "Keep-Alive"
+      ],
+      [
+        "Content-Length",
+        "65"
+      ],
+      [
+        "Content-Type",
+        "application/json; charset=UTF-8"
+      ],
+      [
+        "Host",
+        "localhost:62919"
+      ],
+      [
+        "MS-ASPNETCORE-TOKEN",
+        "[Filtered]"
+      ],
+      [
+        "Origin",
+        "http://localhost:62919"
+      ],
+      [
+        "Referer",
+        "http://localhost:62919/"
+      ],
+      [
+        "User-Agent",
+        "[Filtered]"
+      ],
+      [
+        "X-Original-For",
+        "127.0.0.1:50788"
+      ],
+      [
+        "X-Original-Proto",
+        "http"
+      ],
+      [
+        "X-Requested-With",
+        "XMLHttpRequest"
+      ]
+    ],
+    "env": {
+      "DOCUMENT_ROOT": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\wwwroot",
+      "REMOTE_ADDR": "::1",
+      "SERVER_NAME": "TAMPERE",
+      "SERVER_PORT": "15446",
+      "SERVER_SOFTWARE": "Kestrel"
+    },
+    "inferred_content_type": "application/json"
+  },
+  "contexts": {
+    "server-os": {
+      "name": "Windows",
+      "version": "10",
+      "build": "17134",
+      "raw_description": "Microsoft Windows 10.0.17134 ",
+      "type": "os"
+    },
+    "server-runtime": {
+      "name": ".NET Core",
+      "version": "2.0.7",
+      "raw_description": ".NET Core 4.6.26328.01",
+      "type": "runtime"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1532343407.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager",
+        "level": "info",
+        "message": "User profile is available. Using 'C:\\Users\\[user]\\AppData\\Local\\ASP.NET\\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest."
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.Hosting.Internal.WebHost",
+        "level": "info",
+        "message": "Request starting HTTP/1.1 POST http://localhost:62919/Home/[user]/json; charset=UTF-8 65",
+        "data": {
+          "eventId": "1"
+        }
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+        "level": "info",
+        "message": "Executing action method Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.PostIndex (Sentry.Samples.AspNetCore.Mvc) with arguments () - ModelState is Valid",
+        "data": {
+          "eventId": "1"
+        }
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController",
+        "level": "warning",
+        "message": "Param is null!"
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Sentry.Samples.AspNetCore.Mvc.GameService",
+        "level": "info",
+        "message": "Fetching dungeons and mana level in parallel."
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+        "level": "info",
+        "message": "Executed action Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.PostIndex (Sentry.Samples.AspNetCore.Mvc) in 43.7868ms",
+        "data": {
+          "eventId": "2"
+        }
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+        "level": "info",
+        "message": "Executing action method Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.Error (Sentry.Samples.AspNetCore.Mvc) with arguments ((null)) - ModelState is Valid",
+        "data": {
+          "eventId": "1"
+        }
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.Mvc.ViewFeatures.Internal.ViewResultExecutor",
+        "level": "info",
+        "message": "Executing ViewResult, running view at path /Views/Shared/Error.cshtml.",
+        "data": {
+          "eventId": "1"
+        }
+      },
+      {
+        "timestamp": 1532343443.0,
+        "type": "default",
+        "category": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+        "level": "info",
+        "message": "Executed action Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController.Error (Sentry.Samples.AspNetCore.Mvc) in 146.9482ms",
+        "data": {
+          "eventId": "2"
+        }
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "System.Net.Http.HttpRequestException",
+        "value": "Failed to fetch available Dungeons",
+        "module": "System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "FetchNextPhaseDataAsync",
+              "module": "Sentry.Samples.AspNetCore.Mvc.GameService",
+              "package": "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0",
+              "filename": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "abs_path": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "lineno": 25,
+              "colno": 17,
+              "context_line": "Void MoveNext()",
+              "in_app": true
+            },
+            {
+              "function": "GetResult",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter`1",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "TResult GetResult()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "ExecuteWithThreadLocal",
+              "module": "System.Threading.Tasks.Task",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef)",
+              "in_app": false
+            },
+            {
+              "function": "Run",
+              "module": "System.Threading.ExecutionContext",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)",
+              "in_app": false
+            },
+            {
+              "function": "InnerInvoke",
+              "module": "System.Threading.Tasks.Task`1",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void InnerInvoke()",
+              "in_app": false
+            },
+            {
+              "function": "FetchNextPhaseDataAsync { <lambda> }",
+              "module": "Sentry.Samples.AspNetCore.Mvc.GameService+<>c",
+              "package": "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0",
+              "filename": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "abs_path": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "lineno": 19,
+              "colno": 64,
+              "context_line": "Int32 <FetchNextPhaseDataAsync>b__2_0()",
+              "in_app": true
+            }
+          ]
+        },
+        "thread_id": 25
+      },
+      {
+        "type": "System.Data.DataException",
+        "value": "Invalid Mana level: -10",
+        "module": "System.Data.Common, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "ExecuteWithThreadLocal",
+              "module": "System.Threading.Tasks.Task",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef)",
+              "in_app": false
+            },
+            {
+              "function": "Run",
+              "module": "System.Threading.ExecutionContext",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)",
+              "in_app": false
+            },
+            {
+              "function": "InnerInvoke",
+              "module": "System.Threading.Tasks.Task`1",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void InnerInvoke()",
+              "in_app": false
+            },
+            {
+              "function": "FetchNextPhaseDataAsync { <lambda> }",
+              "module": "Sentry.Samples.AspNetCore.Mvc.GameService+<>c",
+              "package": "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0",
+              "filename": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "abs_path": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "lineno": 20,
+              "colno": 60,
+              "context_line": "Int32 <FetchNextPhaseDataAsync>b__2_1()",
+              "in_app": true
+            }
+          ]
+        },
+        "thread_id": 25
+      },
+      {
+        "type": "System.AggregateException",
+        "value": "One or more errors occurred. (Failed to fetch available Dungeons) (Invalid Mana level: -10)",
+        "module": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "PostIndex",
+              "module": "Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController",
+              "package": "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0",
+              "filename": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs",
+              "abs_path": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs",
+              "lineno": 38,
+              "colno": 17,
+              "context_line": "Void MoveNext()",
+              "in_app": true
+            },
+            {
+              "function": "GetResult",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter`1",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "TResult GetResult()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "FetchNextPhaseDataAsync",
+              "module": "Sentry.Samples.AspNetCore.Mvc.GameService",
+              "package": "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0",
+              "filename": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "abs_path": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\GameService.cs",
+              "lineno": 31,
+              "colno": 17,
+              "context_line": "Void MoveNext()",
+              "in_app": true
+            }
+          ]
+        },
+        "thread_id": 25
+      },
+      {
+        "type": "System.InvalidOperationException",
+        "value": "Bad POST! See Inner exception for details.",
+        "module": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "Invoke",
+              "module": "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware",
+              "package": "Microsoft.AspNetCore.Diagnostics, Version=2.0.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "Invoke",
+              "module": "Microsoft.AspNetCore.Builder.RouterMiddleware",
+              "package": "Microsoft.AspNetCore.Routing, Version=2.0.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "InvokeAsync",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "InvokeFilterPipelineAsync",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "Next",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)",
+              "in_app": false
+            },
+            {
+              "function": "Rethrow",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "InvokeNextResourceFilter",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "InvokeInnerFilterAsync",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "Next",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)",
+              "in_app": false
+            },
+            {
+              "function": "Rethrow",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "InvokeNextActionFilterAsync",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "InvokeActionMethodAsync",
+              "module": "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker",
+              "package": "Microsoft.AspNetCore.Mvc.Core, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+              "context_line": "Void MoveNext()",
+              "in_app": false
+            },
+            {
+              "function": "HandleNonSuccessAndDebuggerNotification",
+              "module": "System.Runtime.CompilerServices.TaskAwaiter",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)",
+              "in_app": false
+            },
+            {
+              "function": "Throw",
+              "module": "System.Runtime.ExceptionServices.ExceptionDispatchInfo",
+              "package": "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e",
+              "context_line": "Void Throw()",
+              "in_app": false
+            },
+            {
+              "function": "PostIndex",
+              "module": "Sentry.Samples.AspNetCore.Mvc.Controllers.HomeController",
+              "package": "Sentry.Samples.AspNetCore.Mvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0",
+              "filename": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs",
+              "abs_path": "C:\\Users\\[user]\\git\\sentry-dotnet\\samples\\Sentry.Samples.AspNetCore.Mvc\\Controllers\\HomeController.cs",
+              "lineno": 53,
+              "colno": 17,
+              "context_line": "Void MoveNext()",
+              "in_app": true
+            }
+          ]
+        },
+        "thread_id": 25
+      }
+    ]
+  },
+  "tags": [
+    [
+      "RequestId",
+      null
+    ]
+  ],
+  "extra": {
+    "Response:HasStarted": true,
+    "System.AggregateException.Data[inventory]": {
+      "BigPotion": 0,
+      "CheeseWheels": 512,
+      "SmallPotion": 3
+    },
+    "System.Data.DataException.Data[inventory]": {
+      "BigPotion": 0,
+      "CheeseWheels": 512,
+      "SmallPotion": 3
+    },
+    "System.InvalidOperationException.Data[inventory]": {
+      "BigPotion": 0,
+      "CheeseWheels": 512,
+      "SmallPotion": 3
+    },
+    "System.Net.Http.HttpRequestException.Data[inventory]": {
+      "BigPotion": 0,
+      "CheeseWheels": 512,
+      "SmallPotion": 3
+    }
+  },
+  "sdk": {
+    "name": "Sentry.AspNetCore",
+    "version": "0.0.1-preview3"
+  },
+  "_meta": {
+    "breadcrumbs": {
+      "values": {
+        "0": {
+          "message": {
+            "": {
+              "rem": [
+                [
+                  "@userpath:replace",
+                  "s",
+                  43,
+                  49
+                ]
+              ],
+              "len": 152
+            }
+          }
+        },
+        "1": {
+          "message": {
+            "": {
+              "rem": [
+                [
+                  "@userpath:replace",
+                  "s",
+                  59,
+                  65
+                ]
+              ],
+              "len": 103
+            }
+          }
+        }
+      }
+    },
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                }
+              },
+              "7": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                }
+              }
+            }
+          }
+        },
+        "1": {
+          "stacktrace": {
+            "frames": {
+              "3": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                }
+              }
+            }
+          }
+        },
+        "2": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 82
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 82
+                  }
+                }
+              },
+              "4": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 70
+                  }
+                }
+              }
+            }
+          }
+        },
+        "3": {
+          "stacktrace": {
+            "frames": {
+              "26": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 82
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        9,
+                        15
+                      ]
+                    ],
+                    "len": 82
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "request": {
+      "cookies": {
+        "1": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@anything:replace",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 32
+            }
+          }
+        },
+        "2": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@anything:replace",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 32
+            }
+          }
+        },
+        "3": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "removeOkDetectToken",
+                  "s",
+                  1,
+                  18
+                ]
+              ],
+              "len": 66
+            }
+          }
+        }
+      },
+      "env": {
+        "DOCUMENT_ROOT": {
+          "": {
+            "rem": [
+              [
+                "@userpath:replace",
+                "s",
+                9,
+                15
+              ]
+            ],
+            "len": 78
+          }
+        }
+      },
+      "headers": {
+        "10": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@anything:replace",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 114
+            }
+          }
+        },
+        "7": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@anything:replace",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 36
+            }
+          }
+        }
+      }
+    },
+    "tags": {
+      "0": {
+        "1": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "user": {
+      "ip_address": {
+        "": {
+          "rem": [
+            [
+              "@anything:remove",
+              "x"
+            ]
+          ]
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__legacy_node_exception__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__legacy_node_exception__pii_stripping.snap
@@ -1,241 +1,317 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: c99bf5ef2eb447d59183ced79601b547
-level: error
-type: error
-transaction: main at Object.<anonymous>
-logentry:
-  formatted: "Error: captureException call"
-logger: ""
-modules:
-  accepts: 1.3.5
-  array-flatten: 1.1.1
-  body-parser: 1.18.2
-  bytes: 3.0.0
-  charenc: 0.0.2
-  content-disposition: 0.5.2
-  content-type: 1.0.4
-  cookie: 0.3.1
-  cookie-signature: 1.0.6
-  crypt: 0.0.2
-  debug: 2.6.9
-  depd: 1.1.2
-  destroy: 1.0.4
-  ee-first: 1.1.1
-  encodeurl: 1.0.2
-  escape-html: 1.0.3
-  etag: 1.8.1
-  express: 4.16.3
-  finalhandler: 1.1.1
-  forwarded: 0.1.2
-  fresh: 0.5.2
-  http-errors: 1.6.3
-  iconv-lite: 0.4.19
-  inherits: 2.0.3
-  ipaddr.js: 1.6.0
-  is-buffer: 1.1.6
-  md5: 2.2.1
-  media-typer: 0.3.0
-  merge-descriptors: 1.0.1
-  methods: 1.1.2
-  mime: 1.4.1
-  mime-db: 1.35.0
-  mime-types: 2.1.19
-  ms: 2.0.0
-  negotiator: 0.6.1
-  on-finished: 2.3.0
-  parseurl: 1.3.2
-  path-to-regexp: 0.1.7
-  proxy-addr: 2.0.3
-  qs: 6.5.1
-  range-parser: 1.2.0
-  raven: 2.6.3
-  raw-body: 2.3.2
-  safe-buffer: 5.1.1
-  send: 0.16.2
-  serve-static: 1.13.2
-  setprototypeof: 1.1.0
-  stack-trace: 0.0.10
-  statuses: 1.4.0
-  timed-out: 4.0.1
-  type-is: 1.6.16
-  unpipe: 1.0.0
-  utils-merge: 1.0.1
-  uuid: 3.0.0
-  vary: 1.1.2
-platform: node
-timestamp: "[timestamp]"
-received: "[received]"
-release: randomRelease
-environment: development
-exception:
-  values:
-    - type: Error
-      value: captureException call
-      stacktrace:
-        frames:
-          - function: null.<anonymous>
-            module: bootstrap_node
-            filename: bootstrap_node.js
-            abs_path: bootstrap_node.js
-            lineno: 612
-            colno: 3
-            in_app: false
-          - function: startup
-            module: bootstrap_node
-            filename: bootstrap_node.js
-            abs_path: bootstrap_node.js
-            lineno: 191
-            colno: 16
-            in_app: false
-          - function: Module.runMain
-            module: module
-            filename: module.js
-            abs_path: module.js
-            lineno: 693
-            colno: 10
-            in_app: false
-          - function: Module._load
-            module: module
-            filename: module.js
-            abs_path: module.js
-            lineno: 497
-            colno: 3
-            in_app: false
-          - function: tryModuleLoad
-            module: module
-            filename: module.js
-            abs_path: module.js
-            lineno: 505
-            colno: 12
-            in_app: false
-          - function: Module.load
-            module: module
-            filename: module.js
-            abs_path: module.js
-            lineno: 565
-            colno: 32
-            in_app: false
-          - function: Module._extensions..js
-            module: module
-            filename: module.js
-            abs_path: module.js
-            lineno: 663
-            colno: 10
-            in_app: false
-          - function: Module._compile
-            module: module
-            filename: module.js
-            abs_path: module.js
-            lineno: 652
-            colno: 30
-            in_app: false
-          - function: Object.<anonymous>
-            module: main
-            filename: "/Users/[user]/Projects/sentry/tmp/main.js"
-            abs_path: "/Users/[user]/Projects/sentry/tmp/main.js"
-            lineno: 21
-            colno: 7
-            pre_context:
-              - "  },"
-              - "  release: \"randomRelease\","
-              - "  environment: \"development\","
-              - "  tags: { git_commit: \"c0deb10c4\" },"
-              - "  extra: { planet: { name: \"Earth\" } }"
-              - "}).install();"
-              - ""
-            context_line: "Raven.captureException(\"captureException call\");"
-            post_context:
-              - //
-              - "// new Promise(function(resolve, reject) {"
-              - "//   reject(new Error(\"promise exception\"));"
-              - "// });"
-              - //
-              - "// throw new Error(\"regular exception\");"
-              - ""
-            in_app: true
-          - function: Raven.captureException
-            module: "raven.lib:client"
-            filename: "/Users/[user]/Projects/sentry/tmp/node_modules/raven/lib/client.js"
-            abs_path: "/Users/[user]/Projects/sentry/tmp/node_modules/raven/lib/client.js"
-            lineno: 407
-            colno: 15
-            pre_context:
-              - "        kwargs.extra.__serialized__ = utils.serializeException(err);"
-              - ""
-              - "        err = new Error(message);"
-              - "      } else {"
-              - "        // This handles when someone does:"
-              - "        //   throw \"something awesome\";"
-              - "        // We synthesize an Error here so we can extract a (rough) stack trace."
-            context_line: "        err = new Error(err);"
-            post_context:
-              - "      }"
-              - "    }"
-              - ""
-              - "    var self = this;"
-              - "    var eventId = this.generateEventId();"
-              - "    parsers.parseError(err, kwargs, function(kw) {"
-              - "      self.process(eventId, kw, cb);"
-            in_app: false
-tags:
-  - - git_commit
-    - c0deb10c4
-  - - server_name
-    - "[.local hostname]"
-extra:
-  node: v8.11.2
-  planet:
-    name: Earth
-_meta:
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "8":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 38
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 38
-            "9":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 61
-              filename:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 61
-  tags:
-    "1":
-      "1":
-        "":
-          rem:
-            - - removeDotLocal
-              - s
-              - 0
-              - 17
-          len: 24
+{
+  "event_id": "c99bf5ef2eb447d59183ced79601b547",
+  "level": "error",
+  "type": "error",
+  "transaction": "main at Object.<anonymous>",
+  "logentry": {
+    "formatted": "Error: captureException call"
+  },
+  "logger": "",
+  "modules": {
+    "accepts": "1.3.5",
+    "array-flatten": "1.1.1",
+    "body-parser": "1.18.2",
+    "bytes": "3.0.0",
+    "charenc": "0.0.2",
+    "content-disposition": "0.5.2",
+    "content-type": "1.0.4",
+    "cookie": "0.3.1",
+    "cookie-signature": "1.0.6",
+    "crypt": "0.0.2",
+    "debug": "2.6.9",
+    "depd": "1.1.2",
+    "destroy": "1.0.4",
+    "ee-first": "1.1.1",
+    "encodeurl": "1.0.2",
+    "escape-html": "1.0.3",
+    "etag": "1.8.1",
+    "express": "4.16.3",
+    "finalhandler": "1.1.1",
+    "forwarded": "0.1.2",
+    "fresh": "0.5.2",
+    "http-errors": "1.6.3",
+    "iconv-lite": "0.4.19",
+    "inherits": "2.0.3",
+    "ipaddr.js": "1.6.0",
+    "is-buffer": "1.1.6",
+    "md5": "2.2.1",
+    "media-typer": "0.3.0",
+    "merge-descriptors": "1.0.1",
+    "methods": "1.1.2",
+    "mime": "1.4.1",
+    "mime-db": "1.35.0",
+    "mime-types": "2.1.19",
+    "ms": "2.0.0",
+    "negotiator": "0.6.1",
+    "on-finished": "2.3.0",
+    "parseurl": "1.3.2",
+    "path-to-regexp": "0.1.7",
+    "proxy-addr": "2.0.3",
+    "qs": "6.5.1",
+    "range-parser": "1.2.0",
+    "raven": "2.6.3",
+    "raw-body": "2.3.2",
+    "safe-buffer": "5.1.1",
+    "send": "0.16.2",
+    "serve-static": "1.13.2",
+    "setprototypeof": "1.1.0",
+    "stack-trace": "0.0.10",
+    "statuses": "1.4.0",
+    "timed-out": "4.0.1",
+    "type-is": "1.6.16",
+    "unpipe": "1.0.0",
+    "utils-merge": "1.0.1",
+    "uuid": "3.0.0",
+    "vary": "1.1.2"
+  },
+  "platform": "node",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "randomRelease",
+  "environment": "development",
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "captureException call",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "null.<anonymous>",
+              "module": "bootstrap_node",
+              "filename": "bootstrap_node.js",
+              "abs_path": "bootstrap_node.js",
+              "lineno": 612,
+              "colno": 3,
+              "in_app": false
+            },
+            {
+              "function": "startup",
+              "module": "bootstrap_node",
+              "filename": "bootstrap_node.js",
+              "abs_path": "bootstrap_node.js",
+              "lineno": 191,
+              "colno": 16,
+              "in_app": false
+            },
+            {
+              "function": "Module.runMain",
+              "module": "module",
+              "filename": "module.js",
+              "abs_path": "module.js",
+              "lineno": 693,
+              "colno": 10,
+              "in_app": false
+            },
+            {
+              "function": "Module._load",
+              "module": "module",
+              "filename": "module.js",
+              "abs_path": "module.js",
+              "lineno": 497,
+              "colno": 3,
+              "in_app": false
+            },
+            {
+              "function": "tryModuleLoad",
+              "module": "module",
+              "filename": "module.js",
+              "abs_path": "module.js",
+              "lineno": 505,
+              "colno": 12,
+              "in_app": false
+            },
+            {
+              "function": "Module.load",
+              "module": "module",
+              "filename": "module.js",
+              "abs_path": "module.js",
+              "lineno": 565,
+              "colno": 32,
+              "in_app": false
+            },
+            {
+              "function": "Module._extensions..js",
+              "module": "module",
+              "filename": "module.js",
+              "abs_path": "module.js",
+              "lineno": 663,
+              "colno": 10,
+              "in_app": false
+            },
+            {
+              "function": "Module._compile",
+              "module": "module",
+              "filename": "module.js",
+              "abs_path": "module.js",
+              "lineno": 652,
+              "colno": 30,
+              "in_app": false
+            },
+            {
+              "function": "Object.<anonymous>",
+              "module": "main",
+              "filename": "/Users/[user]/Projects/sentry/tmp/main.js",
+              "abs_path": "/Users/[user]/Projects/sentry/tmp/main.js",
+              "lineno": 21,
+              "colno": 7,
+              "pre_context": [
+                "  },",
+                "  release: \"randomRelease\",",
+                "  environment: \"development\",",
+                "  tags: { git_commit: \"c0deb10c4\" },",
+                "  extra: { planet: { name: \"Earth\" } }",
+                "}).install();",
+                ""
+              ],
+              "context_line": "Raven.captureException(\"captureException call\");",
+              "post_context": [
+                "//",
+                "// new Promise(function(resolve, reject) {",
+                "//   reject(new Error(\"promise exception\"));",
+                "// });",
+                "//",
+                "// throw new Error(\"regular exception\");",
+                ""
+              ],
+              "in_app": true
+            },
+            {
+              "function": "Raven.captureException",
+              "module": "raven.lib:client",
+              "filename": "/Users/[user]/Projects/sentry/tmp/node_modules/raven/lib/client.js",
+              "abs_path": "/Users/[user]/Projects/sentry/tmp/node_modules/raven/lib/client.js",
+              "lineno": 407,
+              "colno": 15,
+              "pre_context": [
+                "        kwargs.extra.__serialized__ = utils.serializeException(err);",
+                "",
+                "        err = new Error(message);",
+                "      } else {",
+                "        // This handles when someone does:",
+                "        //   throw \"something awesome\";",
+                "        // We synthesize an Error here so we can extract a (rough) stack trace."
+              ],
+              "context_line": "        err = new Error(err);",
+              "post_context": [
+                "      }",
+                "    }",
+                "",
+                "    var self = this;",
+                "    var eventId = this.generateEventId();",
+                "    parsers.parseError(err, kwargs, function(kw) {",
+                "      self.process(eventId, kw, cb);"
+              ],
+              "in_app": false
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "git_commit",
+      "c0deb10c4"
+    ],
+    [
+      "server_name",
+      "[.local hostname]"
+    ]
+  ],
+  "extra": {
+    "node": "v8.11.2",
+    "planet": {
+      "name": "Earth"
+    }
+  },
+  "_meta": {
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "8": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 38
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 38
+                  }
+                }
+              },
+              "9": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 61
+                  }
+                },
+                "filename": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 61
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tags": {
+      "1": {
+        "1": {
+          "": {
+            "rem": [
+              [
+                "removeDotLocal",
+                "s",
+                0,
+                17
+              ]
+            ],
+            "len": 24
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__legacy_python__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__legacy_python__pii_stripping.snap
@@ -1,57 +1,84 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: b308014887f5418c8f797159bfb6fc42
-level: error
-type: error
-logentry:
-  formatted: "ZeroDivisionError: division by zero"
-logger: ""
-modules:
-  python: 3.7.0
-platform: python
-timestamp: "[timestamp]"
-received: "[received]"
-exception:
-  values:
-    - type: ZeroDivisionError
-      value: division by zero
-      module: builtins
-      stacktrace:
-        frames:
-          - function: "<module>"
-            module: __main__
-            filename: "<stdin>"
-            abs_path: "<stdin>"
-            lineno: 1
-            vars:
-              Client: "<class 'raven.base.Client'>"
-              __annotations__: {}
-              __builtins__: "<module 'builtins' (built-in)>"
-              __doc__: ~
-              __loader__: "<class '_frozen_importlib.BuiltinImporter'>"
-              __name__: "'__main__'"
-              __package__: ~
-              __spec__: ~
-              client: "<raven.base.Client object at 0x1025e9400>"
-tags:
-  - - server_name
-    - "[.local hostname]"
-extra:
-  sys.argv:
-    - "''"
-sdk:
-  name: raven-python
-  version: 6.9.0
-_meta:
-  tags:
-    "0":
-      "1":
-        "":
-          rem:
-            - - removeDotLocal
-              - s
-              - 0
-              - 17
-          len: 17
+{
+  "event_id": "b308014887f5418c8f797159bfb6fc42",
+  "level": "error",
+  "type": "error",
+  "logentry": {
+    "formatted": "ZeroDivisionError: division by zero"
+  },
+  "logger": "",
+  "modules": {
+    "python": "3.7.0"
+  },
+  "platform": "python",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "exception": {
+    "values": [
+      {
+        "type": "ZeroDivisionError",
+        "value": "division by zero",
+        "module": "builtins",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<module>",
+              "module": "__main__",
+              "filename": "<stdin>",
+              "abs_path": "<stdin>",
+              "lineno": 1,
+              "vars": {
+                "Client": "<class 'raven.base.Client'>",
+                "__annotations__": {},
+                "__builtins__": "<module 'builtins' (built-in)>",
+                "__doc__": null,
+                "__loader__": "<class '_frozen_importlib.BuiltinImporter'>",
+                "__name__": "'__main__'",
+                "__package__": null,
+                "__spec__": null,
+                "client": "<raven.base.Client object at 0x1025e9400>"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "server_name",
+      "[.local hostname]"
+    ]
+  ],
+  "extra": {
+    "sys.argv": [
+      "''"
+    ]
+  },
+  "sdk": {
+    "name": "raven-python",
+    "version": "6.9.0"
+  },
+  "_meta": {
+    "tags": {
+      "0": {
+        "1": {
+          "": {
+            "rem": [
+              [
+                "removeDotLocal",
+                "s",
+                0,
+                17
+              ]
+            ],
+            "len": 17
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__unity_android__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__unity_android__pii_stripping.snap
@@ -1,291 +1,390 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 39c94eefab9447229d70df71c7d41993
-level: error
-type: error
-logger: ""
-modules:
-  Assembly-CSharp: 0.0.0.0
-  Assembly-CSharp-Editor: 0.0.0.0
-  ExCSS.Unity: 2.0.6.0
-  JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked: 2021.1.3.139
-  Microsoft.Bcl.AsyncInterfaces: 5.0.0.0
-  Mono.Security: 4.0.0.0
-  Sentry: 3.6.0.0
-  Sentry.Unity: 0.3.1.0
-  Sentry.Unity.Editor: 0.3.1.0
-  Sentry.Unity.Editor.Tests: 0.3.1.0
-  Sentry.Unity.Tests: 0.3.1.0
-  System: 4.0.0.0
-  System.Buffers: 4.0.3.0
-  System.Collections.Immutable: 5.0.0.0
-  System.Configuration: 4.0.0.0
-  System.Core: 4.0.0.0
-  System.Memory: 4.0.1.1
-  System.Net.Http: 4.0.0.0
-  System.Numerics.Vectors: 4.1.4.0
-  System.Reflection.Metadata: 5.0.0.0
-  System.Runtime.CompilerServices.Unsafe: 5.0.0.0
-  System.Runtime.Serialization: 4.0.0.0
-  System.Text.Encodings.Web: 5.0.0.1
-  System.Text.Json: 5.0.0.0
-  System.Threading.Tasks.Extensions: 4.2.0.1
-  System.Xml: 4.0.0.0
-  System.Xml.Linq: 4.0.0.0
-  Unity.Cecil: 0.10.0.0
-  Unity.CompilationPipeline.Common: 0.0.0.0
-  Unity.Legacy.NRefactory: 1.0.0.0
-  Unity.Rider.Editor: 0.0.0.0
-  Unity.SerializationLogic: 1.0.0.0
-  Unity.Sysroot.Linux_x86_64: 0.0.0.0
-  Unity.SysrootPackage.Editor: 1.0.0.0
-  Unity.Toolchain.Macos-x86_64-Linux-x86_64: 0.0.0.0
-  UnityEditor: 0.0.0.0
-  UnityEditor.Android.Extensions: 0.0.0.0
-  UnityEditor.Graphs: 0.0.0.0
-  UnityEditor.OSXStandalone.Extensions: 0.0.0.0
-  UnityEditor.TestRunner: 1.0.0.0
-  UnityEditor.UI: 1.0.0.0
-  UnityEditor.VR: 0.0.0.0
-  UnityEditor.iOS.Extensions: 1.0.0.0
-  UnityEditor.iOS.Extensions.Common: 1.0.0.0
-  UnityEditor.iOS.Extensions.Xcode: 1.0.0.0
-  UnityEngine: 0.0.0.0
-  UnityEngine.AIModule: 0.0.0.0
-  UnityEngine.ARModule: 0.0.0.0
-  UnityEngine.AccessibilityModule: 0.0.0.0
-  UnityEngine.AndroidJNIModule: 0.0.0.0
-  UnityEngine.AnimationModule: 0.0.0.0
-  UnityEngine.AssetBundleModule: 0.0.0.0
-  UnityEngine.AudioModule: 0.0.0.0
-  UnityEngine.ClothModule: 0.0.0.0
-  UnityEngine.ClusterInputModule: 0.0.0.0
-  UnityEngine.ClusterRendererModule: 0.0.0.0
-  UnityEngine.CoreModule: 0.0.0.0
-  UnityEngine.CrashReportingModule: 0.0.0.0
-  UnityEngine.DSPGraphModule: 0.0.0.0
-  UnityEngine.DirectorModule: 0.0.0.0
-  UnityEngine.GameCenterModule: 0.0.0.0
-  UnityEngine.GridModule: 0.0.0.0
-  UnityEngine.HotReloadModule: 0.0.0.0
-  UnityEngine.IMGUIModule: 0.0.0.0
-  UnityEngine.ImageConversionModule: 0.0.0.0
-  UnityEngine.InputLegacyModule: 0.0.0.0
-  UnityEngine.InputModule: 0.0.0.0
-  UnityEngine.JSONSerializeModule: 0.0.0.0
-  UnityEngine.LocalizationModule: 0.0.0.0
-  UnityEngine.ParticleSystemModule: 0.0.0.0
-  UnityEngine.PerformanceReportingModule: 0.0.0.0
-  UnityEngine.Physics2DModule: 0.0.0.0
-  UnityEngine.PhysicsModule: 0.0.0.0
-  UnityEngine.ProfilerModule: 0.0.0.0
-  UnityEngine.ScreenCaptureModule: 0.0.0.0
-  UnityEngine.SharedInternalsModule: 0.0.0.0
-  UnityEngine.SpriteMaskModule: 0.0.0.0
-  UnityEngine.SpriteShapeModule: 0.0.0.0
-  UnityEngine.StreamingModule: 0.0.0.0
-  UnityEngine.SubstanceModule: 0.0.0.0
-  UnityEngine.SubsystemsModule: 0.0.0.0
-  UnityEngine.TLSModule: 0.0.0.0
-  UnityEngine.TerrainModule: 0.0.0.0
-  UnityEngine.TerrainPhysicsModule: 0.0.0.0
-  UnityEngine.TestRunner: 1.0.0.0
-  UnityEngine.TextCoreModule: 0.0.0.0
-  UnityEngine.TextRenderingModule: 0.0.0.0
-  UnityEngine.TilemapModule: 0.0.0.0
-  UnityEngine.UI: 1.0.0.0
-  UnityEngine.UIElementsModule: 0.0.0.0
-  UnityEngine.UIModule: 0.0.0.0
-  UnityEngine.UNETModule: 0.0.0.0
-  UnityEngine.UmbraModule: 0.0.0.0
-  UnityEngine.UnityAnalyticsModule: 0.0.0.0
-  UnityEngine.UnityConnectModule: 0.0.0.0
-  UnityEngine.UnityTestProtocolModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAssetBundleModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAudioModule: 0.0.0.0
-  UnityEngine.UnityWebRequestModule: 0.0.0.0
-  UnityEngine.UnityWebRequestTextureModule: 0.0.0.0
-  UnityEngine.UnityWebRequestWWWModule: 0.0.0.0
-  UnityEngine.VFXModule: 0.0.0.0
-  UnityEngine.VRModule: 0.0.0.0
-  UnityEngine.VehiclesModule: 0.0.0.0
-  UnityEngine.VideoModule: 0.0.0.0
-  UnityEngine.WindModule: 0.0.0.0
-  UnityEngine.XRModule: 0.0.0.0
-  mscorlib: 4.0.0.0
-  netstandard: 2.0.0.0
-  nunit.framework: 3.5.0.0
-platform: csharp
-timestamp: "[timestamp]"
-received: "[received]"
-release: "0.1"
-environment: editor
-contexts:
-  Current Culture:
-    Calendar: GregorianCalendar
-    DisplayName: English (United States)
-    Name: en-US
-    type: Current Culture
-  app:
-    app_start_time: "2021-07-01T15:00:18.810059+00:00"
-    build_type: debug
-    type: app
-  device:
-    name: MacFox
-    model: "MacBookPro16,1"
-    battery_level: 87
-    simulator: true
-    memory_size: ~
-    boot_time: ~
-    timezone: ~
-    processor_count: 16
-    cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-    device_type: Desktop
-    battery_status: NotCharging
-    supports_vibration: false
-    type: device
-  gpu:
-    name: AMD Radeon Pro 5300M
-    version: Metal
-    id: 0
-    vendor_id: "0"
-    vendor_name: Apple
-    memory_size: 4080
-    api_type: Metal
-    multi_threaded_rendering: true
-    npot_support: Full
-    max_texture_size: 16384
-    graphics_shader_level: Shader Model 5.0
-    supports_draw_call_instancing: true
-    supports_ray_tracing: false
-    supports_compute_shaders: true
-    supports_geometry_shaders: false
-    type: gpu
-  os:
-    name: Mac OS X 10.16.0
-    type: os
-  runtime:
-    name: Mono
-    version: 5.11.0
-    raw_description: Mono 5.11.0 ((HEAD/e2385dca346)
-    type: runtime
-  unity:
-    install_mode: Editor
-    type: unity
-breadcrumbs:
-  values:
-    - timestamp: 1625151624.054
-      type: default
-      category: scene.beforeload
-      level: info
-      message: BeforeSceneLoad
-      data:
-        scene: 1_BugfarmScene
-exception:
-  values:
-    - type: Exception
-      value: This is an exception
-      stacktrace:
-        frames:
-          - function: "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)"
-            filename: Coroutines.cs
-            abs_path: "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs"
-            lineno: 17
-            in_app: false
-          - function: "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()"
-            filename: IntegrationTests.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs"
-            lineno: 96
-            in_app: true
-          - function: "UnityEngine.GameObject:SendMessage(String)"
-            in_app: false
-          - function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException
-            raw_function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()
-            filename: TestMonoBehaviour.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs"
-            lineno: 12
-            in_app: true
-tags:
-  - - device
-    - "MacBookPro16,1"
-  - - gpu.name
-    - AMD Radeon Pro 5300M
-  - - gpu.vendor
-    - Apple
-  - - level
-    - error
-  - - os.name
-    - Mac OS X 10.16.0
-  - - runtime
-    - Mono 5.11.0
-  - - runtime.name
-    - Mono
-  - - source
-    - log
-  - - unity.device.device_type
-    - Desktop
-  - - unity.gpu.supports_instancing
-    - "true"
-  - - unity.install_mode
-    - Editor
-sdk:
-  name: sentry.dotnet.unity
-  version: 0.3.1
-  packages:
-    - name: "upm:sentry.unity"
-      version: 0.3.1
-    - name: "nuget:Sentry"
-      version: 3.6.0
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      timezone:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 61
-            "1":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 54
-            "3":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 69
-
+{
+  "event_id": "39c94eefab9447229d70df71c7d41993",
+  "level": "error",
+  "type": "error",
+  "logger": "",
+  "modules": {
+    "Assembly-CSharp": "0.0.0.0",
+    "Assembly-CSharp-Editor": "0.0.0.0",
+    "ExCSS.Unity": "2.0.6.0",
+    "JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked": "2021.1.3.139",
+    "Microsoft.Bcl.AsyncInterfaces": "5.0.0.0",
+    "Mono.Security": "4.0.0.0",
+    "Sentry": "3.6.0.0",
+    "Sentry.Unity": "0.3.1.0",
+    "Sentry.Unity.Editor": "0.3.1.0",
+    "Sentry.Unity.Editor.Tests": "0.3.1.0",
+    "Sentry.Unity.Tests": "0.3.1.0",
+    "System": "4.0.0.0",
+    "System.Buffers": "4.0.3.0",
+    "System.Collections.Immutable": "5.0.0.0",
+    "System.Configuration": "4.0.0.0",
+    "System.Core": "4.0.0.0",
+    "System.Memory": "4.0.1.1",
+    "System.Net.Http": "4.0.0.0",
+    "System.Numerics.Vectors": "4.1.4.0",
+    "System.Reflection.Metadata": "5.0.0.0",
+    "System.Runtime.CompilerServices.Unsafe": "5.0.0.0",
+    "System.Runtime.Serialization": "4.0.0.0",
+    "System.Text.Encodings.Web": "5.0.0.1",
+    "System.Text.Json": "5.0.0.0",
+    "System.Threading.Tasks.Extensions": "4.2.0.1",
+    "System.Xml": "4.0.0.0",
+    "System.Xml.Linq": "4.0.0.0",
+    "Unity.Cecil": "0.10.0.0",
+    "Unity.CompilationPipeline.Common": "0.0.0.0",
+    "Unity.Legacy.NRefactory": "1.0.0.0",
+    "Unity.Rider.Editor": "0.0.0.0",
+    "Unity.SerializationLogic": "1.0.0.0",
+    "Unity.Sysroot.Linux_x86_64": "0.0.0.0",
+    "Unity.SysrootPackage.Editor": "1.0.0.0",
+    "Unity.Toolchain.Macos-x86_64-Linux-x86_64": "0.0.0.0",
+    "UnityEditor": "0.0.0.0",
+    "UnityEditor.Android.Extensions": "0.0.0.0",
+    "UnityEditor.Graphs": "0.0.0.0",
+    "UnityEditor.OSXStandalone.Extensions": "0.0.0.0",
+    "UnityEditor.TestRunner": "1.0.0.0",
+    "UnityEditor.UI": "1.0.0.0",
+    "UnityEditor.VR": "0.0.0.0",
+    "UnityEditor.iOS.Extensions": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Common": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Xcode": "1.0.0.0",
+    "UnityEngine": "0.0.0.0",
+    "UnityEngine.AIModule": "0.0.0.0",
+    "UnityEngine.ARModule": "0.0.0.0",
+    "UnityEngine.AccessibilityModule": "0.0.0.0",
+    "UnityEngine.AndroidJNIModule": "0.0.0.0",
+    "UnityEngine.AnimationModule": "0.0.0.0",
+    "UnityEngine.AssetBundleModule": "0.0.0.0",
+    "UnityEngine.AudioModule": "0.0.0.0",
+    "UnityEngine.ClothModule": "0.0.0.0",
+    "UnityEngine.ClusterInputModule": "0.0.0.0",
+    "UnityEngine.ClusterRendererModule": "0.0.0.0",
+    "UnityEngine.CoreModule": "0.0.0.0",
+    "UnityEngine.CrashReportingModule": "0.0.0.0",
+    "UnityEngine.DSPGraphModule": "0.0.0.0",
+    "UnityEngine.DirectorModule": "0.0.0.0",
+    "UnityEngine.GameCenterModule": "0.0.0.0",
+    "UnityEngine.GridModule": "0.0.0.0",
+    "UnityEngine.HotReloadModule": "0.0.0.0",
+    "UnityEngine.IMGUIModule": "0.0.0.0",
+    "UnityEngine.ImageConversionModule": "0.0.0.0",
+    "UnityEngine.InputLegacyModule": "0.0.0.0",
+    "UnityEngine.InputModule": "0.0.0.0",
+    "UnityEngine.JSONSerializeModule": "0.0.0.0",
+    "UnityEngine.LocalizationModule": "0.0.0.0",
+    "UnityEngine.ParticleSystemModule": "0.0.0.0",
+    "UnityEngine.PerformanceReportingModule": "0.0.0.0",
+    "UnityEngine.Physics2DModule": "0.0.0.0",
+    "UnityEngine.PhysicsModule": "0.0.0.0",
+    "UnityEngine.ProfilerModule": "0.0.0.0",
+    "UnityEngine.ScreenCaptureModule": "0.0.0.0",
+    "UnityEngine.SharedInternalsModule": "0.0.0.0",
+    "UnityEngine.SpriteMaskModule": "0.0.0.0",
+    "UnityEngine.SpriteShapeModule": "0.0.0.0",
+    "UnityEngine.StreamingModule": "0.0.0.0",
+    "UnityEngine.SubstanceModule": "0.0.0.0",
+    "UnityEngine.SubsystemsModule": "0.0.0.0",
+    "UnityEngine.TLSModule": "0.0.0.0",
+    "UnityEngine.TerrainModule": "0.0.0.0",
+    "UnityEngine.TerrainPhysicsModule": "0.0.0.0",
+    "UnityEngine.TestRunner": "1.0.0.0",
+    "UnityEngine.TextCoreModule": "0.0.0.0",
+    "UnityEngine.TextRenderingModule": "0.0.0.0",
+    "UnityEngine.TilemapModule": "0.0.0.0",
+    "UnityEngine.UI": "1.0.0.0",
+    "UnityEngine.UIElementsModule": "0.0.0.0",
+    "UnityEngine.UIModule": "0.0.0.0",
+    "UnityEngine.UNETModule": "0.0.0.0",
+    "UnityEngine.UmbraModule": "0.0.0.0",
+    "UnityEngine.UnityAnalyticsModule": "0.0.0.0",
+    "UnityEngine.UnityConnectModule": "0.0.0.0",
+    "UnityEngine.UnityTestProtocolModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAssetBundleModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAudioModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestTextureModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestWWWModule": "0.0.0.0",
+    "UnityEngine.VFXModule": "0.0.0.0",
+    "UnityEngine.VRModule": "0.0.0.0",
+    "UnityEngine.VehiclesModule": "0.0.0.0",
+    "UnityEngine.VideoModule": "0.0.0.0",
+    "UnityEngine.WindModule": "0.0.0.0",
+    "UnityEngine.XRModule": "0.0.0.0",
+    "mscorlib": "4.0.0.0",
+    "netstandard": "2.0.0.0",
+    "nunit.framework": "3.5.0.0"
+  },
+  "platform": "csharp",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "0.1",
+  "environment": "editor",
+  "contexts": {
+    "Current Culture": {
+      "Calendar": "GregorianCalendar",
+      "DisplayName": "English (United States)",
+      "Name": "en-US",
+      "type": "Current Culture"
+    },
+    "app": {
+      "app_start_time": "2021-07-01T15:00:18.810059+00:00",
+      "build_type": "debug",
+      "type": "app"
+    },
+    "device": {
+      "name": "MacFox",
+      "model": "MacBookPro16,1",
+      "battery_level": 87.0,
+      "simulator": true,
+      "memory_size": null,
+      "boot_time": null,
+      "timezone": null,
+      "processor_count": 16,
+      "cpu_description": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
+      "device_type": "Desktop",
+      "battery_status": "NotCharging",
+      "supports_vibration": false,
+      "type": "device"
+    },
+    "gpu": {
+      "name": "AMD Radeon Pro 5300M",
+      "version": "Metal",
+      "id": 0,
+      "vendor_id": "0",
+      "vendor_name": "Apple",
+      "memory_size": 4080,
+      "api_type": "Metal",
+      "multi_threaded_rendering": true,
+      "npot_support": "Full",
+      "max_texture_size": 16384,
+      "graphics_shader_level": "Shader Model 5.0",
+      "supports_draw_call_instancing": true,
+      "supports_ray_tracing": false,
+      "supports_compute_shaders": true,
+      "supports_geometry_shaders": false,
+      "type": "gpu"
+    },
+    "os": {
+      "name": "Mac OS X 10.16.0",
+      "type": "os"
+    },
+    "runtime": {
+      "name": "Mono",
+      "version": "5.11.0",
+      "raw_description": "Mono 5.11.0 ((HEAD/e2385dca346)",
+      "type": "runtime"
+    },
+    "unity": {
+      "install_mode": "Editor",
+      "type": "unity"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1625151624.054,
+        "type": "default",
+        "category": "scene.beforeload",
+        "level": "info",
+        "message": "BeforeSceneLoad",
+        "data": {
+          "scene": "1_BugfarmScene"
+        }
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "This is an exception",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)",
+              "filename": "Coroutines.cs",
+              "abs_path": "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs",
+              "lineno": 17,
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()",
+              "filename": "IntegrationTests.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs",
+              "lineno": 96,
+              "in_app": true
+            },
+            {
+              "function": "UnityEngine.GameObject:SendMessage(String)",
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException",
+              "raw_function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()",
+              "filename": "TestMonoBehaviour.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs",
+              "lineno": 12,
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "device",
+      "MacBookPro16,1"
+    ],
+    [
+      "gpu.name",
+      "AMD Radeon Pro 5300M"
+    ],
+    [
+      "gpu.vendor",
+      "Apple"
+    ],
+    [
+      "level",
+      "error"
+    ],
+    [
+      "os.name",
+      "Mac OS X 10.16.0"
+    ],
+    [
+      "runtime",
+      "Mono 5.11.0"
+    ],
+    [
+      "runtime.name",
+      "Mono"
+    ],
+    [
+      "source",
+      "log"
+    ],
+    [
+      "unity.device.device_type",
+      "Desktop"
+    ],
+    [
+      "unity.gpu.supports_instancing",
+      "true"
+    ],
+    [
+      "unity.install_mode",
+      "Editor"
+    ]
+  ],
+  "sdk": {
+    "name": "sentry.dotnet.unity",
+    "version": "0.3.1",
+    "packages": [
+      {
+        "name": "upm:sentry.unity",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nuget:Sentry",
+        "version": "3.6.0"
+      }
+    ]
+  },
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "timezone": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 61
+                  }
+                }
+              },
+              "1": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 54
+                  }
+                }
+              },
+              "3": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 69
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__unity_ios__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__unity_ios__pii_stripping.snap
@@ -1,291 +1,390 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 39c94eefab9447229d70df71c7d41993
-level: error
-type: error
-logger: ""
-modules:
-  Assembly-CSharp: 0.0.0.0
-  Assembly-CSharp-Editor: 0.0.0.0
-  ExCSS.Unity: 2.0.6.0
-  JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked: 2021.1.3.139
-  Microsoft.Bcl.AsyncInterfaces: 5.0.0.0
-  Mono.Security: 4.0.0.0
-  Sentry: 3.6.0.0
-  Sentry.Unity: 0.3.1.0
-  Sentry.Unity.Editor: 0.3.1.0
-  Sentry.Unity.Editor.Tests: 0.3.1.0
-  Sentry.Unity.Tests: 0.3.1.0
-  System: 4.0.0.0
-  System.Buffers: 4.0.3.0
-  System.Collections.Immutable: 5.0.0.0
-  System.Configuration: 4.0.0.0
-  System.Core: 4.0.0.0
-  System.Memory: 4.0.1.1
-  System.Net.Http: 4.0.0.0
-  System.Numerics.Vectors: 4.1.4.0
-  System.Reflection.Metadata: 5.0.0.0
-  System.Runtime.CompilerServices.Unsafe: 5.0.0.0
-  System.Runtime.Serialization: 4.0.0.0
-  System.Text.Encodings.Web: 5.0.0.1
-  System.Text.Json: 5.0.0.0
-  System.Threading.Tasks.Extensions: 4.2.0.1
-  System.Xml: 4.0.0.0
-  System.Xml.Linq: 4.0.0.0
-  Unity.Cecil: 0.10.0.0
-  Unity.CompilationPipeline.Common: 0.0.0.0
-  Unity.Legacy.NRefactory: 1.0.0.0
-  Unity.Rider.Editor: 0.0.0.0
-  Unity.SerializationLogic: 1.0.0.0
-  Unity.Sysroot.Linux_x86_64: 0.0.0.0
-  Unity.SysrootPackage.Editor: 1.0.0.0
-  Unity.Toolchain.Macos-x86_64-Linux-x86_64: 0.0.0.0
-  UnityEditor: 0.0.0.0
-  UnityEditor.Android.Extensions: 0.0.0.0
-  UnityEditor.Graphs: 0.0.0.0
-  UnityEditor.OSXStandalone.Extensions: 0.0.0.0
-  UnityEditor.TestRunner: 1.0.0.0
-  UnityEditor.UI: 1.0.0.0
-  UnityEditor.VR: 0.0.0.0
-  UnityEditor.iOS.Extensions: 1.0.0.0
-  UnityEditor.iOS.Extensions.Common: 1.0.0.0
-  UnityEditor.iOS.Extensions.Xcode: 1.0.0.0
-  UnityEngine: 0.0.0.0
-  UnityEngine.AIModule: 0.0.0.0
-  UnityEngine.ARModule: 0.0.0.0
-  UnityEngine.AccessibilityModule: 0.0.0.0
-  UnityEngine.AndroidJNIModule: 0.0.0.0
-  UnityEngine.AnimationModule: 0.0.0.0
-  UnityEngine.AssetBundleModule: 0.0.0.0
-  UnityEngine.AudioModule: 0.0.0.0
-  UnityEngine.ClothModule: 0.0.0.0
-  UnityEngine.ClusterInputModule: 0.0.0.0
-  UnityEngine.ClusterRendererModule: 0.0.0.0
-  UnityEngine.CoreModule: 0.0.0.0
-  UnityEngine.CrashReportingModule: 0.0.0.0
-  UnityEngine.DSPGraphModule: 0.0.0.0
-  UnityEngine.DirectorModule: 0.0.0.0
-  UnityEngine.GameCenterModule: 0.0.0.0
-  UnityEngine.GridModule: 0.0.0.0
-  UnityEngine.HotReloadModule: 0.0.0.0
-  UnityEngine.IMGUIModule: 0.0.0.0
-  UnityEngine.ImageConversionModule: 0.0.0.0
-  UnityEngine.InputLegacyModule: 0.0.0.0
-  UnityEngine.InputModule: 0.0.0.0
-  UnityEngine.JSONSerializeModule: 0.0.0.0
-  UnityEngine.LocalizationModule: 0.0.0.0
-  UnityEngine.ParticleSystemModule: 0.0.0.0
-  UnityEngine.PerformanceReportingModule: 0.0.0.0
-  UnityEngine.Physics2DModule: 0.0.0.0
-  UnityEngine.PhysicsModule: 0.0.0.0
-  UnityEngine.ProfilerModule: 0.0.0.0
-  UnityEngine.ScreenCaptureModule: 0.0.0.0
-  UnityEngine.SharedInternalsModule: 0.0.0.0
-  UnityEngine.SpriteMaskModule: 0.0.0.0
-  UnityEngine.SpriteShapeModule: 0.0.0.0
-  UnityEngine.StreamingModule: 0.0.0.0
-  UnityEngine.SubstanceModule: 0.0.0.0
-  UnityEngine.SubsystemsModule: 0.0.0.0
-  UnityEngine.TLSModule: 0.0.0.0
-  UnityEngine.TerrainModule: 0.0.0.0
-  UnityEngine.TerrainPhysicsModule: 0.0.0.0
-  UnityEngine.TestRunner: 1.0.0.0
-  UnityEngine.TextCoreModule: 0.0.0.0
-  UnityEngine.TextRenderingModule: 0.0.0.0
-  UnityEngine.TilemapModule: 0.0.0.0
-  UnityEngine.UI: 1.0.0.0
-  UnityEngine.UIElementsModule: 0.0.0.0
-  UnityEngine.UIModule: 0.0.0.0
-  UnityEngine.UNETModule: 0.0.0.0
-  UnityEngine.UmbraModule: 0.0.0.0
-  UnityEngine.UnityAnalyticsModule: 0.0.0.0
-  UnityEngine.UnityConnectModule: 0.0.0.0
-  UnityEngine.UnityTestProtocolModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAssetBundleModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAudioModule: 0.0.0.0
-  UnityEngine.UnityWebRequestModule: 0.0.0.0
-  UnityEngine.UnityWebRequestTextureModule: 0.0.0.0
-  UnityEngine.UnityWebRequestWWWModule: 0.0.0.0
-  UnityEngine.VFXModule: 0.0.0.0
-  UnityEngine.VRModule: 0.0.0.0
-  UnityEngine.VehiclesModule: 0.0.0.0
-  UnityEngine.VideoModule: 0.0.0.0
-  UnityEngine.WindModule: 0.0.0.0
-  UnityEngine.XRModule: 0.0.0.0
-  mscorlib: 4.0.0.0
-  netstandard: 2.0.0.0
-  nunit.framework: 3.5.0.0
-platform: csharp
-timestamp: "[timestamp]"
-received: "[received]"
-release: "0.1"
-environment: editor
-contexts:
-  Current Culture:
-    Calendar: GregorianCalendar
-    DisplayName: English (United States)
-    Name: en-US
-    type: Current Culture
-  app:
-    app_start_time: "2021-07-01T15:00:18.810059+00:00"
-    build_type: debug
-    type: app
-  device:
-    name: MacFox
-    model: "MacBookPro16,1"
-    battery_level: 87
-    simulator: true
-    memory_size: ~
-    boot_time: ~
-    timezone: ~
-    processor_count: 16
-    cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-    device_type: Desktop
-    battery_status: NotCharging
-    supports_vibration: false
-    type: device
-  gpu:
-    name: AMD Radeon Pro 5300M
-    version: Metal
-    id: 0
-    vendor_id: "0"
-    vendor_name: Apple
-    memory_size: 4080
-    api_type: Metal
-    multi_threaded_rendering: true
-    npot_support: Full
-    max_texture_size: 16384
-    graphics_shader_level: Shader Model 5.0
-    supports_draw_call_instancing: true
-    supports_ray_tracing: false
-    supports_compute_shaders: true
-    supports_geometry_shaders: false
-    type: gpu
-  os:
-    name: Mac OS X 10.16.0
-    type: os
-  runtime:
-    name: Mono
-    version: 5.11.0
-    raw_description: Mono 5.11.0 ((HEAD/e2385dca346)
-    type: runtime
-  unity:
-    install_mode: Editor
-    type: unity
-breadcrumbs:
-  values:
-    - timestamp: 1625151624.054
-      type: default
-      category: scene.beforeload
-      level: info
-      message: BeforeSceneLoad
-      data:
-        scene: 1_BugfarmScene
-exception:
-  values:
-    - type: Exception
-      value: This is an exception
-      stacktrace:
-        frames:
-          - function: "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)"
-            filename: Coroutines.cs
-            abs_path: "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs"
-            lineno: 17
-            in_app: false
-          - function: "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()"
-            filename: IntegrationTests.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs"
-            lineno: 96
-            in_app: true
-          - function: "UnityEngine.GameObject:SendMessage(String)"
-            in_app: false
-          - function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException
-            raw_function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()
-            filename: TestMonoBehaviour.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs"
-            lineno: 12
-            in_app: true
-tags:
-  - - device
-    - "MacBookPro16,1"
-  - - gpu.name
-    - AMD Radeon Pro 5300M
-  - - gpu.vendor
-    - Apple
-  - - level
-    - error
-  - - os.name
-    - Mac OS X 10.16.0
-  - - runtime
-    - Mono 5.11.0
-  - - runtime.name
-    - Mono
-  - - source
-    - log
-  - - unity.device.device_type
-    - Desktop
-  - - unity.gpu.supports_instancing
-    - "true"
-  - - unity.install_mode
-    - Editor
-sdk:
-  name: sentry.dotnet.unity
-  version: 0.3.1
-  packages:
-    - name: "upm:sentry.unity"
-      version: 0.3.1
-    - name: "nuget:Sentry"
-      version: 3.6.0
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      timezone:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 61
-            "1":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 54
-            "3":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 69
-
+{
+  "event_id": "39c94eefab9447229d70df71c7d41993",
+  "level": "error",
+  "type": "error",
+  "logger": "",
+  "modules": {
+    "Assembly-CSharp": "0.0.0.0",
+    "Assembly-CSharp-Editor": "0.0.0.0",
+    "ExCSS.Unity": "2.0.6.0",
+    "JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked": "2021.1.3.139",
+    "Microsoft.Bcl.AsyncInterfaces": "5.0.0.0",
+    "Mono.Security": "4.0.0.0",
+    "Sentry": "3.6.0.0",
+    "Sentry.Unity": "0.3.1.0",
+    "Sentry.Unity.Editor": "0.3.1.0",
+    "Sentry.Unity.Editor.Tests": "0.3.1.0",
+    "Sentry.Unity.Tests": "0.3.1.0",
+    "System": "4.0.0.0",
+    "System.Buffers": "4.0.3.0",
+    "System.Collections.Immutable": "5.0.0.0",
+    "System.Configuration": "4.0.0.0",
+    "System.Core": "4.0.0.0",
+    "System.Memory": "4.0.1.1",
+    "System.Net.Http": "4.0.0.0",
+    "System.Numerics.Vectors": "4.1.4.0",
+    "System.Reflection.Metadata": "5.0.0.0",
+    "System.Runtime.CompilerServices.Unsafe": "5.0.0.0",
+    "System.Runtime.Serialization": "4.0.0.0",
+    "System.Text.Encodings.Web": "5.0.0.1",
+    "System.Text.Json": "5.0.0.0",
+    "System.Threading.Tasks.Extensions": "4.2.0.1",
+    "System.Xml": "4.0.0.0",
+    "System.Xml.Linq": "4.0.0.0",
+    "Unity.Cecil": "0.10.0.0",
+    "Unity.CompilationPipeline.Common": "0.0.0.0",
+    "Unity.Legacy.NRefactory": "1.0.0.0",
+    "Unity.Rider.Editor": "0.0.0.0",
+    "Unity.SerializationLogic": "1.0.0.0",
+    "Unity.Sysroot.Linux_x86_64": "0.0.0.0",
+    "Unity.SysrootPackage.Editor": "1.0.0.0",
+    "Unity.Toolchain.Macos-x86_64-Linux-x86_64": "0.0.0.0",
+    "UnityEditor": "0.0.0.0",
+    "UnityEditor.Android.Extensions": "0.0.0.0",
+    "UnityEditor.Graphs": "0.0.0.0",
+    "UnityEditor.OSXStandalone.Extensions": "0.0.0.0",
+    "UnityEditor.TestRunner": "1.0.0.0",
+    "UnityEditor.UI": "1.0.0.0",
+    "UnityEditor.VR": "0.0.0.0",
+    "UnityEditor.iOS.Extensions": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Common": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Xcode": "1.0.0.0",
+    "UnityEngine": "0.0.0.0",
+    "UnityEngine.AIModule": "0.0.0.0",
+    "UnityEngine.ARModule": "0.0.0.0",
+    "UnityEngine.AccessibilityModule": "0.0.0.0",
+    "UnityEngine.AndroidJNIModule": "0.0.0.0",
+    "UnityEngine.AnimationModule": "0.0.0.0",
+    "UnityEngine.AssetBundleModule": "0.0.0.0",
+    "UnityEngine.AudioModule": "0.0.0.0",
+    "UnityEngine.ClothModule": "0.0.0.0",
+    "UnityEngine.ClusterInputModule": "0.0.0.0",
+    "UnityEngine.ClusterRendererModule": "0.0.0.0",
+    "UnityEngine.CoreModule": "0.0.0.0",
+    "UnityEngine.CrashReportingModule": "0.0.0.0",
+    "UnityEngine.DSPGraphModule": "0.0.0.0",
+    "UnityEngine.DirectorModule": "0.0.0.0",
+    "UnityEngine.GameCenterModule": "0.0.0.0",
+    "UnityEngine.GridModule": "0.0.0.0",
+    "UnityEngine.HotReloadModule": "0.0.0.0",
+    "UnityEngine.IMGUIModule": "0.0.0.0",
+    "UnityEngine.ImageConversionModule": "0.0.0.0",
+    "UnityEngine.InputLegacyModule": "0.0.0.0",
+    "UnityEngine.InputModule": "0.0.0.0",
+    "UnityEngine.JSONSerializeModule": "0.0.0.0",
+    "UnityEngine.LocalizationModule": "0.0.0.0",
+    "UnityEngine.ParticleSystemModule": "0.0.0.0",
+    "UnityEngine.PerformanceReportingModule": "0.0.0.0",
+    "UnityEngine.Physics2DModule": "0.0.0.0",
+    "UnityEngine.PhysicsModule": "0.0.0.0",
+    "UnityEngine.ProfilerModule": "0.0.0.0",
+    "UnityEngine.ScreenCaptureModule": "0.0.0.0",
+    "UnityEngine.SharedInternalsModule": "0.0.0.0",
+    "UnityEngine.SpriteMaskModule": "0.0.0.0",
+    "UnityEngine.SpriteShapeModule": "0.0.0.0",
+    "UnityEngine.StreamingModule": "0.0.0.0",
+    "UnityEngine.SubstanceModule": "0.0.0.0",
+    "UnityEngine.SubsystemsModule": "0.0.0.0",
+    "UnityEngine.TLSModule": "0.0.0.0",
+    "UnityEngine.TerrainModule": "0.0.0.0",
+    "UnityEngine.TerrainPhysicsModule": "0.0.0.0",
+    "UnityEngine.TestRunner": "1.0.0.0",
+    "UnityEngine.TextCoreModule": "0.0.0.0",
+    "UnityEngine.TextRenderingModule": "0.0.0.0",
+    "UnityEngine.TilemapModule": "0.0.0.0",
+    "UnityEngine.UI": "1.0.0.0",
+    "UnityEngine.UIElementsModule": "0.0.0.0",
+    "UnityEngine.UIModule": "0.0.0.0",
+    "UnityEngine.UNETModule": "0.0.0.0",
+    "UnityEngine.UmbraModule": "0.0.0.0",
+    "UnityEngine.UnityAnalyticsModule": "0.0.0.0",
+    "UnityEngine.UnityConnectModule": "0.0.0.0",
+    "UnityEngine.UnityTestProtocolModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAssetBundleModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAudioModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestTextureModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestWWWModule": "0.0.0.0",
+    "UnityEngine.VFXModule": "0.0.0.0",
+    "UnityEngine.VRModule": "0.0.0.0",
+    "UnityEngine.VehiclesModule": "0.0.0.0",
+    "UnityEngine.VideoModule": "0.0.0.0",
+    "UnityEngine.WindModule": "0.0.0.0",
+    "UnityEngine.XRModule": "0.0.0.0",
+    "mscorlib": "4.0.0.0",
+    "netstandard": "2.0.0.0",
+    "nunit.framework": "3.5.0.0"
+  },
+  "platform": "csharp",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "0.1",
+  "environment": "editor",
+  "contexts": {
+    "Current Culture": {
+      "Calendar": "GregorianCalendar",
+      "DisplayName": "English (United States)",
+      "Name": "en-US",
+      "type": "Current Culture"
+    },
+    "app": {
+      "app_start_time": "2021-07-01T15:00:18.810059+00:00",
+      "build_type": "debug",
+      "type": "app"
+    },
+    "device": {
+      "name": "MacFox",
+      "model": "MacBookPro16,1",
+      "battery_level": 87.0,
+      "simulator": true,
+      "memory_size": null,
+      "boot_time": null,
+      "timezone": null,
+      "processor_count": 16,
+      "cpu_description": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
+      "device_type": "Desktop",
+      "battery_status": "NotCharging",
+      "supports_vibration": false,
+      "type": "device"
+    },
+    "gpu": {
+      "name": "AMD Radeon Pro 5300M",
+      "version": "Metal",
+      "id": 0,
+      "vendor_id": "0",
+      "vendor_name": "Apple",
+      "memory_size": 4080,
+      "api_type": "Metal",
+      "multi_threaded_rendering": true,
+      "npot_support": "Full",
+      "max_texture_size": 16384,
+      "graphics_shader_level": "Shader Model 5.0",
+      "supports_draw_call_instancing": true,
+      "supports_ray_tracing": false,
+      "supports_compute_shaders": true,
+      "supports_geometry_shaders": false,
+      "type": "gpu"
+    },
+    "os": {
+      "name": "Mac OS X 10.16.0",
+      "type": "os"
+    },
+    "runtime": {
+      "name": "Mono",
+      "version": "5.11.0",
+      "raw_description": "Mono 5.11.0 ((HEAD/e2385dca346)",
+      "type": "runtime"
+    },
+    "unity": {
+      "install_mode": "Editor",
+      "type": "unity"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1625151624.054,
+        "type": "default",
+        "category": "scene.beforeload",
+        "level": "info",
+        "message": "BeforeSceneLoad",
+        "data": {
+          "scene": "1_BugfarmScene"
+        }
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "This is an exception",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)",
+              "filename": "Coroutines.cs",
+              "abs_path": "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs",
+              "lineno": 17,
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()",
+              "filename": "IntegrationTests.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs",
+              "lineno": 96,
+              "in_app": true
+            },
+            {
+              "function": "UnityEngine.GameObject:SendMessage(String)",
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException",
+              "raw_function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()",
+              "filename": "TestMonoBehaviour.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs",
+              "lineno": 12,
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "device",
+      "MacBookPro16,1"
+    ],
+    [
+      "gpu.name",
+      "AMD Radeon Pro 5300M"
+    ],
+    [
+      "gpu.vendor",
+      "Apple"
+    ],
+    [
+      "level",
+      "error"
+    ],
+    [
+      "os.name",
+      "Mac OS X 10.16.0"
+    ],
+    [
+      "runtime",
+      "Mono 5.11.0"
+    ],
+    [
+      "runtime.name",
+      "Mono"
+    ],
+    [
+      "source",
+      "log"
+    ],
+    [
+      "unity.device.device_type",
+      "Desktop"
+    ],
+    [
+      "unity.gpu.supports_instancing",
+      "true"
+    ],
+    [
+      "unity.install_mode",
+      "Editor"
+    ]
+  ],
+  "sdk": {
+    "name": "sentry.dotnet.unity",
+    "version": "0.3.1",
+    "packages": [
+      {
+        "name": "upm:sentry.unity",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nuget:Sentry",
+        "version": "3.6.0"
+      }
+    ]
+  },
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "timezone": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 61
+                  }
+                }
+              },
+              "1": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 54
+                  }
+                }
+              },
+              "3": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 69
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__unity_linux__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__unity_linux__pii_stripping.snap
@@ -1,291 +1,390 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 39c94eefab9447229d70df71c7d41993
-level: error
-type: error
-logger: ""
-modules:
-  Assembly-CSharp: 0.0.0.0
-  Assembly-CSharp-Editor: 0.0.0.0
-  ExCSS.Unity: 2.0.6.0
-  JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked: 2021.1.3.139
-  Microsoft.Bcl.AsyncInterfaces: 5.0.0.0
-  Mono.Security: 4.0.0.0
-  Sentry: 3.6.0.0
-  Sentry.Unity: 0.3.1.0
-  Sentry.Unity.Editor: 0.3.1.0
-  Sentry.Unity.Editor.Tests: 0.3.1.0
-  Sentry.Unity.Tests: 0.3.1.0
-  System: 4.0.0.0
-  System.Buffers: 4.0.3.0
-  System.Collections.Immutable: 5.0.0.0
-  System.Configuration: 4.0.0.0
-  System.Core: 4.0.0.0
-  System.Memory: 4.0.1.1
-  System.Net.Http: 4.0.0.0
-  System.Numerics.Vectors: 4.1.4.0
-  System.Reflection.Metadata: 5.0.0.0
-  System.Runtime.CompilerServices.Unsafe: 5.0.0.0
-  System.Runtime.Serialization: 4.0.0.0
-  System.Text.Encodings.Web: 5.0.0.1
-  System.Text.Json: 5.0.0.0
-  System.Threading.Tasks.Extensions: 4.2.0.1
-  System.Xml: 4.0.0.0
-  System.Xml.Linq: 4.0.0.0
-  Unity.Cecil: 0.10.0.0
-  Unity.CompilationPipeline.Common: 0.0.0.0
-  Unity.Legacy.NRefactory: 1.0.0.0
-  Unity.Rider.Editor: 0.0.0.0
-  Unity.SerializationLogic: 1.0.0.0
-  Unity.Sysroot.Linux_x86_64: 0.0.0.0
-  Unity.SysrootPackage.Editor: 1.0.0.0
-  Unity.Toolchain.Macos-x86_64-Linux-x86_64: 0.0.0.0
-  UnityEditor: 0.0.0.0
-  UnityEditor.Android.Extensions: 0.0.0.0
-  UnityEditor.Graphs: 0.0.0.0
-  UnityEditor.OSXStandalone.Extensions: 0.0.0.0
-  UnityEditor.TestRunner: 1.0.0.0
-  UnityEditor.UI: 1.0.0.0
-  UnityEditor.VR: 0.0.0.0
-  UnityEditor.iOS.Extensions: 1.0.0.0
-  UnityEditor.iOS.Extensions.Common: 1.0.0.0
-  UnityEditor.iOS.Extensions.Xcode: 1.0.0.0
-  UnityEngine: 0.0.0.0
-  UnityEngine.AIModule: 0.0.0.0
-  UnityEngine.ARModule: 0.0.0.0
-  UnityEngine.AccessibilityModule: 0.0.0.0
-  UnityEngine.AndroidJNIModule: 0.0.0.0
-  UnityEngine.AnimationModule: 0.0.0.0
-  UnityEngine.AssetBundleModule: 0.0.0.0
-  UnityEngine.AudioModule: 0.0.0.0
-  UnityEngine.ClothModule: 0.0.0.0
-  UnityEngine.ClusterInputModule: 0.0.0.0
-  UnityEngine.ClusterRendererModule: 0.0.0.0
-  UnityEngine.CoreModule: 0.0.0.0
-  UnityEngine.CrashReportingModule: 0.0.0.0
-  UnityEngine.DSPGraphModule: 0.0.0.0
-  UnityEngine.DirectorModule: 0.0.0.0
-  UnityEngine.GameCenterModule: 0.0.0.0
-  UnityEngine.GridModule: 0.0.0.0
-  UnityEngine.HotReloadModule: 0.0.0.0
-  UnityEngine.IMGUIModule: 0.0.0.0
-  UnityEngine.ImageConversionModule: 0.0.0.0
-  UnityEngine.InputLegacyModule: 0.0.0.0
-  UnityEngine.InputModule: 0.0.0.0
-  UnityEngine.JSONSerializeModule: 0.0.0.0
-  UnityEngine.LocalizationModule: 0.0.0.0
-  UnityEngine.ParticleSystemModule: 0.0.0.0
-  UnityEngine.PerformanceReportingModule: 0.0.0.0
-  UnityEngine.Physics2DModule: 0.0.0.0
-  UnityEngine.PhysicsModule: 0.0.0.0
-  UnityEngine.ProfilerModule: 0.0.0.0
-  UnityEngine.ScreenCaptureModule: 0.0.0.0
-  UnityEngine.SharedInternalsModule: 0.0.0.0
-  UnityEngine.SpriteMaskModule: 0.0.0.0
-  UnityEngine.SpriteShapeModule: 0.0.0.0
-  UnityEngine.StreamingModule: 0.0.0.0
-  UnityEngine.SubstanceModule: 0.0.0.0
-  UnityEngine.SubsystemsModule: 0.0.0.0
-  UnityEngine.TLSModule: 0.0.0.0
-  UnityEngine.TerrainModule: 0.0.0.0
-  UnityEngine.TerrainPhysicsModule: 0.0.0.0
-  UnityEngine.TestRunner: 1.0.0.0
-  UnityEngine.TextCoreModule: 0.0.0.0
-  UnityEngine.TextRenderingModule: 0.0.0.0
-  UnityEngine.TilemapModule: 0.0.0.0
-  UnityEngine.UI: 1.0.0.0
-  UnityEngine.UIElementsModule: 0.0.0.0
-  UnityEngine.UIModule: 0.0.0.0
-  UnityEngine.UNETModule: 0.0.0.0
-  UnityEngine.UmbraModule: 0.0.0.0
-  UnityEngine.UnityAnalyticsModule: 0.0.0.0
-  UnityEngine.UnityConnectModule: 0.0.0.0
-  UnityEngine.UnityTestProtocolModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAssetBundleModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAudioModule: 0.0.0.0
-  UnityEngine.UnityWebRequestModule: 0.0.0.0
-  UnityEngine.UnityWebRequestTextureModule: 0.0.0.0
-  UnityEngine.UnityWebRequestWWWModule: 0.0.0.0
-  UnityEngine.VFXModule: 0.0.0.0
-  UnityEngine.VRModule: 0.0.0.0
-  UnityEngine.VehiclesModule: 0.0.0.0
-  UnityEngine.VideoModule: 0.0.0.0
-  UnityEngine.WindModule: 0.0.0.0
-  UnityEngine.XRModule: 0.0.0.0
-  mscorlib: 4.0.0.0
-  netstandard: 2.0.0.0
-  nunit.framework: 3.5.0.0
-platform: csharp
-timestamp: "[timestamp]"
-received: "[received]"
-release: "0.1"
-environment: editor
-contexts:
-  Current Culture:
-    Calendar: GregorianCalendar
-    DisplayName: English (United States)
-    Name: en-US
-    type: Current Culture
-  app:
-    app_start_time: "2021-07-01T15:00:18.810059+00:00"
-    build_type: debug
-    type: app
-  device:
-    name: MacFox
-    model: "MacBookPro16,1"
-    battery_level: 87
-    simulator: true
-    memory_size: ~
-    boot_time: ~
-    timezone: ~
-    processor_count: 16
-    cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-    device_type: Desktop
-    battery_status: NotCharging
-    supports_vibration: false
-    type: device
-  gpu:
-    name: AMD Radeon Pro 5300M
-    version: Metal
-    id: 0
-    vendor_id: "0"
-    vendor_name: Apple
-    memory_size: 4080
-    api_type: Metal
-    multi_threaded_rendering: true
-    npot_support: Full
-    max_texture_size: 16384
-    graphics_shader_level: Shader Model 5.0
-    supports_draw_call_instancing: true
-    supports_ray_tracing: false
-    supports_compute_shaders: true
-    supports_geometry_shaders: false
-    type: gpu
-  os:
-    name: Mac OS X 10.16.0
-    type: os
-  runtime:
-    name: Mono
-    version: 5.11.0
-    raw_description: Mono 5.11.0 ((HEAD/e2385dca346)
-    type: runtime
-  unity:
-    install_mode: Editor
-    type: unity
-breadcrumbs:
-  values:
-    - timestamp: 1625151624.054
-      type: default
-      category: scene.beforeload
-      level: info
-      message: BeforeSceneLoad
-      data:
-        scene: 1_BugfarmScene
-exception:
-  values:
-    - type: Exception
-      value: This is an exception
-      stacktrace:
-        frames:
-          - function: "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)"
-            filename: Coroutines.cs
-            abs_path: "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs"
-            lineno: 17
-            in_app: false
-          - function: "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()"
-            filename: IntegrationTests.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs"
-            lineno: 96
-            in_app: true
-          - function: "UnityEngine.GameObject:SendMessage(String)"
-            in_app: false
-          - function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException
-            raw_function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()
-            filename: TestMonoBehaviour.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs"
-            lineno: 12
-            in_app: true
-tags:
-  - - device
-    - "MacBookPro16,1"
-  - - gpu.name
-    - AMD Radeon Pro 5300M
-  - - gpu.vendor
-    - Apple
-  - - level
-    - error
-  - - os.name
-    - Mac OS X 10.16.0
-  - - runtime
-    - Mono 5.11.0
-  - - runtime.name
-    - Mono
-  - - source
-    - log
-  - - unity.device.device_type
-    - Desktop
-  - - unity.gpu.supports_instancing
-    - "true"
-  - - unity.install_mode
-    - Editor
-sdk:
-  name: sentry.dotnet.unity
-  version: 0.3.1
-  packages:
-    - name: "upm:sentry.unity"
-      version: 0.3.1
-    - name: "nuget:Sentry"
-      version: 3.6.0
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      timezone:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 61
-            "1":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 54
-            "3":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 69
-
+{
+  "event_id": "39c94eefab9447229d70df71c7d41993",
+  "level": "error",
+  "type": "error",
+  "logger": "",
+  "modules": {
+    "Assembly-CSharp": "0.0.0.0",
+    "Assembly-CSharp-Editor": "0.0.0.0",
+    "ExCSS.Unity": "2.0.6.0",
+    "JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked": "2021.1.3.139",
+    "Microsoft.Bcl.AsyncInterfaces": "5.0.0.0",
+    "Mono.Security": "4.0.0.0",
+    "Sentry": "3.6.0.0",
+    "Sentry.Unity": "0.3.1.0",
+    "Sentry.Unity.Editor": "0.3.1.0",
+    "Sentry.Unity.Editor.Tests": "0.3.1.0",
+    "Sentry.Unity.Tests": "0.3.1.0",
+    "System": "4.0.0.0",
+    "System.Buffers": "4.0.3.0",
+    "System.Collections.Immutable": "5.0.0.0",
+    "System.Configuration": "4.0.0.0",
+    "System.Core": "4.0.0.0",
+    "System.Memory": "4.0.1.1",
+    "System.Net.Http": "4.0.0.0",
+    "System.Numerics.Vectors": "4.1.4.0",
+    "System.Reflection.Metadata": "5.0.0.0",
+    "System.Runtime.CompilerServices.Unsafe": "5.0.0.0",
+    "System.Runtime.Serialization": "4.0.0.0",
+    "System.Text.Encodings.Web": "5.0.0.1",
+    "System.Text.Json": "5.0.0.0",
+    "System.Threading.Tasks.Extensions": "4.2.0.1",
+    "System.Xml": "4.0.0.0",
+    "System.Xml.Linq": "4.0.0.0",
+    "Unity.Cecil": "0.10.0.0",
+    "Unity.CompilationPipeline.Common": "0.0.0.0",
+    "Unity.Legacy.NRefactory": "1.0.0.0",
+    "Unity.Rider.Editor": "0.0.0.0",
+    "Unity.SerializationLogic": "1.0.0.0",
+    "Unity.Sysroot.Linux_x86_64": "0.0.0.0",
+    "Unity.SysrootPackage.Editor": "1.0.0.0",
+    "Unity.Toolchain.Macos-x86_64-Linux-x86_64": "0.0.0.0",
+    "UnityEditor": "0.0.0.0",
+    "UnityEditor.Android.Extensions": "0.0.0.0",
+    "UnityEditor.Graphs": "0.0.0.0",
+    "UnityEditor.OSXStandalone.Extensions": "0.0.0.0",
+    "UnityEditor.TestRunner": "1.0.0.0",
+    "UnityEditor.UI": "1.0.0.0",
+    "UnityEditor.VR": "0.0.0.0",
+    "UnityEditor.iOS.Extensions": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Common": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Xcode": "1.0.0.0",
+    "UnityEngine": "0.0.0.0",
+    "UnityEngine.AIModule": "0.0.0.0",
+    "UnityEngine.ARModule": "0.0.0.0",
+    "UnityEngine.AccessibilityModule": "0.0.0.0",
+    "UnityEngine.AndroidJNIModule": "0.0.0.0",
+    "UnityEngine.AnimationModule": "0.0.0.0",
+    "UnityEngine.AssetBundleModule": "0.0.0.0",
+    "UnityEngine.AudioModule": "0.0.0.0",
+    "UnityEngine.ClothModule": "0.0.0.0",
+    "UnityEngine.ClusterInputModule": "0.0.0.0",
+    "UnityEngine.ClusterRendererModule": "0.0.0.0",
+    "UnityEngine.CoreModule": "0.0.0.0",
+    "UnityEngine.CrashReportingModule": "0.0.0.0",
+    "UnityEngine.DSPGraphModule": "0.0.0.0",
+    "UnityEngine.DirectorModule": "0.0.0.0",
+    "UnityEngine.GameCenterModule": "0.0.0.0",
+    "UnityEngine.GridModule": "0.0.0.0",
+    "UnityEngine.HotReloadModule": "0.0.0.0",
+    "UnityEngine.IMGUIModule": "0.0.0.0",
+    "UnityEngine.ImageConversionModule": "0.0.0.0",
+    "UnityEngine.InputLegacyModule": "0.0.0.0",
+    "UnityEngine.InputModule": "0.0.0.0",
+    "UnityEngine.JSONSerializeModule": "0.0.0.0",
+    "UnityEngine.LocalizationModule": "0.0.0.0",
+    "UnityEngine.ParticleSystemModule": "0.0.0.0",
+    "UnityEngine.PerformanceReportingModule": "0.0.0.0",
+    "UnityEngine.Physics2DModule": "0.0.0.0",
+    "UnityEngine.PhysicsModule": "0.0.0.0",
+    "UnityEngine.ProfilerModule": "0.0.0.0",
+    "UnityEngine.ScreenCaptureModule": "0.0.0.0",
+    "UnityEngine.SharedInternalsModule": "0.0.0.0",
+    "UnityEngine.SpriteMaskModule": "0.0.0.0",
+    "UnityEngine.SpriteShapeModule": "0.0.0.0",
+    "UnityEngine.StreamingModule": "0.0.0.0",
+    "UnityEngine.SubstanceModule": "0.0.0.0",
+    "UnityEngine.SubsystemsModule": "0.0.0.0",
+    "UnityEngine.TLSModule": "0.0.0.0",
+    "UnityEngine.TerrainModule": "0.0.0.0",
+    "UnityEngine.TerrainPhysicsModule": "0.0.0.0",
+    "UnityEngine.TestRunner": "1.0.0.0",
+    "UnityEngine.TextCoreModule": "0.0.0.0",
+    "UnityEngine.TextRenderingModule": "0.0.0.0",
+    "UnityEngine.TilemapModule": "0.0.0.0",
+    "UnityEngine.UI": "1.0.0.0",
+    "UnityEngine.UIElementsModule": "0.0.0.0",
+    "UnityEngine.UIModule": "0.0.0.0",
+    "UnityEngine.UNETModule": "0.0.0.0",
+    "UnityEngine.UmbraModule": "0.0.0.0",
+    "UnityEngine.UnityAnalyticsModule": "0.0.0.0",
+    "UnityEngine.UnityConnectModule": "0.0.0.0",
+    "UnityEngine.UnityTestProtocolModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAssetBundleModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAudioModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestTextureModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestWWWModule": "0.0.0.0",
+    "UnityEngine.VFXModule": "0.0.0.0",
+    "UnityEngine.VRModule": "0.0.0.0",
+    "UnityEngine.VehiclesModule": "0.0.0.0",
+    "UnityEngine.VideoModule": "0.0.0.0",
+    "UnityEngine.WindModule": "0.0.0.0",
+    "UnityEngine.XRModule": "0.0.0.0",
+    "mscorlib": "4.0.0.0",
+    "netstandard": "2.0.0.0",
+    "nunit.framework": "3.5.0.0"
+  },
+  "platform": "csharp",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "0.1",
+  "environment": "editor",
+  "contexts": {
+    "Current Culture": {
+      "Calendar": "GregorianCalendar",
+      "DisplayName": "English (United States)",
+      "Name": "en-US",
+      "type": "Current Culture"
+    },
+    "app": {
+      "app_start_time": "2021-07-01T15:00:18.810059+00:00",
+      "build_type": "debug",
+      "type": "app"
+    },
+    "device": {
+      "name": "MacFox",
+      "model": "MacBookPro16,1",
+      "battery_level": 87.0,
+      "simulator": true,
+      "memory_size": null,
+      "boot_time": null,
+      "timezone": null,
+      "processor_count": 16,
+      "cpu_description": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
+      "device_type": "Desktop",
+      "battery_status": "NotCharging",
+      "supports_vibration": false,
+      "type": "device"
+    },
+    "gpu": {
+      "name": "AMD Radeon Pro 5300M",
+      "version": "Metal",
+      "id": 0,
+      "vendor_id": "0",
+      "vendor_name": "Apple",
+      "memory_size": 4080,
+      "api_type": "Metal",
+      "multi_threaded_rendering": true,
+      "npot_support": "Full",
+      "max_texture_size": 16384,
+      "graphics_shader_level": "Shader Model 5.0",
+      "supports_draw_call_instancing": true,
+      "supports_ray_tracing": false,
+      "supports_compute_shaders": true,
+      "supports_geometry_shaders": false,
+      "type": "gpu"
+    },
+    "os": {
+      "name": "Mac OS X 10.16.0",
+      "type": "os"
+    },
+    "runtime": {
+      "name": "Mono",
+      "version": "5.11.0",
+      "raw_description": "Mono 5.11.0 ((HEAD/e2385dca346)",
+      "type": "runtime"
+    },
+    "unity": {
+      "install_mode": "Editor",
+      "type": "unity"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1625151624.054,
+        "type": "default",
+        "category": "scene.beforeload",
+        "level": "info",
+        "message": "BeforeSceneLoad",
+        "data": {
+          "scene": "1_BugfarmScene"
+        }
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "This is an exception",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)",
+              "filename": "Coroutines.cs",
+              "abs_path": "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs",
+              "lineno": 17,
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()",
+              "filename": "IntegrationTests.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs",
+              "lineno": 96,
+              "in_app": true
+            },
+            {
+              "function": "UnityEngine.GameObject:SendMessage(String)",
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException",
+              "raw_function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()",
+              "filename": "TestMonoBehaviour.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs",
+              "lineno": 12,
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "device",
+      "MacBookPro16,1"
+    ],
+    [
+      "gpu.name",
+      "AMD Radeon Pro 5300M"
+    ],
+    [
+      "gpu.vendor",
+      "Apple"
+    ],
+    [
+      "level",
+      "error"
+    ],
+    [
+      "os.name",
+      "Mac OS X 10.16.0"
+    ],
+    [
+      "runtime",
+      "Mono 5.11.0"
+    ],
+    [
+      "runtime.name",
+      "Mono"
+    ],
+    [
+      "source",
+      "log"
+    ],
+    [
+      "unity.device.device_type",
+      "Desktop"
+    ],
+    [
+      "unity.gpu.supports_instancing",
+      "true"
+    ],
+    [
+      "unity.install_mode",
+      "Editor"
+    ]
+  ],
+  "sdk": {
+    "name": "sentry.dotnet.unity",
+    "version": "0.3.1",
+    "packages": [
+      {
+        "name": "upm:sentry.unity",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nuget:Sentry",
+        "version": "3.6.0"
+      }
+    ]
+  },
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "timezone": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 61
+                  }
+                }
+              },
+              "1": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 54
+                  }
+                }
+              },
+              "3": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 69
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__unity_macos__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__unity_macos__pii_stripping.snap
@@ -1,291 +1,390 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 39c94eefab9447229d70df71c7d41993
-level: error
-type: error
-logger: ""
-modules:
-  Assembly-CSharp: 0.0.0.0
-  Assembly-CSharp-Editor: 0.0.0.0
-  ExCSS.Unity: 2.0.6.0
-  JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked: 2021.1.3.139
-  Microsoft.Bcl.AsyncInterfaces: 5.0.0.0
-  Mono.Security: 4.0.0.0
-  Sentry: 3.6.0.0
-  Sentry.Unity: 0.3.1.0
-  Sentry.Unity.Editor: 0.3.1.0
-  Sentry.Unity.Editor.Tests: 0.3.1.0
-  Sentry.Unity.Tests: 0.3.1.0
-  System: 4.0.0.0
-  System.Buffers: 4.0.3.0
-  System.Collections.Immutable: 5.0.0.0
-  System.Configuration: 4.0.0.0
-  System.Core: 4.0.0.0
-  System.Memory: 4.0.1.1
-  System.Net.Http: 4.0.0.0
-  System.Numerics.Vectors: 4.1.4.0
-  System.Reflection.Metadata: 5.0.0.0
-  System.Runtime.CompilerServices.Unsafe: 5.0.0.0
-  System.Runtime.Serialization: 4.0.0.0
-  System.Text.Encodings.Web: 5.0.0.1
-  System.Text.Json: 5.0.0.0
-  System.Threading.Tasks.Extensions: 4.2.0.1
-  System.Xml: 4.0.0.0
-  System.Xml.Linq: 4.0.0.0
-  Unity.Cecil: 0.10.0.0
-  Unity.CompilationPipeline.Common: 0.0.0.0
-  Unity.Legacy.NRefactory: 1.0.0.0
-  Unity.Rider.Editor: 0.0.0.0
-  Unity.SerializationLogic: 1.0.0.0
-  Unity.Sysroot.Linux_x86_64: 0.0.0.0
-  Unity.SysrootPackage.Editor: 1.0.0.0
-  Unity.Toolchain.Macos-x86_64-Linux-x86_64: 0.0.0.0
-  UnityEditor: 0.0.0.0
-  UnityEditor.Android.Extensions: 0.0.0.0
-  UnityEditor.Graphs: 0.0.0.0
-  UnityEditor.OSXStandalone.Extensions: 0.0.0.0
-  UnityEditor.TestRunner: 1.0.0.0
-  UnityEditor.UI: 1.0.0.0
-  UnityEditor.VR: 0.0.0.0
-  UnityEditor.iOS.Extensions: 1.0.0.0
-  UnityEditor.iOS.Extensions.Common: 1.0.0.0
-  UnityEditor.iOS.Extensions.Xcode: 1.0.0.0
-  UnityEngine: 0.0.0.0
-  UnityEngine.AIModule: 0.0.0.0
-  UnityEngine.ARModule: 0.0.0.0
-  UnityEngine.AccessibilityModule: 0.0.0.0
-  UnityEngine.AndroidJNIModule: 0.0.0.0
-  UnityEngine.AnimationModule: 0.0.0.0
-  UnityEngine.AssetBundleModule: 0.0.0.0
-  UnityEngine.AudioModule: 0.0.0.0
-  UnityEngine.ClothModule: 0.0.0.0
-  UnityEngine.ClusterInputModule: 0.0.0.0
-  UnityEngine.ClusterRendererModule: 0.0.0.0
-  UnityEngine.CoreModule: 0.0.0.0
-  UnityEngine.CrashReportingModule: 0.0.0.0
-  UnityEngine.DSPGraphModule: 0.0.0.0
-  UnityEngine.DirectorModule: 0.0.0.0
-  UnityEngine.GameCenterModule: 0.0.0.0
-  UnityEngine.GridModule: 0.0.0.0
-  UnityEngine.HotReloadModule: 0.0.0.0
-  UnityEngine.IMGUIModule: 0.0.0.0
-  UnityEngine.ImageConversionModule: 0.0.0.0
-  UnityEngine.InputLegacyModule: 0.0.0.0
-  UnityEngine.InputModule: 0.0.0.0
-  UnityEngine.JSONSerializeModule: 0.0.0.0
-  UnityEngine.LocalizationModule: 0.0.0.0
-  UnityEngine.ParticleSystemModule: 0.0.0.0
-  UnityEngine.PerformanceReportingModule: 0.0.0.0
-  UnityEngine.Physics2DModule: 0.0.0.0
-  UnityEngine.PhysicsModule: 0.0.0.0
-  UnityEngine.ProfilerModule: 0.0.0.0
-  UnityEngine.ScreenCaptureModule: 0.0.0.0
-  UnityEngine.SharedInternalsModule: 0.0.0.0
-  UnityEngine.SpriteMaskModule: 0.0.0.0
-  UnityEngine.SpriteShapeModule: 0.0.0.0
-  UnityEngine.StreamingModule: 0.0.0.0
-  UnityEngine.SubstanceModule: 0.0.0.0
-  UnityEngine.SubsystemsModule: 0.0.0.0
-  UnityEngine.TLSModule: 0.0.0.0
-  UnityEngine.TerrainModule: 0.0.0.0
-  UnityEngine.TerrainPhysicsModule: 0.0.0.0
-  UnityEngine.TestRunner: 1.0.0.0
-  UnityEngine.TextCoreModule: 0.0.0.0
-  UnityEngine.TextRenderingModule: 0.0.0.0
-  UnityEngine.TilemapModule: 0.0.0.0
-  UnityEngine.UI: 1.0.0.0
-  UnityEngine.UIElementsModule: 0.0.0.0
-  UnityEngine.UIModule: 0.0.0.0
-  UnityEngine.UNETModule: 0.0.0.0
-  UnityEngine.UmbraModule: 0.0.0.0
-  UnityEngine.UnityAnalyticsModule: 0.0.0.0
-  UnityEngine.UnityConnectModule: 0.0.0.0
-  UnityEngine.UnityTestProtocolModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAssetBundleModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAudioModule: 0.0.0.0
-  UnityEngine.UnityWebRequestModule: 0.0.0.0
-  UnityEngine.UnityWebRequestTextureModule: 0.0.0.0
-  UnityEngine.UnityWebRequestWWWModule: 0.0.0.0
-  UnityEngine.VFXModule: 0.0.0.0
-  UnityEngine.VRModule: 0.0.0.0
-  UnityEngine.VehiclesModule: 0.0.0.0
-  UnityEngine.VideoModule: 0.0.0.0
-  UnityEngine.WindModule: 0.0.0.0
-  UnityEngine.XRModule: 0.0.0.0
-  mscorlib: 4.0.0.0
-  netstandard: 2.0.0.0
-  nunit.framework: 3.5.0.0
-platform: csharp
-timestamp: "[timestamp]"
-received: "[received]"
-release: "0.1"
-environment: editor
-contexts:
-  Current Culture:
-    Calendar: GregorianCalendar
-    DisplayName: English (United States)
-    Name: en-US
-    type: Current Culture
-  app:
-    app_start_time: "2021-07-01T15:00:18.810059+00:00"
-    build_type: debug
-    type: app
-  device:
-    name: MacFox
-    model: "MacBookPro16,1"
-    battery_level: 87
-    simulator: true
-    memory_size: ~
-    boot_time: ~
-    timezone: ~
-    processor_count: 16
-    cpu_description: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-    device_type: Desktop
-    battery_status: NotCharging
-    supports_vibration: false
-    type: device
-  gpu:
-    name: AMD Radeon Pro 5300M
-    version: Metal
-    id: 0
-    vendor_id: "0"
-    vendor_name: Apple
-    memory_size: 4080
-    api_type: Metal
-    multi_threaded_rendering: true
-    npot_support: Full
-    max_texture_size: 16384
-    graphics_shader_level: Shader Model 5.0
-    supports_draw_call_instancing: true
-    supports_ray_tracing: false
-    supports_compute_shaders: true
-    supports_geometry_shaders: false
-    type: gpu
-  os:
-    name: Mac OS X 10.16.0
-    type: os
-  runtime:
-    name: Mono
-    version: 5.11.0
-    raw_description: Mono 5.11.0 ((HEAD/e2385dca346)
-    type: runtime
-  unity:
-    install_mode: Editor
-    type: unity
-breadcrumbs:
-  values:
-    - timestamp: 1625151624.054
-      type: default
-      category: scene.beforeload
-      level: info
-      message: BeforeSceneLoad
-      data:
-        scene: 1_BugfarmScene
-exception:
-  values:
-    - type: Exception
-      value: This is an exception
-      stacktrace:
-        frames:
-          - function: "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)"
-            filename: Coroutines.cs
-            abs_path: "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs"
-            lineno: 17
-            in_app: false
-          - function: "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()"
-            filename: IntegrationTests.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs"
-            lineno: 96
-            in_app: true
-          - function: "UnityEngine.GameObject:SendMessage(String)"
-            in_app: false
-          - function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException
-            raw_function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()
-            filename: TestMonoBehaviour.cs
-            abs_path: "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs"
-            lineno: 12
-            in_app: true
-tags:
-  - - device
-    - "MacBookPro16,1"
-  - - gpu.name
-    - AMD Radeon Pro 5300M
-  - - gpu.vendor
-    - Apple
-  - - level
-    - error
-  - - os.name
-    - Mac OS X 10.16.0
-  - - runtime
-    - Mono 5.11.0
-  - - runtime.name
-    - Mono
-  - - source
-    - log
-  - - unity.device.device_type
-    - Desktop
-  - - unity.gpu.supports_instancing
-    - "true"
-  - - unity.install_mode
-    - Editor
-sdk:
-  name: sentry.dotnet.unity
-  version: 0.3.1
-  packages:
-    - name: "upm:sentry.unity"
-      version: 0.3.1
-    - name: "nuget:Sentry"
-      version: 3.6.0
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      timezone:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-  exception:
-    values:
-      "0":
-        stacktrace:
-          frames:
-            "0":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 61
-            "1":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 54
-            "3":
-              abs_path:
-                "":
-                  rem:
-                    - - "@userpath:replace"
-                      - s
-                      - 7
-                      - 13
-                  len: 69
-
+{
+  "event_id": "39c94eefab9447229d70df71c7d41993",
+  "level": "error",
+  "type": "error",
+  "logger": "",
+  "modules": {
+    "Assembly-CSharp": "0.0.0.0",
+    "Assembly-CSharp-Editor": "0.0.0.0",
+    "ExCSS.Unity": "2.0.6.0",
+    "JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked": "2021.1.3.139",
+    "Microsoft.Bcl.AsyncInterfaces": "5.0.0.0",
+    "Mono.Security": "4.0.0.0",
+    "Sentry": "3.6.0.0",
+    "Sentry.Unity": "0.3.1.0",
+    "Sentry.Unity.Editor": "0.3.1.0",
+    "Sentry.Unity.Editor.Tests": "0.3.1.0",
+    "Sentry.Unity.Tests": "0.3.1.0",
+    "System": "4.0.0.0",
+    "System.Buffers": "4.0.3.0",
+    "System.Collections.Immutable": "5.0.0.0",
+    "System.Configuration": "4.0.0.0",
+    "System.Core": "4.0.0.0",
+    "System.Memory": "4.0.1.1",
+    "System.Net.Http": "4.0.0.0",
+    "System.Numerics.Vectors": "4.1.4.0",
+    "System.Reflection.Metadata": "5.0.0.0",
+    "System.Runtime.CompilerServices.Unsafe": "5.0.0.0",
+    "System.Runtime.Serialization": "4.0.0.0",
+    "System.Text.Encodings.Web": "5.0.0.1",
+    "System.Text.Json": "5.0.0.0",
+    "System.Threading.Tasks.Extensions": "4.2.0.1",
+    "System.Xml": "4.0.0.0",
+    "System.Xml.Linq": "4.0.0.0",
+    "Unity.Cecil": "0.10.0.0",
+    "Unity.CompilationPipeline.Common": "0.0.0.0",
+    "Unity.Legacy.NRefactory": "1.0.0.0",
+    "Unity.Rider.Editor": "0.0.0.0",
+    "Unity.SerializationLogic": "1.0.0.0",
+    "Unity.Sysroot.Linux_x86_64": "0.0.0.0",
+    "Unity.SysrootPackage.Editor": "1.0.0.0",
+    "Unity.Toolchain.Macos-x86_64-Linux-x86_64": "0.0.0.0",
+    "UnityEditor": "0.0.0.0",
+    "UnityEditor.Android.Extensions": "0.0.0.0",
+    "UnityEditor.Graphs": "0.0.0.0",
+    "UnityEditor.OSXStandalone.Extensions": "0.0.0.0",
+    "UnityEditor.TestRunner": "1.0.0.0",
+    "UnityEditor.UI": "1.0.0.0",
+    "UnityEditor.VR": "0.0.0.0",
+    "UnityEditor.iOS.Extensions": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Common": "1.0.0.0",
+    "UnityEditor.iOS.Extensions.Xcode": "1.0.0.0",
+    "UnityEngine": "0.0.0.0",
+    "UnityEngine.AIModule": "0.0.0.0",
+    "UnityEngine.ARModule": "0.0.0.0",
+    "UnityEngine.AccessibilityModule": "0.0.0.0",
+    "UnityEngine.AndroidJNIModule": "0.0.0.0",
+    "UnityEngine.AnimationModule": "0.0.0.0",
+    "UnityEngine.AssetBundleModule": "0.0.0.0",
+    "UnityEngine.AudioModule": "0.0.0.0",
+    "UnityEngine.ClothModule": "0.0.0.0",
+    "UnityEngine.ClusterInputModule": "0.0.0.0",
+    "UnityEngine.ClusterRendererModule": "0.0.0.0",
+    "UnityEngine.CoreModule": "0.0.0.0",
+    "UnityEngine.CrashReportingModule": "0.0.0.0",
+    "UnityEngine.DSPGraphModule": "0.0.0.0",
+    "UnityEngine.DirectorModule": "0.0.0.0",
+    "UnityEngine.GameCenterModule": "0.0.0.0",
+    "UnityEngine.GridModule": "0.0.0.0",
+    "UnityEngine.HotReloadModule": "0.0.0.0",
+    "UnityEngine.IMGUIModule": "0.0.0.0",
+    "UnityEngine.ImageConversionModule": "0.0.0.0",
+    "UnityEngine.InputLegacyModule": "0.0.0.0",
+    "UnityEngine.InputModule": "0.0.0.0",
+    "UnityEngine.JSONSerializeModule": "0.0.0.0",
+    "UnityEngine.LocalizationModule": "0.0.0.0",
+    "UnityEngine.ParticleSystemModule": "0.0.0.0",
+    "UnityEngine.PerformanceReportingModule": "0.0.0.0",
+    "UnityEngine.Physics2DModule": "0.0.0.0",
+    "UnityEngine.PhysicsModule": "0.0.0.0",
+    "UnityEngine.ProfilerModule": "0.0.0.0",
+    "UnityEngine.ScreenCaptureModule": "0.0.0.0",
+    "UnityEngine.SharedInternalsModule": "0.0.0.0",
+    "UnityEngine.SpriteMaskModule": "0.0.0.0",
+    "UnityEngine.SpriteShapeModule": "0.0.0.0",
+    "UnityEngine.StreamingModule": "0.0.0.0",
+    "UnityEngine.SubstanceModule": "0.0.0.0",
+    "UnityEngine.SubsystemsModule": "0.0.0.0",
+    "UnityEngine.TLSModule": "0.0.0.0",
+    "UnityEngine.TerrainModule": "0.0.0.0",
+    "UnityEngine.TerrainPhysicsModule": "0.0.0.0",
+    "UnityEngine.TestRunner": "1.0.0.0",
+    "UnityEngine.TextCoreModule": "0.0.0.0",
+    "UnityEngine.TextRenderingModule": "0.0.0.0",
+    "UnityEngine.TilemapModule": "0.0.0.0",
+    "UnityEngine.UI": "1.0.0.0",
+    "UnityEngine.UIElementsModule": "0.0.0.0",
+    "UnityEngine.UIModule": "0.0.0.0",
+    "UnityEngine.UNETModule": "0.0.0.0",
+    "UnityEngine.UmbraModule": "0.0.0.0",
+    "UnityEngine.UnityAnalyticsModule": "0.0.0.0",
+    "UnityEngine.UnityConnectModule": "0.0.0.0",
+    "UnityEngine.UnityTestProtocolModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAssetBundleModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAudioModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestTextureModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestWWWModule": "0.0.0.0",
+    "UnityEngine.VFXModule": "0.0.0.0",
+    "UnityEngine.VRModule": "0.0.0.0",
+    "UnityEngine.VehiclesModule": "0.0.0.0",
+    "UnityEngine.VideoModule": "0.0.0.0",
+    "UnityEngine.WindModule": "0.0.0.0",
+    "UnityEngine.XRModule": "0.0.0.0",
+    "mscorlib": "4.0.0.0",
+    "netstandard": "2.0.0.0",
+    "nunit.framework": "3.5.0.0"
+  },
+  "platform": "csharp",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "0.1",
+  "environment": "editor",
+  "contexts": {
+    "Current Culture": {
+      "Calendar": "GregorianCalendar",
+      "DisplayName": "English (United States)",
+      "Name": "en-US",
+      "type": "Current Culture"
+    },
+    "app": {
+      "app_start_time": "2021-07-01T15:00:18.810059+00:00",
+      "build_type": "debug",
+      "type": "app"
+    },
+    "device": {
+      "name": "MacFox",
+      "model": "MacBookPro16,1",
+      "battery_level": 87.0,
+      "simulator": true,
+      "memory_size": null,
+      "boot_time": null,
+      "timezone": null,
+      "processor_count": 16,
+      "cpu_description": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
+      "device_type": "Desktop",
+      "battery_status": "NotCharging",
+      "supports_vibration": false,
+      "type": "device"
+    },
+    "gpu": {
+      "name": "AMD Radeon Pro 5300M",
+      "version": "Metal",
+      "id": 0,
+      "vendor_id": "0",
+      "vendor_name": "Apple",
+      "memory_size": 4080,
+      "api_type": "Metal",
+      "multi_threaded_rendering": true,
+      "npot_support": "Full",
+      "max_texture_size": 16384,
+      "graphics_shader_level": "Shader Model 5.0",
+      "supports_draw_call_instancing": true,
+      "supports_ray_tracing": false,
+      "supports_compute_shaders": true,
+      "supports_geometry_shaders": false,
+      "type": "gpu"
+    },
+    "os": {
+      "name": "Mac OS X 10.16.0",
+      "type": "os"
+    },
+    "runtime": {
+      "name": "Mono",
+      "version": "5.11.0",
+      "raw_description": "Mono 5.11.0 ((HEAD/e2385dca346)",
+      "type": "runtime"
+    },
+    "unity": {
+      "install_mode": "Editor",
+      "type": "unity"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1625151624.054,
+        "type": "default",
+        "category": "scene.beforeload",
+        "level": "info",
+        "message": "BeforeSceneLoad",
+        "data": {
+          "scene": "1_BugfarmScene"
+        }
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "This is an exception",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)",
+              "filename": "Coroutines.cs",
+              "abs_path": "/Users/[user]/buildslave/unity/build/Runtime/Export/Scripting/Coroutines.cs",
+              "lineno": 17,
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()",
+              "filename": "IntegrationTests.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/IntegrationTests.cs",
+              "lineno": 96,
+              "in_app": true
+            },
+            {
+              "function": "UnityEngine.GameObject:SendMessage(String)",
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException",
+              "raw_function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()",
+              "filename": "TestMonoBehaviour.cs",
+              "abs_path": "/Users/[user]/_Workspace/unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs",
+              "lineno": 12,
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "device",
+      "MacBookPro16,1"
+    ],
+    [
+      "gpu.name",
+      "AMD Radeon Pro 5300M"
+    ],
+    [
+      "gpu.vendor",
+      "Apple"
+    ],
+    [
+      "level",
+      "error"
+    ],
+    [
+      "os.name",
+      "Mac OS X 10.16.0"
+    ],
+    [
+      "runtime",
+      "Mono 5.11.0"
+    ],
+    [
+      "runtime.name",
+      "Mono"
+    ],
+    [
+      "source",
+      "log"
+    ],
+    [
+      "unity.device.device_type",
+      "Desktop"
+    ],
+    [
+      "unity.gpu.supports_instancing",
+      "true"
+    ],
+    [
+      "unity.install_mode",
+      "Editor"
+    ]
+  ],
+  "sdk": {
+    "name": "sentry.dotnet.unity",
+    "version": "0.3.1",
+    "packages": [
+      {
+        "name": "upm:sentry.unity",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nuget:Sentry",
+        "version": "3.6.0"
+      }
+    ]
+  },
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "timezone": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "exception": {
+      "values": {
+        "0": {
+          "stacktrace": {
+            "frames": {
+              "0": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 61
+                  }
+                }
+              },
+              "1": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 54
+                  }
+                }
+              },
+              "3": {
+                "abs_path": {
+                  "": {
+                    "rem": [
+                      [
+                        "@userpath:replace",
+                        "s",
+                        7,
+                        13
+                      ]
+                    ],
+                    "len": 69
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__unity_windows__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__unity_windows__pii_stripping.snap
@@ -1,259 +1,337 @@
 ---
-source: relay-general/tests/test_fixtures.rs
+source: relay-server/tests/test_fixtures.rs
 expression: SerializableAnnotated(&event)
 ---
-event_id: 6f6e2d3fa0754d14b37a2bec59619a98
-level: error
-type: error
-logger: ""
-modules:
-  Assembly-CSharp: 0.0.0.0
-  Assembly-CSharp-Editor: 0.0.0.0
-  ExCSS.Unity: 2.0.6.0
-  JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked: 2021.1.3.139
-  Microsoft.Bcl.AsyncInterfaces: 5.0.0.0
-  Mono.Security: 4.0.0.0
-  Sentry: 3.6.0.0
-  Sentry.Unity: 0.3.1.0
-  Sentry.Unity.Editor: 0.3.1.0
-  Sentry.Unity.Editor.Tests: 0.3.1.0
-  Sentry.Unity.Tests: 0.3.1.0
-  System: 4.0.0.0
-  System.Buffers: 4.0.3.0
-  System.Collections.Immutable: 5.0.0.0
-  System.Configuration: 4.0.0.0
-  System.Core: 4.0.0.0
-  System.Memory: 4.0.1.1
-  System.Net.Http: 4.0.0.0
-  System.Numerics.Vectors: 4.1.4.0
-  System.Reflection.Metadata: 5.0.0.0
-  System.Runtime.CompilerServices.Unsafe: 5.0.0.0
-  System.Text.Encodings.Web: 5.0.0.1
-  System.Text.Json: 5.0.0.0
-  System.Threading.Tasks.Extensions: 4.2.0.1
-  System.Xml: 4.0.0.0
-  System.Xml.Linq: 4.0.0.0
-  Unity.Cecil: 0.10.0.0
-  Unity.CompilationPipeline.Common: 0.0.0.0
-  Unity.Legacy.NRefactory: 1.0.0.0
-  Unity.Rider.Editor: 0.0.0.0
-  Unity.SerializationLogic: 1.0.0.0
-  Unity.Sysroot.Linux_x86_64: 0.0.0.0
-  Unity.SysrootPackage.Editor: 1.0.0.0
-  Unity.Toolchain.Macos-x86_64-Linux-x86_64: 0.0.0.0
-  UnityEditor: 0.0.0.0
-  UnityEditor.Android.Extensions: 0.0.0.0
-  UnityEditor.Graphs: 0.0.0.0
-  UnityEditor.TestRunner: 1.0.0.0
-  UnityEditor.UI: 1.0.0.0
-  UnityEditor.VR: 0.0.0.0
-  UnityEditor.WebGL.Extensions: 1.0.0.0
-  UnityEditor.WindowsStandalone.Extensions: 0.0.0.0
-  UnityEngine: 0.0.0.0
-  UnityEngine.AIModule: 0.0.0.0
-  UnityEngine.ARModule: 0.0.0.0
-  UnityEngine.AccessibilityModule: 0.0.0.0
-  UnityEngine.AndroidJNIModule: 0.0.0.0
-  UnityEngine.AnimationModule: 0.0.0.0
-  UnityEngine.AssetBundleModule: 0.0.0.0
-  UnityEngine.AudioModule: 0.0.0.0
-  UnityEngine.ClothModule: 0.0.0.0
-  UnityEngine.ClusterInputModule: 0.0.0.0
-  UnityEngine.ClusterRendererModule: 0.0.0.0
-  UnityEngine.CoreModule: 0.0.0.0
-  UnityEngine.CrashReportingModule: 0.0.0.0
-  UnityEngine.DSPGraphModule: 0.0.0.0
-  UnityEngine.DirectorModule: 0.0.0.0
-  UnityEngine.GameCenterModule: 0.0.0.0
-  UnityEngine.GridModule: 0.0.0.0
-  UnityEngine.HotReloadModule: 0.0.0.0
-  UnityEngine.IMGUIModule: 0.0.0.0
-  UnityEngine.ImageConversionModule: 0.0.0.0
-  UnityEngine.InputLegacyModule: 0.0.0.0
-  UnityEngine.InputModule: 0.0.0.0
-  UnityEngine.JSONSerializeModule: 0.0.0.0
-  UnityEngine.LocalizationModule: 0.0.0.0
-  UnityEngine.ParticleSystemModule: 0.0.0.0
-  UnityEngine.PerformanceReportingModule: 0.0.0.0
-  UnityEngine.Physics2DModule: 0.0.0.0
-  UnityEngine.PhysicsModule: 0.0.0.0
-  UnityEngine.ProfilerModule: 0.0.0.0
-  UnityEngine.ScreenCaptureModule: 0.0.0.0
-  UnityEngine.SharedInternalsModule: 0.0.0.0
-  UnityEngine.SpriteMaskModule: 0.0.0.0
-  UnityEngine.SpriteShapeModule: 0.0.0.0
-  UnityEngine.StreamingModule: 0.0.0.0
-  UnityEngine.SubstanceModule: 0.0.0.0
-  UnityEngine.SubsystemsModule: 0.0.0.0
-  UnityEngine.TLSModule: 0.0.0.0
-  UnityEngine.TerrainModule: 0.0.0.0
-  UnityEngine.TerrainPhysicsModule: 0.0.0.0
-  UnityEngine.TestRunner: 1.0.0.0
-  UnityEngine.TextCoreModule: 0.0.0.0
-  UnityEngine.TextRenderingModule: 0.0.0.0
-  UnityEngine.TilemapModule: 0.0.0.0
-  UnityEngine.UI: 1.0.0.0
-  UnityEngine.UIElementsModule: 0.0.0.0
-  UnityEngine.UIModule: 0.0.0.0
-  UnityEngine.UNETModule: 0.0.0.0
-  UnityEngine.UmbraModule: 0.0.0.0
-  UnityEngine.UnityAnalyticsModule: 0.0.0.0
-  UnityEngine.UnityConnectModule: 0.0.0.0
-  UnityEngine.UnityTestProtocolModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAssetBundleModule: 0.0.0.0
-  UnityEngine.UnityWebRequestAudioModule: 0.0.0.0
-  UnityEngine.UnityWebRequestModule: 0.0.0.0
-  UnityEngine.UnityWebRequestTextureModule: 0.0.0.0
-  UnityEngine.UnityWebRequestWWWModule: 0.0.0.0
-  UnityEngine.VFXModule: 0.0.0.0
-  UnityEngine.VRModule: 0.0.0.0
-  UnityEngine.VehiclesModule: 0.0.0.0
-  UnityEngine.VideoModule: 0.0.0.0
-  UnityEngine.WindModule: 0.0.0.0
-  UnityEngine.XRModule: 0.0.0.0
-  mscorlib: 4.0.0.0
-  netstandard: 2.0.0.0
-  nunit.framework: 3.5.0.0
-platform: csharp
-timestamp: "[timestamp]"
-received: "[received]"
-release: "0.1"
-environment: editor
-contexts:
-  Current Culture:
-    Calendar: GregorianCalendar
-    DisplayName: English (United States)
-    Name: en-US
-    type: Current Culture
-  app:
-    app_start_time: "2021-07-01T08:17:02.531426+00:00"
-    build_type: debug
-    type: app
-  device:
-    name: DESKTOP-23F43DQ
-    model: XPS 15 9570 (Dell Inc.)
-    battery_level: 100
-    simulator: true
-    memory_size: ~
-    boot_time: ~
-    timezone: ~
-    processor_count: 12
-    cpu_description: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
-    device_type: Desktop
-    battery_status: Full
-    supports_vibration: false
-    timezone_display_name: "(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius"
-    type: device
-  gpu:
-    name: NVIDIA GeForce GTX 1050 Ti with Max-Q Design
-    version: "Direct3D 11.0 [level 11.1]"
-    id: 7308
-    vendor_id: "4318"
-    vendor_name: NVIDIA
-    memory_size: 4021
-    api_type: Direct3D11
-    multi_threaded_rendering: true
-    npot_support: Full
-    max_texture_size: 16384
-    graphics_shader_level: Shader Model 5.0
-    supports_draw_call_instancing: true
-    supports_ray_tracing: false
-    supports_compute_shaders: true
-    supports_geometry_shaders: true
-    type: gpu
-  os:
-    name: Windows 10  (10.0.19042) 64bit
-    type: os
-  runtime:
-    name: Mono
-    version: 5.11.0
-    raw_description: Mono 5.11.0 (Visual Studio built mono)
-    type: runtime
-  unity:
-    install_mode: Editor
-    type: unity
-breadcrumbs:
-  values:
-    - timestamp: 1625127430.945
-      type: default
-      category: scene.beforeload
-      level: info
-      message: BeforeSceneLoad
-      data:
-        scene: 1_BugfarmScene
-    - timestamp: 1625127430.952
-      type: default
-      category: unity.logger
-      level: error
-      message: "Exception: This is an exception"
-exception:
-  values:
-    - type: Exception
-      value: This is an exception
-      stacktrace:
-        frames:
-          - function: "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)"
-            in_app: false
-          - function: "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()"
-            filename: IntegrationTests.cs
-            abs_path: "C:/Projects/Unity/sentry-unity/test/Sentry.Unity.Tests/IntegrationTests.cs"
-            lineno: 96
-            in_app: true
-          - function: "UnityEngine.GameObject:SendMessage(String)"
-            in_app: false
-          - function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException
-            raw_function: Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()
-            filename: TestMonoBehaviour.cs
-            abs_path: "C:/Projects/Unity/sentry-unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs"
-            lineno: 12
-            in_app: true
-tags:
-  - - device
-    - XPS 15 9570 (Dell Inc.)
-  - - gpu.name
-    - NVIDIA GeForce GTX 1050 Ti with Max-Q Design
-  - - gpu.vendor
-    - NVIDIA
-  - - level
-    - error
-  - - os.name
-    - Windows 10  (10.0.19042) 64bit
-  - - runtime
-    - Mono 5.11.0
-  - - runtime.name
-    - Mono
-  - - source
-    - log
-  - - unity.device.device_type
-    - Desktop
-  - - unity.gpu.supports_instancing
-    - "true"
-  - - unity.install_mode
-    - Editor
-sdk:
-  name: sentry.dotnet.unity
-  version: 0.3.1
-  packages:
-    - name: "nuget:Sentry"
-      version: 3.6.0
-    - name: "upm:sentry.unity"
-      version: 0.3.1
-_meta:
-  contexts:
-    device:
-      boot_time:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      memory_size:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-      timezone:
-        "":
-          rem:
-            - - "@anything:remove"
-              - x
-
+{
+  "event_id": "6f6e2d3fa0754d14b37a2bec59619a98",
+  "level": "error",
+  "type": "error",
+  "logger": "",
+  "modules": {
+    "Assembly-CSharp": "0.0.0.0",
+    "Assembly-CSharp-Editor": "0.0.0.0",
+    "ExCSS.Unity": "2.0.6.0",
+    "JetBrains.Rider.Unity.Editor.Plugin.Full.Repacked": "2021.1.3.139",
+    "Microsoft.Bcl.AsyncInterfaces": "5.0.0.0",
+    "Mono.Security": "4.0.0.0",
+    "Sentry": "3.6.0.0",
+    "Sentry.Unity": "0.3.1.0",
+    "Sentry.Unity.Editor": "0.3.1.0",
+    "Sentry.Unity.Editor.Tests": "0.3.1.0",
+    "Sentry.Unity.Tests": "0.3.1.0",
+    "System": "4.0.0.0",
+    "System.Buffers": "4.0.3.0",
+    "System.Collections.Immutable": "5.0.0.0",
+    "System.Configuration": "4.0.0.0",
+    "System.Core": "4.0.0.0",
+    "System.Memory": "4.0.1.1",
+    "System.Net.Http": "4.0.0.0",
+    "System.Numerics.Vectors": "4.1.4.0",
+    "System.Reflection.Metadata": "5.0.0.0",
+    "System.Runtime.CompilerServices.Unsafe": "5.0.0.0",
+    "System.Text.Encodings.Web": "5.0.0.1",
+    "System.Text.Json": "5.0.0.0",
+    "System.Threading.Tasks.Extensions": "4.2.0.1",
+    "System.Xml": "4.0.0.0",
+    "System.Xml.Linq": "4.0.0.0",
+    "Unity.Cecil": "0.10.0.0",
+    "Unity.CompilationPipeline.Common": "0.0.0.0",
+    "Unity.Legacy.NRefactory": "1.0.0.0",
+    "Unity.Rider.Editor": "0.0.0.0",
+    "Unity.SerializationLogic": "1.0.0.0",
+    "Unity.Sysroot.Linux_x86_64": "0.0.0.0",
+    "Unity.SysrootPackage.Editor": "1.0.0.0",
+    "Unity.Toolchain.Macos-x86_64-Linux-x86_64": "0.0.0.0",
+    "UnityEditor": "0.0.0.0",
+    "UnityEditor.Android.Extensions": "0.0.0.0",
+    "UnityEditor.Graphs": "0.0.0.0",
+    "UnityEditor.TestRunner": "1.0.0.0",
+    "UnityEditor.UI": "1.0.0.0",
+    "UnityEditor.VR": "0.0.0.0",
+    "UnityEditor.WebGL.Extensions": "1.0.0.0",
+    "UnityEditor.WindowsStandalone.Extensions": "0.0.0.0",
+    "UnityEngine": "0.0.0.0",
+    "UnityEngine.AIModule": "0.0.0.0",
+    "UnityEngine.ARModule": "0.0.0.0",
+    "UnityEngine.AccessibilityModule": "0.0.0.0",
+    "UnityEngine.AndroidJNIModule": "0.0.0.0",
+    "UnityEngine.AnimationModule": "0.0.0.0",
+    "UnityEngine.AssetBundleModule": "0.0.0.0",
+    "UnityEngine.AudioModule": "0.0.0.0",
+    "UnityEngine.ClothModule": "0.0.0.0",
+    "UnityEngine.ClusterInputModule": "0.0.0.0",
+    "UnityEngine.ClusterRendererModule": "0.0.0.0",
+    "UnityEngine.CoreModule": "0.0.0.0",
+    "UnityEngine.CrashReportingModule": "0.0.0.0",
+    "UnityEngine.DSPGraphModule": "0.0.0.0",
+    "UnityEngine.DirectorModule": "0.0.0.0",
+    "UnityEngine.GameCenterModule": "0.0.0.0",
+    "UnityEngine.GridModule": "0.0.0.0",
+    "UnityEngine.HotReloadModule": "0.0.0.0",
+    "UnityEngine.IMGUIModule": "0.0.0.0",
+    "UnityEngine.ImageConversionModule": "0.0.0.0",
+    "UnityEngine.InputLegacyModule": "0.0.0.0",
+    "UnityEngine.InputModule": "0.0.0.0",
+    "UnityEngine.JSONSerializeModule": "0.0.0.0",
+    "UnityEngine.LocalizationModule": "0.0.0.0",
+    "UnityEngine.ParticleSystemModule": "0.0.0.0",
+    "UnityEngine.PerformanceReportingModule": "0.0.0.0",
+    "UnityEngine.Physics2DModule": "0.0.0.0",
+    "UnityEngine.PhysicsModule": "0.0.0.0",
+    "UnityEngine.ProfilerModule": "0.0.0.0",
+    "UnityEngine.ScreenCaptureModule": "0.0.0.0",
+    "UnityEngine.SharedInternalsModule": "0.0.0.0",
+    "UnityEngine.SpriteMaskModule": "0.0.0.0",
+    "UnityEngine.SpriteShapeModule": "0.0.0.0",
+    "UnityEngine.StreamingModule": "0.0.0.0",
+    "UnityEngine.SubstanceModule": "0.0.0.0",
+    "UnityEngine.SubsystemsModule": "0.0.0.0",
+    "UnityEngine.TLSModule": "0.0.0.0",
+    "UnityEngine.TerrainModule": "0.0.0.0",
+    "UnityEngine.TerrainPhysicsModule": "0.0.0.0",
+    "UnityEngine.TestRunner": "1.0.0.0",
+    "UnityEngine.TextCoreModule": "0.0.0.0",
+    "UnityEngine.TextRenderingModule": "0.0.0.0",
+    "UnityEngine.TilemapModule": "0.0.0.0",
+    "UnityEngine.UI": "1.0.0.0",
+    "UnityEngine.UIElementsModule": "0.0.0.0",
+    "UnityEngine.UIModule": "0.0.0.0",
+    "UnityEngine.UNETModule": "0.0.0.0",
+    "UnityEngine.UmbraModule": "0.0.0.0",
+    "UnityEngine.UnityAnalyticsModule": "0.0.0.0",
+    "UnityEngine.UnityConnectModule": "0.0.0.0",
+    "UnityEngine.UnityTestProtocolModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAssetBundleModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestAudioModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestTextureModule": "0.0.0.0",
+    "UnityEngine.UnityWebRequestWWWModule": "0.0.0.0",
+    "UnityEngine.VFXModule": "0.0.0.0",
+    "UnityEngine.VRModule": "0.0.0.0",
+    "UnityEngine.VehiclesModule": "0.0.0.0",
+    "UnityEngine.VideoModule": "0.0.0.0",
+    "UnityEngine.WindModule": "0.0.0.0",
+    "UnityEngine.XRModule": "0.0.0.0",
+    "mscorlib": "4.0.0.0",
+    "netstandard": "2.0.0.0",
+    "nunit.framework": "3.5.0.0"
+  },
+  "platform": "csharp",
+  "timestamp": "[timestamp]",
+  "received": "[received]",
+  "release": "0.1",
+  "environment": "editor",
+  "contexts": {
+    "Current Culture": {
+      "Calendar": "GregorianCalendar",
+      "DisplayName": "English (United States)",
+      "Name": "en-US",
+      "type": "Current Culture"
+    },
+    "app": {
+      "app_start_time": "2021-07-01T08:17:02.531426+00:00",
+      "build_type": "debug",
+      "type": "app"
+    },
+    "device": {
+      "name": "DESKTOP-23F43DQ",
+      "model": "XPS 15 9570 (Dell Inc.)",
+      "battery_level": 100.0,
+      "simulator": true,
+      "memory_size": null,
+      "boot_time": null,
+      "timezone": null,
+      "processor_count": 12,
+      "cpu_description": "Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz",
+      "device_type": "Desktop",
+      "battery_status": "Full",
+      "supports_vibration": false,
+      "timezone_display_name": "(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius",
+      "type": "device"
+    },
+    "gpu": {
+      "name": "NVIDIA GeForce GTX 1050 Ti with Max-Q Design",
+      "version": "Direct3D 11.0 [level 11.1]",
+      "id": 7308,
+      "vendor_id": "4318",
+      "vendor_name": "NVIDIA",
+      "memory_size": 4021,
+      "api_type": "Direct3D11",
+      "multi_threaded_rendering": true,
+      "npot_support": "Full",
+      "max_texture_size": 16384,
+      "graphics_shader_level": "Shader Model 5.0",
+      "supports_draw_call_instancing": true,
+      "supports_ray_tracing": false,
+      "supports_compute_shaders": true,
+      "supports_geometry_shaders": true,
+      "type": "gpu"
+    },
+    "os": {
+      "name": "Windows 10  (10.0.19042) 64bit",
+      "type": "os"
+    },
+    "runtime": {
+      "name": "Mono",
+      "version": "5.11.0",
+      "raw_description": "Mono 5.11.0 (Visual Studio built mono)",
+      "type": "runtime"
+    },
+    "unity": {
+      "install_mode": "Editor",
+      "type": "unity"
+    }
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1625127430.945,
+        "type": "default",
+        "category": "scene.beforeload",
+        "level": "info",
+        "message": "BeforeSceneLoad",
+        "data": {
+          "scene": "1_BugfarmScene"
+        }
+      },
+      {
+        "timestamp": 1625127430.952,
+        "type": "default",
+        "category": "unity.logger",
+        "level": "error",
+        "message": "Exception: This is an exception"
+      }
+    ]
+  },
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "This is an exception",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)",
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.<BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease_WhenProductNameWhitespace>d__3:MoveNext()",
+              "filename": "IntegrationTests.cs",
+              "abs_path": "C:/Projects/Unity/sentry-unity/test/Sentry.Unity.Tests/IntegrationTests.cs",
+              "lineno": 96,
+              "in_app": true
+            },
+            {
+              "function": "UnityEngine.GameObject:SendMessage(String)",
+              "in_app": false
+            },
+            {
+              "function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException",
+              "raw_function": "Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour.TestException ()",
+              "filename": "TestMonoBehaviour.cs",
+              "abs_path": "C:/Projects/Unity/sentry-unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs",
+              "lineno": 12,
+              "in_app": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "tags": [
+    [
+      "device",
+      "XPS 15 9570 (Dell Inc.)"
+    ],
+    [
+      "gpu.name",
+      "NVIDIA GeForce GTX 1050 Ti with Max-Q Design"
+    ],
+    [
+      "gpu.vendor",
+      "NVIDIA"
+    ],
+    [
+      "level",
+      "error"
+    ],
+    [
+      "os.name",
+      "Windows 10  (10.0.19042) 64bit"
+    ],
+    [
+      "runtime",
+      "Mono 5.11.0"
+    ],
+    [
+      "runtime.name",
+      "Mono"
+    ],
+    [
+      "source",
+      "log"
+    ],
+    [
+      "unity.device.device_type",
+      "Desktop"
+    ],
+    [
+      "unity.gpu.supports_instancing",
+      "true"
+    ],
+    [
+      "unity.install_mode",
+      "Editor"
+    ]
+  ],
+  "sdk": {
+    "name": "sentry.dotnet.unity",
+    "version": "0.3.1",
+    "packages": [
+      {
+        "name": "nuget:Sentry",
+        "version": "3.6.0"
+      },
+      {
+        "name": "upm:sentry.unity",
+        "version": "0.3.1"
+      }
+    ]
+  },
+  "_meta": {
+    "contexts": {
+      "device": {
+        "boot_time": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "memory_size": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        },
+        "timezone": {
+          "": {
+            "rem": [
+              [
+                "@anything:remove",
+                "x"
+              ]
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/test_fixtures.rs
+++ b/relay-server/tests/test_fixtures.rs
@@ -83,7 +83,7 @@ macro_rules! event_snapshot {
                 let mut processor = PiiProcessor::new(&compiled);
 
                 process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
-                insta::assert_yaml_snapshot!("pii_stripping", SerializableAnnotated(&event), {
+                insta::assert_json_snapshot!("pii_stripping", SerializableAnnotated(&event), {
                     ".received" => "[received]",
                     ".timestamp" => "[timestamp]"
                 });

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -10,12 +10,12 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures = { workspace = true }
 once_cell = { workspace = true }
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
-tokio = { version = "1.28.0", features = ["macros", "signal", "tracing"] }
+tokio = { workspace = true, features = ["signal"] }
 
 [dev-dependencies]
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
-tokio = { version = "1.28.0", features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
 tokio = { version = "1.28.0", features = ["macros", "signal", "tracing"] }

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 [dependencies]
 relay-log = { path = "../relay-log", features = ["test"] }
 relay-system = { path = "../relay-system" }
-tokio = { version = "1.28.0" }
+tokio = { workspace = true }

--- a/relay-ua/Cargo.toml
+++ b/relay-ua/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 uaparser = { version = "0.6.0" }
 
 [features]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -16,7 +16,7 @@ crash-handler = ["relay-log/crash-handler"]
 
 # Direct dependencies of the main application in `src/`
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["env", "wrap_help"] }
 clap_complete = "4.1.1"
 dialoguer = "0.10.0"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -22,11 +22,11 @@ clap_complete = "4.1.1"
 dialoguer = "0.10.0"
 hostname = "0.3.1"
 once_cell = { workspace = true }
-relay-common = { path = "../relay-common" }
 relay-config = { path = "../relay-config" }
 relay-log = { path = "../relay-log", features = ["init"] }
 relay-server = { path = "../relay-server" }
 relay-statsd = { path = "../relay-statsd" }
+uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemallocator = { version = "0.5.0", features = ["background_threads"] }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.1.4", features = ["env", "wrap_help"] }
 clap_complete = "4.1.1"
 dialoguer = "0.10.0"
 hostname = "0.3.1"
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 relay-common = { path = "../relay-common" }
 relay-config = { path = "../relay-config" }
 relay-log = { path = "../relay-log", features = ["init"] }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -17,7 +17,7 @@ crash-handler = ["relay-log/crash-handler"]
 # Direct dependencies of the main application in `src/`
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.1.4", features = ["env", "wrap_help"] }
+clap = { workspace = true, features = ["env", "wrap_help"] }
 clap_complete = "4.1.1"
 dialoguer = "0.10.0"
 hostname = "0.3.1"

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -5,10 +5,10 @@ use anyhow::{anyhow, bail, Result};
 use clap::ArgMatches;
 use clap_complete::Shell;
 use dialoguer::{Confirm, Select};
-use relay_common::uuid::Uuid;
 use relay_config::{
     Config, ConfigError, ConfigErrorKind, Credentials, MinimalConfig, OverridableConfig, RelayMode,
 };
+use uuid::Uuid;
 
 use crate::cliapp::make_app;
 use crate::utils::get_theme;

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.32"
+anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
-serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.55"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9.17"
 syn = { version = "1.0.39", features = ["full"] }
 

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = "0.9.17"
+serde_yaml = { workspace = true }
 syn = { version = "1.0.39", features = ["full"] }
 
 [dev-dependencies]

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -17,4 +17,4 @@ serde_yaml = "0.9.17"
 syn = { version = "1.0.39", features = ["full"] }
 
 [dev-dependencies]
-insta = "1.31.0"
+insta = { workspace = true }

--- a/tools/document-pii/Cargo.toml
+++ b/tools/document-pii/Cargo.toml
@@ -15,8 +15,8 @@ quote = "1.0.26"
 walkdir = "2.3.2"
 proc-macro2 = "1.0.54"
 clap = { version = "4.1.4", features = ["derive"] }
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = "1.0.93"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9.17"
 path-slash = "0.2.1"
 

--- a/tools/document-pii/Cargo.toml
+++ b/tools/document-pii/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-syn = { version = "2.0.11", features = ["visit", "full", "extra-traits"] }
-quote = "1.0.26"
-walkdir = "2.3.2"
-proc-macro2 = "1.0.54"
 clap = { version = "4.1.4", features = ["derive"] }
+path-slash = "0.2.1"
+proc-macro2 = "1.0.54"
+quote = "1.0.26"
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = "0.9.17"
-path-slash = "0.2.1"
+serde_yaml = { workspace = true }
+syn = { version = "2.0.11", features = ["visit", "full", "extra-traits"] }
+walkdir = "2.3.2"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/tools/document-pii/Cargo.toml
+++ b/tools/document-pii/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 path-slash = "0.2.1"
 proc-macro2 = "1.0.54"
 quote = "1.0.26"

--- a/tools/document-pii/Cargo.toml
+++ b/tools/document-pii/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 syn = { version = "2.0.11", features = ["visit", "full", "extra-traits"] }
 quote = "1.0.26"
 walkdir = "2.3.2"

--- a/tools/document-pii/Cargo.toml
+++ b/tools/document-pii/Cargo.toml
@@ -21,4 +21,4 @@ serde_yaml = "0.9.17"
 path-slash = "0.2.1"
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["ron"] }
+insta = { workspace = true }

--- a/tools/generate-schema/Cargo.toml
+++ b/tools/generate-schema/Cargo.toml
@@ -14,4 +14,4 @@ clap = { version = "4.1.4", features = ["derive"] }
 relay-event-schema = { path = "../../relay-event-schema", features = [
     "jsonschema",
 ] }
-serde_json = "1.0.55"
+serde_json = { workspace = true }

--- a/tools/generate-schema/Cargo.toml
+++ b/tools/generate-schema/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 relay-event-schema = { path = "../../relay-event-schema", features = [
     "jsonschema",
 ] }

--- a/tools/generate-schema/Cargo.toml
+++ b/tools/generate-schema/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.32"
+anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 relay-event-schema = { path = "../../relay-event-schema", features = [
     "jsonschema",

--- a/tools/process-event/Cargo.toml
+++ b/tools/process-event/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 relay-event-schema = { path = "../../relay-event-schema" }
 relay-pii = { path = "../../relay-pii" }
 relay-protocol = { path = "../../relay-protocol" }

--- a/tools/process-event/Cargo.toml
+++ b/tools/process-event/Cargo.toml
@@ -17,4 +17,4 @@ relay-event-schema = { path = "../../relay-event-schema" }
 relay-pii = { path = "../../relay-pii" }
 relay-protocol = { path = "../../relay-protocol" }
 relay-event-normalization = { path = "../../relay-event-normalization" }
-serde_json = "1.0.55"
+serde_json = { workspace = true }

--- a/tools/process-event/Cargo.toml
+++ b/tools/process-event/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.32"
+anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 relay-event-schema = { path = "../../relay-event-schema" }
 relay-pii = { path = "../../relay-pii" }

--- a/tools/scrub-minidump/Cargo.toml
+++ b/tools/scrub-minidump/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 relay-pii = { path = "../../relay-pii" }
-serde_json = "1.0.55"
+serde_json = { workspace = true }

--- a/tools/scrub-minidump/Cargo.toml
+++ b/tools/scrub-minidump/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.32"
+anyhow = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 relay-pii = { path = "../../relay-pii" }
 serde_json = "1.0.55"

--- a/tools/scrub-minidump/Cargo.toml
+++ b/tools/scrub-minidump/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 relay-pii = { path = "../../relay-pii" }
 serde_json = { workspace = true }


### PR DESCRIPTION
Formats all `Cargo.toml` files, removes dependency re-exports, and adopts Cargo
[workspace.dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table)
for common crates. The following crates are now workspace dependencies:

- `anyhow`
- `chrono`
- `clap`
- `criterion`
- `futures`
- `insta`
- `itertools`
- `once_cell`
- `regex`
- `serde`
- `serde_json`
- `serde_yaml`
- `schemars`
- `similar`
- `smallvec`
- `thiserror`
- `tokio`
- `url`
- `uuid`

Additionally, this PR replaces a few instances of YAML snapshots for insta. The majority of the code base uses JSON, RON, or debug.

Closes https://github.com/getsentry/relay/issues/2432
#skip-changelog

