### PR TITLE
feat(metrics): Add source context to code locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Partition and split metric buckets just before sending. Log outcomes for metrics. ([#2682](https://github.com/getsentry/relay/pull/2682))
 
+**Internal**:
+
+- Support source context in metric code locations metadata entries. ([#2781](https://github.com/getsentry/relay/pull/2781))
+
 ## 23.11.2
 
 - `normalize_performance_score` now handles `PerformanceScoreProfile` configs with zero weight components and component weight sums of any number greater than 0. ([#2756](https://github.com/getsentry/relay/pull/2756))

--- a/relay-metrics/src/meta/protocol.rs
+++ b/relay-metrics/src/meta/protocol.rs
@@ -48,6 +48,15 @@ pub struct Location {
     /// The line number.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lineno: Option<u64>,
+    /// Source code leading up to `lineno`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_context: Vec<String>,
+    /// Source code of the current line (`lineno`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_line: Option<String>,
+    /// Source code of the lines after `lineno`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_context: Vec<String>,
 }
 
 /// A Unix timestamp that is truncated to the start of the day.


### PR DESCRIPTION
The product is going to show source context with code locations on
metrics. This PR adds support for source context to the code location
submission payload in the same format that stack frames use.

The Python SDK will start to submit this with https://github.com/getsentry/sentry-python/pull/2539.

