### PR TITLE
ref(sampling): Replace Evaluator with ControlFlow.

### DIFF
--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -238,7 +238,6 @@ impl fmt::Display for MatchedRuleIds {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -266,6 +265,10 @@ mod tests {
             ControlFlow::Continue(_) => panic!("no match found"),
             ControlFlow::Break(m) => m,
         }
+    }
+
+    fn evaluation_is_match(res: ControlFlow<SamplingMatch, SamplingEvaluator>) -> bool {
+        matches!(res, ControlFlow::Break(_))
     }
 
     /// Helper to check if certain rules are matched on.
@@ -404,19 +407,29 @@ mod tests {
 
         // Baseline test.
         let within_timerange = Utc.with_ymd_and_hms(1970, 10, 11, 0, 0, 0).unwrap();
-        assert!(SamplingEvaluator::new(within_timerange)
-            .match_rules(Uuid::default(), &dsc, [rule.clone()].iter())
-            .is_match());
+        let res = SamplingEvaluator::new(within_timerange).match_rules(
+            Uuid::default(),
+            &dsc,
+            [rule.clone()].iter(),
+        );
+
+        assert!(evaluation_is_match(res));
 
         let before_timerange = Utc.with_ymd_and_hms(1969, 1, 1, 0, 0, 0).unwrap();
-        assert!(SamplingEvaluator::new(before_timerange)
-            .match_rules(Uuid::default(), &dsc, [rule.clone()].iter())
-            .is_no_match());
+        let res = SamplingEvaluator::new(before_timerange).match_rules(
+            Uuid::default(),
+            &dsc,
+            [rule.clone()].iter(),
+        );
+        assert!(!evaluation_is_match(res));
 
         let after_timerange = Utc.with_ymd_and_hms(1971, 1, 1, 0, 0, 0).unwrap();
-        assert!(SamplingEvaluator::new(after_timerange)
-            .match_rules(Uuid::default(), &dsc, [rule].iter())
-            .is_no_match());
+        let res = SamplingEvaluator::new(after_timerange).match_rules(
+            Uuid::default(),
+            &dsc,
+            [rule].iter(),
+        );
+        assert!(!evaluation_is_match(res));
     }
 
     /// Checks that `SamplingValueEvaluator` correctly matches the right rules.
@@ -543,7 +556,6 @@ mod tests {
 
         let res = SamplingEvaluator::new(Utc::now()).match_rules(Uuid::default(), &dsc, [].iter());
 
-        assert!(res.is_no_match());
+        assert!(!evaluation_is_match(res));
     }
 }
-*/

--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -262,8 +262,8 @@ mod tests {
             instance,
             rules.iter(),
         ) {
+            ControlFlow::Break(sampling_match) => sampling_match,
             ControlFlow::Continue(_) => panic!("no match found"),
-            ControlFlow::Break(m) => m,
         }
     }
 

--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::num::ParseIntError;
+use std::ops::ControlFlow;
 
 use chrono::{DateTime, Utc};
 use rand::distributions::Uniform;
@@ -21,37 +22,6 @@ fn pseudo_random_from_uuid(id: Uuid) -> f64 {
     let mut generator = Pcg32::new((big_seed >> 64) as u64, big_seed as u64);
     let dist = Uniform::new(0f64, 1f64);
     generator.sample(dist)
-}
-
-/// State of the [`SamplingEvaluator`]'s rule matching.
-///
-/// Enforces a pattern to avoid matching on more rules if a match has already been found.
-#[derive(Debug)]
-pub enum Evaluation {
-    /// Matching has not completed and more rules can be evaluated.
-    ///
-    /// This can happen either if no active rules match the provided data, or if the matched rules
-    /// are factors that require a final sampling value. In this case, the returned evaluator stores
-    /// the state of the matched rules as well as the accumulated sampling factor and can be used to
-    /// evaluate more rules.
-    ///
-    /// If evaluation returns `Continue` and there are no more rules to match, this should be
-    /// considered as "no match".
-    Continue(SamplingEvaluator),
-    /// One or more rules have matched.
-    Matched(SamplingMatch),
-}
-
-impl Evaluation {
-    /// Returns true if a rule has matched.
-    pub fn is_match(&self) -> bool {
-        matches!(self, &Self::Matched(_))
-    }
-
-    /// Returns true if no rule have matched.
-    pub fn is_no_match(&self) -> bool {
-        !self.is_match()
-    }
 }
 
 /// State machine for dynamic sampling.
@@ -80,8 +50,23 @@ impl SamplingEvaluator {
         self
     }
 
-    /// Attemps to find a match for sampling rules.
-    pub fn match_rules<'a, I, G>(mut self, seed: Uuid, instance: &G, rules: I) -> Evaluation
+    /// Attempts to find a match for sampling rules using `ControlFlow`.
+    ///
+    /// This function returns a `ControlFlow` to provide control over the matching process.
+    ///
+    /// - `ControlFlow::Continue`: Indicates that matching is incomplete, and more rules can be evaluated.
+    ///    - This state occurs either if no active rules match the provided data, or if the matched rules
+    ///      are factors requiring a final sampling value.
+    ///    - The returned evaluator contains the state of the matched rules and the accumulated sampling factor.
+    ///    - If this value is returned and there are no more rules to evaluate, it should be interpreted as "no match."
+    ///
+    /// - `ControlFlow::Break`: Indicates that one or more rules have successfully matched.
+    pub fn match_rules<'a, I, G>(
+        mut self,
+        seed: Uuid,
+        instance: &G,
+        rules: I,
+    ) -> ControlFlow<SamplingMatch, Self>
     where
         G: Getter,
         I: Iterator<Item = &'a SamplingRule>,
