### PR TITLE
debug(spool): Add metrics and report an error

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -431,7 +431,7 @@ impl OnDisk {
                 tags.project_id = %envelope.meta().project_id().unwrap_or(ProjectId::new(0)),
                 event_id = ?envelope.event_id(),
                 duration = ?start_time_instant.elapsed(),
-                "Spooled envelope spent more than 1 hour in on-disk spool"
+                "Spooled envelope spent more than 2 hours in on-disk spool"
             );
         }
 

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -423,8 +423,8 @@ impl OnDisk {
             timer(RelayTimers::EnvelopeOnDiskBufferTime) = start_time_instant.elapsed()
         );
 
-        // If envelope stays longer than an 2 hours in on-disk spool, produce an error, so we could
-        // debug what kind of envelope is that.
+        // If an envelope stays longer than 2 hours in on-disk spool, produce an error, so we could
+        // debug what kind of envelope it is.
         if start_time_instant.elapsed() > Duration::from_secs(7200) {
             relay_log::error!(
                 tags.project_key = %envelope.meta().public_key(),

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -243,7 +243,7 @@ pub enum RelayTimers {
     /// Total time in milliseconds an envelope spends in Relay from the time it is received until it
     /// finishes processing and has been submitted to the upstream.
     EnvelopeTotalTime,
-    /// Total time in milliseconds and envelope spends in the Relay on disk buffer.
+    /// Total time in milliseconds an envelope spends in the Relay's on-disk buffer.
     EnvelopeOnDiskBufferTime,
     /// Total time in milliseconds spent evicting outdated and unused projects happens.
     ProjectStateEvictionDuration,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -243,6 +243,8 @@ pub enum RelayTimers {
     /// Total time in milliseconds an envelope spends in Relay from the time it is received until it
     /// finishes processing and has been submitted to the upstream.
     EnvelopeTotalTime,
+    /// Total time in milliseconds and envelope spends in the Relay on disk buffer.
+    EnvelopeOnDiskBufferTime,
     /// Total time in milliseconds spent evicting outdated and unused projects happens.
     ProjectStateEvictionDuration,
     /// Total time in milliseconds spent fetching queued project configuration updates requests to
@@ -351,6 +353,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::EnvelopeWaitTime => "event.wait_time",
             RelayTimers::EnvelopeProcessingTime => "event.processing_time",
             RelayTimers::EnvelopeTotalTime => "event.total_time",
+            RelayTimers::EnvelopeOnDiskBufferTime => "envelope.on_disk_buffer_time",
             RelayTimers::ProjectStateEvictionDuration => "project_state.eviction.duration",
             RelayTimers::ProjectStateRequestDuration => "project_state.request.duration",
             #[cfg(feature = "processing")]


### PR DESCRIPTION
Let's track the timings how long the envelope took to unspool. 
Also add error if the envelope was spooled longer than 2 hours.

Note: This can be chatty in case of the long lasting incident, but this way we will be able to see if any of the envelopes are stuck in the spool, and cannot be unspooled anymore. 
  
This is temporary and just to help with debugging of the on-disk spool. 

related to https://github.com/getsentry/team-ingest/issues/257

#skip-changelog