### PR TITLE
feat(spool): Avoid evicting old project for incoming envelopes

### DIFF
--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -118,7 +118,7 @@ uuid = { workspace = true, features = ["v5"] }
 zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ['test-util'] }
+tokio = { workspace = true, features = ["test-util", "time"] }
 insta = { workspace = true }
 relay-event-schema = { path = "../relay-event-schema", features = [
     "jsonschema",

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -490,7 +490,7 @@ impl Project {
         self.last_updated_at
     }
 
-    /// The last time when this project was used for the incoming envelope.
+    /// The last time that this project was used for an incoming envelope.
     pub fn last_envelope_seen_at(&self) -> Instant {
         self.last_envelope_seen
     }
@@ -820,8 +820,7 @@ impl Project {
         let state = self.valid_state().filter(|state| !state.invalid());
         let mut scoping = envelope.scoping();
 
-        // On every incoming envelopes, which belongs to this project, update when the last it was
-        // seen.
+        // On every incoming envelope, which belongs to this project, update when it was last seen.
         self.last_envelope_seen = envelope.start_time().into();
 
         if let Some(ref state) = state {

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -519,10 +519,10 @@ impl ProjectCacheBroker {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
-        // Get all the projects which have not updated in configured time and also have not gotten
-        // any new incoming envelopes in meantime.
+        // Get all the projects which have not updated in the configured time and also have not gotten
+        // any new incoming envelopes in the meantime.
         //
-        // In case of incident it can happen, that the ProjectState cannot get updated, and we
+        // In case of an incident it can happen, that the ProjectState cannot get updated, and we
         // still getting incoming traffic - we want to keep the buffered envelopes as long as we
         // reasonable can (till the incident is resolved) and process them as usual.
         let expired = self.projects.drain_filter(|_, entry| {

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -519,9 +519,16 @@ impl ProjectCacheBroker {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();
 
-        let expired = self
-            .projects
-            .drain_filter(|_, entry| entry.last_updated_at() + delta <= eviction_start);
+        // Get all the projects which have not updated in configured time and also have not gotten
+        // any new incoming envelopes in meantime.
+        //
+        // In case of incident it can happen, that the ProjectState cannot get updated, and we
+        // still getting incoming traffic - we want to keep the buffered envelopes as long as we
+        // reasonable can (till the incident is resolved) and process them as usual.
+        let expired = self.projects.drain_filter(|_, entry| {
+            entry.last_updated_at() + delta <= eviction_start
+                && entry.last_envelope_seen_at() + delta <= eviction_start
+        });
 
         // Defer dropping the projects to a dedicated thread:
         let mut count = 0;
@@ -952,21 +959,12 @@ mod tests {
     }
 
     async fn project_cache_broker_setup(
+        config: Arc<Config>,
         services: Services,
         buffer_guard: Arc<BufferGuard>,
         state_tx: mpsc::UnboundedSender<UpdateProjectState>,
         buffer_tx: mpsc::UnboundedSender<ManagedEnvelope>,
     ) -> (ProjectCacheBroker, Addr<Buffer>) {
-        let config: Arc<_> = Config::from_json_value(serde_json::json!({
-            "spool": {
-                "envelopes": {
-                    "path": std::env::temp_dir().join(Uuid::new_v4().to_string()),
-                    "max_memory_size": 0, // 0 bytes, to force to spool to disk all the envelopes.
-                }
-            }
-        }))
-        .unwrap()
-        .into();
         let buffer_services = spooler::Services {
             outcome_aggregator: services.outcome_aggregator.clone(),
             project_cache: services.project_cache.clone(),
@@ -1012,9 +1010,25 @@ mod tests {
         let services = mocked_services();
         let (state_tx, _) = mpsc::unbounded_channel();
         let (buffer_tx, mut buffer_rx) = mpsc::unbounded_channel();
-        let (mut broker, buffer_svc) =
-            project_cache_broker_setup(services.clone(), buffer_guard.clone(), state_tx, buffer_tx)
-                .await;
+        let config = Config::from_json_value(serde_json::json!({
+            "spool": {
+                "envelopes": {
+                    "path": std::env::temp_dir().join(Uuid::new_v4().to_string()),
+                    "max_memory_size": 0, // 0 bytes, to force to spool to disk all the envelopes.
+                }
+            }
+        }))
+        .unwrap()
+        .into();
+
+        let (mut broker, buffer_svc) = project_cache_broker_setup(
+            config,
+            services.clone(),
+            buffer_guard.clone(),
+            state_tx,
+            buffer_tx,
+        )
+        .await;
 
         for _ in 0..8 {
             let envelope = buffer_guard
@@ -1065,7 +1079,7 @@ mod tests {
         envelopes.pop().unwrap();
         assert_eq!(buffer_guard.available(), 1);
 
-        // Till now we should have enqueued 5 envleopes and dequeued only 1, it means the index is
+        // Till now we should have enqueued 5 envelopes and dequeued only 1, it means the index is
         // still populated with same keys and values.
         assert_eq!(broker.index.keys().len(), 1);
         assert_eq!(broker.index.values().count(), 1);
@@ -1090,5 +1104,61 @@ mod tests {
             // Nothing will be dequeued.
             assert!(buffer_rx.try_recv().is_err())
         }
+    }
+
+    #[tokio::test]
+    async fn test_eviction() {
+        let num_permits = 5;
+        let buffer_guard: Arc<_> = BufferGuard::new(num_permits).into();
+        let services = mocked_services();
+        let (state_tx, _) = mpsc::unbounded_channel();
+        let (buffer_tx, _) = mpsc::unbounded_channel();
+
+        // Projects should be expired after 2 seconds.
+        let config: Arc<_> = Config::from_json_value(serde_json::json!({
+            "cache": {
+              "project_expiry": 1
+            }
+        }))
+        .unwrap()
+        .into();
+
+        let (mut broker, _) = project_cache_broker_setup(
+            config.clone(),
+            services.clone(),
+            buffer_guard,
+            state_tx,
+            buffer_tx,
+        )
+        .await;
+
+        let key1 = ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap();
+        let project1 = Project::new(key1, config.clone());
+        let key2 = ProjectKey::parse("eeed836b15bb49d7bbf99e64295d9bbb").unwrap();
+        let project2 = Project::new(key2, config);
+
+        broker.projects.insert(key1, project1);
+        broker.projects.insert(key2, project2);
+
+        for _ in 0..20 {
+            let envelope = ManagedEnvelope::untracked(
+                empty_envelope(),
+                services.outcome_aggregator.clone(),
+                services.test_store.clone(),
+            );
+            if let hashbrown::hash_map::Entry::Occupied(mut e) = broker.projects.entry(key2) {
+                e.get_mut()
+                    .check_envelope(envelope, services.outcome_aggregator.clone())
+                    .unwrap();
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // One of the project will be removed.
+        broker.evict_stale_project_caches();
+        // Project 1 did not receive any envelopes, and should be removed now.
+        assert_eq!(broker.projects.len(), 1);
+        assert!(broker.projects.get(&key2).is_some());
     }
 }


### PR DESCRIPTION
In case of the incident , when we keep getting envelopes for the specific project, we should not evict it, and keep it around till the incident resolved , project updated, and buffered envelopes processed. 

related to https://github.com/getsentry/team-ingest/issues/222
followup for https://github.com/getsentry/relay/pull/2294

#skip-changelog