### PR TITLE
Add `from_name` for span data category

### DIFF
--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -78,6 +78,7 @@ impl DataCategory {
             "transaction_processed" => Self::TransactionProcessed,
             "transaction_indexed" => Self::TransactionIndexed,
             "monitor" => Self::Monitor,
+            "span" => Self::Span,
             _ => Self::Unknown,
         }
     }


### PR DESCRIPTION
I forgot to add this in a previous PR. This has not caused any problems because we do not parse rate limits for spans (yet).

#skip-changelog