### PR TITLE
test(integration): Extend test timeout duration

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -799,7 +799,7 @@ def test_transaction_metrics_count_per_root_project(
 
     event, _ = transactions_consumer.get_event()
 
-    metrics_by_project = metrics_by_name_group_by_project(metrics_consumer, timeout=2)
+    metrics_by_project = metrics_by_name_group_by_project(metrics_consumer, timeout=4)
 
     assert metrics_by_project[41]["c:transactions/count_per_root_project@none"] == {
         "timestamp": int(timestamp.timestamp()),


### PR DESCRIPTION
This test has been flaky for some time due to metric messages not always arriving on time. This PR adds some additional time to unflake it.

#skip-changelog