### PR TITLE
feat(spans): Extract size metrics for all resource spans when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Return global config ready status to downstream relays. ([#2765](https://github.com/getsentry/relay/pull/2765))
 - Add Mixed JS/Android Profiles events processing. ([#2706](https://github.com/getsentry/relay/pull/2706))
 - Allow to ingest measurements on a span. ([#2792](https://github.com/getsentry/relay/pull/2792))
+- Extract size metrics for all resource spans when permitted. ([#2805](https://github.com/getsentry/relay/pull/2805))
 
 **Internal**:
 


### PR DESCRIPTION
When the `all_modules` option is enabled, we update the `resource_condition` to allow extracting the size metrics for all `resource` spans and not just `script` and `css` ones.