### PR TITLE
chore(py): Bump python changelog

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.31
+
+- Add `Reservoir` variant to `SamplingRule`. ([#2550](https://github.com/getsentry/relay/pull/2550))
+
 ## 0.8.30
 
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add `Reservoir` variant to `SamplingRule`. ([#2550](https://github.com/getsentry/relay/pull/2550))
-- Remove dynamic sampling abi. ([#2515](https://github.com/getsentry/relay/pull/2515))
+- Remove dynamic sampling ABI. ([#2515](https://github.com/getsentry/relay/pull/2515))
 
 ## 0.8.30
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.31
+## Unreleased
 
 - Add `Reservoir` variant to `SamplingRule`. ([#2550](https://github.com/getsentry/relay/pull/2550))
 - Remove dynamic sampling abi. ([#2515](https://github.com/getsentry/relay/pull/2515))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Remove dynamic sampling ABI. ([#2515](https://github.com/getsentry/relay/pull/2515))
 - Scrub span descriptions with encoded data images. ([#2560](https://github.com/getsentry/relay/pull/2560))
 
-
 ## 0.8.30
 
 - Filter out exceptions originating in Safari extensions. ([#2408](https://github.com/getsentry/relay/pull/2408))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.31
 
 - Add `Reservoir` variant to `SamplingRule`. ([#2550](https://github.com/getsentry/relay/pull/2550))
+- Remove dynamic sampling abi. ([#2515](https://github.com/getsentry/relay/pull/2515))
 
 ## 0.8.30
 


### PR DESCRIPTION
Updating the python changelog to reflect the new samplingrule variant in #2550, and removal of dynamic sampling ABI in #2515
 
#skip-changelog