### PR TITLE
chore(dashboard): Move dashboard functionality to separate submodule

### DIFF
--- a/relay-log/src/dashboard.rs
+++ b/relay-log/src/dashboard.rs
@@ -1,0 +1,43 @@
+use once_cell::sync::Lazy;
+use tokio::sync::broadcast;
+use tracing::Subscriber;
+use tracing_subscriber::Layer;
+
+/// Channel to deliver logs.
+pub static LOGS: Lazy<broadcast::Sender<Vec<u8>>> = Lazy::new(|| {
+    let (tx, _) = broadcast::channel(2000);
+    tx
+});
+
+/// Writer for the logs out to the [`tokio::sync::broadcast`] channel.
+pub struct LogsWriter;
+
+impl std::io::Write for LogsWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let tx = &*LOGS;
+        let buf_len = buf.len();
+        tx.send(buf.to_vec()).ok();
+        Ok(buf_len)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Returns the log writer.
+fn make_logs_writer() -> impl std::io::Write {
+    LogsWriter
+}
+
+/// Returns the dashbaord subscriber.
+pub fn dashboard_subscriber<S>() -> impl Layer<S> + Send + Sync
+where
+    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracing_subscriber::fmt::layer()
+        .with_writer(make_logs_writer)
+        .with_target(true)
+        .with_ansi(true)
+        .compact()
+}

--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -117,6 +117,11 @@ mod setup;
 #[cfg(feature = "init")]
 pub use setup::*;
 
+#[cfg(feature = "dashboard")]
+mod dashboard;
+#[cfg(feature = "dashboard")]
+pub use dashboard::*;
+
 #[cfg(feature = "test")]
 mod test;
 #[cfg(feature = "test")]

--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -118,9 +118,7 @@ mod setup;
 pub use setup::*;
 
 #[cfg(feature = "dashboard")]
-mod dashboard;
-#[cfg(feature = "dashboard")]
-pub use dashboard::*;
+pub mod dashboard;
 
 #[cfg(feature = "test")]
 mod test;

--- a/relay-log/src/utils.rs
+++ b/relay-log/src/utils.rs
@@ -1,18 +1,7 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "dashboard")]
-use once_cell::sync::Lazy;
-#[cfg(feature = "dashboard")]
-use tokio::sync::broadcast;
 use tracing::Level;
-
-/// Channel to deliver logs.
-#[cfg(feature = "dashboard")]
-pub static LOGS: Lazy<broadcast::Sender<Vec<u8>>> = Lazy::new(|| {
-    let (tx, _) = broadcast::channel(2000);
-    tx
-});
 
 /// Returns `true` if backtrace printing is enabled.
 ///

--- a/relay-server/src/endpoints/logs.rs
+++ b/relay-server/src/endpoints/logs.rs
@@ -4,7 +4,7 @@ use axum::{
 };
 
 async fn handle_socket(mut socket: WebSocket) {
-    let mut logs = relay_log::LOGS.subscribe();
+    let mut logs = relay_log::dashboard::receiver();
 
     while let Ok(entry) = logs.recv().await {
         let message = String::from_utf8_lossy(&entry).to_string();


### PR DESCRIPTION
Better code organization: 
* move the dashboard-related code into separate sub-module in the logs crate
* include the submodule only when the `dashboard` feature is enabled

#skip-changelog