### PR TITLE
feat(metric-meta): Add support for metric metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `normalize_performance_score` now handles `PerformanceScoreProfile` configs with zero weight components and component weight sums of any number greater than 0. ([#2756](https://github.com/getsentry/relay/pull/2756))
 
+**Internal**:
+
+- Add support for metric metadata. ([#2751](https://github.com/getsentry/relay/pull/2751))
+
 ## 23.11.1
 
 **Features**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,9 +556,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -3717,15 +3717,18 @@ name = "relay-metrics"
 version = "23.11.1"
 dependencies = [
  "bytecount",
+ "chrono",
  "criterion",
  "fnv",
  "hash32",
+ "hashbrown 0.13.2",
  "insta",
  "itertools",
  "rand",
  "relay-base-schema",
  "relay-common",
  "relay-log",
+ "relay-redis",
  "relay-statsd",
  "relay-system",
  "relay-test",
@@ -3904,6 +3907,7 @@ dependencies = [
  "data-encoding",
  "flate2",
  "futures",
+ "hash32",
  "hashbrown 0.13.2",
  "insta",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ debug = true
 
 [workspace.dependencies]
 anyhow = "1.0.66"
-chrono = { version = "0.4.29", default-features = false, features = [
+chrono = { version = "0.4.31", default-features = false, features = [
     "std",
     "serde",
 ] }
@@ -23,6 +23,8 @@ clap = { version = "4.4.6" }
 criterion = "0.5"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
+hash32 = "0.3.1"
+hashbrown = "0.13.2"
 itertools = "0.10.5"
 once_cell = "1.13.1"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0.93"
 serde_yaml = "0.9.17"
 schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }
 similar-asserts = "1.4.2"
-smallvec = { version = "1.10.0", features = ["serde"] }
+smallvec = { version = "1.11.2", features = ["serde"] }
 thiserror = "1.0.38"
 tokio = { version = "1.28.0", features = ["macros", "sync", "tracing"] }
 url = "2.1.1"

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -502,6 +502,14 @@ struct Metrics {
     /// For example, a value of `0.3` means that only 30% of the emitted metrics will be sent.
     /// Defaults to `1.0` (100%).
     sample_rate: f32,
+    /// Code locations expiry in seconds.
+    ///
+    /// Defaults to 15 days.
+    meta_locations_expiry: u64,
+    /// Maximum amount of code locations to store per metric.
+    ///
+    /// Defaults to 5.
+    meta_locations_max: usize,
 }
 
 impl Default for Metrics {
@@ -513,6 +521,8 @@ impl Default for Metrics {
             hostname_tag: None,
             buffering: true,
             sample_rate: 1.0,
+            meta_locations_expiry: 15 * 24 * 60 * 60,
+            meta_locations_max: 5,
         }
     }
 }
@@ -1756,6 +1766,16 @@ impl Config {
     /// Returns the global sample rate for all metrics.
     pub fn metrics_sample_rate(&self) -> f32 {
         self.values.metrics.sample_rate
+    }
+
+    /// Returns the maximum amount of code locations per metric.
+    pub fn metrics_meta_locations_max(&self) -> usize {
+        self.values.metrics.meta_locations_max
+    }
+
+    /// Returns the expiry for code locations.
+    pub fn metrics_meta_locations_expiry(&self) -> Duration {
+        Duration::from_secs(self.values.metrics.meta_locations_expiry)
     }
 
     /// Returns the default timeout for all upstream HTTP requests.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -33,6 +33,9 @@ pub enum Feature {
     /// Enable processing profiles
     #[serde(rename = "organizations:profiling")]
     Profiling,
+    /// Enable metric metadata.
+    #[serde(rename = "organizations:metric-meta")]
+    MetricMeta,
 
     /// Deprecated, still forwarded for older downstream Relays.
     #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -9,14 +9,19 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[features]
+redis = ["relay-redis/impl"]
+
 [dependencies]
 bytecount = "0.6.0"
 fnv = "1.0.7"
-hash32 = "0.3.1"
+hash32 = { workspace = true }
+hashbrown = { workspace = true }
 itertools = { workspace = true }
 relay-base-schema = { path = "../relay-base-schema" }
 relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log" }
+relay-redis = { path = "../relay-redis", optional = true }
 relay-statsd = { path = "../relay-statsd" }
 relay-system = { path = "../relay-system" }
 serde = { workspace = true }
@@ -24,6 +29,7 @@ serde_json = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
+chrono = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -14,6 +14,7 @@ redis = ["relay-redis/impl"]
 
 [dependencies]
 bytecount = "0.6.0"
+chrono = { workspace = true }
 fnv = "1.0.7"
 hash32 = { workspace = true }
 hashbrown = { workspace = true }
@@ -29,7 +30,6 @@ serde_json = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
-chrono = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -399,29 +399,6 @@ fn parse_gauge(string: &str) -> Option<GaugeValue> {
     })
 }
 
-/// Parses an MRI from a string and a separate type.
-///
-/// The given string must be a part of the MRI, including the following components:
-///  - (optional) The namespace. If missing, it is defaulted to `"custom"`
-///  - (required) The metric name.
-///  - (optional) The unit. If missing, it is defaulted to "none".
-///
-/// The metric type is never part of this string and must be supplied separately.
-fn parse_mri(string: &str, ty: MetricType) -> Option<MetricResourceIdentifier<'_>> {
-    let (name_and_namespace, unit) = protocol::parse_name_unit(string)?;
-
-    let (raw_namespace, name) = name_and_namespace
-        .split_once('/')
-        .unwrap_or(("custom", name_and_namespace));
-
-    Some(MetricResourceIdentifier {
-        ty,
-        name: name.into(),
-        namespace: raw_namespace.parse().ok()?,
-        unit,
-    })
-}
-
 /// Parses tags in the format `tag1,tag2:value`.
 ///
 /// Tag values are optional. For tags with missing values, an empty `""` value is assumed.
@@ -640,7 +617,7 @@ impl Bucket {
         let (mri_str, values_str) = components.next()?.split_once(':')?;
         let ty = components.next().and_then(|s| s.parse().ok())?;
 
-        let mri = parse_mri(mri_str, ty)?;
+        let mri = MetricResourceIdentifier::parse_with_type(mri_str, ty).ok()?;
         let value = match ty {
             MetricType::Counter => BucketValue::Counter(parse_counter(values_str)?),
             MetricType::Distribution => BucketValue::Distribution(parse_distribution(values_str)?),

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -70,6 +70,8 @@
 
 pub mod aggregator;
 
+// TODO: make modul
+
 mod aggregatorservice;
 mod bucket;
 mod meta;

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -69,22 +69,18 @@
 )]
 
 pub mod aggregator;
-
-// TODO: make modul
+pub mod meta;
 
 mod aggregatorservice;
 mod bucket;
-mod meta;
 mod protocol;
-#[cfg(feature = "redis")]
-mod redis_meta;
 mod router;
 mod statsd;
 
 pub use aggregatorservice::*;
 pub use bucket::*;
-pub use meta::*;
-pub use protocol::*;
 #[cfg(feature = "redis")]
-pub use redis_meta::*;
+pub use meta::RedisMetricMetaStore;
+pub use meta::{MetaAggregator, MetricMeta};
+pub use protocol::*;
 pub use router::*;

--- a/relay-metrics/src/lib.rs
+++ b/relay-metrics/src/lib.rs
@@ -72,11 +72,17 @@ pub mod aggregator;
 
 mod aggregatorservice;
 mod bucket;
+mod meta;
 mod protocol;
+#[cfg(feature = "redis")]
+mod redis_meta;
 mod router;
 mod statsd;
 
 pub use aggregatorservice::*;
 pub use bucket::*;
+pub use meta::*;
 pub use protocol::*;
+#[cfg(feature = "redis")]
+pub use redis_meta::*;
 pub use router::*;

--- a/relay-metrics/src/meta.rs
+++ b/relay-metrics/src/meta.rs
@@ -1,0 +1,249 @@
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+};
+
+use chrono::{DateTime, Utc};
+use relay_base_schema::project::ProjectKey;
+use relay_common::time::UnixTimestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::MetricResourceIdentifier;
+
+/// A metric metadata item.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MetricMeta {
+    /// Timestamp scope for the contained metadata.
+    ///
+    /// Metric metadata is collected in daily intervals, so this may be truncated
+    /// to the start of the day (UTC) already.
+    pub timestamp: StartOfDayUnixTimestamp,
+
+    /// The contained metadata mapped by MRI.
+    pub mapping: HashMap<MetricResourceIdentifier<'static>, Vec<MetricMetaItem>>,
+}
+
+/// A metadata item.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum MetricMetaItem {
+    /// A location metadata pointing to the code location where the metric originates from.
+    Location(Location),
+}
+
+/// A code location.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct Location {
+    /// The relative file path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// The absolute file path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub abs_path: Option<String>,
+    /// The containing module name or path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    /// The containing function name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    /// The line number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u32>,
+}
+
+/// A Unix timestamp that is truncated to the start of the day.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StartOfDayUnixTimestamp(UnixTimestamp);
+
+impl StartOfDayUnixTimestamp {
+    /// Creates a new `StartOfDayUnixTimestamp` from a timestamp by truncating it.
+    ///
+    /// May return none when passed an invalid date, but in practice this never fails
+    /// since the [`UnixTimestamp`] is already sufficiently validated.
+    pub fn new(ts: UnixTimestamp) -> Option<Self> {
+        let dt: DateTime<Utc> = DateTime::from_timestamp(ts.as_secs().try_into().ok()?, 0)?;
+        let beginning_of_day = dt.date_naive().and_hms_opt(0, 0, 0)?.and_utc();
+        Some(Self(UnixTimestamp::from_datetime(beginning_of_day)?))
+    }
+
+    /// Returns the underlying unix timestamp, truncated to the start of the day.
+    pub fn as_timestamp(&self) -> UnixTimestamp {
+        self.0
+    }
+}
+
+impl std::ops::Deref for StartOfDayUnixTimestamp {
+    type Target = UnixTimestamp;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for StartOfDayUnixTimestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for StartOfDayUnixTimestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let ts = UnixTimestamp::deserialize(deserializer)?;
+
+        StartOfDayUnixTimestamp::new(ts)
+            .ok_or_else(|| serde::de::Error::custom("invalid timestamp"))
+    }
+}
+
+/// A metrics meta aggregator.
+///
+/// Aggregates metric metadata based on their scope (project, mri, timestamp) and
+/// only keeps the most relevant entries.
+///
+/// Currently we track the first N amount of unique metric meta elements we get.
+///
+/// This should represent the actual adoption rate of different code versions.
+///
+/// This aggregator is purely in memeory and will lose its state on restart,
+/// which may cause multiple different items being emitted after restarts.
+/// For this we have de-deuplication in the storage and the volume overall
+/// of this happening is small enough to just add it to the storage worst case.
+#[derive(Debug)]
+pub struct MetaAggregator {
+    // Backdating lol. The in-memory cache wont hold data for old buckets.
+    // Do we need to check redis for old days?
+    locations: hashbrown::HashMap<Scope, HashSet<Location>>,
+
+    /// Maximum tracked locations.
+    max_locations: usize,
+}
+
+impl MetaAggregator {
+    /// Creates a new metrics meta aggregator.
+    pub fn new() -> Self {
+        Self {
+            locations: hashbrown::HashMap::new(),
+            max_locations: 5, // TODO: dont hardcode this
+        }
+    }
+
+    /// Adds a new meta item to the aggregator.
+    ///
+    /// Returns a new [`MetricMeta`] element when the element should be stored
+    /// or sent upstream for storage.
+    ///
+    /// Returns `None` when the meta item was already seen or is not considered relevant.
+    pub fn aggregate(&mut self, project_key: ProjectKey, meta: MetricMeta) -> Option<MetricMeta> {
+        let mut send_upstream = HashMap::with_capacity(meta.mapping.len());
+
+        for (mri, items) in meta.mapping {
+            let scope = Scope {
+                timestamp: meta.timestamp,
+                project_key,
+                mri,
+            };
+
+            if let Some(items) = self.add_scoped(&scope, items) {
+                send_upstream.insert(scope.mri, items);
+            }
+        }
+
+        if send_upstream.is_empty() {
+            return None;
+        }
+
+        Some(MetricMeta {
+            timestamp: meta.timestamp,
+            mapping: send_upstream,
+        })
+    }
+
+    /// Retrieves all currently relevant metric meta for a project.
+    pub fn get_relevant(&self, project_key: ProjectKey) -> impl Iterator<Item = MetricMeta> {
+        let locations = self
+            .locations
+            .iter()
+            .filter(|(scope, _)| scope.project_key == project_key);
+
+        let mut result = HashMap::new();
+
+        for (scope, locations) in locations {
+            result
+                .entry(scope.timestamp)
+                .or_insert_with(|| MetricMeta {
+                    timestamp: scope.timestamp,
+                    mapping: HashMap::new(),
+                })
+                .mapping
+                .entry(scope.mri.clone()) // This clone sucks
+                .or_insert_with(Vec::new)
+                .extend(locations.iter().cloned().map(MetricMetaItem::Location));
+        }
+
+        result.into_values()
+    }
+
+    /// Remove all contained state related to a project.
+    pub fn clear(&mut self, project_key: ProjectKey) {
+        self.locations
+            .retain(|scope, _| scope.project_key != project_key);
+    }
+
+    fn add_scoped(
+        &mut self,
+        scope: &Scope,
+        items: Vec<MetricMetaItem>,
+    ) -> Option<Vec<MetricMetaItem>> {
+        let locations = self.locations.entry_ref(scope).or_default();
+        let mut send_upstream = Vec::new();
+
+        for item in items {
+            match item {
+                MetricMetaItem::Location(location) => {
+                    if locations.len() > self.max_locations {
+                        break;
+                    }
+
+                    if !locations.contains(&location) {
+                        locations.insert(location.clone());
+                        send_upstream.push(MetricMetaItem::Location(location));
+                    }
+                }
+            }
+        }
+
+        (!send_upstream.is_empty()).then_some(send_upstream)
+    }
+}
+
+impl Default for MetaAggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The metadata scope.
+///
+/// We scope metadata by project, mri and day,
+/// represented as a unix timestamp at the beginning of the day.
+///
+/// The technical scope (e.g. redis key) also includes the organization id, but this
+/// can be inferred from the project.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Scope {
+    pub timestamp: StartOfDayUnixTimestamp,
+    pub project_key: ProjectKey,
+    pub mri: MetricResourceIdentifier<'static>,
+}
+
+impl From<&Scope> for Scope {
+    fn from(value: &Scope) -> Self {
+        value.clone()
+    }
+}

