### PR TITLE
fix(metrics): Bump generic extraction version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Collect `http.decoded_response_content_length`. ([#2638](https://github.com/getsentry/relay/pull/2638))
 - Add TTID and TTFD tags to mobile spans. ([#2662](https://github.com/getsentry/relay/pull/2662))
 - Scrub all DB Core Data spans differently. ([#2686](https://github.com/getsentry/relay/pull/2686))
+- Support generic metrics extraction version 2. ([#2692](https://github.com/getsentry/relay/pull/2692))
 
 ## 23.10.1
 

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -181,15 +181,15 @@ pub struct MetricExtractionConfig {
 }
 
 impl MetricExtractionConfig {
-    /// The latest version for this config struct.
-    pub const VERSION: u16 = 1;
+    /// The maximum version supported by this Relay instance.
+    pub const MAX_VERSION: u16 = 2;
 
     /// Returns an empty `MetricExtractionConfig` with the latest version.
     ///
     /// As opposed to `default()`, this will be enabled once populated with specs.
     pub fn empty() -> Self {
         Self {
-            version: Self::VERSION,
+            version: Self::MAX_VERSION,
             metrics: Vec::new(),
             tags: Vec::new(),
             _conditional_tags_extended: false,
@@ -199,7 +199,7 @@ impl MetricExtractionConfig {
 
     /// Returns `true` if the version of this metric extraction config is supported.
     pub fn is_supported(&self) -> bool {
-        self.version <= Self::VERSION
+        self.version <= Self::MAX_VERSION
     }
 
     /// Returns `true` if metric extraction is configured and compatible with this Relay.

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -181,15 +181,17 @@ pub struct MetricExtractionConfig {
 }
 
 impl MetricExtractionConfig {
-    /// The maximum version supported by this Relay instance.
-    pub const MAX_VERSION: u16 = 2;
+    /// The latest version for this config struct.
+    ///
+    /// This is the maximum version supported by this Relay instance.
+    pub const VERSION: u16 = 2;
 
     /// Returns an empty `MetricExtractionConfig` with the latest version.
     ///
     /// As opposed to `default()`, this will be enabled once populated with specs.
     pub fn empty() -> Self {
         Self {
-            version: Self::MAX_VERSION,
+            version: Self::VERSION,
             metrics: Vec::new(),
             tags: Vec::new(),
             _conditional_tags_extended: false,
@@ -199,7 +201,7 @@ impl MetricExtractionConfig {
 
     /// Returns `true` if the version of this metric extraction config is supported.
     pub fn is_supported(&self) -> bool {
-        self.version <= Self::MAX_VERSION
+        self.version <= Self::VERSION
     }
 
     /// Returns `true` if metric extraction is configured and compatible with this Relay.


### PR DESCRIPTION
External relays of version 23.9.1 (and possibly below) set the `metrics_extracted` flag on transaction items even if transaction metrics extraction is disabled: https://github.com/getsentry/relay/blob/ffebe6020a2a6d42fde90857868736e5769a77d2/relay-server/src/actors/processor.rs#L2099-L2104

We recently [bumped](https://github.com/getsentry/sentry/issues/57759) the transaction metrics version, causing external relays to skip extraction. But because old external relays set the `metrics_extracted` flag anyway, even our internal PoPs skip metrics extraction now.

This PR is a one-time fix to force old external relays to stop extracting generic metrics as well.