### PR TITLE
feat(pii): Allow pii scrubbing expressions for safe fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Group resource spans by scrubbed domain and filename. ([#2654](https://github.com/getsentry/relay/pull/2654))
 - Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
 - Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
+- Allow advanced scrubbing expressions for datascrubbing safe fields. ([#2610](https://github.com/getsentry/relay/pull/2610))
+
+**Bug Fixes**:
+
+- Disable scrubbing for the User-Agent header. ([#2641](https://github.com/getsentry/relay/pull/2641))
 
 **Internal**:
 
@@ -22,10 +27,6 @@
 - Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
-
-**Bug Fixes**:
-
-- Disable scrubbing for the User-Agent header. ([#2641](https://github.com/getsentry/relay/pull/2641))
 
 **Internal**:
 

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__regression_more_odd_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__regression_more_odd_keys.snap
@@ -4,7 +4,7 @@ expression: pii_config
 ---
 {
   "applications": {
-    "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
+    "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent) && !url && !message && !http.request.url && !'*url*' && !'*message*' && !'*http.request.url*'": [
       "@common:filter",
       "@ip:replace"
     ],


### PR DESCRIPTION
This doesn't simply make matching on arrays work, it enables full expression support for safe fields in the datascrubbing config.