### PR TITLE
feat(protocol): Add access to `device.model` on contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Support `device.model` in dynamic sampling and metric extraction. ([#2728](https://github.com/getsentry/relay/pull/2728))
+
 ## 23.11.0
 
 **Features**:

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -669,6 +669,7 @@ impl Getter for Event {
             "contexts.device.brand" => self.context::<DeviceContext>()?.brand.as_str()?.into(),
             "contexts.device.charging" => self.context::<DeviceContext>()?.charging.value()?.into(),
             "contexts.device.family" => self.context::<DeviceContext>()?.family.as_str()?.into(),
+            "contexts.device.model" => self.context::<DeviceContext>()?.model.as_str()?.into(),
             "contexts.device.locale" => self.context::<DeviceContext>()?.locale.as_str()?.into(),
             "contexts.device.online" => self.context::<DeviceContext>()?.online.value()?.into(),
             "contexts.device.orientation" => self


### PR DESCRIPTION
Getter access for device context fields added in #2607 missed `device.model`.
This PR adds this field so it can be used for on-demand metric extraction.

