### PR TITLE
ref(protocol): Clean up imports

### DIFF
--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -6,7 +6,6 @@ use relay_common::glob3::GlobPatterns;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 
-use crate::utils;
 use crate::{Getter, Val};
 
 /// Options for [`EqCondition`].
@@ -39,7 +38,7 @@ pub struct EqCondition {
     pub value: Value,
 
     /// Configuration options for the condition.
-    #[serde(default, skip_serializing_if = "utils::is_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub options: EqCondOptions,
 }
 
@@ -90,6 +89,11 @@ impl EqCondition {
             _ => false,
         }
     }
+}
+
+/// Returns `true` if this value is equal to `Default::default()`.
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == T::default()
 }
 
 macro_rules! impl_cmp_condition {

--- a/relay-protocol/src/lib.rs
+++ b/relay-protocol/src/lib.rs
@@ -23,17 +23,15 @@ mod macros;
 mod meta;
 mod size;
 mod traits;
-mod utils;
 mod value;
 
 pub use self::annotated::*;
-pub use self::condition::*;
+pub use self::condition::RuleCondition;
 pub use self::impls::*;
 pub use self::macros::*;
 pub use self::meta::*;
 pub use self::size::*;
 pub use self::traits::*;
-pub use self::utils::*;
 pub use self::value::*;
 
 #[cfg(feature = "derive")]

--- a/relay-protocol/src/lib.rs
+++ b/relay-protocol/src/lib.rs
@@ -16,8 +16,9 @@
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
 
+pub mod condition;
+
 mod annotated;
-mod condition;
 mod impls;
 mod macros;
 mod meta;

--- a/relay-protocol/src/utils.rs
+++ b/relay-protocol/src/utils.rs
@@ -1,4 +1,0 @@
-/// Returns `true` if this value is equal to `Default::default()`.
-pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
-    *t == T::default()
-}

--- a/relay-sampling/src/config.rs
+++ b/relay-sampling/src/config.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use relay_protocol::{is_default, RuleCondition};
+use relay_protocol::RuleCondition;
 
 /// Represents the dynamic sampling configuration available to a project.
 ///
@@ -85,6 +85,11 @@ impl SamplingRule {
         self.decaying_fn
             .adjust_sample_rate(sample_rate, now, self.time_range)
     }
+}
+
+/// Returns `true` if this value is equal to `Default::default()`.
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    *t == T::default()
 }
 
 /// A sampling strategy definition.

--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -396,6 +396,7 @@ mod tests {
     use std::str::FromStr;
 
     use chrono::{TimeZone, Utc};
+    use relay_protocol::RuleCondition;
     use similar_asserts::assert_eq;
     use uuid::Uuid;
 
@@ -405,7 +406,6 @@ mod tests {
     use crate::dsc::TraceUserContext;
     use crate::evaluation::MatchedRuleIds;
     use crate::DynamicSamplingContext;
-    use relay_protocol::RuleCondition;
 
     use super::*;
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/relay/pull/2608:

* Remove `utils` crate from `relay-protocol`.
* Only re-export `RuleCondition` from the `condition` module.

I was not able to remove the `relay-sampling` dependency anywhere yet, because `relay-cabi` and `relay-dynamic-config` import `SamplingConfig`. But we will be able to change the dependency in https://github.com/getsentry/relay/pull/2595.

#skip-changelog