### PR TITLE
fix(beta): Address beta lint warnings

### DIFF
--- a/relay-event-normalization/src/normalize/contexts.rs
+++ b/relay-event-normalization/src/normalize/contexts.rs
@@ -218,7 +218,7 @@ fn normalize_os_context(os: &mut OsContext) {
     }
 }
 
-fn parse_raw_response_data(response: &mut ResponseContext) -> Option<(&'static str, Value)> {
+fn parse_raw_response_data(response: &ResponseContext) -> Option<(&'static str, Value)> {
     let raw = response.data.as_str()?;
 
     serde_json::from_str(raw)

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -38,7 +38,7 @@ pub enum ReplayError {
 ///
 /// Returns `Ok(())`, if the Replay is valid and can be normalized. Otherwise, returns
 /// `Err(ReplayError::InvalidPayload)` describing the missing or invalid data.
-pub fn validate(replay: &mut Replay) -> Result<(), ReplayError> {
+pub fn validate(replay: &Replay) -> Result<(), ReplayError> {
     replay
         .replay_id
         .value()

--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -69,7 +69,7 @@ fn value_trim_whitespace(value: &mut String, _meta: &mut Meta, state: &Processin
 }
 
 fn verify_value_nonempty<T>(
-    value: &mut T,
+    value: &T,
     meta: &mut Meta,
     state: &ProcessingState<'_>,
 ) -> ProcessingResult
@@ -85,7 +85,7 @@ where
 }
 
 fn verify_value_nonempty_string<T>(
-    value: &mut T,
+    value: &T,
     meta: &mut Meta,
     state: &ProcessingState<'_>,
 ) -> ProcessingResult
@@ -101,7 +101,7 @@ where
 }
 
 fn verify_value_characters(
-    value: &mut str,
+    value: &str,
     meta: &mut Meta,
     state: &ProcessingState<'_>,
 ) -> ProcessingResult {

--- a/relay-metrics/src/aggregation.rs
+++ b/relay-metrics/src/aggregation.rs
@@ -455,7 +455,7 @@ impl Eq for QueuedBucket {}
 impl PartialOrd for QueuedBucket {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         // Comparing order is reversed to convert the max heap into a min heap
-        other.flush_at.partial_cmp(&self.flush_at)
+        Some(other.flush_at.cmp(&self.flush_at))
     }
 }
 

--- a/relay-pii/src/compiledconfig.rs
+++ b/relay-pii/src/compiledconfig.rs
@@ -162,7 +162,7 @@ impl Eq for RuleRef {}
 
 impl PartialOrd for RuleRef {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.id.partial_cmp(&other.id)
+        Some(self.id.cmp(&other.id))
     }
 }
 

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -801,7 +801,7 @@ impl OutcomeBroker {
         // Here we create a fake EventId, when we don't have the real one, so that we can
         // create a kafka message key that spreads the events nicely over all the
         // kafka consumer groups.
-        let key = message.event_id.unwrap_or_else(EventId::new).0;
+        let key = message.event_id.unwrap_or_default().0;
 
         // Dispatch to the correct topic and cluster based on the kind of outcome.
         let topic = if message.is_billing() {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1091,9 +1091,9 @@ impl EnvelopeProcessorService {
                     }
                 } else {
                     // We found a second profile, drop it.
-                    return ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
+                    ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
                         relay_profiling::discard_reason(ProfileError::TooManyProfiles),
-                    )));
+                    )))
                 }
             }
             _ => ItemAction::Keep,

--- a/relay-server/src/actors/relays.rs
+++ b/relay-server/src/actors/relays.rs
@@ -323,10 +323,7 @@ impl RelayCacheService {
         }
 
         relay_log::debug!("relay {relay_id} public key requested");
-        self.channels
-            .entry(relay_id)
-            .or_insert_with(BroadcastChannel::new)
-            .attach(sender);
+        self.channels.entry(relay_id).or_default().attach(sender);
 
         if !self.backoff.started() {
             self.schedule_fetch();


### PR DESCRIPTION
New rust version will introduce new  lint warnings and suggestions. 
This PR fixes those warning for `beta`, so once the new version is released everything still continues to function. 

#skip-changelog 