### PR TITLE
feat(spans): Extract `os.name` tag on mobile spans

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -187,7 +187,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 ("", "ttfd"),
                 ("", "ttid"),
                 ("span.", "main_thread"),
-                ("", "platform"),
+                ("", "os.name"),
             ]
             .map(|(prefix, key)| TagSpec {
                 key: format!("{prefix}{key}"),

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -187,6 +187,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 ("", "ttfd"),
                 ("", "ttid"),
                 ("span.", "main_thread"),
+                ("", "platform"),
             ]
             .map(|(prefix, key)| TagSpec {
                 key: format!("{prefix}{key}"),

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -32,8 +32,8 @@ pub enum SpanTagKey {
     // `"true"` if the transaction was sent by a mobile SDK.
     Mobile,
     DeviceClass,
-    // Mobile platform the transaction originated from.
-    Platform,
+    // Mobile OS the transaction originated from.
+    OsName,
 
     // Specific to spans
     Action,
@@ -89,7 +89,7 @@ impl SpanTagKey {
             SpanTagKey::TimeToInitialDisplay => "ttid",
             SpanTagKey::FileExtension => "file_extension",
             SpanTagKey::MainTread => "main_thread",
-            SpanTagKey::Platform => "platform",
+            SpanTagKey::OsName => "os.name",
         }
     }
 }
@@ -208,10 +208,7 @@ pub fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
         if event.context::<AppContext>().is_some() {
             if let Some(os_context) = event.context::<OsContext>() {
                 if let Some(os_name) = os_context.name.value() {
-                    tags.insert(
-                        SpanTagKey::Platform,
-                        os_name.to_string().to_lowercase().to_owned(),
-                    );
+                    tags.insert(SpanTagKey::OsName, os_name.to_string());
                 }
             }
         }
@@ -1066,7 +1063,7 @@ LIMIT 1
 
         let tags = span.value().unwrap().sentry_tags.value().unwrap();
         assert_eq!(tags.get("main_thread").unwrap().as_str(), Some("true"));
-        assert_eq!(tags.get("platform").unwrap().as_str(), Some("android"));
+        assert_eq!(tags.get("os.name").unwrap().as_str(), Some("Android"));
 
         let span = &event.spans.value().unwrap()[1];
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -205,6 +205,9 @@ pub fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
     if MOBILE_SDKS.contains(&event.sdk_name()) {
         tags.insert(SpanTagKey::Mobile, "true".to_owned());
 
+        // Check if app context exists. This tells us if the span originated from
+        // an app (as opposed to mobile browser) since we are currently focused on
+        // app use cases for mobile.
         if event.context::<AppContext>().is_some() {
             if let Some(os_context) = event.context::<OsContext>() {
                 if let Some(os_name) = os_context.name.value() {

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1038,7 +1038,7 @@ mod tests {
         let json = r#"
         {
             "type": "transaction",
-            "sdk": {"name": "sentry.cocoa"},
+            "sdk": {"name": "sentry.javascript.react-native"},
             "start_timestamp": "2021-04-26T07:59:01+0100",
             "timestamp": "2021-04-26T08:00:00+0100",
             "release": "1.2.3",
@@ -1052,6 +1052,14 @@ mod tests {
                 "device": {
                     "family": "iOS",
                     "model": "iPhone1,1"
+                },
+                "app": {
+                    "app_identifier": "org.reactjs.native.example.RnDiffApp",
+                    "app_name": "RnDiffApp"
+                },
+                "os": {
+                    "name": "iOS",
+                    "version": "16.2"
                 }
             },
             "spans": [

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -32,7 +32,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "device.class": "1",
                 "mobile": "true",
                 "op": "default",
-                "platform": "ios",
+                "os.name": "iOS",
                 "release": "1.2.3",
                 "transaction": "gEt /api/:version/users/",
                 "transaction.method": "GET",
@@ -54,7 +54,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             ),
             tags: {
                 "device.class": "1",
-                "platform": "ios",
+                "os.name": "iOS",
                 "release": "1.2.3",
                 "span.op": "default",
                 "transaction": "gEt /api/:version/users/",
@@ -72,7 +72,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             ),
             tags: {
                 "device.class": "1",
-                "platform": "ios",
+                "os.name": "iOS",
                 "release": "1.2.3",
                 "span.op": "default",
                 "transaction.method": "GET",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -32,6 +32,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "device.class": "1",
                 "mobile": "true",
                 "op": "default",
+                "platform": "ios",
                 "release": "1.2.3",
                 "transaction": "gEt /api/:version/users/",
                 "transaction.method": "GET",
@@ -53,6 +54,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             ),
             tags: {
                 "device.class": "1",
+                "platform": "ios",
                 "release": "1.2.3",
                 "span.op": "default",
                 "transaction": "gEt /api/:version/users/",
@@ -70,6 +72,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             ),
             tags: {
                 "device.class": "1",
+                "platform": "ios",
                 "release": "1.2.3",
                 "span.op": "default",
                 "transaction.method": "GET",


### PR DESCRIPTION
We need to tag "platform" mobile spans originated from, specifically for cross platform use cases. 
Cross platform apps (React Native and Flutter) can run on Apple and Android phones, so we want
to be able to differentiate which os the span originated from.
We don't want to just limit this to `sentry.javascript.react-native` or `sentry.dart.flutter` SDKs
because it is possible users can initialize a Native SDK in addition to the hybdrid SDKs for a
particular project.

We already [extract](https://github.com/getsentry/relay/blob/master/relay-server/src/metrics_extraction/transactions/mod.rs#L174) os.name on transaction metrics so os.name exists on [indexer/strings.py](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_metrics/indexer/strings.py#L128).

To determine the "platform" a mobile span originated from:
1. check if contexts.app exists - this tells us if the span originated from an app (as opposed to mobile browser - since we are currently focused on app use cases only)
2. extract the value on `os.name` (iOS, Android) on the os context

#skip-changelog