### PR TITLE
docs(relay-log): Fix typo in docs

### DIFF
--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -126,7 +126,7 @@ impl Default for LogConfig {
     }
 }
 
-/// Controls interal reporting to Sentry.
+/// Controls internal reporting to Sentry.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct SentryConfig {


### PR DESCRIPTION
#skip-changelog