### PR TITLE
feat: Add Bytespider (Bytedance) to web crawler filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Add Bytespider (Bytedance) to web crawler filter. ([#2747](https://github.com/getsentry/relay/pull/2747))
+
 **Bug Fixes**:
 
 - Fix bug introduced in 23.11.0 that broke profile-transaction association. ([#2733](https://github.com/getsentry/relay/pull/2733))

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -29,7 +29,8 @@ static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
         AWS\sSecurity\sScanner|     # AWS Security Scanner causing DisallowedHost errors in Django, see
                                     # https://forums.aws.amazon.com/thread.jspa?messageID=932404
                                     # and https://github.com/getsentry/sentry-python/issues/641
-        HubSpot\sCrawler            # HubSpot web crawler (web-crawlers@hubspot.com)
+        HubSpot\sCrawler|           # HubSpot web crawler (web-crawlers@hubspot.com)
+        Bytespider                  # Bytedance
     "
     )
     .expect("Invalid web crawlers filter Regex")
@@ -114,6 +115,7 @@ mod tests {
             "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
             "AdsBot-Google (+http://www.google.com/adsbot.html)",
             "Mozilla/5.0 (compatible; HubSpot Crawler; web-crawlers@hubspot.com)",
+            "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)"
         ];
 
         for banned_user_agent in &user_agents {


### PR DESCRIPTION
In a recent tweet we were pointed to `Bytespider`, the web crawler by `Bytedance` (TikTok) causing noise for Sentry issues on peoples sites: https://twitter.com/ThisIsSingleton/status/1726387476317773878

Upon doing some research I found that this has been going on for the last couple months, and all the errors generated were noisy and unactionable

- https://wordpress.org/support/topic/psa-bytedance-and-bytespider-bots-recommend-blocking/
- https://www.reddit.com/r/flask/comments/161fqml/what_to_do_about_bytespider/

Given this seems to be a problematic web crawler (that also doesn't respect `robots.txt`) and that the problem has existed for a couple months now, let's add Bytespider to the default web crawler filter.