### PR TITLE
feat(ai): add LLM token metric span metric extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Extract size metrics for all resource spans when permitted. ([#2805](https://github.com/getsentry/relay/pull/2805))
 - Add size limits on metric related envelope items. ([#2800](https://github.com/getsentry/relay/pull/2800))
 - Include the size offending item in the size limit error message. ([#2801](https://github.com/getsentry/relay/pull/2801))
+- Ingest token metrics data for OpenAI completion calls. ([#2816](https://github.com/getsentry/relay/pull/2816))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -154,7 +154,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             condition: Some(RuleCondition::eq("span.op", "ai.llm.completion")),
             tags: [
                 ("span.sentry_tags.", "group"),
-                ("span.sentry_tags.", "description"),
                 ("span.sentry_tags.", "op"),
                 ("span.data.", "language_model"),
                 ("span.sentry_tags.", "environment"),
@@ -174,7 +173,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             condition: Some(RuleCondition::eq("span.op", "ai.llm.completion")),
             tags: [
                 ("span.sentry_tags.", "group"),
-                ("span.sentry_tags.", "description"),
                 ("span.sentry_tags.", "op"),
                 ("span.data.", "language_model"),
                 ("span.sentry_tags.", "environment"),
@@ -194,7 +192,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             condition: Some(RuleCondition::eq("span.op", "ai.llm.completion")),
             tags: [
                 ("span.sentry_tags.", "group"),
-                ("span.sentry_tags.", "description"),
                 ("span.sentry_tags.", "op"),
                 ("span.data.", "language_model"),
                 ("span.sentry_tags.", "environment"),

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -83,6 +83,7 @@ pub(crate) fn scrub_span_description(span: &Span) -> Option<String> {
                 Some(description.to_owned())
             }
             ("file", _) => scrub_file(description),
+            ("ai", _) => Some(description.to_owned()),
             _ => None,
         })
 }
@@ -771,6 +772,13 @@ mod tests {
     );
 
     span_description_test!(db_prisma, "User find", "db.sql.prisma", "User find");
+
+    span_description_test!(
+        ai_llm_completion,
+        "Here is a prompt",
+        "ai.llm.completion",
+        "Here is a prompt"
+    );
 
     #[test]
     fn informed_sql_parser() {


### PR DESCRIPTION
As part of our LLM monitoring, we are capturing token counter metrics from Open AI completion spans. These three metrics are `prompt`, `completion`, and `total`. These numbers will be added to the span data fields. It is unclear if `total` is needed, as it is just a sum of `prompt` and `completion`, but we can always drop it if doing a sum query is trivial there.

We are tagging these counters with:

`group, description, op, language_model, environment, transaction`.

Note that any field with the word `token` is by default scrubbed, so we are going with `tken`. We can map this back to `Token` either in the UI, or if we build out specific product oriented API endpoints, we can do it there. 


This is intended for an Internal Release, so only the Sentry org will be sending these spans.

See spec document here: https://www.notion.so/sentry/LLM-v0-Tech-Spec-81a1aaae56b54c0e93606edcd882cfcd
Part of https://github.com/getsentry/getsentry/issues/12171


The associated SDK change is here for now https://github.com/getsentry/sentry/pull/61086