### PR TITLE
doc(services): Document global config service must start first

### DIFF
--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -85,6 +85,9 @@ impl UpstreamQuery for GetGlobalConfig {
 pub struct Get;
 
 /// The message for receiving a watch that subscribes to the [`GlobalConfigService`].
+///
+/// The global config service must be up and running, else the subscription
+/// fails.
 pub struct Subscribe;
 
 /// An interface to get [`GlobalConfig`]s through [`GlobalConfigService`].

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -121,7 +121,8 @@ impl ServiceState {
             OutcomeAggregator::new(&config, outcome_producer.clone()).start_in(&runtimes.outcome);
 
         // The global config service must start before dependant services are
-        // started, for subscription requests to be successful.
+        // started. Messages like subscription requests to the global config
+        // service fail if the service is not running.
         let global_config =
             GlobalConfigService::new(config.clone(), upstream_relay.clone()).start();
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -120,6 +120,8 @@ impl ServiceState {
         let outcome_aggregator =
             OutcomeAggregator::new(&config, outcome_producer.clone()).start_in(&runtimes.outcome);
 
+        // The global config service must start before dependant services are
+        // started, for subscription requests to be successful.
         let global_config =
             GlobalConfigService::new(config.clone(), upstream_relay.clone()).start();
 


### PR DESCRIPTION
Services wanting to get timely global config updates can easily get them by subscribing to the global config service. The requirement is for the global config service to start first, to handle subscription messages. This PR documents this requirement.

#skip-changelog