### PR TITLE
feat(spans): Add a measurements field to span protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Partition and split metric buckets just before sending. Log outcomes for metrics. ([#2682](https://github.com/getsentry/relay/pull/2682))
 - Return global config ready status to downstream relays. ([#2765](https://github.com/getsentry/relay/pull/2765))
 - Add Mixed JS/Android Profiles events processing. ([#2706](https://github.com/getsentry/relay/pull/2706))
+- Allow to ingest measurements on a span. ([#2792](https://github.com/getsentry/relay/pull/2792))
 
 **Internal**:
 

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -2409,6 +2409,7 @@ mod tests {
                 data: ~,
                 sentry_tags: ~,
                 received: ~,
+                measurements: ~,
                 other: {},
             },
         ]
@@ -2450,6 +2451,7 @@ mod tests {
                 data: ~,
                 sentry_tags: ~,
                 received: ~,
+                measurements: ~,
                 other: {},
             },
         ]
@@ -2491,6 +2493,7 @@ mod tests {
                 data: ~,
                 sentry_tags: ~,
                 received: ~,
+                measurements: ~,
                 other: {},
             },
         ]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -77,9 +77,6 @@ pub struct Span {
     pub received: Annotated<Timestamp>,
 
     /// Measurements which holds observed values such as web vitals.
-    ///
-    /// Measurements are only available on transactions. They contain measurement values of observed
-    /// values such as Largest Contentful Paint (LCP).
     #[metastructure(skip_serialization = "empty")]
     #[metastructure(omit_from_schema)] // we only document error events for now
     pub measurements: Annotated<Measurements>,

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -4,8 +4,8 @@ use relay_protocol::{Annotated, Empty, FromValue, Getter, IntoValue, Object, Val
 
 use crate::processor::ProcessValue;
 use crate::protocol::{
-    Event, EventId, JsonLenientString, OperationType, OriginType, ProfileContext, SpanId,
-    SpanStatus, Timestamp, TraceContext, TraceId,
+    Event, EventId, JsonLenientString, Measurements, OperationType, OriginType, ProfileContext,
+    SpanId, SpanStatus, Timestamp, TraceContext, TraceId,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
@@ -75,6 +75,14 @@ pub struct Span {
 
     /// Timestamp when the span has been received by Sentry.
     pub received: Annotated<Timestamp>,
+
+    /// Measurements which holds observed values such as web vitals.
+    ///
+    /// Measurements are only available on transactions. They contain measurement values of observed
+    /// values such as Largest Contentful Paint (LCP).
+    #[metastructure(skip_serialization = "empty")]
+    #[metastructure(omit_from_schema)] // we only document error events for now
+    pub measurements: Annotated<Measurements>,
 
     // TODO remove retain when the api stabilizes
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -156,8 +156,10 @@ impl Getter for Span {
 
 #[cfg(test)]
 mod tests {
+    use crate::protocol::Measurement;
     use chrono::{TimeZone, Utc};
     use insta::assert_debug_snapshot;
+    use relay_base_schema::metrics::{InformationUnit, MetricUnit};
     use similar_asserts::assert_eq;
 
     use super::*;
@@ -173,9 +175,22 @@ mod tests {
   "span_id": "fa90fdead5f74052",
   "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
   "status": "ok",
-  "origin": "auto.http"
+  "origin": "auto.http",
+  "measurements": {
+    "memory": {
+      "value": 9001.0,
+      "unit": "byte"
+    }
+  }
 }"#;
-
+        let mut measurements = Object::new();
+        measurements.insert(
+            "memory".into(),
+            Annotated::new(Measurement {
+                value: Annotated::new(9001.0),
+                unit: Annotated::new(MetricUnit::Information(InformationUnit::Byte)),
+            }),
+        );
         let span = Annotated::new(Span {
             timestamp: Annotated::new(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap().into()),
             start_timestamp: Annotated::new(
@@ -188,6 +203,7 @@ mod tests {
             span_id: Annotated::new(SpanId("fa90fdead5f74052".into())),
             status: Annotated::new(SpanStatus::Ok),
             origin: Annotated::new("auto.http".to_owned()),
+            measurements: Annotated::new(Measurements(measurements)),
             ..Default::default()
         });
         assert_eq!(json, span.to_json_pretty().unwrap());
@@ -263,6 +279,7 @@ mod tests {
             data: ~,
             sentry_tags: ~,
             received: ~,
+            measurements: ~,
             other: {},
         }
         "###);

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -37,6 +37,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "transaction.method": "GET",
             },
             received: ~,
+            measurements: ~,
             other: {},
         },
     ],

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -574,6 +574,7 @@ mod tests {
                 data: ~,
                 sentry_tags: ~,
                 received: ~,
+                measurements: ~,
                 other: {},
             },
         ]


### PR DESCRIPTION
As we move towards standalone span ingestion, we need to support passing measurements to spans directly. This change will allow us to receive measurements when ingesting a span.

The side-effect is spans in transactions will also be able to ingest measurements but they won't be used in the product.