### PR TITLE
ref(metrics): Bump transaction metric extraction maximum version

### DIFF
--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -79,7 +79,7 @@ pub struct CustomMeasurementConfig {
 /// Maximum supported version of metrics extraction from transactions.
 ///
 /// The version is an integer scalar, incremented by one on each new version.
-const TRANSACTION_EXTRACT_VERSION: u16 = 1;
+const TRANSACTION_EXTRACT_VERSION: u16 = 2;
 
 /// Deprecated. Defines whether URL transactions should be considered low cardinality.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Goes after https://github.com/getsentry/relay/pull/2415. Goes before Sentry PR: https://github.com/getsentry/sentry/pull/55667.

As part of the global configs, changing the measurements config may result in inappropriate behavior from old relays. To avoid that, we're doing a version bump.

#skip-changelog