### PR TITLE
build(release): Create release in sentry-st

### DIFF
--- a/gocd/templates/libs/relay.libsonnet
+++ b/gocd/templates/libs/relay.libsonnet
@@ -56,6 +56,21 @@ function(region) {
               gocdtasks.script(importstr '../bash/create-sentry-relay-release.sh'),
             ],
           },
+          create_sentry_st_release: {
+            environment_variables: {
+              SENTRY_ORG: 'sentry-st',
+              SENTRY_PROJECT: 'sentry-for-sentry',
+              SENTRY_URL: 'https://sentry-st.sentry.io/',
+              // Temporary; self-service encrypted secrets aren't implemented yet.
+              // This should really be rotated to an internal integration token.
+              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_st_auth_token]}}',
+            },
+            timeout: 1200,
+            elastic_profile_id: 'relay',
+            tasks: [
+              gocdtasks.script(importstr '../bash/create-sentry-relay-release.sh'),
+            ],
+          },
           deploy: {
             timeout: 1200,
             elastic_profile_id: 'relay',


### PR DESCRIPTION
In order to monitor errors emitted from the S4S Relay instances, we need to upload debug symbols to `sentry-st`. 

See https://getsentry.atlassian.net/browse/OPS-4824

#skip-changelog