### PR TITLE
ref(metrics): Store MRI instead of String on metrics Bucket

### DIFF
--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -31,7 +31,7 @@ impl MetricInput {
             let key_id = i % self.num_project_keys;
             let metric_name = format!("c:transactions/foo{}", i % self.num_metric_names);
             let mut bucket = self.bucket.clone();
-            bucket.name = metric_name;
+            bucket.name = metric_name.parse().unwrap();
             let key = ProjectKey::parse(&format!("{key_id:0width$x}", width = 32)).unwrap();
             rv.push((key, bucket));
         }
@@ -64,7 +64,7 @@ fn bench_insert_and_flush(c: &mut Criterion) {
     let counter = Bucket {
         timestamp: UnixTimestamp::now(),
         width: 0,
-        name: "c:transactions/foo@none".to_owned(),
+        name: "c:transactions/foo@none".parse().unwrap(),
         value: BucketValue::counter(42.),
         tags: BTreeMap::new(),
     };

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -460,7 +460,7 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
-            name: "c:transactions/foo".to_owned(),
+            name: "c:transactions/foo".parse().unwrap(),
             value: BucketValue::counter(42.),
             tags: BTreeMap::new(),
         }

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -2,7 +2,10 @@ use relay_common::time::UnixTimestamp;
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::Serialize;
 
-use crate::{aggregator, CounterType, DistributionType, GaugeValue, SetType, SetValue};
+use crate::{
+    aggregator, CounterType, DistributionType, GaugeValue, MetricResourceIdentifier, SetType,
+    SetValue,
+};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Range;
@@ -350,7 +353,7 @@ impl<'a> BucketView<'a> {
     /// Name of the bucket.
     ///
     /// See also: [`Bucket::name`]
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &MetricResourceIdentifier<'static> {
         &self.inner.name
     }
 
@@ -813,13 +816,13 @@ b3:42:75|s"#;
         assert!(!view.is_empty());
         let partials = view.iter().collect::<Vec<_>>();
         assert_eq!(partials.len(), 4);
-        assert_eq!(partials[0].name(), "c:custom/b0@none");
+        assert_eq!(&partials[0].name().to_string(), "c:custom/b0@none");
         assert_eq!(partials[0].len(), 1);
-        assert_eq!(partials[1].name(), "c:custom/b1@none");
+        assert_eq!(&partials[1].name().to_string(), "c:custom/b1@none");
         assert_eq!(partials[1].len(), 1);
-        assert_eq!(partials[2].name(), "d:custom/b2@none");
+        assert_eq!(&partials[2].name().to_string(), "d:custom/b2@none");
         assert_eq!(partials[2].len(), 5);
-        assert_eq!(partials[3].name(), "s:custom/b3@none");
+        assert_eq!(&partials[3].name().to_string(), "s:custom/b3@none");
         assert_eq!(partials[3].len(), 2);
     }
 
@@ -844,11 +847,11 @@ b3:42:75|s"#;
 
         let partials = view.iter().collect::<Vec<_>>();
         assert_eq!(partials.len(), 3);
-        assert_eq!(partials[0].name(), "c:custom/b0@none");
+        assert_eq!(&partials[0].name().to_string(), "c:custom/b0@none");
         assert_eq!(partials[0].len(), 1);
-        assert_eq!(partials[1].name(), "c:custom/b1@none");
+        assert_eq!(&partials[1].name().to_string(), "c:custom/b1@none");
         assert_eq!(partials[1].len(), 1);
-        assert_eq!(partials[2].name(), "d:custom/b2@none");
+        assert_eq!(&partials[2].name().to_string(), "d:custom/b2@none");
         assert_eq!(partials[2].len(), 3);
     }
 
@@ -873,9 +876,9 @@ b3:42:75|s"#;
 
         let partials = view.iter().collect::<Vec<_>>();
         assert_eq!(partials.len(), 2);
-        assert_eq!(partials[0].name(), "d:custom/b2@none");
+        assert_eq!(&partials[0].name().to_string(), "d:custom/b2@none");
         assert_eq!(partials[0].len(), 2);
-        assert_eq!(partials[1].name(), "s:custom/b3@none");
+        assert_eq!(&partials[1].name().to_string(), "s:custom/b3@none");
         assert_eq!(partials[1].len(), 2);
     }
 
