### PR TITLE
chore(gocd): Bumping gocd-jsonnet version

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.5.1"
+      "version": "v2.7"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "22b351221458e2d9add1014d6230e76f1bdd40c1",
-      "sum": "gF65Dh1Po+61V0CV5F05UFDEki0Z4ov4739GZXShqcM="
+      "version": "97af8955747da4f68ce4f70a5128b4e53956e9b2",
+      "sum": "qQiTUU6BkUbKBGblpBppxFBewhIqqQaWlz01ZTGEpi4="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumping to v2.7 of gocd-jsonnet which removes customer-5 as we are getting rid of it.

#skip-changelog
