### PR TITLE
ref(spooler): Move dropped envelope count to tag in sentry error

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -960,7 +960,7 @@ impl Drop for BufferService {
             BufferState::Memory(ram) | BufferState::MemoryFileStandby { ram, .. } => {
                 let count = ram.count();
                 if count > 0 {
-                    relay_log::error!("dropped {count} envelopes");
+                    relay_log::error!(tags.amount = count, "dropped envelopes");
                 }
             }
             BufferState::Disk(_) => (),


### PR DESCRIPTION
This PR moves the number of dropped envelopes from the error message to an event tag, and rewords the message to look closer to similar errors.

This change addresses the following problems:

1. Existing alerts for dropped envelopes match error messages with the pattern `dropped envelope*`. The error message doesn't match the pattern thus it's excluded from the alert. This name change includes the error in the alerts.
2. Sentry will group all similar messages together, even if they have different counts. For example, `dropped 100 envelopes` is grouped into the same issue as `dropped 987654321 envelopes`. The only way to know how many envelopes have been dropped is to get into the issue and inspect the error message of each individual error, as the issue title may indicate a totally different number. Having a common message and removing variables enables trust on error messages.
3. This error represents multiple envelopes dropped. To get alerts on the number of envelopes, we need to make that number a field we can filter by, and add that condition to the alert. This means adding it as a tag.

After deploying this PR, updating the alerts is required.

#skip-changelog