### PR TITLE
fix(crash): Fix the crash-handler feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Remove profile_id from context when no profile is in the envelope. ([#2523](https://github.com/getsentry/relay/pull/2523))
+- Fix reporting of Relay's crashes to Sentry. The `crash-handler` feature did not enable the crash reporter and uploads of crashes were broken. ([#2532](https://github.com/getsentry/relay/pull/2532))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4286,9 +4286,9 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "sentry"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de31c6e03322af2175d3c850c5b5e11efcadc01948cd1fb7b5ad0a7c7b6c7ff2"
+checksum = "0097a48cd1999d983909f07cb03b15241c5af29e5e679379efac1c06296abecc"
 dependencies = [
  "httpdate",
  "native-tls",
@@ -4306,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264e3ad27da3d1ad81b499dbcceae0a50e0e6ffc4b65b93f47d5180d46827644"
+checksum = "18a7b80fa1dd6830a348d38a8d3a9761179047757b7dca29aef82db0118b9670"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -4318,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7144590f7950647e4df5bd95f234c3aa29124729c54bd2457e1224d701d1a91c"
+checksum = "7615dc588930f1fd2e721774f25844ae93add2dbe2d3c2f995ce5049af898147"
 dependencies = [
  "hostname",
  "libc",
@@ -4332,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35614ecf115f55d93583baa02a85cb63acb6567cf91b17690d1147bac1739ca4"
+checksum = "8f51264e4013ed9b16558cce43917b983fa38170de2ca480349ceb57d71d6053"
 dependencies = [
  "once_cell",
  "rand",
@@ -4345,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c4288a1b255e6ff55f111d2e14a48d369da76e86fae15a00ee26a371d82ad4"
+checksum = "2fe6180fa564d40bb942c9f0084ffb5de691c7357ead6a2b7a3154fae9e401dd"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -4367,9 +4367,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a941028a24baf0a5a994d8a39670cecc72a61971bb0155f771537447a46211a"
+checksum = "323160213bba549f9737317b152af116af35c0410f4468772ee9b606d3d6e0fa"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4388,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b268d4a40bb501e7c744c71a62744e81523a2d20e6a749e26aa4fbff6edae2"
+checksum = "0ffe3ab7bf7f65c9f8ccd20aa136ce5b2140aa6d6a11339e823cd43a7d694a9e"
 dependencies = [
  "axum",
  "http",
@@ -4403,9 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec56ebafd7cfc1175bccdf277be582ccc3308b8c353dca5831261a967a6e28c"
+checksum = "38033822128e73f7b6ca74c1631cef8868890c6cb4008a291cf73530f87b4eac"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4415,13 +4415,13 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.31.3"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c56f616602a3b282bf4b4e8e5b4d10bcf9412a987df91c592b95a1f6ef1ee43"
+checksum = "0e663b3eb62ddfc023c9cf5432daf5f1a4f6acb1df4d78dd80b740b32dd1a740"
 dependencies = [
  "debugid",
- "getrandom",
  "hex",
+ "rand",
  "serde",
  "serde_json",
  "thiserror",
@@ -5574,11 +5574,11 @@ checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "ureq"
-version = "2.6.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "log",
  "native-tls",
  "once_cell",

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -34,8 +34,8 @@ tracing-subscriber = { version = "0.3.17", features = [
 ], optional = true }
 
 [features]
-dashboard = ["dep:once_cell", "dep:tokio"]
 default = []
+dashboard = ["dep:once_cell", "dep:tokio"]
 test = ["dep:tracing-subscriber"]
 init = [
     "dep:chrono",

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -15,13 +15,15 @@ chrono = { workspace = true, features = ["clock"], optional = true }
 console = { version = "0.15.5", optional = true }
 once_cell = { version = "1.13.1", optional = true }
 relay-crash = { path = "../relay-crash", optional = true }
-sentry = { version = "0.31.3", features = [
+sentry = { version = "0.31.7", features = [
     "debug-images",
     "tower-axum-matched-path",
     "tracing",
 ], optional = true }
-sentry-core = { version = "0.31.3" }
-tokio = { version = "1", default-features = false, features = ["sync"], optional = true }
+sentry-core = { version = "0.31.7" }
+tokio = { version = "1", default-features = false, features = [
+    "sync",
+], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tracing = "0.1.37"
@@ -32,10 +34,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 ], optional = true }
 
 [features]
-dashboard = [
-    "dep:once_cell",
-    "dep:tokio",
-]
+dashboard = ["dep:once_cell", "dep:tokio"]
 default = []
 test = ["dep:tracing-subscriber"]
 init = [

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -165,10 +165,10 @@ impl Default for SentryConfig {
 }
 
 /// Captures an envelope from the native crash reporter using the main Sentry SDK.
-#[cfg(feature = "relay-crash")]
+#[cfg(feature = "crash-handler")]
 fn capture_native_envelope(data: &[u8]) {
     if let Some(client) = sentry::Hub::main().client() {
-        match sentry::Envelope::from_slice(data) {
+        match sentry::Envelope::from_bytes_raw(data.to_owned()) {
             Ok(envelope) => client.send_envelope(envelope),
             Err(error) => {
                 let error = &error as &dyn std::error::Error;
@@ -270,13 +270,15 @@ pub fn init(config: &LogConfig, sentry: &SentryConfig) {
 
     // Initialize native crash reporting after the Rust SDK, so that `capture_native_envelope` has
     // access to an initialized Hub to capture crashes from the previous run.
-    #[cfg(feature = "relay-crash")]
+    #[cfg(feature = "crash-handler")]
     {
         if let Some(dsn) = sentry.enabled_dsn().map(|d| d.to_string()) {
             if let Some(db) = sentry._crash_db.as_deref() {
+                crate::info!("initializing crash handler in {}", db.display());
                 relay_crash::CrashHandler::new(dsn.as_str(), db)
                     .transport(capture_native_envelope)
                     .release(Some(RELEASE))
+                    .environment(sentry.environment.as_deref())
                     .install();
             }
         }


### PR DESCRIPTION
Repairs the crash handler feature, which was effectively disabled in recent builds.

- Internal feature flagging was broken, and for this reason the functionality was never active when the feature flag was enabled.
- Handling of envelopes from the native crash reporter was broken so that they could not be uploaded.
- The configured environment was not used for native crashes.