### PR TITLE
chore(self-hosted): Publish relay image to dockerhub again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,3 +440,49 @@ jobs:
         run: |
           echo "Testing against ${RELAY_TEST_IMAGE}"
           make test-relay-integration
+
+  publish-to-dockerhub:
+    name: Publish Relay to DockerHub
+    needs: build
+    runs-on: ubuntu-20.04
+    if: ${{ (github.ref_name == 'master') }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - name: Pull the test image
+        id: image_pull
+        env:
+          IMAGE_URL: ghcr.io/getsentry/relay:${{ github.sha }}
+        shell: bash
+        run: |
+          echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
+          echo "Polling for $IMAGE_URL"
+          timeout 20m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
+      - name: Get short SHA for docker tag
+        id: short_sha
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          if [[ -z "$SHORT_SHA" ]]; then
+            echo "Short SHA empty? Re-running rev-parse."
+            git rev-parse --short "$GITHUB_SHA"
+          else
+            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          fi
+      - name: Push built docker image
+        shell: bash
+        env:
+          SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
+          IMAGE_URL: ghcr.io/getsentry/relay:${{ github.sha }}
+        run: |
+          # only login if the password is set
+          if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
+          # We push 3 tags to Dockerhub:
+          # first, the full sha of the commit
+          docker tag ${IMAGE_URL} getsentry/relay:${GITHUB_SHA}
+          docker push getsentry/relay:${GITHUB_SHA}
+          # second, the short sha of the commit
+          docker tag ${IMAGE_URL} getsentry/relay:${SHORT_SHA}
+          docker push getsentry/relay:${SHORT_SHA}
+          # finally, nightly
+          docker tag ${IMAGE_URL} getsentry/relay:nightly
+          docker push getsentry/relay:nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,42 +447,22 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ (github.ref_name == 'master') }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-      - name: Pull the test image
-        id: image_pull
-        env:
-          IMAGE_URL: ghcr.io/getsentry/relay:${{ github.sha }}
-        shell: bash
-        run: |
-          echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
-          echo "Polling for $IMAGE_URL"
-          timeout 20m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
-      - name: Get short SHA for docker tag
-        id: short_sha
-        shell: bash
-        run: |
-          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          if [[ -z "$SHORT_SHA" ]]; then
-            echo "Short SHA empty? Re-running rev-parse."
-            git rev-parse --short "$GITHUB_SHA"
-          else
-            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-          fi
+      - uses: actions/checkout@v3
+      - timeout-minutes: 20
+        run: until docker pull "ghcr.io/getsentry/relay:${{ github.sha }}" 2>/dev/null; do sleep 10; done
       - name: Push built docker image
         shell: bash
-        env:
-          SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
-          IMAGE_URL: ghcr.io/getsentry/relay:${{ github.sha }}
         run: |
-          # only login if the password is set
-          if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
+          IMAGE_URL="ghcr.io/getsentry/relay:${{ github.sha }}"
+          docker login --username=sentrybuilder --password ${{ secrets.DOCKER_HUB_RW_TOKEN }}
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit
-          docker tag ${IMAGE_URL} getsentry/relay:${GITHUB_SHA}
+          docker tag "$IMAGE_URL" getsentry/relay:${GITHUB_SHA}
           docker push getsentry/relay:${GITHUB_SHA}
           # second, the short sha of the commit
-          docker tag ${IMAGE_URL} getsentry/relay:${SHORT_SHA}
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          docker tag "$IMAGE_URL" getsentry/relay:${SHORT_SHA}
           docker push getsentry/relay:${SHORT_SHA}
           # finally, nightly
-          docker tag ${IMAGE_URL} getsentry/relay:nightly
+          docker tag "$IMAGE_URL" getsentry/relay:nightly
           docker push getsentry/relay:nightly


### PR DESCRIPTION
was removed during the [removal of e2e tests](https://github.com/getsentry/relay/pull/2446), this adds it back

#skip-changelog