### PR TITLE
fix(server): Avoid a race condition in dequeuing after global config

### DIFF
--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -498,7 +498,7 @@ impl ProjectCacheBroker {
         };
 
         relay_log::info!(
-            "global config received: {} project were pending",
+            "global config received: {} projects were pending",
             project_keys.len()
         );
 

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -623,12 +623,9 @@ def test_buffer_envelopes_without_global_config(
     finally:
         mini_sentry.test_failures.clear()
 
-    try:
-        envelopes = []
-        # Check that we received exactly {envelope_qty} envelopes.
-        for _ in range(envelope_qty):
-            envelopes.append(events_consumer.get_event(timeout=2))
-        events_consumer.assert_empty()
-        assert len(envelopes) == envelope_qty
-    finally:
-        mini_sentry.test_failures.clear()
+    envelopes = []
+    # Check that we received exactly {envelope_qty} envelopes.
+    for _ in range(envelope_qty):
+        envelopes.append(events_consumer.get_event(timeout=2))
+    events_consumer.assert_empty()
+    assert len(envelopes) == envelope_qty

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -142,7 +142,7 @@ def test_query_retry(failure_type, mini_sentry, relay):
 
         event = mini_sentry.captured_events.get(timeout=12).get_event()
         assert event["logentry"] == {"formatted": "Hello, World!"}
-        assert retry_count == 4
+        assert retry_count == 3
 
         if mini_sentry.test_failures:
             for _, error in mini_sentry.test_failures:


### PR DESCRIPTION
`RequestUpdate` cannot be called directly, we need to go through
`Project::get_or_fetch_state` to ensure that internal invariants are not
violated. In this instance, the message does not create a required channel in
the `Project` instance.

#skip-changelog

