### PR TITLE
feat(webvitals): Update normalize_performance_score to accept components with 0 weight and automatically normalize weights to a sum of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `normalize_performance_score` now handles `PerformanceScoreProfile` configs with zero weight components and component weight sums of any number greater than 0. ([#2756](https://github.com/getsentry/relay/pull/2756))
+
 ## 23.11.1
 
 **Features**:

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -886,11 +886,14 @@ fn normalize_performance_score(
                 let mut score_total = 0.0;
                 let mut weight_total = 0.0;
                 for component in &profile.score_components {
+                    weight_total += component.weight;
+                }
+                for component in &profile.score_components {
+                    let normalized_component_weight = component.weight / weight_total;
                     if let Some(value) = measurements.get_value(component.measurement.as_str()) {
                         let cdf = utils::calculate_cdf_score(value, component.p10, component.p50);
-                        let component_score = cdf * component.weight;
+                        let component_score = cdf * normalized_component_weight;
                         score_total += component_score;
-                        weight_total += component.weight;
                         should_add_total = true;
 
                         measurements.insert(
@@ -905,7 +908,7 @@ fn normalize_performance_score(
                     measurements.insert(
                         format!("score.weight.{}", component.measurement),
                         Measurement {
-                            value: component.weight.into(),
+                            value: normalized_component_weight.into(),
                             unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
                         }
                         .into(),
@@ -916,7 +919,7 @@ fn normalize_performance_score(
                     measurements.insert(
                         "score.total".to_owned(),
                         Measurement {
-                            value: (score_total / weight_total).into(),
+                            value: score_total.into(),
                             unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
                         }
                         .into(),
@@ -2125,6 +2128,302 @@ mod tests {
                         {
                             "measurement": "cls",
                             "weight": 0.25,
+                            "p10": 0.1,
+                            "p50": 0.25
+                        },
+                        {
+                            "measurement": "ttfb",
+                            "weight": 0.0,
+                            "p10": 0.2,
+                            "p50": 0.4
+                        },
+                    ],
+                    "condition": {
+                        "op":"eq",
+                        "name": "event.contexts.browser.name",
+                        "value": "Chrome"
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+
+        normalize_performance_score(&mut event, Some(&performance_score));
+
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
+        {
+          "type": "transaction",
+          "timestamp": 1619420405.0,
+          "start_timestamp": 1619420400.0,
+          "contexts": {
+            "browser": {
+              "name": "Chrome",
+              "version": "120.1.1",
+              "type": "browser",
+            },
+          },
+          "measurements": {
+            "cls": {
+              "value": 0.11,
+            },
+            "fcp": {
+              "value": 1237.0,
+              "unit": "millisecond",
+            },
+            "fid": {
+              "value": 213.0,
+              "unit": "millisecond",
+            },
+            "lcp": {
+              "value": 6596.0,
+              "unit": "millisecond",
+            },
+            "score.cls": {
+              "value": 0.8745668242977945,
+              "unit": "ratio",
+            },
+            "score.fcp": {
+              "value": 0.7167236962527221,
+              "unit": "ratio",
+            },
+            "score.fid": {
+              "value": 0.6552453782760849,
+              "unit": "ratio",
+            },
+            "score.lcp": {
+              "value": 0.03079632190462195,
+              "unit": "ratio",
+            },
+            "score.total": {
+              "value": 0.531962770566569,
+              "unit": "ratio",
+            },
+            "score.weight.cls": {
+              "value": 0.25,
+              "unit": "ratio",
+            },
+            "score.weight.fcp": {
+              "value": 0.15,
+              "unit": "ratio",
+            },
+            "score.weight.fid": {
+              "value": 0.3,
+              "unit": "ratio",
+            },
+            "score.weight.lcp": {
+              "value": 0.3,
+              "unit": "ratio",
+            },
+            "score.weight.ttfb": {
+              "value": 0.0,
+              "unit": "ratio",
+            },
+          },
+        }
+        "###);
+    }
+
+    // Test performance score is calculated correctly when the sum of weights is under 1.
+    // The expected result should normalize the weights to a sum of 1 and scale the weight measurements accordingly.
+    #[test]
+    fn test_computed_performance_score_with_under_normalized_weights() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "timestamp": "2021-04-26T08:00:05+0100",
+            "start_timestamp": "2021-04-26T08:00:00+0100",
+            "measurements": {
+                "fid": {"value": 213, "unit": "millisecond"},
+                "fcp": {"value": 1237, "unit": "millisecond"},
+                "lcp": {"value": 6596, "unit": "millisecond"},
+                "cls": {"value": 0.11}
+            },
+            "contexts": {
+                "browser": {
+                    "name": "Chrome",
+                    "version": "120.1.1",
+                    "type": "browser"
+                }
+            }
+        }
+        "#;
+
+        let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
+
+        let performance_score: PerformanceScoreConfig = serde_json::from_value(json!({
+            "profiles": [
+                {
+                    "name": "Desktop",
+                    "scoreComponents": [
+                        {
+                            "measurement": "fcp",
+                            "weight": 0.03,
+                            "p10": 900,
+                            "p50": 1600
+                        },
+                        {
+                            "measurement": "lcp",
+                            "weight": 0.06,
+                            "p10": 1200,
+                            "p50": 2400
+                        },
+                        {
+                            "measurement": "fid",
+                            "weight": 0.06,
+                            "p10": 100,
+                            "p50": 300
+                        },
+                        {
+                            "measurement": "cls",
+                            "weight": 0.05,
+                            "p10": 0.1,
+                            "p50": 0.25
+                        },
+                        {
+                            "measurement": "ttfb",
+                            "weight": 0.0,
+                            "p10": 0.2,
+                            "p50": 0.4
+                        },
+                    ],
+                    "condition": {
+                        "op":"eq",
+                        "name": "event.contexts.browser.name",
+                        "value": "Chrome"
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+
+        normalize_performance_score(&mut event, Some(&performance_score));
+
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
+        {
+          "type": "transaction",
+          "timestamp": 1619420405.0,
+          "start_timestamp": 1619420400.0,
+          "contexts": {
+            "browser": {
+              "name": "Chrome",
+              "version": "120.1.1",
+              "type": "browser",
+            },
+          },
+          "measurements": {
+            "cls": {
+              "value": 0.11,
+            },
+            "fcp": {
+              "value": 1237.0,
+              "unit": "millisecond",
+            },
+            "fid": {
+              "value": 213.0,
+              "unit": "millisecond",
+            },
+            "lcp": {
+              "value": 6596.0,
+              "unit": "millisecond",
+            },
+            "score.cls": {
+              "value": 0.8745668242977945,
+              "unit": "ratio",
+            },
+            "score.fcp": {
+              "value": 0.7167236962527221,
+              "unit": "ratio",
+            },
+            "score.fid": {
+              "value": 0.6552453782760849,
+              "unit": "ratio",
+            },
+            "score.lcp": {
+              "value": 0.03079632190462195,
+              "unit": "ratio",
+            },
+            "score.total": {
+              "value": 0.531962770566569,
+              "unit": "ratio",
+            },
+            "score.weight.cls": {
+              "value": 0.25,
+              "unit": "ratio",
+            },
+            "score.weight.fcp": {
+              "value": 0.15,
+              "unit": "ratio",
+            },
+            "score.weight.fid": {
+              "value": 0.3,
+              "unit": "ratio",
+            },
+            "score.weight.lcp": {
+              "value": 0.3,
+              "unit": "ratio",
+            },
+            "score.weight.ttfb": {
+              "value": 0.0,
+              "unit": "ratio",
+            },
+          },
+        }
+        "###);
+    }
+
+    // Test performance score is calculated correctly when the sum of weights is over 1.
+    // The expected result should normalize the weights to a sum of 1 and scale the weight measurements accordingly.
+    #[test]
+    fn test_computed_performance_score_with_over_normalized_weights() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "timestamp": "2021-04-26T08:00:05+0100",
+            "start_timestamp": "2021-04-26T08:00:00+0100",
+            "measurements": {
+                "fid": {"value": 213, "unit": "millisecond"},
+                "fcp": {"value": 1237, "unit": "millisecond"},
+                "lcp": {"value": 6596, "unit": "millisecond"},
+                "cls": {"value": 0.11}
+            },
+            "contexts": {
+                "browser": {
+                    "name": "Chrome",
+                    "version": "120.1.1",
+                    "type": "browser"
+                }
+            }
+        }
+        "#;
+
+        let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
+
+        let performance_score: PerformanceScoreConfig = serde_json::from_value(json!({
+            "profiles": [
+                {
+                    "name": "Desktop",
+                    "scoreComponents": [
+                        {
+                            "measurement": "fcp",
+                            "weight": 0.30,
+                            "p10": 900,
+                            "p50": 1600
+                        },
+                        {
+                            "measurement": "lcp",
+                            "weight": 0.60,
+                            "p10": 1200,
+                            "p50": 2400
+                        },
+                        {
+                            "measurement": "fid",
+                            "weight": 0.60,
+                            "p10": 100,
+                            "p50": 300
+                        },
+                        {
+                            "measurement": "cls",
+                            "weight": 0.50,
                             "p10": 0.1,
                             "p50": 0.25
                         },

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -875,12 +875,13 @@ fn normalize_performance_score(
             }
             if let Some(measurements) = event.measurements.value_mut() {
                 let mut should_add_total = false;
-                if !profile
-                    .score_components
-                    .iter()
-                    .all(|c| measurements.contains_key(c.measurement.as_str()) || c.weight == 0.0)
-                {
-                    // Check all measurements exist, otherwise don't add any score components.
+                if profile.score_components.iter().any(|c| {
+                    !measurements.contains_key(c.measurement.as_str())
+                        && c.weight.abs() >= f64::EPSILON
+                }) {
+                    // All measurements with a profile weight greater than 0 are required to exist
+                    // on the event. Skip calculating performance scores if a measurement with
+                    // weight is missing.
                     break;
                 }
                 let mut score_total = 0.0;

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -878,7 +878,7 @@ fn normalize_performance_score(
                 if !profile
                     .score_components
                     .iter()
-                    .all(|c| measurements.contains_key(c.measurement.as_str()))
+                    .all(|c| measurements.contains_key(c.measurement.as_str()) || c.weight == 0.0)
                 {
                     // Check all measurements exist, otherwise don't add any score components.
                     break;
@@ -901,15 +901,15 @@ fn normalize_performance_score(
                             }
                             .into(),
                         );
-                        measurements.insert(
-                            format!("score.weight.{}", component.measurement),
-                            Measurement {
-                                value: component.weight.into(),
-                                unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
-                            }
-                            .into(),
-                        );
                     }
+                    measurements.insert(
+                        format!("score.weight.{}", component.measurement),
+                        Measurement {
+                            value: component.weight.into(),
+                            unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
+                        }
+                        .into(),
+                    );
                 }
 
                 if should_add_total {
@@ -2128,6 +2128,12 @@ mod tests {
                             "p10": 0.1,
                             "p50": 0.25
                         },
+                        {
+                            "measurement": "ttfb",
+                            "weight": 0.0,
+                            "p10": 0.2,
+                            "p50": 0.4
+                        },
                     ],
                     "condition": {
                         "op":"eq",
@@ -2203,6 +2209,10 @@ mod tests {
             },
             "score.weight.lcp": {
               "value": 0.3,
+              "unit": "ratio",
+            },
+            "score.weight.ttfb": {
+              "value": 0.0,
               "unit": "ratio",
             },
           },


### PR DESCRIPTION
- Updates `normalize_performance_score` to accept a `PerformanceScoreProfile` with components of 0 weight. This is needed because we must store 0 weight for unused component to ensure that the sum of all `avg(measurements.score.weight.*)` equals `1` at any given time. Not storing 0 allows the possibility that the total sum of avg weights exceeds 1.
- Updates `normalize_performance_score` to accept a `PerformanceScoreProfile` with a component weights sum of any number greater than 0. Previously, we expected the component weights from the `PerformanceScoreProfile` config to always sum up to 1. This change automatically normalizes the stored component weights so that the sum of stored weights will always equal 1. 