### PR TITLE
fix(profiling): Fix issues detected after logging better errors

### DIFF
--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -197,6 +197,7 @@ pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>
                 project_id = event.project.value().unwrap_or(&0),
                 sdk_name = event.sdk_name(),
                 sdk_version = event.sdk_version(),
+                transaction_id = format!("{:?}", event.id.value()),
                 "invalid profile",
             );
             return Err(ProfileError::InvalidJson(err));
@@ -226,6 +227,7 @@ pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>
                     project_id = event.project.value().unwrap_or(&0),
                     sdk_name = event.sdk_name(),
                     sdk_version = event.sdk_version(),
+                    transaction_id = format!("{:?}", event.id.value()),
                     "invalid profile",
                 );
                 Err(ProfileError::InvalidJson(err))
@@ -238,6 +240,7 @@ pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>
                     project_id = event.project.value().unwrap_or(&0),
                     sdk_name = event.sdk_name(),
                     sdk_version = event.sdk_version(),
+                    transaction_id = format!("{:?}", event.id.value()),
                     "invalid profile",
                 );
                 Err(err)

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -73,6 +73,7 @@ mod tests {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":1e3}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
+        assert_eq!(measurement.unwrap().value, 1e3f64);
     }
 
     #[test]

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -47,9 +47,38 @@ mod tests {
     #[test]
     fn test_value_as_string() {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"1234.56789"}"#;
-        assert!(serde_json::from_str::<MeasurementValue>(measurement_json).is_ok());
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
         assert_eq!(measurement.unwrap().value, 1234.56789);
+    }
+
+    #[test]
+    fn test_value_as_string_scientific_notation() {
+        let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"1e3"}"#;
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_ok());
+        assert_eq!(measurement.unwrap().value, 1e3f64);
+    }
+
+    #[test]
+    fn test_value_as_string_infinity() {
+        let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"+Infinity"}"#;
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_ok());
+        assert_eq!(measurement.unwrap().value, f64::INFINITY);
+    }
+
+    #[test]
+    fn test_value_as_float_scientific_notation() {
+        let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":1e3}"#;
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_ok());
+    }
+
+    #[test]
+    fn test_value_as_float_infinity() {
+        let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":+Infinity}"#;
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_err());
     }
 }

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -168,9 +168,6 @@ pub struct ProfileMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     transaction: Option<TransactionMetadata>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    measurements: Option<HashMap<String, Measurement>>,
-
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     transaction_metadata: BTreeMap<String, String>,
 
