### PR TITLE
feat(inbound-filters) Add support for inbound filtering of legacy Edge browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unrelease
 
+**Features**:
+- Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([2650](https://github.com/getsentry/relay/pull/2650)
+
 **Internal**:
 
 - Disable resource link span ingestion. ([#2647](https://github.com/getsentry/relay/pull/2647))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unrelease
 
 **Features**:
-- Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([2650](https://github.com/getsentry/relay/pull/2650)
+
+- Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([#2650](https://github.com/getsentry/relay/pull/2650)
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([#2650](https://github.com/getsentry/relay/pull/2650)
+- Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([#2650](https://github.com/getsentry/relay/pull/2650))
 
 **Internal**:
 

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -44,6 +44,8 @@ pub enum LegacyBrowser {
     AndroidPre4,
     /// Apply to Safari 5 and older.
     SafariPre6,
+    /// Edge legacy i.e. 12-18.
+    EdgePre79,
     /// An unknown browser configuration for forward compatibility.
     Unknown(String),
 }
@@ -62,6 +64,7 @@ impl FromStr for LegacyBrowser {
             "opera_mini_pre_8" => LegacyBrowser::OperaMiniPre8,
             "android_pre_4" => LegacyBrowser::AndroidPre4,
             "safari_pre_6" => LegacyBrowser::SafariPre6,
+            "edge_pre_79" => LegacyBrowser::EdgePre79,
             _ => LegacyBrowser::Unknown(s.to_owned()),
         };
         Ok(v)
@@ -93,6 +96,7 @@ impl Serialize for LegacyBrowser {
             LegacyBrowser::OperaMiniPre8 => "opera_mini_pre_8",
             LegacyBrowser::AndroidPre4 => "android_pre_4",
             LegacyBrowser::SafariPre6 => "safari_pre_6",
+            LegacyBrowser::EdgePre79 => "edge_pre_79",
             LegacyBrowser::Unknown(string) => string,
         })
     }
@@ -316,7 +320,10 @@ mod tests {
             },
             legacy_browsers: LegacyBrowsersFilterConfig {
                 is_enabled: false,
-                browsers: [LegacyBrowser::Ie9].iter().cloned().collect(),
+                browsers: [LegacyBrowser::Ie9, LegacyBrowser::EdgePre79]
+                    .iter()
+                    .cloned()
+                    .collect(),
             },
             localhost: FilterConfig { is_enabled: true },
             releases: ReleasesFilterConfig {
@@ -354,7 +361,8 @@ mod tests {
           "legacyBrowsers": {
             "isEnabled": false,
             "options": [
-              "ie9"
+              "ie9",
+              "edge_pre_79"
             ]
           },
           "localhost": {

--- a/relay-filter/src/legacy_browsers.rs
+++ b/relay-filter/src/legacy_browsers.rs
@@ -40,6 +40,7 @@ pub fn matches(event: &Event, browsers: &BTreeSet<LegacyBrowser>) -> bool {
                 LegacyBrowser::SafariPre6 => {
                     filter_browser(family, &user_agent, "Safari", |x| x < 6)
                 }
+                LegacyBrowser::EdgePre79 => filter_browser(family, &user_agent, "Edge", |x| x < 79),
                 LegacyBrowser::Unknown(_) => {
                     // unknown browsers should not be filtered
                     false
@@ -149,6 +150,13 @@ mod tests {
         "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 1063; tr-DE) AppleWebKit/533.16 (KHTML like Gecko) Version/5.0 Safari/533.16";
     const SAFARI_6_UA: &str =
         "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.17.4; en-GB) AppleWebKit/605.1.5 (KHTML, like Gecko) Version/6.0 Safari/605.1.5";
+    const EDGE_ANDROID_118_UA: &str =
+        "Mozilla/5.0 (Linux; Android 10; Pixel 3 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.80 Mobile Safari/537.36 EdgA/118.0.2088.58";
+    const EDGE_79_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3919.0 Safari/537.36 Edg/79.0.294.1";
+    const EDGE_18_UA: &str =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.19582";
+    const EDGE_12_UA: &str =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246";
 
     use std::collections::BTreeSet;
 
@@ -270,6 +278,11 @@ mod tests {
                 SAFARI_PRE6_UA,
                 &[LegacyBrowser::OperaPre15, LegacyBrowser::SafariPre6][..],
             ),
+            (EDGE_12_UA, &[LegacyBrowser::EdgePre79][..]),
+            (
+                EDGE_18_UA,
+                &[LegacyBrowser::OperaPre15, LegacyBrowser::EdgePre79][..],
+            ),
         ];
 
         for (ref user_agent, ref active_filters) in &test_configs {
@@ -295,6 +308,10 @@ mod tests {
             (OPERA_MINI_8_UA, LegacyBrowser::OperaMiniPre8),
             (ANDROID_4_UA, LegacyBrowser::AndroidPre4),
             (SAFARI_6_UA, LegacyBrowser::SafariPre6),
+            (EDGE_12_UA, LegacyBrowser::Ie10),
+            (EDGE_18_UA, LegacyBrowser::Ie10),
+            (EDGE_79_UA, LegacyBrowser::EdgePre79),
+            (EDGE_ANDROID_118_UA, LegacyBrowser::EdgePre79),
         ];
 
         for (user_agent, active_filter) in &test_configs {


### PR DESCRIPTION
This PR adds support for filtering legacy edge browser to the LegacyBrowsers inbound filter.

When this option is enabled any edge browser with major version < 79 will be filtered.
Effectively this means that browsers version 12 through 18 will be filtered ( from 18 it jumped to 79).

Resolves: https://github.com/getsentry/sentry/issues/29707