### PR TITLE
chore(spans): Only tag `ttid` & `ttfd` with `exclusive_time` metric

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -184,8 +184,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             tags: [
                 ("", "device.class"),
                 ("", "release"),
-                ("", "ttfd"),
-                ("", "ttid"),
                 ("span.", "main_thread"),
                 ("", "os.name"),
             ]
@@ -196,6 +194,17 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 condition: Some(RuleCondition::eq("span.sentry_tags.mobile", "true")),
             })
             .into(),
+        },
+        TagMapping {
+            metrics: vec![LazyGlob::new("d:spans/exclusive_time@millisecond".into())],
+            tags: [("", "ttfd"), ("", "ttid")]
+                .map(|(prefix, key)| TagSpec {
+                    key: format!("{prefix}{key}"),
+                    field: Some(format!("span.sentry_tags.{}", key)),
+                    value: None,
+                    condition: Some(RuleCondition::eq("span.sentry_tags.mobile", "true")),
+                })
+                .into(),
         },
         // Resource-specific tags:
         TagMapping {

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -181,23 +181,18 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         // Mobile-specific tags:
         TagMapping {
             metrics: vec![LazyGlob::new("d:spans/exclusive_time*@millisecond".into())],
-            tags: [
-                ("", "device.class"),
-                ("", "release"),
-                ("span.", "main_thread"),
-                ("", "os.name"),
-            ]
-            .map(|(prefix, key)| TagSpec {
-                key: format!("{prefix}{key}"),
-                field: Some(format!("span.sentry_tags.{}", key)),
-                value: None,
-                condition: Some(RuleCondition::eq("span.sentry_tags.mobile", "true")),
-            })
-            .into(),
+            tags: ["device.class", "release", "os.name"]
+                .map(|key| TagSpec {
+                    key: key.to_owned(),
+                    field: Some(format!("span.sentry_tags.{}", key)),
+                    value: None,
+                    condition: Some(RuleCondition::eq("span.sentry_tags.mobile", "true")),
+                })
+                .into(),
         },
         TagMapping {
             metrics: vec![LazyGlob::new("d:spans/exclusive_time@millisecond".into())],
-            tags: [("", "ttfd"), ("", "ttid")]
+            tags: [("", "ttfd"), ("", "ttid"), ("span.", "main_thread")]
                 .map(|(prefix, key)| TagSpec {
                     key: format!("{prefix}{key}"),
                     field: Some(format!("span.sentry_tags.{}", key)),

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1216,9 +1216,12 @@ mod tests {
 
         assert!(!metrics.is_empty());
         for metric in metrics {
-            if metric.name == "c:spans/count_per_op@none"
-                || metric.name == "d:spans/exclusive_time_light@millisecond"
-            {
+            if metric.name == "c:spans/count_per_op@none" {
+                continue;
+            }
+            if metric.name == "d:spans/exclusive_time_light@millisecond" {
+                assert!(!metric.tags.contains_key("ttid"));
+                assert!(!metric.tags.contains_key("ttfd"));
                 continue;
             }
             assert_eq!(metric.tag("ttid"), Some("ttid"));

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1068,6 +1068,13 @@ mod tests {
                     "start_timestamp": 1597976300.0000000,
                     "timestamp": 1597976302.0000000,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81"
+                },
+                {
+                    "op": "ui.load.initial_display",
+                    "span_id": "bd429c44b67a3eb2",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976303.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81"
                 }
             ]
         }
@@ -1209,7 +1216,9 @@ mod tests {
 
         assert!(!metrics.is_empty());
         for metric in metrics {
-            if metric.name == "c:spans/count_per_op@none" {
+            if metric.name == "c:spans/count_per_op@none"
+                || metric.name == "d:spans/exclusive_time_light@millisecond"
+            {
                 continue;
             }
             assert_eq!(metric.tag("ttid"), Some("ttid"));

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -36,6 +36,45 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "release": "1.2.3",
                 "transaction": "gEt /api/:version/users/",
                 "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+            received: ~,
+            measurements: ~,
+            other: {},
+        },
+        Span {
+            timestamp: Timestamp(
+                2020-08-21T02:18:23Z,
+            ),
+            start_timestamp: Timestamp(
+                2020-08-21T02:18:20Z,
+            ),
+            exclusive_time: 3000.0,
+            description: ~,
+            op: "ui.load.initial_display",
+            span_id: SpanId(
+                "bd429c44b67a3eb2",
+            ),
+            parent_span_id: ~,
+            trace_id: TraceId(
+                "ff62a8b040f340bda5d830223def1d81",
+            ),
+            segment_id: ~,
+            is_segment: ~,
+            status: ~,
+            tags: ~,
+            origin: ~,
+            profile_id: ~,
+            data: ~,
+            sentry_tags: {
+                "device.class": "1",
+                "mobile": "true",
+                "op": "ui.load.initial_display",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
             },
             received: ~,
             measurements: ~,
@@ -59,6 +98,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "span.op": "default",
                 "transaction": "gEt /api/:version/users/",
                 "transaction.method": "GET",
+                "ttid": "ttid",
             },
         },
         Bucket {
@@ -87,6 +127,53 @@ expression: "(&event.value().unwrap().spans, metrics)"
             ),
             tags: {
                 "span.op": "default",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.op": "ui.load.initial_display",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time_light@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.op": "ui.load.initial_display",
+                "transaction.method": "GET",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_op@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "span.op": "ui.load.initial_display",
             },
         },
     ],


### PR DESCRIPTION
The ttid, ttfd and span.main_thread tag will never need exclusive_time_light since the 
tags will only ever be used in the context of a "transaction".
Updated snapshot test to show an `exclusive_time_light` bucket
isn't created.

#skip-changelog