### PR TITLE
fix(server): Bind exclusively to the port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix reporting of Relay's crashes to Sentry. The `crash-handler` feature did not enable the crash reporter and uploads of crashes were broken. ([#2532](https://github.com/getsentry/relay/pull/2532))
 - Use correct field to pick SQL parser for span normalization. ([#2536](https://github.com/getsentry/relay/pull/2536))
 - Prevent stack overflow on SQL serialization. ([#2538](https://github.com/getsentry/relay/pull/2538))
+- Bind exclusively to the port for the HTTP server. ([#2582](https://github.com/getsentry/relay/pull/2582))
 
 **Internal**:
 

--- a/relay-server/src/actors/server.rs
+++ b/relay-server/src/actors/server.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -111,15 +111,24 @@ impl Service for HttpServer {
             .build();
 
         let handle = Handle::new();
-        let server = axum_server::bind(config.listen_addr())
-            .http_config(http_config)
-            .addr_incoming_config(addr_config)
-            .handle(handle.clone());
+        match TcpListener::bind(config.listen_addr()) {
+            Ok(listener) => {
+                listener.set_nonblocking(true).ok();
+                let server = axum_server::from_tcp(listener)
+                    .http_config(http_config)
+                    .addr_incoming_config(addr_config)
+                    .handle(handle.clone());
 
-        relay_log::info!("spawning http server");
-        relay_log::info!("  listening on http://{}/", config.listen_addr());
-        relay_statsd::metric!(counter(RelayCounters::ServerStarting) += 1);
-        tokio::spawn(server.serve(app));
+                relay_log::info!("spawning http server");
+                relay_log::info!("  listening on http://{}/", config.listen_addr());
+                relay_statsd::metric!(counter(RelayCounters::ServerStarting) += 1);
+                tokio::spawn(server.serve(app));
+            }
+            Err(err) => {
+                relay_log::error!("Failed to start the HTTP server: {err}");
+                std::process::exit(1);
+            }
+        }
 
         tokio::spawn(async move {
             let Shutdown { timeout } = Controller::shutdown_handle().notified().await;


### PR DESCRIPTION
Bind eagerly (and exclusively) to the port for the HTTP server, and fail to start the Relay otherwise.

The proper error should be also provided, e.g.

```
ERROR relay_server::actors::server: Failed to start the HTTP server: Address already in use (os error 48)
```

fix https://github.com/getsentry/relay/issues/2423

#skip-changelog