### PR TITLE
ref(metrics): Improve distribution value performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Support ingestion of custom metrics when the `organizations:custom-metrics` feature flag is enabled. ([#2443](https://github.com/getsentry/relay/pull/2443))
 - Merge span metrics and standalone spans extraction options. ([#2447](https://github.com/getsentry/relay/pull/2447))
 - Support parsing aggregated metric buckets directly from statsd payloads. ([#2468](https://github.com/getsentry/relay/pull/2468), [#2472](https://github.com/getsentry/relay/pull/2472))
+- Improve performance when ingesting distribution metrics with a large number of data points. ([#2483](https://github.com/getsentry/relay/pull/2483))
 - Rename the envelope item type for StatsD payloads to "statsd". ([#2470](https://github.com/getsentry/relay/pull/2470))
 - Add a nanojoule unit for profile measurements. ([#2478](https://github.com/getsentry/relay/pull/2478))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,12 +1280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
-
-[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,11 +3314,11 @@ version = "23.8.0"
 dependencies = [
  "bytecount",
  "criterion",
- "float-ord",
  "fnv",
  "hash32",
  "insta",
  "itertools",
+ "rand",
  "relay-base-schema",
  "relay-common",
  "relay-log",
@@ -3334,6 +3328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
+ "smallvec",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 itertools = "0.10.5"
 once_cell = "1.13.1"
+rand = "0.8.5"
 regex = "1.9.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 data-encoding = "2.3.3"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 hmac = "0.12.1"
-rand = "0.8.5"
+rand = { workspace = true }
 relay-common = { path = "../relay-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [dependencies]
 bytecount = "0.6.0"
-float-ord = "0.3.1"
 fnv = "1.0.7"
 hash32 = "0.3.1"
 itertools = { workspace = true }
@@ -22,17 +21,19 @@ relay-statsd = { path = "../relay-statsd" }
 relay-system = { path = "../relay-system" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
 insta = { workspace = true }
+rand = { workspace = true }
 relay-statsd = { path = "../relay-statsd", features = ["test"] }
 relay-test = { path = "../relay-test" }
 similar-asserts = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
-name = "aggregator"
+name = "benches"
 harness = false

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -50,7 +50,7 @@ impl MergeValue for BucketValue {
     fn merge_into(self, bucket_value: &mut BucketValue) -> Result<(), AggregateMetricsError> {
         match (bucket_value, self) {
             (BucketValue::Counter(lhs), BucketValue::Counter(rhs)) => *lhs += rhs,
-            (BucketValue::Distribution(lhs), BucketValue::Distribution(rhs)) => lhs.extend(&rhs),
+            (BucketValue::Distribution(lhs), BucketValue::Distribution(rhs)) => lhs.extend(rhs),
             (BucketValue::Set(lhs), BucketValue::Set(rhs)) => lhs.extend(rhs),
             (BucketValue::Gauge(lhs), BucketValue::Gauge(rhs)) => lhs.merge(rhs),
             _ => return Err(AggregateMetricsErrorKind::InvalidTypes.into()),
@@ -67,7 +67,7 @@ impl MergeValue for MetricValue {
                 *counter += value;
             }
             (BucketValue::Distribution(distribution), MetricValue::Distribution(value)) => {
-                distribution.insert(value);
+                distribution.push(value);
             }
             (BucketValue::Set(set), MetricValue::Set(value)) => {
                 set.insert(value);
@@ -125,12 +125,13 @@ fn split_at(mut bucket: Bucket, size: usize) -> (Option<Bucket>, Option<Bucket>)
     match bucket.value {
         BucketValue::Counter(_) => (None, Some(bucket)),
         BucketValue::Distribution(ref mut distribution) => {
-            let org = std::mem::take(distribution);
-            let mut new_bucket = bucket.clone();
+            let mut org = std::mem::take(distribution);
 
-            let mut iter = org.iter_values();
-            bucket.value = BucketValue::Distribution((&mut iter).take(split_at).collect());
-            new_bucket.value = BucketValue::Distribution(iter.collect());
+            let mut new_bucket = bucket.clone();
+            new_bucket.value = BucketValue::Distribution(org[split_at..].into());
+
+            org.truncate(split_at);
+            bucket.value = BucketValue::Distribution(org);
 
             (Some(bucket), Some(new_bucket))
         }
@@ -1509,7 +1510,7 @@ mod tests {
         BucketValue::Distribution(dist![2., 4.])
             .merge_into(&mut value)
             .unwrap();
-        assert_eq!(value, BucketValue::Distribution(dist![1., 2., 2., 3., 4.]));
+        assert_eq!(value, BucketValue::Distribution(dist![1., 2., 3., 2., 4.]));
     }
 
     #[test]
@@ -1596,10 +1597,7 @@ mod tests {
             expected_bucket_value_size + 5 * expected_set_entry_size
         );
         let distribution = BucketValue::Distribution(dist![1., 2., 3.]);
-        assert_eq!(
-            distribution.cost(),
-            expected_bucket_value_size + 3 * (8 + 4)
-        );
+        assert_eq!(distribution.cost(), expected_bucket_value_size + 3 * 8);
         let gauge = BucketValue::Gauge(GaugeValue {
             last: 43.,
             min: 42.,
@@ -1852,14 +1850,10 @@ mod tests {
             (
                 "d:transactions/foo@none",
                 MetricValue::Distribution(1.0),
-                fixed_cost + 12,
+                fixed_cost + 8,
             ), // New bucket + 1 element
-            ("d:transactions/foo@none", MetricValue::Distribution(1.0), 0), // no new element
-            (
-                "d:transactions/foo@none",
-                MetricValue::Distribution(2.0),
-                12,
-            ), // 1 new element
+            ("d:transactions/foo@none", MetricValue::Distribution(1.0), 8), // duplicate element
+            ("d:transactions/foo@none", MetricValue::Distribution(2.0), 8), // 1 new element
             (
                 "g:transactions/foo@none",
                 MetricValue::Gauge(0.3),

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -1,10 +1,10 @@
-use std::collections::{btree_map, BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FusedIterator;
 use std::{fmt, mem};
 
-use float_ord::FloatOrd;
 use relay_common::time::UnixTimestamp;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 use crate::protocol::{
     self, CounterType, DistributionType, GaugeType, MetricResourceIdentifier, MetricType,
@@ -71,25 +71,20 @@ impl GaugeValue {
     }
 }
 
-/// Type for counting duplicates in distributions.
-type Count = u32;
-
 /// A distribution of values within a [`Bucket`].
 ///
-/// Distributions store a histogram of values. It allows to iterate both the distribution with
-/// [`iter`](Self::iter) and individual values with [`iter_values`](Self::iter_values).
-///
-/// Based on individual reported values, distributions allow to query the maximum, minimum, or
-/// average of the reported values, as well as statistical quantiles.
+/// Distributions logically store a histogram of values. Based on individual reported values,
+/// distributions allow to query the maximum, minimum, or average of the reported values, as well as
+/// statistical quantiles.
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use relay_metrics::dist;
 ///
 /// let mut dist = dist![1.0, 1.0, 1.0, 2.0];
-/// dist.insert(5.0);
-/// dist.insert_multi(3.0, 7);
+/// dist.push(5.0);
+/// dist.extend(std::iter::repeat(3.0).take(7));
 /// ```
 ///
 /// Logically, this distribution is equivalent to this visualization:
@@ -105,331 +100,12 @@ type Count = u32;
 ///
 /// # Serialization
 ///
-/// Distributions serialize as sorted lists of floating point values. The list contains one entry
-/// for each value in the distribution, including duplicates.
-#[derive(Clone, Default, PartialEq)]
-pub struct DistributionValue {
-    values: BTreeMap<FloatOrd<DistributionType>, Count>,
-    length: Count,
-}
+/// Distributions serialize as lists of floating point values. The list contains one entry for each
+/// value in the distribution, including duplicates.
+pub type DistributionValue = SmallVec<[DistributionType; 3]>;
 
-impl DistributionValue {
-    /// Makes a new, empty `DistributionValue`.
-    ///
-    /// Does not allocate anything on its own.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns the number of values in the map.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::DistributionValue;
-    ///
-    /// let mut dist = DistributionValue::new();
-    /// assert_eq!(dist.len(), 0);
-    /// dist.insert(1.0);
-    /// dist.insert(1.0);
-    /// assert_eq!(dist.len(), 2);
-    /// ```
-    pub fn len(&self) -> Count {
-        self.length
-    }
-
-    /// Returns `true` if the map contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.length == 0
-    }
-
-    /// Adds a value to the distribution.
-    ///
-    /// Returns the number this value occurs in the distribution after inserting.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::DistributionValue;
-    ///
-    /// let mut dist = DistributionValue::new();
-    /// assert_eq!(dist.insert(1.0), 1);
-    /// assert_eq!(dist.insert(1.0), 2);
-    /// assert_eq!(dist.insert(2.0), 1);
-    /// ```
-    pub fn insert(&mut self, value: DistributionType) -> Count {
-        self.insert_multi(value, 1)
-    }
-
-    /// Adds a value multiple times to the distribution.
-    ///
-    /// Returns the number this value occurs in the distribution after inserting.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::DistributionValue;
-    ///
-    /// let mut dist = DistributionValue::new();
-    /// assert_eq!(dist.insert_multi(1.0, 2), 2);
-    /// assert_eq!(dist.insert_multi(1.0, 3), 5);
-    /// ```
-    pub fn insert_multi(&mut self, value: DistributionType, count: Count) -> Count {
-        self.length += count;
-        if count == 0 {
-            return 0;
-        }
-
-        *self
-            .values
-            .entry(FloatOrd(value))
-            .and_modify(|c| *c += count)
-            .or_insert(count)
-    }
-
-    /// Returns `true` if the set contains a value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::dist;
-    ///
-    /// let dist = dist![1.0];
-    ///
-    /// assert_eq!(dist.contains(1.0), true);
-    /// assert_eq!(dist.contains(2.0), false);
-    /// ```
-    pub fn contains(&self, value: impl std::borrow::Borrow<DistributionType>) -> bool {
-        self.values.contains_key(&FloatOrd(*value.borrow()))
-    }
-
-    /// Returns how often the given value occurs in the distribution.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::dist;
-    ///
-    /// let dist = dist![1.0, 1.0];
-    ///
-    /// assert_eq!(dist.get(1.0), 2);
-    /// assert_eq!(dist.get(2.0), 0);
-    /// ```
-    pub fn get(&self, value: impl std::borrow::Borrow<DistributionType>) -> Count {
-        let value = &FloatOrd(*value.borrow());
-        self.values.get(value).copied().unwrap_or(0)
-    }
-
-    /// Gets an iterator that visits unique values in the `DistributionValue` in ascending order.
-    ///
-    /// The iterator yields pairs of values and their count in the distribution.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::dist;
-    ///
-    /// let dist = dist![2.0, 1.0, 3.0, 2.0];
-    ///
-    /// let mut iter = dist.iter();
-    /// assert_eq!(iter.next(), Some((1.0, 1)));
-    /// assert_eq!(iter.next(), Some((2.0, 2)));
-    /// assert_eq!(iter.next(), Some((3.0, 1)));
-    /// assert_eq!(iter.next(), None);
-    /// ```
-    pub fn iter(&self) -> DistributionIter<'_> {
-        DistributionIter {
-            inner: self.values.iter(),
-        }
-    }
-
-    /// Gets an iterator that visits the values in the `DistributionValue` in ascending order.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relay_metrics::dist;
-    ///
-    /// let dist = dist![2.0, 1.0, 3.0, 2.0];
-    ///
-    /// let mut iter = dist.iter_values();
-    /// assert_eq!(iter.next(), Some(1.0));
-    /// assert_eq!(iter.next(), Some(2.0));
-    /// assert_eq!(iter.next(), Some(2.0));
-    /// assert_eq!(iter.next(), Some(3.0));
-    /// assert_eq!(iter.next(), None);
-    /// ```
-    pub fn iter_values(&self) -> DistributionValuesIter<'_> {
-        DistributionValuesIter {
-            inner: self.iter(),
-            current: 0f64,
-            remaining: 0,
-            total: self.length,
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a DistributionValue {
-    type Item = (DistributionType, Count);
-    type IntoIter = DistributionIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl fmt::Debug for DistributionValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_map().entries(self.iter()).finish()
-    }
-}
-
-impl Extend<f64> for DistributionValue {
-    fn extend<T: IntoIterator<Item = DistributionType>>(&mut self, iter: T) {
-        for value in iter.into_iter() {
-            self.insert(value);
-        }
-    }
-}
-
-impl Extend<(DistributionType, Count)> for DistributionValue {
-    fn extend<T: IntoIterator<Item = (DistributionType, Count)>>(&mut self, iter: T) {
-        for (value, count) in iter.into_iter() {
-            self.insert_multi(value, count);
-        }
-    }
-}
-
-impl FromIterator<DistributionType> for DistributionValue {
-    fn from_iter<T: IntoIterator<Item = DistributionType>>(iter: T) -> Self {
-        let mut value = Self::default();
-        value.extend(iter);
-        value
-    }
-}
-
-impl FromIterator<(DistributionType, Count)> for DistributionValue {
-    fn from_iter<T: IntoIterator<Item = (DistributionType, Count)>>(iter: T) -> Self {
-        let mut value = Self::default();
-        value.extend(iter);
-        value
-    }
-}
-
-impl Serialize for DistributionValue {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_seq(self.iter_values())
-    }
-}
-
-impl<'de> Deserialize<'de> for DistributionValue {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct DistributionVisitor;
-
-        impl<'d> serde::de::Visitor<'d> for DistributionVisitor {
-            type Value = DistributionValue;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "a list of floating point values")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'d>,
-            {
-                let mut distribution = DistributionValue::new();
-
-                while let Some(value) = seq.next_element()? {
-                    distribution.insert(value);
-                }
-
-                Ok(distribution)
-            }
-        }
-
-        deserializer.deserialize_seq(DistributionVisitor)
-    }
-}
-
-/// An iterator over distribution entries in a [`DistributionValue`].
-///
-/// This struct is created by the [`iter`](DistributionValue::iter) method on
-/// `DistributionValue`. See its documentation for more.
-#[derive(Clone)]
-pub struct DistributionIter<'a> {
-    inner: btree_map::Iter<'a, FloatOrd<f64>, Count>,
-}
-
-impl Iterator for DistributionIter<'_> {
-    type Item = (DistributionType, Count);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let (value, count) = self.inner.next()?;
-        Some((value.0, *count))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
-}
-
-impl ExactSizeIterator for DistributionIter<'_> {}
-
-impl fmt::Debug for DistributionIter<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(self.clone()).finish()
-    }
-}
-
-/// An iterator over all individual values in a [`DistributionValue`].
-///
-/// This struct is created by the [`iter_values`](DistributionValue::iter_values) method on
-/// `DistributionValue`. See its documentation for more.
-#[derive(Clone)]
-pub struct DistributionValuesIter<'a> {
-    inner: DistributionIter<'a>,
-    current: DistributionType,
-    remaining: Count,
-    total: Count,
-}
-
-impl Iterator for DistributionValuesIter<'_> {
-    type Item = DistributionType;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining > 0 {
-            self.remaining -= 1;
-            self.total -= 1;
-            return Some(self.current);
-        }
-
-        let (value, count) = self.inner.next()?;
-
-        self.current = value;
-        self.remaining = count - 1;
-        self.total -= 1;
-        Some(self.current)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.total as usize;
-        (len, Some(len))
-    }
-}
-
-impl ExactSizeIterator for DistributionValuesIter<'_> {}
-
-impl fmt::Debug for DistributionValuesIter<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(self.clone()).finish()
-    }
-}
+#[doc(hidden)]
+pub use smallvec::smallvec as _smallvec;
 
 /// Creates a [`DistributionValue`] containing the given arguments.
 ///
@@ -442,14 +118,9 @@ impl fmt::Debug for DistributionValuesIter<'_> {
 /// ```
 #[macro_export]
 macro_rules! dist {
-    () => {
-        $crate::DistributionValue::new()
+    ($($x:expr),*$(,)*) => {
+        $crate::_smallvec!($($x),*) as $crate::DistributionValue
     };
-    ($($x:expr),+ $(,)?) => {{
-        let mut distribution = $crate::DistributionValue::new();
-        $( distribution.insert($x); )*
-        distribution
-    }};
 }
 
 /// A set of unique values.
@@ -557,7 +228,7 @@ impl BucketValue {
     pub fn len(&self) -> usize {
         match self {
             BucketValue::Counter(_) => 1,
-            BucketValue::Distribution(distribution) => distribution.len() as usize,
+            BucketValue::Distribution(distribution) => distribution.len(),
             BucketValue::Set(set) => set.len(),
             BucketValue::Gauge(_) => 5,
         }
@@ -579,9 +250,7 @@ impl BucketValue {
             Self::Counter(_) => 0,
             Self::Set(s) => mem::size_of::<SetType>() * s.len(),
             Self::Gauge(_) => 0,
-            Self::Distribution(m) => {
-                m.values.len() * (mem::size_of::<DistributionType>() + mem::size_of::<Count>())
-            }
+            Self::Distribution(d) => d.len() * mem::size_of::<DistributionType>(),
         };
 
         mem::size_of::<Self>() + allocated_cost
@@ -612,7 +281,7 @@ fn parse_counter(string: &str) -> Option<CounterType> {
 fn parse_distribution(string: &str) -> Option<DistributionValue> {
     let mut dist = DistributionValue::default();
     for component in string.split(VALUE_SEPARATOR) {
-        dist.insert(component.parse().ok()?);
+        dist.push(component.parse().ok()?);
     }
     Some(dist)
 }
@@ -959,77 +628,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_distribution_insert() {
-        let mut distribution = DistributionValue::new();
-        assert_eq!(distribution.insert(2f64), 1);
-        assert_eq!(distribution.insert(1f64), 1);
-        assert_eq!(distribution.insert(2f64), 2);
-
-        assert_eq!(distribution.len(), 3);
-
-        assert!(!distribution.contains(0f64));
-        assert!(distribution.contains(1f64));
-        assert!(distribution.contains(2f64));
-
-        assert_eq!(distribution.get(0f64), 0);
-        assert_eq!(distribution.get(1f64), 1);
-        assert_eq!(distribution.get(2f64), 2);
+    fn test_distribution_value_size() {
+        // DistributionValue uses a SmallVec internally to prevent an additional allocation and
+        // indirection in cases where it needs to store only a small number of items. This is
+        // enabled by a comparably large `GaugeValue`, which stores five atoms. Ensure that the
+        // `DistributionValue`'s size does not exceed that of `GaugeValue`.
+        assert!(
+            std::mem::size_of::<DistributionValue>() <= std::mem::size_of::<GaugeValue>(),
+            "distribution value should not exceed gauge {}",
+            std::mem::size_of::<DistributionValue>()
+        );
     }
 
-    #[test]
-    fn test_distribution_insert_multi() {
-        let mut distribution = DistributionValue::new();
-        assert_eq!(distribution.insert_multi(0f64, 0), 0);
-        assert_eq!(distribution.insert_multi(2f64, 2), 2);
-        assert_eq!(distribution.insert_multi(1f64, 1), 1);
-        assert_eq!(distribution.insert_multi(3f64, 1), 1);
-        assert_eq!(distribution.insert_multi(3f64, 2), 3);
-
-        assert_eq!(distribution.len(), 6);
-
-        assert!(!distribution.contains(0f64));
-        assert!(distribution.contains(1f64));
-        assert!(distribution.contains(2f64));
-        assert!(distribution.contains(3f64));
-
-        assert_eq!(distribution.get(0f64), 0);
-        assert_eq!(distribution.get(1f64), 1);
-        assert_eq!(distribution.get(2f64), 2);
-        assert_eq!(distribution.get(3f64), 3);
-    }
-
-    #[test]
-    fn test_distribution_iter_values() {
-        let distribution = dist![2f64, 1f64, 2f64];
-
-        let mut iter = distribution.iter_values();
-        assert_eq!(iter.len(), 3);
-        assert_eq!(iter.next(), Some(1f64));
-        assert_eq!(iter.len(), 2);
-        assert_eq!(iter.next(), Some(2f64));
-        assert_eq!(iter.len(), 1);
-        assert_eq!(iter.next(), Some(2f64));
-        assert_eq!(iter.len(), 0);
-        assert_eq!(iter.next(), None);
-    }
-
-    #[test]
-    fn test_distribution_iter_values_empty() {
-        let distribution = DistributionValue::new();
-        let mut iter = distribution.iter_values();
-        assert_eq!(iter.len(), 0);
-        assert_eq!(iter.next(), None);
-    }
-
-    #[test]
-    fn test_distribution_iter() {
-        let distribution = dist![2f64, 1f64, 2f64];
-
-        let mut iter = distribution.iter();
-        assert_eq!(iter.next(), Some((1f64, 1)));
-        assert_eq!(iter.next(), Some((2f64, 2)));
-        assert_eq!(iter.next(), None);
-    }
     #[test]
     fn test_parse_garbage() {
         let s = "x23-408j17z4232@#34d\nc3456y7^😎";
@@ -1075,9 +685,9 @@ mod tests {
             width: 0,
             name: "d:transactions/foo@none",
             value: Distribution(
-                {
-                    17.5: 1,
-                },
+                [
+                    17.5,
+                ],
             ),
             tags: {},
         }
@@ -1376,26 +986,26 @@ mod tests {
         ]"#;
 
         let buckets = serde_json::from_str::<Vec<Bucket>>(json).unwrap();
-        insta::assert_debug_snapshot!(buckets, @r#"
+        insta::assert_debug_snapshot!(buckets, @r###"
         [
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
                 width: 10,
                 name: "endpoint.response_time",
                 value: Distribution(
-                    {
-                        36.0: 1,
-                        49.0: 1,
-                        57.0: 1,
-                        68.0: 1,
-                    },
+                    [
+                        36.0,
+                        49.0,
+                        57.0,
+                        68.0,
+                    ],
                 ),
                 tags: {
                     "route": "user_index",
                 },
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 chrono = { workspace = true }
-rand = "0.8.5"
+rand = { workspace = true }
 rand_pcg = "0.3.1"
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -212,9 +212,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@none",
                 value: Distribution(
-                    {
-                        2000.0: 1,
-                    },
+                    [
+                        2000.0,
+                    ],
                 ),
                 tags: {},
             },

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -8,9 +8,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -27,9 +27,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -45,9 +45,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -69,9 +69,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -92,9 +92,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -116,9 +116,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -139,9 +139,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -163,9 +163,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -186,9 +186,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -209,9 +209,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -231,9 +231,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -256,9 +256,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -280,9 +280,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -306,9 +306,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -331,9 +331,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -357,9 +357,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -382,9 +382,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -408,9 +408,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -433,9 +433,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -459,9 +459,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -484,9 +484,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -510,9 +510,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -535,9 +535,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -561,9 +561,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -586,9 +586,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -611,9 +611,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -635,9 +635,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -659,9 +659,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -682,9 +682,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -708,9 +708,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -733,9 +733,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -756,9 +756,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -778,9 +778,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -804,9 +804,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -829,9 +829,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -855,9 +855,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -880,9 +880,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -904,9 +904,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -927,9 +927,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -951,9 +951,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -974,9 +974,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -999,9 +999,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1023,9 +1023,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1046,9 +1046,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1068,9 +1068,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1092,9 +1092,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1115,9 +1115,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1139,9 +1139,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1162,9 +1162,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1186,9 +1186,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1209,9 +1209,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",
@@ -1231,9 +1231,9 @@ expression: metrics
         width: 0,
         name: "d:spans/exclusive_time_light@millisecond",
         value: Distribution(
-            {
-                2000.0: 1,
-            },
+            [
+                2000.0,
+            ],
         ),
         tags: {
             "environment": "fake_environment",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -55,9 +55,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
             width: 0,
             name: "d:spans/exclusive_time@millisecond",
             value: Distribution(
-                {
-                    2000.0: 1,
-                },
+                [
+                    2000.0,
+                ],
             ),
             tags: {
                 "device.class": "1",
@@ -72,9 +72,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
             width: 0,
             name: "d:spans/exclusive_time_light@millisecond",
             value: Distribution(
-                {
-                    2000.0: 1,
-                },
+                [
+                    2000.0,
+                ],
             ),
             tags: {
                 "device.class": "1",

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -539,9 +539,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.foo@none",
                 value: Distribution(
-                    {
-                        420.69: 1,
-                    },
+                    [
+                        420.69,
+                    ],
                 ),
                 tags: {
                     "browser.name": "Chrome",
@@ -563,9 +563,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.lcp@millisecond",
                 value: Distribution(
-                    {
-                        3000.0: 1,
-                    },
+                    [
+                        3000.0,
+                    ],
                 ),
                 tags: {
                     "browser.name": "Chrome",
@@ -588,9 +588,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond",
                 value: Distribution(
-                    {
-                        2000.0: 1,
-                    },
+                    [
+                        2000.0,
+                    ],
                 ),
                 tags: {
                     "browser.name": "Chrome",
@@ -612,9 +612,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    {
-                        59000.0: 1,
-                    },
+                    [
+                        59000.0,
+                    ],
                 ),
                 tags: {
                     "browser.name": "Chrome",
@@ -705,9 +705,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.fcp@millisecond",
                 value: Distribution(
-                    {
-                        1.1: 1,
-                    },
+                    [
+                        1.1,
+                    ],
                 ),
                 tags: {
                     "measurement_rating": "good",
@@ -721,9 +721,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.foo@none",
                 value: Distribution(
-                    {
-                        8.8: 1,
-                    },
+                    [
+                        8.8,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -736,9 +736,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.stall_count@none",
                 value: Distribution(
-                    {
-                        3.3: 1,
-                    },
+                    [
+                        3.3,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -751,9 +751,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    {
-                        59000.0: 1,
-                    },
+                    [
+                        59000.0,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -808,9 +808,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.fcp@second",
                 value: Distribution(
-                    {
-                        1.1: 1,
-                    },
+                    [
+                        1.1,
+                    ],
                 ),
                 tags: {
                     "measurement_rating": "good",
@@ -824,9 +824,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.lcp@none",
                 value: Distribution(
-                    {
-                        2.2: 1,
-                    },
+                    [
+                        2.2,
+                    ],
                 ),
                 tags: {
                     "measurement_rating": "good",
@@ -840,9 +840,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    {
-                        59000.0: 1,
-                    },
+                    [
+                        59000.0,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -956,9 +956,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.a_custom1@none",
                 value: Distribution(
-                    {
-                        41.0: 1,
-                    },
+                    [
+                        41.0,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -971,9 +971,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.fcp@millisecond",
                 value: Distribution(
-                    {
-                        0.123: 1,
-                    },
+                    [
+                        0.123,
+                    ],
                 ),
                 tags: {
                     "measurement_rating": "good",
@@ -987,9 +987,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.g_custom2@second",
                 value: Distribution(
-                    {
-                        42.0: 1,
-                    },
+                    [
+                        42.0,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -1002,9 +1002,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    {
-                        2000.0: 1,
-                    },
+                    [
+                        2000.0,
+                    ],
                 ),
                 tags: {
                     "platform": "other",
@@ -1614,9 +1614,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/measurements.lcp@millisecond",
                 value: Distribution(
-                    {
-                        41.0: 1,
-                    },
+                    [
+                        41.0,
+                    ],
                 ),
                 tags: {
                     "measurement_rating": "good",
@@ -1628,9 +1628,9 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond",
                 value: Distribution(
-                    {
-                        2000.0: 1,
-                    },
+                    [
+                        2000.0,
+                    ],
                 ),
                 tags: {
                     "platform": "javascript",

--- a/relay-statsd/Cargo.toml
+++ b/relay-statsd/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 cadence = "0.29.0"
 parking_lot = "0.12.1"
-rand = "0.8.5"
+rand = { workspace = true }
 relay-log = { path = "../relay-log" }
 
 [features]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -664,6 +664,7 @@ def test_transaction_metrics(
         },
     }
 
+    metrics["d:transactions/measurements.foo@none"]["value"].sort()
     assert metrics["d:transactions/measurements.foo@none"] == {
         **common,
         "name": "d:transactions/measurements.foo@none",


### PR DESCRIPTION
Represents distribution metrics as plain unsorted vectors instead of
deduplicated btree maps. This offers greatly improved performance
characteristics during insertion, but comes at the expense of
potentially more memory usage if there are a lot of duplicate values.

During benchmarks, this change reveals approximately 500x speedup for
metrics with 10k to 1M data points per bucket. In practice, large
buckets are much more prevalent than duplicate values.

The new implementation uses `SmallVec`. Since distribution values are
always stored within a `BucketValue` that also contains gauges. Since
`GaugeValue` is a larger struct, that leaves space to inline three float
values before allocating a vector for distributions. Usual production
traffic indicates that this covers the majority of distribution buckets,
so this is a worthwhile optimization.