### PR TITLE
build: Do not block deploys on macOS and Windows tests

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -40,7 +40,6 @@ pipelines:
                     getsentry/relay \
                     ${GO_REVISION_RELAY_REPO} \
                     "Integration Tests" \
-                    "Test (macos-latest)" \
                     "Test (windows-latest)" \
                     "Test All Features (ubuntu-latest)" \
                     "Push GCR Docker Image (relay)" \

--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -40,7 +40,6 @@ pipelines:
                     getsentry/relay \
                     ${GO_REVISION_RELAY_REPO} \
                     "Integration Tests" \
-                    "Test (windows-latest)" \
                     "Test All Features (ubuntu-latest)" \
                     "Push GCR Docker Image (relay)" \
                     "Push GCR Docker Image (relay-pop)"

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -4,7 +4,6 @@
     getsentry/relay \
     "${GO_REVISION_RELAY_REPO}" \
     "Integration Tests" \
-    "Test (windows-latest)" \
     "Test All Features (ubuntu-latest)" \
     "Push GCR Docker Image (relay)" \
     "Push GCR Docker Image (relay-pop)"

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -4,7 +4,6 @@
     getsentry/relay \
     "${GO_REVISION_RELAY_REPO}" \
     "Integration Tests" \
-    "Test (macos-latest)" \
     "Test (windows-latest)" \
     "Test All Features (ubuntu-latest)" \
     "Push GCR Docker Image (relay)" \


### PR DESCRIPTION
We don't run macOS or Windows in production, so we do not have to block deploys on these platform-specific tests.

#skip-changelog