@@ -102,7 +87,7 @@ impl SamplingEvaluator {
                 SamplingValue::SampleRate { value } => {
                     let sample_rate = (value * self.factor).clamp(0.0, 1.0);
 
-                    return Evaluation::Matched(SamplingMatch::new(
+                    return ControlFlow::Break(SamplingMatch::new(
                         self.adjusted_sample_rate(sample_rate),
                         seed,
                         self.rule_ids,
@@ -110,7 +95,7 @@ impl SamplingEvaluator {
                 }
             }
         }
-        Evaluation::Continue(self)
+        ControlFlow::Continue(self)
     }
 
     /// Tries to negate the client side sampling if the evaluator has been provided
@@ -252,6 +237,8 @@ impl fmt::Display for MatchedRuleIds {
         Ok(())
     }
 }
+
+/*
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -276,8 +263,8 @@ mod tests {
             instance,
             rules.iter(),
         ) {
-            Evaluation::Matched(sampling_match) => sampling_match,
-            Evaluation::Continue(_) => panic!("no match found"),
+            ControlFlow::Continue(_) => panic!("no match found"),
+            ControlFlow::Break(m) => m,
         }
     }
 
@@ -355,7 +342,7 @@ mod tests {
             .adjust_client_sample_rate(Some(0.2))
             .match_rules(Uuid::default(), &dsc, rules.iter());
 
-        let Evaluation::Matched(sampling_match) = res else {
+        let ControlFlow::Break(sampling_match) = res else {
             panic!();
         };
 
@@ -559,3 +546,4 @@ mod tests {
         assert!(res.is_no_match());
     }
 }
+*/

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::io::Write;
 use std::net;
 use std::net::IpAddr as NetIPAddr;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -43,7 +44,7 @@ use relay_quotas::{DataCategory, ReasonCode};
 use relay_redis::RedisPool;
 use relay_replays::recording::RecordingScrubber;
 use relay_sampling::config::{RuleType, SamplingMode};
-use relay_sampling::evaluation::{Evaluation, MatchedRuleIds, SamplingEvaluator};
+use relay_sampling::evaluation::{MatchedRuleIds, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
@@ -2412,8 +2413,8 @@ impl EnvelopeProcessorService {
             if let Some(seed) = event.id.value().map(|id| id.0) {
                 let rules = sampling_state.filter_rules(RuleType::Transaction);
                 evaluator = match evaluator.match_rules(seed, event, rules) {
-                    Evaluation::Continue(evaluator) => evaluator,
-                    Evaluation::Matched(sampling_match) => {
+                    ControlFlow::Continue(evaluator) => evaluator,
+                    ControlFlow::Break(sampling_match) => {
                         return SamplingResult::Match(sampling_match);
                     }
                 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -54,8 +54,8 @@ impl SamplingResult {
 impl From<ControlFlow<SamplingMatch, SamplingEvaluator>> for SamplingResult {
     fn from(value: ControlFlow<SamplingMatch, SamplingEvaluator>) -> Self {
         match value {
+            ControlFlow::Break(sampling_match) => Self::Match(sampling_match),
             ControlFlow::Continue(_) => Self::NoMatch,
-            ControlFlow::Break(m) => Self::Match(m),
         }
     }
 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -1,8 +1,10 @@
 //! Functionality for calculating if a trace should be processed or dropped.
+use std::ops::ControlFlow;
+
 use chrono::Utc;
 use relay_base_schema::project::ProjectKey;
 use relay_sampling::config::{RuleType, SamplingMode};
-use relay_sampling::evaluation::{Evaluation, SamplingEvaluator, SamplingMatch};
+use relay_sampling::evaluation::{SamplingEvaluator, SamplingMatch};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 
 use crate::envelope::{Envelope, ItemType};
@@ -49,11 +51,11 @@ impl SamplingResult {
     }
 }
 
-impl From<Evaluation> for SamplingResult {
-    fn from(value: Evaluation) -> Self {
+impl From<ControlFlow<SamplingMatch, SamplingEvaluator>> for SamplingResult {
+    fn from(value: ControlFlow<SamplingMatch, SamplingEvaluator>) -> Self {
         match value {
-            Evaluation::Matched(sampling_match) => Self::Match(sampling_match),
-            Evaluation::Continue(_) => Self::NoMatch,
+            ControlFlow::Continue(_) => Self::NoMatch,
+            ControlFlow::Break(m) => Self::Match(m),
         }
     }
 }


### PR DESCRIPTION
The `Evaluator` enum functioned exactly as `ControlFlow`, so jan had the idea of simply using ControlFlow instead. This is the implementation of that. 

pros:
 * Idiomatic
 * One less type you have to look up when reading the code
 
cons:
 * Conversion to `SamplingResult` looks more messy now.
 * Had to forego some helpful methods I used in testing. 
 
I moved the documentation from the type to the `match_rules` function. Not sure if that's a benefit or disadvantage. 

#skip-changelog
