### PR TITLE
fix(pii): Removes legacy special behaviour from safe fields parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 **Bug Fixes**:
 
 - Disable scrubbing for the User-Agent header. ([#2641](https://github.com/getsentry/relay/pull/2641))
+- Fixes certain safe fields disabling data scrubbing for all string fields. ([#2701](https://github.com/getsentry/relay/pull/2701))
 
 **Internal**:
 

--- a/relay-pii/src/selector.rs
+++ b/relay-pii/src/selector.rs
@@ -165,6 +165,19 @@ pub enum SelectorSpec {
 }
 
 impl SelectorSpec {
+    /// Parses a selector from a string without legacy special handling.
+    pub fn parse_non_legacy(s: &str) -> Result<SelectorSpec, InvalidSelectorError> {
+        handle_selector(
+            SelectorParser::parse(Rule::RootSelector, s)
+                .map_err(|e| InvalidSelectorError::ParseError(Box::new(e)))?
+                .next()
+                .unwrap()
+                .into_inner()
+                .next()
+                .unwrap(),
+        )
+    }
+
     /// Checks if a path matches given selector.
     ///
     /// This walks both the selector and the path starting at the end and towards the root
@@ -315,15 +328,7 @@ impl FromStr for SelectorSpec {
             _ => {}
         }
 
-        handle_selector(
-            SelectorParser::parse(Rule::RootSelector, s)
-                .map_err(|e| InvalidSelectorError::ParseError(Box::new(e)))?
-                .next()
-                .unwrap()
-                .into_inner()
-                .next()
-                .unwrap(),
-        )
+        Self::parse_non_legacy(s)
     }
 }
 


### PR DESCRIPTION
safe fields parsing accidentally triggered legacy behaviour which in some cases could disable data scrubbing for all strings 