### PR TITLE
fix(spans): Scrub SQL cursors

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -275,6 +275,20 @@ mod tests {
     );
 
     scrub_sql_test!(
+        declare_cursor,
+        "DECLARE curs2 CURSOR FOR SELECT * FROM t1",
+        "DECLARE %s CURSOR FOR SELECT * FROM t1"
+    );
+
+    scrub_sql_test!(
+        fetch_cursor,
+        "FETCH LAST FROM curs3 INTO x",
+        "FETCH LAST IN %s INTO %s"
+    );
+
+    scrub_sql_test!(close_cursor, "CLOSE curs1", "CLOSE %s");
+
+    scrub_sql_test!(
         savepoint_quoted_backtick,
         "SAVEPOINT `backtick_quoted_identifier`",
         "SAVEPOINT %s"

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -281,6 +281,12 @@ mod tests {
     );
 
     scrub_sql_test!(
+        declare_cursor_advanced,
+        r#"DECLARE c123456 NO SCROLL CURSOR FOR SELECT "t".* FROM "t" WHERE "t".x = 1 AND y = %s"#,
+        "DECLARE %s NO SCROLL CURSOR FOR SELECT * FROM t WHERE x = %s AND y = %s"
+    );
+
+    scrub_sql_test!(
         fetch_cursor,
         "FETCH LAST FROM curs3 INTO x",
         "FETCH LAST IN %s INTO %s"


### PR DESCRIPTION
Cursor IDs may be generated and thus cause high cardinality.

The `sqlparser` library does not seem to support the full scope of [cursor-related PostgreSQL commands](https://www.postgresql.org/docs/current/plpgsql-cursors.html) yet, so this is best-effort for now.

ref: [internal issue](https://www.notion.so/sentry/Add-parameterization-for-SQL-cursor-a127435d8f804d899ef262d83a142573?pvs=4)

#skip-changelog