### PR TITLE
test(spool): Remove test with relative path

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -970,7 +970,6 @@ impl Drop for BufferService {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use std::time::{Duration, Instant};
 
     use insta::assert_debug_snapshot;
@@ -1024,26 +1023,6 @@ mod tests {
             .await
             .unwrap();
         assert!(target_dir.exists());
-    }
-
-    #[tokio::test]
-    async fn create_spool_directory_root_path() {
-        let spool_file = "spool.db";
-        let buffer_guard: Arc<_> = BufferGuard::new(1).into();
-        let config: Arc<_> = Config::from_json_value(serde_json::json!({
-            "spool": {
-                "envelopes": {
-                    "path": spool_file,
-                }
-            }
-        }))
-        .unwrap()
-        .into();
-        BufferService::create(buffer_guard, services(), config)
-            .await
-            .unwrap();
-        let spool_file = PathBuf::from(spool_file);
-        assert!(spool_file.exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
The test `create_spool_directory_root_path` creates a couple of local files: `spool.db`, `spool.db-wal`, `spool.db-shm`.

Assuming that this test was introduced to test if relative paths work at all, we can consider it proven and remove the test.

#skip-changelog