### PR TITLE
feat(metric-meta): Normalize invalid metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `normalize_performance_score` now handles `PerformanceScoreProfile` configs with zero weight components and component weight sums of any number greater than 0. ([#2756](https://github.com/getsentry/relay/pull/2756))
 
+**Features**:
+
+- Normalize invalid metric names. ([#2769](https://github.com/getsentry/relay/pull/2769))
+
 **Internal**:
 
 - Add support for metric metadata. ([#2751](https://github.com/getsentry/relay/pull/2751))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ dependencies = [
 name = "relay-base-schema"
 version = "23.11.1"
 dependencies = [
+ "regex",
  "relay-common",
  "relay-protocol",
  "schemars",

--- a/relay-base-schema/Cargo.toml
+++ b/relay-base-schema/Cargo.toml
@@ -10,6 +10,7 @@ license-file = "../LICENSE.md"
 publish = false
 
 [dependencies]
+regex = { workspace = true }
 relay-common = { path = "../relay-common" }
 relay-protocol = { path = "../relay-protocol" }
 schemars = { workspace = true, optional = true }

--- a/relay-event-normalization/src/normalize/processor.rs
+++ b/relay-event-normalization/src/normalize/processor.rs
@@ -14,7 +14,9 @@ use std::mem;
 use std::ops::Range;
 
 use chrono::{DateTime, Duration, Utc};
-use relay_base_schema::metrics::{is_valid_metric_name, DurationUnit, FractionUnit, MetricUnit};
+use relay_base_schema::metrics::{
+    can_be_valid_metric_name, DurationUnit, FractionUnit, MetricUnit,
+};
 use relay_common::time::UnixTimestamp;
 use relay_event_schema::processor::{
     self, MaxChars, ProcessingAction, ProcessingResult, ProcessingState, Processor,
@@ -959,7 +961,7 @@ fn remove_invalid_measurements(
             None => return false,
         };
 
-        if !is_valid_metric_name(name) {
+        if !can_be_valid_metric_name(name) {
             meta.add_error(Error::invalid(format!(
                 "Metric name contains invalid characters: \"{name}\""
             )));

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -1051,8 +1051,8 @@ mod tests {
     fn test_parse_invalid_name() {
         let s = "foo#bar:42|c";
         let timestamp = UnixTimestamp::from_secs(4711);
-        let metric = Bucket::parse(s.as_bytes(), timestamp);
-        assert!(metric.is_err());
+        let metric = Bucket::parse(s.as_bytes(), timestamp).unwrap();
+        assert_eq!(metric.name, "c:custom/foo_bar@none");
     }
 
     #[test]


### PR DESCRIPTION
Sentry currently generates metrics with dashes in their names. Generally we want to normalize invalid metric names instead of dropping them. The Python SDK already has this logic, we're now also implementing it in relay. 
Consecutive invalid characters will be replaced with a single underscore. Metric names still need to start with a valid character.
