### PR TITLE
fix(spans): Skip HTTP size metrics if zero

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -1,6 +1,6 @@
 use relay_base_schema::data_category::DataCategory;
 use relay_common::glob2::LazyGlob;
-use relay_sampling::condition::RuleCondition;
+use relay_sampling::condition::{EqCondition, RuleCondition};
 
 use crate::feature::Feature;
 use crate::metrics::{MetricExtractionConfig, MetricSpec, TagMapping, TagSpec};
@@ -83,21 +83,33 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             category: DataCategory::Span,
             mri: "d:spans/http.response_content_length@byte".into(),
             field: Some("span.data.http\\.response_content_length".into()),
-            condition: Some(span_op_conditions.clone() & resource_condition.clone()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone()
+                    & RuleCondition::gt("span.data.http\\.response_content_length", 0),
+            ),
             tags: Default::default(),
         },
         MetricSpec {
             category: DataCategory::Span,
             mri: "d:spans/http.decoded_response_body_length@byte".into(),
             field: Some("span.data.http\\.decoded_response_body_length".into()),
-            condition: Some(span_op_conditions.clone() & resource_condition.clone()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone()
+                    & RuleCondition::gt("span.data.http\\.decoded_response_body_length", 0),
+            ),
             tags: Default::default(),
         },
         MetricSpec {
             category: DataCategory::Span,
             mri: "d:spans/http.response_transfer_size@byte".into(),
             field: Some("span.data.http\\.response_transfer_size".into()),
-            condition: Some(span_op_conditions.clone() & resource_condition.clone()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone()
+                    & RuleCondition::gt("span.data.http\\.response_transfer_size", 0),
+            ),
             tags: Default::default(),
         },
     ]);

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -1,6 +1,6 @@
 use relay_base_schema::data_category::DataCategory;
 use relay_common::glob2::LazyGlob;
-use relay_sampling::condition::{EqCondition, RuleCondition};
+use relay_sampling::condition::RuleCondition;
 
 use crate::feature::Feature;
 use crate::metrics::{MetricExtractionConfig, MetricSpec, TagMapping, TagSpec};

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -444,12 +444,26 @@ mod tests {
                     "parent_span_id": "9756d8d7b2b364ff",
                     "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
                     "data": {
-                        "http.decoded_response_content_length": 128950,
+                        "http.decoded_response_body_length": 128950,
                         "http.response_content_length": 36170,
                         "http.response_transfer_size": 36470,
                         "resource.render_blocking_status": "blocking"
                     },
                     "hash": "e2fae740cccd3789"
+                },
+                {
+                    "timestamp": 1694732408.3145,
+                    "start_timestamp": 1694732407.8367,
+                    "span_id": "97c0ef9770a02f9d",
+                    "parent_span_id": "9756d8d7b2b364ff",
+                    "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+                    "op": "resource.link",
+                    "description": "domain.com/zero-length-00",
+                    "data": {
+                        "http.decoded_response_body_length": 0,
+                        "http.response_content_length": 0,
+                        "http.response_transfer_size": 0
+                    }
                 }
             ]
         }
@@ -969,7 +983,7 @@ mod tests {
                     "parent_span_id": "9756d8d7b2b364ff",
                     "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
                     "data": {
-                        "http.decoded_response_content_length": 128950,
+                        "http.decoded_response_body_length": 128950,
                         "http.response_content_length": 36170,
                         "http.response_transfer_size": 36470,
                         "resource.render_blocking_status": "blocking"

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1311,6 +1311,24 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
+        name: "d:spans/http.decoded_response_body_length@byte",
+        value: Distribution(
+            [
+                128950.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "resource.render_blocking_status": "blocking",
+            "span.description": "https://cdn.domain.com/path/to/file-hk2YHeW7Eo2XLCi*z*KuljsgCAD6hyWCyOYZM.css",
+            "span.group": "fd1c98edd40299a3",
+            "span.op": "resource.link",
+            "transaction": "gEt /api/:version/users/",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
         name: "d:spans/http.response_transfer_size@byte",
         value: Distribution(
             [
@@ -1324,6 +1342,47 @@ expression: metrics
             "span.group": "fd1c98edd40299a3",
             "span.op": "resource.link",
             "transaction": "gEt /api/:version/users/",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
+        name: "d:spans/exclusive_time@millisecond",
+        value: Distribution(
+            [
+                477.800131,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.category": "resource",
+            "span.description": "domain.com/zero-length-*",
+            "span.group": "c30e0c2b28682cb7",
+            "span.op": "resource.link",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1694732408),
+        width: 0,
+        name: "d:spans/exclusive_time_light@millisecond",
+        value: Distribution(
+            [
+                477.800131,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "http.status_code": "500",
+            "span.category": "resource",
+            "span.description": "domain.com/zero-length-*",
+            "span.group": "c30e0c2b28682cb7",
+            "span.op": "resource.link",
+            "transaction.method": "POST",
+            "transaction.op": "myop",
         },
     },
 ]


### PR DESCRIPTION
Do not extract metrics for response body length, etc. when they are zero.

#skip-changelog