### PR TITLE
fix(spans): Denylist more db ops

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -9,7 +9,13 @@ use crate::metrics::{MetricExtractionConfig, MetricSpec, TagMapping, TagSpec};
 use crate::project::ProjectConfig;
 
 /// A list of `span.op` patterns that indicate databases that should be skipped.
-const DISABLED_DATABASES: &[&str] = &["*clickhouse*", "*mongodb*", "*redis*", "*compiler*"];
+const DISABLED_DATABASES: &[&str] = &[
+    "*clickhouse*",
+    "*compile*",
+    "*mongodb*",
+    "*redis*",
+    "db.orm",
+];
 
 /// A list of span.op` patterns we want to enable for mobile.
 const MOBILE_OPS: &[&str] = &["app.*", "ui.load*"];


### PR DESCRIPTION
Investigation [here](https://www.notion.so/sentry/Span-groups-per-op-db-8fd872ad96b6407395eefcbb4796cd91) surfaced more span ops that we cannot group properly at the moment.

Ideally, we would use an allowlist instead of a denylist (e.g. based on the `db.system` property), but we need to keep supporting legacy SDKs that do not send that information.

#skip-changelog