### PR TITLE
ref(processor): Move unreal and dynamic sampling into separate sub-modules

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::io::Write;
-use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -20,22 +19,17 @@ use relay_event_normalization::{
 };
 use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo};
 use relay_event_schema::processor::{self, process_value, ProcessingAction, ProcessingState};
-use relay_event_schema::protocol::{
-    Contexts, Event, EventType, IpAddr, Metrics, NetworkReportError, TraceContext,
-};
+use relay_event_schema::protocol::{Event, EventType, IpAddr, Metrics, NetworkReportError};
 use relay_filter::FilterStatKey;
 use relay_metrics::aggregator::partition_buckets;
 use relay_metrics::aggregator::AggregatorConfig;
 use relay_metrics::{Bucket, BucketsView, MergeBuckets, MetricMeta, MetricNamespace};
 use relay_pii::{scrub_graphql, PiiAttachmentsProcessor, PiiConfigError, PiiProcessor};
 use relay_profiling::ProfileId;
-use relay_protocol::{Annotated, Empty, Value};
+use relay_protocol::{Annotated, Value};
+
 use relay_quotas::{DataCategory, Scoping};
-use relay_sampling::config::{RuleType, SamplingMode};
-use relay_sampling::evaluation::{
-    MatchedRuleIds, ReservoirCounters, ReservoirEvaluator, SamplingEvaluator,
-};
-use relay_sampling::{DynamicSamplingContext, SamplingConfig};
+use relay_sampling::evaluation::{MatchedRuleIds, ReservoirCounters, ReservoirEvaluator};
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
 use tokio::sync::Semaphore;
@@ -47,6 +41,7 @@ use {
     relay_event_normalization::{span, StoreConfig, StoreProcessor},
     relay_event_schema::protocol::Span,
     relay_metrics::{Aggregator, RedisMetricMetaStore},
+    relay_protocol::Empty,
     relay_quotas::{RateLimitingError, RedisRateLimiter},
     relay_redis::RedisPool,
     symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
@@ -68,11 +63,14 @@ use crate::utils::{
     self, extract_transaction_count, ExtractionMode, ManagedEnvelope, SamplingResult,
 };
 
+mod dynamic_sampling;
 mod event;
 mod profile;
 mod replay;
 mod report;
 mod session;
+#[cfg(feature = "processing")]
+mod unreal;
 
 /// The minimum clock drift for correction to apply.
 const MINIMUM_CLOCK_DRIFT: Duration = Duration::from_secs(55 * 60);
@@ -725,39 +723,6 @@ impl EnvelopeProcessorService {
         })
     }
 
-    /// Expands Unreal 4 items inside an envelope.
-    ///
-    /// If the envelope does NOT contain an `UnrealReport` item, it doesn't do anything. If the
-    /// envelope contains an `UnrealReport` item, it removes it from the envelope and inserts new
-    /// items for each of its contents.
-    ///
-    /// The envelope may be dropped if it exceeds size limits after decompression. Particularly,
-    /// this includes cases where a single attachment file exceeds the maximum file size. This is in
-    /// line with the behavior of the envelope endpoint.
-    ///
-    /// After this, [`EnvelopeProcessorService`] should be able to process the envelope the same
-    /// way it processes any other envelopes.
-    #[cfg(feature = "processing")]
-    fn expand_unreal(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
-        let envelope = &mut state.envelope_mut();
-
-        if let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::UnrealReport) {
-            utils::expand_unreal_envelope(item, envelope, &self.inner.config)?;
-        }
-
-        Ok(())
-    }
-
-    /// Extracts event information from an unreal context.
-    ///
-    /// If the event does not contain an unreal context, this function does not perform any action.
-    /// If there was no event payload prior to this function, it is created.
-    #[cfg(feature = "processing")]
-    fn process_unreal(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
-        utils::process_unreal_envelope(&mut state.event, state.managed_envelope.envelope_mut())
-            .map_err(ProcessingError::InvalidUnrealReport)
-    }
-
     /// Adds processing placeholders for special attachments.
     ///
     /// If special attachments are present in the envelope, this adds placeholder payloads to the
@@ -839,67 +804,6 @@ impl EnvelopeProcessorService {
         });
 
         Ok(())
-    }
-
-    /// Ensures there is a valid dynamic sampling context and corresponding project state.
-    ///
-    /// The dynamic sampling context (DSC) specifies the project_key of the project that initiated
-    /// the trace. That project state should have been loaded previously by the project cache and is
-    /// available on the `ProcessEnvelopeState`. Under these conditions, this cannot happen:
-    ///
-    ///  - There is no DSC in the envelope headers. This occurs with older or third-party SDKs.
-    ///  - The project key does not exist. This can happen if the project key was disabled, the
-    ///    project removed, or in rare cases when a project from another Sentry instance is referred
-    ///    to.
-    ///  - The project key refers to a project from another organization. In this case the project
-    ///    cache does not resolve the state and instead leaves it blank.
-    ///  - The project state could not be fetched. This is a runtime error, but in this case Relay
-    ///    should fall back to the next-best sampling rule set.
-    ///
-    /// In all of the above cases, this function will compute a new DSC using information from the
-    /// event payload, similar to how SDKs do this. The `sampling_project_state` is also switched to
-    /// the main project state.
-    ///
-    /// If there is no transaction event in the envelope, this function will do nothing.
-    fn normalize_dsc(&self, state: &mut ProcessEnvelopeState) {
-        if state.envelope().dsc().is_some() && state.sampling_project_state.is_some() {
-            return;
-        }
-
-        // The DSC can only be computed if there's a transaction event. Note that `from_transaction`
-        // below already checks for the event type.
-        let Some(event) = state.event.value() else {
-            return;
-        };
-        let Some(key_config) = state.project_state.get_public_key_config() else {
-            return;
-        };
-
-        if let Some(dsc) = utils::dsc_from_event(key_config.public_key, event) {
-            state.envelope_mut().set_dsc(dsc);
-            state.sampling_project_state = Some(state.project_state.clone());
-        }
-    }
-
-    fn filter_event(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
-        let event = match state.event.value_mut() {
-            Some(event) => event,
-            // Some events are created by processing relays (e.g. unreal), so they do not yet
-            // exist at this point in non-processing relays.
-            None => return Ok(()),
-        };
-
-        let client_ip = state.managed_envelope.envelope().meta().client_addr();
-        let filter_settings = &state.project_state.config.filter_settings;
-
-        metric!(timer(RelayTimers::EventProcessingFiltering), {
-            relay_filter::should_filter(event, client_ip, filter_settings).map_err(|err| {
-                state
-                    .managed_envelope
-                    .reject(Outcome::Filtered(err.clone()));
-                ProcessingError::EventFiltered(err)
-            })
-        })
     }
 
     #[cfg(feature = "processing")]
@@ -1289,158 +1193,6 @@ impl EnvelopeProcessorService {
         Ok(span)
     }
 
