### PR TITLE
ref(py): Rename sampling to rule condition

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Validate span timestamps and IDs in light normalization on renormalization. ([#2679](https://github.com/getsentry/relay/pull/2679))
+- Rename `validate_sampling_condition` to `validate_rule_condition`. ([#2720](https://github.com/getsentry/relay/pull/2720))
 
 ## 0.8.35
 

--- a/py/sentry_relay/processing.py
+++ b/py/sentry_relay/processing.py
@@ -27,6 +27,7 @@ __all__ = [
     "pii_strip_event",
     "pii_selector_suggestions_from_event",
     "VALID_PLATFORMS",
+    "validate_rule_condition",
     "validate_sampling_condition",
     "validate_sampling_configuration",
     "validate_project_config",
@@ -237,11 +238,20 @@ def compare_version(a, b):
 
 def validate_sampling_condition(condition):
     """
-    Validate a dynamic rule condition. Used in dynamic sampling serializer.
-    The parameter is a string containing the rule condition as JSON.
+    Deprecated legacy alias. Please use ``validate_rule_condition`` instead.
+    """
+    return validate_rule_condition(condition)
+
+
+def validate_rule_condition(condition):
+    """
+    Validate a dynamic rule condition. Used by dynamic sampling, metric extraction, and metric
+    tagging.
+
+    :param condition: A string containing the condition encoded as JSON.
     """
     assert isinstance(condition, str)
-    raw_error = rustcall(lib.relay_validate_sampling_condition, encode_str(condition))
+    raw_error = rustcall(lib.relay_validate_rule_condition, encode_str(condition))
     error = decode_str(raw_error, free=True)
     if error:
         raise ValueError(error)

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -229,13 +229,13 @@ def compare_versions():
     assert sentry_relay.compare_versions("1.0.0", "1.0") == -1
 
 
-def test_validate_sampling_condition():
+def test_validate_rule_condition():
     """
     Test that a valid condition passes
     """
     # Should not throw
     condition = '{"op": "eq", "name": "field_2", "value": ["UPPER", "lower"]}'
-    sentry_relay.validate_sampling_condition(condition)
+    sentry_relay.validate_rule_condition(condition)
 
 
 def test_invalid_sampling_condition():
@@ -245,8 +245,7 @@ def test_invalid_sampling_condition():
     # Should throw
     condition = '{"op": "legacyBrowser", "value": [1,2,3]}'
     with pytest.raises(ValueError):
-
-        sentry_relay.validate_sampling_condition(condition)
+        sentry_relay.validate_rule_condition(condition)
 
 
 def test_validate_sampling_configuration():

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -605,9 +605,11 @@ int32_t relay_compare_versions(const struct RelayStr *a,
                                const struct RelayStr *b);
 
 /**
- * Validate a sampling rule condition.
+ * Validate a dynamic rule condition.
+ *
+ * Used by dynamic sampling, metric extraction, and metric tagging.
  */
-struct RelayStr relay_validate_sampling_condition(const struct RelayStr *value);
+struct RelayStr relay_validate_rule_condition(const struct RelayStr *value);
 
 /**
  * Validate whole rule ( this will be also implemented in Sentry for better error messages)

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -292,10 +292,12 @@ pub unsafe extern "C" fn relay_compare_versions(a: *const RelayStr, b: *const Re
     }
 }
 
-/// Validate a sampling rule condition.
+/// Validate a dynamic rule condition.
+///
+/// Used by dynamic sampling, metric extraction, and metric tagging.
 #[no_mangle]
 #[relay_ffi::catch_unwind]
-pub unsafe extern "C" fn relay_validate_sampling_condition(value: *const RelayStr) -> RelayStr {
+pub unsafe extern "C" fn relay_validate_rule_condition(value: *const RelayStr) -> RelayStr {
     let ret_val = match serde_json::from_str::<RuleCondition>((*value).as_str()) {
         Ok(condition) => {
             if condition.supported() {


### PR DESCRIPTION
Renames `validate_sampling_condition` to `validate_rule_condition` in the C-ABI
and python bindings to make it clear that this function validates all kinds of
rule conditions.

