### PR TITLE
ref(crons): Partition monitor check-ins by monitor slug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,6 +3700,7 @@ version = "23.9.1"
 dependencies = [
  "once_cell",
  "regex",
+ "relay-base-schema",
  "serde",
  "serde_json",
  "similar-asserts",

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -12,10 +12,11 @@ publish = false
 [dependencies]
 once_cell = { workspace = true }
 regex = { workspace = true }
+relay-base-schema = { path = "../relay-base-schema" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v5"] }
 
 [dev-dependencies]
 similar-asserts = { workspace = true }

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -199,13 +199,14 @@ pub fn process_check_in(
 
     // Use the project_id + monitor_slug as the routing key hint. This helps ensure monitor
     // check-ins are processed in order by consistently routing check-ins from the same monitor.
-    let project_id_slug_key: Vec<u8> = [
-        &project_id.value().to_be_bytes()[..],
+
+    let project_id_slug_key = [
+        &project_id.value().to_be_bytes(),
         check_in.monitor_slug.as_bytes(),
     ]
     .concat();
 
-    let routing_hint = Uuid::new_v5(namespace, project_id_slug_key.as_slice());
+    let routing_hint = Uuid::new_v5(namespace, &project_id_slug_key);
 
     Ok(ProcessedCheckInResult {
         routing_hint,

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -200,13 +200,10 @@ pub fn process_check_in(
     // Use the project_id + monitor_slug as the routing key hint. This helps ensure monitor
     // check-ins are processed in order by consistently routing check-ins from the same monitor.
 
-    let project_id_slug_key = [
-        &project_id.value().to_be_bytes(),
-        check_in.monitor_slug.as_bytes(),
-    ]
-    .concat();
+    let slug = &check_in.monitor_slug;
+    let project_id_slug_key = format!("{project_id}:{slug}");
 
-    let routing_hint = Uuid::new_v5(namespace, &project_id_slug_key);
+    let routing_hint = Uuid::new_v5(namespace, project_id_slug_key.as_bytes());
 
     Ok(ProcessedCheckInResult {
         routing_hint,

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -329,7 +329,7 @@ mod tests {
         let result = process_check_in(json.as_bytes(), ProjectId::new(1));
 
         // The routing_hint should be consistent for the (project_id, monitor_slug)
-        let expected_uuid = Uuid::parse_str("3612580a-5d37-594b-9a90-d8142792f9c8").unwrap();
+        let expected_uuid = Uuid::parse_str("66e5c5fa-b1b9-5980-8d85-432c1874521a").unwrap();
 
         if let Ok(processed_result) = result {
             assert_eq!(String::from_utf8(processed_result.payload).unwrap(), json);

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1117,9 +1117,10 @@ impl EnvelopeProcessorService {
                 return ItemAction::Keep;
             }
 
-            match relay_monitors::process_check_in(&item.payload()) {
-                Ok(processed) => {
-                    item.set_payload(ContentType::Json, processed);
+            match relay_monitors::process_check_in(&item.payload(), state.project_id) {
+                Ok(result) => {
+                    item.set_routing_hint(result.routing_hint);
+                    item.set_payload(ContentType::Json, result.payload);
                     ItemAction::Keep
                 }
                 Err(error) => {


### PR DESCRIPTION
This change will group check-ins beloning to the same monitor into the same partition.

This is valuable since it will help to better grantee the ordering of check-ins during processing. Though by no means does this solve all ordering issues

#skip-changelog