### PR TITLE
feat(profiling): Log SDK name and version in errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,6 +3785,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "insta",
+ "relay-base-schema",
  "relay-event-schema",
  "relay-log",
  "relay-protocol",

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 android_trace_log = { version = "0.3.0", features = ["serde"] }
 chrono = { workspace = true }
 data-encoding = "2.3.3"
+relay-base-schema = { path = "../relay-base-schema" }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-log = { path = "../relay-log" }
 relay-protocol = { path = "../relay-protocol" }

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -193,7 +193,6 @@ pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>
             relay_log::warn!(
                 error = &err as &dyn Error,
                 from = "minimal",
-                original = err.inner().to_string(),
                 platform = event.platform.as_str(),
                 project_id = event.project.value().unwrap_or(&0),
                 sdk_name = event.sdk_name(),
@@ -223,7 +222,6 @@ pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>
                 relay_log::warn!(
                     error = &err as &dyn Error,
                     from = "parsing",
-                    original = err.inner().to_string(),
                     platform = profile.platform,
                     project_id = event.project.value().unwrap_or(&0),
                     sdk_name = event.sdk_name(),

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -39,12 +39,17 @@ mod tests {
     #[test]
     fn test_value_as_float() {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":1234.56789}"#;
-        assert!(serde_json::from_str::<MeasurementValue>(measurement_json).is_ok());
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_ok());
+        assert_eq!(measurement.unwrap().value, 1234.56789);
     }
 
     #[test]
     fn test_value_as_string() {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"1234.56789"}"#;
         assert!(serde_json::from_str::<MeasurementValue>(measurement_json).is_ok());
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_ok());
+        assert_eq!(measurement.unwrap().value, 1234.56789);
     }
 }

--- a/relay-profiling/src/utils.rs
+++ b/relay-profiling/src/utils.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 use serde::{de, Deserialize};
+use serde_json::{Map, Value};
 
 pub fn is_zero(n: &u64) -> bool {
     *n == 0
@@ -15,13 +16,28 @@ where
 {
     #[derive(Deserialize)]
     #[serde(untagged)]
-    enum StringOrInt<T> {
+    enum StringOrNumber<T> {
         String(String),
         Number(T),
+        Bool(bool),
+        Array(Vec<Value>),
+        Object(Map<String, Value>),
     }
 
-    match StringOrInt::<T>::deserialize(deserializer)? {
-        StringOrInt::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
-        StringOrInt::Number(i) => Ok(i),
+    match StringOrNumber::<T>::deserialize(deserializer)? {
+        StringOrNumber::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
+        StringOrNumber::Number(n) => Ok(n),
+        StringOrNumber::Bool(v) => Err(serde::de::Error::custom(format!(
+            "unsupported value: {:?}",
+            v
+        ))),
+        StringOrNumber::Array(v) => Err(serde::de::Error::custom(format!(
+            "unsupported value: {:?}",
+            v
+        ))),
+        StringOrNumber::Object(v) => Err(serde::de::Error::custom(format!(
+            "unsupported value: {:?}",
+            v
+        ))),
     }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1097,7 +1097,7 @@ impl EnvelopeProcessorService {
             ItemType::Profile if transaction_count == 0 => ItemAction::DropSilently,
             // First profile found in the envelope, we'll keep it if metadata are valid.
             ItemType::Profile if !found_profile => {
-                match relay_profiling::parse_metadata(&item.payload(), state.event.value()) {
+                match relay_profiling::parse_metadata(&item.payload(), state.project_id) {
                     Ok(_) => {
                         found_profile = true;
                         ItemAction::Keep

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1153,9 +1153,7 @@ impl EnvelopeProcessorService {
                     return ItemAction::DropSilently;
                 }
                 // If we don't have an event at this stage, we need to drop the profile.
-                let event = if let Some(event) = state.event.value() {
-                    event
-                } else {
+                let Some(event) = state.event.value() else {
                     return ItemAction::DropSilently;
                 };
                 match relay_profiling::expand_profile(&item.payload(), event) {


### PR DESCRIPTION
Follow-up to my previous PR to make logs even more useful by adding the previous error containing the value with the issue and the SDK name and version.

#skip-changelog