### PR TITLE
feat(gocd): Enable `de` region deployments

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.5.1"
+      "version": "v2.5"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "22b351221458e2d9add1014d6230e76f1bdd40c1",
-      "sum": "gF65Dh1Po+61V0CV5F05UFDEki0Z4ov4739GZXShqcM="
+      "version": "3bf82872351389af174fdc471e29768dc381b850",
+      "sum": "LHNV5r7rjuh9F06UtMawnq9Zn2RICJYEWSUIJ8OUqxg="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumps the `gocd-jsonnet` version to add `de` region deployments.

https://github.com/getsentry/gocd-jsonnet/pull/59

#skip-changelog