### PR TITLE
feat(config): Add `RELAY_LOG_LEVEL` env variable to control log level

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -223,6 +223,8 @@ trait ConfigObject: DeserializeOwned + Serialize {
 pub struct OverridableConfig {
     /// The operation mode of this relay.
     pub mode: Option<String>,
+    /// The log level of this relay.
+    pub log_level: Option<String>,
     /// The upstream relay or sentry instance.
     pub upstream: Option<String>,
     /// Alternate upstream provided through a Sentry DSN. Key and project will be ignored.
@@ -1329,6 +1331,10 @@ impl Config {
             relay.mode = mode
                 .parse::<RelayMode>()
                 .with_context(|| ConfigError::field("mode"))?;
+        }
+
+        if let Some(log_level) = overrides.log_level {
+            self.values.logging.level = log_level.parse()?;
         }
 
         if let Some(upstream) = overrides.upstream {

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -80,6 +80,7 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
 
     OverridableConfig {
         mode: matches.get_one("mode").cloned(),
+        log_level: matches.get_one("log_level").cloned(),
         upstream: matches.get_one("upstream").cloned(),
         upstream_dsn: matches.get_one("upstream_dsn").cloned(),
         host: matches.get_one("host").cloned(),
@@ -100,6 +101,7 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
 pub fn extract_config_env_vars() -> OverridableConfig {
     OverridableConfig {
         mode: env::var("RELAY_MODE").ok(),
+        log_level: env::var("RELAY_LOG_LEVEL").ok(),
         upstream: env::var("RELAY_UPSTREAM_URL").ok(),
         upstream_dsn: env::var("RELAY_UPSTREAM_DSN").ok(),
         host: env::var("RELAY_HOST").ok(),

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -38,6 +38,12 @@ pub fn make_app() -> Command {
                         .value_parser(["managed", "proxy", "static"]),
                 )
                 .arg(
+                    Arg::new("log_level")
+                        .long("log-level")
+                        .help("The relay log level")
+                        .value_parser(["info", "warn", "error", "debug", "trace"]),
+                )
+                .arg(
                     Arg::new("secret_key")
                         .long("secret-key")
                         .short('s')


### PR DESCRIPTION
Adding the ability to control level of the logging using environment variable: `RELAY_LOG_LEVEL`

#skip-changelog