### PR TITLE
feat(sampling): Add profile context early and expose getter for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Group resource spans by scrubbed domain and filename. ([#2654](https://github.com/getsentry/relay/pull/2654))
 - Convert transactions to spans for all organizations. ([#2659](https://github.com/getsentry/relay/pull/2659))
 - Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
-- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640), [#2675](https://github.com/getsentry/relay/pull/2675), [#2707](https://github.com/getsentry/relay/pull/2707))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640), [#2675](https://github.com/getsentry/relay/pull/2675), [#2707](https://github.com/getsentry/relay/pull/2707), [#2715](https://github.com/getsentry/relay/pull/2715))
 - Allow advanced scrubbing expressions for datascrubbing safe fields. ([#2670](https://github.com/getsentry/relay/pull/2670))
 - Disable graphql scrubbing when datascrubbing is disabled. ([#2689](https://github.com/getsentry/relay/pull/2689))
 - Track when a span was received. ([#2688](https://github.com/getsentry/relay/pull/2688))

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -14,9 +14,9 @@ use crate::processor::ProcessValue;
 use crate::protocol::{
     AppContext, Breadcrumb, Breakdowns, BrowserContext, ClientSdkInfo, Contexts, Csp, DebugMeta,
     DefaultContext, DeviceContext, EventType, Exception, ExpectCt, ExpectStaple, Fingerprint, Hpkp,
-    LenientString, Level, LogEntry, Measurements, Metrics, OsContext, RelayInfo, Request,
-    ResponseContext, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, TraceContext,
-    TransactionInfo, User, Values,
+    LenientString, Level, LogEntry, Measurements, Metrics, OsContext, ProfileContext, RelayInfo,
+    Request, ResponseContext, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp,
+    TraceContext, TransactionInfo, User, Values,
 };
 
 /// Wrapper around a UUID with slightly different formatting.
@@ -708,6 +708,12 @@ impl Getter for Event {
             "contexts.browser.version" => {
                 self.context::<BrowserContext>()?.version.as_str()?.into()
             }
+            "contexts.profile.profile_id" => self
+                .context::<ProfileContext>()?
+                .profile_id
+                .value()?
+                .0
+                .into(),
             "contexts.device.uuid" => self.context::<DeviceContext>()?.uuid.value()?.into(),
             "contexts.trace.status" => self
                 .context::<TraceContext>()?
@@ -1102,6 +1108,11 @@ mod tests {
                     kernel_version: Annotated::new("17.4.0".to_string()),
                     ..OsContext::default()
                 });
+                contexts.add(ProfileContext {
+                    profile_id: Annotated::new(EventId(uuid!(
+                        "abadcade-feed-dead-beef-8addadfeedaa"
+                    ))),
+                });
                 contexts
             }),
             ..Default::default()
@@ -1185,6 +1196,10 @@ mod tests {
             Some(Val::String("https://sentry.io")),
             event.get_value("event.request.url")
         );
+        assert_eq!(
+            Some(Val::Uuid(uuid!("abadcade-feed-dead-beef-8addadfeedaa"))),
+            event.get_value("event.contexts.profile.profile_id")
+        )
     }
 
     #[test]

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -118,10 +118,12 @@ mod utils;
 
 const MAX_PROFILE_DURATION: Duration = Duration::from_secs(30);
 
+pub type ProfileId = EventId;
+
 #[derive(Debug, Deserialize)]
 struct MinimalProfile {
     #[serde(alias = "profile_id")]
-    event_id: EventId,
+    event_id: ProfileId,
     platform: String,
     #[serde(default)]
     version: sample::Version,
@@ -134,7 +136,7 @@ fn minimal_profile_from_json(
     serde_path_to_error::deserialize(d)
 }
 
-pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<(), ProfileError> {
+pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<ProfileId, ProfileError> {
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {
@@ -183,7 +185,7 @@ pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<(), Profi
             _ => return Err(ProfileError::PlatformNotSupported),
         },
     };
-    Ok(())
+    Ok(profile.event_id)
 }
 
 pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>), ProfileError> {

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -118,6 +118,9 @@ mod utils;
 
 const MAX_PROFILE_DURATION: Duration = Duration::from_secs(30);
 
+/// Unique identifier for a profile.
+///
+/// Same format as event IDs.
 pub type ProfileId = EventId;
 
 #[derive(Debug, Deserialize)]
@@ -188,7 +191,7 @@ pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<ProfileId
     Ok(profile.event_id)
 }
 
-pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>), ProfileError> {
+pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(ProfileId, Vec<u8>), ProfileError> {
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -39,7 +39,7 @@ use relay_filter::FilterStatKey;
 use relay_metrics::aggregator::AggregatorConfig;
 use relay_metrics::{Bucket, MergeBuckets, MetricNamespace};
 use relay_pii::{scrub_graphql, PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
-use relay_profiling::{ProfileError, ProfileId};
+use relay_profiling::ProfileError;
 use relay_protocol::{Annotated, Array, Empty, FromValue, Object, Value};
 use relay_quotas::{DataCategory, ReasonCode};
 use relay_replays::recording::RecordingScrubber;

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -31,8 +31,8 @@ use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo};
 use relay_event_schema::processor::{self, ProcessingAction, ProcessingState};
 use relay_event_schema::protocol::{
     Breadcrumb, ClientReport, Contexts, Csp, Event, EventType, ExpectCt, ExpectStaple, Hpkp,
-    IpAddr, LenientString, Metrics, NetworkReportError, OtelContext, RelayInfo, Replay,
-    SecurityReportType, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
+    IpAddr, LenientString, Metrics, NetworkReportError, OtelContext, ProfileContext, RelayInfo,
+    Replay, SecurityReportType, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
     Timestamp, TraceContext, UserReport, Values,
 };
 use relay_filter::FilterStatKey;
@@ -58,7 +58,7 @@ use {
     crate::actors::project_cache::UpdateRateLimits,
     crate::utils::{EnvelopeLimiter, MetricsLimiter},
     relay_event_normalization::{span, StoreConfig, StoreProcessor},
-    relay_event_schema::protocol::{ProfileContext, Span},
+    relay_event_schema::protocol::Span,
     relay_metrics::Aggregator,
     relay_quotas::{RateLimitingError, RedisRateLimiter},
     relay_redis::RedisPool,

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1199,14 +1199,12 @@ impl EnvelopeProcessorService {
         });
         if found_profile_id.is_none() {
             // Remove profile context from event.
-            if let Some(Some(contexts)) = state
-                .event
-                .value_mut()
-                .as_mut()
-                .filter(|event| event.ty.value() == Some(&EventType::Transaction))
-                .map(|event| event.contexts.value_mut())
-            {
-                contexts.remove::<ProfileContext>();
+            if let Some(event) = state.event.value_mut() {
+                if event.ty.value() == Some(&EventType::Transaction) {
+                    if let Some(contexts) = event.contexts.value_mut() {
+                        contexts.remove::<ProfileContext>();
+                    }
+                }
             }
         }
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1197,6 +1197,18 @@ impl EnvelopeProcessorService {
             }
             _ => ItemAction::Keep,
         });
+        if found_profile_id.is_none() {
+            // Remove profile context from event.
+            if let Some(Some(contexts)) = state
+                .event
+                .value_mut()
+                .as_mut()
+                .filter(|event| event.ty.value() == Some(&EventType::Transaction))
+                .map(|event| event.contexts.value_mut())
+            {
+                contexts.remove::<ProfileContext>();
+            }
+        }
     }
 
     /// Remove replays if the feature flag is not enabled.


### PR DESCRIPTION
In order to create dynamic sampling rules depending on the profile ID, add the profile ID to the transaction event's `profile` context and expose it via the event's `Getter` implementation.

Note that most transaction processing still occurs only in processing relays, and it might happen that events that have a profile ID at the time of sampling will not have a profile ID anymore after processing.

Fixes https://github.com/getsentry/relay/issues/2710