### PR TITLE
ref(metrics): Stop producing has_profile on transactions/duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Write span tags to `span.sentry_tags`. ([#2555](https://github.com/getsentry/relay/pull/2555))
 - Use JSON instead of MsgPack for Kafka spans. ([#2556](https://github.com/getsentry/relay/pull/2556))
 - Add `profile_id` to spans. ([#2569](https://github.com/getsentry/relay/pull/2569))
-- Introduce a dedicated usage metric for transactions that replaces the duration metric. ([#2571](https://github.com/getsentry/relay/pull/2571))
+- Introduce a dedicated usage metric for transactions that replaces the duration metric. ([#2571](https://github.com/getsentry/relay/pull/2571), [#2589](https://github.com/getsentry/relay/pull/2589))
 - Restore the profiling killswitch. ([#2573](https://github.com/getsentry/relay/pull/2573))
 - Add `scraping_attempts` field to the event schema. ([#2575](https://github.com/getsentry/relay/pull/2575))
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -331,12 +331,18 @@ impl TransactionExtractor<'_> {
 
         // Duration
         let duration = relay_common::time::chrono_to_positive_millis(end - start);
+        let has_profile = if self.config.version >= 3 {
+            false
+        } else {
+            self.has_profile
+        };
+
         metrics.project_metrics.push(
             TransactionMetric::Duration {
                 unit: DurationUnit::MilliSecond,
                 value: duration,
                 tags: TransactionDurationTags {
-                    has_profile: self.has_profile, // TODO: Stop producing this in v3
+                    has_profile,
                     universal_tags: tags.clone(),
                 },
             }


### PR DESCRIPTION
Finishes the move to `c:transactions/usage@none`.

