### PR TITLE
fix: Replace owners-ingest with team ingest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners
-*   @getsentry/owners-ingest
+*   @getsentry/ingest
 
 # Legal
 /LICENSE.md  @getsentry/owners-legal

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,14 @@ updates:
     schedule:
       interval: daily
     reviewers:
-      - "@getsentry/owners-ingest"
+      - "@getsentry/ingest"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     reviewers:
-      - "@getsentry/owners-ingest"
+      - "@getsentry/ingest"
     open-pull-requests-limit: 0 # security updates only
 
   - package-ecosystem: "github-actions"
@@ -22,4 +22,4 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     reviewers:
-      - "@getsentry/owners-ingest"
+      - "@getsentry/ingest"


### PR DESCRIPTION
We are working with the Ingest team on consolidating the [owners-ingest team](https://github.com/orgs/getsentry/teams/owners-ingest) and [ingest team](https://github.com/orgs/getsentry/teams/ingest) in GitHub, owners-ingest will be deprecated.

Related PR in security-as-code: https://github.com/getsentry/security-as-code/pull/477

_#skip-changelog_