### PR TITLE
fix(spans): Handle ActiveRecord official and custom spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Exclude more spans fron metrics extraction. ([#2522](https://github.com/getsentry/relay/pull/2522))
+- Exclude more spans fron metrics extraction. ([#2522](https://github.com/getsentry/relay/pull/2522), [#2525](https://github.com/getsentry/relay/pull/2525))
 
 ## 23.9.1
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -47,7 +47,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                     inner: Box::new(RuleCondition::Glob(GlobCondition {
                         name: span_op_field_name.into(),
                         value: GlobPatterns::new(vec![
-                            "*activerecord*".into(),
+                            "*active*record*".into(),
                             "*clickhouse*".into(),
                             "*mongodb*".into(),
                             "*redis*".into(),

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2245,10 +2245,11 @@ impl EnvelopeProcessorService {
             .and_then(|system| system.as_str())
             .unwrap_or_default();
         op.starts_with("db")
-            && !(op.contains("clickhouse")
+            && !(op.contains("active_record")
+                || op.contains("activerecord")
+                || op.contains("clickhouse")
                 || op.contains("mongodb")
-                || op.contains("redis")
-                || op.contains("activerecord"))
+                || op.contains("redis"))
             && !(op == "db.sql.query" && !(description.contains(r#""$"#) || system == "mongodb"))
     }
 


### PR DESCRIPTION
Handle the official op spelling as well as the custom one.

https://github.com/getsentry/sentry-ruby/blob/ace338c6d1e7a75885a8524991c88d491261aad0/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb#L7C1-L7C1