### PR TITLE
fix(metrics): Fix the measurement unit for ttfd

### DIFF
--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -412,7 +412,7 @@ fn get_metric_measurement_unit(measurement_name: &str) -> Option<MetricUnit> {
         "frames_frozen" => Some(MetricUnit::None),
         "frames_frozen_rate" => Some(MetricUnit::Fraction(FractionUnit::Ratio)),
         "time_to_initial_display" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
-        "time_to_first_display" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
+        "time_to_full_display" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
 
         // React-Native
         "stall_count" => Some(MetricUnit::None),


### PR DESCRIPTION
I think we meant to say "time_to_full_display" here
since that's the measurement the mobile sdks send!

#skip-changelog