### PR TITLE
fix(replays): Cap replay event size by setting bag-size for unsized fields

### DIFF
--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -34,6 +34,14 @@ use crate::protocol::{
     ClientSdkInfo, Contexts, EventId, LenientString, Request, Tags, Timestamp, User,
 };
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(rename_all = "lowercase"))]
+pub enum ReplayType {
+    Session,
+    Error,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 #[metastructure(process_func = "process_replay", value_type = "Replay")]
@@ -82,7 +90,7 @@ pub struct Replay {
     ///   "replay_type": "session"
     /// }
     /// ```
-    pub replay_type: Annotated<String>,
+    pub replay_type: Annotated<ReplayType>,
 
     /// Segment identifier.
     ///
@@ -134,10 +142,12 @@ pub struct Replay {
     pub urls: Annotated<Array<String>>,
 
     /// A list of error-ids discovered during the lifetime of the segment.
-    pub error_ids: Annotated<Array<String>>,
+    #[metastructure(bag_size = "medium")]
+    pub error_ids: Annotated<Array<EventId>>,
 
     /// A list of trace-ids discovered during the lifetime of the segment.
-    pub trace_ids: Annotated<Array<String>>,
+    #[metastructure(bag_size = "medium")]
+    pub trace_ids: Annotated<Array<EventId>>,
 
     /// Contexts describing the environment (e.g. device, os or browser).
     #[metastructure(skip_serialization = "empty")]

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -82,6 +82,7 @@ pub struct Replay {
     ///   "replay_type": "session"
     /// }
     /// ```
+    #[metastructure(bag_size = "small")]
     pub replay_type: Annotated<String>,
 
     /// Segment identifier.
@@ -149,6 +150,7 @@ pub struct Replay {
     ///
     /// A string representing the platform the SDK is submitting from. This will be used by the
     /// Sentry interface to customize various components in the interface.
+    #[metastructure(bag_size = "small")]
     pub platform: Annotated<String>,
 
     /// The release version of the application.
@@ -160,7 +162,8 @@ pub struct Replay {
         required = "false",
         trim_whitespace = "true",
         nonempty = "true",
-        skip_serialization = "empty"
+        skip_serialization = "empty",
+        bag_size = "small"
     )]
     pub release: Annotated<LenientString>,
 
@@ -175,7 +178,8 @@ pub struct Replay {
         allow_chars = "a-zA-Z0-9_.-",
         trim_whitespace = "true",
         required = "false",
-        nonempty = "true"
+        nonempty = "true",
+        bag_size = "small"
     )]
     pub dist: Annotated<String>,
 
@@ -188,7 +192,8 @@ pub struct Replay {
         max_chars = "environment",
         nonempty = "true",
         required = "false",
-        trim_whitespace = "true"
+        trim_whitespace = "true",
+        bag_size = "small"
     )]
     pub environment: Annotated<String>,
 
@@ -199,7 +204,7 @@ pub struct Replay {
     pub tags: Annotated<Tags>,
 
     /// Static value. Should always be "replay_event".
-    #[metastructure(field = "type")]
+    #[metastructure(field = "type", bag_size = "small")]
     pub ty: Annotated<String>,
 
     /// Information about the user who triggered this event.

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -82,7 +82,7 @@ pub struct Replay {
     ///   "replay_type": "session"
     /// }
     /// ```
-    #[metastructure(bag_size = "small")]
+    #[metastructure(max_chars = "environment")]
     pub replay_type: Annotated<String>,
 
     /// Segment identifier.
@@ -150,7 +150,7 @@ pub struct Replay {
     ///
     /// A string representing the platform the SDK is submitting from. This will be used by the
     /// Sentry interface to customize various components in the interface.
-    #[metastructure(bag_size = "small")]
+    #[metastructure(max_chars = "environment")]
     pub platform: Annotated<String>,
 
     /// The release version of the application.
@@ -162,8 +162,7 @@ pub struct Replay {
         required = "false",
         trim_whitespace = "true",
         nonempty = "true",
-        skip_serialization = "empty",
-        bag_size = "small"
+        skip_serialization = "empty"
     )]
     pub release: Annotated<LenientString>,
 
@@ -179,7 +178,7 @@ pub struct Replay {
         trim_whitespace = "true",
         required = "false",
         nonempty = "true",
-        bag_size = "small"
+        max_chars = "environment"
     )]
     pub dist: Annotated<String>,
 
@@ -192,8 +191,7 @@ pub struct Replay {
         max_chars = "environment",
         nonempty = "true",
         required = "false",
-        trim_whitespace = "true",
-        bag_size = "small"
+        trim_whitespace = "true"
     )]
     pub environment: Annotated<String>,
 
@@ -204,7 +202,7 @@ pub struct Replay {
     pub tags: Annotated<Tags>,
 
     /// Static value. Should always be "replay_event".
-    #[metastructure(field = "type", bag_size = "small")]
+    #[metastructure(field = "type", max_chars = "environment")]
     pub ty: Annotated<String>,
 
     /// Information about the user who triggered this event.

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -34,14 +34,6 @@ use crate::protocol::{
     ClientSdkInfo, Contexts, EventId, LenientString, Request, Tags, Timestamp, User,
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "jsonschema", schemars(rename_all = "lowercase"))]
-pub enum ReplayType {
-    Session,
-    Error,
-}
-
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 #[metastructure(process_func = "process_replay", value_type = "Replay")]
@@ -90,7 +82,7 @@ pub struct Replay {
     ///   "replay_type": "session"
     /// }
     /// ```
-    pub replay_type: Annotated<ReplayType>,
+    pub replay_type: Annotated<String>,
 
     /// Segment identifier.
     ///
@@ -143,11 +135,11 @@ pub struct Replay {
 
     /// A list of error-ids discovered during the lifetime of the segment.
     #[metastructure(bag_size = "medium")]
-    pub error_ids: Annotated<Array<EventId>>,
+    pub error_ids: Annotated<Array<String>>,
 
     /// A list of trace-ids discovered during the lifetime of the segment.
     #[metastructure(bag_size = "medium")]
-    pub trace_ids: Annotated<Array<EventId>>,
+    pub trace_ids: Annotated<Array<String>>,
 
     /// Contexts describing the environment (e.g. device, os or browser).
     #[metastructure(skip_serialization = "empty")]


### PR DESCRIPTION
Ref: https://sentry.my.sentry.io/organizations/sentry/issues/396171/?referrer=slack

#skip-changelog