### PR TITLE
fix(pii): Replace only user in the userpath

### DIFF
--- a/relay-pii/src/builtin.rs
+++ b/relay-pii/src/builtin.rs
@@ -1256,6 +1256,24 @@ HdmUCGvfKiF2CodxyLon1XkK8pX+Ap86MbJhluqK
             ];
         );
         assert_text_rule!(
+            rule = "@userpath";
+            input = r#"make
+            export PATH=$PATH:$HOME/collectd_exporter
+            log
+            log
+            log
+            "#;
+            output = r#"make
+            export PATH=$PATH:$HOME/[user]
+            log
+            log
+            log
+            "#;
+            remarks = vec![
+                Remark::with_range(RemarkType::Substituted, "@userpath", (41, 47)),
+            ];
+        );
+        assert_text_rule!(
             rule = "@userpath:replace";
             input = "File in /Users/mitsuhiko/Development/sentry-stripping";
             output = "File in /Users/[user]/Development/sentry-stripping";

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -231,7 +231,7 @@ static PATH_REGEX: Lazy<Regex> = Lazy::new(|| {
                 )
             )
             (
-                [^/\\]+
+                [A–Za-z0–9'\._!\#^~-]+
             )
         ",
     )

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -231,7 +231,7 @@ static PATH_REGEX: Lazy<Regex> = Lazy::new(|| {
                 )
             )
             (
-                [A–Za-z0–9'\._!\#^~-]+
+                [A–Za-z0–9'\.\ _!\#^~-]+
             )
         ",
     )

--- a/relay-server/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -324,7 +324,7 @@ expression: SerializableAnnotated(&event)
         "type": "default",
         "category": "Microsoft.AspNetCore.Hosting.Internal.WebHost",
         "level": "info",
-        "message": "Request starting HTTP/1.1 POST http://localhost:62919/Home/[user] application/json; charset=UTF-8 65",
+        "message": "Request starting HTTP/1.1 POST http://localhost:62919/Home/[user]/json; charset=UTF-8 65",
         "data": {
           "eventId": "1"
         }

--- a/relay-server/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__dotnet__pii_stripping.snap
@@ -324,7 +324,7 @@ expression: SerializableAnnotated(&event)
         "type": "default",
         "category": "Microsoft.AspNetCore.Hosting.Internal.WebHost",
         "level": "info",
-        "message": "Request starting HTTP/1.1 POST http://localhost:62919/Home/[user]/json; charset=UTF-8 65",
+        "message": "Request starting HTTP/1.1 POST http://localhost:62919/Home/[user] application/json; charset=UTF-8 65",
         "data": {
           "eventId": "1"
         }


### PR DESCRIPTION
Explicitly use only allowed characters for the username. 

Currently we replace everything till between the slashes, and if the slash after username is missing we will replace everything till the end of the input string. 



fix: https://github.com/getsentry/relay/issues/2722


#skip-changelog