### PR TITLE
fix(spans): Add the system tag to disambiguate db span op count

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -129,7 +129,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             mri: "c:spans/count_per_op@none".into(),
             field: None,
             condition: Some(duration_condition.clone()),
-            tags: ["category", "op"]
+            tags: ["category", "op", "system"]
                 .map(|key| TagSpec {
                     key: format!("span.{key}"),
                     field: Some(format!("span.sentry_tags.{key}")),

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -642,6 +642,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -754,6 +755,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -813,6 +815,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -925,6 +928,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -984,6 +988,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -1039,6 +1044,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1094,6 +1100,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1151,6 +1158,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1268,6 +1276,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "mongodb",
         },
     },
     Bucket {
@@ -1323,6 +1332,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1390,6 +1400,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.activerecord",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1402,6 +1413,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.redis.command",
+            "span.system": "redis",
         },
     },
     Bucket {

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -677,6 +677,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -789,6 +790,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -848,6 +850,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -960,6 +963,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db.sql.query",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -1019,6 +1023,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "postgresql",
         },
     },
     Bucket {
@@ -1074,6 +1079,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1129,6 +1135,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "mydatabase",
         },
     },
     Bucket {
@@ -1186,6 +1193,7 @@ expression: metrics
         tags: {
             "span.category": "db",
             "span.op": "db",
+            "span.system": "mydatabase",
         },
     },
     Bucket {


### PR DESCRIPTION
Some spans have generic op names like `db` or even `db.sql.query` but contains MongoDB queries. In order to get a more accurate count, we'd like to add this tag to further categorize them properly.

#skip-changelog