### PR TITLE
feat(spans): Add TTID and TTFD tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,19 @@
 # Changelog
 
-## Unrelease
+## Unreleased
 
 **Features**:
 
 - Add inbound filters option to filter legacy Edge browsers (i.e. versions 12-18 ) ([#2650](https://github.com/getsentry/relay/pull/2650))
 - Group resource spans by scrubbed domain and filename. ([#2654](https://github.com/getsentry/relay/pull/2654))
+- Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
 
 **Internal**:
 
 - Disable resource link span ingestion. ([#2647](https://github.com/getsentry/relay/pull/2647))
 - Collect `http.decoded_response_content_length`. ([#2638](https://github.com/getsentry/relay/pull/2638))
-
-
-**Features**:
-
-- Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
-- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
+- Add TTID and TTFD tags to mobile spans. ([#2662](https://github.com/getsentry/relay/pull/2662))
 
 ## 23.10.1
 
@@ -25,7 +22,6 @@
 - Update Docker Debian image from 10 to 12. ([#2622](https://github.com/getsentry/relay/pull/2622))
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
-
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -145,7 +145,9 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 ("span.", "system"),
                 ("", "transaction.method"),
                 ("", "transaction.op"),
-                ("", "resource.render_blocking_status"), // only set for resource spans.
+                ("", "resource.render_blocking_status"), // only set for resource spans
+                ("", "ttid"),                            // only set for mobile spans
+                ("", "ttfd"),                            // only set for mobile spans
             ]
             .map(|(prefix, key)| TagSpec {
                 key: format!("{prefix}{key}"),

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -392,12 +392,12 @@ pub(crate) fn extract_tags(
     if let Some(end_time) = span.timestamp.value() {
         if let Some(initial_display) = initial_display {
             if end_time <= &initial_display {
-                span_tags.insert(SpanTagKey::TimeToInitialDisplay, "true".to_owned());
+                span_tags.insert(SpanTagKey::TimeToInitialDisplay, "ttid".to_owned());
             }
         }
         if let Some(full_display) = full_display {
             if end_time <= &full_display {
-                span_tags.insert(SpanTagKey::TimeToFullDisplay, "true".to_owned());
+                span_tags.insert(SpanTagKey::TimeToFullDisplay, "ttfd".to_owned());
             }
         }
     }
@@ -891,15 +891,15 @@ LIMIT 1
         // First two spans contribute to initial display & full display:
         for span in &spans[..2] {
             let tags = span.value().unwrap().sentry_tags.value().unwrap();
-            assert_eq!(tags.get("ttid").unwrap().as_str(), Some("true"));
-            assert_eq!(tags.get("ttfd").unwrap().as_str(), Some("true"));
+            assert_eq!(tags.get("ttid").unwrap().as_str(), Some("ttid"));
+            assert_eq!(tags.get("ttfd").unwrap().as_str(), Some("ttfd"));
         }
 
         // First four spans contribute to full display:
         for span in &spans[2..4] {
             let tags = span.value().unwrap().sentry_tags.value().unwrap();
             assert_eq!(tags.get("ttid"), None);
-            assert_eq!(tags.get("ttfd").unwrap().as_str(), Some("true"));
+            assert_eq!(tags.get("ttfd").unwrap().as_str(), Some("ttfd"));
         }
 
         for span in &spans[4..] {

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1180,8 +1180,8 @@ mod tests {
             "exclusive_time": 100,
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
             "sentry_tags": {
-                "ttid": "true",
-                "ttfd": "true"
+                "ttid": "ttid",
+                "ttfd": "ttfd"
             }
         }"#;
         let span = Annotated::from_json(span).unwrap().into_value().unwrap();
@@ -1189,8 +1189,8 @@ mod tests {
 
         assert!(!metrics.is_empty());
         for metric in metrics {
-            assert_eq!(metric.tag("ttid"), Some("true"));
-            assert_eq!(metric.tag("ttfd"), Some("true"));
+            assert_eq!(metric.tag("ttid"), Some("ttid"));
+            assert_eq!(metric.tag("ttfd"), Some("ttfd"));
         }
     }
 }


### PR DESCRIPTION
If `ui.load.initial_display` and/or `ui.load.full_display` spans are present, mark spans happening before those with `ttid` and `ttfd` tags.