### PR TITLE
fix(spans): Scrub resource span description even when we don't detect an extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use correct field to pick SQL parser for span normalization. ([#2536](https://github.com/getsentry/relay/pull/2536))
 - Prevent stack overflow on SQL serialization. ([#2538](https://github.com/getsentry/relay/pull/2538))
 - Bind exclusively to the port for the HTTP server. ([#2582](https://github.com/getsentry/relay/pull/2582))
+- Scrub resource spans even when there's no domain or extension or when the description is an image. ([#2591](https://github.com/getsentry/relay/pull/2591))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -13,7 +13,7 @@ const DISABLED_DATABASES: &[&str] = &["*clickhouse*", "*mongodb*", "*redis*", "*
 const MOBILE_OPS: &[&str] = &["app.*", "ui.load*"];
 
 /// A list of patterns found in MongoDB queries
-const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*"];
+const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
 
 /// Adds configuration for extracting metrics from spans.
 ///

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -12,6 +12,9 @@ const DISABLED_DATABASES: &[&str] = &["*clickhouse*", "*mongodb*", "*redis*", "*
 /// A list of span.op` patterns we want to enable for mobile.
 const MOBILE_OPS: &[&str] = &["app.*", "ui.load*"];
 
+/// A list of patterns found in MongoDB queries
+const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*"];
+
 /// Adds configuration for extracting metrics from spans.
 ///
 /// This configuration is temporarily hard-coded here. It will later be provided by the upstream.
@@ -42,7 +45,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
     } else {
         let is_disabled = RuleCondition::glob("span.op", DISABLED_DATABASES);
         let is_mongo = RuleCondition::eq("span.system", "mongodb")
-            | RuleCondition::glob("span.description", vec!["*\"$*", "{*", "*({*"]);
+            | RuleCondition::glob("span.description", MONGODB_QUERIES);
 
         let mut conditions = RuleCondition::eq("span.op", "http.client")
             | RuleCondition::glob("span.op", MOBILE_OPS)

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -42,7 +42,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
     } else {
         let is_disabled = RuleCondition::glob("span.op", DISABLED_DATABASES);
         let is_mongo = RuleCondition::eq("span.system", "mongodb")
-            | RuleCondition::glob("span.description", vec!["*\"$*", "{*"]);
+            | RuleCondition::glob("span.description", vec!["*\"$*", "{*", "*({*"]);
 
         let mut conditions = RuleCondition::eq("span.op", "http.client")
             | RuleCondition::glob("span.op", MOBILE_OPS)

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -33,7 +33,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         return;
     }
 
-    let resource_condition = RuleCondition::eq("span.category", "resource");
+    let resource_condition = RuleCondition::glob("span.op", "resource*");
 
     // Add conditions to filter spans if a specific module is enabled.
     // By default, this will extract all spans.
@@ -49,7 +49,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
 
         let mut conditions = RuleCondition::eq("span.op", "http.client")
             | RuleCondition::glob("span.op", MOBILE_OPS)
-            | (RuleCondition::eq("span.category", "db") & !is_disabled & !is_mongo);
+            | (RuleCondition::glob("span.op", "db*") & !is_disabled & !is_mongo);
 
         if project_config
             .features

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -602,6 +602,15 @@ mod tests {
         "data:image/svg+xml"
     );
 
+    span_description_test!(
+        db_category_with_mongodb_query,
+        "find({some_id:1234567890},{limit:100})",
+        "db",
+        ""
+    );
+
+    span_description_test!(db_category_with_not_sql, "{someField:someValue}", "db", "");
+
     #[test]
     fn informed_sql_parser() {
         let json = r#"

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn scrub_span_description(span: &mut Span, rules: &Vec<SpanDescriptio
                     || sub.contains("mongodb")
                     || sub.contains("redis")
                     || is_legacy_activerecord(sub, db_system)
-                    || is_sql_mongodb(sub, description, db_system)
+                    || is_sql_mongodb(description, db_system)
                 {
                     None
                 } else {
@@ -84,8 +84,11 @@ pub(crate) fn scrub_span_description(span: &mut Span, rules: &Vec<SpanDescriptio
 }
 
 /// A span declares `op: db.sql.query`, but contains mongodb.
-fn is_sql_mongodb(sub_op: &str, description: &str, db_system: Option<&str>) -> bool {
-    sub_op == "sql.query" && (description.contains("\"$") || db_system == Some("mongodb"))
+fn is_sql_mongodb(description: &str, db_system: Option<&str>) -> bool {
+    description.contains("\"$")
+        || description.contains("({")
+        || description.starts_with('{')
+        || db_system == Some("mongodb")
 }
 
 /// We are unable to parse active record when we do not know which database is being used.

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -106,7 +106,7 @@ fn is_legacy_activerecord(sub_op: &str, db_system: Option<&str>) -> bool {
 fn scrub_core_data(string: &str) -> Option<String> {
     match DB_SQL_TRANSACTION_CORE_DATA_REGEX.replace_all(string, "*") {
         Cow::Owned(scrubbed) => Some(scrubbed),
-        Cow::Borrowed(_) => Some("".into()),
+        Cow::Borrowed(_) => None,
     }
 }
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -224,7 +224,7 @@ fn scrub_resource_identifiers(mut string: &str) -> Option<String> {
                 }
                 return Some(format!("{domain}/*"));
             }
-            Some(string.into())
+            None
         }
     }
 }

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -93,6 +93,7 @@ pub(crate) fn scrub_span_description(span: &mut Span, rules: &Vec<SpanDescriptio
 fn is_sql_mongodb(description: &str, db_system: Option<&str>) -> bool {
     description.contains("\"$")
         || description.contains("({")
+        || description.contains("[{")
         || description.starts_with('{')
         || db_system == Some("mongodb")
 }

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -184,7 +184,12 @@ fn scrub_redis_keys(string: &str) -> Option<String> {
 
 fn scrub_resource_identifiers(mut string: &str) -> Option<String> {
     // Remove query parameters or the fragment.
-    if let Some(pos) = string.find('?') {
+    if string.starts_with("data:") {
+        if let Some(pos) = string.find(';') {
+            return Some(string[..pos].into());
+        }
+        return Some("data:*/*".into());
+    } else if let Some(pos) = string.find('?') {
         string = &string[..pos];
     } else if let Some(pos) = string.find('#') {
         string = &string[..pos];
@@ -585,6 +590,13 @@ mod tests {
         "/page?action=name",
         "resource.script",
         "/page"
+    );
+
+    span_description_test!(
+        resource_img_embedded,
+        "data:image/svg+xml;base64,PHN2ZyB4bW",
+        "resource.img",
+        "data:image/svg+xml"
     );
 
     #[test]

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -592,7 +592,7 @@ mod tests {
         resource_script_with_no_extension,
         "https://www.domain.com/page?id=1234567890",
         "resource.script",
-        "*.domain.com"
+        "*.domain.com/*"
     );
 
     span_description_test!(

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -224,7 +224,7 @@ fn scrub_resource_identifiers(mut string: &str) -> Option<String> {
                 }
                 return Some(format!("{domain}/*"));
             }
-            None
+            Some(string.into())
         }
     }
 }

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -222,7 +222,7 @@ fn scrub_resource_identifiers(mut string: &str) -> Option<String> {
                 if let Some(extension) = url.path().rsplit_once('.') {
                     return Some(format!("{domain}/*.{}", extension.1));
                 }
-                return Some(domain);
+                return Some(format!("{domain}/*"));
             }
             Some(string.into())
         }

--- a/relay-event-normalization/src/regexes.rs
+++ b/relay-event-normalization/src/regexes.rs
@@ -78,3 +78,6 @@ pub static RESOURCE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static DB_SQL_TRANSACTION_CORE_DATA_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?P<int>\d+)").unwrap());


### PR DESCRIPTION
- Fix fallback case for resource span scrubbing when the regex doesn't work
- Expand the patterns we look for to identify a MongoDB query
- Remove scrubbing for CoreData transactions