@@ -180,6 +177,8 @@ pub struct ProfileMetadata {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SampleProfile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    measurements: Option<HashMap<String, Measurement>>,
     #[serde(flatten)]
     metadata: ProfileMetadata,
     profile: Profile,

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -424,6 +424,7 @@ mod tests {
 
     fn generate_profile() -> SampleProfile {
         SampleProfile {
+            measurements: None,
             metadata: ProfileMetadata {
                 debug_meta: Option::None,
                 version: Version::V1,
@@ -448,7 +449,6 @@ mod tests {
                 transactions: Vec::new(),
                 release: Some("1.0".to_string()),
                 dist: "9999".to_string(),
-                measurements: None,
                 transaction_metadata: BTreeMap::new(),
                 transaction_tags: BTreeMap::new(),
             },

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -158,8 +158,8 @@ pub struct ProfileMetadata {
     platform: String,
     timestamp: DateTime<Utc>,
 
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    release: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    release: Option<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     dist: String,
 
@@ -381,8 +381,11 @@ pub fn parse_sample_profile(
         }
     }
 
-    if let Some(release) = transaction_metadata.get("release") {
-        profile.metadata.release = release.to_owned();
+    // Do not replace the release if we're passing one already.
+    if profile.metadata.release.is_none() {
+        if let Some(release) = transaction_metadata.get("release") {
+            profile.metadata.release = Some(release.to_owned());
+        }
     }
 
     if let Some(dist) = transaction_metadata.get("dist") {
@@ -444,7 +447,7 @@ mod tests {
                 event_id: EventId::new(),
                 transaction: Option::None,
                 transactions: Vec::new(),
-                release: "1.0".to_string(),
+                release: Some("1.0".to_string()),
                 dist: "9999".to_string(),
                 measurements: None,
                 transaction_metadata: BTreeMap::new(),
@@ -901,13 +904,10 @@ mod tests {
 
     #[test]
     fn test_extract_transaction_tags() {
-        let transaction_metadata = BTreeMap::from([
-            ("release".to_string(), "some-random-release".to_string()),
-            (
-                "transaction".to_string(),
-                "some-random-transaction".to_string(),
-            ),
-        ]);
+        let transaction_metadata = BTreeMap::from([(
+            "transaction".to_string(),
+            "some-random-transaction".to_string(),
+        )]);
 
         let payload = include_bytes!("../tests/fixtures/profiles/sample/roundtrip.json");
         let profile_json = parse_sample_profile(payload, transaction_metadata, BTreeMap::new());
@@ -918,7 +918,6 @@ mod tests {
         let output: SampleProfile = serde_path_to_error::deserialize(d)
             .map_err(ProfileError::InvalidJson)
             .unwrap();
-        assert_eq!(output.metadata.release, "some-random-release".to_string());
         assert_eq!(
             output.metadata.transaction.unwrap().name,
             "some-random-transaction".to_string()
@@ -967,5 +966,59 @@ mod tests {
         ]);
 
         assert!(profile.is_above_max_duration());
+    }
+
+    #[test]
+    fn test_accept_null_or_empty_release() {
+        let payload = r#"{
+            "version":"1",
+            "device":{
+                "architecture":"arm64e",
+                "is_emulator":true,
+                "locale":"en_US",
+                "manufacturer":"Apple",
+                "model":"iPhome11,3"
+            },
+            "os":{
+                "name":"iOS",
+                "version":"16.0",
+                "build_number":"H3110"
+            },
+            "environment":"testing",
+            "event_id":"961d6b96017644db895eafd391682003",
+            "platform":"cocoa",
+            "release":null,
+            "timestamp":"2023-11-01T15:27:15.081230Z",
+            "transaction":{
+                "active_thread_id": 1,
+                "id":"9789498b-6970-4dda-b2a1-f9cb91d1a445",
+                "name":"blah",
+                "trace_id":"809ff2c0-e185-4c21-8f21-6a6fef009352"
+            },
+            "dist":"9999",
+            "profile":{
+                "samples":[
+                    {
+                        "stack_id":0,
+                        "elapsed_since_start_ns":1,
+                        "thread_id":1
+                    },
+                    {
+                        "stack_id":0,
+                        "elapsed_since_start_ns":2,
+                        "thread_id":1
+                    }
+                ],
+                "stacks":[[0]],
+                "frames":[{
+                    "function":"main"
+                }],
+                "thread_metadata":{},
+                "queue_metadata":{}
+            }
+        }"#;
+        let profile = parse_profile(payload.as_bytes());
+        assert!(profile.is_ok());
+        assert_eq!(profile.unwrap().metadata.release, None);
     }
 }

--- a/relay-profiling/src/sample.rs
+++ b/relay-profiling/src/sample.rs
@@ -9,7 +9,7 @@ use crate::error::ProfileError;
 use crate::measurements::Measurement;
 use crate::native_debug_image::NativeDebugImage;
 use crate::transaction_metadata::TransactionMetadata;
-use crate::utils::deserialize_number_from_string;
+use crate::utils::{deserialize_number_from_string, string_is_null_or_empty};
 use crate::MAX_PROFILE_DURATION;
 
 const MAX_PROFILE_DURATION_NS: u64 = MAX_PROFILE_DURATION.as_nanos() as u64;
@@ -158,7 +158,7 @@ pub struct ProfileMetadata {
     platform: String,
     timestamp: DateTime<Utc>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "string_is_null_or_empty")]
     release: Option<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     dist: String,

--- a/relay-profiling/src/utils.rs
+++ b/relay-profiling/src/utils.rs
@@ -43,3 +43,7 @@ where
         AnyType::Null => Err(serde::de::Error::custom("unsupported null value")),
     }
 }
+
+pub fn string_is_null_or_empty(s: &Option<String>) -> bool {
+    s.as_deref().map_or(true, |s| s.is_empty())
+}

--- a/relay-profiling/src/utils.rs
+++ b/relay-profiling/src/utils.rs
@@ -16,28 +16,30 @@ where
 {
     #[derive(Deserialize)]
     #[serde(untagged)]
-    enum StringOrNumber<T> {
-        String(String),
-        Number(T),
-        Bool(bool),
+    enum AnyType<T> {
         Array(Vec<Value>),
+        Bool(bool),
+        Null,
+        Number(T),
         Object(Map<String, Value>),
+        String(String),
     }
 
-    match StringOrNumber::<T>::deserialize(deserializer)? {
-        StringOrNumber::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
-        StringOrNumber::Number(n) => Ok(n),
-        StringOrNumber::Bool(v) => Err(serde::de::Error::custom(format!(
+    match AnyType::<T>::deserialize(deserializer)? {
+        AnyType::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
+        AnyType::Number(n) => Ok(n),
+        AnyType::Bool(v) => Err(serde::de::Error::custom(format!(
             "unsupported value: {:?}",
             v
         ))),
-        StringOrNumber::Array(v) => Err(serde::de::Error::custom(format!(
+        AnyType::Array(v) => Err(serde::de::Error::custom(format!(
             "unsupported value: {:?}",
             v
         ))),
-        StringOrNumber::Object(v) => Err(serde::de::Error::custom(format!(
+        AnyType::Object(v) => Err(serde::de::Error::custom(format!(
             "unsupported value: {:?}",
             v
         ))),
+        AnyType::Null => Err(serde::de::Error::custom("unsupported null value")),
     }
 }


### PR DESCRIPTION
- We'll start accepting `null` values for the `release` field as we accept no field/empty string already and some SDKs are sending `null` values already.
- `measurements` parsing was done when validating the profile metadata and it's not necessary to do this at this stage so we moved it when we process the profile.
- We wanted to log the invalid value when trying to decode a number or float to a string and we ended up not taking `null` values into account. With this change, we'll log we tried to decode a `null` value, making it more explicit on what the error is.

#skip-changelog