### PR TITLE
fix(server): Do not call shutdown on runtimes

### DIFF
--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -269,7 +269,6 @@ mod utils;
 mod testutils;
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use relay_config::Config;
 use relay_system::{Controller, Service};
@@ -305,13 +304,8 @@ pub fn run(config: Config) -> anyhow::Result<()> {
         anyhow::Ok(())
     })?;
 
-    // Shut down the tokio runtime 100ms after the shutdown timeout has completed. Our services do
-    // not exit by themselves, and the shutdown timeout should have given them enough time to
-    // complete their tasks. The additional 100ms allow services to run their error handlers.
-    main_runtime.shutdown_timeout(Duration::from_millis(100));
-
-    // Shutdown all runtimes.
-    runtimes.shutdown();
+    drop(runtimes);
+    drop(main_runtime);
 
     relay_log::info!("relay shutdown complete");
     Ok(())

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -305,18 +305,6 @@ impl Runtimes {
                 .then(|| create_runtime("store-rt", 1)),
         }
     }
-
-    /// Shuts down the runtime. Drops all futures immediately.
-    pub fn shutdown(self) {
-        self.upstream.shutdown_background();
-        self.project.shutdown_background();
-        self.aggregator.shutdown_background();
-        self.outcome.shutdown_background();
-        #[cfg(feature = "processing")]
-        if let Some(r) = self.store {
-            r.shutdown_background()
-        }
-    }
 }
 
 #[axum::async_trait]


### PR DESCRIPTION
This change should prevent panics on shutdown, that is

> A Tokio 1.x context was found, but it is being shutdown.

From the [tokio docs](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#shutdown):

> Tasks spawned through [Runtime::spawn](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.spawn) keep running until they yield. Then they are dropped.

> The [shutdown_background](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.shutdown_background) and [shutdown_timeout](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.shutdown_timeout) methods can be used if waiting forever is undesired. When the timeout is reached, spawned work that did not stop in time and threads running it are leaked.

In our case, waiting for _blocking_ tasks is acceptable, as long as they stop when they yield.

Fixes https://github.com/getsentry/relay/issues/2475, [POP-RELAY-2W9](https://sentry.my.sentry.io/organizations/sentry/issues/400039/), [RELAY-2NP0](https://sentry.my.sentry.io/organizations/sentry/issues/400040/).

#skip-changelog