-    /// Computes the sampling decision on the incoming event
-    fn run_dynamic_sampling(&self, state: &mut ProcessEnvelopeState) {
-        // Running dynamic sampling involves either:
-        // - Tagging whether an incoming error has a sampled trace connected to it.
-        // - Computing the actual sampling decision on an incoming transaction.
-        match state.event_type().unwrap_or_default() {
-            EventType::Default | EventType::Error => {
-                self.tag_error_with_sampling_decision(state);
-            }
-            EventType::Transaction => {
-                match state.project_state.config.transaction_metrics {
-                    Some(ErrorBoundary::Ok(ref c)) if c.is_enabled() => (),
-                    _ => return,
-                }
-
-                let sampling_config = match state.project_state.config.sampling {
-                    Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
-                    _ => None,
-                };
-
-                let root_state = state.sampling_project_state.as_ref();
-                let root_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
-                    Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
-                    _ => None,
-                };
-
-                state.sampling_result = Self::compute_sampling_decision(
-                    self.inner.config.processing_enabled(),
-                    &state.reservoir,
-                    sampling_config,
-                    state.event.value(),
-                    root_config,
-                    state.envelope().dsc(),
-                );
-            }
-            _ => {}
-        }
-    }
-
-    /// Computes the sampling decision on the incoming transaction.
-    fn compute_sampling_decision(
-        processing_enabled: bool,
-        reservoir: &ReservoirEvaluator,
-        sampling_config: Option<&SamplingConfig>,
-        event: Option<&Event>,
-        root_sampling_config: Option<&SamplingConfig>,
-        dsc: Option<&DynamicSamplingContext>,
-    ) -> SamplingResult {
-        if (sampling_config.is_none() || event.is_none())
-            && (root_sampling_config.is_none() || dsc.is_none())
-        {
-            return SamplingResult::NoMatch;
-        }
-
-        if sampling_config.map_or(false, |config| config.unsupported())
-            || root_sampling_config.map_or(false, |config| config.unsupported())
-        {
-            if processing_enabled {
-                relay_log::error!("found unsupported rules even as processing relay");
-            } else {
-                return SamplingResult::NoMatch;
-            }
-        }
-
-        let adjustment_rate = match sampling_config
-            .or(root_sampling_config)
-            .map(|config| config.mode)
-        {
-            Some(SamplingMode::Received) => None,
-            Some(SamplingMode::Total) => dsc.and_then(|dsc| dsc.sample_rate),
-            Some(SamplingMode::Unsupported) => {
-                if processing_enabled {
-                    relay_log::error!("found unsupported sampling mode even as processing Relay");
-                }
-                return SamplingResult::NoMatch;
-            }
-            None => {
-                relay_log::error!("cannot sample without at least one sampling config");
-                return SamplingResult::NoMatch;
-            }
-        };
-
-        let mut evaluator = SamplingEvaluator::new(Utc::now())
-            .adjust_client_sample_rate(adjustment_rate)
-            .set_reservoir(reservoir);
-
-        if let (Some(event), Some(sampling_state)) = (event, sampling_config) {
-            if let Some(seed) = event.id.value().map(|id| id.0) {
-                let rules = sampling_state.filter_rules(RuleType::Transaction);
-                evaluator = match evaluator.match_rules(seed, event, rules) {
-                    ControlFlow::Continue(evaluator) => evaluator,
-                    ControlFlow::Break(sampling_match) => {
-                        return SamplingResult::Match(sampling_match);
-                    }
-                }
-            };
-        }
-
-        if let (Some(dsc), Some(sampling_state)) = (dsc, root_sampling_config) {
-            let rules = sampling_state.filter_rules(RuleType::Trace);
-            return evaluator.match_rules(dsc.trace_id, dsc, rules).into();
-        }
-
-        SamplingResult::NoMatch
-    }
-
-    /// Runs dynamic sampling on an incoming error and tags it in case of successful sampling
-    /// decision.
-    ///
-    /// This execution of dynamic sampling is technically a "simulation" since we will use the result
-    /// only for tagging errors and not for actually sampling incoming events.
-    fn tag_error_with_sampling_decision(&self, state: &mut ProcessEnvelopeState) {
-        let (Some(dsc), Some(event)) = (
-            state.managed_envelope.envelope().dsc(),
-            state.event.value_mut(),
-        ) else {
-            return;
-        };
-
-        let root_state = state.sampling_project_state.as_ref();
-        let config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
-            Some(ErrorBoundary::Ok(ref config)) => config,
-            _ => return,
-        };
-
-        if config.unsupported() {
-            if self.inner.config.processing_enabled() {
-                relay_log::error!("found unsupported rules even as processing relay");
-            }
-
-            return;
-        }
-
-        let Some(sampled) = utils::is_trace_fully_sampled(config, dsc) else {
-            return;
-        };
-
-        // We want to get the trace context, in which we will inject the `sampled` field.
-        let context = event
-            .contexts
-            .get_or_insert_with(Contexts::new)
-            .get_or_default::<TraceContext>();
-
-        // We want to update `sampled` only if it was not set, since if we don't check this
-        // we will end up overriding the value set by downstream Relays and this will lead
-        // to more complex debugging in case of problems.
-        if context.sampled.is_empty() {
-            relay_log::trace!("tagged error with `sampled = {}` flag", sampled);
-            context.sampled = Annotated::new(sampled);
-        }
-    }
-
     /// Apply the dynamic sampling decision from `compute_sampling_decision`.
     fn sample_envelope(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
         if let SamplingResult::Match(sampling_match) = std::mem::take(&mut state.sampling_result) {
@@ -1557,22 +1309,22 @@ impl EnvelopeProcessorService {
             // the envelope.
 
             if_processing!({
-                self.expand_unreal(state)?;
+                unreal::expand(state, &self.inner.config)?;
             });
 
             event::extract(state, &self.inner.config)?;
             profile::transfer_id(state);
 
             if_processing!({
-                self.process_unreal(state)?;
+                unreal::process(state)?;
                 self.create_placeholders(state);
             });
 
             event::finalize(state, &self.inner.config)?;
             self.light_normalize_event(state)?;
-            self.normalize_dsc(state);
-            self.filter_event(state)?;
-            self.run_dynamic_sampling(state);
+            dynamic_sampling::normalize(state);
+            event::filter(state)?;
+            dynamic_sampling::run(state, &self.inner.config);
 
             // We avoid extracting metrics if we are not sampling the event while in non-processing
             // relays, in order to synchronize rate limits on indexed and processed transactions.
@@ -2095,16 +1847,9 @@ mod tests {
     use relay_event_normalization::{
         MeasurementsConfig, NormalizeProcessor, RedactionRule, TransactionNameRule,
     };
-    use relay_event_schema::protocol::{EventId, LenientString, TransactionSource};
+    use relay_event_schema::protocol::{EventId, TransactionSource};
     use relay_pii::DataScrubbingConfig;
-    use relay_protocol::RuleCondition;
-    use relay_sampling::config::{
-        DecayingFunction, RuleId, RuleType, SamplingConfig, SamplingMode, SamplingRule,
-        SamplingValue, TimeRange,
-    };
-    use relay_sampling::evaluation::SamplingMatch;
     use similar_asserts::assert_eq;
-    use uuid::Uuid;
 
     use crate::extractors::RequestMeta;
     use crate::metrics_extraction::transactions::types::{
@@ -2112,312 +1857,9 @@ mod tests {
     };
     use crate::metrics_extraction::IntoMetric;
 
-    use crate::testutils::{
-        self, create_test_processor, new_envelope, state_with_rule_and_condition,
-    };
-    use crate::utils::Semaphore as TestSemaphore;
+    use crate::testutils::{self, create_test_processor};
 
     use super::*;
-
-    fn dummy_reservoir() -> ReservoirEvaluator<'static> {
-        ReservoirEvaluator::new(ReservoirCounters::default())
-    }
-
-    fn mocked_event(event_type: EventType, transaction: &str, release: &str) -> Event {
-        Event {
-            id: Annotated::new(EventId::new()),
-            ty: Annotated::new(event_type),
-            transaction: Annotated::new(transaction.to_string()),
-            release: Annotated::new(LenientString(release.to_string())),
-            ..Event::default()
-        }
-    }
-
-    #[tokio::test]
-    async fn test_dsc_respects_metrics_extracted() {
-        relay_test::setup();
-        let (outcome_aggregator, test_store) = testutils::processor_services();
-
-        let config = Config::from_json_value(serde_json::json!({
-            "processing": {
-                "enabled": true,
-                "kafka_config": [],
-            }
-        }))
-        .unwrap();
-
-        let service: EnvelopeProcessorService = create_test_processor(config);
-
-        // Gets a ProcessEnvelopeState, either with or without the metrics_exracted flag toggled.
-        let get_state = |version: Option<u16>| {
-            let event = Event {
-                id: Annotated::new(EventId::new()),
-                ty: Annotated::new(EventType::Transaction),
-                transaction: Annotated::new("testing".to_owned()),
-                ..Event::default()
-            };
-
-            let mut project_state = state_with_rule_and_condition(
-                Some(0.0),
-                RuleType::Transaction,
-                RuleCondition::all(),
-            );
-
-            if let Some(version) = version {
-                project_state.config.transaction_metrics =
-                    ErrorBoundary::Ok(relay_dynamic_config::TransactionMetricsConfig {
-                        version,
-                        ..Default::default()
-                    })
-                    .into();
-            }
-
-            ProcessEnvelopeState {
-                event: Annotated::from(event),
-                metrics: Default::default(),
-                sample_rates: None,
-                sampling_result: SamplingResult::Pending,
-                extracted_metrics: Default::default(),
-                project_state: Arc::new(project_state),
-                sampling_project_state: None,
-                project_id: ProjectId::new(42),
-                managed_envelope: ManagedEnvelope::new(
-                    new_envelope(false, "foo"),
-                    TestSemaphore::new(42).try_acquire().unwrap(),
-                    outcome_aggregator.clone(),
-                    test_store.clone(),
-                ),
-                profile_id: None,
-                event_metrics_extracted: false,
-                reservoir: dummy_reservoir(),
-                global_config: Arc::default(),
-            }
-        };
-
-        // None represents no TransactionMetricsConfig, DS will not be run
-        let mut state = get_state(None);
-        service.run_dynamic_sampling(&mut state);
-        assert!(state.sampling_result.should_keep());
-
-        // Current version is 1, so it won't run DS if it's outdated
-        let mut state = get_state(Some(0));
-        service.run_dynamic_sampling(&mut state);
-        assert!(state.sampling_result.should_keep());
-
-        // Dynamic sampling is run, as the transactionmetrics version is up to date.
-        let mut state = get_state(Some(1));
-        service.run_dynamic_sampling(&mut state);
-        assert!(state.sampling_result.should_drop());
-    }
-
-    #[test]
-    fn test_it_keeps_or_drops_transactions() {
-        let event = Event {
-            id: Annotated::new(EventId::new()),
-            ty: Annotated::new(EventType::Transaction),
-            transaction: Annotated::new("testing".to_owned()),
-            ..Event::default()
-        };
-
-        for (sample_rate, should_keep) in [(0.0, false), (1.0, true)] {
-            let sampling_config = SamplingConfig {
-                rules: vec![SamplingRule {
-                    condition: RuleCondition::all(),
-                    sampling_value: SamplingValue::SampleRate { value: sample_rate },
-                    ty: RuleType::Transaction,
-                    id: RuleId(1),
-                    time_range: Default::default(),
-                    decaying_fn: DecayingFunction::Constant,
-                }],
-                ..SamplingConfig::new()
-            };
-
-            // TODO: This does not test if the sampling decision is actually applied. This should be
-            // refactored to send a proper Envelope in and call process_state to cover the full
-            // pipeline.
-            let res = EnvelopeProcessorService::compute_sampling_decision(
-                false,
-                &dummy_reservoir(),
-                Some(&sampling_config),
-                Some(&event),
-                None,
-                None,
-            );
-            assert_eq!(res.should_keep(), should_keep);
-        }
-    }
-
-    fn process_envelope_with_root_project_state(
-        envelope: Box<Envelope>,
-        sampling_project_state: Option<Arc<ProjectState>>,
-    ) -> Envelope {
-        let processor = create_test_processor(Default::default());
-        let (outcome_aggregator, test_store) = testutils::processor_services();
-
-        let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
-            project_state: Arc::new(ProjectState::allowed()),
-            sampling_project_state,
-            reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
-        };
-
-        let envelope_response = processor.process(message).unwrap();
-        let ctx = envelope_response.envelope.unwrap();
-        ctx.envelope().clone()
-    }
-
-    fn extract_first_event_from_envelope(envelope: Envelope) -> Event {
-        let item = envelope.items().next().unwrap();
-        let annotated_event: Annotated<Event> =
-            Annotated::from_json_bytes(&item.payload()).unwrap();
-        annotated_event.into_value().unwrap()
-    }
-
-    fn mocked_error_item() -> Item {
-        let mut item = Item::new(ItemType::Event);
-        item.set_payload(
-            ContentType::Json,
-            r#"{
-              "event_id": "52df9022835246eeb317dbd739ccd059",
-              "exception": {
-                "values": [
-                    {
-                      "type": "mytype",
-                      "value": "myvalue",
-                      "module": "mymodule",
-                      "thread_id": 42,
-                      "other": "value"
-                    }
-                ]
-              }
-            }"#,
-        );
-        item
-    }
-
-    fn project_state_with_single_rule(sample_rate: f64) -> ProjectState {
-        let sampling_config = SamplingConfig {
-            rules: vec![SamplingRule {
-                condition: RuleCondition::all(),
-                sampling_value: SamplingValue::SampleRate { value: sample_rate },
-                ty: RuleType::Trace,
-                id: RuleId(1),
-                time_range: Default::default(),
-                decaying_fn: Default::default(),
-            }],
-            ..SamplingConfig::new()
-        };
-
-        let mut sampling_project_state = ProjectState::allowed();
-        sampling_project_state.config.sampling = Some(ErrorBoundary::Ok(sampling_config));
-        sampling_project_state
-    }
-
-    #[tokio::test]
-    async fn test_error_is_tagged_correctly_if_trace_sampling_result_is_some() {
-        let event_id = EventId::new();
-        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
-            .parse()
-            .unwrap();
-        let request_meta = RequestMeta::new(dsn);
-        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
-        let dsc = DynamicSamplingContext {
-            trace_id: Uuid::new_v4(),
-            public_key: ProjectKey::parse("abd0f232775f45feab79864e580d160b").unwrap(),
-            release: Some("1.1.1".to_string()),
-            user: Default::default(),
-            replay_id: None,
-            environment: None,
-            transaction: Some("transaction1".into()),
-            sample_rate: None,
-            sampled: Some(true),
-            other: BTreeMap::new(),
-        };
-        envelope.set_dsc(dsc);
-        envelope.add_item(mocked_error_item());
-
-        // We test with sample rate equal to 100%.
-        let sampling_project_state = project_state_with_single_rule(1.0);
-        let new_envelope = process_envelope_with_root_project_state(
-            envelope.clone(),
-            Some(Arc::new(sampling_project_state)),
-        );
-        let event = extract_first_event_from_envelope(new_envelope);
-        let trace_context = event.context::<TraceContext>().unwrap();
-        assert!(trace_context.sampled.value().unwrap());
-
-        // We test with sample rate equal to 0%.
-        let sampling_project_state = project_state_with_single_rule(0.0);
-        let new_envelope = process_envelope_with_root_project_state(
-            envelope,
-            Some(Arc::new(sampling_project_state)),
-        );
-        let event = extract_first_event_from_envelope(new_envelope);
-        let trace_context = event.context::<TraceContext>().unwrap();
-        assert!(!trace_context.sampled.value().unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_error_is_not_tagged_if_already_tagged() {
-        let event_id = EventId::new();
-        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
-            .parse()
-            .unwrap();
-        let request_meta = RequestMeta::new(dsn);
-
-        // We test tagging with an incoming event that has already been tagged by downstream Relay.
-        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
-        let mut item = Item::new(ItemType::Event);
-        item.set_payload(
-            ContentType::Json,
-            r#"{
-              "event_id": "52df9022835246eeb317dbd739ccd059",
-              "exception": {
-                "values": [
-                    {
-                      "type": "mytype",
-                      "value": "myvalue",
-                      "module": "mymodule",
-                      "thread_id": 42,
-                      "other": "value"
-                    }
-                ]
-              },
-              "contexts": {
-                "trace": {
-                    "sampled": true
-                }
-              }
-            }"#,
-        );
-        envelope.add_item(item);
-        let sampling_project_state = project_state_with_single_rule(0.0);
-        let new_envelope = process_envelope_with_root_project_state(
-            envelope,
-            Some(Arc::new(sampling_project_state)),
-        );
-        let event = extract_first_event_from_envelope(new_envelope);
-        let trace_context = event.context::<TraceContext>().unwrap();
-        assert!(trace_context.sampled.value().unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_error_is_tagged_correctly_if_trace_sampling_result_is_none() {
-        let event_id = EventId::new();
-        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
-            .parse()
-            .unwrap();
-        let request_meta = RequestMeta::new(dsn);
-
-        // We test tagging when root project state and dsc are none.
-        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
-        envelope.add_item(mocked_error_item());
-        let new_envelope = process_envelope_with_root_project_state(envelope, None);
-        let event = extract_first_event_from_envelope(new_envelope);
-
-        assert!(event.contexts.value().is_none());
-    }
 
     #[tokio::test]
     async fn test_browser_version_extraction_with_pii_like_data() {
@@ -2705,146 +2147,5 @@ mod tests {
             hardcoded_value, derived_value,
             "Update `MEASUREMENT_MRI_OVERHEAD` if the naming scheme changed."
         );
-    }
-
-    // Helper to extract the sampling match from SamplingResult if thats the variant.
-    fn get_sampling_match(sampling_result: SamplingResult) -> SamplingMatch {
-        if let SamplingResult::Match(sampling_match) = sampling_result {
-            sampling_match
-        } else {
-            panic!()
-        }
-    }
-
-    /// Happy path test for compute_sampling_decision.
-    #[test]
-    fn test_compute_sampling_decision_matching() {
-        let event = mocked_event(EventType::Transaction, "foo", "bar");
-        let rule = SamplingRule {
-            condition: RuleCondition::all(),
-            sampling_value: SamplingValue::SampleRate { value: 1.0 },
-            ty: RuleType::Transaction,
-            id: RuleId(0),
-            time_range: TimeRange::default(),
-            decaying_fn: Default::default(),
-        };
-
-        let sampling_config = SamplingConfig {
-            rules: vec![rule],
-            ..SamplingConfig::new()
-        };
-
-        let res = EnvelopeProcessorService::compute_sampling_decision(
-            false,
-            &dummy_reservoir(),
-            Some(&sampling_config),
-            Some(&event),
-            None,
-            None,
-        );
-        assert!(res.is_match());
-    }
-
-    #[test]
-    fn test_matching_with_unsupported_rule() {
-        let event = mocked_event(EventType::Transaction, "foo", "bar");
-        let rule = SamplingRule {
-            condition: RuleCondition::all(),
-            sampling_value: SamplingValue::SampleRate { value: 1.0 },
-            ty: RuleType::Transaction,
-            id: RuleId(0),
-            time_range: TimeRange::default(),
-            decaying_fn: Default::default(),
-        };
-
-        let unsupported_rule = SamplingRule {
-            condition: RuleCondition::all(),
-            sampling_value: SamplingValue::SampleRate { value: 1.0 },
-            ty: RuleType::Unsupported,
-            id: RuleId(0),
-            time_range: TimeRange::default(),
-            decaying_fn: Default::default(),
-        };
-
-        let sampling_config = SamplingConfig {
-            rules: vec![rule, unsupported_rule],
-            ..SamplingConfig::new()
-        };
-
-        // Unsupported rule should result in no match if processing is not enabled.
-        let res = EnvelopeProcessorService::compute_sampling_decision(
-            false,
-            &dummy_reservoir(),
-            Some(&sampling_config),
-            Some(&event),
-            None,
-            None,
-        );
-        assert!(res.is_no_match());
-
-        // Match if processing is enabled.
-        let res = EnvelopeProcessorService::compute_sampling_decision(
-            true,
-            &dummy_reservoir(),
-            Some(&sampling_config),
-            Some(&event),
-            None,
-            None,
-        );
-        assert!(res.is_match());
-    }
-
-    #[test]
-    fn test_client_sample_rate() {
-        let dsc = DynamicSamplingContext {
-            trace_id: Uuid::new_v4(),
-            public_key: ProjectKey::parse("abd0f232775f45feab79864e580d160b").unwrap(),
-            release: Some("1.1.1".to_string()),
-            user: Default::default(),
-            replay_id: None,
-            environment: None,
-            transaction: Some("transaction1".into()),
-            sample_rate: Some(0.5),
-            sampled: Some(true),
-            other: BTreeMap::new(),
-        };
-
-        let rule = SamplingRule {
-            condition: RuleCondition::all(),
-            sampling_value: SamplingValue::SampleRate { value: 0.2 },
-            ty: RuleType::Trace,
-            id: RuleId(0),
-            time_range: TimeRange::default(),
-            decaying_fn: Default::default(),
-        };
-
-        let mut sampling_config = SamplingConfig {
-            rules: vec![rule],
-            ..SamplingConfig::new()
-        };
-
-        let res = EnvelopeProcessorService::compute_sampling_decision(
-            false,
-            &dummy_reservoir(),
-            None,
-            None,
-            Some(&sampling_config),
-            Some(&dsc),
-        );
-
-        assert_eq!(get_sampling_match(res).sample_rate(), 0.2);
-
-        sampling_config.mode = SamplingMode::Total;
-
-        let res = EnvelopeProcessorService::compute_sampling_decision(
-            false,
-            &dummy_reservoir(),
-            None,
-            None,
-            Some(&sampling_config),
-            Some(&dsc),
-        );
-
-        assert_eq!(get_sampling_match(res).sample_rate(), 0.4);
     }
 }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1542,13 +1542,13 @@ impl EnvelopeProcessorService {
             };
         }
 
-        session::process(state, self.inner.config.clone());
+        session::process(state, &self.inner.config);
         report::process(
             state,
-            self.inner.config.clone(),
+            &self.inner.config,
             self.inner.outcome_aggregator.clone(),
         );
-        replay::process(state, self.inner.config.clone())?;
+        replay::process(state, &self.inner.config)?;
         profile::filter(state);
 
         if state.creates_event() {
@@ -1560,7 +1560,7 @@ impl EnvelopeProcessorService {
                 self.expand_unreal(state)?;
             });
 
-            event::extract(state, self.inner.config.clone())?;
+            event::extract(state, &self.inner.config)?;
             profile::transfer_id(state);
 
             if_processing!({
@@ -1568,7 +1568,7 @@ impl EnvelopeProcessorService {
                 self.create_placeholders(state);
             });
 
-            event::finalize(state, self.inner.config.clone())?;
+            event::finalize(state, &self.inner.config)?;
             self.light_normalize_event(state)?;
             self.normalize_dsc(state);
             self.filter_event(state)?;
@@ -1589,7 +1589,7 @@ impl EnvelopeProcessorService {
 
         if_processing!({
             self.enforce_quotas(state)?;
-            profile::process(state, self.inner.config.clone());
+            profile::process(state, &self.inner.config);
             self.process_check_ins(state);
         });
 

--- a/relay-server/src/actors/processor/dynamic_sampling.rs
+++ b/relay-server/src/actors/processor/dynamic_sampling.rs
@@ -1,0 +1,674 @@
+//! Dynamic sampling processor related code.
+
+use std::ops::ControlFlow;
+
+use chrono::Utc;
+use relay_base_schema::events::EventType;
+use relay_config::Config;
+use relay_dynamic_config::ErrorBoundary;
+use relay_event_schema::protocol::{Contexts, Event, TraceContext};
+use relay_protocol::{Annotated, Empty};
+use relay_sampling::config::{RuleType, SamplingMode};
+use relay_sampling::evaluation::{ReservoirEvaluator, SamplingEvaluator};
+use relay_sampling::{DynamicSamplingContext, SamplingConfig};
+
+use crate::actors::processor::ProcessEnvelopeState;
+use crate::utils::{self, SamplingResult};
+
+/// Ensures there is a valid dynamic sampling context and corresponding project state.
+///
+/// The dynamic sampling context (DSC) specifies the project_key of the project that initiated
+/// the trace. That project state should have been loaded previously by the project cache and is
+/// available on the `ProcessEnvelopeState`. Under these conditions, this cannot happen:
+///
+///  - There is no DSC in the envelope headers. This occurs with older or third-party SDKs.
+///  - The project key does not exist. This can happen if the project key was disabled, the
+///    project removed, or in rare cases when a project from another Sentry instance is referred
+///    to.
+///  - The project key refers to a project from another organization. In this case the project
+///    cache does not resolve the state and instead leaves it blank.
+///  - The project state could not be fetched. This is a runtime error, but in this case Relay
+///    should fall back to the next-best sampling rule set.
+///
+/// In all of the above cases, this function will compute a new DSC using information from the
+/// event payload, similar to how SDKs do this. The `sampling_project_state` is also switched to
+/// the main project state.
+///
+/// If there is no transaction event in the envelope, this function will do nothing.
+pub fn normalize(state: &mut ProcessEnvelopeState) {
+    if state.envelope().dsc().is_some() && state.sampling_project_state.is_some() {
+        return;
+    }
+
+    // The DSC can only be computed if there's a transaction event. Note that `dsc_from_event`
+    // below already checks for the event type.
+    let Some(event) = state.event.value() else {
+        return;
+    };
+    let Some(key_config) = state.project_state.get_public_key_config() else {
+        return;
+    };
+
+    if let Some(dsc) = utils::dsc_from_event(key_config.public_key, event) {
+        state.envelope_mut().set_dsc(dsc);
+        state.sampling_project_state = Some(state.project_state.clone());
+    }
+}
+
+/// Computes the sampling decision on the incoming event
+pub fn run(state: &mut ProcessEnvelopeState, config: &Config) {
+    // Running dynamic sampling involves either:
+    // - Tagging whether an incoming error has a sampled trace connected to it.
+    // - Computing the actual sampling decision on an incoming transaction.
+    match state.event_type().unwrap_or_default() {
+        EventType::Default | EventType::Error => {
+            tag_error_with_sampling_decision(state, config);
+        }
+        EventType::Transaction => {
+            match state.project_state.config.transaction_metrics {
+                Some(ErrorBoundary::Ok(ref c)) if c.is_enabled() => (),
+                _ => return,
+            }
+
+            let sampling_config = match state.project_state.config.sampling {
+                Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
+                _ => None,
+            };
+
+            let root_state = state.sampling_project_state.as_ref();
+            let root_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
+                Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
+                _ => None,
+            };
+
+            state.sampling_result = compute_sampling_decision(
+                config.processing_enabled(),
+                &state.reservoir,
+                sampling_config,
+                state.event.value(),
+                root_config,
+                state.envelope().dsc(),
+            );
+        }
+        _ => {}
+    }
+}
+
+/// Computes the sampling decision on the incoming transaction.
+fn compute_sampling_decision(
+    processing_enabled: bool,
+    reservoir: &ReservoirEvaluator,
+    sampling_config: Option<&SamplingConfig>,
+    event: Option<&Event>,
+    root_sampling_config: Option<&SamplingConfig>,
+    dsc: Option<&DynamicSamplingContext>,
+) -> SamplingResult {
+    if (sampling_config.is_none() || event.is_none())
+        && (root_sampling_config.is_none() || dsc.is_none())
+    {
+        return SamplingResult::NoMatch;
+    }
+
+    if sampling_config.map_or(false, |config| config.unsupported())
+        || root_sampling_config.map_or(false, |config| config.unsupported())
+    {
+        if processing_enabled {
+            relay_log::error!("found unsupported rules even as processing relay");
+        } else {
+            return SamplingResult::NoMatch;
+        }
+    }
+
+    let adjustment_rate = match sampling_config
+        .or(root_sampling_config)
+        .map(|config| config.mode)
+    {
+        Some(SamplingMode::Received) => None,
+        Some(SamplingMode::Total) => dsc.and_then(|dsc| dsc.sample_rate),
+        Some(SamplingMode::Unsupported) => {
+            if processing_enabled {
+                relay_log::error!("found unsupported sampling mode even as processing Relay");
+            }
+            return SamplingResult::NoMatch;
+        }
+        None => {
+            relay_log::error!("cannot sample without at least one sampling config");
+            return SamplingResult::NoMatch;
+        }
+    };
+
+    let mut evaluator = SamplingEvaluator::new(Utc::now())
+        .adjust_client_sample_rate(adjustment_rate)
+        .set_reservoir(reservoir);
+
+    if let (Some(event), Some(sampling_state)) = (event, sampling_config) {
+        if let Some(seed) = event.id.value().map(|id| id.0) {
+            let rules = sampling_state.filter_rules(RuleType::Transaction);
+            evaluator = match evaluator.match_rules(seed, event, rules) {
+                ControlFlow::Continue(evaluator) => evaluator,
+                ControlFlow::Break(sampling_match) => {
+                    return SamplingResult::Match(sampling_match);
+                }
+            }
+        };
+    }
+
+    if let (Some(dsc), Some(sampling_state)) = (dsc, root_sampling_config) {
+        let rules = sampling_state.filter_rules(RuleType::Trace);
+        return evaluator.match_rules(dsc.trace_id, dsc, rules).into();
+    }
+
+    SamplingResult::NoMatch
+}
+
+/// Runs dynamic sampling on an incoming error and tags it in case of successful sampling
+/// decision.
+///
+/// This execution of dynamic sampling is technically a "simulation" since we will use the result
+/// only for tagging errors and not for actually sampling incoming events.
+fn tag_error_with_sampling_decision(state: &mut ProcessEnvelopeState, config: &Config) {
+    let (Some(dsc), Some(event)) = (
+        state.managed_envelope.envelope().dsc(),
+        state.event.value_mut(),
+    ) else {
+        return;
+    };
+
+    let root_state = state.sampling_project_state.as_ref();
+    let sampling_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
+        Some(ErrorBoundary::Ok(ref config)) => config,
+        _ => return,
+    };
+
+    if sampling_config.unsupported() {
+        if config.processing_enabled() {
+            relay_log::error!("found unsupported rules even as processing relay");
+        }
+
+        return;
+    }
+
+    let Some(sampled) = utils::is_trace_fully_sampled(sampling_config, dsc) else {
+        return;
+    };
+
+    // We want to get the trace context, in which we will inject the `sampled` field.
+    let context = event
+        .contexts
+        .get_or_insert_with(Contexts::new)
+        .get_or_default::<TraceContext>();
+
+    // We want to update `sampled` only if it was not set, since if we don't check this
+    // we will end up overriding the value set by downstream Relays and this will lead
+    // to more complex debugging in case of problems.
+    if context.sampled.is_empty() {
+        relay_log::trace!("tagged error with `sampled = {}` flag", sampled);
+        context.sampled = Annotated::new(sampled);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use relay_base_schema::project::{ProjectId, ProjectKey};
+    use relay_event_schema::protocol::{EventId, LenientString};
+    use relay_protocol::RuleCondition;
+    use relay_sampling::config::{
+        DecayingFunction, RuleId, SamplingRule, SamplingValue, TimeRange,
+    };
+    use relay_sampling::evaluation::{ReservoirCounters, SamplingMatch};
+    use uuid::Uuid;
+
+    use crate::actors::processor::ProcessEnvelope;
+    use crate::actors::project::ProjectState;
+    use crate::envelope::{ContentType, Envelope, Item, ItemType};
+    use crate::extractors::RequestMeta;
+    use crate::testutils::{
+        self, create_test_processor, new_envelope, state_with_rule_and_condition,
+    };
+    use crate::utils::{ManagedEnvelope, Semaphore as TestSemaphore};
+
+    use super::*;
+
+    fn mocked_event(event_type: EventType, transaction: &str, release: &str) -> Event {
+        Event {
+            id: Annotated::new(EventId::new()),
+            ty: Annotated::new(event_type),
+            transaction: Annotated::new(transaction.to_string()),
+            release: Annotated::new(LenientString(release.to_string())),
+            ..Event::default()
+        }
+    }
+
+    fn dummy_reservoir() -> ReservoirEvaluator<'static> {
+        ReservoirEvaluator::new(ReservoirCounters::default())
+    }
+
+    // Helper to extract the sampling match from SamplingResult if thats the variant.
+    fn get_sampling_match(sampling_result: SamplingResult) -> SamplingMatch {
+        if let SamplingResult::Match(sampling_match) = sampling_result {
+            sampling_match
+        } else {
+            panic!()
+        }
+    }
+
+    fn process_envelope_with_root_project_state(
+        envelope: Box<Envelope>,
+        sampling_project_state: Option<Arc<ProjectState>>,
+    ) -> Envelope {
+        let processor = create_test_processor(Default::default());
+        let (outcome_aggregator, test_store) = testutils::processor_services();
+
+        let message = ProcessEnvelope {
+            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
+            project_state: Arc::new(ProjectState::allowed()),
+            sampling_project_state,
+            reservoir_counters: ReservoirCounters::default(),
+            global_config: Arc::default(),
+        };
+
+        let envelope_response = processor.process(message).unwrap();
+        let ctx = envelope_response.envelope.unwrap();
+        ctx.envelope().clone()
+    }
+
+    fn extract_first_event_from_envelope(envelope: Envelope) -> Event {
+        let item = envelope.items().next().unwrap();
+        let annotated_event: Annotated<Event> =
+            Annotated::from_json_bytes(&item.payload()).unwrap();
+        annotated_event.into_value().unwrap()
+    }
+
+    fn mocked_error_item() -> Item {
+        let mut item = Item::new(ItemType::Event);
+        item.set_payload(
+            ContentType::Json,
+            r#"{
+              "event_id": "52df9022835246eeb317dbd739ccd059",
+              "exception": {
+                "values": [
+                    {
+                      "type": "mytype",
+                      "value": "myvalue",
+                      "module": "mymodule",
+                      "thread_id": 42,
+                      "other": "value"
+                    }
+                ]
+              }
+            }"#,
+        );
+        item
+    }
+
+    #[tokio::test]
+    async fn test_error_is_tagged_correctly_if_trace_sampling_result_is_none() {
+        let event_id = EventId::new();
+        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
+            .parse()
+            .unwrap();
+        let request_meta = RequestMeta::new(dsn);
+
+        // We test tagging when root project state and dsc are none.
+        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
+        envelope.add_item(mocked_error_item());
+        let new_envelope = process_envelope_with_root_project_state(envelope, None);
+        let event = extract_first_event_from_envelope(new_envelope);
+
+        assert!(event.contexts.value().is_none());
+    }
+
+    #[test]
+    fn test_it_keeps_or_drops_transactions() {
+        let event = Event {
+            id: Annotated::new(EventId::new()),
+            ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("testing".to_owned()),
+            ..Event::default()
+        };
+
+        for (sample_rate, should_keep) in [(0.0, false), (1.0, true)] {
+            let sampling_config = SamplingConfig {
+                rules: vec![SamplingRule {
+                    condition: RuleCondition::all(),
+                    sampling_value: SamplingValue::SampleRate { value: sample_rate },
+                    ty: RuleType::Transaction,
+                    id: RuleId(1),
+                    time_range: Default::default(),
+                    decaying_fn: DecayingFunction::Constant,
+                }],
+                ..SamplingConfig::new()
+            };
+
+            // TODO: This does not test if the sampling decision is actually applied. This should be
+            // refactored to send a proper Envelope in and call process_state to cover the full
+            // pipeline.
+            let res = compute_sampling_decision(
+                false,
+                &dummy_reservoir(),
+                Some(&sampling_config),
+                Some(&event),
+                None,
+                None,
+            );
+            assert_eq!(res.should_keep(), should_keep);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dsc_respects_metrics_extracted() {
+        relay_test::setup();
+        let (outcome_aggregator, test_store) = testutils::processor_services();
+
+        let config = Config::from_json_value(serde_json::json!({
+            "processing": {
+                "enabled": true,
+                "kafka_config": [],
+            }
+        }))
+        .unwrap();
+
+        // Gets a ProcessEnvelopeState, either with or without the metrics_exracted flag toggled.
+        let get_state = |version: Option<u16>| {
+            let event = Event {
+                id: Annotated::new(EventId::new()),
+                ty: Annotated::new(EventType::Transaction),
+                transaction: Annotated::new("testing".to_owned()),
+                ..Event::default()
+            };
+
+            let mut project_state = state_with_rule_and_condition(
+                Some(0.0),
+                RuleType::Transaction,
+                RuleCondition::all(),
+            );
+
+            if let Some(version) = version {
+                project_state.config.transaction_metrics =
+                    ErrorBoundary::Ok(relay_dynamic_config::TransactionMetricsConfig {
+                        version,
+                        ..Default::default()
+                    })
+                    .into();
+            }
+
+            ProcessEnvelopeState {
+                event: Annotated::from(event),
+                metrics: Default::default(),
+                sample_rates: None,
+                sampling_result: SamplingResult::Pending,
+                extracted_metrics: Default::default(),
+                project_state: Arc::new(project_state),
+                sampling_project_state: None,
+                project_id: ProjectId::new(42),
+                managed_envelope: ManagedEnvelope::new(
+                    new_envelope(false, "foo"),
+                    TestSemaphore::new(42).try_acquire().unwrap(),
+                    outcome_aggregator.clone(),
+                    test_store.clone(),
+                ),
+                profile_id: None,
+                event_metrics_extracted: false,
+                reservoir: dummy_reservoir(),
+                global_config: Arc::default(),
+            }
+        };
+
+        // None represents no TransactionMetricsConfig, DS will not be run
+        let mut state = get_state(None);
+        run(&mut state, &config);
+        assert!(state.sampling_result.should_keep());
+
+        // Current version is 1, so it won't run DS if it's outdated
+        let mut state = get_state(Some(0));
+        run(&mut state, &config);
+        assert!(state.sampling_result.should_keep());
+
+        // Dynamic sampling is run, as the transactionmetrics version is up to date.
+        let mut state = get_state(Some(1));
+        run(&mut state, &config);
+        assert!(state.sampling_result.should_drop());
+    }
+
+    fn project_state_with_single_rule(sample_rate: f64) -> ProjectState {
+        let sampling_config = SamplingConfig {
+            rules: vec![SamplingRule {
+                condition: RuleCondition::all(),
+                sampling_value: SamplingValue::SampleRate { value: sample_rate },
+                ty: RuleType::Trace,
+                id: RuleId(1),
+                time_range: Default::default(),
+                decaying_fn: Default::default(),
+            }],
+            ..SamplingConfig::new()
+        };
+
+        let mut sampling_project_state = ProjectState::allowed();
+        sampling_project_state.config.sampling = Some(ErrorBoundary::Ok(sampling_config));
+        sampling_project_state
+    }
+
+    #[tokio::test]
+    async fn test_error_is_tagged_correctly_if_trace_sampling_result_is_some() {
+        let event_id = EventId::new();
+        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
+            .parse()
+            .unwrap();
+        let request_meta = RequestMeta::new(dsn);
+        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
+        let dsc = DynamicSamplingContext {
+            trace_id: Uuid::new_v4(),
+            public_key: ProjectKey::parse("abd0f232775f45feab79864e580d160b").unwrap(),
+            release: Some("1.1.1".to_string()),
+            user: Default::default(),
+            replay_id: None,
+            environment: None,
+            transaction: Some("transaction1".into()),
+            sample_rate: None,
+            sampled: Some(true),
+            other: BTreeMap::new(),
+        };
+        envelope.set_dsc(dsc);
+        envelope.add_item(mocked_error_item());
+
+        // We test with sample rate equal to 100%.
+        let sampling_project_state = project_state_with_single_rule(1.0);
+        let new_envelope = process_envelope_with_root_project_state(
+            envelope.clone(),
+            Some(Arc::new(sampling_project_state)),
+        );
+        let event = extract_first_event_from_envelope(new_envelope);
+        let trace_context = event.context::<TraceContext>().unwrap();
+        assert!(trace_context.sampled.value().unwrap());
+
+        // We test with sample rate equal to 0%.
+        let sampling_project_state = project_state_with_single_rule(0.0);
+        let new_envelope = process_envelope_with_root_project_state(
+            envelope,
+            Some(Arc::new(sampling_project_state)),
+        );
+        let event = extract_first_event_from_envelope(new_envelope);
+        let trace_context = event.context::<TraceContext>().unwrap();
+        assert!(!trace_context.sampled.value().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_error_is_not_tagged_if_already_tagged() {
+        let event_id = EventId::new();
+        let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
+            .parse()
+            .unwrap();
+        let request_meta = RequestMeta::new(dsn);
+
+        // We test tagging with an incoming event that has already been tagged by downstream Relay.
+        let mut envelope = Envelope::from_request(Some(event_id), request_meta);
+        let mut item = Item::new(ItemType::Event);
+        item.set_payload(
+            ContentType::Json,
+            r#"{
+              "event_id": "52df9022835246eeb317dbd739ccd059",
+              "exception": {
+                "values": [
+                    {
+                      "type": "mytype",
+                      "value": "myvalue",
+                      "module": "mymodule",
+                      "thread_id": 42,
+                      "other": "value"
+                    }
+                ]
+              },
+              "contexts": {
+                "trace": {
+                    "sampled": true
+                }
+              }
+            }"#,
+        );
+        envelope.add_item(item);
+        let sampling_project_state = project_state_with_single_rule(0.0);
+        let new_envelope = process_envelope_with_root_project_state(
+            envelope,
+            Some(Arc::new(sampling_project_state)),
+        );
+        let event = extract_first_event_from_envelope(new_envelope);
+        let trace_context = event.context::<TraceContext>().unwrap();
+        assert!(trace_context.sampled.value().unwrap());
+    }
+
+    /// Happy path test for compute_sampling_decision.
+    #[test]
+    fn test_compute_sampling_decision_matching() {
+        let event = mocked_event(EventType::Transaction, "foo", "bar");
+        let rule = SamplingRule {
+            condition: RuleCondition::all(),
+            sampling_value: SamplingValue::SampleRate { value: 1.0 },
+            ty: RuleType::Transaction,
+            id: RuleId(0),
+            time_range: TimeRange::default(),
+            decaying_fn: Default::default(),
+        };
+
+        let sampling_config = SamplingConfig {
+            rules: vec![rule],
+            ..SamplingConfig::new()
+        };
+
+        let res = compute_sampling_decision(
+            false,
+            &dummy_reservoir(),
+            Some(&sampling_config),
+            Some(&event),
+            None,
+            None,
+        );
+        assert!(res.is_match());
+    }
+
+    #[test]
+    fn test_matching_with_unsupported_rule() {
+        let event = mocked_event(EventType::Transaction, "foo", "bar");
+        let rule = SamplingRule {
+            condition: RuleCondition::all(),
+            sampling_value: SamplingValue::SampleRate { value: 1.0 },
+            ty: RuleType::Transaction,
+            id: RuleId(0),
+            time_range: TimeRange::default(),
+            decaying_fn: Default::default(),
+        };
+
+        let unsupported_rule = SamplingRule {
+            condition: RuleCondition::all(),
+            sampling_value: SamplingValue::SampleRate { value: 1.0 },
+            ty: RuleType::Unsupported,
+            id: RuleId(0),
+            time_range: TimeRange::default(),
+            decaying_fn: Default::default(),
+        };
+
+        let sampling_config = SamplingConfig {
+            rules: vec![rule, unsupported_rule],
+            ..SamplingConfig::new()
+        };
+
+        // Unsupported rule should result in no match if processing is not enabled.
+        let res = compute_sampling_decision(
+            false,
+            &dummy_reservoir(),
+            Some(&sampling_config),
+            Some(&event),
+            None,
+            None,
+        );
+        assert!(res.is_no_match());
+
+        // Match if processing is enabled.
+        let res = compute_sampling_decision(
+            true,
+            &dummy_reservoir(),
+            Some(&sampling_config),
+            Some(&event),
+            None,
+            None,
+        );
+        assert!(res.is_match());
+    }
+
+    #[test]
+    fn test_client_sample_rate() {
+        let dsc = DynamicSamplingContext {
+            trace_id: Uuid::new_v4(),
+            public_key: ProjectKey::parse("abd0f232775f45feab79864e580d160b").unwrap(),
+            release: Some("1.1.1".to_string()),
+            user: Default::default(),
+            replay_id: None,
+            environment: None,
+            transaction: Some("transaction1".into()),
+            sample_rate: Some(0.5),
+            sampled: Some(true),
+            other: BTreeMap::new(),
+        };
+
+        let rule = SamplingRule {
+            condition: RuleCondition::all(),
+            sampling_value: SamplingValue::SampleRate { value: 0.2 },
+            ty: RuleType::Trace,
+            id: RuleId(0),
+            time_range: TimeRange::default(),
+            decaying_fn: Default::default(),
+        };
+
+        let mut sampling_config = SamplingConfig {
+            rules: vec![rule],
+            ..SamplingConfig::new()
+        };
+
+        let res = compute_sampling_decision(
+            false,
+            &dummy_reservoir(),
+            None,
+            None,
+            Some(&sampling_config),
+            Some(&dsc),
+        );
+
+        assert_eq!(get_sampling_match(res).sample_rate(), 0.2);
+
+        sampling_config.mode = SamplingMode::Total;
+
+        let res = compute_sampling_decision(
+            false,
+            &dummy_reservoir(),
+            None,
+            None,
+            Some(&sampling_config),
+            Some(&dsc),
+        );
+
+        assert_eq!(get_sampling_match(res).sample_rate(), 0.4);
+    }
+}

--- a/relay-server/src/actors/processor/event.rs
+++ b/relay-server/src/actors/processor/event.rs
@@ -1,5 +1,4 @@
 use std::error::Error;
-use std::sync::Arc;
 
 use chrono::Duration as SignedDuration;
 use once_cell::sync::OnceCell;
@@ -34,10 +33,7 @@ use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
 ///  3. Attachments `__sentry-event` and `__sentry-breadcrumb1/2`.
 ///  4. A multipart form data body.
 ///  5. If none match, `Annotated::empty()`.
-pub fn extract(
-    state: &mut ProcessEnvelopeState,
-    config: Arc<Config>,
-) -> Result<(), ProcessingError> {
+pub fn extract(state: &mut ProcessEnvelopeState, config: &Config) -> Result<(), ProcessingError> {
     let envelope = &mut state.envelope_mut();
 
     // Remove all items first, and then process them. After this function returns, only
@@ -108,7 +104,7 @@ pub fn extract(
         })?
     } else if attachment_item.is_some() || breadcrumbs1.is_some() || breadcrumbs2.is_some() {
         relay_log::trace!("extracting attached event data");
-        event_from_attachments(config.as_ref(), attachment_item, breadcrumbs1, breadcrumbs2)?
+        event_from_attachments(config, attachment_item, breadcrumbs1, breadcrumbs2)?
     } else if let Some(item) = form_item {
         relay_log::trace!("extracting form data");
         let len = item.len();
@@ -130,10 +126,7 @@ pub fn extract(
     Ok(())
 }
 
-pub fn finalize(
-    state: &mut ProcessEnvelopeState,
-    config: Arc<Config>,
-) -> Result<(), ProcessingError> {
+pub fn finalize(state: &mut ProcessEnvelopeState, config: &Config) -> Result<(), ProcessingError> {
     let is_transaction = state.event_type() == Some(EventType::Transaction);
     let envelope = state.managed_envelope.envelope_mut();
 

--- a/relay-server/src/actors/processor/profile.rs
+++ b/relay-server/src/actors/processor/profile.rs
@@ -1,10 +1,7 @@
 //! Profiles related processor code.
 
 #[cfg(feature = "processing")]
-use {
-    crate::envelope::ContentType, relay_config::Config, relay_dynamic_config::Feature,
-    std::sync::Arc,
-};
+use {crate::envelope::ContentType, relay_config::Config, relay_dynamic_config::Feature};
 
 use relay_base_schema::events::EventType;
 use relay_event_schema::protocol::{Contexts, ProfileContext};
@@ -68,7 +65,7 @@ pub fn transfer_id(state: &mut ProcessEnvelopeState) {
 
 /// Processes profiles and set the profile ID in the profile context on the transaction if successful.
 #[cfg(feature = "processing")]
-pub fn process(state: &mut ProcessEnvelopeState, config: Arc<Config>) {
+pub fn process(state: &mut ProcessEnvelopeState, config: &Config) {
     let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
     let mut found_profile_id = None;
     state.managed_envelope.retain_items(|item| match item.ty() {

--- a/relay-server/src/actors/processor/replay.rs
+++ b/relay-server/src/actors/processor/replay.rs
@@ -2,7 +2,6 @@
 
 use std::error::Error;
 use std::net::IpAddr;
-use std::sync::Arc;
 
 use bytes::Bytes;
 use relay_config::Config;
@@ -23,10 +22,7 @@ use crate::statsd::RelayTimers;
 use crate::utils::ItemAction;
 
 /// Removes replays if the feature flag is not enabled.
-pub fn process(
-    state: &mut ProcessEnvelopeState,
-    config: Arc<Config>,
-) -> Result<(), ProcessingError> {
+pub fn process(state: &mut ProcessEnvelopeState, config: &Config) -> Result<(), ProcessingError> {
     let project_state = &state.project_state;
     let replays_enabled = project_state.has_feature(Feature::SessionReplay);
     let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);

--- a/relay-server/src/actors/processor/report.rs
+++ b/relay-server/src/actors/processor/report.rs
@@ -2,7 +2,6 @@
 
 use std::collections::BTreeMap;
 use std::error::Error;
-use std::sync::Arc;
 
 use chrono::{Duration as SignedDuration, Utc};
 use relay_common::time::UnixTimestamp;
@@ -48,7 +47,7 @@ pub enum ClientReportField {
 /// system.
 pub fn process(
     state: &mut ProcessEnvelopeState,
-    config: Arc<Config>,
+    config: &Config,
     outcome_aggregator: Addr<TrackOutcome>,
 ) {
     process_client_reports(state, config, outcome_aggregator);
@@ -136,7 +135,7 @@ fn outcome_from_parts(field: ClientReportField, reason: &str) -> Result<Outcome,
 /// system.
 fn process_client_reports(
     state: &mut ProcessEnvelopeState,
-    config: Arc<Config>,
+    config: &Config,
     outcome_aggregator: Addr<TrackOutcome>,
 ) {
     // if client outcomes are disabled we leave the the client reports unprocessed
@@ -280,6 +279,8 @@ fn process_client_reports(
 
 #[cfg(test)]
 mod tests {
+
+    use std::sync::Arc;
 
     use relay_event_schema::protocol::EventId;
     use relay_sampling::config::RuleId;

--- a/relay-server/src/actors/processor/session.rs
+++ b/relay-server/src/actors/processor/session.rs
@@ -2,7 +2,6 @@
 
 use std::error::Error;
 use std::net;
-use std::sync::Arc;
 
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use relay_config::Config;
@@ -23,7 +22,7 @@ use crate::utils::ItemAction;
 ///
 /// Both are removed from the envelope if they contain invalid JSON or if their timestamps
 /// are out of range after clock drift correction.
-pub fn process(state: &mut ProcessEnvelopeState, config: Arc<Config>) {
+pub fn process(state: &mut ProcessEnvelopeState, config: &Config) {
     let received = state.managed_envelope.received_at();
     let extracted_metrics = &mut state.extracted_metrics.project_metrics;
     let metrics_config = state.project_state.config().session_metrics;
@@ -38,7 +37,7 @@ pub fn process(state: &mut ProcessEnvelopeState, config: Arc<Config>) {
         let should_keep = match item.ty() {
             ItemType::Session => process_session(
                 item,
-                config.clone(),
+                config,
                 received,
                 client.as_deref(),
                 client_addr,
@@ -48,7 +47,7 @@ pub fn process(state: &mut ProcessEnvelopeState, config: Arc<Config>) {
             ),
             ItemType::Sessions => process_session_aggregates(
                 item,
-                config.clone(),
+                config,
                 received,
                 client.as_deref(),
                 client_addr,
@@ -134,7 +133,7 @@ fn is_valid_session_timestamp(
 #[allow(clippy::too_many_arguments)]
 fn process_session(
     item: &mut Item,
-    config: Arc<Config>,
+    config: &Config,
     received: DateTime<Utc>,
     client: Option<&str>,
     client_addr: Option<net::IpAddr>,
@@ -243,7 +242,7 @@ fn process_session(
 #[allow(clippy::too_many_arguments)]
 fn process_session_aggregates(
     item: &mut Item,
-    config: Arc<Config>,
+    config: &Config,
     received: DateTime<Utc>,
     client: Option<&str>,
     client_addr: Option<net::IpAddr>,
@@ -352,7 +351,7 @@ mod tests {
         fn run_session_producer(&mut self) -> bool {
             process_session(
                 &mut self.item,
-                Arc::new(Config::default()),
+                &Config::default(),
                 self.received,
                 self.client,
                 self.client_addr,

--- a/relay-server/src/actors/processor/unreal.rs
+++ b/relay-server/src/actors/processor/unreal.rs
@@ -18,7 +18,7 @@ use crate::utils;
 /// this includes cases where a single attachment file exceeds the maximum file size. This is in
 /// line with the behavior of the envelope endpoint.
 ///
-/// After this, [`EnvelopeProcessorService`] should be able to process the envelope the same
+/// After this, [`crate::actors::processor::EnvelopeProcessorService`] should be able to process the envelope the same
 /// way it processes any other envelopes.
 pub fn expand(state: &mut ProcessEnvelopeState, config: &Config) -> Result<(), ProcessingError> {
     let envelope = &mut state.envelope_mut();

--- a/relay-server/src/actors/processor/unreal.rs
+++ b/relay-server/src/actors/processor/unreal.rs
@@ -1,0 +1,40 @@
+//! Unreal 4 processort related code.
+//!
+//! These functions are included only in the processing mode.
+
+use relay_config::Config;
+
+use crate::actors::processor::{ProcessEnvelopeState, ProcessingError};
+use crate::envelope::ItemType;
+use crate::utils;
+
+/// Expands Unreal 4 items inside an envelope.
+///
+/// If the envelope does NOT contain an `UnrealReport` item, it doesn't do anything. If the
+/// envelope contains an `UnrealReport` item, it removes it from the envelope and inserts new
+/// items for each of its contents.
+///
+/// The envelope may be dropped if it exceeds size limits after decompression. Particularly,
+/// this includes cases where a single attachment file exceeds the maximum file size. This is in
+/// line with the behavior of the envelope endpoint.
+///
+/// After this, [`EnvelopeProcessorService`] should be able to process the envelope the same
+/// way it processes any other envelopes.
+pub fn expand(state: &mut ProcessEnvelopeState, config: &Config) -> Result<(), ProcessingError> {
+    let envelope = &mut state.envelope_mut();
+
+    if let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::UnrealReport) {
+        utils::expand_unreal_envelope(item, envelope, config)?;
+    }
+
+    Ok(())
+}
+
+/// Extracts event information from an unreal context.
+///
+/// If the event does not contain an unreal context, this function does not perform any action.
+/// If there was no event payload prior to this function, it is created.
+pub fn process(state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+    utils::process_unreal_envelope(&mut state.event, state.managed_envelope.envelope_mut())
+        .map_err(ProcessingError::InvalidUnrealReport)
+}


### PR DESCRIPTION
This PR contains few following changes:

* moves `unreal` processor related code into separate sub-module
* moves `dynamic sampling` processor related code (and also related tests) into separate sub-module
* instead of cloning and passing the `Arc<Config>` just use `&Config` for all sub-modules

#skip-changelog