### PR TITLE
fix(on-demand): Add url field to the event getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Group resource spans by scrubbed domain and filename. ([#2654](https://github.com/getsentry/relay/pull/2654))
 - Convert transactions to spans for all organizations. ([#2659](https://github.com/getsentry/relay/pull/2659))
 - Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
-- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640), [#2675](https://github.com/getsentry/relay/pull/2675))
 - Allow advanced scrubbing expressions for datascrubbing safe fields. ([#2670](https://github.com/getsentry/relay/pull/2670))
 
 **Bug Fixes**:

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -650,6 +650,7 @@ impl Getter for Event {
             "user.geo.region" => self.user.value()?.geo.value()?.region.as_str()?.into(),
             "user.geo.subdivision" => self.user.value()?.geo.value()?.subdivision.as_str()?.into(),
             "request.method" => self.request.value()?.method.as_str()?.into(),
+            "request.url" => self.request.value()?.url.as_str()?.into(),
             "sdk.name" => self.client_sdk.value()?.name.as_str()?.into(),
             "sdk.version" => self.client_sdk.value()?.version.as_str()?.into(),
 

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -1069,6 +1069,7 @@ mod tests {
                     Annotated::new("user-agent".into()),
                     Annotated::new("Slurp".into()),
                 ))]))),
+                url: Annotated::new("https://sentry.io".into()),
                 ..Default::default()
             }),
             transaction: Annotated::new("some-transaction".into()),
@@ -1177,6 +1178,10 @@ mod tests {
         assert_eq!(
             Some(Val::Uuid(uuid!("abadcade-feed-dead-beef-baddadfeeded"))),
             event.get_value("event.contexts.device.uuid")
+        );
+        assert_eq!(
+            Some(Val::String("https://sentry.io")),
+            event.get_value("event.request.url")
         );
     }
 


### PR DESCRIPTION
This PR adds the support to the `request.url` in the `Event` `Getter`.