### PR TITLE
build(py): Bump milksnake dependency

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -113,8 +113,8 @@ setup(
     zip_safe=False,
     platforms="any",
     python_requires=">=3.8",
-    install_requires=["milksnake>=0.1.2"],
-    setup_requires=["milksnake>=0.1.2"],
+    install_requires=["milksnake>=0.1.6"],
+    setup_requires=["milksnake>=0.1.6"],
     milksnake_tasks=[build_native],
     cmdclass={"sdist": CustomSDist},
 )


### PR DESCRIPTION
Bump milksnake version to be compatible with Python 3.11.

See https://github.com/getsentry/milksnake/pull/32.

#skip-changelog