### PR TITLE
feat(spans): Extract more tags for resource spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Scrub span descriptions with encoded data images. ([#2560](https://github.com/getsentry/relay/pull/2560))
 - Accept spans needed for the mobile Starfish module. ([#2570](https://github.com/getsentry/relay/pull/2570))
+- Add additional tags for resource spans. ([#2578](https://github.com/getsentry/relay/pull/2578))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Scrub span descriptions with encoded data images. ([#2560](https://github.com/getsentry/relay/pull/2560))
 - Accept spans needed for the mobile Starfish module. ([#2570](https://github.com/getsentry/relay/pull/2570))
-- Add additional tags for resource spans. ([#2578](https://github.com/getsentry/relay/pull/2578))
+- Extract size metrics and blocking status tag for resource spans. ([#2578](https://github.com/getsentry/relay/pull/2578))
 
 **Bug Fixes**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -160,15 +160,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 value: None,
                 condition: None,
             })
-            .into_iter()
-            // Tags taken directly from the span payload:
-            .chain(std::iter::once(TagSpec {
-                key: "span.status".into(),
-                field: Some("span.status".into()),
-                value: None,
-                condition: None,
-            }))
-            .collect(),
+            .into(),
         },
     ]);
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -110,6 +110,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 ("span.", "system"),
                 ("", "transaction.method"),
                 ("", "transaction.op"),
+                ("", "resource.render_blocking_status"), // only set for resource spans.
             ]
             .map(|(prefix, key)| TagSpec {
                 key: format!("{prefix}{key}"),
@@ -152,7 +153,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 ("span.", "group"),
                 ("span.", "op"),
                 ("", "transaction"),
-                ("", "resource.render_blocking_status"), // only set for resource spans.
+                ("", "resource.render_blocking_status"),
             ]
             .map(|(prefix, key)| TagSpec {
                 key: format!("{prefix}{key}"),

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -117,6 +117,25 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 })
                 .into(),
         },
+        TagMapping {
+            metrics: vec![LazyGlob::new("d:spans/exclusive_time*@millisecond".into())],
+            tags: [
+                ("", "http.decoded_response_body_length"),
+                ("", "http.response_content_length"),
+                ("", "http.response_transfer_size"),
+                ("", "resource.render_blocking_status"),
+                ("", "transaction"),
+                ("", "type"),
+                ("span.", "domain"),
+            ]
+            .map(|(prefix, key)| TagSpec {
+                key: format!("{prefix}{key}"),
+                field: Some(format!("span.sentry_tags.{}", key)),
+                value: None,
+                condition: Some(RuleCondition::glob("span.op", "resource.*")),
+            })
+            .into(),
+        },
     ]);
 
     config._span_metrics_extended = true;

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -125,7 +125,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 ("", "http.response_transfer_size"),
                 ("", "resource.render_blocking_status"),
                 ("", "transaction"),
-                ("", "type"),
                 ("span.", "domain"),
             ]
             .map(|(prefix, key)| TagSpec {

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -72,21 +72,21 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         },
         MetricSpec {
             category: DataCategory::Span,
-            mri: "d:spans/http.response_content_length@none".into(),
+            mri: "d:spans/http.response_content_length@byte".into(),
             field: Some("span.data.http\\.response_content_length".into()),
             condition: Some(span_op_conditions.clone() & resource_condition.clone()),
             tags: Default::default(),
         },
         MetricSpec {
             category: DataCategory::Span,
-            mri: "d:spans/http.decoded_response_body_length@none".into(),
+            mri: "d:spans/http.decoded_response_body_length@byte".into(),
             field: Some("span.data.http\\.decoded_response_body_length".into()),
             condition: Some(span_op_conditions.clone() & resource_condition.clone()),
             tags: Default::default(),
         },
         MetricSpec {
             category: DataCategory::Span,
-            mri: "d:spans/http.response_transfer_size@none".into(),
+            mri: "d:spans/http.response_transfer_size@byte".into(),
             field: Some("span.data.http\\.response_transfer_size".into()),
             condition: Some(span_op_conditions.clone() & resource_condition.clone()),
             tags: Default::default(),
@@ -142,9 +142,9 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         // Resource-specific tags:
         TagMapping {
             metrics: vec![
-                LazyGlob::new("d:spans/http.response_content_length@none".into()),
-                LazyGlob::new("d:spans/http.decoded_response_body_length@none".into()),
-                LazyGlob::new("d:spans/http.response_transfer_size@none".into()),
+                LazyGlob::new("d:spans/http.response_content_length@byte".into()),
+                LazyGlob::new("d:spans/http.decoded_response_body_length@byte".into()),
+                LazyGlob::new("d:spans/http.response_transfer_size@byte".into()),
             ],
             tags: [
                 ("", "environment"),

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -125,7 +125,7 @@ impl SpanTagKey {
 /// Render-blocking resources are static files, such as fonts, CSS, and JavaScript that block or
 /// delay the browser from rendering page content to the screen.
 ///
-/// See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus.
+/// See <https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus>.
 enum RenderBlockingStatus {
     Blocking,
     NonBlocking,

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -42,15 +42,19 @@ pub enum SpanTagKey {
     DeviceClass,
 
     // Specific to spans
-    Description,
-    Group,
-    SpanOp,
-    Category,
-    Module,
     Action,
+    Category,
+    Description,
     Domain,
-    System,
+    Group,
+    HttpDecodedResponseBodyLength,
+    HttpResponseContentLength,
+    HttpResponseTransferSize,
+    Module,
+    ResourceRenderBlockingStatus,
+    SpanOp,
     StatusCode,
+    System,
 }
 
 impl SpanTagKey {
@@ -70,15 +74,19 @@ impl SpanTagKey {
             SpanTagKey::Mobile => "mobile",
             SpanTagKey::DeviceClass => "device.class",
 
-            SpanTagKey::Description => "span.description",
-            SpanTagKey::Group => "span.group",
-            SpanTagKey::SpanOp => "span.op",
-            SpanTagKey::Category => "span.category",
-            SpanTagKey::Module => "span.module",
             SpanTagKey::Action => "span.action",
+            SpanTagKey::Category => "span.category",
+            SpanTagKey::Description => "span.description",
             SpanTagKey::Domain => "span.domain",
-            SpanTagKey::System => "span.system",
+            SpanTagKey::Group => "span.group",
+            SpanTagKey::HttpDecodedResponseBodyLength => "http.decoded_response_body_length",
+            SpanTagKey::HttpResponseContentLength => "http.response_content_length",
+            SpanTagKey::HttpResponseTransferSize => "http.response_transfer_size",
+            SpanTagKey::Module => "span.module",
+            SpanTagKey::ResourceRenderBlockingStatus => "resource.render_blocking_status",
+            SpanTagKey::SpanOp => "span.op",
             SpanTagKey::StatusCode => "span.status_code",
+            SpanTagKey::System => "span.system",
         }
     }
 
@@ -97,15 +105,19 @@ impl SpanTagKey {
             SpanTagKey::Mobile => "mobile",
             SpanTagKey::DeviceClass => "device.class",
 
-            SpanTagKey::Description => "description",
-            SpanTagKey::Group => "group",
-            SpanTagKey::SpanOp => "op",
-            SpanTagKey::Category => "category",
-            SpanTagKey::Module => "module",
             SpanTagKey::Action => "action",
+            SpanTagKey::Category => "category",
+            SpanTagKey::Description => "description",
             SpanTagKey::Domain => "domain",
-            SpanTagKey::System => "system",
+            SpanTagKey::Group => "group",
+            SpanTagKey::HttpDecodedResponseBodyLength => "http.decoded_response_body_length",
+            SpanTagKey::HttpResponseContentLength => "http.response_content_length",
+            SpanTagKey::HttpResponseTransferSize => "http.response_transfer_size",
+            SpanTagKey::Module => "module",
+            SpanTagKey::ResourceRenderBlockingStatus => "resource.render_blocking_status",
+            SpanTagKey::SpanOp => "op",
             SpanTagKey::StatusCode => "status_code",
+            SpanTagKey::System => "system",
         }
     }
 }
@@ -299,7 +311,7 @@ pub(crate) fn extract_tags(span: &Span, config: &Config) -> BTreeMap<SpanTagKey,
             span_tags.insert(SpanTagKey::Action, act);
         }
 
-        let domain = if span_op == "http.client" {
+        let domain = if span_op == "http.client" || span_op.starts_with("resource.") {
             // HACK: Parse the normalized description to get the normalized domain.
             scrubbed_description
                 .and_then(|d| d.split_once(' '))
@@ -339,6 +351,56 @@ pub(crate) fn extract_tags(span: &Span, config: &Config) -> BTreeMap<SpanTagKey,
 
             let truncated = truncate_string(scrubbed_desc.to_owned(), config.max_tag_value_size);
             span_tags.insert(SpanTagKey::Description, truncated);
+        }
+
+        if span_op.starts_with("resource.") {
+            if let Some(http_response_content_length) = span
+                .data
+                .value()
+                .and_then(|data| data.get("http.response_content_length"))
+                .and_then(|value| value.as_str())
+            {
+                span_tags.insert(
+                    SpanTagKey::HttpResponseContentLength,
+                    http_response_content_length.to_owned(),
+                );
+            }
+
+            if let Some(http_decoded_response_body_length) = span
+                .data
+                .value()
+                .and_then(|data| data.get("http.decoded_response_body_length"))
+                .and_then(|value| value.as_str())
+            {
+                span_tags.insert(
+                    SpanTagKey::HttpDecodedResponseBodyLength,
+                    http_decoded_response_body_length.to_owned(),
+                );
+            }
+
+            if let Some(http_response_transfer_size) = span
+                .data
+                .value()
+                .and_then(|data| data.get("http.response_transfer_size"))
+                .and_then(|value| value.as_str())
+            {
+                span_tags.insert(
+                    SpanTagKey::HttpResponseTransferSize,
+                    http_response_transfer_size.to_owned(),
+                );
+            }
+
+            if let Some(resource_render_blocking_status) = span
+                .data
+                .value()
+                .and_then(|data| data.get("resource.render_blocking_status"))
+                .and_then(|value| value.as_str())
+            {
+                span_tags.insert(
+                    SpanTagKey::ResourceRenderBlockingStatus,
+                    resource_render_blocking_status.to_owned(),
+                );
+            }
         }
     }
 

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -433,6 +433,23 @@ mod tests {
                     "timestamp": 1597976302.0000000,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok"
+                },
+                {
+                    "timestamp": 1694732408.3145,
+                    "start_timestamp": 1694732407.8367,
+                    "exclusive_time": 477.800131,
+                    "description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCiE38F1Fz22KuljsgCAD6hyWCyOYZM.css",
+                    "op": "resource.link",
+                    "span_id": "97c0ef9770a02f9d",
+                    "parent_span_id": "9756d8d7b2b364ff",
+                    "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+                    "data": {
+                        "http.decoded_response_content_length": 128950,
+                        "http.response_content_length": 36170,
+                        "http.response_transfer_size": 36470,
+                        "resource.render_blocking_status": "blocking"
+                    },
+                    "hash": "e2fae740cccd3789"
                 }
             ]
         }
@@ -941,6 +958,23 @@ mod tests {
                     "start_timestamp": 1695255134.469436,
                     "timestamp": 1695255136.137952,
                     "trace_id": "2dc90ee797b94299ba5ad82b816fc9f8"
+                },
+                {
+                    "timestamp": 1694732408.3145,
+                    "start_timestamp": 1694732407.8367,
+                    "exclusive_time": 477.800131,
+                    "description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCiE38F1Fz22KuljsgCAD6hyWCyOYZM.css",
+                    "op": "resource.link",
+                    "span_id": "97c0ef9770a02f9d",
+                    "parent_span_id": "9756d8d7b2b364ff",
+                    "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+                    "data": {
+                        "http.decoded_response_content_length": 128950,
+                        "http.response_content_length": 36170,
+                        "http.response_transfer_size": 36470,
+                        "resource.render_blocking_status": "blocking"
+                    },
+                    "hash": "e2fae740cccd3789"
                 }
             ]
         }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1243,9 +1243,85 @@ expression: metrics
             "span.group": "022f81fdf31228bf",
             "span.op": "resource.script",
             "span.status": "ok",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
