### PR TITLE
ref(metrics): Remove unused result.

### DIFF
--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -804,8 +804,7 @@ impl Aggregator {
         project_key: ProjectKey,
         buckets: I,
         max_total_bucket_bytes: Option<usize>,
-    ) -> Result<(), AggregateMetricsError>
-    where
+    ) where
         I: IntoIterator<Item = Bucket>,
     {
         for bucket in buckets.into_iter() {
@@ -824,8 +823,6 @@ impl Aggregator {
                 );
             }
         }
-
-        Ok(())
     }
 
     /// Split buckets into N logical partitions, determined by the bucket key.

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::iter::FusedIterator;
 use std::time::Duration;
 
@@ -265,16 +264,8 @@ impl AggregatorService {
             project_key,
             buckets,
         } = msg;
-        if let Err(err) =
-            self.aggregator
-                .merge_all(project_key, buckets, self.max_total_bucket_bytes)
-        {
-            relay_log::error!(
-                tags.aggregator = &self.aggregator.name(),
-                error = &err as &dyn Error,
-                "failed to merge buckets"
-            );
-        }
+        self.aggregator
+            .merge_all(project_key, buckets, self.max_total_bucket_bytes);
     }
 
     fn handle_message(&mut self, msg: Aggregator) {


### PR DESCRIPTION
`merge_all` never returns anything else than Ok, so it's annoying for the caller to have to deal with an error case that can never happen. 

#skip-changelog