### PR TITLE
ref(metrics): Automatically track namespace as tag

### DIFF
--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -163,7 +163,7 @@ impl Error for ParseMetricError {}
 /// Right now this successfully deserializes any kind of string, but in reality only `"sessions"`
 /// (for release health) and `"transactions"` (for metrics-enhanced performance) is supported.
 /// Everything else is dropped both in the metrics aggregator and in the store service.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MetricNamespace {
     /// Metrics extracted from sessions.
     Sessions,
@@ -185,6 +185,19 @@ pub enum MetricNamespace {
     Unsupported,
 }
 
+impl MetricNamespace {
+    /// Returns the string representation for this metric type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MetricNamespace::Sessions => "sessions",
+            MetricNamespace::Transactions => "transactions",
+            MetricNamespace::Spans => "spans",
+            MetricNamespace::Custom => "custom",
+            MetricNamespace::Unsupported => "unsupported",
+        }
+    }
+}
+
 impl std::str::FromStr for MetricNamespace {
     type Err = ParseMetricError;
 
@@ -203,13 +216,7 @@ relay_common::impl_str_serde!(MetricNamespace, "a valid metric namespace");
 
 impl fmt::Display for MetricNamespace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MetricNamespace::Sessions => write!(f, "sessions"),
-            MetricNamespace::Transactions => write!(f, "transactions"),
-            MetricNamespace::Spans => write!(f, "spans"),
-            MetricNamespace::Custom => write!(f, "custom"),
-            MetricNamespace::Unsupported => write!(f, "unsupported"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -13,7 +13,7 @@ pub enum MetricSets {
     ///
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_name`: A low-cardinality representation of the metric name.
+    ///  - `namespace`: The namespace of the metric for which the bucket was created.
     UniqueBucketsCreated,
 }
 
@@ -31,14 +31,14 @@ pub enum MetricCounters {
     ///
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_name`: A low-cardinality representation of the metric name.
+    ///  - `namespace`: The namespace of the metric.
     MergeHit,
 
     /// Incremented every time a bucket is created.
     ///
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_name`: A low-cardinality representation of the metric name.
+    ///  - `namespace`: The namespace of the metric.
     MergeMiss,
 
     /// Incremented every time a bucket is dropped.
@@ -170,8 +170,8 @@ pub enum MetricGauges {
     /// The average number of elements in a bucket when flushed.
     ///
     /// This metric is tagged with:
-    ///  - `metric_type`: "counter", "distribution", "gauge" or "set".
-    ///  - `metric_name`: Low-cardinality name of the metric.
+    ///  - `metric_type`: "c", "d", "g" or "s".
+    ///  - `namespace`: The namespace of the metric.
     AvgBucketSize,
 }
 

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -1,7 +1,5 @@
 use relay_statsd::{CounterMetric, GaugeMetric, HistogramMetric, SetMetric, TimerMetric};
 
-use crate::BucketValue;
-
 /// Set metrics for Relay Metrics.
 pub enum MetricSets {
     /// Count the number of unique buckets created.
@@ -15,7 +13,7 @@ pub enum MetricSets {
     ///
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_name`: A low-cardinality representation of the metric name (see [`metric_name_tag`]).
+    ///  - `metric_name`: A low-cardinality representation of the metric name.
     UniqueBucketsCreated,
 }
 
@@ -33,14 +31,14 @@ pub enum MetricCounters {
     ///
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_name`: A low-cardinality representation of the metric name (see [`metric_name_tag`]).
+    ///  - `metric_name`: A low-cardinality representation of the metric name.
     MergeHit,
 
     /// Incremented every time a bucket is created.
     ///
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
-    ///  - `metric_name`: A low-cardinality representation of the metric name (see [`metric_name_tag`]).
+    ///  - `metric_name`: A low-cardinality representation of the metric name.
     MergeMiss,
 
     /// Incremented every time a bucket is dropped.
@@ -184,51 +182,5 @@ impl GaugeMetric for MetricGauges {
             Self::BucketsCost => "metrics.buckets.cost",
             Self::AvgBucketSize => "metrics.buckets.size",
         }
-    }
-}
-
-/// Returns a low-cardinality metric name for use as a tag key on statsd metrics.
-///
-/// In order to keep this low-cardinality, we only enumerate a handful of well-known, high volume
-/// names. The rest gets mapped to "other".
-pub(crate) fn metric_name_tag(value: &str) -> &'static str {
-    if let Some(value) = [
-        "c:sessions/session@none",
-        "s:sessions/user@none",
-        "s:sessions/error@none",
-        "d:transactions/duration@millisecond",
-        "s:transactions/user@none",
-        "c:transactions/count_per_root_project@none",
-    ]
-    .into_iter()
-    .find(|x| x == &value)
-    {
-        return value;
-    }
-
-    if value.starts_with("d:transactions/breakdowns.") {
-        return "d:transactions/breakdowns.*";
-    }
-    if value.starts_with("d:transactions/measurements.") {
-        return "d:transactions/measurements.*";
-    }
-
-    if value.starts_with("s:spans/") {
-        return "s:spans/";
-    }
-    if value.starts_with("d:spans/") {
-        return "d:spans/";
-    }
-
-    "other"
-}
-
-/// Returns the metric type for use as a tag key on statsd metrics.
-pub(crate) fn metric_type_tag(value: &BucketValue) -> &'static str {
-    match value {
-        BucketValue::Counter(_) => "counter",
-        BucketValue::Distribution(_) => "distribution",
-        BucketValue::Set(_) => "set",
-        BucketValue::Gauge(_) => "gauge",
     }
 }


### PR DESCRIPTION
Tracks the metric's namespace as tag instead of the previous hand-crafted list
of partial metric names in bucketing metrics for internal logging. This will
scale better with future additions to metrics.

#skip-changelog

