### PR TITLE
tests: Configure retries with backoffs for requests

### DIFF
--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -1,9 +1,14 @@
 import time
 
-import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-session = requests.session()
+
+session = Session()
+retries = Retry(total=5, backoff_factor=0.1)
+session.mount("http://", HTTPAdapter(max_retries=retries))
 
 
 class SentryLike:


### PR DESCRIPTION
It seems like sometimes we cannot properly establish connection to the mini sentry, and failing. 

This PR adds `Retry` config with back off to try to mitigate this issue.

Example of a failing job https://github.com/getsentry/relay/actions/runs/6663221361/job/18108771404

Follow-up for #2643 

#skip-changelog