### PR TITLE
fix(spans): Strip more quotes

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -485,6 +485,24 @@ mod tests {
     );
 
     scrub_sql_test!(
+        quotes_in_join,
+        r#"SELECT "foo" FROM "a" JOIN "b" ON (b_id = b.id)"#,
+        "SELECT foo FROM a JOIN b ON (b_id = id)"
+    );
+
+    scrub_sql_test!(
+        quotes_in_function,
+        r#"SELECT UPPER("b"."c")"#,
+        "SELECT UPPER(c)"
+    );
+
+    scrub_sql_test!(
+        quotes_in_cast,
+        r#"SELECT UPPER("b"."c"::text)"#,
+        "SELECT UPPER(c)"
+    );
+
+    scrub_sql_test!(
         parameters_in,
         "select column FROM table1 WHERE id IN (1, 2, 3)",
         "SELECT column FROM table1 WHERE id IN (%s)"


### PR DESCRIPTION
This PR fixes two regressions that were caused by switching to a proper SQL parser:

* Simplify identifiers when casts are involved, e.g. `SELECT UPPER("b"."c"::text)`
* Strip quotes from table names in JOINs, e.g. `SELECT * FROM a join "b"`

#skip-changelog