### PR TITLE
ref(upstream): Only log error if failure reoccurs

### DIFF
--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -371,10 +371,22 @@ impl UpstreamProjectSourceService {
                     }
                 }
                 Err(err) => {
-                    relay_log::error!(
-                        error = &err as &dyn std::error::Error,
-                        "error fetching project states"
-                    );
+                    let attempts = channels_batch
+                        .values()
+                        .map(|b| b.attempts)
+                        .max()
+                        .unwrap_or(0);
+                    // Only log an error if the request failed more than once.
+                    // We are not interested in spurious failures. Our retry mechanism is able to
+                    // handle those.
+                    if attempts >= 2 {
+                        relay_log::error!(
+                            error = &err as &dyn std::error::Error,
+                            attempts = attempts,
+                            "error fetching project states",
+                        );
+                    }
+
                     metric!(
                         histogram(RelayHistograms::ProjectStatePending) =
                             self.state_channels.len() as u64

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -377,7 +377,7 @@ impl UpstreamProjectSourceService {
                         .max()
                         .unwrap_or(0);
                     // Only log an error if the request failed more than once.
-                    // We are not interested in spurious failures. Our retry mechanism is able to
+                    // We are not interested in single failures. Our retry mechanism is able to
                     // handle those.
                     if attempts >= 2 {
                         relay_log::error!(


### PR DESCRIPTION
Our upstreams sometimes respond with `503 Service Unavailable`. To reduce noise in our error logs, only log an error if we could not fetch a project state more than once. Example:

```
ERROR relay_server::actors::project_upstream: error fetching project states error=upstream request returned error 503 Service Unavailable error.sources=[no error details] attempts=6
```

#skip-changelog