### PR TITLE
feat(normalization): Run store processor in light normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@
 **Features**:
 
 - Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([#2650](https://github.com/getsentry/relay/pull/2650))
+- Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
 
 **Internal**:
 
 - Disable resource link span ingestion. ([#2647](https://github.com/getsentry/relay/pull/2647))
-
-**Features**:
-
-- Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
-- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
+- Run StoreProcessor in light normalization. ((#2657)[https://github.com/getsentry/relay/pull/2657])
 
 ## 23.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unrelease
+## Unreleased
 
 **Features**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
 - Add `locale` ,`screen_width_pixels`, `screen_height_pixels`, and `uuid` to the device context. ([#2640](https://github.com/getsentry/relay/pull/2640))
+- Run StoreProcessor in light normalization. ((#2657)[https://github.com/getsentry/relay/pull/2657])
 
 ## 0.8.31
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -135,7 +135,11 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         enable_trimming: config.enable_trimming.unwrap_or_default(),
         measurements: None,
     };
-    light_normalize_event(&mut event, light_normalization_config)?;
+    light_normalize_event(
+        &mut event,
+        light_normalization_config,
+        StoreConfig::default(),
+    )?;
     process_value(&mut event, &mut *processor, ProcessingState::root())?;
     RelayStr::from_string(event.to_json()?)
 }

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -615,6 +615,7 @@ mod tests {
                         light_normalize_spans: true,
                         ..Default::default()
                     },
+                    crate::StoreConfig::default(),
                 );
                 assert!(res.is_ok());
 

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -63,7 +63,7 @@ pub fn extract_metrics(event: &Event, config: &MetricExtractionConfig) -> Vec<Bu
 mod tests {
     use chrono::{DateTime, Utc};
     use relay_dynamic_config::{Feature, FeatureSet, ProjectConfig};
-    use relay_event_normalization::LightNormalizationConfig;
+    use relay_event_normalization::{LightNormalizationConfig, StoreConfig};
     use relay_event_schema::protocol::Timestamp;
     use relay_protocol::Annotated;
     use std::collections::BTreeSet;
@@ -485,6 +485,7 @@ mod tests {
                 light_normalize_spans: true,
                 ..Default::default()
             },
+            StoreConfig::default(),
         )
         .unwrap();
 
@@ -1007,6 +1008,7 @@ mod tests {
                 light_normalize_spans: true,
                 ..Default::default()
             },
+            StoreConfig::default(),
         )
         .unwrap();
 
@@ -1065,6 +1067,7 @@ mod tests {
                 device_class_synthesis_config: true,
                 ..Default::default()
             },
+            StoreConfig::default(),
         )
         .unwrap();
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -434,7 +434,7 @@ mod tests {
     use relay_dynamic_config::AcceptTransactionNames;
     use relay_event_normalization::{
         set_default_transaction_source, BreakdownsConfig, DynamicMeasurementsConfig,
-        LightNormalizationConfig, MeasurementsConfig,
+        LightNormalizationConfig, MeasurementsConfig, StoreConfig,
     };
     use relay_event_schema::protocol::User;
     use relay_metrics::BucketValue;
@@ -522,6 +522,7 @@ mod tests {
                 light_normalize_spans: true,
                 ..Default::default()
             },
+            StoreConfig::default(),
         )
         .unwrap();
 
@@ -751,6 +752,7 @@ mod tests {
         relay_event_normalization::light_normalize_event(
             &mut event,
             LightNormalizationConfig::default(),
+            StoreConfig::default(),
         )
         .unwrap();
 
@@ -876,6 +878,7 @@ mod tests {
         relay_event_normalization::light_normalize_event(
             &mut event,
             LightNormalizationConfig::default(),
+            StoreConfig::default(),
         )
         .unwrap();
 
@@ -1052,6 +1055,7 @@ mod tests {
                 measurements: Some(config),
                 ..Default::default()
             },
+            StoreConfig::default(),
         )
         .unwrap();
 
@@ -1683,6 +1687,7 @@ mod tests {
         let _ = relay_event_normalization::light_normalize_event(
             &mut event,
             LightNormalizationConfig::default(),
+            StoreConfig::default(),
         );
 
         let config = TransactionMetricsConfig::default();

--- a/relay-server/tests/test_fixtures.rs
+++ b/relay-server/tests/test_fixtures.rs
@@ -72,7 +72,7 @@ macro_rules! event_snapshot {
                 let mut event = load_fixture();
 
                 let config = LightNormalizationConfig::default();
-                light_normalize_event(&mut event, config).unwrap();
+                light_normalize_event(&mut event, config, StoreConfig::default()).unwrap();
 
                 let config = StoreConfig::default();
                 let mut processor = StoreProcessor::new(config, None);

--- a/tools/process-event/src/main.rs
+++ b/tools/process-event/src/main.rs
@@ -83,8 +83,12 @@ impl Cli {
         }
 
         if self.store {
-            light_normalize_event(&mut event, LightNormalizationConfig::default())
-                .map_err(|e| format_err!("{e}"))?;
+            light_normalize_event(
+                &mut event,
+                LightNormalizationConfig::default(),
+                StoreConfig::default(),
+            )
+            .map_err(|e| format_err!("{e}"))?;
             let mut processor = StoreProcessor::new(StoreConfig::default(), None);
             process_value(&mut event, &mut processor, ProcessingState::root())
                 .map_err(|e| format_err!("{e}"))


### PR DESCRIPTION
Run `StoreProcessor` as part of light normalization in all relays. Since `is_renormalize` is enabled, effectively this change is a NOOP.

## Context

As we plan on getting rid of light normalization and unifying all normalization, we'll move all normalization steps from light normalization to `StoreNormalization`.