### PR TITLE
fix(replays): Disable scrubbing for replay_id field

### DIFF
--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -69,6 +69,7 @@ pub struct Replay {
     ///   "replay_id": "fc6d8c0c43fc4630ad850ee518f1b9d0"
     /// }
     /// ```
+    #[metastructure(pii = "false")]
     pub replay_id: Annotated<EventId>,
 
     /// The type of sampling that captured the replay.


### PR DESCRIPTION
We're getting this error in Snuba: https://sentry.sentry.io/issues/4488839662/?project=300688&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=5

I believe the PII scrubber doesn't like something about the UUID and is scrubbing it.  I thought PII scrubbing was disabled by default unless the field was marked.  I've added PII false to the field for now but I would appreciate if I could get some additional insights into how the PII scrubber works so I can avoid these types of issues in the future.

Resolves #SNUBA-3TJ