### PR TITLE
fix(profiles): Bump android-trace-log version to prevent panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixes the `TraceContext.status` not being defaulted to `unknown` before the new metrics extraction pipeline. ([#2436](https://github.com/getsentry/relay/pull/2436))
 - Support on-demand metrics for alerts and widgets in external Relays. ([#2440](https://github.com/getsentry/relay/pull/2440))
 - Prevent sporadic data loss in `EnvelopeProcessorService`. ([#2454](https://github.com/getsentry/relay/pull/2454))
+- Prevent panic when android trace contains invalid start time. ([#2457](https://github.com/getsentry/relay/pull/2457))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "android_trace_log"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbde12639dffb3ef0549232753981842c669e142255e48aaa2748a1e0f534a96"
+checksum = "5b6b53e6d20664ddcbc06b80f29c64330f3c3aa01b597a8743f4368623a03718"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,15 +473,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "serde",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ debug = true
 
 [workspace.dependencies]
 anyhow = "1.0.66"
-chrono = { version = "0.4.24", default-features = false, features = [
+chrono = { version = "0.4.28", default-features = false, features = [
     "std",
     "serde",
 ] }

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -130,7 +130,8 @@ impl UnixTimestamp {
 
     /// Returns the timestamp as chrono datetime.
     pub fn as_datetime(self) -> Option<DateTime<Utc>> {
-        NaiveDateTime::from_timestamp_opt(self.0 as i64, 0).map(|n| DateTime::from_utc(n, Utc))
+        NaiveDateTime::from_timestamp_opt(self.0 as i64, 0)
+            .map(|n| DateTime::from_naive_utc_and_offset(n, Utc))
     }
 
     /// Converts the UNIX timestamp into an `Instant` based on the current system timestamp.

--- a/relay-event-normalization/src/transactions/rules.rs
+++ b/relay-event-normalization/src/transactions/rules.rs
@@ -194,7 +194,7 @@ mod tests {
         let parsed_time = DateTime::parse_from_rfc3339("2022-11-30T00:00:00Z").unwrap();
         let result = TransactionNameRule {
             pattern: LazyGlob::new("/auth/login/*/**".to_string()),
-            expiry: DateTime::from_utc(parsed_time.naive_utc(), Utc),
+            expiry: DateTime::from_naive_utc_and_offset(parsed_time.naive_utc(), Utc),
             redaction: RedactionRule::Replace {
                 substitution: String::from(":id"),
             },
@@ -220,7 +220,7 @@ mod tests {
         let parsed_time = DateTime::parse_from_rfc3339("2022-11-30T00:00:00Z").unwrap();
         let result = TransactionNameRule {
             pattern: LazyGlob::new("/auth/login/*/**".to_string()),
-            expiry: DateTime::from_utc(parsed_time.naive_utc(), Utc),
+            expiry: DateTime::from_naive_utc_and_offset(parsed_time.naive_utc(), Utc),
             redaction: RedactionRule::Replace {
                 substitution: default_substitution(),
             },

--- a/relay-event-schema/src/protocol/types.rs
+++ b/relay-event-schema/src/protocol/types.rs
@@ -1016,7 +1016,7 @@ impl FromValue for Timestamp {
             Annotated(Some(Value::String(value)), mut meta) => {
                 // NaiveDateTime parses "%Y-%m-%dT%H:%M:%S%.f"
                 let parsed = match value.parse::<NaiveDateTime>() {
-                    Ok(dt) => Ok(DateTime::from_utc(dt, Utc)),
+                    Ok(dt) => Ok(DateTime::from_naive_utc_and_offset(dt, Utc)),
 
                     // XXX: This actually accepts more than RFC 3339. SDKs are strongly discouraged
                     // from exercising that freedom. We should only support RFC3339.

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../LICENSE"
 publish = false
 
 [dependencies]
-android_trace_log = { version = "0.2.0", features = ["serde"] }
+android_trace_log = { version = "0.3.0", features = ["serde"] }
 chrono = { workspace = true }
 data-encoding = "2.3.3"
 relay-event-schema = { path = "../relay-event-schema" }


### PR DESCRIPTION
Fixes https://github.com/getsentry/relay/issues/2451.

See also https://github.com/chayleaf/android-trace-log/pull/2.