### PR TITLE
feat(event-schema): Add getters for most contexts in Discover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
-- Extend the number of supported fields for the `Event` `Getter`. ([#2640](https://github.com/getsentry/relay/pull/2640))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Drop events starting or ending before January 1, 1970 UTC. ([#2613](https://github.com/getsentry/relay/pull/2613))
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
-- Extend the number of supported fields for the `Event` `Getter`. ([#2640](https://github.com/getsentry/relay/pull/2640))
+- Add `locale` ,`screen_width_pixels`, `screen_height_pixels`, and `uuid` to the device context. ([#2640](https://github.com/getsentry/relay/pull/2640))
 
 ## 0.8.31
 

--- a/relay-event-schema/src/protocol/contexts/device.rs
+++ b/relay-event-schema/src/protocol/contexts/device.rs
@@ -58,6 +58,14 @@ pub struct DeviceContext {
     #[metastructure(pii = "maybe")]
     pub screen_resolution: Annotated<String>,
 
+    /// Width of the screen in pixels.
+    #[metastructure(pii = "maybe")]
+    pub screen_width_pixels: Annotated<u64>,
+
+    /// Height of the screen in pixels.
+    #[metastructure(pii = "maybe")]
+    pub screen_height_pixels: Annotated<u64>,
+
     /// Device screen density.
     #[metastructure(pii = "maybe")]
     pub screen_density: Annotated<f64>,
@@ -114,6 +122,10 @@ pub struct DeviceContext {
     #[metastructure(pii = "maybe")]
     pub timezone: Annotated<String>,
 
+    /// ISO 639-1 code of the locale the device is set to.
+    #[metastructure(pii = "maybe")]
+    pub locale: Annotated<String>,
+
     /// Number of "logical processors".
     ///
     /// For example, 8.
@@ -161,18 +173,6 @@ pub struct DeviceContext {
 
     /// Whether location support is available on the device.
     pub supports_location_service: Annotated<bool>,
-
-    /// Width of the screen in pixels.
-    #[metastructure(pii = "maybe")]
-    pub screen_width_pixels: Annotated<u64>,
-
-    /// Height of the screen in pixels.
-    #[metastructure(pii = "maybe")]
-    pub screen_height_pixels: Annotated<u64>,
-
-    /// Locale of the device.
-    #[metastructure(pii = "maybe")]
-    pub locale: Annotated<String>,
 
     /// UUID of the device.
     #[metastructure(pii = "maybe")]
@@ -235,6 +235,8 @@ mod tests {
   "manufacturer": "Apple",
   "brand": "iphone",
   "screen_resolution": "800x600",
+  "screen_width_pixels": 1920,
+  "screen_height_pixels": 1080,
   "screen_density": 1.1,
   "screen_dpi": 1,
   "online": true,
@@ -250,6 +252,7 @@ mod tests {
   "external_free_storage": 2097152,
   "boot_time": "2018-02-08T12:52:12Z",
   "timezone": "Europe/Vienna",
+  "locale": "de-AT",
   "processor_count": 8,
   "cpu_description": "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz",
   "processor_frequency": 2400,
@@ -261,9 +264,6 @@ mod tests {
   "supports_gyroscope": true,
   "supports_audio": true,
   "supports_location_service": true,
-  "screen_width_pixels": 1920,
-  "screen_height_pixels": 1080,
-  "locale": "US",
   "uuid": "abadcade-feed-dead-beef-baddadfeeded",
   "other": "value",
   "type": "device"
@@ -280,6 +280,8 @@ mod tests {
             manufacturer: Annotated::new("Apple".to_string()),
             brand: Annotated::new("iphone".to_string()),
             screen_resolution: Annotated::new("800x600".to_string()),
+            screen_width_pixels: Annotated::new(1920),
+            screen_height_pixels: Annotated::new(1080),
             screen_density: Annotated::new(1.1),
             screen_dpi: Annotated::new(1),
             online: Annotated::new(true),
@@ -294,6 +296,7 @@ mod tests {
             external_free_storage: Annotated::new(2_097_152),
             boot_time: Annotated::new("2018-02-08T12:52:12Z".to_string()),
             timezone: Annotated::new("Europe/Vienna".to_string()),
+            locale: Annotated::new("de-AT".to_string()),
             processor_count: Annotated::new(8),
             cpu_description: Annotated::new(
                 "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz".to_string(),
@@ -307,9 +310,6 @@ mod tests {
             supports_gyroscope: Annotated::new(true),
             supports_audio: Annotated::new(true),
             supports_location_service: Annotated::new(true),
-            screen_width_pixels: Annotated::new(1920),
-            screen_height_pixels: Annotated::new(1080),
-            locale: Annotated::new("US".to_string()),
             uuid: Annotated::new(uuid!("abadcade-feed-dead-beef-baddadfeeded")),
             other: {
                 let mut map = Object::new();

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::processor::ProcessValue;
 use crate::protocol::{
-    Breadcrumb, Breakdowns, BrowserContext, ClientSdkInfo, Contexts, Csp, DebugMeta,
+    AppContext, Breadcrumb, Breakdowns, BrowserContext, ClientSdkInfo, Contexts, Csp, DebugMeta,
     DefaultContext, DeviceContext, EventType, Exception, ExpectCt, ExpectStaple, Fingerprint, Hpkp,
     LenientString, Level, LogEntry, Measurements, Metrics, OsContext, RelayInfo, Request,
     ResponseContext, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, TraceContext,
@@ -654,6 +654,9 @@ impl Getter for Event {
             "sdk.version" => self.client_sdk.value()?.version.as_str()?.into(),
 
             // Partial implementation of contexts.
+            "contexts.app.in_foreground" => {
+                self.context::<AppContext>()?.in_foreground.value()?.into()
+            }
             "contexts.device.arch" => self.context::<DeviceContext>()?.arch.as_str()?.into(),
             "contexts.device.battery_level" => self
                 .context::<DeviceContext>()?
@@ -715,6 +718,10 @@ impl Getter for Event {
                 .status_code
                 .value()?
                 .into(),
+            "contexts.unreal.crash_type" => match self.contexts.value()?.get_key("unreal")? {
+                super::Context::Other(context) => context.get("crash_type")?.value()?.into(),
+                _ => return None,
+            },
 
             // Computed fields (see Discover)
             "duration" => {

--- a/relay-server/tests/snapshots/test_fixtures__android__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__android__pii_stripping.snap
@@ -31,6 +31,8 @@ expression: SerializableAnnotated(&event)
       "manufacturer": "Google",
       "brand": "google",
       "screen_resolution": null,
+      "screen_width_pixels": null,
+      "screen_height_pixels": null,
       "screen_density": null,
       "screen_dpi": null,
       "online": true,
@@ -45,8 +47,6 @@ expression: SerializableAnnotated(&event)
       "external_free_storage": 534702080,
       "boot_time": null,
       "timezone": null,
-      "screen_width_pixels": null,
-      "screen_height_pixels": null,
       "archs": [
         "x86"
       ],

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -1210,7 +1210,7 @@ expression: "relay_event_schema::protocol::event_json_schema()"
               "minimum": 0.0
             },
             "locale": {
-              "description": " Locale of the device.",
+              "description": " ISO 639-1 code of the locale the device is set to.",
               "default": null,
               "type": [
                 "string",


### PR DESCRIPTION
Add field implementations in the `Getter` on `Event` for most contexts declared by Discover. This is needed for ondemand metric extraction in widgets, so that all context fields can be used in widget queries. 

For the full list of Discover fields, see:

https://github.com/getsentry/sentry/blob/master/src/sentry/snuba/events.py

After this has merged, the metrics extraction allow list in Sentry can be updated. It is located here:

https://github.com/getsentry/sentry/blob/8c61340c93045bc1c9e4d1fa1a77b062c8dfb44e/src/sentry/snuba/metrics/extraction.py#L51