### PR TITLE
Revert "feat(sampling): Add profile context early and expose getter for it"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Group resource spans by scrubbed domain and filename. ([#2654](https://github.com/getsentry/relay/pull/2654))
 - Convert transactions to spans for all organizations. ([#2659](https://github.com/getsentry/relay/pull/2659))
 - Filter outliers (>180s) for mobile measurements. ([#2649](https://github.com/getsentry/relay/pull/2649))
-- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640), [#2675](https://github.com/getsentry/relay/pull/2675), [#2707](https://github.com/getsentry/relay/pull/2707), [#2715](https://github.com/getsentry/relay/pull/2715))
+- Allow access to more context fields in dynamic sampling and metric extraction. ([#2607](https://github.com/getsentry/relay/pull/2607), [#2640](https://github.com/getsentry/relay/pull/2640), [#2675](https://github.com/getsentry/relay/pull/2675), [#2707](https://github.com/getsentry/relay/pull/2707))
 - Allow advanced scrubbing expressions for datascrubbing safe fields. ([#2670](https://github.com/getsentry/relay/pull/2670))
 - Disable graphql scrubbing when datascrubbing is disabled. ([#2689](https://github.com/getsentry/relay/pull/2689))
 - Track when a span was received. ([#2688](https://github.com/getsentry/relay/pull/2688))

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -14,9 +14,9 @@ use crate::processor::ProcessValue;
 use crate::protocol::{
     AppContext, Breadcrumb, Breakdowns, BrowserContext, ClientSdkInfo, Contexts, Csp, DebugMeta,
     DefaultContext, DeviceContext, EventType, Exception, ExpectCt, ExpectStaple, Fingerprint, Hpkp,
-    LenientString, Level, LogEntry, Measurements, Metrics, OsContext, ProfileContext, RelayInfo,
-    Request, ResponseContext, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp,
-    TraceContext, TransactionInfo, User, Values,
+    LenientString, Level, LogEntry, Measurements, Metrics, OsContext, RelayInfo, Request,
+    ResponseContext, Span, Stacktrace, Tags, TemplateInfo, Thread, Timestamp, TraceContext,
+    TransactionInfo, User, Values,
 };
 
 /// Wrapper around a UUID with slightly different formatting.
@@ -709,12 +709,6 @@ impl Getter for Event {
             "contexts.browser.version" => {
                 self.context::<BrowserContext>()?.version.as_str()?.into()
             }
-            "contexts.profile.profile_id" => self
-                .context::<ProfileContext>()?
-                .profile_id
-                .value()?
-                .0
-                .into(),
             "contexts.device.uuid" => self.context::<DeviceContext>()?.uuid.value()?.into(),
             "contexts.trace.status" => self
                 .context::<TraceContext>()?
@@ -1109,11 +1103,6 @@ mod tests {
                     kernel_version: Annotated::new("17.4.0".to_string()),
                     ..OsContext::default()
                 });
-                contexts.add(ProfileContext {
-                    profile_id: Annotated::new(EventId(uuid!(
-                        "abadcade-feed-dead-beef-8addadfeedaa"
-                    ))),
-                });
                 contexts
             }),
             ..Default::default()
@@ -1197,10 +1186,6 @@ mod tests {
             Some(Val::String("https://sentry.io")),
             event.get_value("event.request.url")
         );
-        assert_eq!(
-            Some(Val::Uuid(uuid!("abadcade-feed-dead-beef-8addadfeedaa"))),
-            event.get_value("event.contexts.profile.profile_id")
-        )
     }
 
     #[test]

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -118,15 +118,10 @@ mod utils;
 
 const MAX_PROFILE_DURATION: Duration = Duration::from_secs(30);
 
-/// Unique identifier for a profile.
-///
-/// Same format as event IDs.
-pub type ProfileId = EventId;
-
 #[derive(Debug, Deserialize)]
 struct MinimalProfile {
     #[serde(alias = "profile_id")]
-    event_id: ProfileId,
+    event_id: EventId,
     platform: String,
     #[serde(default)]
     version: sample::Version,
@@ -139,7 +134,7 @@ fn minimal_profile_from_json(
     serde_path_to_error::deserialize(d)
 }
 
-pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<ProfileId, ProfileError> {
+pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<(), ProfileError> {
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {
@@ -188,10 +183,10 @@ pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<ProfileId
             _ => return Err(ProfileError::PlatformNotSupported),
         },
     };
-    Ok(profile.event_id)
+    Ok(())
 }
 
-pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(ProfileId, Vec<u8>), ProfileError> {
+pub fn expand_profile(payload: &[u8], event: &Event) -> Result<(EventId, Vec<u8>), ProfileError> {
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {


### PR DESCRIPTION
Reverts getsentry/relay#2715

This breaks associating profiles and transactions. We'll revert to restore the feature and find the root cause after.

#skip-changelog