### PR TITLE
meta(gh): Remove external codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,3 @@
 
 # Build & Releases
 /.github/workflows/release*.yml  @getsentry/release-approvers
-
-# AWS Extension
-/relay-aws-extension/  @getsentry/team-web-sdk-backend
-
-# Profiling
-/relay-profiling/ @getsentry/profiling


### PR DESCRIPTION
Removes the web platform and profiling team from codeowners. For the time being,
the ingest team is the only required reviewer and owner of the code in the Relay
repository. The only remaining exceptions are files with legal implications.

This repository uses codeowners differently than the main Sentry repository,
especially because review from _all_ owners is _required_ to merge a PR. For
this reason, we opt to remove codeowners that otherwise have to approve changes
not in their scope.

Please note that contributions are still welcome as they were in the past.

#skip-changelog

