### PR TITLE
ref(server): Create metric buckets in place of metrics

### DIFF
--- a/relay-event-normalization/src/normalize/utils.rs
+++ b/relay-event-normalization/src/normalize/utils.rs
@@ -88,7 +88,7 @@ pub fn extract_http_status_code(event: &Event) -> Option<String> {
 /// column in Discover for Transactions, barring:
 ///
 /// * imprecision caused by HLL sketching in Snuba, which we don't have in events
-/// * hash collisions in `MetricValue::set_from_display`, which we don't have in events
+/// * hash collisions in `BucketValue::set_from_display`, which we don't have in events
 /// * MD5-collisions caused by `EventUser.hash_from_tag`, which we don't have in metrics
 ///
 ///   MD5 is used to efficiently look up the current event user for an event, and if there is a

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -34,7 +34,7 @@ use relay_event_schema::protocol::{
     UserReport, Values,
 };
 use relay_filter::FilterStatKey;
-use relay_metrics::{Bucket, InsertMetrics, MergeBuckets, Metric, MetricNamespace};
+use relay_metrics::{Bucket, MergeBuckets, MetricNamespace};
 use relay_pii::{PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
 use relay_profiling::ProfileError;
 use relay_protocol::{Annotated, Array, Empty, FromValue, Object, Value};
@@ -230,7 +230,7 @@ impl ExtractedMetrics {
         let project_key = envelope.meta().public_key();
 
         if !self.project_metrics.is_empty() {
-            project_cache.send(InsertMetrics::new(project_key, self.project_metrics));
+            project_cache.send(MergeBuckets::new(project_key, self.project_metrics));
         }
 
         if !self.sampling_metrics.is_empty() {
@@ -241,7 +241,7 @@ impl ExtractedMetrics {
             // dependent_project_with_tracing  -> metrics goes to root
             // root_project_with_tracing       -> metrics goes to root == self
             let sampling_project_key = utils::get_sampling_key(envelope).unwrap_or(project_key);
-            project_cache.send(InsertMetrics::new(
+            project_cache.send(MergeBuckets::new(
                 sampling_project_key,
                 self.sampling_metrics,
             ));
@@ -656,7 +656,7 @@ impl EnvelopeProcessorService {
         client_addr: Option<net::IpAddr>,
         metrics_config: SessionMetricsConfig,
         clock_drift_processor: &ClockDriftProcessor,
-        extracted_metrics: &mut Vec<Metric>,
+        extracted_metrics: &mut Vec<Bucket>,
     ) -> bool {
         let mut changed = false;
         let payload = item.payload();
@@ -765,7 +765,7 @@ impl EnvelopeProcessorService {
         client_addr: Option<net::IpAddr>,
         metrics_config: SessionMetricsConfig,
         clock_drift_processor: &ClockDriftProcessor,
-        extracted_metrics: &mut Vec<Metric>,
+        extracted_metrics: &mut Vec<Bucket>,
     ) -> bool {
         let mut changed = false;
         let payload = item.payload();
@@ -2868,7 +2868,7 @@ mod tests {
         client_addr: Option<net::IpAddr>,
         metrics_config: SessionMetricsConfig,
         clock_drift_processor: ClockDriftProcessor,
-        extracted_metrics: Vec<Metric>,
+        extracted_metrics: Vec<Bucket>,
     }
 
     impl<'a> TestProcessSessionArguments<'a> {
@@ -3984,8 +3984,7 @@ mod tests {
                 tags,
             };
 
-            let metric: Metric = measurement.into_metric(UnixTimestamp::now());
-
+            let metric: Bucket = measurement.into_metric(UnixTimestamp::now());
             metric.name.len() - unit.to_string().len() - name.len()
         };
         assert_eq!(

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -923,7 +923,7 @@ mod tests {
     use std::sync::Arc;
 
     use relay_common::time::UnixTimestamp;
-    use relay_metrics::{BucketValue, MetricValue};
+    use relay_metrics::BucketValue;
     use relay_test::mock_service;
     use serde_json::json;
 
@@ -1027,10 +1027,11 @@ mod tests {
         project
     }
 
-    fn create_transaction_metric() -> Metric {
-        Metric {
+    fn create_transaction_metric() -> Bucket {
+        Bucket {
             name: "d:transactions/foo".to_string(),
-            value: MetricValue::Counter(1.0),
+            width: 0,
+            value: BucketValue::counter(1.0),
             timestamp: UnixTimestamp::now(),
             tags: Default::default(),
         }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1,7 +1,7 @@
 use relay_common::time::UnixTimestamp;
 use relay_dynamic_config::MetricExtractionConfig;
 use relay_event_schema::protocol::{Event, Span};
-use relay_metrics::Metric;
+use relay_metrics::Bucket;
 use relay_quotas::DataCategory;
 
 use crate::metrics_extraction::generic::{self, Extractable};
@@ -43,7 +43,7 @@ impl Extractable for Span {
 /// valid timestamps.
 ///
 /// If this is a transaction event with spans, metrics will also be extracted from the spans.
-pub fn extract_metrics(event: &Event, config: &MetricExtractionConfig) -> Vec<Metric> {
+pub fn extract_metrics(event: &Event, config: &MetricExtractionConfig) -> Vec<Bucket> {
     let mut metrics = generic::extract_metrics(event, config);
 
     relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use relay_common::time::UnixTimestamp;
 use relay_dynamic_config::{MetricExtractionConfig, TagMapping, TagSource, TagSpec};
-use relay_metrics::{Metric, MetricResourceIdentifier, MetricType, MetricValue};
+use relay_metrics::{Bucket, BucketValue, MetricResourceIdentifier, MetricType};
 use relay_protocol::{Getter, Val};
 use relay_quotas::DataCategory;
 
@@ -20,7 +20,7 @@ pub trait Extractable: Getter {
 /// The instance must have a valid timestamp; if the timestamp is missing or invalid, no metrics are
 /// extracted. Timestamp and clock drift correction should occur before metrics extraction to ensure
 /// valid timestamps.
-pub fn extract_metrics<T>(instance: &T, config: &MetricExtractionConfig) -> Vec<Metric>
+pub fn extract_metrics<T>(instance: &T, config: &MetricExtractionConfig) -> Vec<Bucket>
 where
     T: Extractable,
 {
@@ -53,8 +53,9 @@ where
             continue;
         };
 
-        metrics.push(Metric {
+        metrics.push(Bucket {
             name: mri.to_string(),
+            width: 0,
             value,
             timestamp,
             tags: extract_tags(instance, &metric_spec.tags),
@@ -67,7 +68,7 @@ where
     metrics
 }
 
-pub fn tmp_apply_tags<T>(metrics: &mut [Metric], instance: &T, mappings: &[TagMapping])
+pub fn tmp_apply_tags<T>(metrics: &mut [Bucket], instance: &T, mappings: &[TagMapping])
 where
     T: Getter,
 {
@@ -125,17 +126,17 @@ fn read_metric_value(
     instance: &impl Getter,
     field: Option<&str>,
     ty: MetricType,
-) -> Option<MetricValue> {
+) -> Option<BucketValue> {
     Some(match ty {
-        MetricType::Counter => MetricValue::Counter(match field {
+        MetricType::Counter => BucketValue::counter(match field {
             Some(field) => instance.get_value(field)?.as_f64()?,
             None => 1.0,
         }),
         MetricType::Distribution => {
-            MetricValue::Distribution(instance.get_value(field?)?.as_f64()?)
+            BucketValue::distribution(instance.get_value(field?)?.as_f64()?)
         }
-        MetricType::Set => MetricValue::set_from_str(instance.get_value(field?)?.as_str()?),
-        MetricType::Gauge => MetricValue::Gauge(instance.get_value(field?)?.as_f64()?),
+        MetricType::Set => BucketValue::set_from_str(instance.get_value(field?)?.as_str()?),
+        MetricType::Gauge => BucketValue::gauge(instance.get_value(field?)?.as_f64()?),
     })
 }
 

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -168,18 +168,19 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1597976302),
+                width: 0,
                 name: "c:transactions/counter@none",
                 value: Counter(
                     1.0,
                 ),
-                timestamp: UnixTimestamp(1597976302),
                 tags: {},
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -204,18 +205,21 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1597976302),
+                width: 0,
                 name: "d:transactions/duration@none",
                 value: Distribution(
-                    2000.0,
+                    {
+                        2000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1597976302),
                 tags: {},
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -242,18 +246,21 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1597976302),
+                width: 0,
                 name: "s:transactions/users@none",
                 value: Set(
-                    943162418,
+                    {
+                        943162418,
+                    },
                 ),
-                timestamp: UnixTimestamp(1597976302),
                 tags: {},
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -292,14 +299,15 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1597976302),
+                width: 0,
                 name: "c:transactions/counter@none",
                 value: Counter(
                     1.0,
                 ),
-                timestamp: UnixTimestamp(1597976302),
                 tags: {
                     "fast": "no",
                     "id": "4711",
@@ -307,7 +315,7 @@ mod tests {
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -345,20 +353,21 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1597976302),
+                width: 0,
                 name: "c:transactions/counter@none",
                 value: Counter(
                     1.0,
                 ),
-                timestamp: UnixTimestamp(1597976302),
                 tags: {
                     "fast": "yes",
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -400,19 +409,20 @@ mod tests {
         let config = serde_json::from_value(config_json).unwrap();
 
         let metrics = extract_metrics(event.value().unwrap(), &config);
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1597976302),
+                width: 0,
                 name: "c:transactions/counter@none",
                 value: Counter(
                     1.0,
                 ),
-                timestamp: UnixTimestamp(1597976302),
                 tags: {
                     "fast": "yes",
                 },
             },
         ]
-        "#);
+        "###);
     }
 }

--- a/relay-server/src/metrics_extraction/mod.rs
+++ b/relay-server/src/metrics_extraction/mod.rs
@@ -1,5 +1,5 @@
 use relay_common::time::UnixTimestamp;
-use relay_metrics::Metric;
+use relay_metrics::Bucket;
 
 mod generic;
 
@@ -8,5 +8,5 @@ pub mod sessions;
 pub mod transactions;
 
 pub trait IntoMetric {
-    fn into_metric(self, timestamp: UnixTimestamp) -> Metric;
+    fn into_metric(self, timestamp: UnixTimestamp) -> Bucket;
 }

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -474,14 +474,15 @@ mod tests {
             );
         }
 
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084960),
+                width: 0,
                 name: "c:sessions/session@none",
                 value: Counter(
                     135.0,
                 ),
-                timestamp: UnixTimestamp(1581084960),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -489,12 +490,13 @@ mod tests {
                     "session.status": "init",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084960),
+                width: 0,
                 name: "c:sessions/session@none",
                 value: Counter(
                     12.0,
                 ),
-                timestamp: UnixTimestamp(1581084960),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -502,12 +504,13 @@ mod tests {
                     "session.status": "errored_preaggr",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084960),
+                width: 0,
                 name: "c:sessions/session@none",
                 value: Counter(
                     5.0,
                 ),
-                timestamp: UnixTimestamp(1581084960),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -515,12 +518,13 @@ mod tests {
                     "session.status": "abnormal",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084960),
+                width: 0,
                 name: "c:sessions/session@none",
                 value: Counter(
                     7.0,
                 ),
-                timestamp: UnixTimestamp(1581084960),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -528,12 +532,13 @@ mod tests {
                     "session.status": "crashed",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084961),
+                width: 0,
                 name: "c:sessions/session@none",
                 value: Counter(
                     15.0,
                 ),
-                timestamp: UnixTimestamp(1581084961),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -541,12 +546,13 @@ mod tests {
                     "session.status": "init",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084961),
+                width: 0,
                 name: "c:sessions/session@none",
                 value: Counter(
                     3.0,
                 ),
-                timestamp: UnixTimestamp(1581084961),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -554,12 +560,15 @@ mod tests {
                     "session.status": "errored_preaggr",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1581084961),
+                width: 0,
                 name: "s:sessions/user@none",
                 value: Set(
-                    3097475539,
+                    {
+                        3097475539,
+                    },
                 ),
-                timestamp: UnixTimestamp(1581084961),
                 tags: {
                     "environment": "development",
                     "release": "my-project-name@1.0.0",
@@ -568,6 +577,6 @@ mod tests {
                 },
             },
         ]
-        "#);
+        "###);
     }
 }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -1,14 +1,17 @@
 ---
-source: relay-server/src/metrics_extraction/spans/mod.rs
+source: relay-server/src/metrics_extraction/event.rs
 expression: metrics
 ---
 [
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -19,12 +22,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -34,12 +40,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -55,12 +64,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -75,12 +87,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -96,12 +111,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -116,12 +134,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -137,12 +158,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -157,12 +181,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -177,12 +204,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -196,12 +226,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -218,12 +251,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -239,12 +275,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -262,12 +301,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -284,12 +326,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -307,12 +352,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -329,12 +377,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -352,12 +403,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -374,12 +428,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -397,12 +454,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -419,12 +479,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -442,12 +505,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -464,12 +530,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -487,12 +556,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -509,12 +581,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -531,12 +606,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -552,12 +630,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -573,12 +654,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -593,12 +677,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -614,12 +701,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -634,12 +724,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -654,12 +747,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -673,12 +769,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -696,12 +795,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -718,12 +820,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -741,12 +846,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -763,12 +871,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -784,12 +895,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -804,12 +918,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -825,12 +942,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -845,12 +965,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -867,12 +990,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -888,12 +1014,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -908,12 +1037,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -927,12 +1059,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -948,12 +1083,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -968,12 +1106,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -989,12 +1130,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -1009,12 +1153,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -1030,12 +1177,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -1050,12 +1200,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
@@ -1069,12 +1222,15 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
-    Metric {
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            2000.0,
+            {
+                2000.0: 1,
+            },
         ),
-        timestamp: UnixTimestamp(1597976302),
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -50,12 +50,15 @@ expression: "(&event.value().unwrap().spans, metrics)"
         },
     ],
     [
-        Metric {
+        Bucket {
+            timestamp: UnixTimestamp(1597976302),
+            width: 0,
             name: "d:spans/exclusive_time@millisecond",
             value: Distribution(
-                2000.0,
+                {
+                    2000.0: 1,
+                },
             ),
-            timestamp: UnixTimestamp(1597976302),
             tags: {
                 "device.class": "1",
                 "release": "1.2.3",
@@ -64,12 +67,15 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "transaction.method": "GET",
             },
         },
-        Metric {
+        Bucket {
+            timestamp: UnixTimestamp(1597976302),
+            width: 0,
             name: "d:spans/exclusive_time_light@millisecond",
             value: Distribution(
-                2000.0,
+                {
+                    2000.0: 1,
+                },
             ),
-            timestamp: UnixTimestamp(1597976302),
             tags: {
                 "device.class": "1",
                 "release": "1.2.3",

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -7,7 +7,7 @@ use relay_event_normalization::utils as normalize_utils;
 use relay_event_schema::protocol::{
     AsPair, BrowserContext, Event, OsContext, TraceContext, TransactionSource,
 };
-use relay_metrics::{DurationUnit, Metric};
+use relay_metrics::{Bucket, DurationUnit};
 
 use crate::metrics_extraction::generic;
 use crate::metrics_extraction::transactions::types::{
@@ -203,10 +203,10 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
 #[derive(Debug, Default)]
 pub struct ExtractedMetrics {
     /// Metrics associated with the project of the envelope.
-    pub project_metrics: Vec<Metric>,
+    pub project_metrics: Vec<Bucket>,
 
     /// Metrics associated with the project of the trace parent.
-    pub sampling_metrics: Vec<Metric>,
+    pub sampling_metrics: Vec<Bucket>,
 }
 
 impl ExtractedMetrics {
@@ -396,7 +396,7 @@ mod tests {
         MeasurementsConfig,
     };
     use relay_event_schema::protocol::User;
-    use relay_metrics::MetricValue;
+    use relay_metrics::BucketValue;
     use relay_protocol::Annotated;
 
     use super::*;
@@ -853,7 +853,7 @@ mod tests {
 
         let duration_metric = &extracted.project_metrics[0];
         assert_eq!(duration_metric.name, "d:transactions/duration@millisecond");
-        assert_eq!(duration_metric.value, MetricValue::Distribution(59000.0));
+        assert_eq!(duration_metric.value, BucketValue::distribution(59000.0));
 
         assert_eq!(duration_metric.tags.len(), 4);
         assert_eq!(duration_metric.tags["release"], "1.2.3");

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -532,14 +532,17 @@ mod tests {
         ]
         "#);
 
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.foo@none",
                 value: Distribution(
-                    420.69,
+                    {
+                        420.69: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "browser.name": "Chrome",
                     "dist": "foo",
@@ -555,12 +558,15 @@ mod tests {
                     "transaction.status": "ok",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.lcp@millisecond",
                 value: Distribution(
-                    3000.0,
+                    {
+                        3000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "browser.name": "Chrome",
                     "dist": "foo",
@@ -577,12 +583,15 @@ mod tests {
                     "transaction.status": "ok",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond",
                 value: Distribution(
-                    2000.0,
+                    {
+                        2000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "browser.name": "Chrome",
                     "dist": "foo",
@@ -598,12 +607,15 @@ mod tests {
                     "transaction.status": "ok",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    {
+                        59000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "browser.name": "Chrome",
                     "dist": "foo",
@@ -619,12 +631,15 @@ mod tests {
                     "transaction.status": "ok",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "s:transactions/user@none",
                 value: Set(
-                    933084975,
+                    {
+                        933084975,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "browser.name": "Chrome",
                     "dist": "foo",
@@ -641,7 +656,7 @@ mod tests {
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -683,14 +698,17 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.fcp@millisecond",
                 value: Distribution(
-                    1.1,
+                    {
+                        1.1: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "measurement_rating": "good",
                     "platform": "other",
@@ -698,36 +716,45 @@ mod tests {
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.foo@none",
                 value: Distribution(
-                    8.8,
+                    {
+                        8.8: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "platform": "other",
                     "transaction": "<unlabeled transaction>",
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.stall_count@none",
                 value: Distribution(
-                    3.3,
+                    {
+                        3.3: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "platform": "other",
                     "transaction": "<unlabeled transaction>",
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    {
+                        59000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "platform": "other",
                     "transaction": "<unlabeled transaction>",
@@ -735,7 +762,7 @@ mod tests {
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -774,14 +801,17 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.fcp@second",
                 value: Distribution(
-                    1.1,
+                    {
+                        1.1: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "measurement_rating": "good",
                     "platform": "other",
@@ -789,12 +819,15 @@ mod tests {
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/measurements.lcp@none",
                 value: Distribution(
-                    2.2,
+                    {
+                        2.2: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "measurement_rating": "good",
                     "platform": "other",
@@ -802,12 +835,15 @@ mod tests {
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    59000.0,
+                    {
+                        59000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "platform": "other",
                     "transaction": "<unlabeled transaction>",
@@ -815,7 +851,7 @@ mod tests {
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -913,26 +949,32 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420402),
+                width: 0,
                 name: "d:transactions/measurements.a_custom1@none",
                 value: Distribution(
-                    41.0,
+                    {
+                        41.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420402),
                 tags: {
                     "platform": "other",
                     "transaction": "foo",
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420402),
+                width: 0,
                 name: "d:transactions/measurements.fcp@millisecond",
                 value: Distribution(
-                    0.123,
+                    {
+                        0.123: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420402),
                 tags: {
                     "measurement_rating": "good",
                     "platform": "other",
@@ -940,24 +982,30 @@ mod tests {
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420402),
+                width: 0,
                 name: "d:transactions/measurements.g_custom2@second",
                 value: Distribution(
-                    42.0,
+                    {
+                        42.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420402),
                 tags: {
                     "platform": "other",
                     "transaction": "foo",
                     "transaction.status": "unknown",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420402),
+                width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    2000.0,
+                    {
+                        2000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420402),
                 tags: {
                     "platform": "other",
                     "transaction": "foo",
@@ -965,7 +1013,7 @@ mod tests {
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -1167,21 +1215,22 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.sampling_metrics, @r#"
+        insta::assert_debug_snapshot!(extracted.sampling_metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420400),
+                width: 0,
                 name: "c:transactions/count_per_root_project@none",
                 value: Counter(
                     1.0,
                 ),
-                timestamp: UnixTimestamp(1619420400),
                 tags: {
                     "decision": "keep",
                     "transaction": "root_transaction",
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]
@@ -1558,31 +1607,37 @@ mod tests {
         };
 
         let extracted = extractor.extract(event.value().unwrap()).unwrap();
-        insta::assert_debug_snapshot!(extracted.project_metrics, @r#"
+        insta::assert_debug_snapshot!(extracted.project_metrics, @r###"
         [
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420402),
+                width: 0,
                 name: "d:transactions/measurements.lcp@millisecond",
                 value: Distribution(
-                    41.0,
+                    {
+                        41.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420402),
                 tags: {
                     "measurement_rating": "good",
                     "platform": "javascript",
                 },
             },
-            Metric {
+            Bucket {
+                timestamp: UnixTimestamp(1619420402),
+                width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    2000.0,
+                    {
+                        2000.0: 1,
+                    },
                 ),
-                timestamp: UnixTimestamp(1619420402),
                 tags: {
                     "platform": "javascript",
                     "satisfaction": "tolerated",
                 },
             },
         ]
-        "#);
+        "###);
     }
 }

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -1,9 +1,11 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Display;
 
 use relay_common::time::UnixTimestamp;
 use relay_metrics::{
-    CounterType, DistributionType, DurationUnit, Metric, MetricNamespace, MetricUnit, MetricValue,
+    Bucket, BucketValue, CounterType, DistributionType, DurationUnit, MetricNamespace,
+    MetricResourceIdentifier, MetricUnit,
 };
 
 use crate::metrics_extraction::IntoMetric;
@@ -44,54 +46,60 @@ pub enum TransactionMetric {
 }
 
 impl IntoMetric for TransactionMetric {
-    fn into_metric(self, timestamp: UnixTimestamp) -> Metric {
+    fn into_metric(self, timestamp: UnixTimestamp) -> Bucket {
         let namespace = MetricNamespace::Transactions;
-        match self {
-            TransactionMetric::User { value, tags } => Metric::new_mri(
-                namespace,
-                "user",
+
+        let (name, value, unit, tags) = match self {
+            TransactionMetric::User { value, tags } => (
+                Cow::Borrowed("user"),
+                BucketValue::set_from_str(&value),
                 MetricUnit::None,
-                MetricValue::set_from_str(&value),
-                timestamp,
                 tags.into(),
             ),
-            TransactionMetric::Breakdown { value, tags, name } => Metric::new_mri(
-                namespace,
-                format!("breakdowns.{name}").as_str(),
-                MetricUnit::Duration(DurationUnit::MilliSecond),
-                MetricValue::Distribution(value),
-                timestamp,
-                tags.into(),
-            ),
-            TransactionMetric::CountPerRootProject { value, tags } => Metric::new_mri(
-                namespace,
-                "count_per_root_project",
-                MetricUnit::None,
-                MetricValue::Counter(value),
-                timestamp,
-                tags.into(),
-            ),
-            TransactionMetric::Duration { unit, value, tags } => Metric::new_mri(
-                namespace,
-                "duration",
+            TransactionMetric::Duration { unit, value, tags } => (
+                Cow::Borrowed("duration"),
+                BucketValue::distribution(value),
                 MetricUnit::Duration(unit),
-                MetricValue::Distribution(value),
-                timestamp,
+                tags.into(),
+            ),
+            TransactionMetric::CountPerRootProject { value, tags } => (
+                Cow::Borrowed("count_per_root_project"),
+                BucketValue::counter(value),
+                MetricUnit::None,
+                tags.into(),
+            ),
+            TransactionMetric::Breakdown { name, value, tags } => (
+                Cow::Owned(format!("breakdowns.{name}")),
+                BucketValue::distribution(value),
+                MetricUnit::Duration(DurationUnit::MilliSecond),
                 tags.into(),
             ),
             TransactionMetric::Measurement {
-                name: kind,
+                name,
                 value,
                 unit,
                 tags,
-            } => Metric::new_mri(
-                namespace,
-                format!("measurements.{kind}").as_str(),
+            } => (
+                Cow::Owned(format!("measurements.{name}")),
+                BucketValue::distribution(value),
                 unit,
-                MetricValue::Distribution(value),
-                timestamp,
                 tags.into(),
             ),
+        };
+
+        let mri = MetricResourceIdentifier {
+            ty: value.ty(),
+            namespace,
+            name: &name,
+            unit,
+        };
+
+        Bucket {
+            timestamp,
+            width: 0,
+            name: mri.to_string(),
+            value,
+            tags,
         }
     }
 }

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -243,7 +243,7 @@ impl<M: MetricsContainer, Q: AsRef<Vec<Quota>>> MetricsLimiter<M, Q> {
 #[cfg(test)]
 mod tests {
     use relay_base_schema::project::{ProjectId, ProjectKey};
-    use relay_metrics::{Metric, MetricValue};
+    use relay_metrics::{Bucket, BucketValue};
     use relay_quotas::{Quota, QuotaScope};
     use smallvec::smallvec;
 
@@ -252,26 +252,29 @@ mod tests {
     #[test]
     fn profiles_limits_are_reported() {
         let metrics = vec![
-            Metric {
+            Bucket {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
+                width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: Default::default(),
-                value: MetricValue::Distribution(123.0),
+                value: BucketValue::distribution(123.0),
             },
-            Metric {
+            Bucket {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
+                width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: MetricValue::Distribution(456.0),
+                value: BucketValue::distribution(456.0),
             },
-            Metric {
+            Bucket {
                 // unrelated metric
                 timestamp: UnixTimestamp::now(),
+                width: 0,
                 name: "something_else".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: MetricValue::Distribution(123.0),
+                value: BucketValue::distribution(123.0),
             },
         ];
         let quotas = vec![Quota {
@@ -320,26 +323,29 @@ mod tests {
     #[test]
     fn profiles_quota_is_enforced() {
         let metrics = vec![
-            Metric {
+            Bucket {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
+                width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: Default::default(),
-                value: MetricValue::Distribution(123.0),
+                value: BucketValue::distribution(123.0),
             },
-            Metric {
+            Bucket {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
+                width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: MetricValue::Distribution(456.0),
+                value: BucketValue::distribution(456.0),
             },
-            Metric {
+            Bucket {
                 // unrelated metric
                 timestamp: UnixTimestamp::now(),
+                width: 0,
                 name: "something_else".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: MetricValue::Distribution(123.0),
+                value: BucketValue::distribution(123.0),
             },
         ];
         let quotas = vec![Quota {


### PR DESCRIPTION
The `Metrics` type is being phased out in favor of `Bucket`. Since all metrics
can be represented as a bucket with a single entry, this PR updates metric
extraction to emit buckets directly.

Note that we currently hard-code the bucket width of `0` everywhere. This is a
workaround for the current public API and is pending revision.

#skip-changelog

