### PR TITLE
chore(rust-beta): Address lint warnings

### DIFF
--- a/relay-event-normalization/src/geo.rs
+++ b/relay-event-normalization/src/geo.rs
@@ -55,7 +55,7 @@ impl GeoIpLookup {
                     .and_then(|city| Some(city.names.as_ref()?.get("en")?.to_string())),
             ),
             subdivision: Annotated::from(city.subdivisions.as_ref().and_then(|subdivisions| {
-                subdivisions.get(0).and_then(|subdivision| {
+                subdivisions.first().and_then(|subdivision| {
                     subdivision.names.as_ref().and_then(|subdivision_names| {
                         subdivision_names
                             .get("en")

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -474,7 +474,7 @@ fn sql_tables_from_query(db_system: Option<&str>, query: &str) -> Option<String>
             if !visitor.table_names.is_empty() {
                 s.push(',');
             }
-            for (_i, name) in visitor.table_names.into_iter().enumerate() {
+            for name in visitor.table_names.into_iter() {
                 write!(&mut s, "{name},").ok();
             }
             (!s.is_empty()).then_some(s)

--- a/relay-pii/tests/replay.rs
+++ b/relay-pii/tests/replay.rs
@@ -31,7 +31,7 @@ fn test_scrub_pii_from_annotated_replay() {
     // Assert URLs field scrubs array items.
     let urls = replay_value.urls.value().unwrap();
     assert_eq!(
-        urls.get(0).and_then(|a| a.as_str()),
+        urls.first().and_then(|a| a.as_str()),
         Some("sentry.io?ssn=[Filtered]")
     );
     assert_eq!(urls.get(1).and_then(|a| a.as_str()), Some("[Filtered]"));

--- a/relay-protocol/src/lib.rs
+++ b/relay-protocol/src/lib.rs
@@ -29,7 +29,6 @@ mod value;
 pub use self::annotated::*;
 pub use self::condition::RuleCondition;
 pub use self::impls::*;
-pub use self::macros::*;
 pub use self::meta::*;
 pub use self::size::*;
 pub use self::traits::*;

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -145,7 +145,7 @@ impl ProjectState {
 
     /// Returns configuration options for the public key.
     pub fn get_public_key_config(&self) -> Option<&PublicKeyConfig> {
-        self.public_keys.get(0)
+        self.public_keys.first()
     }
 
     /// Returns `true` if the entire project should be considered


### PR DESCRIPTION
Make sure the Relay can be compiled with rust beta: `1.75.0` at this point.

#skip-changelog