### PR TITLE
feat(metrics): Add size limits for metric envelope items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Return global config ready status to downstream relays. ([#2765](https://github.com/getsentry/relay/pull/2765))
 - Add Mixed JS/Android Profiles events processing. ([#2706](https://github.com/getsentry/relay/pull/2706))
 - Allow to ingest measurements on a span. ([#2792](https://github.com/getsentry/relay/pull/2792))
+- Add size limits on metric related envelope items. ([#2800](https://github.com/getsentry/relay/pull/2800))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -563,6 +563,12 @@ struct Limits {
     max_profile_size: ByteSize,
     /// The maximum payload size for a span.
     max_span_size: ByteSize,
+    /// The maximum payload size for a stasd metric.
+    max_statsd_size: ByteSize,
+    /// The maximum payload size for metric buckets.
+    max_metric_buckets_size: ByteSize,
+    /// The maximum payload size for metric metadata.
+    max_metric_meta_size: ByteSize,
     /// The maximum payload size for a compressed replay.
     max_replay_compressed_size: ByteSize,
     /// The maximum payload size for an uncompressed replay.
@@ -604,6 +610,9 @@ impl Default for Limits {
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
             max_profile_size: ByteSize::mebibytes(50),
             max_span_size: ByteSize::mebibytes(1),
+            max_statsd_size: ByteSize::kibibytes(100),
+            max_metric_buckets_size: ByteSize::mebibytes(1),
+            max_metric_meta_size: ByteSize::mebibytes(1),
             max_replay_compressed_size: ByteSize::mebibytes(10),
             max_replay_uncompressed_size: ByteSize::mebibytes(100),
             max_replay_message_size: ByteSize::mebibytes(15),
@@ -1926,6 +1935,21 @@ impl Config {
     /// Returns the maximum number of sessions per envelope.
     pub fn max_session_count(&self) -> usize {
         self.values.limits.max_session_count
+    }
+
+    /// Returns the maximum payload size of a statsd metric in bytes.
+    pub fn max_statsd_size(&self) -> usize {
+        self.values.limits.max_statsd_size.as_bytes()
+    }
+
+    /// Returns the maximum payload size of metric buckets in bytes.
+    pub fn max_metric_buckets_size(&self) -> usize {
+        self.values.limits.max_metric_buckets_size.as_bytes()
+    }
+
+    /// Returns the maximum payload size of metric metadata in bytes.
+    pub fn max_metric_meta_size(&self) -> usize {
+        self.values.limits.max_metric_meta_size.as_bytes()
     }
 
     /// Returns the maximum payload size for general API requests.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -563,7 +563,7 @@ struct Limits {
     max_profile_size: ByteSize,
     /// The maximum payload size for a span.
     max_span_size: ByteSize,
-    /// The maximum payload size for a stasd metric.
+    /// The maximum payload size for a statsd metric.
     max_statsd_size: ByteSize,
     /// The maximum payload size for metric buckets.
     max_metric_buckets_size: ByteSize,
@@ -610,7 +610,7 @@ impl Default for Limits {
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
             max_profile_size: ByteSize::mebibytes(50),
             max_span_size: ByteSize::mebibytes(1),
-            max_statsd_size: ByteSize::kibibytes(100),
+            max_statsd_size: ByteSize::mebibytes(1),
             max_metric_buckets_size: ByteSize::mebibytes(1),
             max_metric_meta_size: ByteSize::mebibytes(1),
             max_replay_compressed_size: ByteSize::mebibytes(10),

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -11,11 +11,17 @@ use crate::utils::{ItemAction, ManagedEnvelope};
 ///
 /// The following limits are checked:
 ///
-///  - `max_event_size`
 ///  - `max_attachment_size`
 ///  - `max_attachments_size`
-///  - `max_session_count`
+///  - `max_check_in_size`
+///  - `max_event_size`
+///  - `max_metric_buckets_size`
+///  - `max_metric_meta_size`
 ///  - `max_profile_size`
+///  - `max_replay_compressed_size`
+///  - `max_session_count`
+///  - `max_span_size`
+///  - `max_statsd_size`
 pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool {
     let mut event_size = 0;
     let mut attachments_size = 0;
@@ -63,9 +69,21 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> bool 
                 }
             }
             ItemType::UserReport => (),
-            ItemType::Statsd => (),
-            ItemType::MetricBuckets => (),
-            ItemType::MetricMeta => (),
+            ItemType::Statsd => {
+                if item.len() > config.max_statsd_size() {
+                    return false;
+                }
+            }
+            ItemType::MetricBuckets => {
+                if item.len() > config.max_metric_buckets_size() {
+                    return false;
+                }
+            }
+            ItemType::MetricMeta => {
+                if item.len() > config.max_metric_meta_size() {
+                    return false;
+                }
+            }
             ItemType::Span => {
                 if item.len() > config.max_span_size() {
                     return false;


### PR DESCRIPTION
Introduce the missing size limits for the metric envelope items.