### PR TITLE
ref(metrics): Remove InsertMetrics and related traits

### DIFF
--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -167,7 +167,7 @@ pub enum BucketValue {
     #[serde(rename = "s")]
     Set(SetValue),
     /// Aggregates [`MetricValue::Gauge`](crate::MetricValue::Gauge) values always retaining the
-    /// maximum, minimum, and last value, as well as the sum and count of all values.
+    /// latest, minimum, and maximum value, as well as the sum and count of all values.
     ///
     /// **Note**: The "last" component of this aggregation is not commutative.
     ///

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::protocol::{
-    self, CounterType, DistributionType, GaugeType, MetricResourceIdentifier, MetricType,
-    MetricValue, MetricsContainer, SetType,
+    self, hash_set_value, CounterType, DistributionType, GaugeType, MetricResourceIdentifier,
+    MetricType, SetType,
 };
-use crate::{hash_set_value, ParseMetricError};
+use crate::ParseMetricError;
 
 const VALUE_SEPARATOR: char = ':';
 
@@ -136,7 +136,8 @@ pub type SetValue = BTreeSet<SetType>;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value")]
 pub enum BucketValue {
-    /// Aggregates [`MetricValue::Counter`] values by adding them into a single value.
+    /// Aggregates [`MetricValue::Counter`](crate::MetricValue::Counter) values by adding them into
+    /// a single value.
     ///
     /// ```text
     /// 2, 1, 3, 2 => 8
@@ -145,7 +146,8 @@ pub enum BucketValue {
     /// This variant serializes to a double precision float.
     #[serde(rename = "c")]
     Counter(CounterType),
-    /// Aggregates [`MetricValue::Distribution`] values by collecting their values.
+    /// Aggregates [`MetricValue::Distribution`](crate::MetricValue::Distribution) values by
+    /// collecting their values.
     ///
     /// ```text
     /// 2, 1, 3, 2 => [1, 2, 2, 3]
@@ -154,7 +156,8 @@ pub enum BucketValue {
     /// This variant serializes to a list of double precision floats, see [`DistributionValue`].
     #[serde(rename = "d")]
     Distribution(DistributionValue),
-    /// Aggregates [`MetricValue::Set`] values by storing their hash values in a set.
+    /// Aggregates [`MetricValue::Set`](crate::MetricValue::Set) values by storing their hash values
+    /// in a set.
     ///
     /// ```text
     /// 2, 1, 3, 2 => {1, 2, 3}
@@ -163,8 +166,8 @@ pub enum BucketValue {
     /// This variant serializes to a list of 32-bit integers.
     #[serde(rename = "s")]
     Set(SetValue),
-    /// Aggregates [`MetricValue::Gauge`] values always retaining the maximum, minimum, and last
-    /// value, as well as the sum and count of all values.
+    /// Aggregates [`MetricValue::Gauge`](crate::MetricValue::Gauge) values always retaining the
+    /// maximum, minimum, and last value, as well as the sum and count of all values.
     ///
     /// **Note**: The "last" component of this aggregation is not commutative.
     ///
@@ -255,16 +258,21 @@ impl BucketValue {
 
         mem::size_of::<Self>() + allocated_cost
     }
-}
 
-impl From<MetricValue> for BucketValue {
-    fn from(value: MetricValue) -> Self {
-        match value {
-            MetricValue::Counter(value) => Self::counter(value),
-            MetricValue::Distribution(value) => Self::distribution(value),
-            MetricValue::Set(value) => Self::set(value),
-            MetricValue::Gauge(value) => Self::gauge(value),
+    /// Merges the given `bucket_value` into `self`.
+    ///
+    /// Returns `Ok(())` if the two bucket values can be merged. This is the case when both bucket
+    /// values are of the same variant. Otherwise, this returns `Err(other)`.
+    pub fn merge(&mut self, other: Self) -> Result<(), Self> {
+        match (self, other) {
+            (Self::Counter(slf), Self::Counter(other)) => *slf += other,
+            (Self::Distribution(slf), Self::Distribution(other)) => slf.extend_from_slice(&other),
+            (Self::Set(slf), Self::Set(other)) => slf.extend(other),
+            (Self::Gauge(slf), Self::Gauge(other)) => slf.merge(other),
+            (_, other) => return Err(other),
         }
+
+        Ok(())
     }
 }
 
@@ -555,23 +563,17 @@ impl Bucket {
     pub fn parse_all(slice: &[u8], timestamp: UnixTimestamp) -> ParseBuckets<'_> {
         ParseBuckets { slice, timestamp }
     }
-}
 
-impl MetricsContainer for Bucket {
-    fn name(&self) -> &str {
-        self.name.as_str()
-    }
-
-    fn len(&self) -> usize {
-        self.value.len()
-    }
-
-    fn tag(&self, name: &str) -> Option<&str> {
+    /// Returns the value of the specified tag if it exists.
+    pub fn tag(&self, name: &str) -> Option<&str> {
         self.tags.get(name).map(|s| s.as_str())
     }
 
-    fn remove_tag(&mut self, name: &str) {
-        self.tags.remove(name);
+    /// Removes the value of the specified tag.
+    ///
+    /// If the tag exists, the removed value is returned.
+    pub fn remove_tag(&mut self, name: &str) -> Option<String> {
+        self.tags.remove(name)
     }
 }
 
@@ -637,6 +639,46 @@ mod tests {
             std::mem::size_of::<DistributionValue>() <= std::mem::size_of::<GaugeValue>(),
             "distribution value should not exceed gauge {}",
             std::mem::size_of::<DistributionValue>()
+        );
+    }
+
+    #[test]
+    fn test_bucket_value_merge_counter() {
+        let mut value = BucketValue::Counter(42.);
+        value.merge(BucketValue::Counter(43.)).unwrap();
+        assert_eq!(value, BucketValue::Counter(85.));
+    }
+
+    #[test]
+    fn test_bucket_value_merge_distribution() {
+        let mut value = BucketValue::Distribution(dist![1., 2., 3.]);
+        value
+            .merge(BucketValue::Distribution(dist![2., 4.]))
+            .unwrap();
+        assert_eq!(value, BucketValue::Distribution(dist![1., 2., 3., 2., 4.]));
+    }
+
+    #[test]
+    fn test_bucket_value_merge_set() {
+        let mut value = BucketValue::Set(vec![1, 2].into_iter().collect());
+        value.merge(BucketValue::Set([2, 3].into())).unwrap();
+        assert_eq!(value, BucketValue::Set(vec![1, 2, 3].into_iter().collect()));
+    }
+
+    #[test]
+    fn test_bucket_value_merge_gauge() {
+        let mut value = BucketValue::Gauge(GaugeValue::single(42.));
+        value.merge(BucketValue::gauge(43.)).unwrap();
+
+        assert_eq!(
+            value,
+            BucketValue::Gauge(GaugeValue {
+                last: 43.,
+                min: 42.,
+                max: 43.,
+                sum: 85.,
+                count: 2,
+            })
         );
     }
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -399,46 +399,6 @@ impl Metric {
     }
 }
 
-/// Common interface for `Metric` and `Bucket`.
-pub trait MetricsContainer {
-    /// Returns the full metric name (MRI) of this container.
-    fn name(&self) -> &str;
-
-    /// Returns the number of raw data points in this container.
-    ///
-    /// See [`BucketValue::len`](crate::BucketValue::len).
-    fn len(&self) -> usize;
-
-    /// Returns `true` if this container contains no values.
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns the value of the given tag, if present.
-    fn tag(&self, name: &str) -> Option<&str>;
-
-    /// Removes the given tag, if present.
-    fn remove_tag(&mut self, name: &str);
-}
-
-impl MetricsContainer for Metric {
-    fn name(&self) -> &str {
-        self.name.as_str()
-    }
-
-    fn len(&self) -> usize {
-        1
-    }
-
-    fn tag(&self, name: &str) -> Option<&str> {
-        self.tags.get(name).map(|s| s.as_str())
-    }
-
-    fn remove_tag(&mut self, name: &str) {
-        self.tags.remove(name);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use similar_asserts::assert_eq;

--- a/relay-metrics/src/router.rs
+++ b/relay-metrics/src/router.rs
@@ -4,14 +4,12 @@
 use std::collections::BTreeMap;
 
 use itertools::Itertools;
-use relay_base_schema::project::ProjectKey;
-use relay_system::{Addr, FromMessage, NoResponse, Recipient, Service};
+use relay_system::{Addr, NoResponse, Recipient, Service};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AcceptsMetrics, Aggregator, AggregatorConfig, AggregatorService, Bucket, FlushBuckets,
-    InsertMetrics, MergeBuckets, Metric, MetricNamespace, MetricResourceIdentifier,
-    MetricsContainer,
+    AcceptsMetrics, Aggregator, AggregatorConfig, AggregatorService, FlushBuckets, MergeBuckets,
+    MetricNamespace, MetricResourceIdentifier,
 };
 
 /// Contains an [`AggregatorConfig`] for a specific scope.
@@ -67,9 +65,7 @@ impl RouterService {
             secondary_aggregators: secondary_aggregators
                 .into_iter()
                 .map(|c| {
-                    let namespace = match c.condition {
-                        Condition::Eq(Field::Namespace(namespace)) => namespace,
-                    };
+                    let Condition::Eq(Field::Namespace(namespace)) = c.condition;
                     (
                         namespace,
                         AggregatorService::named(c.name, c.config, receiver.clone()),
@@ -101,53 +97,6 @@ impl Service for RouterService {
             }
             relay_log::info!("metrics router stopped");
         });
-    }
-}
-
-/// Generalization of [`InsertMetrics`] and [`MergeBuckets`].
-///
-/// Used to handle these messages generically.
-trait Insert {
-    type Item: MetricsContainer;
-    fn into_parts(self) -> (ProjectKey, Vec<Self::Item>);
-    fn from_parts(project_key: ProjectKey, items: Vec<Self::Item>) -> Self;
-}
-
-impl Insert for InsertMetrics {
-    type Item = Metric;
-
-    fn into_parts(self) -> (ProjectKey, Vec<Self::Item>) {
-        let InsertMetrics {
-            project_key,
-            metrics,
-        } = self;
-        (project_key, metrics)
-    }
-
-    fn from_parts(project_key: ProjectKey, items: Vec<Self::Item>) -> Self {
-        Self {
-            project_key,
-            metrics: items,
-        }
-    }
-}
-
-impl Insert for MergeBuckets {
-    type Item = Bucket;
-
-    fn into_parts(self) -> (ProjectKey, Vec<Self::Item>) {
-        let MergeBuckets {
-            project_key,
-            buckets,
-        } = self;
-        (project_key, buckets)
-    }
-
-    fn from_parts(project_key: ProjectKey, items: Vec<Self::Item>) -> Self {
-        Self {
-            project_key,
-            buckets: items,
-        }
     }
 }
 
@@ -188,30 +137,29 @@ impl StartedRouter {
                     sender.send(accepts);
                 });
             }
-            Aggregator::InsertMetrics(msg) => self.handle_metrics(msg),
-            Aggregator::MergeBuckets(msg) => self.handle_metrics(msg),
+            Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
             #[cfg(test)]
             Aggregator::BucketCountInquiry(_, _sender) => (), // not supported
         }
     }
 
-    fn handle_metrics<M: Insert>(&mut self, message: M)
-    where
-        Aggregator: FromMessage<M>,
-    {
-        let (project_key, metrics) = message.into_parts();
-        let metrics_by_namespace = metrics.into_iter().group_by(|m| {
-            MetricResourceIdentifier::parse(m.name())
+    fn handle_merge_buckets(&mut self, message: MergeBuckets) {
+        let metrics_by_namespace = message.buckets.into_iter().group_by(|bucket| {
+            MetricResourceIdentifier::parse(&bucket.name)
                 .map(|mri| mri.namespace)
                 .ok()
         });
+
         // TODO: Parse MRI only once, move validation from Aggregator here.
         for (namespace, group) in metrics_by_namespace.into_iter() {
-            let agg = namespace
-                .and_then(|ns| self.secondary_aggregators.get_mut(&ns))
-                .unwrap_or(&mut self.default_aggregator);
-            let message = M::from_parts(project_key, group.collect());
-            agg.send(message);
+            let aggregator = namespace
+                .and_then(|ns| self.secondary_aggregators.get(&ns))
+                .unwrap_or(&self.default_aggregator);
+
+            aggregator.send(MergeBuckets {
+                project_key: message.project_key,
+                buckets: group.collect(),
+            });
         }
     }
 }

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -29,13 +29,6 @@ impl SetMetric for MetricSets {
 
 /// Counter metrics for Relay Metrics.
 pub enum MetricCounters {
-    /// Incremented for every metric that is inserted.
-    ///
-    /// This metric is tagged with:
-    ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_type`: The type of the metric (e.g. `"counter"`).
-    InsertMetric,
-
     /// Incremented every time two buckets or two metrics are merged.
     ///
     /// This metric is tagged with:
@@ -62,7 +55,6 @@ pub enum MetricCounters {
 impl CounterMetric for MetricCounters {
     fn name(&self) -> &'static str {
         match *self {
-            Self::InsertMetric => "metrics.insert",
             Self::MergeHit => "metrics.buckets.merge.hit",
             Self::MergeMiss => "metrics.buckets.merge.miss",
             Self::BucketsDropped => "metrics.buckets.dropped",

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -473,7 +473,7 @@ impl EncodeEnvelope {
 #[cfg(feature = "processing")]
 #[derive(Debug)]
 pub struct RateLimitFlushBuckets {
-    pub bucket_limiter: MetricsLimiter<Bucket>,
+    pub bucket_limiter: MetricsLimiter,
     pub partition_key: Option<u64>,
 }
 

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use relay_base_schema::project::ProjectKey;
 use relay_config::{Config, RelayMode};
-use relay_metrics::{self, Aggregator, FlushBuckets, InsertMetrics, MergeBuckets};
+use relay_metrics::{self, Aggregator, FlushBuckets, MergeBuckets};
 use relay_quotas::RateLimits;
 use relay_redis::RedisPool;
 use relay_statsd::metric;
@@ -196,8 +196,8 @@ pub struct SpoolHealth;
 /// information.
 ///
 /// There are also higher-level operations, such as [`CheckEnvelope`] and [`ValidateEnvelope`] that
-/// inspect contents of envelopes for ingestion, as well as [`InsertMetrics`] and [`MergeBuckets`]
-/// to aggregate metrics associated with a project.
+/// inspect contents of envelopes for ingestion, as well as [`MergeBuckets`] to aggregate metrics
+/// associated with a project.
 ///
 /// See the enumerated variants for a full list of available messages for this service.
 pub enum ProjectCache {
@@ -210,7 +210,6 @@ pub enum ProjectCache {
     ),
     ValidateEnvelope(ValidateEnvelope),
     UpdateRateLimits(UpdateRateLimits),
-    InsertMetrics(InsertMetrics),
     MergeBuckets(MergeBuckets),
     FlushBuckets(FlushBuckets),
     UpdateBufferIndex(UpdateBufferIndex),
@@ -278,14 +277,6 @@ impl FromMessage<UpdateRateLimits> for ProjectCache {
 
     fn from_message(message: UpdateRateLimits, _: ()) -> Self {
         Self::UpdateRateLimits(message)
-    }
-}
-
-impl FromMessage<InsertMetrics> for ProjectCache {
-    type Response = relay_system::NoResponse;
-
-    fn from_message(message: InsertMetrics, _: ()) -> Self {
-        Self::InsertMetrics(message)
     }
 }
 
@@ -760,14 +751,6 @@ impl ProjectCacheBroker {
             .merge_rate_limits(message.rate_limits);
     }
 
-    fn handle_insert_metrics(&mut self, message: InsertMetrics) {
-        let aggregator = self.services.aggregator.clone();
-        let outcome_aggregator = self.services.outcome_aggregator.clone();
-        // Only keep if we have an aggregator, otherwise drop because we know that we were disabled.
-        self.get_or_create_project(message.project_key())
-            .insert_metrics(aggregator, outcome_aggregator, message.metrics());
-    }
-
     fn handle_merge_buckets(&mut self, message: MergeBuckets) {
         let aggregator = self.services.aggregator.clone();
         let outcome_aggregator = self.services.outcome_aggregator.clone();
@@ -802,7 +785,6 @@ impl ProjectCacheBroker {
             }
             ProjectCache::ValidateEnvelope(message) => self.handle_validate_envelope(message),
             ProjectCache::UpdateRateLimits(message) => self.handle_rate_limits(message),
-            ProjectCache::InsertMetrics(message) => self.handle_insert_metrics(message),
             ProjectCache::MergeBuckets(message) => self.handle_merge_buckets(message),
             ProjectCache::FlushBuckets(message) => self.handle_flush_buckets(message),
             ProjectCache::UpdateBufferIndex(message) => self.handle_buffer_index(message),


### PR DESCRIPTION
This change removes `InsertMetrics` in favor of `MergeBuckets`. The
former message was no longer used by production code, as the `Metric`
type is being phased out in favor of directly using `Bucket` for all
metrics. Most notably, all methods that were generic over both metrics
and buckets are now specific to buckets.

Continuation of #2476. 
#skip-changelog