### PR TITLE
chore(project): Add an error for special case on missing channel for state update

### DIFF
--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -894,9 +894,9 @@ impl Project {
             self.backoff.reset();
         }
 
-        let channel = match self.state_channel.take() {
-            Some(channel) => channel,
-            None => return,
+        let Some(channel) = self.state_channel.take() else {
+            relay_log::error!(tags.project_key = %self.project_key, "channel is missing for the state update");
+            return;
         };
 
         // If the channel has `no_cache` set but we are not a `no_cache` request, we have


### PR DESCRIPTION
This PR adds the error for the case, when the state channel is missing when the state update is requested. 


related: https://github.com/getsentry/team-ingest/issues/248

#skip-changelog