### PR TITLE
fix(spans): Filter DB spans for MongDB queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Rename the envelope item type for StatsD payloads to "statsd". ([#2470](https://github.com/getsentry/relay/pull/2470))
 - Add a nanojoule unit for profile measurements. ([#2478](https://github.com/getsentry/relay/pull/2478))
 - Add a timestamp field to report profile's start time on Android. ([#2486](https://github.com/getsentry/relay/pull/2486))
-- Filter span metrics extraction based on features. ([#2511](https://github.com/getsentry/relay/pull/2511))
+- Filter span metrics extraction based on features. ([#2511](https://github.com/getsentry/relay/pull/2511), [#2520](https://github.com/getsentry/relay/pull/2520))
 
 ## 23.8.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -2,7 +2,7 @@ use relay_base_schema::data_category::DataCategory;
 use relay_common::glob2::LazyGlob;
 use relay_common::glob3::GlobPatterns;
 use relay_sampling::condition::{
-    AndCondition, EqCondition, GlobCondition, NotCondition, RuleCondition,
+    AndCondition, EqCondition, GlobCondition, NotCondition, OrCondition, RuleCondition,
 };
 use serde_json::Value;
 
@@ -64,9 +64,18 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                                 value: Value::String("db.sql.query".into()),
                                 options: Default::default(),
                             }),
-                            RuleCondition::Glob(GlobCondition {
-                                name: "span.description".into(),
-                                value: GlobPatterns::new(vec![r#"*"$*"#.into()]),
+                            RuleCondition::Or(OrCondition {
+                                inner: vec![
+                                    RuleCondition::Eq(EqCondition {
+                                        name: "span.system".into(),
+                                        value: Value::String("mongodb".into()),
+                                        options: Default::default(),
+                                    }),
+                                    RuleCondition::Glob(GlobCondition {
+                                        name: "span.description".into(),
+                                        value: GlobPatterns::new(vec![r#"*"$*"#.into()]),
+                                    }),
+                                ],
                             }),
                         ],
                     })),

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -56,6 +56,21 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                         options: Default::default(),
                     })),
                 }),
+                RuleCondition::Not(NotCondition {
+                    inner: Box::new(RuleCondition::And(AndCondition {
+                        inner: vec![
+                            RuleCondition::Eq(EqCondition {
+                                name: span_op_field_name.into(),
+                                value: Value::String("db.sql.query".into()),
+                                options: Default::default(),
+                            }),
+                            RuleCondition::Glob(GlobCondition {
+                                name: "span.description".into(),
+                                value: GlobPatterns::new(vec![r#"*"$*"#.into()]),
+                            }),
+                        ],
+                    })),
+                }),
             ],
         }))
     };

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2290,7 +2290,12 @@ impl EnvelopeProcessorService {
                     let Some(span_op) = inner_span.op.value() else {
                         continue;
                     };
-                    if all_modules_enabled || span_op.starts_with("db") {
+                    let Some(span_description) = inner_span.description.value() else {
+                        continue;
+                    };
+                    if all_modules_enabled
+                        || span_op.starts_with("db") && !span_description.contains(r#""$"#)
+                    {
                         // HACK: clone the span to set the segment_id. This should happen
                         // as part of normalization once standalone spans reach wider adoption.
                         let mut new_span = inner_span.clone();

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -434,7 +434,6 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok"
                 }
-
             ]
         }
         "#;
@@ -833,8 +832,34 @@ mod tests {
                     "timestamp": 1597976302.0000000,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok"
+                },
+                {
+                    "description": "things.count({\"$and\":[{\"services\":{\"$exists\":true}},{\"test_id\":38}]})",
+                    "op": "db.sql.query",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "db.system": "mongodb",
+                        "db.operation": "count"
+                    }
+                },
+                {
+                    "description": "DELETE FROM table WHERE conditions",
+                    "op": "db.sql.query",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "db.system": "MyDatabase"
+                    }
                 }
-
             ]
         }
         "#;

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -491,4 +491,51 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "d:spans/exclusive_time@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.action": "DELETE",
+            "span.category": "db",
+            "span.domain": "table",
+            "span.module": "db",
+            "span.op": "db.sql.query",
+            "span.status": "ok",
+            "span.system": "mydatabase",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "d:spans/exclusive_time_light@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.action": "DELETE",
+            "span.category": "db",
+            "span.domain": "table",
+            "span.module": "db",
+            "span.op": "db.sql.query",
+            "span.status": "ok",
+            "span.system": "mydatabase",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
 ]


### PR DESCRIPTION
We know grouping is not good for spans of MongoDB queries and we want to ignore them.

MongoDB queries are basically JSON so we're looking for `"$` in `span.description` and ignoring spans if it's in there. 