### PR TITLE
feat(protocol): Implement Getter for request.headers

### DIFF
--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -771,6 +771,13 @@ impl Getter for Event {
                     self.extra_at(rest)?.into()
                 } else if let Some(rest) = path.strip_prefix("tags.") {
                     self.tags.value()?.get(rest)?.into()
+                } else if let Some(rest) = path.strip_prefix("request.headers.") {
+                    self.request
+                        .value()?
+                        .headers
+                        .value()?
+                        .get_header(rest)?
+                        .into()
                 } else {
                     return None;
                 }


### PR DESCRIPTION
This exposes `request.headers` via `Getter` so that it can be accessed in metric
extraction and dynamic sampling. The product needs to access the `Referer`
header.

Note that the referer is a common attribute which will be extracted into a
dedicated field in a separate PR.

#skip-changelog

