### PR TITLE
fix(user-report): Accept user reports with trailing whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,11 @@
 - Add Mixed JS/Android Profiles events processing. ([#2706](https://github.com/getsentry/relay/pull/2706))
 - Allow to ingest measurements on a span. ([#2792](https://github.com/getsentry/relay/pull/2792))
 
-**Bug Fixes**:
-
-- Ignore whitespaces when parsing user reports. ([#2798](https://github.com/getsentry/relay/pull/2798))
-
 **Internal**:
 
 - Support source context in metric code locations metadata entries. ([#2781](https://github.com/getsentry/relay/pull/2781))
 - Temporarily add metric summaries on spans and top-level transaction events to link DDM with performance monitoring. ([#2757](https://github.com/getsentry/relay/pull/2757))
+- Ignore whitespaces when parsing user reports. ([#2798](https://github.com/getsentry/relay/pull/2798))
 
 ## 23.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add Mixed JS/Android Profiles events processing. ([#2706](https://github.com/getsentry/relay/pull/2706))
 - Allow to ingest measurements on a span. ([#2792](https://github.com/getsentry/relay/pull/2792))
 
+**Bug Fixes**:
+
+- Ignore whitespaces when parsing user reports. ([#2798](https://github.com/getsentry/relay/pull/2798))
+
 **Internal**:
 
 - Support source context in metric code locations metadata entries. ([#2781](https://github.com/getsentry/relay/pull/2781))

--- a/relay-server/src/actors/processor/report.rs
+++ b/relay-server/src/actors/processor/report.rs
@@ -66,27 +66,13 @@ fn process_user_reports(state: &mut ProcessEnvelopeState) {
             return ItemAction::Keep;
         };
 
-        let report = match serde_json::from_slice::<UserReport>(&item.payload()) {
+        let payload = item.payload();
+        // sentry-native 0.4.18 and below is sending reports with trailing whitespaces
+        let payload = trim_whitespaces(&payload);
+        let report = match serde_json::from_slice::<UserReport>(payload) {
             Ok(session) => session,
             Err(error) => {
-                let mut payload = item.payload();
-                payload.truncate(100_000);
-                relay_log::with_scope(
-                    move |scope| {
-                        scope.add_attachment(relay_log::protocol::Attachment {
-                            buffer: payload.into(),
-                            filename: "payload.json".to_owned(),
-                            content_type: Some("application/json".to_owned()),
-                            ty: None,
-                        })
-                    },
-                    || {
-                        relay_log::error!(
-                            error = &error as &dyn Error,
-                            "failed to store user report"
-                        );
-                    },
-                );
+                relay_log::error!(error = &error as &dyn Error, "failed to store user report");
                 return ItemAction::DropSilently;
             }
         };
@@ -105,6 +91,16 @@ fn process_user_reports(state: &mut ProcessEnvelopeState) {
         item.set_payload(ContentType::Json, json_string);
         ItemAction::Keep
     });
+}
+
+fn trim_whitespaces(data: &[u8]) -> &[u8] {
+    let Some(from) = data.iter().position(|x| !x.is_ascii_whitespace()) else {
+        return &[];
+    };
+    let Some(to) = data.iter().rposition(|x| !x.is_ascii_whitespace()) else {
+        return &[];
+    };
+    &data[from..to + 1]
 }
 
 /// Parse an outcome from an outcome ID and a reason string.
@@ -560,5 +556,14 @@ mod tests {
             outcome_from_parts(ClientReportField::RateLimited, "foo_reason").unwrap(),
             Outcome::RateLimited(Some(ReasonCode::new("foo_reason")))
         );
+    }
+
+    #[test]
+    fn test_trim_whitespaces() {
+        assert_eq!(trim_whitespaces(b""), b"");
+        assert_eq!(trim_whitespaces(b" \n\r "), b"");
+        assert_eq!(trim_whitespaces(b" \nx\r "), b"x");
+        assert_eq!(trim_whitespaces(b" {foo: bar} "), b"{foo: bar}");
+        assert_eq!(trim_whitespaces(b"{ foo: bar}"), b"{ foo: bar}");
     }
 }

--- a/relay-server/src/actors/processor/report.rs
+++ b/relay-server/src/actors/processor/report.rs
@@ -67,7 +67,9 @@ fn process_user_reports(state: &mut ProcessEnvelopeState) {
         };
 
         let payload = item.payload();
-        // sentry-native 0.4.18 and below is sending reports with trailing whitespaces
+        // There is a customer SDK which sends invalid reports with a trailing `\n`,
+        // strip it here, even if they update/fix their SDK there will still be many old
+        // versions with the broken SDK out there.
         let payload = trim_whitespaces(&payload);
         let report = match serde_json::from_slice::<UserReport>(payload) {
             Ok(session) => session,


### PR DESCRIPTION
We have a customer with a forked version of the native SDK which is sending invalid user reports with a trailing `\n`. Trim the payload before parsing it to allow user reports to go through.