### PR TITLE
feat(globalconfig): Only report upstream errors after elapsed interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
 
+**Internal**:
+
+- Report global config fetch errors after interval of constant failures elapsed. ([#2628](https://github.com/getsentry/relay/pull/2628))
+
 ## 23.10.0
 
 **Features**:


### PR DESCRIPTION
Especially during deployments, Relay sometimes faces some 503s or timeouts from upstream, and reports an error. Having a handful of such errors is noisy and doesn't help to identify when problems really exist.

This change introduces an interval the global config service has to wait before reporting such errors, while consistently failing fetches.

Note that the interval does not impact other types of errors, like failure to send requests to upstream (e.g. network is down) or global config missing from the response. These errors are consistent and should be reported as early as possible.

Resolves https://github.com/getsentry/relay/issues/2609.