### PR TITLE
chore(project_state): Add config option for always requesting full project state

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1746,7 +1746,7 @@ impl Config {
     }
 
     /// Returns `true` if the full project state should be requested from upstream.
-    pub fn project_state_full(&self) -> bool {
+    pub fn request_full_project_config(&self) -> bool {
         self.values.cache.project_request_full_config
     }
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -821,6 +821,8 @@ pub struct Spool {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 struct Cache {
+    /// The full project state will be requested by this Relay if set to `true`.
+    project_state_full: bool,
     /// The cache timeout for project configurations in seconds.
     project_expiry: u32,
     /// Continue using project state this many seconds after cache expiry while a new state is
@@ -857,6 +859,7 @@ struct Cache {
 impl Default for Cache {
     fn default() -> Self {
         Cache {
+            project_state_full: false,
             project_expiry: 300, // 5 minutes
             project_grace_period: 0,
             relay_expiry: 3600,   // 1 hour
@@ -1740,6 +1743,11 @@ impl Config {
     /// Returns the expiry timeout for cached projects.
     pub fn project_cache_expiry(&self) -> Duration {
         Duration::from_secs(self.values.cache.project_expiry.into())
+    }
+
+    /// Returns `true` if the full project state should be requested from upstream.
+    pub fn project_state_full(&self) -> bool {
+        self.values.cache.project_state_full
     }
 
     /// Returns the expiry timeout for cached relay infos (public keys).

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -822,7 +822,7 @@ pub struct Spool {
 #[serde(default)]
 struct Cache {
     /// The full project state will be requested by this Relay if set to `true`.
-    project_state_full: bool,
+    project_request_full_config: bool,
     /// The cache timeout for project configurations in seconds.
     project_expiry: u32,
     /// Continue using project state this many seconds after cache expiry while a new state is
@@ -859,7 +859,7 @@ struct Cache {
 impl Default for Cache {
     fn default() -> Self {
         Cache {
-            project_state_full: false,
+            project_request_full_config: false,
             project_expiry: 300, // 5 minutes
             project_grace_period: 0,
             relay_expiry: 3600,   // 1 hour
@@ -1747,7 +1747,7 @@ impl Config {
 
     /// Returns `true` if the full project state should be requested from upstream.
     pub fn project_state_full(&self) -> bool {
-        self.values.cache.project_state_full
+        self.values.cache.project_request_full_config
     }
 
     /// Returns the expiry timeout for cached relay infos (public keys).

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -276,7 +276,7 @@ impl UpstreamProjectSourceService {
 
             let query = GetProjectStates {
                 public_keys: channels_batch.keys().copied().collect(),
-                full_config: config.processing_enabled() || config.project_state_full(),
+                full_config: config.processing_enabled() || config.request_full_project_config(),
                 no_cache: channels_batch.values().any(|c| c.no_cache),
             };
 

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -276,7 +276,7 @@ impl UpstreamProjectSourceService {
 
             let query = GetProjectStates {
                 public_keys: channels_batch.keys().copied().collect(),
-                full_config: config.processing_enabled(),
+                full_config: config.processing_enabled() || config.project_state_full(),
                 no_cache: channels_batch.values().any(|c| c.no_cache),
             };
 


### PR DESCRIPTION
Introduce the configuration option, which allows to configure Relay to always request the full project state from the upstream. 

related: https://github.com/getsentry/team-ingest/issues/231

#skip-changelog