### PR TITLE
ref(metrics): Rename the metrics envelope item to "statsd"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Support ingestion of custom metrics when the `organizations:custom-metrics` feature flag is enabled. ([#2443](https://github.com/getsentry/relay/pull/2443))
 - Merge span metrics and standalone spans extraction options. ([#2447](https://github.com/getsentry/relay/pull/2447))
 - Support parsing aggregated metric buckets directly from statsd payloads. ([#2468](https://github.com/getsentry/relay/pull/2468))
+- Rename the envelope item type for StatsD payloads to "statsd". ([#2470](https://github.com/getsentry/relay/pull/2470))
 
 ## 23.8.0
 

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -11,8 +11,7 @@
 //! looks like this:
 //!
 //! ```text
-//! endpoint.response_time@millisecond:57|d|#route:user_index
-//! endpoint.hits:1|c|#route:user_index
+#![doc = include_str!("../tests/fixtures/buckets.statsd.txt")]
 //! ```
 //!
 //! The metric type is part of its signature just like the unit. Therefore, it is allowed to reuse a
@@ -25,7 +24,7 @@
 //!
 //! ```text
 //! {}
-//! {"type": "metrics", "timestamp": 1615889440, ...}
+//! {"type": "statsd", "timestamp": 1615889440, ...}
 #![doc = include_str!("../tests/fixtures/buckets.statsd.txt")]
 //! ...
 //! ```

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -429,7 +429,7 @@ pub struct ProcessEnvelope {
 /// Parses a list of metrics or metric buckets and pushes them to the project's aggregator.
 ///
 /// This parses and validates the metrics:
-///  - For [`Metrics`](ItemType::Metrics), each metric is parsed separately, and invalid metrics are
+///  - For [`Metrics`](ItemType::Statsd), each metric is parsed separately, and invalid metrics are
 ///    ignored independently.
 ///  - For [`MetricBuckets`](ItemType::MetricBuckets), the entire list of buckets is parsed and
 ///    dropped together on parsing failure.
@@ -1632,7 +1632,7 @@ impl EnvelopeProcessorService {
             // Aggregate data is never considered as part of deduplication
             ItemType::Session => false,
             ItemType::Sessions => false,
-            ItemType::Metrics => false,
+            ItemType::Statsd => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
             ItemType::Profile => false,
@@ -2628,7 +2628,7 @@ impl EnvelopeProcessorService {
 
         for item in items {
             let payload = item.payload();
-            if item.ty() == &ItemType::Metrics {
+            if item.ty() == &ItemType::Statsd {
                 let mut timestamp = item.timestamp().unwrap_or(received_timestamp);
                 clock_drift_processor.process_timestamp(&mut timestamp);
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -262,7 +262,7 @@ fn queue_envelope(
 ) -> Result<(), BadStoreRequest> {
     // Remove metrics from the envelope and queue them directly on the project's `Aggregator`.
     let mut metric_items = Vec::new();
-    let is_metric = |i: &Item| matches!(i.ty(), ItemType::Metrics | ItemType::MetricBuckets);
+    let is_metric = |i: &Item| matches!(i.ty(), ItemType::Statsd | ItemType::MetricBuckets);
     let envelope = managed_envelope.envelope_mut();
     while let Some(item) = envelope.take_item_by(is_metric) {
         metric_items.push(item);

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -97,7 +97,7 @@ pub enum ItemType {
     /// Aggregated session data.
     Sessions,
     /// Individual metrics in text encoding.
-    Metrics,
+    Statsd,
     /// Buckets of preaggregated metrics encoded as JSON.
     MetricBuckets,
     /// Client internal report (eg: outcomes).
@@ -147,7 +147,7 @@ impl fmt::Display for ItemType {
             Self::UserReport => write!(f, "user_report"),
             Self::Session => write!(f, "session"),
             Self::Sessions => write!(f, "sessions"),
-            Self::Metrics => write!(f, "metrics"),
+            Self::Statsd => write!(f, "statsd"),
             Self::MetricBuckets => write!(f, "metric_buckets"),
             Self::ClientReport => write!(f, "client_report"),
             Self::Profile => write!(f, "profile"),
@@ -175,7 +175,7 @@ impl std::str::FromStr for ItemType {
             "user_report" => Self::UserReport,
             "session" => Self::Session,
             "sessions" => Self::Sessions,
-            "metrics" => Self::Metrics,
+            "statsd" => Self::Statsd,
             "metric_buckets" => Self::MetricBuckets,
             "client_report" => Self::ClientReport,
             "profile" => Self::Profile,
@@ -552,7 +552,7 @@ impl Item {
             ItemType::UnrealReport => Some(DataCategory::Error),
             ItemType::Attachment => Some(DataCategory::Attachment),
             ItemType::Session | ItemType::Sessions => None,
-            ItemType::Metrics | ItemType::MetricBuckets => None,
+            ItemType::Statsd | ItemType::MetricBuckets => None,
             ItemType::FormData => None,
             ItemType::UserReport => None,
             ItemType::Profile => Some(if indexed {
@@ -722,7 +722,7 @@ impl Item {
             ItemType::UserReport
             | ItemType::Session
             | ItemType::Sessions
-            | ItemType::Metrics
+            | ItemType::Statsd
             | ItemType::MetricBuckets
             | ItemType::ClientReport
             | ItemType::ReplayEvent
@@ -753,7 +753,7 @@ impl Item {
             ItemType::ReplayEvent => true,
             ItemType::Session => false,
             ItemType::Sessions => false,
-            ItemType::Metrics => false,
+            ItemType::Statsd => false,
             ItemType::MetricBuckets => false,
             ItemType::ClientReport => false,
             ItemType::ReplayRecording => false,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -98,7 +98,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Attachment => None,
         ItemType::Session => None,
         ItemType::Sessions => None,
-        ItemType::Metrics => None,
+        ItemType::Statsd => None,
         ItemType::MetricBuckets => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -61,7 +61,7 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool 
                 }
             }
             ItemType::UserReport => (),
-            ItemType::Metrics => (),
+            ItemType::Statsd => (),
             ItemType::MetricBuckets => (),
             ItemType::Span => {
                 if item.len() > config.max_span_size() {

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -225,7 +225,7 @@ class SentryLike:
         envelope.add_item(
             Item(
                 payload=PayloadRef(bytes=payload.encode()),
-                type="metrics",
+                type="statsd",
                 headers=None if timestamp is None else {"timestamp": timestamp},
             )
         )


### PR DESCRIPTION
The envelope item for StatsD payloads was called "metrics" historically. To make it more clear that this contains StatsD, it is now renamed to "statsd".