### PR TITLE
feat(spans): Sanitize file extension

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -271,11 +271,7 @@ fn scrub_resource_path(path: &str) -> String {
     }
 
     // Only accept short, clean file extensions.
-    if let Some((invalid, _)) = extension
-        .bytes()
-        .enumerate()
-        .find(|(_, c)| !c.is_ascii_alphanumeric())
-    {
+    if let Some(invalid) = extension.bytes().position(|c| !c.is_ascii_alphanumeric()) {
         extension = &extension[..invalid];
     }
     if extension.len() > MAX_EXTENSION_LENGTH {

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -23,6 +23,9 @@ static DUMMY_BASE_URL: Lazy<Url> = Lazy::new(|| "http://replace_me".parse().unwr
 /// Segments longer than this are treated as identifiers.
 const MAX_SEGMENT_LENGTH: usize = 25;
 
+/// Some bundlers attach characters to the end of a filename, try to catch those.
+const MAX_EXTENSION_LENGTH: usize = 10;
+
 /// Attempts to replace identifiers in the span description with placeholders.
 ///
 /// Returns `None` if no scrubbing can be performed.
@@ -264,6 +267,18 @@ fn scrub_resource_path(path: &str) -> String {
     if extension.contains('/') {
         // Not really an extension
         base_path = path;
+        extension = "";
+    }
+
+    // Only accept short, clean file extensions.
+    if let Some((invalid, _)) = extension
+        .bytes()
+        .enumerate()
+        .find(|(_, c)| !c.is_ascii_alphanumeric())
+    {
+        extension = &extension[..invalid];
+    }
+    if extension.len() > MAX_EXTENSION_LENGTH {
         extension = "";
     }
 
@@ -630,6 +645,27 @@ mod tests {
         "/page?action=name",
         "resource.script",
         "/page"
+    );
+
+    span_description_test!(
+        resource_script_with_long_extension,
+        "/path/to/file.thisismycustomfileextension2000",
+        "resource.script",
+        "/*/file"
+    );
+
+    span_description_test!(
+        resource_script_with_long_suffix,
+        "/path/to/file.js~ri~some-_-1,,thing-_-words%2Fhere~ri~",
+        "resource.script",
+        "/*/file.js"
+    );
+
+    span_description_test!(
+        resource_script_with_tilde_extension,
+        "/path/to/file.~~",
+        "resource.script",
+        "/*/file"
     );
 
     span_description_test!(


### PR DESCRIPTION
* Sanitize file extensions like `.js~some~data` to `.js`. 
* Drop file extensions that are longer than 10 chars after sanitation.

#skip-changelog