### PR TITLE
ref(project-upstream): Extract IDs from sentry errors

### DIFF
--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -218,7 +218,7 @@ impl UpstreamProjectSourceService {
                         result = "timeout",
                     );
                     relay_log::error!(
-                        project_key = id.as_str(),
+                        tags.project_key = id.as_str(),
                         "error fetching project state: deadline exceeded"
                     );
                 }
@@ -362,7 +362,7 @@ impl UpstreamProjectSourceService {
                             .unwrap_or(ErrorBoundary::Ok(None))
                             .unwrap_or_else(|error| {
                                 relay_log::error!(
-                                    project_key = key.as_str(),
+                                    tags.project_key = key.as_str(),
                                     error,
                                     "error fetching project state: deserialization error"
                                 );

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -217,7 +217,10 @@ impl UpstreamProjectSourceService {
                         counter(RelayCounters::ProjectUpstreamCompleted) += 1,
                         result = "timeout",
                     );
-                    relay_log::error!("error fetching project state {id}: deadline exceeded");
+                    relay_log::error!(
+                        project_key = id.as_str(),
+                        "error fetching project state: deadline exceeded"
+                    );
                 }
                 !channel.expired()
             });
@@ -358,7 +361,11 @@ impl UpstreamProjectSourceService {
                             .remove(&key)
                             .unwrap_or(ErrorBoundary::Ok(None))
                             .unwrap_or_else(|error| {
-                                relay_log::error!(error, "error fetching project state {key}");
+                                relay_log::error!(
+                                    project_key = key.as_str(),
+                                    error,
+                                    "error fetching project state: deserialization error"
+                                );
                                 Some(ProjectState::err())
                             })
                             .unwrap_or_else(ProjectState::missing);
@@ -387,7 +394,7 @@ impl UpstreamProjectSourceService {
                         relay_log::error!(
                             error = &err as &dyn std::error::Error,
                             attempts = attempts,
-                            "error fetching project states",
+                            "error fetching project state batch",
                         );
                     }
 


### PR DESCRIPTION
Very similar to https://github.com/getsentry/relay/pull/2698. This PR moves the project key out of the error message in the project upstream, in order to reduce the scope of the problem in the current observability.

The diff aims to solve the following issues:
1. Sentry groups these issues together, having a different name for the issue description and error message. For example, you could look at a project key that didn't have issues for 1w, while the issue gets new errors from different project keys. To identify these keys, you need to go through each new event and inspect that error message.
2. It's not viable to measure the impacted project keys. With project keys as tags, it's possible to see the breakdown of project keys and see e.g. if there are just a few impacted projects.

#skip-changelog