--- a/relay-metrics/src/meta/aggregator.rs
+++ b/relay-metrics/src/meta/aggregator.rs
@@ -3,106 +3,10 @@ use std::{
     hash::Hash,
 };
 
-use chrono::{DateTime, Utc};
 use relay_base_schema::project::ProjectKey;
-use relay_common::time::UnixTimestamp;
-use serde::{Deserialize, Serialize};
 
+use super::{Item, Location, MetricMeta, StartOfDayUnixTimestamp};
 use crate::{statsd::MetricCounters, MetricResourceIdentifier};
-
-/// A metric metadata item.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct MetricMeta {
-    /// Timestamp scope for the contained metadata.
-    ///
-    /// Metric metadata is collected in daily intervals, so this may be truncated
-    /// to the start of the day (UTC) already.
-    pub timestamp: StartOfDayUnixTimestamp,
-
-    /// The contained metadata mapped by MRI.
-    pub mapping: HashMap<MetricResourceIdentifier<'static>, Vec<MetricMetaItem>>,
-}
-
-/// A metadata item.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum MetricMetaItem {
-    /// A location metadata pointing to the code location where the metric originates from.
-    Location(Location),
-    /// Unknown item.
-    #[serde(other)]
-    Unknown,
-}
-
-/// A code location.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub struct Location {
-    /// The relative file path.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub filename: Option<String>,
-    /// The absolute file path.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub abs_path: Option<String>,
-    /// The containing module name or path.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub module: Option<String>,
-    /// The containing function name.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub function: Option<String>,
-    /// The line number.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lineno: Option<u64>, // TODO nachschauen
-}
-
-/// A Unix timestamp that is truncated to the start of the day.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct StartOfDayUnixTimestamp(UnixTimestamp);
-
-impl StartOfDayUnixTimestamp {
-    /// Creates a new `StartOfDayUnixTimestamp` from a timestamp by truncating it.
-    ///
-    /// May return none when passed an invalid date, but in practice this never fails
-    /// since the [`UnixTimestamp`] is already sufficiently validated.
-    pub fn new(ts: UnixTimestamp) -> Option<Self> {
-        let dt: DateTime<Utc> = DateTime::from_timestamp(ts.as_secs().try_into().ok()?, 0)?;
-        let beginning_of_day = dt.date_naive().and_hms_opt(0, 0, 0)?.and_utc();
-        Some(Self(UnixTimestamp::from_datetime(beginning_of_day)?))
-    }
-
-    /// Returns the underlying unix timestamp, truncated to the start of the day.
-    pub fn as_timestamp(&self) -> UnixTimestamp {
-        self.0
-    }
-}
-
-impl std::ops::Deref for StartOfDayUnixTimestamp {
-    type Target = UnixTimestamp;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Serialize for StartOfDayUnixTimestamp {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for StartOfDayUnixTimestamp {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let ts = UnixTimestamp::deserialize(deserializer)?;
-
-        StartOfDayUnixTimestamp::new(ts)
-            .ok_or_else(|| serde::de::Error::custom("invalid timestamp"))
-    }
-}
 
 /// A metrics meta aggregator.
 ///
@@ -186,7 +90,7 @@ impl MetaAggregator {
                 .mapping
                 .entry(scope.mri.clone()) // This clone sucks
                 .or_insert_with(Vec::new)
-                .extend(locations.iter().cloned().map(MetricMetaItem::Location));
+                .extend(locations.iter().cloned().map(Item::Location));
         }
 
         result.into_values()
@@ -198,28 +102,24 @@ impl MetaAggregator {
             .retain(|scope, _| scope.project_key != project_key);
     }
 
-    fn add_scoped(
-        &mut self,
-        scope: &Scope,
-        items: Vec<MetricMetaItem>,
-    ) -> Option<Vec<MetricMetaItem>> {
+    fn add_scoped(&mut self, scope: &Scope, items: Vec<Item>) -> Option<Vec<Item>> {
         // Entry ref needs hashbrown, we would have to clone the scope without or do a separate lookup.
         let locations = self.locations.entry_ref(scope).or_default();
         let mut send_upstream = Vec::new();
 
         for item in items {
             match item {
-                MetricMetaItem::Location(location) => {
+                Item::Location(location) => {
                     if locations.len() > self.max_locations {
                         break;
                     }
 
                     if !locations.contains(&location) {
                         locations.insert(location.clone());
-                        send_upstream.push(MetricMetaItem::Location(location));
+                        send_upstream.push(Item::Location(location));
                     }
                 }
-                MetricMetaItem::Unknown => {}
+                Item::Unknown => {}
             }
         }
 

--- a/relay-metrics/src/meta/aggregator.rs
+++ b/relay-metrics/src/meta/aggregator.rs
@@ -72,7 +72,7 @@ impl MetaAggregator {
     }
 
     /// Retrieves all currently relevant metric meta for a project.
-    pub fn get_relevant(&self, project_key: ProjectKey) -> impl Iterator<Item = MetricMeta> {
+    pub fn get_all_relevant(&self, project_key: ProjectKey) -> impl Iterator<Item = MetricMeta> {
         let locations = self
             .locations
             .iter()

--- a/relay-metrics/src/meta/aggregator.rs
+++ b/relay-metrics/src/meta/aggregator.rs
@@ -23,7 +23,7 @@ use crate::{statsd::MetricCounters, MetricResourceIdentifier};
 /// of this happening is small enough to just add it to the storage worst case.
 #[derive(Debug)]
 pub struct MetaAggregator {
-    ///
+    /// All tracked code locations.
     locations: hashbrown::HashMap<Scope, HashSet<Location>>,
 
     /// Maximum tracked locations.
@@ -64,7 +64,7 @@ impl MetaAggregator {
             return None;
         }
 
-        relay_statsd::metric!(counter(MetricCounters::MetaLocationUpdate) += 1);
+        relay_statsd::metric!(counter(MetricCounters::MetaAggregatorUpdate) += 1);
         Some(MetricMeta {
             timestamp: meta.timestamp,
             mapping: send_upstream,

--- a/relay-metrics/src/meta/mod.rs
+++ b/relay-metrics/src/meta/mod.rs
@@ -1,0 +1,11 @@
+//! Functionality for aggregating and storing of metrics metadata.
+
+mod aggregator;
+mod protocol;
+#[cfg(feature = "redis")]
+mod redis;
+
+pub use self::aggregator::*;
+pub use self::protocol::*;
+#[cfg(feature = "redis")]
+pub use self::redis::*;

--- a/relay-metrics/src/meta/protocol.rs
+++ b/relay-metrics/src/meta/protocol.rs
@@ -47,7 +47,7 @@ pub struct Location {
     pub function: Option<String>,
     /// The line number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lineno: Option<u64>, // TODO nachschauen
+    pub lineno: Option<u64>,
 }
 
 /// A Unix timestamp that is truncated to the start of the day.

--- a/relay-metrics/src/meta/protocol.rs
+++ b/relay-metrics/src/meta/protocol.rs
@@ -1,0 +1,101 @@
+use std::{collections::HashMap, hash::Hash};
+
+use chrono::{DateTime, Utc};
+use relay_common::time::UnixTimestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::MetricResourceIdentifier;
+
+/// A metric metadata item.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MetricMeta {
+    /// Timestamp scope for the contained metadata.
+    ///
+    /// Metric metadata is collected in daily intervals, so this may be truncated
+    /// to the start of the day (UTC) already.
+    pub timestamp: StartOfDayUnixTimestamp,
+
+    /// The contained metadata mapped by MRI.
+    pub mapping: HashMap<MetricResourceIdentifier<'static>, Vec<Item>>,
+}
+
+/// A metadata item.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Item {
+    /// A location metadata pointing to the code location where the metric originates from.
+    Location(Location),
+    /// Unknown item.
+    #[serde(other)]
+    Unknown,
+}
+
+/// A code location.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct Location {
+    /// The relative file path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// The absolute file path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub abs_path: Option<String>,
+    /// The containing module name or path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    /// The containing function name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    /// The line number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u64>, // TODO nachschauen
+}
+
+/// A Unix timestamp that is truncated to the start of the day.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StartOfDayUnixTimestamp(UnixTimestamp);
+
+impl StartOfDayUnixTimestamp {
+    /// Creates a new `StartOfDayUnixTimestamp` from a timestamp by truncating it.
+    ///
+    /// May return none when passed an invalid date, but in practice this never fails
+    /// since the [`UnixTimestamp`] is already sufficiently validated.
+    pub fn new(ts: UnixTimestamp) -> Option<Self> {
+        let dt: DateTime<Utc> = DateTime::from_timestamp(ts.as_secs().try_into().ok()?, 0)?;
+        let beginning_of_day = dt.date_naive().and_hms_opt(0, 0, 0)?.and_utc();
+        Some(Self(UnixTimestamp::from_datetime(beginning_of_day)?))
+    }
+
+    /// Returns the underlying unix timestamp, truncated to the start of the day.
+    pub fn as_timestamp(&self) -> UnixTimestamp {
+        self.0
+    }
+}
+
+impl std::ops::Deref for StartOfDayUnixTimestamp {
+    type Target = UnixTimestamp;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for StartOfDayUnixTimestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for StartOfDayUnixTimestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let ts = UnixTimestamp::deserialize(deserializer)?;
+
+        StartOfDayUnixTimestamp::new(ts)
+            .ok_or_else(|| serde::de::Error::custom("invalid timestamp"))
+    }
+}

--- a/relay-metrics/src/meta/protocol.rs
+++ b/relay-metrics/src/meta/protocol.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash};
+use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use relay_common::time::UnixTimestamp;
@@ -94,7 +94,6 @@ impl<'de> Deserialize<'de> for StartOfDayUnixTimestamp {
         D: serde::Deserializer<'de>,
     {
         let ts = UnixTimestamp::deserialize(deserializer)?;
-
         StartOfDayUnixTimestamp::new(ts)
             .ok_or_else(|| serde::de::Error::custom("invalid timestamp"))
     }

--- a/relay-metrics/src/meta/redis.rs
+++ b/relay-metrics/src/meta/redis.rs
@@ -5,7 +5,8 @@ use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
 use relay_redis::{RedisError, RedisPool};
 
-use crate::{statsd::MetricCounters, MetricMeta, MetricMetaItem, MetricResourceIdentifier};
+use super::{Item, MetricMeta};
+use crate::{statsd::MetricCounters, MetricResourceIdentifier};
 
 /// Redis metric meta
 pub struct RedisMetricMetaStore {
@@ -39,11 +40,11 @@ impl RedisMetricMetaStore {
 
             for item in items {
                 match item {
-                    MetricMetaItem::Location(location) => {
+                    Item::Location(location) => {
                         let member = serde_json::to_string(&location).unwrap();
                         location_cmd.arg(member);
                     }
-                    MetricMetaItem::Unknown => {}
+                    Item::Unknown => {}
                 }
             }
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -292,14 +292,6 @@ impl<'a> MetricResourceIdentifier<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a str> for MetricResourceIdentifier<'a> {
-    type Error = ParseMetricError;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        Self::parse(value)
-    }
-}
-
 impl<'de> Deserialize<'de> for MetricResourceIdentifier<'static> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -3,6 +3,7 @@ use std::hash::Hasher as _;
 use std::{borrow::Cow, error::Error};
 
 use hash32::{FnvHasher, Hasher as _};
+use serde::{Deserialize, Serialize};
 
 #[doc(inline)]
 pub use relay_base_schema::metrics::{
@@ -215,7 +216,7 @@ impl fmt::Display for MetricNamespace {
 /// let mri = MetricResourceIdentifier::parse(string).expect("should parse");
 /// assert_eq!(mri.to_string(), string);
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MetricResourceIdentifier<'a> {
     /// The type of a metric, determining its aggregation and evaluation.
     ///
@@ -249,13 +250,33 @@ impl<'a> MetricResourceIdentifier<'a> {
         let (raw_ty, rest) = name.split_once(':').ok_or(ParseMetricError(()))?;
         let ty = raw_ty.parse()?;
 
-        let (raw_namespace, rest) = rest.split_once('/').ok_or(ParseMetricError(()))?;
-        let (name, unit) = parse_name_unit(rest).ok_or(ParseMetricError(()))?;
+        Self::parse_with_type(rest, ty)
+    }
 
-        Ok(Self {
+    /// Parses an MRI from a string and a separate type.
+    ///
+    /// The given string must be a part of the MRI, including the following components:
+    ///  - (optional) The namespace. If missing, it is defaulted to `"custom"`
+    ///  - (required) The metric name.
+    ///  - (optional) The unit. If missing, it is defaulted to "none".
+    ///
+    /// The metric type is never part of this string and must be supplied separately.
+    ///
+    /// This is exposed to the crate for [`crate::Bucket::parse_str`].
+    pub(crate) fn parse_with_type(
+        string: &'a str,
+        ty: MetricType,
+    ) -> Result<Self, ParseMetricError> {
+        let (name_and_namespace, unit) = parse_name_unit(string).ok_or(ParseMetricError(()))?;
+
+        let (raw_namespace, name) = name_and_namespace
+            .split_once('/')
+            .unwrap_or(("custom", name_and_namespace));
+
+        Ok(MetricResourceIdentifier {
             ty,
-            namespace: raw_namespace.parse()?,
             name: Cow::Borrowed(name),
+            namespace: raw_namespace.parse()?,
             unit,
         })
     }
@@ -268,6 +289,37 @@ impl<'a> MetricResourceIdentifier<'a> {
             name: Cow::Owned(self.name.into_owned()),
             unit: self.unit,
         }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for MetricResourceIdentifier<'a> {
+    type Error = ParseMetricError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for MetricResourceIdentifier<'static> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        let result = MetricResourceIdentifier::parse(&string)
+            .map_err(serde::de::Error::custom)?
+            .into_owned();
+
+        Ok(result)
+    }
+}
+
+impl Serialize for MetricResourceIdentifier<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 
@@ -307,7 +359,7 @@ pub(crate) fn validate_tag_value(tag_value: &mut String) {
 ///
 /// Returns [`MetricUnit::None`] if no unit is specified. Returns `None` if the name or value are
 /// invalid.
-pub(crate) fn parse_name_unit(string: &str) -> Option<(&str, MetricUnit)> {
+fn parse_name_unit(string: &str) -> Option<(&str, MetricUnit)> {
     let mut components = string.split('@');
     let name = components.next()?;
     if !relay_base_schema::metrics::is_valid_metric_name(name) {
@@ -342,5 +394,64 @@ mod tests {
     fn test_sizeof_unit() {
         assert_eq!(std::mem::size_of::<MetricUnit>(), 16);
         assert_eq!(std::mem::align_of::<MetricUnit>(), 1);
+    }
+
+    #[test]
+    fn test_parse_mri_lenient() {
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:foo@none").unwrap(),
+            MetricResourceIdentifier {
+                ty: MetricType::Counter,
+                namespace: MetricNamespace::Custom,
+                name: "foo".into(),
+                unit: MetricUnit::None,
+            },
+        );
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:foo").unwrap(),
+            MetricResourceIdentifier {
+                ty: MetricType::Counter,
+                namespace: MetricNamespace::Custom,
+                name: "foo".into(),
+                unit: MetricUnit::None,
+            },
+        );
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:custom/foo").unwrap(),
+            MetricResourceIdentifier {
+                ty: MetricType::Counter,
+                namespace: MetricNamespace::Custom,
+                name: "foo".into(),
+                unit: MetricUnit::None,
+            },
+        );
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:custom/foo@millisecond").unwrap(),
+            MetricResourceIdentifier {
+                ty: MetricType::Counter,
+                namespace: MetricNamespace::Custom,
+                name: "foo".into(),
+                unit: MetricUnit::Duration(DurationUnit::MilliSecond),
+            },
+        );
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:something/foo").unwrap(),
+            MetricResourceIdentifier {
+                ty: MetricType::Counter,
+                namespace: MetricNamespace::Unsupported,
+                name: "foo".into(),
+                unit: MetricUnit::None,
+            },
+        );
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:foo@something").unwrap(),
+            MetricResourceIdentifier {
+                ty: MetricType::Counter,
+                namespace: MetricNamespace::Custom,
+                name: "foo".into(),
+                unit: MetricUnit::Custom(CustomUnit::parse("something").unwrap()),
+            },
+        );
+        assert!(MetricResourceIdentifier::parse("foo").is_err());
     }
 }

--- a/relay-metrics/src/redis_meta.rs
+++ b/relay-metrics/src/redis_meta.rs
@@ -1,0 +1,110 @@
+use hash32::{FnvHasher, Hasher as _};
+use relay_base_schema::project::ProjectId;
+use relay_common::time::UnixTimestamp;
+use relay_redis::{RedisError, RedisPool};
+
+use crate::{MetricMeta, MetricMetaItem, MetricResourceIdentifier};
+
+/// Redis metric meta
+pub struct RedisMetricMetaStore {
+    redis: RedisPool,
+    expiry_in_seconds: u64,
+}
+
+impl RedisMetricMetaStore {
+    /// Creates a new Redis metrics meta store.
+    pub fn new(redis: RedisPool) -> Self {
+        Self {
+            redis,
+            // 14 days + 1 to make sure it stays at least the entire day
+            expiry_in_seconds: 15 * 24 * 60 * 60, // TODO: dont hardcode this
+        }
+    }
+
+    /// Stores metric metadata in Redis.
+    pub fn store(
+        &self,
+        organization_id: u64,
+        project_id: ProjectId,
+        meta: MetricMeta,
+    ) -> Result<(), RedisError> {
+        let mut client = self.redis.client()?;
+        let mut connection = client.connection()?;
+
+        for (mri, items) in meta.mapping {
+            let key = self.build_redis_key(organization_id, project_id, *meta.timestamp, &mri);
+
+            // Should be fine if we don't batch here, we expect a very small amount of locations
+            // from the aggregator.
+            let mut location_cmd = relay_redis::redis::cmd("SADD");
+            location_cmd.arg(&key);
+
+            for item in items {
+                match item {
+                    MetricMetaItem::Location(location) => {
+                        let member = serde_json::to_string(&location).unwrap();
+                        location_cmd.arg(member);
+                    }
+                }
+            }
+
+            relay_log::trace!("storing metric meta for project {organization_id}:{project_id}");
+            location_cmd
+                .query(&mut connection)
+                .map_err(RedisError::Redis)?;
+
+            // use original timestamp to not bump expiry
+            let expire_at = meta.timestamp.as_secs() + self.expiry_in_seconds;
+            relay_redis::redis::Cmd::expire_at(key, expire_at as usize)
+                .query(&mut connection)
+                .map_err(RedisError::Redis)?;
+        }
+
+        Ok(())
+    }
+
+    fn build_redis_key(
+        &self,
+        organization_id: u64,
+        project_id: ProjectId,
+        timestamp: UnixTimestamp,
+        mri: &MetricResourceIdentifier<'_>,
+    ) -> String {
+        let mri_hash = mri_to_fnv1a32(mri);
+
+        format!("mm:l:{{{organization_id}}}:{project_id}:{mri_hash}:{timestamp}")
+    }
+}
+
+/// Converts an MRI to a fnv1a32 hash.
+///
+/// Sentry also uses the exact same algorithm to hash MRIs.
+fn mri_to_fnv1a32(mri: &MetricResourceIdentifier<'_>) -> u32 {
+    let mut hasher = FnvHasher::default();
+
+    let s = mri.to_string();
+    // hash the bytes directly, `write_str` on the hasher adds a 0xff byte at the end
+    std::hash::Hasher::write(&mut hasher, s.as_bytes());
+    hasher.finish32()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mri_hash() {
+        fn test_mri(s: &str, expected_hash: u32) {
+            let mri = MetricResourceIdentifier::parse(s).unwrap();
+            assert_eq!(mri_to_fnv1a32(&mri), expected_hash);
+        }
+
+        // Sentry has the same tests.
+        test_mri("c:transactions/count_per_root_project@none", 2684394786);
+        test_mri("d:transactions/duration@millisecond", 1147819254);
+        test_mri("s:transactions/user@none", 1739810785);
+        test_mri("c:custom/user.click@none", 1248146441);
+        test_mri("d:custom/page.load@millisecond", 2103554973);
+        test_mri("s:custom/username@none", 670706478);
+    }
+}

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -52,6 +52,7 @@ pub enum MetricCounters {
     /// sent upstream.
     MetaAggregatorUpdate,
     /// Incremented every time a redis key is updated to store or update metadata.
+    #[cfg(feature = "redis")]
     MetaRedisUpdate,
 }
 
@@ -62,6 +63,7 @@ impl CounterMetric for MetricCounters {
             Self::MergeMiss => "metrics.buckets.merge.miss",
             Self::BucketsDropped => "metrics.buckets.dropped",
             Self::MetaAggregatorUpdate => "metrics.meta.agg.update",
+            #[cfg(feature = "redis")]
             Self::MetaRedisUpdate => "metrics.meta.redis.update",
         }
     }

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -48,6 +48,11 @@ pub enum MetricCounters {
     /// This metric is tagged with:
     ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
     BucketsDropped,
+    /// Incremented every time the meta aggregator emitted an update that needs to be stored or
+    /// sent upstream.
+    MetaLocationUpdate,
+    /// Incremented every time a redis key is updated to store or update metadata.
+    MetaRedisUpdate,
 }
 
 impl CounterMetric for MetricCounters {
@@ -56,6 +61,8 @@ impl CounterMetric for MetricCounters {
             Self::MergeHit => "metrics.buckets.merge.hit",
             Self::MergeMiss => "metrics.buckets.merge.miss",
             Self::BucketsDropped => "metrics.buckets.dropped",
+            Self::MetaLocationUpdate => "metrics.meta.agg.miss",
+            Self::MetaRedisUpdate => "metrics.meta.redis.update",
         }
     }
 }

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -50,7 +50,7 @@ pub enum MetricCounters {
     BucketsDropped,
     /// Incremented every time the meta aggregator emitted an update that needs to be stored or
     /// sent upstream.
-    MetaLocationUpdate,
+    MetaAggregatorUpdate,
     /// Incremented every time a redis key is updated to store or update metadata.
     MetaRedisUpdate,
 }
@@ -61,7 +61,7 @@ impl CounterMetric for MetricCounters {
             Self::MergeHit => "metrics.buckets.merge.hit",
             Self::MergeMiss => "metrics.buckets.merge.miss",
             Self::BucketsDropped => "metrics.buckets.dropped",
-            Self::MetaLocationUpdate => "metrics.meta.agg.miss",
+            Self::MetaAggregatorUpdate => "metrics.meta.agg.update",
             Self::MetaRedisUpdate => "metrics.meta.redis.update",
         }
     }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -26,6 +26,7 @@ processing = [
     "bytes/serde",
     "relay-config/processing",
     "relay-kafka/producer",
+    "relay-metrics/redis",
     "relay-quotas/redis",
     "relay-redis/impl",
     "relay-sampling/redis",
@@ -49,7 +50,8 @@ chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"
 futures = { workspace = true }
-hashbrown = "0.13.2"
+hash32 = { workspace = true }
+hashbrown = { workspace = true }
 itertools = { workspace = true }
 json-forensics = { version = "0.1.1" }
 mime = "0.3.16"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -92,7 +92,7 @@ rmp-serde = "1.1.1"
 rust-embed = { version = "8.0.0", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, features = ["drain_filter"]  }
 sqlx = { version = "0.7.0", features = [
     "macros",
     "migrate",

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3150,8 +3150,16 @@ impl EnvelopeProcessorService {
         }
     }
 
-    #[cfg(not(feature = "processing"))]
     fn handle_encode_metric_meta(&self, message: EncodeMetricMeta) {
+        #[cfg(feature = "processing")]
+        if self.inner.config.processing_enabled() {
+            return self.store_metric_meta(message);
+        }
+
+        self.encode_metric_meta(message);
+    }
+
+    fn encode_metric_meta(&self, message: EncodeMetricMeta) {
         let EncodeMetricMeta { scoping, meta } = message;
 
         let upstream = self.inner.config.upstream_descriptor();
@@ -3176,7 +3184,7 @@ impl EnvelopeProcessorService {
     }
 
     #[cfg(feature = "processing")]
-    fn handle_encode_metric_meta(&self, message: EncodeMetricMeta) {
+    fn store_metric_meta(&self, message: EncodeMetricMeta) {
         let EncodeMetricMeta { scoping, meta } = message;
 
         let Some(ref metric_meta_store) = self.inner.metric_meta_store else {

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3184,11 +3184,10 @@ impl EnvelopeProcessorService {
         };
 
         let r = metric_meta_store.store(scoping.organization_id, scoping.project_id, meta);
-
         if let Err(error) = r {
             relay_log::error!(
                 error = &error as &dyn std::error::Error,
-                "failed to add code locations to redis set"
+                "failed to store metric meta in redis"
             )
         }
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -37,11 +37,11 @@ use relay_event_schema::protocol::{
 };
 use relay_filter::FilterStatKey;
 use relay_metrics::aggregator::AggregatorConfig;
-use relay_metrics::{Bucket, MergeBuckets, MetricNamespace};
+use relay_metrics::{Bucket, MergeBuckets, MetricMeta, MetricNamespace};
 use relay_pii::{scrub_graphql, PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
 use relay_profiling::{ProfileError, ProfileId};
 use relay_protocol::{Annotated, Array, Empty, FromValue, Object, Value};
-use relay_quotas::{DataCategory, ReasonCode};
+use relay_quotas::{DataCategory, ReasonCode, Scoping};
 use relay_replays::recording::RecordingScrubber;
 use relay_sampling::config::{RuleType, SamplingMode};
 use relay_sampling::evaluation::{
@@ -59,7 +59,7 @@ use {
     crate::utils::{EnvelopeLimiter, MetricsLimiter},
     relay_event_normalization::{span, StoreConfig, StoreProcessor},
     relay_event_schema::protocol::Span,
-    relay_metrics::Aggregator,
+    relay_metrics::{Aggregator, RedisMetricMetaStore},
     relay_quotas::{RateLimitingError, RedisRateLimiter},
     relay_redis::RedisPool,
     symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
@@ -68,7 +68,7 @@ use {
 use crate::actors::envelopes::{EnvelopeManager, SendEnvelope, SendEnvelopeError, SubmitEnvelope};
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::project::ProjectState;
-use crate::actors::project_cache::ProjectCache;
+use crate::actors::project_cache::{AddMetricMeta, ProjectCache};
 use crate::actors::upstream::{SendRequest, UpstreamRelay};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
@@ -470,6 +470,15 @@ pub struct ProcessMetrics {
     pub sent_at: Option<DateTime<Utc>>,
 }
 
+/// Parses a list of metric meta items and pushes them to the project cache for aggregation.
+#[derive(Debug)]
+pub struct ProcessMetricMeta {
+    /// A list of metric meta items.
+    pub items: Vec<Item>,
+    /// The target project.
+    pub project_key: ProjectKey,
+}
+
 /// Applies HTTP content encoding to an envelope's payload.
 ///
 /// This message is a workaround for a single-threaded upstream service.
@@ -485,6 +494,18 @@ impl EncodeEnvelope {
     }
 }
 
+/// Encodes metric meta into an envelope and sends it upstream.
+///
+/// Upstream means directly into redis for processing relays
+/// and otherwise submitting the envelope with the envelope manager.
+#[derive(Debug)]
+pub struct EncodeMetricMeta {
+    /// Scoping of the meta.
+    pub scoping: Scoping,
+    /// The metric meta.
+    pub meta: MetricMeta,
+}
+
 /// Applies rate limits to metrics buckets and forwards them to the envelope manager.
 #[cfg(feature = "processing")]
 #[derive(Debug)]
@@ -497,7 +518,9 @@ pub struct RateLimitBuckets {
 pub enum EnvelopeProcessor {
     ProcessEnvelope(Box<ProcessEnvelope>),
     ProcessMetrics(Box<ProcessMetrics>),
+    ProcessMetricMeta(Box<ProcessMetricMeta>),
     EncodeEnvelope(Box<EncodeEnvelope>),
+    EncodeMetricMeta(Box<EncodeMetricMeta>),
     #[cfg(feature = "processing")]
     RateLimitFlushBuckets(RateLimitBuckets),
 }
@@ -520,11 +543,27 @@ impl FromMessage<ProcessMetrics> for EnvelopeProcessor {
     }
 }
 
+impl FromMessage<ProcessMetricMeta> for EnvelopeProcessor {
+    type Response = NoResponse;
+
+    fn from_message(message: ProcessMetricMeta, _: ()) -> Self {
+        Self::ProcessMetricMeta(Box::new(message))
+    }
+}
+
 impl FromMessage<EncodeEnvelope> for EnvelopeProcessor {
     type Response = NoResponse;
 
     fn from_message(message: EncodeEnvelope, _: ()) -> Self {
         Self::EncodeEnvelope(Box::new(message))
+    }
+}
+
+impl FromMessage<EncodeMetricMeta> for EnvelopeProcessor {
+    type Response = NoResponse;
+
+    fn from_message(message: EncodeMetricMeta, _: ()) -> Self {
+        Self::EncodeMetricMeta(Box::new(message))
     }
 }
 
@@ -558,6 +597,8 @@ struct InnerProcessor {
     #[cfg(feature = "processing")]
     rate_limiter: Option<RedisRateLimiter>,
     geoip_lookup: Option<GeoIpLookup>,
+    #[cfg(feature = "processing")]
+    metric_meta_store: Option<RedisMetricMetaStore>,
 }
 
 impl EnvelopeProcessorService {
@@ -587,6 +628,7 @@ impl EnvelopeProcessorService {
             redis_pool: redis.clone(),
             #[cfg(feature = "processing")]
             rate_limiter: redis
+                .clone()
                 .map(|pool| RedisRateLimiter::new(pool).max_limit(config.max_rate_limit())),
             config,
             envelope_manager,
@@ -596,6 +638,8 @@ impl EnvelopeProcessorService {
             geoip_lookup,
             #[cfg(feature = "processing")]
             aggregator,
+            #[cfg(feature = "processing")]
+            metric_meta_store: redis.map(RedisMetricMetaStore::new),
         };
 
         Self {
@@ -1711,6 +1755,7 @@ impl EnvelopeProcessorService {
             ItemType::Sessions => false,
             ItemType::Statsd => false,
             ItemType::MetricBuckets => false,
+            ItemType::MetricMeta => false,
             ItemType::ClientReport => false,
             ItemType::Profile => false,
             ItemType::ReplayEvent => false,
@@ -2981,6 +3026,34 @@ impl EnvelopeProcessorService {
         }
     }
 
+    fn handle_process_metric_meta(&self, message: ProcessMetricMeta) {
+        let ProcessMetricMeta { items, project_key } = message;
+
+        for item in items {
+            if item.ty() != &ItemType::MetricMeta {
+                relay_log::error!(
+                    "invalid item of type {} passed to ProcessMetricMeta",
+                    item.ty()
+                );
+                continue;
+            }
+
+            let payload = item.payload();
+            match serde_json::from_slice::<MetricMeta>(&payload) {
+                Ok(meta) => {
+                    relay_log::trace!("adding metric metadata to project cache");
+                    self.inner
+                        .project_cache
+                        .send(AddMetricMeta { project_key, meta });
+                }
+                Err(error) => {
+                    relay_log::debug!(error = &error as &dyn Error, "failed to parse metric meta",);
+                    metric!(counter(RelayCounters::MetricMetaParsingFailed) += 1);
+                }
+            }
+        }
+    }
+
     /// Check and apply rate limits to metrics buckets.
     #[cfg(feature = "processing")]
     fn handle_rate_limit_flush_buckets(&self, message: RateLimitBuckets) {
@@ -3075,11 +3148,60 @@ impl EnvelopeProcessorService {
         }
     }
 
+    #[cfg(not(feature = "processing"))]
+    fn handle_encode_metric_meta(&self, message: EncodeMetricMeta) {
+        let EncodeMetricMeta { scoping, meta } = message;
+
+        let upstream = self.inner.config.upstream_descriptor();
+        let dsn = crate::extractors::PartialDsn {
+            scheme: upstream.scheme(),
+            public_key: scoping.project_key,
+            host: upstream.host().to_owned(),
+            port: upstream.port(),
+            path: "".to_owned(),
+            project_id: Some(scoping.project_id),
+        };
+
+        let mut item = Item::new(ItemType::MetricMeta);
+        item.set_payload(ContentType::Json, serde_json::to_vec(&meta).unwrap());
+        let mut envelope = Envelope::from_request(None, RequestMeta::outbound(dsn));
+        envelope.add_item(item);
+        let envelope = ManagedEnvelope::standalone(envelope, Addr::dummy(), Addr::dummy()); // xD
+
+        self.inner
+            .envelope_manager
+            .send(SubmitEnvelope { envelope });
+    }
+
+    #[cfg(feature = "processing")]
+    fn handle_encode_metric_meta(&self, message: EncodeMetricMeta) {
+        let EncodeMetricMeta { scoping, meta } = message;
+
+        let Some(ref metric_meta_store) = self.inner.metric_meta_store else {
+            return;
+        };
+
+        let r = metric_meta_store.store(scoping.organization_id, scoping.project_id, meta);
+
+        if let Err(error) = r {
+            relay_log::error!(
+                error = &error as &dyn std::error::Error,
+                "failed to add code locations to redis set"
+            )
+        }
+    }
+
     fn handle_message(&self, message: EnvelopeProcessor) {
         match message {
             EnvelopeProcessor::ProcessEnvelope(message) => self.handle_process_envelope(*message),
             EnvelopeProcessor::ProcessMetrics(message) => self.handle_process_metrics(*message),
+            EnvelopeProcessor::ProcessMetricMeta(message) => {
+                self.handle_process_metric_meta(*message)
+            }
             EnvelopeProcessor::EncodeEnvelope(message) => self.handle_encode_envelope(*message),
+            EnvelopeProcessor::EncodeMetricMeta(message) => {
+                self.handle_encode_metric_meta(*message)
+            }
             #[cfg(feature = "processing")]
             EnvelopeProcessor::RateLimitFlushBuckets(message) => {
                 self.handle_rate_limit_flush_buckets(message);
@@ -3577,6 +3699,8 @@ mod tests {
             geoip_lookup: None,
             #[cfg(feature = "processing")]
             aggregator,
+            #[cfg(feature = "processing")]
+            metric_meta_store: None,
         };
 
         EnvelopeProcessorService {
@@ -3599,6 +3723,8 @@ mod tests {
             geoip_lookup: None,
             #[cfg(feature = "processing")]
             aggregator: Addr::dummy(),
+            #[cfg(feature = "processing")]
+            metric_meta_store: None,
         };
 
         EnvelopeProcessorService {

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -457,9 +457,9 @@ impl Project {
             rate_limits: RateLimits::new(),
             last_no_cache: Instant::now(),
             reservoir_counters: Arc::default(),
-            config,
-            metric_meta_aggregator: MetaAggregator::new(),
+            metric_meta_aggregator: MetaAggregator::new(config.metrics_meta_locations_max()),
             has_pending_metric_meta: false,
+            config,
         }
     }
 
@@ -728,10 +728,7 @@ impl Project {
             return;
         }
 
-        let Some(meta) = self
-            .metric_meta_aggregator
-            .aggregate(self.project_key, meta)
-        else {
+        let Some(meta) = self.metric_meta_aggregator.add(self.project_key, meta) else {
             // Nothing to do. Which means there is also no pending data.
             relay_log::trace!("metric meta aggregator already has data, nothing to send upstream");
             return;

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -1037,10 +1037,6 @@ impl Project {
     /// NOTE: This function does not check the expiry of the project state.
     pub fn scoping(&self) -> Option<Scoping> {
         let state = self.state_value()?;
-        self.build_scoping(&state)
-    }
-
-    fn build_scoping(&self, state: &ProjectState) -> Option<Scoping> {
         Some(Scoping {
             organization_id: state.organization_id.unwrap_or(0),
             project_id: state.project_id?,

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -102,6 +102,8 @@ pub enum ItemType {
     Statsd,
     /// Buckets of preaggregated metrics encoded as JSON.
     MetricBuckets,
+    /// Additional metadata for metrics
+    MetricMeta,
     /// Client internal report (eg: outcomes).
     ClientReport,
     /// Profile event payload encoded as JSON.
@@ -156,6 +158,7 @@ impl fmt::Display for ItemType {
             Self::Sessions => write!(f, "sessions"),
             Self::Statsd => write!(f, "statsd"),
             Self::MetricBuckets => write!(f, "metric_buckets"),
+            Self::MetricMeta => write!(f, "metric_meta"),
             Self::ClientReport => write!(f, "client_report"),
             Self::Profile => write!(f, "profile"),
             Self::ReplayEvent => write!(f, "replay_event"),
@@ -186,6 +189,7 @@ impl std::str::FromStr for ItemType {
             "sessions" => Self::Sessions,
             "statsd" => Self::Statsd,
             "metric_buckets" => Self::MetricBuckets,
+            "metric_meta" => Self::MetricMeta,
             "client_report" => Self::ClientReport,
             "profile" => Self::Profile,
             "replay_event" => Self::ReplayEvent,
@@ -563,7 +567,7 @@ impl Item {
             ItemType::UnrealReport => Some(DataCategory::Error),
             ItemType::Attachment => Some(DataCategory::Attachment),
             ItemType::Session | ItemType::Sessions => None,
-            ItemType::Statsd | ItemType::MetricBuckets => None,
+            ItemType::Statsd | ItemType::MetricBuckets | ItemType::MetricMeta => None,
             ItemType::FormData => None,
             ItemType::UserReport => None,
             ItemType::UserReportV2 => None,
@@ -745,6 +749,7 @@ impl Item {
             | ItemType::Sessions
             | ItemType::Statsd
             | ItemType::MetricBuckets
+            | ItemType::MetricMeta
             | ItemType::ClientReport
             | ItemType::ReplayEvent
             | ItemType::ReplayRecording
@@ -779,6 +784,7 @@ impl Item {
             ItemType::Sessions => false,
             ItemType::Statsd => false,
             ItemType::MetricBuckets => false,
+            ItemType::MetricMeta => false,
             ItemType::ClientReport => false,
             ItemType::ReplayRecording => false,
             ItemType::Profile => true,

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1086,6 +1086,14 @@ impl Envelope {
         index.map(|index| self.items.swap_remove(index))
     }
 
+    /// Removes and returns the all items that match the given condition.
+    pub fn take_items_by<F>(&mut self, mut cond: F) -> SmallVec<[Item; 3]>
+    where
+        F: FnMut(&Item) -> bool,
+    {
+        self.items.drain_filter(|item| cond(item)).collect()
+    }
+
     /// Adds a new item to this envelope.
     pub fn add_item(&mut self, item: Item) {
         self.items.push(item)

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -466,6 +466,11 @@ pub enum RelayCounters {
     /// Failure can happen, for example, when there's a network error. Refer to
     /// [`UpstreamRequestError`](crate::actors::upstream::UpstreamRequestError) for all cases.
     ProjectUpstreamFailed,
+    /// Number of full metric data flushes.
+    ///
+    /// A full flush takes all contained items of the aggregator and flushes them upstream,
+    /// at best this happens once per freshly loaded project.
+    ProjectStateFlushAllMetricMeta,
     /// Number of Relay server starts.
     ///
     /// This can be used to track unwanted restarts due to crashes or termination.
@@ -576,6 +581,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProjectStateGet => "project_state.get",
             RelayCounters::ProjectStateRequest => "project_state.request",
             RelayCounters::ProjectStateNoCache => "project_state.no_cache",
+            RelayCounters::ProjectStateFlushAllMetricMeta => "project_state.flush_all_metric_meta",
             #[cfg(feature = "processing")]
             RelayCounters::ProjectStateRedis => "project_state.redis.requests",
             RelayCounters::ProjectUpstreamCompleted => "project_upstream.completed",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -542,6 +542,8 @@ pub enum RelayCounters {
     EvictingStaleProjectCaches,
     /// Number of times that parsing a metrics bucket item from an envelope failed.
     MetricBucketsParsingFailed,
+    /// Number of times that parsing a metric meta item from an envelope failed.
+    MetricMetaParsingFailed,
     /// Count extraction of transaction names. Tag with the decision to drop / replace / use original.
     MetricsTransactionNameExtracted,
     /// Number of Events with an OpenTelemetry Context
@@ -590,6 +592,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ResponsesStatusCodes => "responses.status_codes",
             RelayCounters::EvictingStaleProjectCaches => "project_cache.eviction",
             RelayCounters::MetricBucketsParsingFailed => "metrics.buckets.parsing_failed",
+            RelayCounters::MetricMetaParsingFailed => "metrics.meta.parsing_failed",
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
             RelayCounters::GlobalConfigFetched => "global_config.fetch",

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -113,7 +113,7 @@ impl ManagedEnvelope {
     ///
     /// As opposed to [`new`](Self::new), this does not require a queue permit. This makes it
     /// suitable for unit testing internals of the processing pipeline.
-    #[cfg(test)]
+    #[cfg(any(not(feature = "processing"), test))]
     pub fn standalone(
         envelope: Box<Envelope>,
         outcome_aggregator: Addr<TrackOutcome>,

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -113,7 +113,6 @@ impl ManagedEnvelope {
     ///
     /// As opposed to [`new`](Self::new), this does not require a queue permit. This makes it
     /// suitable for unit testing internals of the processing pipeline.
-    #[cfg(any(not(feature = "processing"), test))]
     pub fn standalone(
         envelope: Box<Envelope>,
         outcome_aggregator: Addr<TrackOutcome>,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -102,6 +102,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Sessions => None,
         ItemType::Statsd => None,
         ItemType::MetricBuckets => None,
+        ItemType::MetricMeta => None,
         ItemType::FormData => None,
         ItemType::UserReport => None,
         ItemType::Profile => None,

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -65,6 +65,7 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool 
             ItemType::UserReport => (),
             ItemType::Statsd => (),
             ItemType::MetricBuckets => (),
+            ItemType::MetricMeta => (),
             ItemType::Span => {
                 if item.len() > config.max_span_size() {
                     return false;


### PR DESCRIPTION
Implements `metric_meta` envelope item and storage in Redis.

Epic: https://github.com/getsentry/sentry/issues/60260