### PR TITLE
test(metrics): Add tests for protocol docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3325,6 +3326,7 @@ dependencies = [
  "relay-test",
  "serde",
  "serde_json",
+ "similar-asserts",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
 ] }
 clap = { version = "4.1.4" }
 criterion = "0.5"
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3", default-features = false, features = ["std"] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 itertools = "0.10.5"
 once_cell = "1.13.1"

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -30,6 +30,7 @@ criterion = { workspace = true }
 insta = { workspace = true }
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }
+similar-asserts = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -670,55 +670,7 @@ pub struct ParseBucketError(#[source] serde_json::Error);
 /// metric type.
 ///
 /// ```json
-/// [
-///   {
-///     "timestamp": 1615889440,
-///     "width": 10,
-///     "name": "endpoint.response_time",
-///     "type": "d",
-///     "unit": "millisecond",
-///     "value": [36, 49, 57, 68],
-///     "tags": {
-///       "route": "user_index"
-///     }
-///   },
-///   {
-///     "timestamp": 1615889440,
-///     "width": 10,
-///     "name": "endpoint.hits",
-///     "type": "c",
-///     "value": 4,
-///     "tags": {
-///       "route": "user_index"
-///     }
-///   },
-///   {
-///     "timestamp": 1615889440,
-///     "width": 10,
-///     "name": "endpoint.parallel_requests",
-///     "type": "g",
-///     "value": {
-///       "max": 42.0,
-///       "min": 17.0,
-///       "sum": 2210.0,
-///       "last": 25.0,
-///       "count": 85
-///     }
-///   },
-///   {
-///     "timestamp": 1615889440,
-///     "width": 10,
-///     "name": "endpoint.users",
-///     "type": "s",
-///     "value": [
-///       3182887624,
-///       4267882815
-///     ],
-///     "tags": {
-///       "route": "user_index"
-///     }
-///   }
-/// ]
+#[doc = include_str!("../tests/fixtures/buckets.json")]
 /// ```
 ///
 /// To parse a submission payload, use [`Bucket::parse_all`].
@@ -2105,6 +2057,8 @@ impl Drop for AggregatorService {
 mod tests {
     use std::sync::{Arc, RwLock};
 
+    use similar_asserts::assert_eq;
+
     use super::*;
 
     #[derive(Default)]
@@ -2253,6 +2207,15 @@ mod tests {
         assert_eq!(iter.next(), Some((1f64, 1)));
         assert_eq!(iter.next(), Some((2f64, 2)));
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_bucket_docs_roundtrip() {
+        let json = include_str!("../tests/fixtures/buckets.json").trim_end();
+        let buckets = Bucket::parse_all(json.as_bytes()).unwrap();
+
+        let serialized = serde_json::to_string_pretty(&buckets).unwrap();
+        assert_eq!(json, &serialized);
     }
 
     #[test]

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -2210,15 +2210,6 @@ mod tests {
     }
 
     #[test]
-    fn test_bucket_docs_roundtrip() {
-        let json = include_str!("../tests/fixtures/buckets.json").trim_end();
-        let buckets = Bucket::parse_all(json.as_bytes()).unwrap();
-
-        let serialized = serde_json::to_string_pretty(&buckets).unwrap();
-        assert_eq!(json, &serialized);
-    }
-
-    #[test]
     fn test_parse_buckets() {
         let json = r#"[
           {
@@ -2342,6 +2333,17 @@ mod tests {
 ]"#;
 
         let buckets = Bucket::parse_all(json.as_bytes()).unwrap();
+        let serialized = serde_json::to_string_pretty(&buckets).unwrap();
+        assert_eq!(json, serialized);
+    }
+
+    #[test]
+    fn test_bucket_docs_roundtrip() {
+        let json = include_str!("../tests/fixtures/buckets.json")
+            .trim_end()
+            .replace("\r\n", "\n");
+        let buckets = Bucket::parse_all(json.as_bytes()).unwrap();
+
         let serialized = serde_json::to_string_pretty(&buckets).unwrap();
         assert_eq!(json, serialized);
     }

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -26,7 +26,7 @@
 //! ```text
 //! {}
 //! {"type": "metrics", "timestamp": 1615889440, ...}
-//! endpoint.response_time@millisecond:57|d|#route:user_index
+#![doc = include_str!("../tests/fixtures/metrics.statsd.txt")]
 //! ...
 //! ```
 //!
@@ -48,29 +48,7 @@
 //! Aggregate buckets are encoded in JSON with the following schema:
 //!
 //! ```json
-//! [
-//!   {
-//!     "name": "endpoint.response_time",
-//!     "unit": "millisecond",
-//!     "value": [36, 49, 57, 68],
-//!     "type": "d",
-//!     "timestamp": 1615889440,
-//!     "width": 10,
-//!     "tags": {
-//!       "route": "user_index"
-//!     }
-//!   },
-//!   {
-//!     "name": "endpoint.hits",
-//!     "value": 4,
-//!     "type": "c",
-//!     "timestamp": 1615889440,
-//!     "width": 10,
-//!     "tags": {
-//!       "route": "user_index"
-//!     }
-//!   }
-//! ]
+#![doc = include_str!("../tests/fixtures/buckets.json")]
 //! ```
 //!
 //! # Ingestion
@@ -80,25 +58,13 @@
 //! separate message:
 //!
 //! ```json
-//! {
-//!   "org_id": 1,
-//!   "project_id": 42,
-//!   "name": "endpoint.response_time",
-//!   "unit": "millisecond",
-//!   "value": [36, 49, 57, 68],
-//!   "type": "d",
-//!   "timestamp": 1615889440,
-//!   "tags": {
-//!     "route": "user_index"
-//!   }
-//! }
+#![doc = include_str!("../tests/fixtures/kafka.json")]
 //! ```
 #![warn(missing_docs)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
-#![allow(clippy::derive_partial_eq_without_eq)]
 
 mod aggregation;
 mod protocol;

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -374,8 +374,7 @@ fn parse_tags(string: &str) -> Option<BTreeMap<String, String>> {
 /// submission looks like this:
 ///
 /// ```text
-/// endpoint.response_time@millisecond:57|d|#route:user_index
-/// endpoint.hits:1|c|#route:user_index
+#[doc = include_str!("../tests/fixtures/metrics.statsd.txt")]
 /// ```
 ///
 /// To parse a submission payload, use [`Metric::parse_all`].
@@ -387,16 +386,7 @@ fn parse_tags(string: &str) -> Option<BTreeMap<String, String>> {
 /// metric (see [crate documentation](crate)).
 ///
 /// ```json
-/// {
-///   "name": "endpoint.response_time",
-///   "unit": "millisecond",
-///   "value": 57,
-///   "type": "d",
-///   "timestamp": 1615889449,
-///   "tags": {
-///     "route": "user_index"
-///   }
-/// }
+#[doc = include_str!("../tests/fixtures/metrics.json")]
 /// ```
 ///
 /// # Hashing of Sets
@@ -408,17 +398,13 @@ fn parse_tags(string: &str) -> Option<BTreeMap<String, String>> {
 /// **Example**:
 ///
 /// ```text
-/// endpoint.users:e2546e4c-ecd0-43ad-ae27-87960e57a658|s
+#[doc = include_str!("../tests/fixtures/set.statsd.txt")]
 /// ```
 ///
 /// The above submission is represented as:
 ///
 /// ```json
-/// {
-///   "name": "endpoint.users",
-///   "value": 4267882815,
-///   "type": "s"
-/// }
+#[doc = include_str!("../tests/fixtures/set.json")]
 /// ```
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -669,6 +655,8 @@ impl FusedIterator for ParseMetrics<'_> {}
 
 #[cfg(test)]
 mod tests {
+    use similar_asserts::assert_eq;
+
     use super::*;
 
     #[test]
@@ -928,5 +916,32 @@ mod tests {
 
         let metric_count = Metric::parse_all(s.as_bytes(), timestamp).count();
         assert_eq!(metric_count, 2);
+    }
+
+    #[test]
+    fn test_metrics_docs() {
+        let text = include_str!("../tests/fixtures/metrics.statsd.txt").trim_end();
+        let json = include_str!("../tests/fixtures/metrics.json").trim_end();
+
+        let timestamp = UnixTimestamp::from_secs(1615889449);
+        let statsd_metrics = Metric::parse_all(text.as_bytes(), timestamp)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        let json_metrics: Vec<Metric> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(statsd_metrics, json_metrics);
+    }
+
+    #[test]
+    fn test_set_docs() {
+        let text = include_str!("../tests/fixtures/set.statsd.txt").trim_end();
+        let json = include_str!("../tests/fixtures/set.json").trim_end();
+
+        let timestamp = UnixTimestamp::from_secs(1615889449);
+        let statsd_metric = Metric::parse(text.as_bytes(), timestamp).unwrap();
+        let json_metric: Metric = serde_json::from_str(json).unwrap();
+
+        assert_eq!(statsd_metric, json_metric);
     }
 }

--- a/relay-metrics/tests/fixtures/buckets.json
+++ b/relay-metrics/tests/fixtures/buckets.json
@@ -1,0 +1,53 @@
+[
+  {
+    "timestamp": 1615889440,
+    "width": 10,
+    "name": "endpoint.response_time",
+    "type": "d",
+    "value": [
+      36.0,
+      49.0,
+      57.0,
+      68.0
+    ],
+    "tags": {
+      "route": "user_index"
+    }
+  },
+  {
+    "timestamp": 1615889440,
+    "width": 10,
+    "name": "endpoint.hits",
+    "type": "c",
+    "value": 4.0,
+    "tags": {
+      "route": "user_index"
+    }
+  },
+  {
+    "timestamp": 1615889440,
+    "width": 10,
+    "name": "endpoint.parallel_requests",
+    "type": "g",
+    "value": {
+      "max": 42.0,
+      "min": 17.0,
+      "sum": 2210.0,
+      "last": 25.0,
+      "count": 85
+    }
+  },
+  {
+    "timestamp": 1615889440,
+    "width": 10,
+    "name": "endpoint.users",
+    "type": "s",
+    "value": [
+      3182887624,
+      4267882815
+    ],
+    "tags": {
+      "route": "user_index"
+    }
+  }
+]

--- a/relay-metrics/tests/fixtures/kafka.json
+++ b/relay-metrics/tests/fixtures/kafka.json
@@ -1,0 +1,17 @@
+{
+  "org_id": 1,
+  "project_id": 42,
+  "name": "endpoint.response_time",
+  "unit": "millisecond",
+  "value": [
+    36.0,
+    49.0,
+    57.0,
+    68.0
+  ],
+  "type": "d",
+  "timestamp": 1615889440,
+  "tags": {
+    "route": "user_index"
+  }
+}

--- a/relay-metrics/tests/fixtures/metrics.json
+++ b/relay-metrics/tests/fixtures/metrics.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "d:custom/endpoint.response_time@millisecond",
+    "unit": "millisecond",
+    "value": 57.0,
+    "type": "d",
+    "timestamp": 1615889449,
+    "tags": {
+      "route": "user_index"
+    }
+  },
+  {
+    "name": "c:custom/endpoint.hits@none",
+    "unit": "none",
+    "value": 1.0,
+    "type": "c",
+    "timestamp": 1615889449,
+    "tags": {
+      "route": "user_index"
+    }
+  }
+]

--- a/relay-metrics/tests/fixtures/metrics.statsd.txt
+++ b/relay-metrics/tests/fixtures/metrics.statsd.txt
@@ -1,0 +1,2 @@
+endpoint.response_time@millisecond:57.0|d|#route:user_index
+endpoint.hits:1.0|c|#route:user_index

--- a/relay-metrics/tests/fixtures/set.json
+++ b/relay-metrics/tests/fixtures/set.json
@@ -1,0 +1,6 @@
+{
+  "name": "s:custom/endpoint.users@none",
+  "timestamp": 1615889449,
+  "value": 4267882815,
+  "type": "s"
+}

--- a/relay-metrics/tests/fixtures/set.statsd.txt
+++ b/relay-metrics/tests/fixtures/set.statsd.txt
@@ -1,0 +1,1 @@
+endpoint.users:e2546e4c-ecd0-43ad-ae27-87960e57a658|s

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -14,7 +14,7 @@ futures = { workspace = true }
 once_cell = { workspace = true }
 relay-log = { path = "../relay-log" }
 relay-statsd = { path = "../relay-statsd" }
-tokio = { workspace = true, features = ["signal"] }
+tokio = { workspace = true, features = ["rt", "signal"] }
 
 [dev-dependencies]
 relay-statsd = { path = "../relay-statsd", features = ["test"] }


### PR DESCRIPTION
To ensure that the documented payloads are valid and roundtrip properly, this PR
moves all payloads from doc comments into test fixture files and adds tests to
assert their content. As an added benefit, the module-level docs and struct docs
now contain identical examples.

#skip-changelog

