### PR TITLE
fix(crons): Allow empty check_in_id via POST

### DIFF
--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -125,7 +125,7 @@ pub struct CheckInContexts {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CheckIn {
     /// Unique identifier of this check-in.
-    #[serde(serialize_with = "uuid_simple")]
+    #[serde(default, serialize_with = "uuid_simple")]
     pub check_in_id: Uuid,
 
     /// Identifier of the monitor for this check-in.

--- a/tests/integration/test_monitors.py
+++ b/tests/integration/test_monitors.py
@@ -122,21 +122,20 @@ def test_monitor_post_json_body(mini_sentry, relay):
     relay = relay(mini_sentry)
     mini_sentry.add_basic_project_config(42)
 
-    check_in = generate_check_in("my-monitor")
-    # NB: Slug Should not be part of the payload!
-    monitor_slug = check_in.pop("monitor_slug")
-
-    # Include monitor_config since this is a major use-case for POST w/ json
-    check_in["monitor_config"] = {
-        "schedule": {"type": "crontab", "value": "0 * * * *"},
-        "checkin_margin": 5,
-        "max_runtime": 10,
-        "timezone": "America/Los_Angles",
+    check_in = {
+        "status": "in_progress",
+        "duration": 21,
+        "monitor_config": {
+            "schedule": {"type": "crontab", "value": "0 * * * *"},
+            "checkin_margin": 5,
+            "max_runtime": 10,
+            "timezone": "America/Los_Angles",
+        },
     }
 
     public_key = relay.get_dsn_public_key(42)
-    response = relay.post(f"/api/42/cron/{monitor_slug}/{public_key}", json=check_in)
-    assert response.status_code == 202
+    response = relay.post(f"/api/42/cron/my-monitor/{public_key}", json=check_in)
+    assert response.status_code == 202, response.text
 
     envelope = mini_sentry.captured_events.get(timeout=1)
     assert len(envelope.items) == 1
@@ -145,7 +144,7 @@ def test_monitor_post_json_body(mini_sentry, relay):
 
     check_in = json.loads(item.get_bytes().decode())
     assert check_in == {
-        "check_in_id": "a460c25ff2554577b920fcfacae4e5eb",
+        "check_in_id": "00000000000000000000000000000000",
         "monitor_slug": "my-monitor",
         "status": "in_progress",
         "duration": 21.0,


### PR DESCRIPTION
You are not required to send a check_in_id when POSTing a check-in.

#skip-changelog