### PR TITLE
feat(spans): Allow ingestion of metrics summary on spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Temporarily add metric summaries on spans and top-level transaction events to link DDM with performance monitoring. ([#2757](https://github.com/getsentry/relay/pull/2757))
 - Add size limits on metric related envelope items. ([#2800](https://github.com/getsentry/relay/pull/2800))
 - Include the size offending item in the size limit error message. ([#2801](https://github.com/getsentry/relay/pull/2801))
+- Allow ingestion of metrics summary on spans. ([#2823](https://github.com/getsentry/relay/pull/2823))
 
 ## 23.11.2
 

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -2265,6 +2265,7 @@ mod tests {
                 sentry_tags: ~,
                 received: ~,
                 measurements: ~,
+                _metrics_summary: ~,
                 other: {},
             },
         ]
@@ -2307,6 +2308,7 @@ mod tests {
                 sentry_tags: ~,
                 received: ~,
                 measurements: ~,
+                _metrics_summary: ~,
                 other: {},
             },
         ]
@@ -2349,6 +2351,7 @@ mod tests {
                 sentry_tags: ~,
                 received: ~,
                 measurements: ~,
+                _metrics_summary: ~,
                 other: {},
             },
         ]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -94,8 +94,8 @@ pub struct Span {
     pub other: Object<Value>,
 }
 
-impl From<&Event> for Span {
-    fn from(event: &Event) -> Self {
+impl From<&mut Event> for Span {
+    fn from(event: &mut Event) -> Self {
         let mut span = Self {
             description: event.transaction.clone(),
             is_segment: Some(true).into(),
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn span_from_event() {
-        let event = Annotated::<Event>::from_json(
+        let mut event = Annotated::<Event>::from_json(
             r#"{
                 "contexts": {
                     "profile": {"profile_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab"},
@@ -273,7 +273,7 @@ mod tests {
         .into_value()
         .unwrap();
 
-        assert_debug_snapshot!(Span::from(&event), @r###"
+        assert_debug_snapshot!(Span::from(&mut event), @r###"
         Span {
             timestamp: ~,
             start_timestamp: ~,

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -94,8 +94,8 @@ pub struct Span {
     pub other: Object<Value>,
 }
 
-impl From<&mut Event> for Span {
-    fn from(event: &mut Event) -> Self {
+impl From<&Event> for Span {
+    fn from(event: &Event) -> Self {
         let mut span = Self {
             description: event.transaction.clone(),
             is_segment: Some(true).into(),
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn span_from_event() {
-        let mut event = Annotated::<Event>::from_json(
+        let event = Annotated::<Event>::from_json(
             r#"{
                 "contexts": {
                     "profile": {"profile_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab"},
@@ -273,7 +273,7 @@ mod tests {
         .into_value()
         .unwrap();
 
-        assert_debug_snapshot!(Span::from(&mut event), @r###"
+        assert_debug_snapshot!(Span::from(&event), @r###"
         Span {
             timestamp: ~,
             start_timestamp: ~,

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -81,6 +81,13 @@ pub struct Span {
     #[metastructure(omit_from_schema)] // we only document error events for now
     pub measurements: Annotated<Measurements>,
 
+    /// Temporary protocol support for metric summaries.
+    ///
+    /// This shall move to a stable location once we have stabilized the
+    /// interface.  This is intentionally not typed today.
+    #[metastructure(skip_serialization = "empty")]
+    pub _metrics_summary: Annotated<Value>,
+
     // TODO remove retain when the api stabilizes
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
@@ -95,6 +102,7 @@ impl From<&Event> for Span {
             received: event.received.clone(),
             start_timestamp: event.start_timestamp.clone(),
             timestamp: event.timestamp.clone(),
+            _metrics_summary: event._metrics_summary.clone(),
             ..Default::default()
         };
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -253,6 +253,19 @@ mod tests {
                         "span_id": "FA90FDEAD5F74052",
                         "type": "trace"
                     }
+                },
+                "_metrics_summary": {
+                    "some_metric": [
+                        {
+                            "min": 1.0,
+                            "max": 2.0,
+                            "sum": 3.0,
+                            "count": 2,
+                            "tags": {
+                                "environment": "test"
+                            }
+                        }
+                    ]
                 }
             }"#,
         )
@@ -288,7 +301,37 @@ mod tests {
             sentry_tags: ~,
             received: ~,
             measurements: ~,
-            _metrics_summary: ~,
+            _metrics_summary: Object(
+                {
+                    "some_metric": Array(
+                        [
+                            Object(
+                                {
+                                    "count": I64(
+                                        2,
+                                    ),
+                                    "max": F64(
+                                        2.0,
+                                    ),
+                                    "min": F64(
+                                        1.0,
+                                    ),
+                                    "sum": F64(
+                                        3.0,
+                                    ),
+                                    "tags": Object(
+                                        {
+                                            "environment": String(
+                                                "test",
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                    ),
+                },
+            ),
             other: {},
         }
         "###);

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -288,6 +288,7 @@ mod tests {
             sentry_tags: ~,
             received: ~,
             measurements: ~,
+            _metrics_summary: ~,
             other: {},
         }
         "###);

--- a/relay-server/src/actors/processor/span/processing.rs
+++ b/relay-server/src/actors/processor/span/processing.rs
@@ -1,6 +1,5 @@
 //! Contains the processing-only functionality.
 
-use std::collections::BTreeSet;
 use std::error::Error;
 use std::sync::Arc;
 
@@ -8,10 +7,9 @@ use chrono::{DateTime, Utc};
 use relay_base_schema::events::EventType;
 use relay_config::Config;
 use relay_dynamic_config::{ErrorBoundary, Feature, ProjectConfig};
-use relay_event_normalization::span::attributes;
 use relay_event_normalization::span::tag_extraction;
 use relay_event_schema::processor::{process_value, ProcessingState};
-use relay_event_schema::protocol::{Span, SpanAttribute};
+use relay_event_schema::protocol::Span;
 use relay_metrics::{aggregator::AggregatorConfig, MetricNamespace, UnixTimestamp};
 use relay_pii::PiiProcessor;
 use relay_protocol::{Annotated, Empty};

--- a/relay-server/src/actors/processor/span/processing.rs
+++ b/relay-server/src/actors/processor/span/processing.rs
@@ -149,11 +149,9 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState) {
         .has_feature(Feature::SpanMetricsExtraction);
     let custom_metrics_enabled = state.project_state.has_feature(Feature::CustomMetrics);
 
-    let Some(event) = state.event.value_mut() else {
+    let Some(event) = state.event.value() else {
         return;
     };
-
-    attributes::normalize_spans(event, &BTreeSet::from([SpanAttribute::ExclusiveTime]));
 
     let extract_transaction_span = span_metrics_extraction_enabled
         || (custom_metrics_enabled && !event._metrics_summary.is_empty());

--- a/relay-server/src/actors/processor/span/processing.rs
+++ b/relay-server/src/actors/processor/span/processing.rs
@@ -157,13 +157,13 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState) {
             return;
         };
 
-        // Extract transaction as a span.
-        let mut transaction_span: Span = event.into();
-
         // Metrics summary is empty so we don't need to ingest the span.
-        if transaction_span._metrics_summary.is_empty() {
+        if event._metrics_summary.is_empty() {
             return;
         }
+
+        // Extract transaction as a span.
+        let mut transaction_span: Span = event.into();
 
         // Extract tags to add to this span as well
         let shared_tags = tag_extraction::extract_shared_tags(event);

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -38,6 +38,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             },
             received: ~,
             measurements: ~,
+            _metrics_summary: ~,
             other: {},
         },
     ],

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -40,6 +40,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             },
             received: ~,
             measurements: ~,
+            _metrics_summary: ~,
             other: {},
         },
         Span {

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -573,6 +573,7 @@ mod tests {
                 sentry_tags: ~,
                 received: ~,
                 measurements: ~,
+                _metrics_summary: ~,
                 other: {},
             },
         ]

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1580,3 +1580,66 @@ def test_span_ingestion(
             "retention_days": 90,
         },
     ]
+
+
+def test_span_extraction_with_ddm(
+    mini_sentry,
+    relay_with_processing,
+    spans_consumer,
+):
+    spans_consumer = spans_consumer()
+
+    relay = relay_with_processing()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:custom-metrics",
+    ]
+
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    metrics_summary = {
+        "c:spans/some_metric@none": [
+            {
+                "min": 1.0,
+                "max": 2.0,
+                "sum": 3.0,
+                "count": 4,
+                "tags": {
+                    "environment": "test",
+                },
+            },
+        ],
+    }
+    event["_metrics_summary"] = metrics_summary
+
+    relay.send_event(project_id, event)
+
+    transaction_span = spans_consumer.get_span()
+    del transaction_span["start_time"]
+    del transaction_span["span"]["received"]
+    assert transaction_span == {
+        "event_id": "cbf6960622e14a45abc1f03b2055b186",
+        "project_id": 42,
+        "organization_id": 1,
+        "retention_days": 90,
+        "span": {
+            "description": "hi",
+            "exclusive_time": 2000.0,
+            "is_segment": True,
+            "op": "hi",
+            "segment_id": "968cff94913ebb07",
+            "sentry_tags": {"transaction": "hi", "transaction.op": "hi"},
+            "span_id": "968cff94913ebb07",
+            "start_timestamp": datetime.fromisoformat(event["start_timestamp"])
+            .replace(tzinfo=timezone.utc)
+            .timestamp(),
+            "status": "unknown",
+            "timestamp": datetime.fromisoformat(event["timestamp"])
+            .replace(tzinfo=timezone.utc)
+            .timestamp(),
+            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+            "_metrics_summary": metrics_summary,
+        },
+    }
+
+    spans_consumer.assert_empty()

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1592,6 +1592,7 @@ def test_span_extraction_with_ddm(
     relay = relay_with_processing()
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["spanAttributes"] = ["exclusive-time"]
     project_config["config"]["features"] = [
         "organizations:custom-metrics",
     ]


### PR DESCRIPTION
In order to ingest metrics summary on spans, we need to add the field to the protocol and copy it during extraction.

On top of that, since span extraction is not always enabled when DDM is, we check if we need to persist the span by looking if it contains a non-empty metrics summary value and then persist the span if it does.