### PR TITLE
feat(py): Add validate_pii_selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Allow advanced scrubbing expressions for datascrubbing safe fields. ([#2670](https://github.com/getsentry/relay/pull/2670))
 - Track when a span was received. ([#2688](https://github.com/getsentry/relay/pull/2688))
 - Add context for NEL (Network Error Logging) reports to the event schema. ([#2421](https://github.com/getsentry/relay/pull/2421))
+- Add `validate_pii_selector` to CABI for safe fields validation. ([#2687](https://github.com/getsentry/relay/pull/2687))
 
 **Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `validate_pii_selector` to validate safe fields. ([#2687](https://github.com/getsentry/relay/pull/2687))
+
 ## 0.8.34
 
 - Add context for NEL (Network Error Logging) reports to the event schema. ([#2421](https://github.com/getsentry/relay/pull/2421))

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -21,6 +21,7 @@ __all__ = [
     "is_glob_match",
     "is_codeowners_path_match",
     "parse_release",
+    "validate_pii_selector",
     "validate_pii_config",
     "convert_datascrubbing_config",
     "pii_strip_event",
@@ -164,6 +165,17 @@ def is_codeowners_path_match(value, pattern):
     return rustcall(
         lib.relay_is_codeowners_path_match, make_buf(value), encode_str(pattern)
     )
+
+
+def validate_pii_selector(selector):
+    """
+    Validate a PII selector spec. Used to validate datascrubbing safe fields.
+    """
+    assert isinstance(selector, str)
+    raw_error = rustcall(lib.relay_validate_pii_selector, encode_str(selector))
+    error = decode_str(raw_error, free=True)
+    if error:
+        raise ValueError(error)
 
 
 def validate_pii_config(config):

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -128,6 +128,24 @@ def test_normalize_user_agent(must_normalize):
         assert "contexts" not in event
 
 
+def test_validate_pii_selector():
+    sentry_relay.validate_pii_selector("test")
+    sentry_relay.validate_pii_selector("$user.id")
+    sentry_relay.validate_pii_selector("extra.'sys.argv'.**")
+
+    with pytest.raises(ValueError) as e:
+        sentry_relay.validate_pii_selector("no_spaces allowed")
+    assert str(e.value) == 'invalid syntax near "no_spaces allowed"'
+
+    with pytest.raises(ValueError) as e:
+        sentry_relay.validate_pii_selector("unterminated.'string")
+    assert str(e.value) == 'invalid syntax near "unterminated.\'string"'
+
+    with pytest.raises(ValueError) as e:
+        sentry_relay.validate_pii_selector("double.**.wildcard.**")
+    assert str(e.value) == "deep wildcard used more than once"
+
+
 def test_validate_pii_config():
     sentry_relay.validate_pii_config("{}")
     sentry_relay.validate_pii_config('{"applications": {}}')

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -553,6 +553,11 @@ struct RelayStr relay_store_normalizer_normalize_event(struct RelayStoreNormaliz
 bool relay_translate_legacy_python_json(struct RelayStr *event);
 
 /**
+ * Validates a PII selector spec. Used to validate datascrubbing safe fields.
+ */
+struct RelayStr relay_validate_pii_selector(const struct RelayStr *value);
+
+/**
  * Validate a PII config against the schema. Used in project options UI.
  */
 struct RelayStr relay_validate_pii_config(const struct RelayStr *value);


### PR DESCRIPTION
Expose a function to validate PII selectors directly, so we can use it to validate safe fields in Sentry.