### PR TITLE
feat(spans): Strip qualified wildcards

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -503,6 +503,12 @@ mod tests {
     );
 
     scrub_sql_test!(
+        qualified_wildcard,
+        r#"SELECT "foo".* FROM "foo""#,
+        "SELECT * FROM foo"
+    );
+
+    scrub_sql_test!(
         parameters_in,
         "select column FROM table1 WHERE id IN (1, 2, 3)",
         "SELECT column FROM table1 WHERE id IN (%s)"

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -98,9 +98,16 @@ impl NormalizeVisitor {
         // Iterate over selected item.
         for mut item in std::mem::take(&mut select.projection) {
             // Normalize aliases.
-            if let SelectItem::ExprWithAlias { ref mut alias, .. } = &mut item {
-                alias.quote_style = None;
-            }
+            let item = match item {
+                // Remove alias.
+                SelectItem::ExprWithAlias { ref mut alias, .. } => {
+                    alias.quote_style = None;
+                    item
+                }
+                // Strip prefix, e.g. `"mytable".*`.
+                SelectItem::QualifiedWildcard(_, options) => SelectItem::Wildcard(options),
+                _ => item,
+            };
             if Self::is_collapsible(&item) {
                 collapse.push(item);
             } else {


### PR DESCRIPTION
Strip prefixes off qualified wildcards in SQL span descriptions, e.g. `"mytable".*`.

#skip-changelog