### PR TITLE
fix(pii): Disable scrubbing for the User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
 - Remove from events spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 
+**Bug Fixes**:
+
+- Disable scrubbing for the User-Agent header. ([#2641](https://github.com/getsentry/relay/pull/2641))
+
 **Internal**:
 
 - Report global config fetch errors after interval of constant failures elapsed. ([#2628](https://github.com/getsentry/relay/pull/2628))

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -14,7 +14,7 @@ use crate::{
 /// We define this list independently of `metastructure(pii = true/false)` because the new PII
 /// scrubber should be able to strip more.
 static DATASCRUBBER_IGNORE: Lazy<SelectorSpec> = Lazy::new(|| {
-    "(debug_meta.** | $frame.filename | $frame.abs_path | $logentry.formatted | $error.value)"
+    "(debug_meta.** | $frame.filename | $frame.abs_path | $logentry.formatted | $error.value | $request.headers.user-agent)"
         .parse()
         .unwrap()
 });
@@ -274,10 +274,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
 
     #[test]
     fn test_convert_default_pii_config() {
-        insta::assert_json_snapshot!(simple_enabled_pii_config(), @r#"
+        insta::assert_json_snapshot!(simple_enabled_pii_config(), @r###"
         {
           "applications": {
-            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
+            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent)": [
               "@common:filter",
               "@ip:replace"
             ],
@@ -289,7 +289,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -299,10 +299,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r#"
+        insta::assert_json_snapshot!(pii_config, @r###"
         {
           "applications": {
-            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
+            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent)": [
               "@common:filter",
               "@ip:replace"
             ],
@@ -314,7 +314,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -324,7 +324,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r#"
+        insta::assert_json_snapshot!(pii_config, @r###"
         {
           "rules": {
             "strip-fields": {
@@ -337,7 +337,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             }
           },
           "applications": {
-            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
+            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent)": [
               "@common:filter",
               "@ip:replace",
               "strip-fields"
@@ -350,7 +350,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -360,10 +360,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r#"
+        insta::assert_json_snapshot!(pii_config, @r###"
         {
           "applications": {
-            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !foobar": [
+            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent) && !foobar": [
               "@common:filter",
               "@ip:replace"
             ],
@@ -375,7 +375,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -387,10 +387,10 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..Default::default()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r#"
+        insta::assert_json_snapshot!(pii_config, @r###"
         {
           "applications": {
-            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
+            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent)": [
               "@ip:replace"
             ],
             "$http.env.REMOTE_ADDR || $user.ip_address || $sdk.client_ip": [
@@ -398,7 +398,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1256,7 +1256,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ..simple_enabled_config()
         });
 
-        insta::assert_json_snapshot!(pii_config, @r#"
+        insta::assert_json_snapshot!(pii_config, @r###"
         {
           "rules": {
             "strip-fields": {
@@ -1269,7 +1269,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             }
           },
           "applications": {
-            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value)": [
+            "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent)": [
               "@common:filter",
               "@ip:replace",
               "strip-fields"
@@ -1282,7 +1282,7 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             ]
           }
         }
-        "#);
+        "###);
 
         let pii_config = pii_config.unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -754,6 +754,35 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_user_agent_ip_scrubbing() {
+        let mut data = Event::from_value(
+            serde_json::json!({
+                "request": {
+                    "headers": [
+                        ["User-Agent", "127.0.0.1"],
+                        ["X-Client-Ip", "10.0.0.1"]
+                    ]
+                },
+            })
+            .into(),
+        );
+
+        let scrubbing_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_ip_addresses: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+
+        let pii_config = to_pii_config(&scrubbing_config).unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+
+        assert_debug_snapshot!(&data);
+    }
+
+    #[test]
     fn test_remove_debugmeta_path() {
         let config = serde_json::from_str::<PiiConfig>(
             r#"

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -779,7 +779,7 @@ mod tests {
 
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_debug_snapshot!(&data);
+        assert_annotated_snapshot!(&data);
     }
 
     #[test]

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__regression_more_odd_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__regression_more_odd_keys.snap
@@ -1,10 +1,10 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: pii_config
 ---
 {
   "applications": {
-    "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
+    "($string || $number || $array || $object) && !(debug_meta.** || $frame.filename || $frame.abs_path || $logentry.formatted || $error.value || $http.headers.user-agent) && !url && !message && !'http.request.url' && !'*url*' && !'*message*' && !'*http.request.url*'": [
       "@common:filter",
       "@ip:replace"
     ],

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__ignore_user_agent_ip_scrubbing.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__ignore_user_agent_ip_scrubbing.snap
@@ -2,109 +2,38 @@
 source: relay-pii/src/processor.rs
 expression: "&data"
 ---
-Event {
-    id: ~,
-    level: ~,
-    version: ~,
-    ty: ~,
-    fingerprint: ~,
-    culprit: ~,
-    transaction: ~,
-    transaction_info: ~,
-    time_spent: ~,
-    logentry: ~,
-    logger: ~,
-    modules: ~,
-    platform: ~,
-    timestamp: ~,
-    start_timestamp: ~,
-    received: ~,
-    server_name: ~,
-    release: ~,
-    dist: ~,
-    environment: ~,
-    site: ~,
-    user: ~,
-    request: Request {
-        url: ~,
-        method: ~,
-        data: ~,
-        query_string: ~,
-        fragment: ~,
-        cookies: ~,
-        headers: Headers(
-            PairList(
+{
+  "request": {
+    "headers": [
+      [
+        "User-Agent",
+        "127.0.0.1"
+      ],
+      [
+        "X-Client-Ip",
+        "[ip]"
+      ]
+    ]
+  },
+  "_meta": {
+    "request": {
+      "headers": {
+        "1": {
+          "1": {
+            "": {
+              "rem": [
                 [
-                    (
-                        HeaderName(
-                            "User-Agent",
-                        ),
-                        HeaderValue(
-                            "127.0.0.1",
-                        ),
-                    ),
-                    (
-                        HeaderName(
-                            "X-Client-Ip",
-                        ),
-                        Annotated(
-                            HeaderValue(
-                                "[ip]",
-                            ),
-                            Meta {
-                                remarks: [
-                                    Remark {
-                                        ty: Substituted,
-                                        rule_id: "@ip:replace",
-                                        range: Some(
-                                            (
-                                                0,
-                                                4,
-                                            ),
-                                        ),
-                                    },
-                                ],
-                                errors: [],
-                                original_length: Some(
-                                    8,
-                                ),
-                                original_value: None,
-                            },
-                        ),
-                    ),
-                ],
-            ),
-        ),
-        body_size: ~,
-        env: ~,
-        inferred_content_type: ~,
-        api_target: ~,
-        other: {},
-    },
-    contexts: ~,
-    breadcrumbs: ~,
-    exceptions: ~,
-    stacktrace: ~,
-    template: ~,
-    threads: ~,
-    tags: ~,
-    extra: ~,
-    debug_meta: ~,
-    client_sdk: ~,
-    ingest_path: ~,
-    errors: ~,
-    key_id: ~,
-    project: ~,
-    grouping_config: ~,
-    checksum: ~,
-    csp: ~,
-    hpkp: ~,
-    expectct: ~,
-    expectstaple: ~,
-    spans: ~,
-    measurements: ~,
-    breakdowns: ~,
-    scraping_attempts: ~,
-    _metrics: ~,
-    other: {},
+                  "@ip:replace",
+                  "s",
+                  0,
+                  4
+                ]
+              ],
+              "len": 8
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__ignore_user_agent_ip_scrubbing.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__ignore_user_agent_ip_scrubbing.snap
@@ -1,0 +1,110 @@
+---
+source: relay-pii/src/processor.rs
+expression: "&data"
+---
+Event {
+    id: ~,
+    level: ~,
+    version: ~,
+    ty: ~,
+    fingerprint: ~,
+    culprit: ~,
+    transaction: ~,
+    transaction_info: ~,
+    time_spent: ~,
+    logentry: ~,
+    logger: ~,
+    modules: ~,
+    platform: ~,
+    timestamp: ~,
+    start_timestamp: ~,
+    received: ~,
+    server_name: ~,
+    release: ~,
+    dist: ~,
+    environment: ~,
+    site: ~,
+    user: ~,
+    request: Request {
+        url: ~,
+        method: ~,
+        data: ~,
+        query_string: ~,
+        fragment: ~,
+        cookies: ~,
+        headers: Headers(
+            PairList(
+                [
+                    (
+                        HeaderName(
+                            "User-Agent",
+                        ),
+                        HeaderValue(
+                            "127.0.0.1",
+                        ),
+                    ),
+                    (
+                        HeaderName(
+                            "X-Client-Ip",
+                        ),
+                        Annotated(
+                            HeaderValue(
+                                "[ip]",
+                            ),
+                            Meta {
+                                remarks: [
+                                    Remark {
+                                        ty: Substituted,
+                                        rule_id: "@ip:replace",
+                                        range: Some(
+                                            (
+                                                0,
+                                                4,
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                errors: [],
+                                original_length: Some(
+                                    8,
+                                ),
+                                original_value: None,
+                            },
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        body_size: ~,
+        env: ~,
+        inferred_content_type: ~,
+        api_target: ~,
+        other: {},
+    },
+    contexts: ~,
+    breadcrumbs: ~,
+    exceptions: ~,
+    stacktrace: ~,
+    template: ~,
+    threads: ~,
+    tags: ~,
+    extra: ~,
+    debug_meta: ~,
+    client_sdk: ~,
+    ingest_path: ~,
+    errors: ~,
+    key_id: ~,
+    project: ~,
+    grouping_config: ~,
+    checksum: ~,
+    csp: ~,
+    hpkp: ~,
+    expectct: ~,
+    expectstaple: ~,
+    spans: ~,
+    measurements: ~,
+    breakdowns: ~,
+    scraping_attempts: ~,
+    _metrics: ~,
+    other: {},
+}


### PR DESCRIPTION
Some User-Agents are being scrubbed by the IP rule, this disables scrubbing for the entire Header as suggested here https://github.com/getsentry/relay/issues/1826#issuecomment-1427631617

Fixes: #1826


