### PR TITLE
ref(normalization): Restore SchemaProcessor

### DIFF
--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -24,6 +24,7 @@ mod legacy;
 mod normalize;
 mod regexes;
 mod remove_other;
+mod schema;
 mod statsd;
 mod timestamp;
 mod transactions;

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -1113,7 +1113,7 @@ mod tests {
         self, process_value, ProcessingAction, ProcessingState, Processor,
     };
     use relay_event_schema::protocol::{
-        CError, ClientSdkInfo, Contexts, Csp, DeviceContext, Event, Headers, IpAddr, Measurement,
+        ClientSdkInfo, Contexts, Csp, DeviceContext, Event, Headers, IpAddr, Measurement,
         Measurements, Request, Span, SpanId, Tags, TraceContext, TraceId, TransactionSource,
     };
     use relay_protocol::{get_value, Annotated, Meta, Object, SerializableAnnotated};

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -24,7 +24,7 @@ use relay_event_schema::protocol::{
     IpAddr, LogEntry, Measurement, Measurements, NelContext, Request, Span, SpanAttribute,
     SpanStatus, Tags, TraceContext, User,
 };
-use relay_protocol::{Annotated, Array, Empty, Error, ErrorKind, Meta, Object, Value};
+use relay_protocol::{Annotated, Empty, Error, ErrorKind, Meta, Object, Value};
 use smallvec::SmallVec;
 
 use crate::normalize::utils::validate_span;
@@ -33,8 +33,8 @@ use crate::span::tag_extraction::{self, extract_span_tags};
 use crate::timestamp::TimestampProcessor;
 use crate::utils::{self, MAX_DURATION_MOBILE_MS};
 use crate::{
-    breakdowns, end_all_spans, normalize_transaction_name, set_default_transaction_source, span,
-    trimming, user_agent, validate_transaction, BreakdownsConfig, ClockDriftProcessor,
+    breakdowns, end_all_spans, normalize_transaction_name, schema, set_default_transaction_source,
+    span, trimming, user_agent, validate_transaction, BreakdownsConfig, ClockDriftProcessor,
     DynamicMeasurementsConfig, GeoIpLookup, PerformanceScoreConfig, RawUserAgentInfo,
     SpanDescriptionRule, TransactionNameConfig,
 };
@@ -228,6 +228,9 @@ impl<'a> Processor for NormalizeProcessor<'a> {
             return Ok(());
         }
 
+        // Check for required and non-empty values
+        schema::SchemaProcessor.process_event(event, meta, ProcessingState::root())?;
+
         TimestampProcessor.process_event(event, meta, ProcessingState::root())?;
 
         // Process security reports first to ensure all props.
@@ -345,114 +348,6 @@ impl<'a> Processor for NormalizeProcessor<'a> {
 
         Ok(())
     }
