### PR TITLE
feat(spans): Scrub IDs in SQL table names

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -665,7 +665,7 @@ mod tests {
         "/*some comment `my_function'*/ SELECT * FROM foo WHERE ...",
         "SELECT * FROM foo WHERE ..."
     );
- 
+
     scrub_sql_test!(
         jsonb,
         r#"SELECT * FROM "a" WHERE "a"."b" = $1 AND (obj->'id' <@ '[123]'::jsonb) AND "a"."b" != $2"#,
@@ -694,6 +694,7 @@ mod tests {
         uuid_in_table_name,
         "SELECT * FROM prefix_0123456789abcdef0123456789ABCDEF_006_suffix",
         "SELECT * FROM prefix_00_00_suffix"
+    );
 
     scrub_sql_test!(
         clickhouse,

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -667,6 +667,30 @@ mod tests {
     );
 
     scrub_sql_test!(
+        digits_in_table_name,
+        "SELECT * FROM temp_12c",
+        "SELECT * FROM temp_00c"
+    );
+
+    scrub_sql_test!(
+        single_digit_in_table_name,
+        "SELECT * FROM temp_1c",
+        "SELECT * FROM temp_1c"
+    );
+
+    scrub_sql_test!(
+        digits_in_table_name,
+        r#"SELECT * FROM "foo".temp_12c"#,
+        "SELECT * FROM temp_00c"
+    );
+
+    scrub_sql_test!(
+        uuid_in_table_name,
+        "SELECT * FROM prefix_0123456789abcdef0123456789ABCDEF_06_suffix",
+        "SELECT * FROM prefix_00000000000000000000000000000000_00_suffix"
+    );
+
+    scrub_sql_test!(
         clickhouse,
         "SELECT (toStartOfHour(finish_ts, 'Universal') AS _snuba_time), (uniqIf((nullIf(user, '') AS _snuba_user), greater(multiIf(equals(tupleElement(('duration', 300), 1), 'lcp'), (if(has(measurements.key, 'lcp'), arrayElement(measurements.value, indexOf(measurements.key, 'lcp')), NULL) AS `_snuba_measurements[lcp]`), (duration AS _snuba_duration)), multiply(tupleElement(('duration', 300), 2), 4))) AS _snuba_count_miserable_user), (ifNull(divide(plus(_snuba_count_miserable_user, 4.56), plus(nullIf(uniqIf(_snuba_user, greater(multiIf(equals(tupleElement(('duration', 300), 1), 'lcp'), `_snuba_measurements[lcp]`, _snuba_duration), 0)), 0), 113.45)), 0) AS _snuba_user_misery), _snuba_count_miserable_user, (divide(countIf(notEquals(transaction_status, 0) AND notEquals(transaction_status, 1) AND notEquals(transaction_status, 2)), count()) AS _snuba_failure_rate), (divide(count(), divide(3600.0, 60)) AS _snuba_tpm_3600) FROM transactions_dist WHERE equals(('transaction' AS _snuba_type), 'transaction') AND greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime('2023-06-13T09:08:51', 'Universal')) AND less(_snuba_finish_ts, toDateTime('2023-07-11T09:08:51', 'Universal')) AND in((project_id AS _snuba_project_id), [123, 456, 789]) AND equals((environment AS _snuba_environment), 'production') GROUP BY _snuba_time ORDER BY _snuba_time ASC LIMIT 10000 OFFSET 0",
         "SELECT (toStartOfHour(finish_ts, %s) AS _snuba_time), (uniqIf((nullIf(user, %s) AS _snuba_user), greater(multiIf(equals(tupleElement((%s, %s), %s), %s), (if(has(key, %s), arrayElement(value, indexOf(key, %s)), NULL) AS `_snuba_measurements[lcp]`), (duration AS _snuba_duration)), multiply(tupleElement((%s, %s), %s), %s))) AS _snuba_count_miserable_user), (ifNull(divide(plus(_snuba_count_miserable_user, %s), plus(nullIf(uniqIf(_snuba_user, greater(multiIf(equals(tupleElement((%s, %s), %s), %s), `_snuba_measurements[lcp]`, _snuba_duration), %s)), %s), %s)), %s) AS _snuba_user_misery), _snuba_count_miserable_user, (divide(countIf(notEquals(transaction_status, %s) AND notEquals(transaction_status, %s) AND notEquals(transaction_status, %s)), count()) AS _snuba_failure_rate), (divide(count(), divide(%s, %s)) AS _snuba_tpm_3600) FROM transactions_dist WHERE equals((%s AS _snuba_type), %s) AND greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime(%s, %s)) AND less(_snuba_finish_ts, toDateTime(%s, %s)) AND in((project_id AS _snuba_project_id), [%s, %s, %s]) AND equals((environment AS _snuba_environment), %s) GROUP BY _snuba_time ORDER BY _snuba_time ASC LIMIT %s OFFSET %s"

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -403,7 +403,7 @@ mod tests {
     scrub_sql_test!(
         already_scrubbed,
         "SELECT * FROM table123 WHERE id = %s",
-        "SELECT * FROM table00 WHERE id = %s"
+        "SELECT * FROM table{%s} WHERE id = %s"
     );
 
     scrub_sql_test!(
@@ -675,7 +675,7 @@ mod tests {
     scrub_sql_test!(
         digits_in_table_name,
         "SELECT * FROM temp_12c",
-        "SELECT * FROM temp_00c"
+        "SELECT * FROM temp_{%s}c"
     );
 
     scrub_sql_test!(
@@ -687,13 +687,13 @@ mod tests {
     scrub_sql_test!(
         digits_in_compound_table_name,
         r#"SELECT * FROM "foo"."temp_12c""#,
-        "SELECT * FROM temp_00c"
+        "SELECT * FROM temp_{%s}c"
     );
 
     scrub_sql_test!(
         uuid_in_table_name,
         "SELECT * FROM prefix_0123456789abcdef0123456789ABCDEF_006_suffix",
-        "SELECT * FROM prefix_00_00_suffix"
+        "SELECT * FROM prefix_{%s}_{%s}_suffix"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -403,7 +403,7 @@ mod tests {
     scrub_sql_test!(
         already_scrubbed,
         "SELECT * FROM table123 WHERE id = %s",
-        "SELECT * FROM table123 WHERE id = %s"
+        "SELECT * FROM table00 WHERE id = %s"
     );
 
     scrub_sql_test!(
@@ -679,15 +679,15 @@ mod tests {
     );
 
     scrub_sql_test!(
-        digits_in_table_name,
-        r#"SELECT * FROM "foo".temp_12c"#,
+        digits_in_compound_table_name,
+        r#"SELECT * FROM "foo"."temp_12c""#,
         "SELECT * FROM temp_00c"
     );
 
     scrub_sql_test!(
         uuid_in_table_name,
-        "SELECT * FROM prefix_0123456789abcdef0123456789ABCDEF_06_suffix",
-        "SELECT * FROM prefix_00000000000000000000000000000000_00_suffix"
+        "SELECT * FROM prefix_0123456789abcdef0123456789ABCDEF_006_suffix",
+        "SELECT * FROM prefix_00_00_suffix"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -18,6 +18,7 @@ use sqlparser::dialect::{Dialect, GenericDialect};
 /// because not everything in SQL is an expression.
 const MAX_EXPRESSION_DEPTH: usize = 64;
 
+/// Regex used to scrub UUIDs and multi-digit numbers from table names and other identifiers.
 static TABLE_NAME_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)[0-9a-f]{32}|\d\d+").unwrap());
 
 /// Derive the SQL dialect from `db_system` (the value obtained from `span.data.system`)

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -170,7 +170,7 @@ impl NormalizeVisitor {
 
     fn scrub_name(name: &mut Ident) {
         name.quote_style = None;
-        if let Cow::Owned(s) = TABLE_NAME_REGEX.replace_all(&name.value, "00") {
+        if let Cow::Owned(s) = TABLE_NAME_REGEX.replace_all(&name.value, "{%s}") {
             name.value = s
         };
     }


### PR DESCRIPTION
Automatically generated table names can cause high cardinality for span metrics & deteriorate the user experience by creating a separate group for every generated table.

Use a regex to scrub obviously generated names:

1. Numbers with more than one digit.
2. 32-digit hexadecimals a.k.a. UUIDs.

#skip-changelog