### PR TITLE
feat(webvitals): Move back to storing weighted Performance scores instead of cdf

### DIFF
--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -795,7 +795,7 @@ fn normalize_performance_score(
                         measurements.insert(
                             format!("score.{}", component.measurement),
                             Measurement {
-                                value: cdf.into(),
+                                value: component_score.into(),
                                 unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
                             }
                             .into(),
@@ -2074,19 +2074,19 @@ mod tests {
               "unit": "millisecond",
             },
             "score.cls": {
-              "value": 0.8745668242977945,
+              "value": 0.21864170607444863,
               "unit": "ratio",
             },
             "score.fcp": {
-              "value": 0.7167236962527221,
+              "value": 0.10750855443790831,
               "unit": "ratio",
             },
             "score.fid": {
-              "value": 0.6552453782760849,
+              "value": 0.19657361348282545,
               "unit": "ratio",
             },
             "score.lcp": {
-              "value": 0.03079632190462195,
+              "value": 0.009238896571386584,
               "unit": "ratio",
             },
             "score.total": {
@@ -2222,19 +2222,19 @@ mod tests {
               "unit": "millisecond",
             },
             "score.cls": {
-              "value": 0.8745668242977945,
+              "value": 0.21864170607444863,
               "unit": "ratio",
             },
             "score.fcp": {
-              "value": 0.7167236962527221,
+              "value": 0.10750855443790831,
               "unit": "ratio",
             },
             "score.fid": {
-              "value": 0.6552453782760849,
+              "value": 0.19657361348282545,
               "unit": "ratio",
             },
             "score.lcp": {
-              "value": 0.03079632190462195,
+              "value": 0.009238896571386584,
               "unit": "ratio",
             },
             "score.total": {
@@ -2370,19 +2370,19 @@ mod tests {
               "unit": "millisecond",
             },
             "score.cls": {
-              "value": 0.8745668242977945,
+              "value": 0.21864170607444863,
               "unit": "ratio",
             },
             "score.fcp": {
-              "value": 0.7167236962527221,
+              "value": 0.10750855443790831,
               "unit": "ratio",
             },
             "score.fid": {
-              "value": 0.6552453782760849,
+              "value": 0.19657361348282545,
               "unit": "ratio",
             },
             "score.lcp": {
-              "value": 0.03079632190462195,
+              "value": 0.009238896571386584,
               "unit": "ratio",
             },
             "score.total": {


### PR DESCRIPTION
Updates `normalize_performance_score` to go back to storing weighted performance scores.

#skip-changelog