### PR TITLE
fix(server): Immediatly set global config to watch contents.

### DIFF
--- a/relay-server/src/actors/global_config.rs
+++ b/relay-server/src/actors/global_config.rs
@@ -87,7 +87,9 @@ pub struct Get;
 /// The message for receiving a watch that subscribes to the [`GlobalConfigService`].
 ///
 /// The global config service must be up and running, else the subscription
-/// fails.
+/// fails. Subscribers should use the initial value when they get the watch
+/// rather than only waiting for the watch to update, in case a global config
+///  is only updated once, such as is the case with the static config file.
 pub struct Subscribe;
 
 /// An interface to get [`GlobalConfig`]s through [`GlobalConfigService`].

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2807,6 +2807,10 @@ impl Service for EnvelopeProcessorService {
                 return;
             };
 
+            // In case we use static global config, the watch wont be updated repeatedly, so we
+            // should immediatly use the content of the watch.
+            self.global_config = subscription.borrow().clone();
+
             loop {
                 let next_msg = async {
                     let permit_result = semaphore.clone().acquire_owned().await;


### PR DESCRIPTION
Envelopeprocessorservice updated the global config only when the watch changed, however, if we use static config then the watch won't change after we first set its contents to the static config. If we subscribe after it was first set, we wouldn't ever get to use the static config in the envelope processor service.

to fix this, we immediatly update the  global config in envelope processor service to the contents of the watch. 

#skip-changelog