### PR TITLE
feat(spans): Scrub SQL aliases

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -443,13 +443,13 @@ mod tests {
     scrub_sql_test!(
         collapse_partial_column_lists,
         r#"SELECT myfield1, "a"."b", count(*) AS c, another_field, another_field2 FROM table1 WHERE %s"#,
-        "SELECT .., count(*) AS c, .. FROM table1 WHERE %s"
+        "SELECT .., count(*), .. FROM table1 WHERE %s"
     );
 
     scrub_sql_test!(
         collapse_partial_column_lists_2,
         r#"SELECT DISTINCT a, b,c ,d , e, f, g, h, COALESCE(foo, %s) AS "id" FROM x"#,
-        "SELECT DISTINCT .., COALESCE(foo, %s) AS id FROM x"
+        "SELECT DISTINCT .., COALESCE(foo, %s) FROM x"
     );
 
     scrub_sql_test!(
@@ -610,6 +610,12 @@ mod tests {
             ELSE 30
         END"#,
         "UPDATE tbl SET foo = CASE WHEN .. THEN .. END"
+    );
+
+    scrub_sql_test!(
+        unique_alias,
+        "SELECT pg_advisory_unlock(%s, %s) AS t0123456789abcdef",
+        "SELECT pg_advisory_unlock(%s, %s)"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -96,14 +96,11 @@ impl NormalizeVisitor {
         let mut collapse = vec![];
 
         // Iterate over selected item.
-        for mut item in std::mem::take(&mut select.projection) {
+        for item in std::mem::take(&mut select.projection) {
             // Normalize aliases.
             let item = match item {
                 // Remove alias.
-                SelectItem::ExprWithAlias { ref mut alias, .. } => {
-                    alias.quote_style = None;
-                    item
-                }
+                SelectItem::ExprWithAlias { expr, .. } => SelectItem::UnnamedExpr(expr),
                 // Strip prefix, e.g. `"mytable".*`.
                 SelectItem::QualifiedWildcard(_, options) => SelectItem::Wildcard(options),
                 _ => item,


### PR DESCRIPTION
Aliases in SQL queries are sometimes generated and can cause high cardinality.

ref: [internal issue](https://www.notion.so/sentry/Scrub-Postgres-AS-aliases-6c70248883174805a6e1f009046243d9?pvs=4)

#skip-changelog