### PR TITLE
ref(spans): Stop applying clustering rules

### DIFF
--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1013,7 +1013,6 @@ pub fn light_normalize_event(
         // can revert some changes to ProcessingAction)
         let mut transactions_processor = transactions::TransactionsProcessor::new(
             config.transaction_name_config,
-            config.enrich_spans,
             config.transaction_range,
         );
         transactions_processor.process_event(event, meta, ProcessingState::root())?;

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1014,7 +1014,6 @@ pub fn light_normalize_event(
         let mut transactions_processor = transactions::TransactionsProcessor::new(
             config.transaction_name_config,
             config.enrich_spans,
-            config.span_description_rules,
             config.transaction_range,
         );
         transactions_processor.process_event(event, meta, ProcessingState::root())?;

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -14,7 +14,6 @@ use relay_protocol::{Annotated, Meta, Remark, RemarkType};
 
 use crate::normalize::span::description::scrub_span_description;
 use crate::regexes::TRANSACTION_NAME_NORMALIZER_REGEX;
-use crate::SpanDescriptionRule;
 use crate::TransactionNameRule;
 
 /// Configuration for sanitizing unparameterized transaction names.
@@ -28,7 +27,6 @@ pub struct TransactionNameConfig<'r> {
 #[derive(Debug, Default)]
 pub struct TransactionsProcessor<'r> {
     name_config: TransactionNameConfig<'r>,
-    span_desc_rules: Vec<SpanDescriptionRule>,
     timestamp_range: Option<Range<UnixTimestamp>>,
     enrich_spans: bool,
 }
@@ -38,22 +36,10 @@ impl<'r> TransactionsProcessor<'r> {
     pub fn new(
         name_config: TransactionNameConfig<'r>,
         enrich_spans: bool,
-        span_description_rules: Option<&Vec<SpanDescriptionRule>>,
         timestamp_range: Option<Range<UnixTimestamp>>,
     ) -> Self {
-        let mut span_desc_rules = if let Some(span_desc_rules) = span_description_rules {
-            span_desc_rules.clone()
-        } else {
-            vec![]
-        };
-
-        if enrich_spans && !name_config.rules.is_empty() {
-            span_desc_rules.extend(name_config.rules.iter().map(SpanDescriptionRule::from));
-        }
-
         Self {
             name_config,
-            span_desc_rules,
             timestamp_range,
             enrich_spans,
         }
@@ -471,7 +457,7 @@ impl Processor for TransactionsProcessor<'_> {
         span.op.get_or_insert_with(|| "default".to_owned());
 
         if self.enrich_spans {
-            scrub_span_description(span, &self.span_desc_rules);
+            scrub_span_description(span);
         }
 
         span.process_child_values(self, state)?;
@@ -564,7 +550,6 @@ mod tests {
         let processor = &mut TransactionsProcessor::new(
             TransactionNameConfig::default(),
             false,
-            None,
             Some(UnixTimestamp::now()..UnixTimestamp::now()),
         );
 
@@ -1680,7 +1665,6 @@ mod tests {
                 },
                 false,
                 None,
-                None,
             ),
             ProcessingState::root(),
         )
@@ -1745,7 +1729,6 @@ mod tests {
                     rules: rules.as_ref(),
                 },
                 false,
-                None,
                 None,
             ),
             ProcessingState::root(),
@@ -1835,7 +1818,6 @@ mod tests {
                 rules: rules.as_ref(),
             },
             false,
-            None,
             None,
         );
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
@@ -1969,7 +1951,6 @@ mod tests {
                 },
                 false,
                 None,
-                None,
             ),
             ProcessingState::root(),
         )
@@ -2037,7 +2018,6 @@ mod tests {
                     rules: rules.as_ref(),
                 },
                 false,
-                None,
                 None,
             ),
             ProcessingState::root(),
@@ -2155,12 +2135,7 @@ mod tests {
 
         process_value(
             &mut event,
-            &mut TransactionsProcessor::new(
-                TransactionNameConfig { rules: &[rule] },
-                false,
-                None,
-                None,
-            ),
+            &mut TransactionsProcessor::new(TransactionNameConfig { rules: &[rule] }, false, None),
             ProcessingState::root(),
         )
         .unwrap();
@@ -2389,7 +2364,6 @@ mod tests {
                 },
                 false,
                 None,
-                None,
             ),
             ProcessingState::root(),
         )
@@ -2435,7 +2409,6 @@ mod tests {
                     }],
                 },
                 false,
-                None,
                 None,
             ),
             ProcessingState::root(),

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1230,7 +1230,6 @@ def test_spans(
         "organization_id": 1,
         "retention_days": 90,
         "span": {
-            "data": {"description.scrubbed": "GET *"},
             "description": "GET /api/0/organizations/?member=1",
             "exclusive_time": 500.0,
             "is_segment": False,


### PR DESCRIPTION
We currently still apply scrubbing rules discovered by [the clusterer](https://develop.sentry.dev/transaction-clustering/) to spans, but this is effectively dead code, because we decided to scrub HTTP spans more aggressively a while ago (see details below).

By removing the clusterer-related code, we can simplify a lot.

Note: I'm leaving the span clustering rules in the project config for now, because there might still be outdated configs that do apply it.

### Details

`apply_span_rename_rules` still gets called, but only if a span has `op:http*` and it does not have a `description.scrubbed` yet:

https://github.com/getsentry/relay/blob/e188c586f81a641a00596a7b39ff87802e835e77/relay-event-normalization/src/normalize/span/description/mod.rs#L239-L240

https://github.com/getsentry/relay/blob/e188c586f81a641a00596a7b39ff87802e835e77/relay-event-normalization/src/normalize/span/description/mod.rs#L261

However, spans with `op:http*` always have a `description.scrubbed` before calling `span_rename_rules`, because we fall back to a method-only description:

https://github.com/getsentry/relay/blob/e188c586f81a641a00596a7b39ff87802e835e77/relay-event-normalization/src/normalize/span/description/mod.rs#L131-L133

#skip-changelog