### PR TITLE
feat(librelay): Support global config normalization

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))
 - Add a `DataCategory` for monitor seats (crons). ([#2480](https://github.com/getsentry/relay/pull/2480))
+- Expose global config normalization function. ([#2498](https://github.com/getsentry/relay/pull/2498))
 
 ## 0.8.29
 

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -272,9 +272,9 @@ def normalize_global_config(config):
 
     :param config: the global config to validate.
     """
-    config = json.dumps(config)
-    rv = rustcall(lib.normalize_global_config, encode_str(config))
-    decoded = decode_str(rv, free=True)
+    serialized = json.dumps(config)
+    normalized = rustcall(lib.normalize_global_config, encode_str(serialized))
+    decoded = decode_str(normalized, free=True)
     return json.loads(decoded)
 
 

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -29,6 +29,7 @@ __all__ = [
     "validate_sampling_condition",
     "validate_sampling_configuration",
     "validate_project_config",
+    "normalize_global_config",
     "run_dynamic_sampling",
 ]
 
@@ -259,6 +260,26 @@ def validate_project_config(config, strict: bool):
     error = decode_str(raw_error, free=True)
     if error:
         raise ValueError(error)
+
+
+def normalize_global_config(config):
+    """Normalize the global config.
+
+    Normalization consists on deserializing and serializing back the given
+    global config. If deserializing fails, throw an exception. Note that even if
+    the roundtrip doesn't produce errors, the given config may differ from
+    normalized one.
+
+    :param config: the global config to validate.
+    """
+    assert isinstance(config, str)
+    rv = rustcall(lib.normalize_global_config, encode_str(config))
+    try:
+        decoded = decode_str(rv, free=True)
+        parsed = json.loads(decoded)
+        return parsed
+    except Exception:
+        raise ValueError("Normalization error: incorrect input config")
 
 
 def run_dynamic_sampling(sampling_config, root_sampling_config, dsc, event):

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -265,21 +265,17 @@ def validate_project_config(config, strict: bool):
 def normalize_global_config(config):
     """Normalize the global config.
 
-    Normalization consists on deserializing and serializing back the given
+    Normalization consists of deserializing and serializing back the given
     global config. If deserializing fails, throw an exception. Note that even if
     the roundtrip doesn't produce errors, the given config may differ from
     normalized one.
 
     :param config: the global config to validate.
     """
-    assert isinstance(config, str)
+    config = json.dumps(config)
     rv = rustcall(lib.normalize_global_config, encode_str(config))
-    try:
-        decoded = decode_str(rv, free=True)
-        parsed = json.loads(decoded)
-        return parsed
-    except Exception:
-        raise ValueError("Normalization error: incorrect input config")
+    decoded = decode_str(rv, free=True)
+    return json.loads(decoded)
 
 
 def run_dynamic_sampling(sampling_config, root_sampling_config, dsc, event):

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -274,8 +274,11 @@ def normalize_global_config(config):
     """
     serialized = json.dumps(config)
     normalized = rustcall(lib.normalize_global_config, encode_str(serialized))
-    decoded = decode_str(normalized, free=True)
-    return json.loads(decoded)
+    rv = decode_str(normalized, free=True)
+    try:
+        return json.loads(rv)
+    except json.JSONDecodeError:
+        raise ValueError(rv)
 
 
 def run_dynamic_sampling(sampling_config, root_sampling_config, dsc, event):

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -295,8 +295,12 @@ def test_global_config_subset_normalized():
 
 def test_global_config_unparsable():
     config = {"measurements": {"maxCustomMeasurements": -5}}
-    with pytest.raises(json.decoder.JSONDecodeError):
+    with pytest.raises(ValueError) as e:
         sentry_relay.normalize_global_config(config)
+    assert (
+        str(e.value)
+        == "invalid value: integer `-5`, expected usize at line 1 column 45"
+    )
 
 
 def test_run_dynamic_sampling_with_valid_params_and_match():

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -281,6 +281,25 @@ def test_validate_project_config():
     assert str(e.value) == 'json atom at path ".foobar" is missing from rhs'
 
 
+def test_global_config_equal_normalization():
+    config = {"measurements": {"maxCustomMeasurements": 0}}
+    assert config == sentry_relay.normalize_global_config(json.dumps(config))
+
+
+def test_global_config_subset_normalized():
+    config = {"measurements": {"builtinMeasurements": [], "maxCustomMeasurements": 0}}
+    normalized = sentry_relay.normalize_global_config(json.dumps(config))
+    config["measurements"].pop("builtinMeasurements")
+    assert config == normalized
+
+
+def test_global_config_unparsable():
+    config = {"measurements": {"maxCustomMeasurements": -5}}
+    with pytest.raises(ValueError) as ex:
+        sentry_relay.normalize_global_config(json.dumps(config))
+    assert str(ex.value) == "Normalization error: incorrect input config"
+
+
 def test_run_dynamic_sampling_with_valid_params_and_match():
     sampling_config = """{
        "rules": [],

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -283,21 +283,20 @@ def test_validate_project_config():
 
 def test_global_config_equal_normalization():
     config = {"measurements": {"maxCustomMeasurements": 0}}
-    assert config == sentry_relay.normalize_global_config(json.dumps(config))
+    assert config == sentry_relay.normalize_global_config(config)
 
 
 def test_global_config_subset_normalized():
     config = {"measurements": {"builtinMeasurements": [], "maxCustomMeasurements": 0}}
-    normalized = sentry_relay.normalize_global_config(json.dumps(config))
+    normalized = sentry_relay.normalize_global_config(config)
     config["measurements"].pop("builtinMeasurements")
     assert config == normalized
 
 
 def test_global_config_unparsable():
     config = {"measurements": {"maxCustomMeasurements": -5}}
-    with pytest.raises(ValueError) as ex:
-        sentry_relay.normalize_global_config(json.dumps(config))
-    assert str(ex.value) == "Normalization error: incorrect input config"
+    with pytest.raises(json.decoder.JSONDecodeError):
+        sentry_relay.normalize_global_config(config)
 
 
 def test_run_dynamic_sampling_with_valid_params_and_match():

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -612,6 +612,11 @@ struct RelayStr relay_validate_project_config(const struct RelayStr *value,
                                               bool strict);
 
 /**
+ * Normalize a global config.
+ */
+struct RelayStr normalize_global_config(const struct RelayStr *value);
+
+/**
  * Runs dynamic sampling given the sampling config, root sampling config, DSC and event.
  *
  * Returns the sampling decision containing the sample_rate and the list of matched rule ids.

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -332,7 +332,6 @@ pub unsafe extern "C" fn relay_validate_project_config(
 /// Normalize a global config.
 #[no_mangle]
 #[relay_ffi::catch_unwind]
-// pub unsafe extern "C" fn normalize_global_config(value: *const RelayStr) -> NormalizationResult {
 pub unsafe extern "C" fn normalize_global_config(value: *const RelayStr) -> RelayStr {
     let value = (*value).as_str();
     match normalize_json::<GlobalConfig>(value) {

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -11,7 +11,7 @@ use std::slice;
 use chrono::Utc;
 use once_cell::sync::OnceCell;
 use relay_common::glob::{glob_match_bytes, GlobOptions};
-use relay_dynamic_config::{validate_json, ProjectConfig};
+use relay_dynamic_config::{normalize_json, validate_json, GlobalConfig, ProjectConfig};
 use relay_event_normalization::{
     light_normalize_event, GeoIpLookup, LightNormalizationConfig, RawUserAgentInfo, StoreConfig,
     StoreProcessor,
@@ -326,6 +326,18 @@ pub unsafe extern "C" fn relay_validate_project_config(
     match validate_json::<ProjectConfig>(value, strict) {
         Ok(()) => RelayStr::default(),
         Err(e) => RelayStr::from_string(e.to_string()),
+    }
+}
+
+/// Normalize a global config.
+#[no_mangle]
+#[relay_ffi::catch_unwind]
+// pub unsafe extern "C" fn normalize_global_config(value: *const RelayStr) -> NormalizationResult {
+pub unsafe extern "C" fn normalize_global_config(value: *const RelayStr) -> RelayStr {
+    let value = (*value).as_str();
+    match normalize_json::<GlobalConfig>(value) {
+        Ok(normalized) => RelayStr::from_string(normalized),
+        Err(_) => RelayStr::default(),
     }
 }
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -336,7 +336,7 @@ pub unsafe extern "C" fn normalize_global_config(value: *const RelayStr) -> Rela
     let value = (*value).as_str();
     match normalize_json::<GlobalConfig>(value) {
         Ok(normalized) => RelayStr::from_string(normalized),
-        Err(_) => RelayStr::default(),
+        Err(e) => RelayStr::from_string(e.to_string()),
     }
 }
 

--- a/relay-dynamic-config/src/utils.rs
+++ b/relay-dynamic-config/src/utils.rs
@@ -2,6 +2,16 @@ use assert_json_diff::{assert_json_matches_no_panic, CompareMode, Config};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Normalizes the given value by deserializing it and serializing it back.
+pub fn normalize_json<'de, S>(value: &'de str) -> anyhow::Result<String>
+where
+    S: Serialize + Deserialize<'de>,
+{
+    let deserialized: S = serde_json::from_str(value)?;
+    let serialized = serde_json::to_value(&deserialized)?.to_string();
+    Ok(serialized)
+}
+
 /// Validate that the given JSON resolves to a valid instance of type `S`.
 ///
 /// If `strict` is true, verify that reserializing the instance results in the same fields.


### PR DESCRIPTION
Exposes a global config normalization function. This is to be used for validating a correct global config.

Normalization consists of deserializing and serializing back a global config. The serialized output looks like what Relay forwards downstream, and an exception is thrown if the input is unparsable.