### PR TITLE
feat(metrics): Support timestamps in statsd datagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 - Support ingestion of custom metrics when the `organizations:custom-metrics` feature flag is enabled. ([#2443](https://github.com/getsentry/relay/pull/2443))
 - Merge span metrics and standalone spans extraction options. ([#2447](https://github.com/getsentry/relay/pull/2447))
-- Support parsing aggregated metric buckets directly from statsd payloads. ([#2468](https://github.com/getsentry/relay/pull/2468))
+- Support parsing aggregated metric buckets directly from statsd payloads. ([#2468](https://github.com/getsentry/relay/pull/2468), [#2472](https://github.com/getsentry/relay/pull/2472))
 - Rename the envelope item type for StatsD payloads to "statsd". ([#2470](https://github.com/getsentry/relay/pull/2470))
 
 ## 23.8.0

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -24,16 +24,18 @@
 //!
 //! ```text
 //! {}
-//! {"type": "statsd", "timestamp": 1615889440, ...}
+//! {"type": "statsd", ...}
 #![doc = include_str!("../tests/fixtures/buckets.statsd.txt")]
 //! ...
 //! ```
 //!
 //! Note that the name format used in the statsd protocol is different from the MRI: Metric names
-//! are not prefixed with `<ty>:` as the type is somewhere else in the protocol.
+//! are not prefixed with `<ty>:` as the type is somewhere else in the protocol. If no metric
+//! namespace is specified, the `"custom"` namespace is assumed.
 //!
-//! The timestamp in the item header is used to send backdated metrics. If it is omitted,
-//! the `received` time of the envelope is assumed.
+//! Optionally, a timestamp can be added to every line of the submitted envelope. The timestamp has
+//! to be a valid Unix timestamp (UTC) and must be prefixed with `T`. If it is omitted, the
+//! `received` time of the envelope is assumed.
 //!
 //! # Aggregation
 //!

--- a/relay-metrics/tests/fixtures/buckets.json
+++ b/relay-metrics/tests/fixtures/buckets.json
@@ -1,6 +1,6 @@
 [
   {
-    "timestamp": 1615889449,
+    "timestamp": 1615889440,
     "width": 0,
     "name": "d:custom/endpoint.response_time@millisecond",
     "type": "d",
@@ -15,7 +15,7 @@
     }
   },
   {
-    "timestamp": 1615889449,
+    "timestamp": 1615889440,
     "width": 0,
     "name": "c:custom/endpoint.hits@none",
     "type": "c",
@@ -25,7 +25,7 @@
     }
   },
   {
-    "timestamp": 1615889449,
+    "timestamp": 1615889440,
     "width": 0,
     "name": "g:custom/endpoint.parallel_requests@none",
     "type": "g",
@@ -41,7 +41,7 @@
     }
   },
   {
-    "timestamp": 1615889449,
+    "timestamp": 1615889440,
     "width": 0,
     "name": "s:custom/endpoint.users@none",
     "type": "s",

--- a/relay-metrics/tests/fixtures/buckets.statsd.txt
+++ b/relay-metrics/tests/fixtures/buckets.statsd.txt
@@ -1,4 +1,4 @@
-endpoint.response_time@millisecond:36:49:57:68|d|#route:user_index
-endpoint.hits:4|c|#route:user_index
-endpoint.parallel_requests:25:17:42:220:85|g|#route:user_index
-endpoint.users:3182887624:4267882815|s|#route:user_index
+endpoint.response_time@millisecond:36:49:57:68|d|#route:user_index|T1615889440
+endpoint.hits:4|c|#route:user_index|T1615889440
+endpoint.parallel_requests:25:17:42:220:85|g|#route:user_index|T1615889440
+endpoint.users:3182887624:4267882815|s|#route:user_index|T1615889440

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -38,7 +38,6 @@ use std::time::Instant;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use relay_common::time::UnixTimestamp;
 use relay_dynamic_config::ErrorBoundary;
 use relay_event_schema::protocol::{EventId, EventType};
 use relay_protocol::Value;
@@ -470,13 +469,6 @@ pub struct ItemHeaders {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     sample_rates: Option<Value>,
 
-    /// A custom timestamp associated with the item.
-    ///
-    /// For metrics, this field can be used to backdate a submission.
-    /// The given timestamp determines the bucket into which the metric will be aggregated.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    timestamp: Option<UnixTimestamp>,
-
     /// Flag indicating if metrics have already been extracted from the item.
     ///
     /// In order to only extract metrics once from an item while through a
@@ -509,7 +501,6 @@ impl Item {
                 filename: None,
                 rate_limited: false,
                 sample_rates: None,
-                timestamp: None,
                 other: BTreeMap::new(),
                 metrics_extracted: false,
             },
@@ -647,11 +638,6 @@ impl Item {
         if matches!(sample_rates, Value::Array(ref a) if !a.is_empty()) {
             self.headers.sample_rates = Some(sample_rates);
         }
-    }
-
-    /// Get custom timestamp for this item. Currently used to backdate metrics.
-    pub fn timestamp(&self) -> Option<UnixTimestamp> {
-        self.headers.timestamp
     }
 
     /// Returns the metrics extracted flag.

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -220,26 +220,16 @@ class SentryLike:
         envelope.add_item(Item(PayloadRef(json=payload), type="client_report"))
         self.send_envelope(project_id, envelope)
 
-    def send_metrics(self, project_id, payload, timestamp=None):
+    def send_metrics(self, project_id, payload):
         envelope = Envelope()
         envelope.add_item(
-            Item(
-                payload=PayloadRef(bytes=payload.encode()),
-                type="statsd",
-                headers=None if timestamp is None else {"timestamp": timestamp},
-            )
+            Item(payload=PayloadRef(bytes=payload.encode()), type="statsd")
         )
         self.send_envelope(project_id, envelope)
 
-    def send_metrics_buckets(self, project_id, payload, timestamp=None):
+    def send_metrics_buckets(self, project_id, payload):
         envelope = Envelope()
-        envelope.add_item(
-            Item(
-                payload=PayloadRef(json=payload),
-                type="metric_buckets",
-                headers=None if timestamp is None else {"timestamp": timestamp},
-            )
-        )
+        envelope.add_item(Item(payload=PayloadRef(json=payload), type="metric_buckets"))
         self.send_envelope(project_id, envelope)
 
     def send_security_report(


### PR DESCRIPTION
Instead of envelope headers, support timestamps as part of statsd datagrams.
This allows to send metric aggregations from different times in a single item.

