### PR TITLE
ref(metric-meta): Capture envelope payload in a sentry issue

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -3040,7 +3040,7 @@ impl EnvelopeProcessorService {
                 continue;
             }
 
-            let payload = item.payload();
+            let mut payload = item.payload();
             match serde_json::from_slice::<MetricMeta>(&payload) {
                 Ok(meta) => {
                     relay_log::trace!("adding metric metadata to project cache");
@@ -3049,8 +3049,26 @@ impl EnvelopeProcessorService {
                         .send(AddMetricMeta { project_key, meta });
                 }
                 Err(error) => {
-                    relay_log::debug!(error = &error as &dyn Error, "failed to parse metric meta",);
                     metric!(counter(RelayCounters::MetricMetaParsingFailed) += 1);
+
+                    relay_log::with_scope(
+                        move |scope| {
+                            // truncate the payload to basically 200KiB, just in case
+                            payload.truncate(200_000);
+                            scope.add_attachment(relay_log::protocol::Attachment {
+                                buffer: payload.into(),
+                                filename: "payload.json".to_owned(),
+                                content_type: Some("application/json".to_owned()),
+                                ty: None,
+                            })
+                        },
+                        || {
+                            relay_log::error!(
+                                error = &error as &dyn Error,
+                                "failed to parse metric meta"
+                            )
+                        },
+                    );
                 }
             }
         }


### PR DESCRIPTION
We want to temporarily capture the event payload to figure out why the metadata sent by Sentry is rejected by relay.


#skip-changelog