### PR TITLE
chore(deps): Bump chrono version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6b53e6d20664ddcbc06b80f29c64330f3c3aa01b597a8743f4368623a03718"
 dependencies = [
- "chrono 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
  "log",
  "nom",
  "serde",
@@ -122,7 +122,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e2e9a7b2d67ca2b6e886b610ae20ac845cf37980df84892e38f6046e8fc225f"
 dependencies = [
- "chrono 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
  "lazy_static",
  "regex",
 ]
@@ -473,21 +473,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.28"
-source = "git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea#5a6b2b40a781c19ad34a3593313468d922fceeea"
+checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -3058,7 +3046,7 @@ dependencies = [
 name = "relay-auth"
 version = "23.8.0"
 dependencies = [
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "data-encoding",
  "ed25519-dalek",
  "hmac",
@@ -3098,7 +3086,7 @@ name = "relay-cabi"
 version = "0.8.29"
 dependencies = [
  "anyhow",
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "json-forensics",
  "lru",
  "once_cell",
@@ -3123,7 +3111,7 @@ dependencies = [
 name = "relay-common"
 version = "23.8.0"
 dependencies = [
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "globset",
  "lru",
  "once_cell",
@@ -3199,7 +3187,7 @@ name = "relay-event-normalization"
 version = "23.8.0"
 dependencies = [
  "bytecount",
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "dynfmt",
  "insta",
  "itertools",
@@ -3231,7 +3219,7 @@ name = "relay-event-schema"
 version = "23.8.0"
 dependencies = [
  "bytecount",
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "cookie",
  "debugid",
  "enumset",
@@ -3315,7 +3303,7 @@ dependencies = [
 name = "relay-log"
 version = "23.8.0"
 dependencies = [
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "console",
  "relay-crash",
  "sentry",
@@ -3394,7 +3382,7 @@ name = "relay-profiling"
 version = "23.8.0"
 dependencies = [
  "android_trace_log",
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "data-encoding",
  "insta",
  "relay-event-schema",
@@ -3478,7 +3466,7 @@ dependencies = [
 name = "relay-sampling"
 version = "23.8.0"
 dependencies = [
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "insta",
  "rand",
  "rand_pcg",
@@ -3505,7 +3493,7 @@ dependencies = [
  "brotli",
  "bytecount",
  "bytes",
- "chrono 0.4.28 (git+https://github.com/chronotope/chrono.git?rev=5a6b2b40a781c19ad34a3593313468d922fceeea)",
+ "chrono",
  "data-encoding",
  "flate2",
  "futures",
@@ -3797,7 +3785,7 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
 dependencies = [
- "chrono 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",
@@ -4584,7 +4572,7 @@ checksum = "dfafda6f24906ce579407407046298bc9cd5ed608227694657cb186d4faca1da"
 dependencies = [
  "anylog",
  "bytes",
- "chrono 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
  "elementtree",
  "flate2",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ debug = true
 
 [workspace.dependencies]
 anyhow = "1.0.66"
-# Temporarily get chrono from git until https://github.com/chronotope/chrono/pull/1254 has been released.
-chrono = { git = "https://github.com/chronotope/chrono.git", rev = "5a6b2b40a781c19ad34a3593313468d922fceeea", default-features = false, features = [
+chrono = { version = "0.4.29", default-features = false, features = [
     "std",
     "serde",
 ] }


### PR DESCRIPTION
Reverts #2469 and bumps chrono to an official version again.

#skip-changelog