### PR TITLE
chore(spans): Stop double writing tags to `span.data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Fix hot-loop burning CPU when upstream service is unavailable. ([#2518](https://github.com/getsentry/relay/pull/2518))
 - Extract new low-cardinality transaction duration metric for statistical detectors. ([#2513](https://github.com/getsentry/relay/pull/2513))
 - Introduce reservoir sampling rule. ([#2550](https://github.com/getsentry/relay/pull/2550))
-- Write span tags to `span.sentry_tags`. ([#2555](https://github.com/getsentry/relay/pull/2555))
+- Write span tags to `span.sentry_tags` instead of `span.data`. ([#2555](https://github.com/getsentry/relay/pull/2555), [#2598](https://github.com/getsentry/relay/pull/2598))
 - Use JSON instead of MsgPack for Kafka spans. ([#2556](https://github.com/getsentry/relay/pull/2556))
 - Add `profile_id` to spans. ([#2569](https://github.com/getsentry/relay/pull/2569))
 - Introduce a dedicated usage metric for transactions that replaces the duration metric. ([#2571](https://github.com/getsentry/relay/pull/2571), [#2589](https://github.com/getsentry/relay/pull/2589))

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -58,38 +58,6 @@ pub enum SpanTagKey {
 }
 
 impl SpanTagKey {
-    /// The key used to write this tag into `span.data`.
-    ///
-    /// This key corresponds to the tag key on span metrics.
-    /// NOTE: This method can be removed once we stop double-writing span tags.
-    pub fn data_key(&self) -> &str {
-        match self {
-            SpanTagKey::Release => "release",
-            SpanTagKey::User => "user",
-            SpanTagKey::Environment => "environment",
-            SpanTagKey::Transaction => "transaction",
-            SpanTagKey::TransactionMethod => "transaction.method",
-            SpanTagKey::TransactionOp => "transaction.op",
-            SpanTagKey::HttpStatusCode => "http.status_code",
-            SpanTagKey::Mobile => "mobile",
-            SpanTagKey::DeviceClass => "device.class",
-
-            SpanTagKey::Action => "span.action",
-            SpanTagKey::Category => "span.category",
-            SpanTagKey::Description => "span.description",
-            SpanTagKey::Domain => "span.domain",
-            SpanTagKey::Group => "span.group",
-            SpanTagKey::HttpDecodedResponseBodyLength => "http.decoded_response_body_length",
-            SpanTagKey::HttpResponseContentLength => "http.response_content_length",
-            SpanTagKey::HttpResponseTransferSize => "http.response_transfer_size",
-            SpanTagKey::Module => "span.module",
-            SpanTagKey::ResourceRenderBlockingStatus => "resource.render_blocking_status",
-            SpanTagKey::SpanOp => "span.op",
-            SpanTagKey::StatusCode => "span.status_code",
-            SpanTagKey::System => "span.system",
-        }
-    }
-
     /// The key used to write this tag into `span.sentry_keys`.
     ///
     /// This key corresponds to the tag key in the snuba span dataset.
@@ -182,17 +150,6 @@ pub(crate) fn extract_span_tags(event: &mut Event, config: &Config) {
                 .chain(tags.clone())
                 .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v)))
                 .collect(),
-        );
-
-        // Double write to `span.data` for now. This can be removed once all users of these fields
-        // have switched to `sentry_tags`.
-        let data = span.data.value_mut().get_or_insert_with(Default::default);
-        data.extend(
-            shared_tags
-                .clone()
-                .into_iter()
-                .chain(tags)
-                .map(|(k, v)| (k.data_key().to_owned(), Annotated::new(v.into()))),
         );
     }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2369,18 +2369,6 @@ impl EnvelopeProcessorService {
                     .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v)))
                     .collect(),
             );
-            // Double write to `span.data` for now. This can be removed once all users of these fields
-            // have switched to `sentry_tags`.
-            let data = transaction_span
-                .data
-                .value_mut()
-                .get_or_insert_with(Default::default);
-            data.extend(
-                shared_tags
-                    .clone()
-                    .into_iter()
-                    .map(|(k, v)| (k.data_key().to_owned(), Annotated::new(v.into()))),
-            );
             add_span(transaction_span.into());
         }
     }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -27,26 +27,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             tags: ~,
             origin: ~,
             profile_id: ~,
-            data: {
-                "device.class": String(
-                    "1",
-                ),
-                "mobile": String(
-                    "true",
-                ),
-                "release": String(
-                    "1.2.3",
-                ),
-                "span.op": String(
-                    "default",
-                ),
-                "transaction": String(
-                    "gEt /api/:version/users/",
-                ),
-                "transaction.method": String(
-                    "GET",
-                ),
-            },
+            data: ~,
             sentry_tags: {
                 "device.class": "1",
                 "mobile": "true",

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1230,16 +1230,7 @@ def test_spans(
         "organization_id": 1,
         "retention_days": 90,
         "span": {
-            "data": {
-                "description.scrubbed": "GET *",
-                "span.category": "http",
-                "span.description": "GET *",
-                "span.group": "37e3d9fab1ae9162",
-                "span.module": "http",
-                "span.op": "http",
-                "transaction": "hi",
-                "transaction.op": "hi",
-            },
+            "data": {"description.scrubbed": "GET *"},
             "description": "GET /api/0/organizations/?member=1",
             "exclusive_time": 500.0,
             "is_segment": False,
@@ -1270,10 +1261,6 @@ def test_spans(
         "organization_id": 1,
         "retention_days": 90,
         "span": {
-            "data": {
-                "transaction": "hi",
-                "transaction.op": "hi",
-            },
             "description": "hi",
             "exclusive_time": 2000.0,
             "is_segment": True,


### PR DESCRIPTION
The sentry span consumer and all other users of `span.data.*` tags take its data from `span.sentry_tags` now, so we can stop double-writing.