### PR TITLE
chore(config): Remove TLS from generated config

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -441,10 +441,13 @@ pub struct Relay {
     /// The port to bind for the unencrypted relay HTTP server.
     pub port: u16,
     /// Optional port to bind for the encrypted relay HTTPS server.
+    #[serde(skip_serializing)]
     pub tls_port: Option<u16>,
     /// The path to the identity (DER-encoded PKCS12) to use for TLS.
+    #[serde(skip_serializing)]
     pub tls_identity_path: Option<PathBuf>,
     /// Password for the PKCS12 archive.
+    #[serde(skip_serializing)]
     pub tls_identity_password: Option<String>,
     /// Always override project IDs from the URL and DSN with the identifier used at the upstream.
     ///

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -279,22 +279,6 @@ pub fn init_config<P: AsRef<Path>>(config_path: P, _matches: &ArgMatches) -> Res
             utils::prompt_value("upstream", &mut mincfg.relay.upstream)?;
             utils::prompt_value("listen interface", &mut mincfg.relay.host)?;
             utils::prompt_value("listen port", &mut mincfg.relay.port)?;
-
-            if Confirm::with_theme(get_theme())
-                .with_prompt("do you want listen to TLS")
-                .interact()?
-            {
-                let mut port = mincfg.relay.port.saturating_add(443);
-                utils::prompt_value("tls port", &mut port)?;
-                mincfg.relay.tls_port = Some(port);
-                mincfg.relay.tls_identity_path =
-                    Some(PathBuf::from(utils::prompt_value_no_default::<String>(
-                        "path to your DER-encoded PKCS #12 archive",
-                    )?));
-                mincfg.relay.tls_identity_password = Some(
-                    utils::prompt_value_no_default::<String>("password for your PKCS #12 archive")?,
-                );
-            }
         }
 
         // TODO: Enable this once logging to Sentry is more useful.


### PR DESCRIPTION
Relay does not support TLS and the suggestion is to use the proxy in front of it for this use case. 

This means we should not include any mentions about TLS into the generated config. 


#skip-changelog