### PR TITLE
instr(metrics): Fix tag on error and add full name

### DIFF
--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -184,39 +184,3 @@ impl GaugeMetric for MetricGauges {
         }
     }
 }
-
-/// Returns a low-cardinality metric name for use as a tag key on statsd metrics.
-///
-/// In order to keep this low-cardinality, we only enumerate a handful of well-known, high volume
-/// names. The rest gets mapped to "other".
-pub(crate) fn metric_name_tag(value: &str) -> &'static str {
-    if let Some(value) = [
-        "c:sessions/session@none",
-        "s:sessions/user@none",
-        "s:sessions/error@none",
-        "d:transactions/duration@millisecond",
-        "s:transactions/user@none",
-        "c:transactions/count_per_root_project@none",
-    ]
-    .into_iter()
-    .find(|x| x == &value)
-    {
-        return value;
-    }
-
-    if value.starts_with("d:transactions/breakdowns.") {
-        return "d:transactions/breakdowns.*";
-    }
-    if value.starts_with("d:transactions/measurements.") {
-        return "d:transactions/measurements.*";
-    }
-
-    if value.starts_with("s:spans/") {
-        return "s:spans/";
-    }
-    if value.starts_with("d:spans/") {
-        return "d:spans/";
-    }
-
-    "other"
-}


### PR DESCRIPTION
Fix previous instrumentation of `AggregateMetricsError`, and add the full metric name as an additional (non-indexed) data field for verification.

ref: https://github.com/getsentry/team-ingest/issues/227

#skip-changelog