### PR TITLE
chore(spans): Disable resource link span indestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unrelease
+
+**Internal**:
+
+- Disable resource link span ingestion. ([#2647](https://github.com/getsentry/relay/pull/2647))
+
 ## 23.10.1
 
 **Features**:

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -16,7 +16,7 @@ const MOBILE_OPS: &[&str] = &["app.*", "ui.load*"];
 const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
 
 /// A list of patterns for resource span ops we'd like to ingest.
-const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css", "resource.link"];
+const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css"];
 
 /// Adds configuration for extracting metrics from spans.
 ///

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2273,9 +2273,7 @@ impl EnvelopeProcessorService {
             .and_then(|system| system.as_str())
             .unwrap_or_default();
         (resource_span_extraction_enabled
-            && (op.contains("resource.script")
-                || op.contains("resource.css")
-                || op.contains("resource.link")))
+            && (op.contains("resource.script") || op.contains("resource.css")))
             || op == "http.client"
             || op.starts_with("app.")
             || op.starts_with("ui.load")

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1297,63 +1297,6 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_content_length@byte",
-        value: Distribution(
-            [
-                36170.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "resource.render_blocking_status": "blocking",
-            "span.description": "https://*.domain.com/path/to/*.css",
-            "span.domain": "*.domain.com",
-            "span.group": "52c9cf14584b4101",
-            "span.op": "resource.link",
-            "transaction": "gEt /api/:version/users/",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1694732408),
-        width: 0,
-        name: "d:spans/http.decoded_response_body_length@byte",
-        value: Distribution(
-            [
-                128950.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "resource.render_blocking_status": "blocking",
-            "span.description": "https://*.domain.com/path/to/*.css",
-            "span.domain": "*.domain.com",
-            "span.group": "52c9cf14584b4101",
-            "span.op": "resource.link",
-            "transaction": "gEt /api/:version/users/",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1694732408),
-        width: 0,
-        name: "d:spans/http.response_transfer_size@byte",
-        value: Distribution(
-            [
-                36470.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "resource.render_blocking_status": "blocking",
-            "span.description": "https://*.domain.com/path/to/*.css",
-            "span.domain": "*.domain.com",
-            "span.group": "52c9cf14584b4101",
-            "span.op": "resource.link",
-            "transaction": "gEt /api/:version/users/",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1694732408),
-        width: 0,
         name: "d:spans/exclusive_time@millisecond",
         value: Distribution(
             [


### PR DESCRIPTION
`resource.link` spans are collected when a resource (`script`, `css` or `img`) is preloaded which means they will likely appear as its own `resource.(img|css|script)` span soon after, producing 2 spans of the same data which might not be useful.

As we're chasing cardinality, we'll disable ingesting those spans until we have a better handle on cardinality and we feel they add value to the product.