### PR TITLE
Revert "feat(spool): Avoid evicting old project for incoming envelopes"

### DIFF
--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -118,7 +118,7 @@ uuid = { workspace = true, features = ["v5"] }
 zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util", "time"] }
+tokio = { workspace = true, features = ['test-util'] }
 insta = { workspace = true }
 relay-event-schema = { path = "../relay-event-schema", features = [
     "jsonschema",


### PR DESCRIPTION
Reverts getsentry/relay#2581

This should be a temporary revert to validate the assumption that this change could cause the relay to keep the some of the incoming envelopes in memory for the longer period of time.  Which can cause very slow memory leak. 

related to: https://github.com/getsentry/team-ingest/issues/248

#skip-changelog