### PR TITLE
instr(metrics): Ignore invalid timestamp errors

### DIFF
--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::iter::FusedIterator;
 use std::time::Duration;
 
@@ -265,16 +264,8 @@ impl AggregatorService {
             project_key,
             buckets,
         } = msg;
-        if let Err(err) =
-            self.aggregator
-                .merge_all(project_key, buckets, self.max_total_bucket_bytes)
-        {
-            relay_log::error!(
-                tags.aggregator = &self.aggregator.name(),
-                error = &err as &dyn Error,
-                "failed to merge buckets"
-            );
-        }
+        self.aggregator
+            .merge_all(project_key, buckets, self.max_total_bucket_bytes);
     }
 
     fn handle_message(&mut self, msg: Aggregator) {


### PR DESCRIPTION
Ignore `InvalidTimestamp` error on metrics aggregation.

The metrics aggregator only accept timestamps from the last 5 days. But incoming metrics buckets can always contain invalid timestamps, even when we validated the timestamps on the payload before, because the timestamp may have become invalid while the metric was aggregated in a downstream relay.

With custom metrics, there is no pre-validation at all, so we will see even more `InvalidTimestamp` errors as their usage increases.

ref: https://github.com/getsentry/team-ingest/issues/227

#skip-changelog