### PR TITLE
ref(config): Cleanup metric config

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -517,7 +517,7 @@ impl Default for Metrics {
     }
 }
 
-/// Controls processing of metrics and metric metadata.
+/// Controls processing of Sentry metrics and metric metadata.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 struct SentryMetrics {

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -185,7 +185,7 @@ def test_metrics_max_batch_size(mini_sentry, relay, max_batch_size, expected_eve
             "debounce_delay": 0,
             "max_secs_in_past": forever,
             "max_secs_in_future": forever,
-            "max_flush_bytes": max_batch_size,
+            "flush_max_batch_size": max_batch_size,
         },
     }
     relay = relay(mini_sentry, options=relay_config)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -185,7 +185,7 @@ def test_metrics_max_batch_size(mini_sentry, relay, max_batch_size, expected_eve
             "debounce_delay": 0,
             "max_secs_in_past": forever,
             "max_secs_in_future": forever,
-            "flush_max_batch_size": max_batch_size,
+            "max_flush_bytes": max_batch_size,
         },
     }
     relay = relay(mini_sentry, options=relay_config)


### PR DESCRIPTION
The metric metadata config is a brand new config for a very experimental feature (we can assume no one uses it), unfortunately I wasn't careful and added it to the `metrics:` key, which is already being used for statsd metrics emitted by relay, not related to metric processing.

#skip-changelog