### PR TITLE
feat(spans): Allow activerecord with db.system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - Exclude more spans fron metrics extraction. ([#2522](https://github.com/getsentry/relay/pull/2522))
 - Remove filtering for Android events with missing close events. ([#2524](https://github.com/getsentry/relay/pull/2524))
-- Exclude more spans fron metrics extraction. ([#2522](https://github.com/getsentry/relay/pull/2522), [#2525](https://github.com/getsentry/relay/pull/2525))
+- Exclude more spans fron metrics extraction. ([#2522](https://github.com/getsentry/relay/pull/2522), [#2525](https://github.com/getsentry/relay/pull/2525), [#2545](https://github.com/getsentry/relay/pull/2545))
 
 ## 23.9.1
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -47,7 +47,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                     inner: Box::new(RuleCondition::Glob(GlobCondition {
                         name: span_op_field_name.into(),
                         value: GlobPatterns::new(vec![
-                            "*active*record*".into(),
                             "*clickhouse*".into(),
                             "*mongodb*".into(),
                             "*redis*".into(),

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -488,7 +488,7 @@ mod tests {
         scrub_span_description(span.value_mut().as_mut().unwrap(), &vec![]);
         let scrubbed = get_value!(span.data["description.scrubbed"]);
 
-        // Do not scrub active record.
+        // When db.system is missing, no scrubbed description (i.e. no group) is set.
         assert!(scrubbed.is_none());
     }
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2244,11 +2244,7 @@ impl EnvelopeProcessorService {
             .and_then(|system| system.as_str())
             .unwrap_or_default();
         op.starts_with("db")
-            && !(op.contains("active_record")
-                || op.contains("activerecord")
-                || op.contains("clickhouse")
-                || op.contains("mongodb")
-                || op.contains("redis"))
+            && !(op.contains("clickhouse") || op.contains("mongodb") || op.contains("redis"))
             && !(op == "db.sql.query" && !(description.contains(r#""$"#) || system == "mongodb"))
     }
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2245,7 +2245,7 @@ impl EnvelopeProcessorService {
             .unwrap_or_default();
         op.starts_with("db")
             && !(op.contains("clickhouse") || op.contains("mongodb") || op.contains("redis"))
-            && !(op == "db.sql.query" && !(description.contains(r#""$"#) || system == "mongodb"))
+            && !(op == "db.sql.query" && (description.contains(r#""$"#) || system == "mongodb"))
     }
 
     #[cfg(feature = "processing")]

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -538,4 +538,51 @@ expression: metrics
             "transaction.op": "myop",
         },
     },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "d:spans/exclusive_time@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.action": "DELETE",
+            "span.category": "db",
+            "span.domain": "table",
+            "span.module": "db",
+            "span.op": "db.sql.activerecord",
+            "span.status": "ok",
+            "span.system": "mydatabase",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "d:spans/exclusive_time_light@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.action": "DELETE",
+            "span.category": "db",
+            "span.domain": "table",
+            "span.module": "db",
+            "span.op": "db.sql.activerecord",
+            "span.status": "ok",
+            "span.system": "mydatabase",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
 ]


### PR DESCRIPTION
We've seen SQL query normalization fail when the queries are prepended with an active record comment, for example

```SQL
/*some comment `my_function'*/ SELECT 1
```

Normalization works fine when `sqlparser` is able to parse the query though. Having a `db.system` in `span.data` is a strong indicator that we will be able to parse the query. So we re-allow activerecord spans if they have a `db.system` set.

In addition, this PR also improves the fallback regex behavior for this kind of comments.

ref: [internal issue](https://www.notion.so/sentry/Scrub-ActiveRecord-query-comments-236925a9eaa24423880ae285939f8588?pvs=4)