### PR TITLE
ref(normalization): Remove TransactionsProcessor

### DIFF
--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -30,6 +30,7 @@ use crate::{
 
 pub mod breakdowns;
 pub mod nel;
+pub(crate) mod processor;
 pub mod span;
 pub mod user_agent;
 pub mod utils;
@@ -37,7 +38,6 @@ pub mod utils;
 mod contexts;
 mod logentry;
 mod mechanism;
-mod processor;
 mod request;
 mod stacktrace;
 


### PR DESCRIPTION
This PR removes the transaction processor and moves its normalization to `NormalizeProcessor`, bringing us a step closer to having a single processor. There are no new normalization steps in this PR.

#skip-changelog