### PR TITLE
ref(spans): Scrub data image descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Scrub span descriptions with encoded data images. ([#2560](https://github.com/getsentry/relay/pull/2560))
+
 **Bug Fixes**:
 
 - Remove profile_id from context when no profile is in the envelope. ([#2523](https://github.com/getsentry/relay/pull/2523))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Scrub span descriptions with encoded data images. ([#2560](https://github.com/getsentry/relay/pull/2560))
+
 ## 0.8.30
 
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -91,6 +91,10 @@ fn scrub_http(string: &str) -> Option<String> {
         return None;
     };
 
+    if url.starts_with("data:image/") {
+        return Some(format!("{method} data:image/*"));
+    }
+
     let scrubbed = match Url::parse(url) {
         Ok(url) => {
             let host = url.host().map(|h| h.to_string())?;
@@ -365,6 +369,13 @@ mod tests {
         "GET /clients/8ff81d74-606d-4c75-ac5e-cee65cbbc866/project/01234",
         "http.client",
         "GET *"
+    );
+
+    span_description_test!(
+        span_description_scrub_data_images,
+        "GET data:image/png;base64,drtfghaksjfdhaeh/blah/blah/blah",
+        "http.client",
+        "GET data:image/*"
     );
 
     span_description_test!(


### PR DESCRIPTION
In span descriptions fetching encoded data images, the actual encoded image provides no value to the span. However, the number of `/`s is forcing the span description clusterer to misbehave.

Resolves https://github.com/getsentry/team-ingest/issues/221.