### PR TITLE
fix(normalization): Skip normalize processor in renormalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - License is now FSL instead of BSL ([#2739](https://github.com/getsentry/relay/pull/2739))
 - Support `device.model` in dynamic sampling and metric extraction. ([#2728](https://github.com/getsentry/relay/pull/2728))
 - Support comparison operators (`>`, `>=`, `<`, `<=`) for strings in dynamic sampling and metric extraction rules. Previously, these comparisons were only possible on numbers. ([#2730](https://github.com/getsentry/relay/pull/2730))
+- Skip running `NormalizeProcessor` on renormalization. ([#2744](https://github.com/getsentry/relay/pull/2744))
 
 ## 23.11.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - License is now FSL instead of BSL ([#2739](https://github.com/getsentry/relay/pull/2739))
+- Skip running `NormalizeProcessor` on renormalization. ([#2744](https://github.com/getsentry/relay/pull/2744))
 
 ## 0.8.36
 

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -191,6 +191,10 @@ impl<'a> Processor for NormalizeProcessor<'a> {
         meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
+        if self.config.is_renormalize {
+            return Ok(());
+        }
+
         if event.ty.value() == Some(&EventType::Transaction) {
             // TODO: Parts of this processor should probably be a filter so we
             // can revert some changes to ProcessingAction)


### PR DESCRIPTION
This PR skips running `NormalizeProcessor`, formerly `light_normalize_event`, when `is_renormalize` flag is enabled.

In previous normalization PRs, I wrongly assumed normalization always runs sequentially: light normalization and store normalization in relays during ingestion, and renormalization in Sentry. This is not the case for tests in `sentry`, where renormalization is called with incomplete event payloads, meaning renormalization doesn't only have to consider idempotent actions but the sentry tests. For example, [this test](https://github.com/getsentry/sentry/blob/39fdf1a2c64abc7abeec0cc10ec9b7ce511bbf4c/tests/sentry/eventstore/test_models.py#L557) fails on lib-relay bump in [CI here](https://github.com/getsentry/sentry/actions/runs/6903580690/job/18782568772?pr=60078#step:4:3211).