### PR TITLE
ref(metrics): Allow MRI to be owned

### DIFF
--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -407,7 +407,7 @@ fn parse_gauge(string: &str) -> Option<GaugeValue> {
 ///  - (optional) The unit. If missing, it is defaulted to "none".
 ///
 /// The metric type is never part of this string and must be supplied separately.
-fn parse_mri(string: &str, ty: MetricType) -> Option<MetricResourceIdentifier> {
+fn parse_mri(string: &str, ty: MetricType) -> Option<MetricResourceIdentifier<'_>> {
     let (name_and_namespace, unit) = protocol::parse_name_unit(string)?;
 
     let (raw_namespace, name) = name_and_namespace
@@ -416,7 +416,7 @@ fn parse_mri(string: &str, ty: MetricType) -> Option<MetricResourceIdentifier> {
 
     Some(MetricResourceIdentifier {
         ty,
-        name,
+        name: name.into(),
         namespace: raw_namespace.parse().ok()?,
         unit,
     })

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -1,6 +1,6 @@
-use std::error::Error;
 use std::fmt;
 use std::hash::Hasher as _;
+use std::{borrow::Cow, error::Error};
 
 use hash32::{FnvHasher, Hasher as _};
 
@@ -234,7 +234,7 @@ pub struct MetricResourceIdentifier<'a> {
     pub namespace: MetricNamespace,
 
     /// The display name of the metric in the allowed character set.
-    pub name: &'a str,
+    pub name: Cow<'a, str>,
 
     /// The verbatim unit name of the metric value.
     ///
@@ -255,9 +255,19 @@ impl<'a> MetricResourceIdentifier<'a> {
         Ok(Self {
             ty,
             namespace: raw_namespace.parse()?,
-            name,
+            name: Cow::Borrowed(name),
             unit,
         })
+    }
+
+    /// Converts the MRI into an owned version with a static lifetime.
+    pub fn into_owned(self) -> MetricResourceIdentifier<'static> {
+        MetricResourceIdentifier {
+            ty: self.ty,
+            namespace: self.namespace,
+            name: Cow::Owned(self.name.into_owned()),
+            unit: self.unit,
+        }
     }
 }
 

--- a/relay-server/src/metrics_extraction/sessions/types.rs
+++ b/relay-server/src/metrics_extraction/sessions/types.rs
@@ -114,7 +114,7 @@ impl IntoMetric for SessionMetric {
         let mri = MetricResourceIdentifier {
             ty: value.ty(),
             namespace: MetricNamespace::Sessions,
-            name: &name,
+            name: name.into(),
             unit: MetricUnit::None,
         };
 

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -110,7 +110,7 @@ impl IntoMetric for TransactionMetric {
         let mri = MetricResourceIdentifier {
             ty: value.ty(),
             namespace,
-            name: &name,
+            name,
             unit,
         };
 

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -73,7 +73,7 @@ impl<Q: AsRef<Vec<Quota>>> MetricsLimiter<Q> {
                     _ => 0,
                 };
 
-                let has_profile = matches!(mri.name, "usage" | "duration")
+                let has_profile = matches!(mri.name.as_ref(), "usage" | "duration")
                     && metric.tag(PROFILE_TAG) == Some("true");
 
                 Some((count, has_profile))


### PR DESCRIPTION
This allows us to pass a MRI as an owned structure and allows for less conversions between String <-> MRI down the line. This will also make it possible to implement Deserialize for the MRI

Needed for:  #2751

#skip-changelog