-
-    fn before_process<T: ProcessValue>(
-        &mut self,
-        value: Option<&T>,
-        meta: &mut Meta,
-        state: &ProcessingState<'_>,
-    ) -> ProcessingResult {
-        if value.is_none() && state.attrs().required && !meta.has_errors() {
-            meta.add_error(ErrorKind::MissingAttribute);
-        }
-        Ok(())
-    }
-
-    fn process_string(
-        &mut self,
-        value: &mut String,
-        meta: &mut Meta,
-        state: &ProcessingState<'_>,
-    ) -> ProcessingResult {
-        value_trim_whitespace(value, meta, state);
-        verify_value_nonempty_string(value, meta, state)?;
-        verify_value_characters(value, meta, state)?;
-        Ok(())
-    }
-
-    fn process_array<T>(
-        &mut self,
-        value: &mut Array<T>,
-        meta: &mut Meta,
-        state: &ProcessingState<'_>,
-    ) -> ProcessingResult
-    where
-        T: ProcessValue,
-    {
-        value.process_child_values(self, state)?;
-        verify_value_nonempty(value, meta, state)?;
-        Ok(())
-    }
-
-    fn process_object<T>(
-        &mut self,
-        value: &mut Object<T>,
-        meta: &mut Meta,
-        state: &ProcessingState<'_>,
-    ) -> ProcessingResult
-    where
-        T: ProcessValue,
-    {
-        value.process_child_values(self, state)?;
-        verify_value_nonempty(value, meta, state)?;
-        Ok(())
-    }
-}
-
-fn value_trim_whitespace(value: &mut String, _meta: &mut Meta, state: &ProcessingState<'_>) {
-    if state.attrs().trim_whitespace {
-        let new_value = value.trim().to_owned();
-        value.clear();
-        value.push_str(&new_value);
-    }
-}
-
-fn verify_value_nonempty<T>(
-    value: &T,
-    meta: &mut Meta,
-    state: &ProcessingState<'_>,
-) -> ProcessingResult
-where
-    T: Empty,
-{
-    if state.attrs().nonempty && value.is_empty() {
-        meta.add_error(Error::nonempty());
-        Err(ProcessingAction::DeleteValueHard)
-    } else {
-        Ok(())
-    }
-}
-
-fn verify_value_nonempty_string<T>(
-    value: &T,
-    meta: &mut Meta,
-    state: &ProcessingState<'_>,
-) -> ProcessingResult
-where
-    T: Empty,
-{
-    if state.attrs().nonempty && value.is_empty() {
-        meta.add_error(Error::nonempty_string());
-        Err(ProcessingAction::DeleteValueHard)
-    } else {
-        Ok(())
-    }
-}
-
-fn verify_value_characters(
-    value: &str,
-    meta: &mut Meta,
-    state: &ProcessingState<'_>,
-) -> ProcessingResult {
-    if let Some(ref character_set) = state.attrs().characters {
-        for c in value.chars() {
-            if !(character_set.char_is_valid)(c) {
-                meta.add_error(Error::invalid(format!("invalid character {c:?}")));
-                return Err(ProcessingAction::DeleteValueSoft);
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Backfills the client IP address on for the NEL reports.
@@ -1218,11 +1113,10 @@ mod tests {
         self, process_value, ProcessingAction, ProcessingState, Processor,
     };
     use relay_event_schema::protocol::{
-        CError, ClientSdkInfo, Contexts, Csp, DeviceContext, Event, Headers, IpAddr, MachException,
-        Measurement, Measurements, Mechanism, MechanismMeta, PosixSignal, RawStacktrace, Request,
-        Span, SpanId, Tags, TraceContext, TraceId, TransactionSource, User,
+        CError, ClientSdkInfo, Contexts, Csp, DeviceContext, Event, Headers, IpAddr, Measurement,
+        Measurements, Request, Span, SpanId, Tags, TraceContext, TraceId, TransactionSource,
     };
-    use relay_protocol::{get_value, Annotated, ErrorKind, Meta, Object, SerializableAnnotated};
+    use relay_protocol::{get_value, Annotated, Meta, Object, SerializableAnnotated};
     use serde_json::json;
 
     use crate::normalize::processor::{
@@ -3711,165 +3605,5 @@ mod tests {
         range: None,
     },
 ]"#);
-    }
-
-    // TODO(ja): Enable this test
-    // fn assert_nonempty_base<T>(expected_error: &str)
-    // where
-    //     T: Default + PartialEq + ProcessValue,
-    // {
-    //     #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
-    //     struct Foo<T> {
-    //         #[metastructure(required = "true", nonempty = "true")]
-    //         bar: Annotated<T>,
-    //         bar2: Annotated<T>,
-    //     }
-
-    //     let mut wrapper = Annotated::new(Foo {
-    //         bar: Annotated::new(T::default()),
-    //         bar2: Annotated::new(T::default()),
-    //     });
-    //     process_value(&mut wrapper, &mut SchemaProcessor, ProcessingState::root()).unwrap();
-
-    //     assert_eq!(
-    //         wrapper,
-    //         Annotated::new(Foo {
-    //             bar: Annotated::from_error(Error::expected(expected_error), None),
-    //             bar2: Annotated::new(T::default())
-    //         })
-    //     );
-    // }
-
-    // #[test]
-    // fn test_nonempty_string() {
-    //     assert_nonempty_base::<String>("a non-empty string");
-    // }
-
-    // #[test]
-    // fn test_nonempty_array() {
-    //     assert_nonempty_base::<Array<u64>>("a non-empty value");
-    // }
-
-    // #[test]
-    // fn test_nonempty_object() {
-    //     assert_nonempty_base::<Object<u64>>("a non-empty value");
-    // }
-
-    #[test]
-    fn test_invalid_email() {
-        let mut user = Annotated::new(User {
-            email: Annotated::new("bananabread".to_owned()),
-            ..Default::default()
-        });
-
-        let expected = user.clone();
-        let mut processor = NormalizeProcessor::new(NormalizeProcessorConfig::default());
-        processor::process_value(&mut user, &mut processor, ProcessingState::root()).unwrap();
-
-        assert_eq!(user, expected);
-    }
-
-    #[test]
-    fn test_client_sdk_missing_attribute() {
-        let mut info = Annotated::new(ClientSdkInfo {
-            name: Annotated::new("sentry.rust".to_string()),
-            ..Default::default()
-        });
-
-        let mut processor = NormalizeProcessor::new(NormalizeProcessorConfig::default());
-        processor::process_value(&mut info, &mut processor, ProcessingState::root()).unwrap();
-
-        let expected = Annotated::new(ClientSdkInfo {
-            name: Annotated::new("sentry.rust".to_string()),
-            version: Annotated::from_error(ErrorKind::MissingAttribute, None),
-            ..Default::default()
-        });
-
-        assert_eq!(info, expected);
-    }
-
-    #[test]
-    fn test_mechanism_missing_attributes() {
-        let mut mechanism = Annotated::new(Mechanism {
-            ty: Annotated::new("mytype".to_string()),
-            meta: Annotated::new(MechanismMeta {
-                errno: Annotated::new(CError {
-                    name: Annotated::new("ENOENT".to_string()),
-                    ..Default::default()
-                }),
-                mach_exception: Annotated::new(MachException {
-                    name: Annotated::new("EXC_BAD_ACCESS".to_string()),
-                    ..Default::default()
-                }),
-                signal: Annotated::new(PosixSignal {
-                    name: Annotated::new("SIGSEGV".to_string()),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            }),
-            ..Default::default()
-        });
-
-        let mut processor = NormalizeProcessor::new(NormalizeProcessorConfig::default());
-        processor::process_value(&mut mechanism, &mut processor, ProcessingState::root()).unwrap();
-
-        let expected = Annotated::new(Mechanism {
-            ty: Annotated::new("mytype".to_string()),
-            meta: Annotated::new(MechanismMeta {
-                errno: Annotated::new(CError {
-                    number: Annotated::empty(),
-                    name: Annotated::new("ENOENT".to_string()),
-                }),
-                mach_exception: Annotated::new(MachException {
-                    ty: Annotated::empty(),
-                    code: Annotated::empty(),
-                    subcode: Annotated::empty(),
-                    name: Annotated::new("EXC_BAD_ACCESS".to_string()),
-                }),
-                signal: Annotated::new(PosixSignal {
-                    number: Annotated::empty(),
-                    code: Annotated::empty(),
-                    name: Annotated::new("SIGSEGV".to_string()),
-                    code_name: Annotated::empty(),
-                }),
-                ..Default::default()
-            }),
-            ..Default::default()
-        });
-
-        assert_eq!(mechanism, expected);
-    }
-
-    #[test]
-    fn test_stacktrace_missing_attribute() {
-        let mut stack = Annotated::new(RawStacktrace::default());
-
-        let mut processor = NormalizeProcessor::new(NormalizeProcessorConfig::default());
-        processor::process_value(&mut stack, &mut processor, ProcessingState::root()).unwrap();
-
-        let expected = Annotated::new(RawStacktrace {
-            frames: Annotated::from_error(ErrorKind::MissingAttribute, None),
-            ..Default::default()
-        });
-
-        assert_eq!(stack, expected);
-    }
-
-    #[test]
-    fn test_newlines_release() {
-        let mut event = Annotated::new(Event {
-            release: Annotated::new("42\n".to_string().into()),
-            ..Default::default()
-        });
-
-        let mut processor = NormalizeProcessor::new(NormalizeProcessorConfig::default());
-        processor::process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
-
-        let expected = Annotated::new(Event {
-            release: Annotated::new("42".to_string().into()),
-            ..Default::default()
-        });
-
-        assert_eq!(get_value!(expected.release!), get_value!(event.release!));
     }
 }

--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -1,0 +1,293 @@
+use relay_event_schema::processor::{
+    ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor,
+};
+use relay_protocol::{Array, Empty, Error, ErrorKind, Meta, Object};
+
+pub struct SchemaProcessor;
+
+impl Processor for SchemaProcessor {
+    fn process_string(
+        &mut self,
+        value: &mut String,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        value_trim_whitespace(value, meta, state);
+        verify_value_nonempty_string(value, meta, state)?;
+        verify_value_characters(value, meta, state)?;
+        Ok(())
+    }
+
+    fn process_array<T>(
+        &mut self,
+        value: &mut Array<T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult
+    where
+        T: ProcessValue,
+    {
+        value.process_child_values(self, state)?;
+        verify_value_nonempty(value, meta, state)?;
+        Ok(())
+    }
+
+    fn process_object<T>(
+        &mut self,
+        value: &mut Object<T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult
+    where
+        T: ProcessValue,
+    {
+        value.process_child_values(self, state)?;
+        verify_value_nonempty(value, meta, state)?;
+        Ok(())
+    }
+
+    fn before_process<T: ProcessValue>(
+        &mut self,
+        value: Option<&T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        if value.is_none() && state.attrs().required && !meta.has_errors() {
+            meta.add_error(ErrorKind::MissingAttribute);
+        }
+
+        Ok(())
+    }
+}
+
+fn value_trim_whitespace(value: &mut String, _meta: &mut Meta, state: &ProcessingState<'_>) {
+    if state.attrs().trim_whitespace {
+        let new_value = value.trim().to_owned();
+        value.clear();
+        value.push_str(&new_value);
+    }
+}
+
+fn verify_value_nonempty<T>(
+    value: &T,
+    meta: &mut Meta,
+    state: &ProcessingState<'_>,
+) -> ProcessingResult
+where
+    T: Empty,
+{
+    if state.attrs().nonempty && value.is_empty() {
+        meta.add_error(Error::nonempty());
+        Err(ProcessingAction::DeleteValueHard)
+    } else {
+        Ok(())
+    }
+}
+
+fn verify_value_nonempty_string<T>(
+    value: &T,
+    meta: &mut Meta,
+    state: &ProcessingState<'_>,
+) -> ProcessingResult
+where
+    T: Empty,
+{
+    if state.attrs().nonempty && value.is_empty() {
+        meta.add_error(Error::nonempty_string());
+        Err(ProcessingAction::DeleteValueHard)
+    } else {
+        Ok(())
+    }
+}
+
+fn verify_value_characters(
+    value: &str,
+    meta: &mut Meta,
+    state: &ProcessingState<'_>,
+) -> ProcessingResult {
+    if let Some(ref character_set) = state.attrs().characters {
+        for c in value.chars() {
+            if !(character_set.char_is_valid)(c) {
+                meta.add_error(Error::invalid(format!("invalid character {c:?}")));
+                return Err(ProcessingAction::DeleteValueSoft);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_event_schema::processor::{self, ProcessingState};
+    use relay_event_schema::protocol::{
+        CError, ClientSdkInfo, Event, MachException, Mechanism, MechanismMeta, PosixSignal,
+        RawStacktrace, User,
+    };
+    use relay_protocol::{Annotated, ErrorKind};
+    use similar_asserts::assert_eq;
+
+    use super::*;
+
+    // TODO(ja): Enable this test
+    // fn assert_nonempty_base<T>(expected_error: &str)
+    // where
+    //     T: Default + PartialEq + ProcessValue,
+    // {
+    //     #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+    //     struct Foo<T> {
+    //         #[metastructure(required = "true", nonempty = "true")]
+    //         bar: Annotated<T>,
+    //         bar2: Annotated<T>,
+    //     }
+
+    //     let mut wrapper = Annotated::new(Foo {
+    //         bar: Annotated::new(T::default()),
+    //         bar2: Annotated::new(T::default()),
+    //     });
+    //     process_value(&mut wrapper, &mut SchemaProcessor, ProcessingState::root()).unwrap();
+
+    //     assert_eq!(
+    //         wrapper,
+    //         Annotated::new(Foo {
+    //             bar: Annotated::from_error(Error::expected(expected_error), None),
+    //             bar2: Annotated::new(T::default())
+    //         })
+    //     );
+    // }
+
+    // #[test]
+    // fn test_nonempty_string() {
+    //     assert_nonempty_base::<String>("a non-empty string");
+    // }
+
+    // #[test]
+    // fn test_nonempty_array() {
+    //     assert_nonempty_base::<Array<u64>>("a non-empty value");
+    // }
+
+    // #[test]
+    // fn test_nonempty_object() {
+    //     assert_nonempty_base::<Object<u64>>("a non-empty value");
+    // }
+
+    #[test]
+    fn test_invalid_email() {
+        let mut user = Annotated::new(User {
+            email: Annotated::new("bananabread".to_owned()),
+            ..Default::default()
+        });
+
+        let expected = user.clone();
+        processor::process_value(&mut user, &mut SchemaProcessor, ProcessingState::root()).unwrap();
+
+        assert_eq!(user, expected);
+    }
+
+    #[test]
+    fn test_client_sdk_missing_attribute() {
+        let mut info = Annotated::new(ClientSdkInfo {
+            name: Annotated::new("sentry.rust".to_string()),
+            ..Default::default()
+        });
+
+        processor::process_value(&mut info, &mut SchemaProcessor, ProcessingState::root()).unwrap();
+
+        let expected = Annotated::new(ClientSdkInfo {
+            name: Annotated::new("sentry.rust".to_string()),
+            version: Annotated::from_error(ErrorKind::MissingAttribute, None),
+            ..Default::default()
+        });
+
+        assert_eq!(info, expected);
+    }
+
+    #[test]
+    fn test_mechanism_missing_attributes() {
+        let mut mechanism = Annotated::new(Mechanism {
+            ty: Annotated::new("mytype".to_string()),
+            meta: Annotated::new(MechanismMeta {
+                errno: Annotated::new(CError {
+                    name: Annotated::new("ENOENT".to_string()),
+                    ..Default::default()
+                }),
+                mach_exception: Annotated::new(MachException {
+                    name: Annotated::new("EXC_BAD_ACCESS".to_string()),
+                    ..Default::default()
+                }),
+                signal: Annotated::new(PosixSignal {
+                    name: Annotated::new("SIGSEGV".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        processor::process_value(
+            &mut mechanism,
+            &mut SchemaProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        let expected = Annotated::new(Mechanism {
+            ty: Annotated::new("mytype".to_string()),
+            meta: Annotated::new(MechanismMeta {
+                errno: Annotated::new(CError {
+                    number: Annotated::empty(),
+                    name: Annotated::new("ENOENT".to_string()),
+                }),
+                mach_exception: Annotated::new(MachException {
+                    ty: Annotated::empty(),
+                    code: Annotated::empty(),
+                    subcode: Annotated::empty(),
+                    name: Annotated::new("EXC_BAD_ACCESS".to_string()),
+                }),
+                signal: Annotated::new(PosixSignal {
+                    number: Annotated::empty(),
+                    code: Annotated::empty(),
+                    name: Annotated::new("SIGSEGV".to_string()),
+                    code_name: Annotated::empty(),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        assert_eq!(mechanism, expected);
+    }
+
+    #[test]
+    fn test_stacktrace_missing_attribute() {
+        let mut stack = Annotated::new(RawStacktrace::default());
+
+        processor::process_value(&mut stack, &mut SchemaProcessor, ProcessingState::root())
+            .unwrap();
+
+        let expected = Annotated::new(RawStacktrace {
+            frames: Annotated::from_error(ErrorKind::MissingAttribute, None),
+            ..Default::default()
+        });
+
+        assert_eq!(stack, expected);
+    }
+
+    #[test]
+    fn test_newlines_release() {
+        let mut event = Annotated::new(Event {
+            release: Annotated::new("42\n".to_string().into()),
+            ..Default::default()
+        });
+
+        processor::process_value(&mut event, &mut SchemaProcessor, ProcessingState::root())
+            .unwrap();
+
+        let expected = Annotated::new(Event {
+            release: Annotated::new("42".to_string().into()),
+            ..Default::default()
+        });
+
+        assert_eq!(expected, event);
+    }
+}


### PR DESCRIPTION
Reverts https://github.com/getsentry/relay/commit/e2f51fe646872d7ba193309508f3b2f27a4a4368.

After a short discussion with the team, we've agreed to have a processor that calls others processors instead of doing everything. This will make dealing with specific features for the whole event easier, instead of an on-visitor-item basis. This PR doesn't change any behavior.

#skip-changelog