### PR TITLE
fix(spans): Remove mobile outliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Disable resource link span ingestion. ([#2647](https://github.com/getsentry/relay/pull/2647))
 
+**Features**:
+
+- Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
+
 ## 23.10.1
 
 **Features**:
@@ -13,7 +18,7 @@
 - Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
-- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
+
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -19,9 +19,6 @@ const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
 /// A list of patterns for resource span ops we'd like to ingest.
 const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css", "resource.link"];
 
-// TODO: docs
-const MAX_EXCLUSIVE_TIME_MOBILE_MS: f64 = 180_000.0;
-
 /// Adds configuration for extracting metrics from spans.
 ///
 /// This configuration is temporarily hard-coded here. It will later be provided by the upstream.

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -1,5 +1,6 @@
 use relay_base_schema::data_category::DataCategory;
 use relay_common::glob2::LazyGlob;
+use relay_event_normalization::utils::MAX_DURATION_MOBILE_MS;
 use relay_protocol::RuleCondition;
 use serde_json::Number;
 
@@ -69,7 +70,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
     let duration_condition = RuleCondition::negate(RuleCondition::glob("span.op", MOBILE_OPS))
         | RuleCondition::lte(
             "span.exclusive_time",
-            Number::from_f64(MAX_EXCLUSIVE_TIME_MOBILE_MS).unwrap_or(0.into()),
+            Number::from_f64(MAX_DURATION_MOBILE_MS).unwrap_or(0.into()),
         );
 
     config.metrics.extend([

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -28,6 +28,7 @@ use smallvec::SmallVec;
 
 use crate::span::tag_extraction::{self, extract_span_tags};
 use crate::timestamp::TimestampProcessor;
+use crate::utils::MAX_DURATION_MOBILE_MS;
 use crate::{
     schema, transactions, trimming, BreakdownsConfig, ClockDriftProcessor, GeoIpLookup,
     RawUserAgentInfo, SpanDescriptionRule, StoreConfig, TransactionNameConfig,
@@ -439,6 +440,30 @@ fn normalize_app_start_measurements(measurements: &mut Measurements) {
     }
 }
 
+/// New SDKs do not send measurements when they exceed 180 seconds.
+///
+/// Drop those outlier measurements for older SDKs.
+fn filter_mobile_outliers(measurements: &mut Measurements) {
+    // Filter outliers for mobile:
+    for key in [
+        "app_start_cold",
+        "app_start_warm",
+        "time_to_initial_display",
+        "time_to_full_display",
+    ] {
+        if let Some(value) = measurements.get_value(key) {
+            if value > MAX_DURATION_MOBILE_MS {
+                measurements.remove(key);
+            }
+        }
+    }
+}
+
+fn normalize_mobile_measurements(measurements: &mut Measurements) {
+    normalize_app_start_measurements(measurements);
+    filter_mobile_outliers(measurements);
+}
+
 fn normalize_units(measurements: &mut Measurements) {
     for (name, measurement) in measurements.iter_mut() {
         let measurement = match measurement.value_mut() {
@@ -464,7 +489,7 @@ fn normalize_measurements(
         // Only transaction events may have a measurements interface
         event.measurements = Annotated::empty();
     } else if let Annotated(Some(ref mut measurements), ref mut meta) = event.measurements {
-        normalize_app_start_measurements(measurements);
+        normalize_mobile_measurements(measurements);
         normalize_units(measurements);
         if let Some(measurements_config) = measurements_config {
             remove_invalid_measurements(measurements, meta, measurements_config, max_mri_len);
@@ -3708,6 +3733,18 @@ mod tests {
             },
         ]
         "###);
+    }
+
+    #[test]
+    fn test_filter_mobile_outliers() {
+        let mut measurements =
+            Annotated::<Measurements>::from_json(r#"{"app_start_warm": {"value": 180001}}"#)
+                .unwrap()
+                .into_value()
+                .unwrap();
+        assert_eq!(measurements.len(), 1);
+        filter_mobile_outliers(&mut measurements);
+        assert_eq!(measurements.len(), 0);
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -444,7 +444,6 @@ fn normalize_app_start_measurements(measurements: &mut Measurements) {
 ///
 /// Drop those outlier measurements for older SDKs.
 fn filter_mobile_outliers(measurements: &mut Measurements) {
-    // Filter outliers for mobile:
     for key in [
         "app_start_cold",
         "app_start_warm",

--- a/relay-event-normalization/src/normalize/utils.rs
+++ b/relay-event-normalization/src/normalize/utils.rs
@@ -13,6 +13,12 @@ pub const MOBILE_SDKS: [&str; 4] = [
     "sentry.javascript.react-native",
 ];
 
+/// Maximum length of a mobile span or measurement in milliseconds.
+///
+/// Spans like `ui.load` with an `exclusive_time` that exceeds this number will be removed,
+/// as well as mobile measurements (on transactions) such as `app.start.cold`, etc.
+pub const MAX_DURATION_MOBILE_MS: f64 = 180_000.0;
+
 /// Extract the HTTP status code from the span data.
 pub fn http_status_code_from_span(span: &Span) -> Option<String> {
     // For SDKs which put the HTTP status code into the span data.

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -61,8 +61,10 @@ pub fn extract_metrics(event: &Event, config: &MetricExtractionConfig) -> Vec<Bu
 
 #[cfg(test)]
 mod tests {
+    use chrono::{DateTime, Utc};
     use relay_dynamic_config::{Feature, FeatureSet, ProjectConfig};
     use relay_event_normalization::LightNormalizationConfig;
+    use relay_event_schema::protocol::Timestamp;
     use relay_protocol::Annotated;
     use std::collections::BTreeSet;
 
@@ -1081,5 +1083,68 @@ mod tests {
         let config = project.metric_extraction.ok().unwrap();
         let metrics = extract_metrics(event.value().unwrap(), &config);
         insta::assert_debug_snapshot!((&event.value().unwrap().spans, metrics));
+    }
+
+    //     `app_start_cold`/`app.start.cold`
+
+    // `app_start_warm`/`app.start.warm`
+
+    // `time_to_initial_display`/`ui.load.initial_display`
+
+    // `time_to_full_display`/`ui.load.full_display`
+
+    /// Helper function for span metric extraction tests.
+    fn extract_span_metrics(span_op: &str, duration_millis: f64) -> Vec<Bucket> {
+        let mut span = Span::default();
+        span.timestamp
+            .set_value(Some(Timestamp::from(DateTime::<Utc>::MAX_UTC))); // whatever
+        span.op.set_value(Some(span_op.into()));
+        span.exclusive_time.set_value(Some(duration_millis));
+        let mut config = ProjectConfig::default();
+        config.features.0.insert(Feature::SpanMetricsExtraction);
+        config.sanitize(); // apply defaults for span extraction
+
+        let extraction_config = config.metric_extraction.ok().unwrap();
+        generic::extract_metrics(&span, &extraction_config)
+    }
+
+    #[test]
+    fn test_app_start_cold_inlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("app.start.cold", 180000.0), @"");
+    }
+
+    #[test]
+    fn test_app_start_cold_outlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("app.start.cold", 181000.0), @"");
+    }
+
+    #[test]
+    fn test_app_start_warm_inlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("app.start.warm", 180000.0), @"");
+    }
+
+    #[test]
+    fn test_app_start_warm_outlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("app.start.warm", 181000.0), @"");
+    }
+
+    #[test]
+    fn test_ui_load_initial_display_inlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.initial_display", 180000.0), @"");
+    }
+
+    #[test]
+    fn test_ui_load_initial_display_outlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.initial_display", 181000.0), @"");
+    }
+
+    #[test]
+    fn test_ui_load_full_display_inlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.full_display", 180000.0), @"");
+    }
+
+    #[test]
+    fn test_ui_load_full_display_outlier() {
+        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.full_display", 181000.0), @"");
     }
 }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1085,14 +1085,6 @@ mod tests {
         insta::assert_debug_snapshot!((&event.value().unwrap().spans, metrics));
     }
 
-    //     `app_start_cold`/`app.start.cold`
-
-    // `app_start_warm`/`app.start.warm`
-
-    // `time_to_initial_display`/`ui.load.initial_display`
-
-    // `time_to_full_display`/`ui.load.full_display`
-
     /// Helper function for span metric extraction tests.
     fn extract_span_metrics(span_op: &str, duration_millis: f64) -> Vec<Bucket> {
         let mut span = Span::default();
@@ -1111,41 +1103,53 @@ mod tests {
 
     #[test]
     fn test_app_start_cold_inlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("app.start.cold", 180000.0), @"");
+        assert_eq!(2, extract_span_metrics("app.start.cold", 180000.0).len());
     }
 
     #[test]
     fn test_app_start_cold_outlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("app.start.cold", 181000.0), @"");
+        assert_eq!(0, extract_span_metrics("app.start.cold", 181000.0).len());
     }
 
     #[test]
     fn test_app_start_warm_inlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("app.start.warm", 180000.0), @"");
