### PR TITLE
chore(metric): Tag metric with the project state type

### DIFF
--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -274,14 +274,18 @@ impl UpstreamProjectSourceService {
                     channels_batch.len() as u64
             );
 
+            let full_config = config.processing_enabled() || config.request_full_project_config();
             let query = GetProjectStates {
                 public_keys: channels_batch.keys().copied().collect(),
-                full_config: config.processing_enabled() || config.request_full_project_config(),
                 no_cache: channels_batch.values().any(|c| c.no_cache),
+                full_config,
             };
 
             // count number of http requests for project states
-            metric!(counter(RelayCounters::ProjectStateRequest) += 1);
+            metric!(
+                counter(RelayCounters::ProjectStateRequest) += 1,
+                full = &full_config.to_string(),
+            );
 
             let upstream_relay = upstream_relay.clone();
             requests.push(async move {

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -18,6 +18,7 @@ use crate::endpoints::common::ServiceUnavailable;
 use crate::endpoints::forward;
 use crate::extractors::SignedJson;
 use crate::service::ServiceState;
+use crate::statsd::RelayCounters;
 
 /// V2 version of this endpoint.
 ///
@@ -56,6 +57,10 @@ enum ProjectStateWrapper {
 impl ProjectStateWrapper {
     /// Create a wrapper which forces serialization into external or internal format
     pub fn new(state: ProjectState, full: bool) -> Self {
+        relay_statsd::metric!(
+            counter(RelayCounters::ProjectStateResponse) += 1,
+            full = &full.to_string(),
+        );
         if full {
             Self::Full(state)
         } else {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -432,6 +432,12 @@ pub enum RelayCounters {
     ///  - `full`: Either `true` if the full project state is requested or `false` - when the
     ///  limited project state is requested.
     ProjectStateRequest,
+    /// Number of project state HTTP responses to the incoming requests.
+    ///
+    /// This metric tagged with:
+    ///  - `full`: Either `true` if the full project state is requested or `false` - when the
+    ///  limited project state is requested.
+    ProjectStateResponse,
     /// Number of times a project config was requested with `.no-cache`.
     ///
     /// This effectively counts the number of envelopes or events that have been sent with a
@@ -570,6 +576,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::Outcomes => "events.outcomes",
             RelayCounters::ProjectStateGet => "project_state.get",
             RelayCounters::ProjectStateRequest => "project_state.request",
+            RelayCounters::ProjectStateResponse => "project_state.response",
             RelayCounters::ProjectStateNoCache => "project_state.no_cache",
             #[cfg(feature = "processing")]
             RelayCounters::ProjectStateRedis => "project_state.redis.requests",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -427,6 +427,10 @@ pub enum RelayCounters {
     ///
     /// Note that after an update loop has completed, there may be more projects pending updates.
     /// This is indicated by `project_state.pending`.
+    ///
+    /// This metric is tagged with:
+    ///  - `full`: Either `true` if the full project state is requested or `false` - when the
+    ///  limited project state is requested.
     ProjectStateRequest,
     /// Number of times a project config was requested with `.no-cache`.
     ///


### PR DESCRIPTION
Add the `full` tag to `ProjectStateRequest` metric, to measure what types of the project states are  requested. 
This can be just temporary for the rollout procedure and once we sure that PoPs are fetching full project config, these changes can be reverted.  


related: https://github.com/getsentry/team-ingest/issues/231

#skip-changelog 