### PR TITLE
fix(spans): Add resource size tags

### DIFF
--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -336,14 +336,18 @@ pub(crate) fn extract_tags(
 
         if span_op.starts_with("resource.") {
             if let Some(data) = span.data.value() {
-                if let Some(Annotated(Some(Value::F64(value)), _)) =
-                    data.get("http.response_content_length")
+                if let Some(value) = data
+                    .get("http.response_content_length")
+                    .and_then(Annotated::value)
+                    .and_then(Value::as_f64)
                 {
                     span_tags.insert(SpanTagKey::HttpResponseContentLength, value.to_string());
                 }
 
-                if let Some(Annotated(Some(Value::F64(value)), _)) =
-                    data.get("http.decoded_response_content_length")
+                if let Some(value) = data
+                    .get("http.decoded_response_content_length")
+                    .and_then(Annotated::value)
+                    .and_then(Value::as_f64)
                 {
                     span_tags.insert(
                         SpanTagKey::HttpDecodedResponseContentLength,
@@ -351,8 +355,10 @@ pub(crate) fn extract_tags(
                     );
                 }
 
-                if let Some(Annotated(Some(Value::F64(value)), _)) =
-                    data.get("http.response_transfer_size")
+                if let Some(value) = data
+                    .get("http.response_transfer_size")
+                    .and_then(Annotated::value)
+                    .and_then(Value::as_f64)
                 {
                     span_tags.insert(SpanTagKey::HttpResponseTransferSize, value.to_string());
                 }

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -7,7 +7,7 @@ use std::ops::ControlFlow;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use relay_event_schema::protocol::{Event, Span, Timestamp, TraceContext};
-use relay_protocol::{Annotated, Value};
+use relay_protocol::Annotated;
 use sqlparser::ast::Visit;
 use sqlparser::ast::{ObjectName, Visitor};
 use url::Url;
@@ -339,28 +339,25 @@ pub(crate) fn extract_tags(
                 if let Some(value) = data
                     .get("http.response_content_length")
                     .and_then(Annotated::value)
-                    .and_then(Value::as_f64)
+                    .and_then(|v| String::try_from(v).ok())
                 {
-                    span_tags.insert(SpanTagKey::HttpResponseContentLength, value.to_string());
+                    span_tags.insert(SpanTagKey::HttpResponseContentLength, value);
                 }
 
                 if let Some(value) = data
                     .get("http.decoded_response_content_length")
                     .and_then(Annotated::value)
-                    .and_then(Value::as_f64)
+                    .and_then(|v| String::try_from(v).ok())
                 {
-                    span_tags.insert(
-                        SpanTagKey::HttpDecodedResponseContentLength,
-                        value.to_string(),
-                    );
+                    span_tags.insert(SpanTagKey::HttpDecodedResponseContentLength, value);
                 }
 
                 if let Some(value) = data
                     .get("http.response_transfer_size")
                     .and_then(Annotated::value)
-                    .and_then(Value::as_f64)
+                    .and_then(|v| String::try_from(v).ok())
                 {
-                    span_tags.insert(SpanTagKey::HttpResponseTransferSize, value.to_string());
+                    span_tags.insert(SpanTagKey::HttpResponseTransferSize, value);
                 }
             }
 

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -85,18 +85,6 @@ impl Value {
         }
     }
 
-    /// Returns a floating point number if this value can be converted, else `None`.
-    ///
-    /// Note that this function does not parse strings.
-    pub fn as_f64(&self) -> Option<f64> {
-        match self {
-            Value::I64(f) => Some(*f as f64),
-            Value::U64(f) => Some(*f as f64),
-            Value::F64(f) => Some(*f),
-            _ => None,
-        }
-    }
-
     /// Constructs a `Value` from a `serde_json::Value` object.
     fn from_json(value: serde_json::Value) -> Option<Self> {
         Some(match value {
@@ -125,6 +113,21 @@ impl Value {
                     .map(|(k, v)| (k, Annotated::<Value>::from(v)))
                     .collect(),
             ),
+        })
+    }
+}
+
+impl TryFrom<&Value> for String {
+    type Error = ();
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        Ok(match value {
+            Value::Bool(v) => v.to_string(),
+            Value::I64(v) => v.to_string(),
+            Value::U64(v) => v.to_string(),
+            Value::F64(v) => v.to_string(),
+            Value::String(v) => v.to_string(),
+            _ => return Err(()),
         })
     }
 }

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -85,6 +85,18 @@ impl Value {
         }
     }
 
+    /// Returns a floating point number if this value can be converted, else `None`.
+    ///
+    /// Note that this function does not parse strings.
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Value::I64(f) => Some(*f as f64),
+            Value::U64(f) => Some(*f as f64),
+            Value::F64(f) => Some(*f),
+            _ => None,
+        }
+    }
+
     /// Constructs a `Value` from a `serde_json::Value` object.
     fn from_json(value: serde_json::Value) -> Option<Self> {
         Some(match value {


### PR DESCRIPTION
Add the following data items to `sentry_tags`, so they can be queried from indexed spans:

* `http.response_content_length`
* `http.decoded_response_content_length`
* `http.response_transfer_size`

Downside: Because `sentry_tags` have to be strings, these numbers will be encoded as strings.

#skip-changelog