@@ -902,9 +905,9 @@ b3:42:75|s"#;
 
         let partials = view.iter().collect::<Vec<_>>();
         assert_eq!(partials.len(), 2);
-        assert_eq!(partials[0].name(), "d:custom/b2@none");
+        assert_eq!(&partials[0].name().to_string(), "d:custom/b2@none");
         assert_eq!(partials[0].len(), 4);
-        assert_eq!(partials[1].name(), "s:custom/b3@none");
+        assert_eq!(&partials[1].name().to_string(), "s:custom/b3@none");
         assert_eq!(partials[1].len(), 1);
     }
 

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -583,7 +583,7 @@ impl StoreService {
                 MetricKafkaMessage {
                     org_id,
                     project_id,
-                    name: bucket.name,
+                    name: bucket.name.to_string(),
                     value: bucket.value,
                     timestamp: bucket.timestamp,
                     tags: bucket.tags,

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1201,7 +1201,7 @@ mod tests {
 
         assert!(!metrics.is_empty());
         for metric in metrics {
-            if metric.name == "c:spans/count_per_op@none" {
+            if metric.name == "c:spans/count_per_op@none".parse().unwrap() {
                 continue;
             }
             assert_eq!(metric.tag("ttid"), Some("ttid"));

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -44,17 +44,17 @@ where
 
         // Parse the MRI so that we can obtain the type, but subsequently re-serialize it into the
         // generated metric to ensure the MRI is normalized.
-        let Ok(mri) = MetricResourceIdentifier::parse(&metric_spec.mri) else {
+        let Ok(name) = MetricResourceIdentifier::parse(&metric_spec.mri) else {
             relay_log::error!(mri = metric_spec.mri, "invalid MRI for metric extraction");
             continue;
         };
 
-        let Some(value) = read_metric_value(instance, metric_spec.field.as_deref(), mri.ty) else {
+        let Some(value) = read_metric_value(instance, metric_spec.field.as_deref(), name.ty) else {
             continue;
         };
 
         metrics.push(Bucket {
-            name: mri.to_string(),
+            name: name.into_owned(),
             width: 0,
             value,
             timestamp,
@@ -76,7 +76,7 @@ where
         let mut lazy_tags = None;
 
         for metric in &mut *metrics {
-            if mapping.matches(&metric.name) {
+            if mapping.matches(&metric.name.to_string()) {
                 let tags = lazy_tags.get_or_insert_with(|| extract_tags(instance, &mapping.tags));
 
                 for (key, val) in tags {

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -238,7 +238,10 @@ mod tests {
 
         let session_metric = &metrics[0];
         assert_eq!(session_metric.timestamp, started());
-        assert_eq!(session_metric.name, "c:sessions/session@none");
+        assert_eq!(
+            session_metric.name,
+            "c:sessions/session@none".parse().unwrap()
+        );
         assert!(matches!(session_metric.value, BucketValue::Counter(_)));
         assert_eq!(session_metric.tags["session.status"], "init");
         assert_eq!(session_metric.tags["release"], "1.0.0");
@@ -246,7 +249,7 @@ mod tests {
 
         let user_metric = &metrics[1];
         assert_eq!(user_metric.timestamp, started());
-        assert_eq!(user_metric.name, "s:sessions/user@none");
+        assert_eq!(user_metric.name, "s:sessions/user@none".parse().unwrap());
         assert!(matches!(user_metric.value, BucketValue::Set(_)));
         assert!(!user_metric.tags.contains_key("session.status"));
         assert_eq!(user_metric.tags["release"], "1.0.0");
@@ -275,7 +278,7 @@ mod tests {
         // A none-initial update which is not errored/crashed/abnormal will only emit a user metric.
         assert_eq!(metrics.len(), 1);
         let user_metric = &metrics[0];
-        assert_eq!(user_metric.name, "s:sessions/user@none");
+        assert_eq!(user_metric.name, "s:sessions/user@none".parse().unwrap());
         assert!(matches!(user_metric.value, BucketValue::Set(_)));
         assert!(!user_metric.tags.contains_key("session.status"));
     }
@@ -315,13 +318,16 @@ mod tests {
 
             let session_metric = &metrics[expected_metrics - 2];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(session_metric.name, "s:sessions/error@none");
+            assert_eq!(
+                session_metric.name,
+                "s:sessions/error@none".parse().unwrap()
+            );
             assert!(matches!(session_metric.value, BucketValue::Set(_)));
             assert_eq!(session_metric.tags.len(), 1); // Only the release tag
 
             let user_metric = &metrics[expected_metrics - 1];
             assert_eq!(user_metric.timestamp, started());
-            assert_eq!(user_metric.name, "s:sessions/user@none");
+            assert_eq!(user_metric.name, "s:sessions/user@none".parse().unwrap());
             assert!(matches!(user_metric.value, BucketValue::Set(_)));
             assert_eq!(user_metric.tags["session.status"], "errored");
             assert_eq!(user_metric.tags["release"], "1.0.0");
@@ -350,19 +356,22 @@ mod tests {
 
         assert_eq!(metrics.len(), 4);
 
-        assert_eq!(metrics[0].name, "s:sessions/error@none");
-        assert_eq!(metrics[1].name, "s:sessions/user@none");
+        assert_eq!(metrics[0].name, "s:sessions/error@none".parse().unwrap());
+        assert_eq!(metrics[1].name, "s:sessions/user@none".parse().unwrap());
         assert_eq!(metrics[1].tags["session.status"], "errored");
 
         let session_metric = &metrics[2];
         assert_eq!(session_metric.timestamp, started());
-        assert_eq!(session_metric.name, "c:sessions/session@none");
+        assert_eq!(
+            session_metric.name,
+            "c:sessions/session@none".parse().unwrap()
+        );
         assert!(matches!(session_metric.value, BucketValue::Counter(_)));
         assert_eq!(session_metric.tags["session.status"], "crashed");
 
         let user_metric = &metrics[3];
         assert_eq!(user_metric.timestamp, started());
-        assert_eq!(user_metric.name, "s:sessions/user@none");
+        assert_eq!(user_metric.name, "s:sessions/user@none".parse().unwrap());
         assert!(matches!(user_metric.value, BucketValue::Set(_)));
         assert_eq!(user_metric.tags["session.status"], "crashed");
     }
@@ -401,13 +410,16 @@ mod tests {
 
             assert_eq!(metrics.len(), 4);
 
-            assert_eq!(metrics[0].name, "s:sessions/error@none");
-            assert_eq!(metrics[1].name, "s:sessions/user@none");
+            assert_eq!(metrics[0].name, "s:sessions/error@none".parse().unwrap());
+            assert_eq!(metrics[1].name, "s:sessions/user@none".parse().unwrap());
             assert_eq!(metrics[1].tags["session.status"], "errored");
 
             let session_metric = &metrics[2];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(session_metric.name, "c:sessions/session@none");
+            assert_eq!(
+                session_metric.name,
+                "c:sessions/session@none".parse().unwrap()
+            );
             assert!(matches!(session_metric.value, BucketValue::Counter(_)));
             assert_eq!(session_metric.tags["session.status"], "abnormal");
 
@@ -417,7 +429,7 @@ mod tests {
 
             let user_metric = &metrics[3];
             assert_eq!(user_metric.timestamp, started());
-            assert_eq!(user_metric.name, "s:sessions/user@none");
+            assert_eq!(user_metric.name, "s:sessions/user@none".parse().unwrap());
             assert!(matches!(user_metric.value, BucketValue::Set(_)));
             assert_eq!(user_metric.tags["session.status"], "abnormal");
 

--- a/relay-server/src/metrics_extraction/sessions/types.rs
+++ b/relay-server/src/metrics_extraction/sessions/types.rs
@@ -111,7 +111,7 @@ impl IntoMetric for SessionMetric {
             }
         };
 
-        let mri = MetricResourceIdentifier {
+        let name = MetricResourceIdentifier {
             ty: value.ty(),
             namespace: MetricNamespace::Sessions,
             name: name.into(),
@@ -121,7 +121,7 @@ impl IntoMetric for SessionMetric {
         Bucket {
             timestamp,
             width: 0,
-            name: mri.to_string(),
+            name,
             value,
             tags,
         }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -992,10 +992,13 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| m.name == "d:transactions/duration@millisecond".parse().unwrap())
             .unwrap();
 
-        assert_eq!(duration_metric.name, "d:transactions/duration@millisecond");
+        assert_eq!(
+            duration_metric.name,
+            "d:transactions/duration@millisecond".parse().unwrap()
+        );
         assert_eq!(duration_metric.value, BucketValue::distribution(59000.0));
 
         assert_eq!(duration_metric.tags.len(), 4);
@@ -1173,7 +1176,7 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| m.name == "d:transactions/duration@millisecond".parse().unwrap())
             .unwrap();
 
         assert_eq!(
@@ -1212,7 +1215,7 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| m.name == "d:transactions/duration@millisecond".parse().unwrap())
             .unwrap();
 
         assert_eq!(
@@ -1359,7 +1362,7 @@ mod tests {
         let buckets_by_name = extracted
             .project_metrics
             .into_iter()
-            .map(|Bucket { name, tags, .. }| (name, tags))
+            .map(|Bucket { name, tags, .. }| (name.to_string(), tags))
             .collect::<BTreeMap<_, _>>();
         assert_eq!(
             buckets_by_name["d:transactions/measurements.frames_frozen@none"]["device.class"],
@@ -1392,7 +1395,7 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| m.name == "d:transactions/duration@millisecond".parse().unwrap())
             .unwrap();
 
         duration_metric.tags.get("transaction").cloned()

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -107,7 +107,7 @@ impl IntoMetric for TransactionMetric {
             ),
         };
 
-        let mri = MetricResourceIdentifier {
+        let name = MetricResourceIdentifier {
             ty: value.ty(),
             namespace,
             name,
@@ -117,7 +117,7 @@ impl IntoMetric for TransactionMetric {
         Bucket {
             timestamp,
             width: 0,
-            name: mri.to_string(),
+            name,
             value,
             tags,
         }

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -1,9 +1,7 @@
 //! Quota and rate limiting helpers for metrics and metrics buckets.
 use chrono::{DateTime, Utc};
 use relay_common::time::UnixTimestamp;
-use relay_metrics::{
-    Bucket, BucketView, BucketViewValue, MetricNamespace, MetricResourceIdentifier,
-};
+use relay_metrics::{Bucket, BucketView, BucketViewValue, MetricNamespace};
 use relay_quotas::{DataCategory, ItemScoping, Quota, RateLimits, Scoping};
 use relay_system::Addr;
 
@@ -48,14 +46,7 @@ pub fn extract_transaction_count(
     metric: &BucketView<'_>,
     mode: ExtractionMode,
 ) -> Option<TransactionCount> {
-    let mri = match MetricResourceIdentifier::parse(metric.name()) {
-        Ok(mri) => mri,
-        Err(_) => {
-            relay_log::error!("invalid MRI: {}", metric.name());
-            return None;
-        }
-    };
-
+    let mri = metric.name();
     if mri.namespace != MetricNamespace::Transactions {
         return None;
     }
@@ -308,7 +299,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".parse().unwrap(),
                 tags: Default::default(),
                 value: BucketValue::distribution(123.0),
             },
@@ -316,7 +307,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".parse().unwrap(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(456.0),
             },
@@ -324,7 +315,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".parse().unwrap(),
                 tags: Default::default(),
                 value: BucketValue::counter(1.0),
             },
@@ -332,7 +323,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".parse().unwrap(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::counter(1.0),
             },
@@ -340,7 +331,7 @@ mod tests {
                 // unrelated metric
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "something_else".to_string(),
+                name: "something_else".parse().unwrap(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(123.0),
             },
@@ -396,7 +387,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".parse().unwrap(),
                 tags: Default::default(),
                 value: BucketValue::distribution(123.0),
             },
@@ -404,7 +395,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".parse().unwrap(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(456.0),
             },
@@ -412,7 +403,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".parse().unwrap(),
                 tags: Default::default(),
                 value: BucketValue::counter(1.0),
             },
@@ -420,7 +411,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".parse().unwrap(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::counter(1.0),
             },
@@ -428,7 +419,7 @@ mod tests {
                 // unrelated metric
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "something_else".to_string(),
+                name: "something_else".parse().unwrap(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(123.0),
             },


### PR DESCRIPTION
Store the parsed MRI in the Bucket instead of the plain string. We re-parse the MRI in multiple spots which means we always have to do the error handling even though this will never fail.

Storing the MRI instead of the string form allows us to get rid of the surplus parses and just generally gives us more assertions and information in the type system.

#skip-changelog