### PR TITLE
ref(sampling): Remove dependency from sampling to event schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,7 +3828,6 @@ dependencies = [
  "rand_pcg",
  "relay-base-schema",
  "relay-common",
- "relay-event-schema",
  "relay-log",
  "relay-protocol",
  "serde",

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -15,7 +15,6 @@ rand = { workspace = true }
 rand_pcg = "0.3.1"
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }
-relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }
 serde = { workspace = true }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1990,7 +1990,7 @@ impl EnvelopeProcessorService {
             return;
         };
 
-        if let Some(dsc) = DynamicSamplingContext::from_transaction(key_config.public_key, event) {
+        if let Some(dsc) = utils::dsc_from_event(key_config.public_key, event) {
             state.envelope_mut().set_dsc(dsc);
             state.sampling_project_state = Some(state.project_state.clone());
         }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -2,10 +2,12 @@
 use std::ops::ControlFlow;
 
 use chrono::Utc;
+use relay_base_schema::events::EventType;
 use relay_base_schema::project::ProjectKey;
-use relay_sampling::config::{RuleType, SamplingMode};
+use relay_event_schema::protocol::{Event, TraceContext};
+use relay_sampling::config::{RuleType, SamplingConfig, SamplingMode};
+use relay_sampling::dsc::{DynamicSamplingContext, TraceUserContext};
 use relay_sampling::evaluation::{SamplingEvaluator, SamplingMatch};
-use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 
 use crate::envelope::{Envelope, ItemType};
 
@@ -110,6 +112,47 @@ pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
     envelope
         .get_item_by(|item| item.ty() == &ItemType::Transaction || item.ty() == &ItemType::Event)?;
     envelope.dsc().map(|dsc| dsc.public_key)
+}
+
+/// Computes a dynamic sampling context from a transaction event.
+///
+/// Returns `None` if the passed event is not a transaction event, or if it does not contain a
+/// trace ID in its trace context. All optional fields in the dynamic sampling context are
+/// populated with the corresponding attributes from the event payload if they are available.
+///
+/// Since sampling information is not available in the event payload, the `sample_rate` field
+/// cannot be set when computing the dynamic sampling context from a transaction event.
+pub fn dsc_from_event(public_key: ProjectKey, event: &Event) -> Option<DynamicSamplingContext> {
+    if event.ty.value() != Some(&EventType::Transaction) {
+        return None;
+    }
+
+    let Some(trace) = event.context::<TraceContext>() else {
+        return None;
+    };
+    let trace_id = trace.trace_id.value()?.0.parse().ok()?;
+    let user = event.user.value();
+
+    Some(DynamicSamplingContext {
+        trace_id,
+        public_key,
+        release: event.release.as_str().map(str::to_owned),
+        environment: event.environment.value().cloned(),
+        transaction: event.transaction.value().cloned(),
+        replay_id: None,
+        sample_rate: None,
+        user: TraceUserContext {
+            user_segment: user
+                .and_then(|u| u.segment.value().cloned())
+                .unwrap_or_default(),
+            user_id: user
+                .and_then(|u| u.id.as_str())
+                .unwrap_or_default()
+                .to_owned(),
+        },
+        sampled: None,
+        other: Default::default(),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `relay-sampling` crate implements generic functionality to define and
evaluate dynamic sampling rules. Originally, the functions were tied to the
event schema, but now can run independently of that based on the `Getter` trait.

This PR removes the build dependency on `relay-event-schema`. The only remaining
use was in a constructor of `DynamicSamplingContext` that creates the DSC from a
transaction event. Since this is business logic specific to the envelope
processor, this utility is now moved to `relay_server::utils::dynamic_sampling`.

#skip-changelog