+        name: "d:spans/exclusive_time@millisecond",
+        value: Distribution(
+            [
+                477.800131,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.category": "resource",
+            "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
+            "span.group": "fd1c98edd40299a3",
+            "span.op": "resource.link",
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
+        name: "d:spans/exclusive_time_light@millisecond",
+        value: Distribution(
+            [
+                477.800131,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.category": "resource",
+            "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
+            "span.group": "fd1c98edd40299a3",
+            "span.op": "resource.link",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
+        name: "d:spans/http.response_content_length@none",
+        value: Distribution(
+            [
+                36170.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "resource.render_blocking_status": "blocking",
+            "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
+            "span.group": "fd1c98edd40299a3",
+            "span.op": "resource.link",
+            "transaction": "gEt /api/:version/users/",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
+        name: "d:spans/http.response_transfer_size@none",
+        value: Distribution(
+            [
+                36470.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "resource.render_blocking_status": "blocking",
+            "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
+            "span.group": "fd1c98edd40299a3",
+            "span.op": "resource.link",
+            "transaction": "gEt /api/:version/users/",
         },
     },
 ]

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1259,6 +1259,7 @@ expression: metrics
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
+            "resource.render_blocking_status": "blocking",
             "span.category": "resource",
             "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
             "span.group": "fd1c98edd40299a3",
@@ -1280,6 +1281,7 @@ expression: metrics
         tags: {
             "environment": "fake_environment",
             "http.status_code": "500",
+            "resource.render_blocking_status": "blocking",
             "span.category": "resource",
             "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
             "span.group": "fd1c98edd40299a3",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1243,6 +1243,7 @@ expression: metrics
             "span.group": "022f81fdf31228bf",
             "span.op": "resource.script",
             "span.status": "ok",
+            "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
         },

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1293,7 +1293,7 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_content_length@none",
+        name: "d:spans/http.response_content_length@byte",
         value: Distribution(
             [
                 36170.0,
@@ -1311,7 +1311,7 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_transfer_size@none",
+        name: "d:spans/http.response_transfer_size@byte",
         value: Distribution(
             [
                 36470.0,


### PR DESCRIPTION
This PR extracts the following new metrics and tags for `resource` spans:

* `d:spans/http.response_content_length@byte`
* `http.decoded_response_body_length@byte`
* `d:spans/http.response_transfer_size@byte`

These are tagged by environment, description, domain, group, span op, transaction and the new `resource.render_blocking_status` tag. The new tag is also added to the `exclusive_time` and `exclusive_time` light metrics.

Static strings added here: https://github.com/getsentry/sentry/pull/57810

ref: [internal issue](https://www.notion.so/sentry/Ensure-resource-spans-contain-correct-data-1c5c2cbe58bc408b84e763a29843384a)