### PR TITLE
feat(protocol): Add scraping_attempts field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Write span tags to `span.sentry_tags`. ([#2555](https://github.com/getsentry/relay/pull/2555))
 - Use JSON instead of MsgPack for Kafka spans. ([#2556](https://github.com/getsentry/relay/pull/2556))
 - Add `profile_id` to spans. ([#2569](https://github.com/getsentry/relay/pull/2569))
+- Add `scraping_attempts` field to the event schema. ([#2575](https://github.com/getsentry/relay/pull/2575))
 
 ## 23.9.1
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `scraping_attempts` field to the event schema. ([#2575](https://github.com/getsentry/relay/pull/2575))
+
 ## 0.8.31
 
 - Add `Reservoir` variant to `SamplingRule`. ([#2550](https://github.com/getsentry/relay/pull/2550))

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -483,7 +483,7 @@ pub struct Event {
     /// Information about attempts to scrape a JS source or sourcemap file from the web.
     /// This field is populated by sentry.
     #[metastructure(omit_from_schema)] // not part of external schema
-    pub scraping_attempts: Annotated<Object<Value>>,
+    pub scraping_attempts: Annotated<Array<Value>>,
 
     /// Internal ingestion and processing metrics.
     ///
@@ -972,6 +972,19 @@ mod tests {
         );
         assert_eq!(None, event.extra_at("c.e"));
         assert_eq!(None, event.extra_at("c.f"));
+    }
+
+    #[test]
+    fn test_scrape_attempts() {
+        let json = serde_json::json!({
+            "scraping_attempts": [
+                {"status": "not_attempted", "url": "http://example.com/embedded.js"},
+                {"status": "not_attempted", "url": "http://example.com/embedded.js.map"},
+            ]
+        });
+
+        let event = Event::from_value(json.into());
+        assert!(!event.value().unwrap().scraping_attempts.meta().has_errors());
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -480,6 +480,11 @@ pub struct Event {
     #[metastructure(omit_from_schema)] // we only document error events for now
     pub breakdowns: Annotated<Breakdowns>,
 
+    /// Information about attempts to scrape a JS source or sourcemap file from the web.
+    /// This field is populated by sentry.
+    #[metastructure(omit_from_schema)] // not part of external schema
+    pub scraping_attempts: Annotated<Object<Value>>,
+
     /// Internal ingestion and processing metrics.
     ///
     /// This value should not be ingested and will be overwritten by the store normalizer.

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -483,7 +483,7 @@ pub struct Event {
     /// Information about attempts to scrape a JS source or sourcemap file from the web.
     /// This field is populated by sentry.
     #[metastructure(omit_from_schema)] // not part of external schema
-    pub scraping_attempts: Annotated<Array<Value>>,
+    pub scraping_attempts: Annotated<Value>,
 
     /// Internal ingestion and processing metrics.
     ///

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__does_not_scrub_if_no_graphql.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__does_not_scrub_if_no_graphql.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: "&data"
 ---
 Event {
@@ -105,6 +105,7 @@ Event {
     spans: ~,
     measurements: ~,
     breakdowns: ~,
+    scraping_attempts: ~,
     _metrics: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_with_variables.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_with_variables.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: "&data"
 ---
 Event {
@@ -105,6 +105,7 @@ Event {
     spans: ~,
     measurements: ~,
     breakdowns: ~,
+    scraping_attempts: ~,
     _metrics: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_without_variables.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_without_variables.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: "&data"
 ---
 Event {
@@ -86,6 +86,7 @@ Event {
     spans: ~,
     measurements: ~,
     breakdowns: ~,
+    scraping_attempts: ~,
     _metrics: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_original_value.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_original_value.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: "&data"
 ---
 Event {
@@ -116,6 +116,7 @@ Event {
     spans: ~,
     measurements: ~,
     breakdowns: ~,
+    scraping_attempts: ~,
     _metrics: ~,
     other: {},
 }


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/57461 introduced a new top-level field on the event that is only written by sentry. To prevent errors when the event passes through normalization after writing `scraping_attempts`, make sure that the new field is part of the schema known by (lib)relay.