### PR TITLE
chore(spool): Add periodic check for in-memory buffer with additional metrics

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -786,6 +786,11 @@ fn spool_envelopes_max_connections() -> u32 {
     20
 }
 
+/// Defaualt period for garbage collection in the spooler.
+fn spool_envelopes_check_interval() -> u64 {
+    60
+}
+
 /// Persistent buffering configuration for incoming envelopes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvelopeSpool {
@@ -809,6 +814,11 @@ pub struct EnvelopeSpool {
     /// This is a hard upper bound and defaults to 524288000 bytes (500MB).
     #[serde(default = "spool_envelopes_max_memory_size")]
     max_memory_size: ByteSize,
+
+    /// The interval for the internal check to run and issue specific to the spooler mertrics and
+    /// errors.
+    #[serde(default = "spool_envelopes_check_interval")]
+    check_interval: u64,
 }
 
 impl Default for EnvelopeSpool {
@@ -819,6 +829,7 @@ impl Default for EnvelopeSpool {
             min_connections: spool_envelopes_min_connections(),
             max_disk_size: spool_envelopes_max_disk_size(),
             max_memory_size: spool_envelopes_max_memory_size(),
+            check_interval: spool_envelopes_check_interval(),
         }
     }
 }
@@ -1847,6 +1858,11 @@ impl Config {
     /// The maximum size of the memory buffer, in bytes.
     pub fn spool_envelopes_max_memory_size(&self) -> usize {
         self.values.spool.envelopes.max_memory_size.as_bytes()
+    }
+
+    /// The interval to run the check.
+    pub fn spool_envelopes_check_interval(&self) -> Duration {
+        Duration::from_secs(self.values.spool.envelopes.check_interval)
     }
 
     /// Returns the maximum size of an event payload in bytes.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -815,7 +815,7 @@ pub struct EnvelopeSpool {
     #[serde(default = "spool_envelopes_max_memory_size")]
     max_memory_size: ByteSize,
 
-    /// The interval for the internal check to run and issue specific to the spooler mertrics and
+    /// The interval for the internal check to run and issue specific to the spooler metrics and
     /// errors.
     #[serde(default = "spool_envelopes_check_interval")]
     check_interval: u64,

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -33,7 +33,6 @@ static NUMBER_OF_ENVELOPES_PER_KEY: usize = 1000;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
-use std::fmt::Display;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -115,15 +114,6 @@ impl QueueKey {
             own_key,
             sampling_key,
         }
-    }
-}
-
-impl Display for QueueKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "own_key = {}, sampling_key = {}",
-            self.own_key, self.sampling_key
-        ))
     }
 }
 
@@ -269,12 +259,13 @@ impl InMemory {
         let count = self.buffer.keys().len();
         relay_statsd::metric!(gauge(RelayGauges::BufferProjectsMemoryCount) = count as u64);
 
-        // Go over the buffered emvelopes and check if any of the keys exceeds the threshold.
+        // Go over the buffered envelopes and check if any of the keys exceeds the threshold.
         for (key, values) in &self.buffer {
             let number_of_envelopes = values.len();
             if number_of_envelopes > NUMBER_OF_ENVELOPES_PER_KEY {
                 relay_log::error!(
-                    key = %key,
+                    tags.own_key = %key.own_key,
+                    tags.sampling_key = %key.sampling_key,
                     count = number_of_envelopes,
                     "Number of envelopes per key in memory exceeds the threshold"
                 );

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -266,7 +266,7 @@ impl InMemory {
 
     /// Runs the check for in-memory buffer and emits the metrics and/or errors.
     fn check(&self) {
-        let count = self.buffer.keys().count();
+        let count = self.buffer.keys().len();
         relay_statsd::metric!(gauge(RelayGauges::BufferProjectsMemoryCount) = count as u64);
 
         // Go over the buffered emvelopes and check if any of the keys exceeds the threshold.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -20,7 +20,7 @@ pub enum RelayGauges {
     ///
     /// The disk buffer size can be configured with `spool.envelopes.max_disk_size`.
     BufferEnvelopesDiskCount,
-    /// Number unique project keys currently in memory.
+    /// The current count of the keys in the "in-memory" buffer.
     BufferProjectsMemoryCount,
 }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -20,6 +20,8 @@ pub enum RelayGauges {
     ///
     /// The disk buffer size can be configured with `spool.envelopes.max_disk_size`.
     BufferEnvelopesDiskCount,
+    /// Number unique project keys currently in memory.
+    BufferProjectsMemoryCount,
 }
 
 impl GaugeMetric for RelayGauges {
@@ -29,6 +31,7 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",
+            RelayGauges::BufferProjectsMemoryCount => "buffer.projects_mem_count",
         }
     }
 }
@@ -392,7 +395,6 @@ pub enum RelayCounters {
     BufferEnvelopesWritten,
     /// Number of _envelopes_ the envelope buffer reads back from disk.
     BufferEnvelopesRead,
-    ///
     /// Number of outcomes and reasons for rejected Envelopes.
     ///
     /// This metric is tagged with:


### PR DESCRIPTION
This is the temporary metric and the error, which we issue periodically to check the status of in-memory buffer:
* how many keys in there
* and how many keys are exceed the threshold 


related to https://github.com/getsentry/team-ingest/issues/248

#skip-changelog