### PR TITLE
fix(spans): Use db.system for SQL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove profile_id from context when no profile is in the envelope. ([#2523](https://github.com/getsentry/relay/pull/2523))
 - Fix reporting of Relay's crashes to Sentry. The `crash-handler` feature did not enable the crash reporter and uploads of crashes were broken. ([#2532](https://github.com/getsentry/relay/pull/2532))
+- Use correct field to pick SQL parser for span normalization. ([#2536](https://github.com/getsentry/relay/pull/2536))
 
 **Internal**:
 


### PR DESCRIPTION
The SQL parser used for span description normalization and grouping accessed the wrong field to pick the SQL dialect. This bug did not durface in unit tests, because I passed the system string into those tests directly.