### PR TITLE
ref(metrics): Remove deprecated `Metric` type and improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Merge span metrics and standalone spans extraction options. ([#2447](https://github.com/getsentry/relay/pull/2447))
 - Support parsing aggregated metric buckets directly from statsd payloads. ([#2468](https://github.com/getsentry/relay/pull/2468), [#2472](https://github.com/getsentry/relay/pull/2472))
 - Improve performance when ingesting distribution metrics with a large number of data points. ([#2483](https://github.com/getsentry/relay/pull/2483))
+- Improve documentation for metrics bucketing. ([#2503](https://github.com/getsentry/relay/pull/2503))
 - Rename the envelope item type for StatsD payloads to "statsd". ([#2470](https://github.com/getsentry/relay/pull/2470))
 - Add a nanojoule unit for profile measurements. ([#2478](https://github.com/getsentry/relay/pull/2478))
 - Add a timestamp field to report profile's start time on Android. ([#2486](https://github.com/getsentry/relay/pull/2486))

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -614,7 +614,7 @@ pub struct Bucket {
 }
 
 impl Bucket {
-    /// Parse a statsd-compatible payload.
+    /// Parses a statsd-compatible payload.
     ///
     /// ```text
     /// [<ns>/]<name>[@<unit>]:<value>|<type>[|#<tags>]`

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -136,52 +136,124 @@ pub type SetValue = BTreeSet<SetType>;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value")]
 pub enum BucketValue {
-    /// Aggregates [`MetricValue::Counter`](crate::MetricValue::Counter) values by adding them into
-    /// a single value.
+    /// Counts instances of an event ([`MetricType::Counter`]).
+    ///
+    /// Counters can be incremented and decremented. The default operation is to increment a counter
+    /// by `1`, although increments by larger values are equally possible.
+    ///
+    /// # Statsd Format
+    ///
+    /// Counters are declared as `"c"`. Alternatively, `"m"` is allowed.
+    ///
+    /// There can be a variable number of floating point values. If more than one value is given,
+    /// the values are summed into a single counter value:
     ///
     /// ```text
-    /// 2, 1, 3, 2 => 8
+    /// endpoint.hits:4.5:21:17.0|c
     /// ```
+    ///
+    /// # Serialization
     ///
     /// This variant serializes to a double precision float.
+    ///
+    /// # Aggregation
+    ///
+    /// Counters aggregate by folding individual values into a single sum value per bucket. The sum
+    /// is ingested and stored directly.
     #[serde(rename = "c")]
     Counter(CounterType),
-    /// Aggregates [`MetricValue::Distribution`](crate::MetricValue::Distribution) values by
-    /// collecting their values.
+
+    /// Builds a statistical distribution over values reported ([`MetricType::Distribution`]).
+    ///
+    /// Based on individual reported values, distributions allow to query the maximum, minimum, or
+    /// average of the reported values, as well as statistical quantiles. With an increasing number
+    /// of values in the distribution, its accuracy becomes approximate.
+    ///
+    /// # Statsd Format
+    ///
+    /// Distributions are declared as `"d"`. Alternatively, `"d"` and `"ms"` are allowed.
+    ///
+    /// There can be a variable number of floating point values. These values are collected directly
+    /// in a list per bucket.
     ///
     /// ```text
-    /// 2, 1, 3, 2 => [1, 2, 2, 3]
+    /// endpoint.response_time@millisecond:36:49:57:68|d
     /// ```
+    ///
+    /// # Serialization
     ///
     /// This variant serializes to a list of double precision floats, see [`DistributionValue`].
+    ///
+    /// # Aggregation
+    ///
+    /// During ingestion, all individual reported values are collected in a lossless format. In
+    /// storage, these values are compressed into data sketches that allow to query quantiles.
+    /// Separately, the count and sum of the reported values is stored, which makes distributions a
+    /// strict superset of counters.
     #[serde(rename = "d")]
     Distribution(DistributionValue),
-    /// Aggregates [`MetricValue::Set`](crate::MetricValue::Set) values by storing their hash values
-    /// in a set.
+
+    /// Counts the number of unique reported values.
+    ///
+    /// Sets allow sending arbitrary discrete values, including strings, and store the deduplicated
+    /// count. With an increasing number of unique values in the set, its accuracy becomes
+    /// approximate. It is not possible to query individual values from a set.
+    ///
+    /// # Statsd Format
+    ///
+    /// Sets are declared as `"s"`. Values in the list should be deduplicated.
+    ///
     ///
     /// ```text
-    /// 2, 1, 3, 2 => {1, 2, 3}
+    /// endpoint.users:3182887624:4267882815|s
+    /// endpoint.users:e2546e4c-ecd0-43ad-ae27-87960e57a658|s
     /// ```
+    ///
+    /// # Serialization
     ///
     /// This variant serializes to a list of 32-bit integers.
+    ///
+    /// # Aggregation
+    ///
+    /// Set values are internally represented as 32-bit integer hashes of the original value. These
+    /// hashes can be ingested directly as seen in the first example above. If raw strings are sent,
+    /// they will be hashed on-the-fly.
+    ///
+    /// Internally, set metrics are stored in data sketches that expose an approximate cardinality.
     #[serde(rename = "s")]
     Set(SetValue),
-    /// Aggregates [`MetricValue::Gauge`](crate::MetricValue::Gauge) values always retaining the
-    /// latest, minimum, and maximum value, as well as the sum and count of all values.
+
+    /// Stores absolute snapshots of values.
     ///
-    /// **Note**: The "last" component of this aggregation is not commutative.
+    /// In addition to plain [counters](Self::Counter), gauges store a snapshot of the maximum,
+    /// minimum and sum of all values, as well as the last reported value. Note that the "last"
+    /// component of this aggregation is not commutative. Which value is preserved as last value is
+    /// implementation-defined.
+    ///
+    /// # Statsd Format
+    ///
+    /// Gauges are declared as `"g"`. There are two ways to ingest gauges:
+    ///  1. As a single value. In this case, the provided value is assumed as the last, minimum,
+    ///     maximum, and the sum.
+    ///  2. As a sequence of five values in the order: `last`, `min`, `max`, `sum`, `count`.
     ///
     /// ```text
-    /// 1, 2, 3, 2 => {
-    ///   last: 2
-    ///   min: 1,
-    ///   max: 3,
-    ///   sum: 8,
-    ///   count: 4,
-    /// }
+    /// endpoint.parallel_requests:25|g
+    /// endpoint.parallel_requests:25:17:42:220:85|g
     /// ```
     ///
-    /// This variant serializes to a structure, see [`GaugeValue`].
+    /// # Serialization
+    ///
+    /// This variant serializes to a structure with named fields, see [`GaugeValue`].
+    ///
+    /// # Aggregation
+    ///
+    /// Gauges aggregate by folding each of the components based on their semantics:
+    ///  - `last` assumes the newly added value
+    ///  - `min` retains the smaller value
+    ///  - `max` retains the larger value
+    ///  - `sum` adds the new value to the existing sum
+    ///  - `count` adds the count of the newly added gauge (defaulting to `1`)
     #[serde(rename = "g")]
     Gauge(GaugeValue),
 }
@@ -400,10 +472,10 @@ fn parse_timestamp(string: &str) -> Option<UnixTimestamp> {
 /// # Submission Protocol
 ///
 /// ```text
-/// <name>[@unit]:<value>[:<value>...]|<type>|#<tag_key>:<tag_value>,<tag>
+/// <name>[@unit]:<value>[:<value>...]|<type>|#<tag_key>:<tag_value>,<tag>|T<timestamp>
 /// ```
 ///
-/// See the field documentation on this struct for more information on the components. An example
+/// See the field documentation on [`Bucket`] for more information on the components. An example
 /// submission looks like this:
 ///
 /// ```text
@@ -414,24 +486,17 @@ fn parse_timestamp(string: &str) -> Option<UnixTimestamp> {
 ///
 /// # JSON Representation
 ///
-/// In addition to the submission protocol, metrics can be represented as structured data in JSON.
-/// In addition to the field values from the submission protocol, a timestamp is added to every
-/// metric (see [crate documentation](crate)).
+/// Alternatively to the submission protocol, metrics can be represented as structured data in JSON.
+/// The data type of the `value` field is determined by the metric type.
+///
+/// In addition to the submission protocol, buckets have a required [`width`](Self::width) field in
+/// their JSON representation.
 ///
 /// ```json
 #[doc = include_str!("../tests/fixtures/buckets.json")]
 /// ```
 ///
-/// # Submission Protocol
-///
-/// Buckets are always represented as JSON. The data type of the `value` field is determined by the
-/// metric type.
-///
-/// ```json
-#[doc = include_str!("../tests/fixtures/buckets.json")]
-/// ```
-///
-/// To parse a submission payload, use [`Bucket::parse_all`].
+/// To parse a JSON payload, use [`serde_json`].
 ///
 /// # Hashing of Sets
 ///
@@ -452,33 +517,105 @@ fn parse_timestamp(string: &str) -> Option<UnixTimestamp> {
 /// ```
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Bucket {
-    /// The start time of the time window.
+    /// The start time of the bucket's time window.
     ///
     /// If a timestamp is not supplied as part of the submission payload, the default timestamp
     /// supplied to [`Bucket::parse`] or [`Bucket::parse_all`] is associated with the metric. It is
     /// then aligned with the aggregation window.
-    pub timestamp: UnixTimestamp,
-    /// The length of the time window in seconds.
-    pub width: u64,
-    /// The MRI (metric resource identifier).
     ///
-    /// See [`Metric::name`](crate::Metric::name).
+    /// # Statsd Format
+    ///
+    /// In statsd, timestamps are part of the `|`-separated list following values. Timestamps start
+    /// with with the literal character `'T'` followed by the UNIX timestamp.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// endpoint.hits:1|c|T1615889440
+    /// ```
+    pub timestamp: UnixTimestamp,
+
+    /// The length of the time window in seconds.
+    ///
+    /// To initialize a new bucket, choose `0` as width. Once the bucket is tracked by Relay's
+    /// aggregator, the width is aligned with configuration for the namespace and the  timestamp is
+    /// adjusted accordingly.
+    ///
+    /// # Statsd Format
+    ///
+    /// Specifying the bucket width in statsd is not supported.
+    pub width: u64,
+
+    /// The name of the metric in MRI (metric resource identifier) format.
+    ///
+    /// MRIs have the format `<type>:<ns>/<name>@<unit>`. See [`MetricResourceIdentifier`] for
+    /// information on fields and representations.
+    ///
+    /// # Statsd Format
+    ///
+    /// MRIs are sent in a more relaxed format: `[<namespace/]name[@unit]`. The value type is not
+    /// part of the metric name and namespaces are optional.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// endpoint.hits:1|c
+    /// custom/endpoint.hits:1|c
+    /// custom/endpoint.duration@millisecond:21.5|d
+    /// ```
     pub name: String,
+
     /// The type and aggregated values of this bucket.
     ///
-    /// See [`Metric::value`](crate::Metric::value) for a mapping to inbound data.
+    /// Buckets support multiple values that are aggregated and can be accessed using a range of
+    /// aggregation functions depending on the value type. While always a variable number of values
+    /// can be sent in, some aggregations reduce the raw values to a fixed set of aggregates.
+    ///
+    /// See [`BucketValue`] for more examples and semantics.
+    ///
+    /// # Statsd Payload
+    ///
+    /// The bucket value and its type are specified in separate fields following the metric name in
+    /// the format: `<name>:<value>|<type>`. Values must be base-10 floating point numbers with
+    /// optional decimal places.
+    ///
+    /// It is possible to pack multiple values into a single datagram, but note that the type and
+    /// the value representation must match for this. Refer to the [`BucketValue`] docs for more
+    /// examples.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// endpoint.hits:21|c
+    /// endpoint.hits:4.5|c
+    /// ```
     #[serde(flatten)]
     pub value: BucketValue,
+
     /// A list of tags adding dimensions to the metric for filtering and aggregation.
     ///
-    /// See [`Metric::tags`](crate::Metric::tags). Every combination of tags results in a different
-    /// bucket.
+    /// Tags allow to compute separate aggregates to filter or group metric values by any number of
+    /// dimensions. Tags consist of a unique tag key and one associated value. For tags with missing
+    /// values, an empty `""` value is assumed at query time.
+    ///
+    /// # Statsd Format
+    ///
+    /// Tags are preceded with a hash `#` and specified in a comma (`,`) separated list. Each tag
+    /// can either be a tag name, or a `name:value` combination. Tags are optional and can be
+    /// omitted.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// endpoint.hits:1|c|#route:user_index,environment:production,release:1.4.0
+    /// ```
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub tags: BTreeMap<String, String>,
 }
 
 impl Bucket {
-    /// Parse statsd-compatible payload of format
+    /// Parse a statsd-compatible payload.
+    ///
     /// ```text
     /// [<ns>/]<name>[@<unit>]:<value>|<type>[|#<tags>]`
     /// ```

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Protocol
 //!
-//! Clients submit metrics in a [text-based protocol](Metric) based on StatsD. A sample submission
+//! Clients submit metrics in a [text-based protocol](Bucket) based on StatsD. A sample submission
 //! looks like this:
 //!
 //! ```text

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -1,10 +1,8 @@
-use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
 use std::hash::Hasher as _;
 
 use hash32::{FnvHasher, Hasher as _};
-use serde::{Deserialize, Serialize};
 
 #[doc(inline)]
 pub use relay_base_schema::metrics::{
@@ -25,85 +23,38 @@ pub type SetType = u32;
 /// Type used for Gauge entries
 pub type GaugeType = f64;
 
-/// The [typed value](Metric::value) of a metric.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(tag = "type", content = "value")]
-pub enum MetricValue {
-    /// Counts instances of an event. See [`MetricType::Counter`].
-    #[serde(rename = "c")]
-    Counter(CounterType),
-    /// Builds a statistical distribution over values reported. See [`MetricType::Distribution`].
-    #[serde(rename = "d")]
-    Distribution(DistributionType),
-    /// Counts the number of unique reported values. See [`MetricType::Set`].
-    ///
-    /// Set values can be specified as strings in the submission protocol. They are always hashed
-    /// into a 32-bit value and the original value is dropped. If the submission protocol contains a
-    /// 32-bit integer, it will be used directly, instead.
-    #[serde(rename = "s")]
-    Set(SetType),
-    /// Stores absolute snapshots of values. See [`MetricType::Gauge`].
-    #[serde(rename = "g")]
-    Gauge(GaugeType),
-}
-
-impl MetricValue {
-    /// Creates a [`MetricValue::Set`] from the given string.
-    pub fn set_from_str(string: &str) -> Self {
-        Self::Set(hash_set_value(string))
-    }
-
-    /// Creates a [`MetricValue::Set`] from any type that implements `Display`.
-    pub fn set_from_display(display: impl fmt::Display) -> Self {
-        Self::set_from_str(&display.to_string())
-    }
-
-    /// Returns the type of this value.
-    pub fn ty(&self) -> MetricType {
-        match self {
-            Self::Counter(_) => MetricType::Counter,
-            Self::Distribution(_) => MetricType::Distribution,
-            Self::Set(_) => MetricType::Set,
-            Self::Gauge(_) => MetricType::Gauge,
-        }
-    }
-}
-
-impl fmt::Display for MetricValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MetricValue::Counter(value) => value.fmt(f),
-            MetricValue::Distribution(value) => value.fmt(f),
-            MetricValue::Set(value) => value.fmt(f),
-            MetricValue::Gauge(value) => value.fmt(f),
-        }
-    }
-}
-
-/// The type of a [`MetricValue`], determining its aggregation and evaluation.
+/// The type of a [`BucketValue`](crate::BucketValue), determining its aggregation and evaluation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum MetricType {
     /// Counts instances of an event.
     ///
     /// Counters can be incremented and decremented. The default operation is to increment a counter
     /// by `1`, although increments by larger values are equally possible.
+    ///
+    /// Counters are declared as `"c"`. Alternatively, `"m"` is allowed.
     Counter,
     /// Builds a statistical distribution over values reported.
     ///
     /// Based on individual reported values, distributions allow to query the maximum, minimum, or
     /// average of the reported values, as well as statistical quantiles. With an increasing number
     /// of values in the distribution, its accuracy becomes approximate.
+    ///
+    /// Distributions are declared as `"d"`. Alternatively, `"d"` and `"ms"` are allowed.
     Distribution,
     /// Counts the number of unique reported values.
     ///
     /// Sets allow sending arbitrary discrete values, including strings, and store the deduplicated
     /// count. With an increasing number of unique values in the set, its accuracy becomes
     /// approximate. It is not possible to query individual values from a set.
+    ///
+    /// Sets are declared as `"s"`.
     Set,
     /// Stores absolute snapshots of values.
     ///
     /// In addition to plain [counters](Self::Counter), gauges store a snapshot of the maximum,
     /// minimum and sum of all values, as well as the last reported value.
+    ///
+    /// Gauges are declared as `"g"`.
     Gauge,
 }
 
@@ -155,14 +106,23 @@ impl Error for ParseMetricError {}
 
 /// The namespace of a metric.
 ///
-/// Namespaces allow to identify the product entity that the metric got extracted from, and/or
-/// identify the use case that the metric belongs to. These namespaces cannot be defined freely,
-/// instead they are defined by Sentry. Over time, there will be more namespaces as we introduce
-/// new metrics-based products.
+/// Namespaces allow to identify the product entity that the metric got extracted from, and identify
+/// the use case that the metric belongs to. These namespaces cannot be defined freely, instead they
+/// are defined by Sentry. Over time, there will be more namespaces as we introduce new
+/// metrics-based functionality.
 ///
-/// Right now this successfully deserializes any kind of string, but in reality only `"sessions"`
-/// (for release health) and `"transactions"` (for metrics-enhanced performance) is supported.
-/// Everything else is dropped both in the metrics aggregator and in the store service.
+/// # Parsing
+///
+/// Parsing a metric namespace from strings is infallible. Unknown strings are mapped to
+/// [`MetricNamespace::Unsupported`]. Metrics with such a namespace will be dropped.
+///
+/// # Ingestion
+///
+/// During ingestion, the metric namespace is validated against a list of known and enabled
+/// namespaces. Metrics in disabled namespaces are dropped during ingestion.
+///
+/// At a later stage, namespaces are used to route metrics to their associated infra structure and
+/// enforce usecase-specific configuration.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MetricNamespace {
     /// Metrics extracted from sessions.
@@ -213,26 +173,70 @@ impl fmt::Display for MetricNamespace {
     }
 }
 
-/// A metric name parsed as MRI, a naming scheme which includes most of the metric's bucket key
-/// (excl. timestamp and tags).
+/// A unique identifier for metrics including typing and namespacing.
 ///
-/// For more information see [`Metric::name`].
-#[derive(Debug)]
+/// MRIs have the format `<type>:<namespace>/<name>[@<unit>]`. The unit is optional and defaults to
+/// [`MetricUnit::None`].
+///
+/// # Statsd Format
+///
+/// In the statsd submission payload, MRIs are sent in a more relaxed format:
+/// `[<namespace/]name[@unit]`. The differences to the internal MRI format are:
+///  - Types are not part of metric naming. Instead, the type is declared in a separate field
+///    following the value.
+///  - The namespace is optional. If missing, `"custom"` is assumed.
+///
+/// # Background
+///
+/// MRIs follow three core principles:
+///
+/// 1. **Robustness:** Metrics must be addressed via a stable identifier. During ingestion in Relay
+///    and Snuba, metrics are preaggregated and bucketed based on this identifier, so it cannot
+///    change over time without breaking bucketing.
+/// 2. **Uniqueness:** The identifier for metrics must be unique across variations of units and
+///    metric types, within and across use cases, as well as between projects and organizations.
+/// 3. **Abstraction:** The user-facing product changes its terminology over time, and splits
+///    concepts into smaller parts. The internal metric identifiers must abstract from that, and
+///    offer sufficient granularity to allow for such changes.
+///
+/// # Example
+///
+/// ```
+/// use relay_metrics::MetricResourceIdentifier;
+///
+/// let string = "c:custom/test@second";
+/// let mri = MetricResourceIdentifier::parse(string).expect("should parse");
+/// assert_eq!(mri.to_string(), string);
+/// ```
+#[derive(Debug, PartialEq)]
 pub struct MetricResourceIdentifier<'a> {
-    /// The metric type.
+    /// The type of a metric, determining its aggregation and evaluation.
+    ///
+    /// In MRIs, the type is specified with its short name: counter (`c`), set (`s`), distribution
+    /// (`d`), and gauge (`g`). See [`MetricType`] for more information.
     pub ty: MetricType,
-    /// The namespace/usecase for this metric. For example `sessions` or `transactions`. In the
-    /// case of the statsd protocol, a missing namespace is converted into the valueconverted into
-    /// the value `"custom"`.
+
+    /// The namespace for this metric.
+    ///
+    /// In statsd submissions payloads, the namespace is optional and defaults to `"custom"`.
+    /// Otherwise, the namespace must be declared explicitly.
+    ///
+    /// Note that in Sentry the namespace is also referred to as "use case" or "usecase". There is a
+    /// list of known and enabled namespaces. Metrics of unknown or disabled namespaces are dropped
+    /// during ingestion.
     pub namespace: MetricNamespace,
-    /// The actual name, such as `duration` as part of `d:transactions/duration@ms`
+
+    /// The display name of the metric in the allowed character set.
     pub name: &'a str,
-    /// The metric unit.
+
+    /// The verbatim unit name of the metric value.
+    ///
+    /// The unit is optional and defaults to [`MetricUnit::None`] (`"none"`).
     pub unit: MetricUnit,
 }
 
 impl<'a> MetricResourceIdentifier<'a> {
-    /// Parses and validates an MRI of the form `<ty>:<ns>/<name>@<unit>`
+    /// Parses and validates an MRI.
     pub fn parse(name: &'a str) -> Result<Self, ParseMetricError> {
         // Note that this is NOT `VALUE_SEPARATOR`:
         let (raw_ty, rest) = name.split_once(':').ok_or(ParseMetricError(()))?;
@@ -311,94 +315,6 @@ pub(crate) fn hash_set_value(string: &str) -> u32 {
     hasher.finish32()
 }
 
-/// A single metric value representing the payload sent from clients.
-///
-/// As opposed to bucketed metric aggregations, this single metrics always represent a single
-/// submission and cannot store multiple values.
-///
-/// See the [crate documentation](crate) for general information on Metrics.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct Metric {
-    /// The metric resource identifier, in short MRI.
-    ///
-    /// MRIs follow three core principles:
-
-    /// 1. **Robustness:** Metrics must be addressed via a stable identifier. During ingestion in
-    ///    Relay and Snuba, metrics are preaggregated and bucketed based on this identifier, so it
-    ///    cannot change over time without breaking bucketing.
-    /// 2. **Uniqueness:** The identifier for metrics must be unique across variations of units and
-    ///    metric types, within and across use cases, as well as between projects and
-    ///    organizations.
-    /// 3. **Abstraction:** The user-facing product changes its terminology over time, and splits
-    ///    concepts into smaller parts. The internal metric identifiers must abstract from that,
-    ///    and offer sufficient granularity to allow for such changes.
-    ///
-    /// MRIs have the format `<type>:<ns>/<name>@<unit>`, comprising the following components:
-    ///
-    /// * **Type:** counter (`c`), set (`s`), distribution (`d`), gauge (`g`), and evaluated (`e`)
-    ///   for derived numeric metrics (the latter is a pure query-time construct and is not relevant
-    ///   to Relay or ingestion). See [`MetricType`].
-    /// * **Namespace:** Identifying the product entity and use case affiliation of the metric. See
-    /// [`MetricNamespace`].
-    /// * **Name:** The display name of the metric in the allowed character set.
-    /// * **Unit:** The verbatim unit name. See [`MetricUnit`].
-    ///
-    /// Parsing a metric (or set of metrics) should not fail hard if the MRI is invalid, so this is
-    /// typed as string. Later in the metrics aggregator, the MRI is parsed using
-    /// [`MetricResourceIdentifier`] and validated for invalid characters as well.
-    /// [`MetricResourceIdentifier`] is also used in the kafka producer to route certain namespaces
-    /// to certain topics.
-    pub name: String,
-    /// The value of the metric.
-    ///
-    /// [Distributions](MetricType::Distribution) and [counters](MetricType::Counter) require numeric
-    /// values which can either be integral or floating point. In contrast, [sets](MetricType::Set)
-    /// and [gauges](MetricType::Gauge) can store any unique value including custom strings.
-    #[serde(flatten)]
-    pub value: MetricValue,
-    /// The timestamp for this metric value.
-    pub timestamp: UnixTimestamp,
-    /// A list of tags adding dimensions to the metric for filtering and aggregation.
-    ///
-    /// Tags are preceded with a hash `#` and specified in a comma (`,`) separated list. Each tag
-    /// can either be a tag name, or a `name:value` combination. For tags with missing values, an
-    /// empty `""` value is assumed.
-    ///
-    /// Tags are optional and can be omitted.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub tags: BTreeMap<String, String>,
-}
-
-impl Metric {
-    /// Creates a new metric using the MRI naming format.
-    ///
-    /// See [`Metric::name`].
-    ///
-    /// MRI is the metric resource identifier in the format `<type>:<ns>/<name>@<unit>`. This name
-    /// ensures that just the name determines correct bucketing of metrics with name collisions.
-    pub fn new_mri(
-        namespace: MetricNamespace,
-        name: impl AsRef<str>,
-        unit: MetricUnit,
-        value: MetricValue,
-        timestamp: UnixTimestamp,
-        tags: BTreeMap<String, String>,
-    ) -> Self {
-        Self {
-            name: MetricResourceIdentifier {
-                ty: value.ty(),
-                name: name.as_ref(),
-                namespace,
-                unit,
-            }
-            .to_string(),
-            value,
-            timestamp,
-            tags,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use similar_asserts::assert_eq;
@@ -409,60 +325,5 @@ mod tests {
     fn test_sizeof_unit() {
         assert_eq!(std::mem::size_of::<MetricUnit>(), 16);
         assert_eq!(std::mem::align_of::<MetricUnit>(), 1);
-    }
-
-    #[test]
-    fn test_serde_json() {
-        let json = r#"{
-  "name": "foo",
-  "type": "c",
-  "value": 42.0,
-  "timestamp": 4711,
-  "tags": {
-    "empty": "",
-    "full": "value"
-  }
-}"#;
-
-        let metric = serde_json::from_str::<Metric>(json).unwrap();
-        insta::assert_debug_snapshot!(metric, @r#"
-        Metric {
-            name: "foo",
-            value: Counter(
-                42.0,
-            ),
-            timestamp: UnixTimestamp(4711),
-            tags: {
-                "empty": "",
-                "full": "value",
-            },
-        }
-        "#);
-
-        let string = serde_json::to_string_pretty(&metric).unwrap();
-        assert_eq!(string, json);
-    }
-
-    #[test]
-    fn test_serde_json_defaults() {
-        // NB: timestamp is required in JSON as opposed to the text representation
-        let json = r#"{
-            "name": "foo",
-            "value": 42,
-            "type": "c",
-            "timestamp": 4711
-        }"#;
-
-        let metric = serde_json::from_str::<Metric>(json).unwrap();
-        insta::assert_debug_snapshot!(metric, @r#"
-        Metric {
-            name: "foo",
-            value: Counter(
-                42.0,
-            ),
-            timestamp: UnixTimestamp(4711),
-            tags: {},
-        }
-        "#);
     }
 }

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -181,7 +181,7 @@ impl fmt::Display for MetricNamespace {
 /// # Statsd Format
 ///
 /// In the statsd submission payload, MRIs are sent in a more relaxed format:
-/// `[<namespace/]name[@unit]`. The differences to the internal MRI format are:
+/// `[<namespace>/]<name>[@<unit>]`. The differences to the internal MRI format are:
 ///  - Types are not part of metric naming. Instead, the type is declared in a separate field
 ///    following the value.
 ///  - The namespace is optional. If missing, `"custom"` is assumed.


### PR DESCRIPTION
Removes the unused `Metric` and `MetricValue` types in favor of `Bucket` and
`BucketValue`. Documentation has been moved to these types and expanded with
more examples.

