### PR TITLE
docs(dashboard): Add instructions for required WASM target

### DIFF
--- a/relay-dashboard/README.md
+++ b/relay-dashboard/README.md
@@ -11,6 +11,16 @@ Right now you can:
 
 # Development
 
+## Requirements
+
+First, install the WASM target:
+
+```sh
+rustup target add wasm32-unknown-unknown
+```
+
+## Running
+
 Run Relay:
 
 ```sh

--- a/relay-dashboard/README.md
+++ b/relay-dashboard/README.md
@@ -13,7 +13,7 @@ Right now you can:
 
 ## Requirements
 
-First, install the WASM target:
+In order to build the dashboard, an additional compilation target is required:
 
 ```sh
 rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
The target `wasm32-unknown-unknown` is required for the build. This PR documents it in the README.

#skip-changelog