### PR TITLE
instr(server): Log project state and pending count

### DIFF
--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -228,6 +228,7 @@ impl UpstreamProjectSourceService {
                         pending = channel.pending,
                         tags.did_error = channel.errors > 0,
                         tags.was_pending = channel.pending > 0,
+                        tags.project_key = id.to_string(),
                         "error fetching project state {id}: deadline exceeded",
                     );
                 }

--- a/relay-server/src/actors/project_upstream.rs
+++ b/relay-server/src/actors/project_upstream.rs
@@ -83,6 +83,10 @@ struct ProjectStateChannel {
     deadline: Instant,
     no_cache: bool,
     attempts: u64,
+    /// How often the request failed.
+    errors: usize,
+    /// How often a "pending" response was received for this project state.
+    pending: usize,
 }
 
 impl ProjectStateChannel {
@@ -97,6 +101,8 @@ impl ProjectStateChannel {
             channel: sender.into_channel(),
             deadline: now + timeout,
             attempts: 0,
+            errors: 0,
+            pending: 0,
         }
     }
 
@@ -217,7 +223,13 @@ impl UpstreamProjectSourceService {
                         counter(RelayCounters::ProjectUpstreamCompleted) += 1,
                         result = "timeout",
                     );
-                    relay_log::error!("error fetching project state {id}: deadline exceeded");
+                    relay_log::error!(
+                        errors = channel.errors,
+                        pending = channel.pending,
+                        tags.did_error = channel.errors > 0,
+                        tags.was_pending = channel.pending > 0,
+                        "error fetching project state {id}: deadline exceeded",
+                    );
                 }
                 !channel.expired()
             });
@@ -344,8 +356,9 @@ impl UpstreamProjectSourceService {
                         histogram(RelayHistograms::ProjectStateReceived) =
                             response.configs.len() as u64
                     );
-                    for (key, channel) in channels_batch {
+                    for (key, mut channel) in channels_batch {
                         if response.pending.contains(&key) {
+                            channel.pending += 1;
                             self.state_channels.insert(key, channel);
                             continue;
                         }
@@ -392,7 +405,12 @@ impl UpstreamProjectSourceService {
                             self.state_channels.len() as u64
                     );
                     // Put the channels back into the queue, we will retry again shortly.
-                    self.state_channels.extend(channels_batch)
+                    self.state_channels.extend(channels_batch.into_iter().map(
+                        |(key, mut channel)| {
+                            channel.errors += 1;
+                            (key, channel)
+                        },
+                    ))
                 }
             }
         }


### PR DESCRIPTION
These tags & context items should help us understand why exactly the error occurs.

```
error fetching project state {id}: deadline exceeded
```

#skip-changelog