### PR TITLE
ref(globalconfig): Use endpoint v3

### DIFF
--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -65,7 +65,7 @@ impl UpstreamQuery for GetGlobalConfig {
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
-        Cow::Borrowed("/api/0/relays/projectconfigs/?version=4")
+        Cow::Borrowed("/api/0/relays/projectconfigs/?version=3")
     }
 
     fn retry() -> bool {

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -315,7 +315,7 @@ def mini_sentry(request):  # noqa
 
         version = flask_request.args.get("version")
 
-        if version == "4" and flask_request.json.get("global"):
+        if version == "3" and flask_request.json.get("global"):
             # There are no fields in global config for now
             global_ = {}
 

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -182,7 +182,7 @@ def test_pending_projects(mini_sentry, relay):
 
     def request_config():
         return relay.post(
-            "/api/0/relays/projectconfigs/?version=4",
+            "/api/0/relays/projectconfigs/?version=3",
             data=packed,
             headers={
                 "X-Sentry-Relay-Id": relay.relay_id,
@@ -450,6 +450,6 @@ def test_get_global_config(mini_sentry, relay):
 
     body = {"publicKeys": [], "global": True}
     packed, signature = SecretKey.parse(relay.secret_key).pack(body)
-    data = get_response(relay, packed, signature, version="4")
+    data = get_response(relay, packed, signature, version="3")
 
     assert data["global"] == GLOBAL_CONFIG


### PR DESCRIPTION
See [doc (internal)](https://www.notion.so/Global-project-config-endpoint-version-decision-8deba7570a364dbd8580335af33a8a03).

Goes after https://github.com/getsentry/sentry/pull/55756.

#skip-changelog