### PR TITLE
fix(ci): Require symbolicator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
         arch: [amd64]
         image_name: [relay, relay-pop]
 
-
     name: Build Docker Image
     runs-on: ubuntu-latest
 
@@ -430,6 +429,7 @@ jobs:
           python-version: 3.8
           snuba: true
           kafka: true
+          symbolicator: true
 
       - name: Download Docker Image
         uses: actions/download-artifact@v3


### PR DESCRIPTION
`setup-sentry` for integration tests seems to require an explicit symbolicator flag now, see https://github.com/getsentry/sentry/pull/56253.

#skip-changelog