### PR TITLE
deps: bump docker debian images from buster (10) to bookworm (12)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    open-pull-requests-limit: 0 # security updates only
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      - "@getsentry/owners-ingest"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@getsentry/owners-ingest"
+    open-pull-requests-limit: 0 # security updates only
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    reviewers:
+      - "@getsentry/owners-ingest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 23.11.0
+
+**Features**:
+
+- Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
+
 ## 23.10.0
 
 **Features**:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,22 +10,22 @@ ARG RUST_TOOLCHAIN_VERSION
 ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 
 RUN yum -y update \
-    && yum -y install centos-release-scl epel-release \
-    # install a modern compiler toolchain
-    && yum -y install cmake3 devtoolset-10 git \
-    # below required for sentry-native
-    llvm-toolset-7.0-clang-devel \
-    && yum clean all \
-    && rm -rf /var/cache/yum \
-    && ln -s /usr/bin/cmake3 /usr/bin/cmake
+  && yum -y install centos-release-scl epel-release \
+  # install a modern compiler toolchain
+  && yum -y install cmake3 devtoolset-10 git \
+  # below required for sentry-native
+  llvm-toolset-7.0-clang-devel \
+  && yum clean all \
+  && rm -rf /var/cache/yum \
+  && ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --profile minimal --default-toolchain=${RUST_TOOLCHAIN_VERSION} \
-    && echo -e '[registries.crates-io]\nprotocol = "sparse"\n[net]\ngit-fetch-with-cli = true' > $CARGO_HOME/config
+  | sh -s -- -y --profile minimal --default-toolchain=${RUST_TOOLCHAIN_VERSION} \
+  && echo -e '[registries.crates-io]\nprotocol = "sparse"\n[net]\ngit-fetch-with-cli = true' > $CARGO_HOME/config
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli
 
@@ -44,40 +44,40 @@ COPY . .
 
 # Build with the modern compiler toolchain enabled
 RUN : \
-    && export BUILD_TARGET="$(arch)-unknown-linux-gnu" \
-    && scl enable devtoolset-10 llvm-toolset-7.0 -- \
-    make build-linux-release \
-    TARGET=${BUILD_TARGET} \
-    RELAY_FEATURES=${RELAY_FEATURES}
+  && export BUILD_TARGET="$(arch)-unknown-linux-gnu" \
+  && scl enable devtoolset-10 llvm-toolset-7.0 -- \
+  make build-linux-release \
+  TARGET=${BUILD_TARGET} \
+  RELAY_FEATURES=${RELAY_FEATURES}
 
 # Collect source bundle
 # Produces `relay-bin`, `relay-debug.zip` and `relay.src.zip` in current directory
 RUN : \
-    && export BUILD_TARGET="$(arch)-unknown-linux-gnu" \
-    && make collect-source-bundle \
-    TARGET=${BUILD_TARGET}
+  && export BUILD_TARGET="$(arch)-unknown-linux-gnu" \
+  && make collect-source-bundle \
+  TARGET=${BUILD_TARGET}
 
 ###################
 ### Final stage ###
 ###################
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates gosu curl --no-install-recommends \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y ca-certificates gosu curl --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV \
-    RELAY_UID=10001 \
-    RELAY_GID=10001
+  RELAY_UID=10001 \
+  RELAY_GID=10001
 
 # Create a new user and group with fixed uid/gid
 RUN groupadd --system relay --gid $RELAY_GID \
-    && useradd --system --gid relay --uid $RELAY_UID relay
+  && useradd --system --gid relay --uid $RELAY_UID relay
 
 RUN mkdir /work /etc/relay \
-    && chown relay:relay /work /etc/relay
+  && chown relay:relay /work /etc/relay
 VOLUME ["/work", "/etc/relay"]
 WORKDIR /work
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,20 +1,20 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates gosu curl --no-install-recommends \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y ca-certificates gosu curl --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV \
-    RELAY_UID=10001 \
-    RELAY_GID=10001
+  RELAY_UID=10001 \
+  RELAY_GID=10001
 
 # Create a new user and group with fixed uid/gid
 RUN groupadd --system relay --gid $RELAY_GID \
-    && useradd --system --gid relay --uid $RELAY_UID relay
+  && useradd --system --gid relay --uid $RELAY_UID relay
 
 RUN mkdir /work /etc/relay \
-    && chown relay:relay /work /etc/relay
+  && chown relay:relay /work /etc/relay
 VOLUME ["/work", "/etc/relay"]
 WORKDIR /work
 


### PR DESCRIPTION
- update the base Debian image used in our Dockerfiles from Buster (10) to Bookworm (12)
- add custom dependabot configuration to cover Rust, Docker, and Github Actions dependencies

#2619 