### PR TITLE
doc(py): Fix relay-cabi version and changelog to 0.8.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "relay-cabi"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "chrono",

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
-- Add `scraping_attempts` field to the event schema. ([#2575](https://github.com/getsentry/relay/pull/2575))
 - Drop events starting or ending before January 1, 1970 UTC. ([#2613](https://github.com/getsentry/relay/pull/2613))
 - Remove event spans starting or ending before January 1, 1970 UTC. ([#2627](https://github.com/getsentry/relay/pull/2627))
 - Remove event breadcrumbs dating before January 1, 1970 UTC. ([#2635](https://github.com/getsentry/relay/pull/2635))
 - Add `PerformanceScoreConfig` config and performance score calculations to measurements for frontend events. ([#2632](https://github.com/getsentry/relay/pull/2632))
 - Add `locale` ,`screen_width_pixels`, `screen_height_pixels`, and `uuid` to the device context. ([#2640](https://github.com/getsentry/relay/pull/2640))
+
+## 0.8.32
+
+- Add `scraping_attempts` field to the event schema. ([#2575](https://github.com/getsentry/relay/pull/2575))
 
 ## 0.8.31
 

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-cabi"
-version = "0.8.31"
+version = "0.8.32"
 authors = ["Sentry <oss@sentry.io>"]
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"


### PR DESCRIPTION
This is usually done by the [release workflow](https://github.com/getsentry/relay/actions/workflows/release_library.yml), but it failed for unknown reasons for 0.8.32.

#skip-changelog