### PR TITLE
feat(metrics): Add device.class to transaction metrics

### DIFF
--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -14,16 +14,9 @@ use url::Url;
 
 use crate::span::description::parse_query;
 use crate::utils::{
-    extract_http_status_code, extract_transaction_op, get_eventuser_tag, http_status_code_from_span,
+    extract_http_status_code, extract_transaction_op, get_eventuser_tag,
+    http_status_code_from_span, MOBILE_SDKS,
 };
-
-/// Used to decide when to extract mobile-specific span tags.
-const MOBILE_SDKS: [&str; 4] = [
-    "sentry.cocoa",
-    "sentry.dart.flutter",
-    "sentry.java.android",
-    "sentry.javascript.react-native",
-];
 
 /// A list of supported span tags for tag extraction.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/relay-event-normalization/src/normalize/utils.rs
+++ b/relay-event-normalization/src/normalize/utils.rs
@@ -5,6 +5,14 @@
 
 use relay_event_schema::protocol::{Event, ResponseContext, Span, TraceContext, User};
 
+/// Used to decide when to extract mobile-specific tags.
+pub const MOBILE_SDKS: [&str; 4] = [
+    "sentry.cocoa",
+    "sentry.dart.flutter",
+    "sentry.java.android",
+    "sentry.javascript.react-native",
+];
+
 /// Extract the HTTP status code from the span data.
 pub fn http_status_code_from_span(span: &Span) -> Option<String> {
     // For SDKs which put the HTTP status code into the span data.

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -182,6 +182,10 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
         tags.insert(CommonTag::HttpStatusCode, status_code);
     }
 
+    if let Some(device_class) = event.tag_value("device.class") {
+        tags.insert(CommonTag::DeviceClass, device_class.to_owned());
+    }
+
     let custom_tags = &config.extract_custom_tags;
     if !custom_tags.is_empty() {
         // XXX(slow): event tags are a flat array
@@ -457,7 +461,8 @@ mod tests {
             },
             "tags": {
                 "fOO": "bar",
-                "bogus": "absolutely"
+                "bogus": "absolutely",
+                "device.class": "1"
             },
             "measurements": {
                 "foo": {"value": 420.69},
@@ -582,6 +587,7 @@ mod tests {
                 ),
                 tags: {
                     "browser.name": "Chrome",
+                    "device.class": "1",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
@@ -606,6 +612,7 @@ mod tests {
                 ),
                 tags: {
                     "browser.name": "Chrome",
+                    "device.class": "1",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
@@ -631,6 +638,7 @@ mod tests {
                 ),
                 tags: {
                     "browser.name": "Chrome",
+                    "device.class": "1",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
@@ -664,6 +672,7 @@ mod tests {
                 ),
                 tags: {
                     "browser.name": "Chrome",
+                    "device.class": "1",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",
@@ -701,6 +710,7 @@ mod tests {
                 ),
                 tags: {
                     "browser.name": "Chrome",
+                    "device.class": "1",
                     "dist": "foo",
                     "environment": "fake_environment",
                     "fOO": "bar",

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use relay_base_schema::events::EventType;
 use relay_common::time::UnixTimestamp;
 use relay_dynamic_config::{TagMapping, TransactionMetricsConfig};
-use relay_event_normalization::utils::{self as normalize_utils, MOBILE_SDKS};
+use relay_event_normalization::utils as normalize_utils;
 use relay_event_schema::protocol::{
     AsPair, BrowserContext, Event, OsContext, TraceContext, TransactionSource,
 };
@@ -182,7 +182,7 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
         tags.insert(CommonTag::HttpStatusCode, status_code);
     }
 
-    if MOBILE_SDKS.contains(&event.sdk_name()) {
+    if normalize_utils::MOBILE_SDKS.contains(&event.sdk_name()) {
         if let Some(device_class) = event.tag_value("device.class") {
             tags.insert(CommonTag::DeviceClass, device_class.to_owned());
         }

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -228,6 +228,7 @@ pub enum CommonTag {
     BrowserName,
     OsName,
     GeoCountryCode,
+    DeviceClass,
     Custom(String),
 }
 
@@ -246,6 +247,7 @@ impl Display for CommonTag {
             CommonTag::BrowserName => "browser.name",
             CommonTag::OsName => "os.name",
             CommonTag::GeoCountryCode => "geo.country_code",
+            CommonTag::DeviceClass => "device.class",
             CommonTag::Custom(s) => s,
         };
         write!(f, "{name}")


### PR DESCRIPTION
Transfer the `device.class` tag that we already set on transaction payloads to transaction metrics.

`device.class` is a low-cardinality tag with only three possible values ("1", "2", "3"), and it is only set for mobile SDKs.

#skip-changelog