### PR TITLE
feat(spans): Do not scrub Prisma spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Track when a span was received. ([#2688](https://github.com/getsentry/relay/pull/2688))
 - Add context for NEL (Network Error Logging) reports to the event schema. ([#2421](https://github.com/getsentry/relay/pull/2421))
 - Add `validate_pii_selector` to CABI for safe fields validation. ([#2687](https://github.com/getsentry/relay/pull/2687))
+- Do not scrub Prisma spans. ([#2711](https://github.com/getsentry/relay/pull/2711))
 
 **Bug Fixes**:
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -53,6 +53,11 @@ pub(crate) fn scrub_span_description(span: &Span) -> Option<String> {
                 // spans coming from CoreData need to be scrubbed differently.
                 } else if span_origin == Some("auto.db.core_data") {
                     scrub_core_data(description)
+                } else if sub.contains("prisma") {
+                    // We're not able to extract the exact query ran.
+                    // The description will only contain the entity queried and
+                    // the query type ("User find" for example).
+                    Some(description.to_owned())
                 } else {
                     sql::scrub_queries(db_system, description)
                 }
@@ -698,6 +703,8 @@ mod tests {
         "resource.script",
         "*/zero-length-*"
     );
+
+    span_description_test!(db_prisma, "User find", "db.sql.prisma", "User find");
 
     #[test]
     fn informed_sql_parser() {


### PR DESCRIPTION
Until now, since we assumed they were SQL queries, we tried to scrub them and failed so we'd return `None` and were discarding them.