### PR TITLE
ref(project-upstream): Emit error on multiple project fetch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add TTID and TTFD tags to mobile spans. ([#2662](https://github.com/getsentry/relay/pull/2662))
 - Scrub all DB Core Data spans differently. ([#2686](https://github.com/getsentry/relay/pull/2686))
 - Support generic metrics extraction version 2. ([#2692](https://github.com/getsentry/relay/pull/2692))
+- Emit error on continued project config fetch failures for an interval. ([#2700](https://github.com/getsentry/relay/pull/2700))
 
 ## 23.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Add TTID and TTFD tags to mobile spans. ([#2662](https://github.com/getsentry/relay/pull/2662))
 - Scrub all DB Core Data spans differently. ([#2686](https://github.com/getsentry/relay/pull/2686))
 - Support generic metrics extraction version 2. ([#2692](https://github.com/getsentry/relay/pull/2692))
-- Emit error on continued project config fetch failures for an interval. ([#2700](https://github.com/getsentry/relay/pull/2700))
+- Emit error on continued project config fetch failures after a time interval. ([#2700](https://github.com/getsentry/relay/pull/2700))
 
 ## 23.10.1
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -716,6 +716,11 @@ struct Http {
     ///
     /// This time is only used before going into a network outage mode.
     retry_delay: u64,
+    /// The interval in seconds for continued failed project fetches at which Relay will error.
+    ///
+    /// A successful fetch resets this interval. Relay does nothing during long
+    /// times without emitting requests.
+    project_failure_interval: u64,
     /// Content encoding to apply to upstream store requests.
     ///
     /// By default, Relay applies `gzip` content encoding to compress upstream requests. Compression
@@ -743,6 +748,7 @@ impl Default for Http {
             auth_interval: Some(600), // 10 minutes
             outage_grace_period: DEFAULT_NETWORK_OUTAGE_GRACE_PERIOD,
             retry_delay: default_retry_delay(),
+            project_failure_interval: default_project_failure_interval(),
             encoding: HttpEncoding::Gzip,
         }
     }
@@ -751,6 +757,11 @@ impl Default for Http {
 /// Default for unavailable upstream retry period, 1s.
 fn default_retry_delay() -> u64 {
     1
+}
+
+/// Default for project failure interval, 90s.
+fn default_project_failure_interval() -> u64 {
+    90
 }
 
 /// Default for max memory size, 500 MB.
@@ -1623,6 +1634,11 @@ impl Config {
     /// requests. This is the time Relay waits before retrying the same request.
     pub fn http_retry_delay(&self) -> Duration {
         Duration::from_secs(self.values.http.retry_delay)
+    }
+
+    /// Time of continued project request failures before Relay emits an error.
+    pub fn http_project_failure_interval(&self) -> Duration {
+        Duration::from_secs(self.values.http.project_failure_interval)
     }
 
     /// Content encoding of upstream requests.

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -163,6 +163,16 @@ pub struct UpstreamProjectSourceService {
     inner_tx: mpsc::UnboundedSender<Vec<Option<UpstreamResponse>>>,
     inner_rx: mpsc::UnboundedReceiver<Vec<Option<UpstreamResponse>>>,
     fetch_handle: SleepHandle,
+    /// Instant when the last fetch failed, `None` if there aren't any failures.
+    ///
+    /// Relay updates this value to the instant when the first fetch fails, and
+    /// resets it to `None` on successful responses. Relay does nothing during
+    /// long times without requests.
+    last_failed_fetch: Option<Instant>,
+    /// Duration of continued fetch fails before emitting an error.
+    ///
+    /// Relay emits an error if all requests for at least this interval fail.
+    failure_interval: Duration,
 }
 
 impl UpstreamProjectSourceService {
@@ -175,9 +185,11 @@ impl UpstreamProjectSourceService {
             state_channels: HashMap::new(),
             fetch_handle: SleepHandle::idle(),
             upstream_relay,
-            config,
             inner_tx,
             inner_rx,
+            last_failed_fetch: None,
+            failure_interval: config.http_project_failure_interval(),
+            config,
         }
     }
 
@@ -342,6 +354,7 @@ impl UpstreamProjectSourceService {
                     // Otherwise we might refuse to fetch any project configs because of a
                     // single, reproducible 500 we observed for a particular project.
                     self.backoff.reset();
+                    self.last_failed_fetch = None;
 
                     // Count number of project states returned (via http requests).
                     metric!(
@@ -375,6 +388,8 @@ impl UpstreamProjectSourceService {
                     }
                 }
                 Err(err) => {
+                    self.track_failed_response();
+
                     let attempts = channels_batch
                         .values()
                         .map(|b| b.attempts)
@@ -416,6 +431,23 @@ impl UpstreamProjectSourceService {
             // because everything went fine or because all the requests have expired).
             // Next time a user wants a project it should schedule fetch requests.
             self.backoff.reset();
+        }
+    }
+
+    /// Tracks the last failed fetch, and emits an error if it exceeds the failure interval.
+    fn track_failed_response(&mut self) {
+        match self.last_failed_fetch {
+            None => self.last_failed_fetch = Some(Instant::now()),
+            Some(last_failed) => {
+                let failure_duration = last_failed.elapsed();
+                if failure_duration >= self.failure_interval {
+                    relay_log::error!(
+                        failure_duration = format!("{} seconds", failure_duration.as_secs()),
+                        backoff_attempts = self.backoff.attempt(),
+                        "can't fetch project states"
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR makes Relay emit an error after continued project config fetch failures for an interval. Currently, Relay emits some errors on some specific failure cases, but there's a metric to tell whether it's failing all project config fetches or just a few of them. The interval can be configured with `http.project_failure_interval`.

## Approach

Relay tracks the time of a failed fetch, and resets it on a successful one. If some time elapses and Relay hasn't reset the time, it emits an error for each failed request. This should create a big spike of errors after a continued time of failed fetches, demanding attention to the issue.

The fetch time is represented as `Option<Instant>`. Without the option, resetting the instant means setting the most recent time. In that case, Relay would emit an error if a fetch fails after some time of not emitting any fetches at all. This scenario is more likely to happen in low-volume environments, like some Self-Hosted instances.

### Default interval

I've set an arbitrary default value of 90 seconds. This should be short enough to determine Relay is having issues without false positives, and long enough to retry the same request twice with default values (`max_retry_interval = 60s`).