+        assert_eq!(2, extract_span_metrics("app.start.warm", 180000.0).len());
     }
 
     #[test]
     fn test_app_start_warm_outlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("app.start.warm", 181000.0), @"");
+        assert_eq!(0, extract_span_metrics("app.start.warm", 181000.0).len());
     }
 
     #[test]
     fn test_ui_load_initial_display_inlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.initial_display", 180000.0), @"");
+        assert_eq!(
+            2,
+            extract_span_metrics("ui.load.initial_display", 180000.0).len()
+        );
     }
 
     #[test]
     fn test_ui_load_initial_display_outlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.initial_display", 181000.0), @"");
+        assert_eq!(
+            0,
+            extract_span_metrics("ui.load.initial_display", 181000.0).len()
+        );
     }
 
     #[test]
     fn test_ui_load_full_display_inlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.full_display", 180000.0), @"");
+        assert_eq!(
+            2,
+            extract_span_metrics("ui.load.full_display", 180000.0).len()
+        );
     }
 
     #[test]
     fn test_ui_load_full_display_outlier() {
-        insta::assert_debug_snapshot!(extract_span_metrics("ui.load.full_display", 181000.0), @"");
+        assert_eq!(
+            0,
+            extract_span_metrics("ui.load.full_display", 181000.0).len()
+        );
     }
 }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1100,6 +1100,7 @@ mod tests {
             .set_value(Some(Timestamp::from(DateTime::<Utc>::MAX_UTC))); // whatever
         span.op.set_value(Some(span_op.into()));
         span.exclusive_time.set_value(Some(duration_millis));
+
         let mut config = ProjectConfig::default();
         config.features.0.insert(Feature::SpanMetricsExtraction);
         config.sanitize(); // apply defaults for span extraction

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -32,12 +32,12 @@ where
     };
 
     for metric_spec in &config.metrics {
-        if metric_spec.category != instance.category() {
+        if dbg!(metric_spec).category != instance.category() {
             continue;
         }
 
         if let Some(ref condition) = &metric_spec.condition {
-            if !condition.matches(instance) {
+            if !dbg!(condition.matches(instance)) {
                 continue;
             }
         }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -37,7 +37,7 @@ where
         }
 
         if let Some(ref condition) = &metric_spec.condition {
-            if dbg!(dbg!(condition).matches(instance)) {
+            if !condition.matches(instance) {
                 continue;
             }
         }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -37,7 +37,7 @@ where
         }
 
         if let Some(ref condition) = &metric_spec.condition {
-            if condition.matches(instance) {
+            if dbg!(dbg!(condition).matches(instance)) {
                 continue;
             }
         }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -32,12 +32,12 @@ where
     };
 
     for metric_spec in &config.metrics {
-        if dbg!(metric_spec).category != instance.category() {
+        if metric_spec.category != instance.category() {
             continue;
         }
 
         if let Some(ref condition) = &metric_spec.condition {
-            if !dbg!(condition.matches(instance)) {
+            if condition.matches(instance) {
                 continue;
             }
         }


### PR DESCRIPTION
The following measurements are not sent by newer mobile SDKs if they exceed 180 seconds:

- `app_start_cold`
- `app_start_warm`
- `time_to_initial_display`
- `time_to_full_display`

The same goes for the corresponding span ops. To align the behavior for normal SDKs and to prevent the skew that these outliers cause in averages, drop them in normalization / suppress their span metrics.

ref: [internal issue](https://www.notion.so/sentry/Don-t-extract-metrics-from-outlier-mobile-spans-85fdaec4646e4300ae45f491adde99d2?pvs=4)