### PR TITLE
ref(spans): List metric tags explicitly

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -1,11 +1,10 @@
 use relay_base_schema::data_category::DataCategory;
-use relay_common::glob2::LazyGlob;
 use relay_event_normalization::utils::MAX_DURATION_MOBILE_MS;
 use relay_protocol::RuleCondition;
 use serde_json::Number;
 
 use crate::feature::Feature;
-use crate::metrics::{MetricExtractionConfig, MetricSpec, TagMapping, TagSpec};
+use crate::metrics::{MetricExtractionConfig, MetricSpec};
 use crate::project::ProjectConfig;
 use crate::Tag;
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -128,6 +128,9 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 Tag::with_key("device.class")
                     .from_field("span.sentry_tags.device.class")
                     .when(mobile_condition.clone()),
+                Tag::with_key("os.name") // TODO: might not be needed on both `exclusive_time` metrics
+                    .from_field("span.sentry_tags.os.name")
+                    .when(mobile_condition.clone()),
                 Tag::with_key("release")
                     .from_field("span.sentry_tags.release")
                     .when(mobile_condition.clone()),
@@ -189,6 +192,9 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 // Mobile:
                 Tag::with_key("device.class")
                     .from_field("span.sentry_tags.device.class")
+                    .when(mobile_condition.clone()),
+                Tag::with_key("os.name") // TODO: might not be needed on both `exclusive_time` metrics
+                    .from_field("span.sentry_tags.os.name")
                     .when(mobile_condition.clone()),
                 Tag::with_key("release")
                     .from_field("span.sentry_tags.release")

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -76,170 +76,8 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             "span.exclusive_time",
             Number::from_f64(MAX_DURATION_MOBILE_MS).unwrap_or(0.into()),
         );
-
-    // config.metrics.extend([
-    //     MetricSpec {
-    //         category: DataCategory::Span,
-    //         mri: "d:spans/exclusive_time@millisecond".into(),
-    //         field: Some("span.exclusive_time".into()),
-    //         condition: Some(span_op_conditions.clone() & duration_condition.clone()),
-    //         tags: vec![TagSpec {
-    //             key: "transaction".into(),
-    //             field: Some("span.sentry_tags.transaction".into()),
-    //             value: None,
-    //             condition: None,
-    //         }],
-    //     },
-    //     MetricSpec {
-    //         category: DataCategory::Span,
-    //         mri: "d:spans/exclusive_time_light@millisecond".into(),
-    //         field: Some("span.exclusive_time".into()),
-    //         condition: Some(span_op_conditions.clone() & duration_condition.clone()),
-    //         tags: Default::default(),
-    //     },
-    //     MetricSpec {
-    //         category: DataCategory::Span,
-    //         mri: "d:spans/http.response_content_length@byte".into(),
-    //         field: Some("span.data.http\\.response_content_length".into()),
-    //         condition: Some(
-    //             span_op_conditions.clone()
-    //                 & resource_condition.clone()
-    //                 & RuleCondition::gt("span.data.http\\.response_content_length", 0),
-    //         ),
-    //         tags: Default::default(),
-    //     },
-    //     MetricSpec {
-    //         category: DataCategory::Span,
-    //         mri: "d:spans/http.decoded_response_content_length@byte".into(),
-    //         field: Some("span.data.http\\.decoded_response_content_length".into()),
-    //         condition: Some(
-    //             span_op_conditions.clone()
-    //                 & resource_condition.clone()
-    //                 & RuleCondition::gt("span.data.http\\.decoded_response_content_length", 0),
-    //         ),
-    //         tags: Default::default(),
-    //     },
-    //     MetricSpec {
-    //         category: DataCategory::Span,
-    //         mri: "d:spans/http.response_transfer_size@byte".into(),
-    //         field: Some("span.data.http\\.response_transfer_size".into()),
-    //         condition: Some(
-    //             span_op_conditions.clone()
-    //                 & resource_condition.clone()
-    //                 & RuleCondition::gt("span.data.http\\.response_transfer_size", 0),
-    //         ),
-    //         tags: Default::default(),
-    //     },
-    //     MetricSpec {
-    //         category: DataCategory::Span,
-    //         mri: "c:spans/count_per_op@none".into(),
-    //         field: None,
-    //         condition: Some(duration_condition.clone()),
-    //         tags: ["category", "op", "system"]
-    //             .map(|key| TagSpec {
-    //                 key: format!("span.{key}"),
-    //                 field: Some(format!("span.sentry_tags.{key}")),
-    //                 value: None,
-    //                 condition: None,
-    //             })
-    //             .into(),
-    //     },
-    // ]);
-
-    config.tags.extend([
-        TagMapping {
-            metrics: vec![LazyGlob::new("d:spans/exclusive_time*@millisecond".into())],
-            tags: [
-                ("", "environment"),
-                ("", "transaction.method"),
-                ("", "transaction.op"),
-                ("span.", "action"),
-                ("span.", "category"),
-                ("span.", "description"),
-                ("span.", "domain"),
-                ("span.", "group"),
-                ("span.", "module"),
-                ("span.", "op"),
-                ("span.", "status_code"),
-                ("span.", "system"),
-            ]
-            .map(|(prefix, key)| TagSpec {
-                key: format!("{prefix}{key}"),
-                field: Some(format!("span.sentry_tags.{}", key)),
-                value: None,
-                condition: None,
-            })
-            .into_iter()
-            // Tags taken directly from the span payload:
-            .chain(std::iter::once(TagSpec {
-                key: "span.status".into(),
-                field: Some("span.status".into()),
-                value: None,
-                condition: None,
-            }))
-            .collect(),
-        },
-        // Mobile-specific tags:
-        TagMapping {
-            metrics: vec![LazyGlob::new("d:spans/exclusive_time*@millisecond".into())],
-            tags: [
-                ("", "device.class"),
-                ("", "release"),
-                ("", "ttfd"),
-                ("", "ttid"),
-                ("span.", "main_thread"),
-            ]
-            .map(|(prefix, key)| TagSpec {
-                key: format!("{prefix}{key}"),
-                field: Some(format!("span.sentry_tags.{}", key)),
-                value: None,
-                condition: Some(RuleCondition::eq("span.sentry_tags.mobile", "true")),
-            })
-            .into(),
-        },
-        // Resource-specific tags:
-        TagMapping {
-            metrics: vec![
-                LazyGlob::new("d:spans/http.response_content_length@byte".into()),
-                LazyGlob::new("d:spans/http.decoded_response_content_length@byte".into()),
-                LazyGlob::new("d:spans/http.response_transfer_size@byte".into()),
-            ],
-            tags: [
-                ("", "environment"),
-                ("", "file_extension"),
-                ("", "resource.render_blocking_status"),
-                ("", "transaction"),
-                ("span.", "description"),
-                ("span.", "domain"),
-                ("span.", "group"),
-                ("span.", "op"),
-            ]
-            .map(|(prefix, key)| TagSpec {
-                key: format!("{prefix}{key}"),
-                field: Some(format!("span.sentry_tags.{}", key)),
-                value: None,
-                condition: Some(resource_condition.clone()),
-            })
-            .into(),
-        },
-        TagMapping {
-            metrics: vec![LazyGlob::new("d:spans/exclusive_time*@millisecond".into())],
-            tags: [
-                ("", "file_extension"),
-                ("", "resource.render_blocking_status"),
-            ]
-            .map(|(prefix, key)| TagSpec {
-                key: format!("{prefix}{key}"),
-                field: Some(format!("span.sentry_tags.{}", key)),
-                value: None,
-                condition: Some(resource_condition.clone()),
-            })
-            .into(),
-        },
-    ]);
-
-    // / NEW /////
     let mobile_condition = RuleCondition::eq("span.sentry_tags.mobile", "true");
+
     config.metrics.extend([
         MetricSpec {
             category: DataCategory::Span,
@@ -296,6 +134,13 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 Tag::with_key("span.main_thread")
                     .from_field("span.sentry_tags.main_thread")
                     .when(mobile_condition.clone()),
+                // Resource module:
+                Tag::with_key("file_extension")
+                    .from_field("span.sentry_tags.file_extension")
+                    .when(resource_condition.clone()),
+                Tag::with_key("resource.render_blocking_status")
+                    .from_field("span.sentry_tags.resource.render_blocking_status")
+                    .when(resource_condition.clone()),
             ],
         },
         MetricSpec {

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -77,74 +77,74 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             Number::from_f64(MAX_DURATION_MOBILE_MS).unwrap_or(0.into()),
         );
 
-    config.metrics.extend([
-        MetricSpec {
-            category: DataCategory::Span,
-            mri: "d:spans/exclusive_time@millisecond".into(),
-            field: Some("span.exclusive_time".into()),
-            condition: Some(span_op_conditions.clone() & duration_condition.clone()),
-            tags: vec![TagSpec {
-                key: "transaction".into(),
-                field: Some("span.sentry_tags.transaction".into()),
-                value: None,
-                condition: None,
-            }],
-        },
-        MetricSpec {
-            category: DataCategory::Span,
-            mri: "d:spans/exclusive_time_light@millisecond".into(),
-            field: Some("span.exclusive_time".into()),
-            condition: Some(span_op_conditions.clone() & duration_condition.clone()),
-            tags: Default::default(),
-        },
-        MetricSpec {
-            category: DataCategory::Span,
-            mri: "d:spans/http.response_content_length@byte".into(),
-            field: Some("span.data.http\\.response_content_length".into()),
-            condition: Some(
-                span_op_conditions.clone()
-                    & resource_condition.clone()
-                    & RuleCondition::gt("span.data.http\\.response_content_length", 0),
-            ),
-            tags: Default::default(),
-        },
-        MetricSpec {
-            category: DataCategory::Span,
-            mri: "d:spans/http.decoded_response_content_length@byte".into(),
-            field: Some("span.data.http\\.decoded_response_content_length".into()),
-            condition: Some(
-                span_op_conditions.clone()
-                    & resource_condition.clone()
-                    & RuleCondition::gt("span.data.http\\.decoded_response_content_length", 0),
-            ),
-            tags: Default::default(),
-        },
-        MetricSpec {
-            category: DataCategory::Span,
-            mri: "d:spans/http.response_transfer_size@byte".into(),
-            field: Some("span.data.http\\.response_transfer_size".into()),
-            condition: Some(
-                span_op_conditions.clone()
-                    & resource_condition.clone()
-                    & RuleCondition::gt("span.data.http\\.response_transfer_size", 0),
-            ),
-            tags: Default::default(),
-        },
-        MetricSpec {
-            category: DataCategory::Span,
-            mri: "c:spans/count_per_op@none".into(),
-            field: None,
-            condition: Some(duration_condition.clone()),
-            tags: ["category", "op", "system"]
-                .map(|key| TagSpec {
-                    key: format!("span.{key}"),
-                    field: Some(format!("span.sentry_tags.{key}")),
-                    value: None,
-                    condition: None,
-                })
-                .into(),
-        },
-    ]);
+    // config.metrics.extend([
+    //     MetricSpec {
+    //         category: DataCategory::Span,
+    //         mri: "d:spans/exclusive_time@millisecond".into(),
+    //         field: Some("span.exclusive_time".into()),
+    //         condition: Some(span_op_conditions.clone() & duration_condition.clone()),
+    //         tags: vec![TagSpec {
+    //             key: "transaction".into(),
+    //             field: Some("span.sentry_tags.transaction".into()),
+    //             value: None,
+    //             condition: None,
+    //         }],
+    //     },
+    //     MetricSpec {
+    //         category: DataCategory::Span,
+    //         mri: "d:spans/exclusive_time_light@millisecond".into(),
+    //         field: Some("span.exclusive_time".into()),
+    //         condition: Some(span_op_conditions.clone() & duration_condition.clone()),
+    //         tags: Default::default(),
+    //     },
+    //     MetricSpec {
+    //         category: DataCategory::Span,
+    //         mri: "d:spans/http.response_content_length@byte".into(),
+    //         field: Some("span.data.http\\.response_content_length".into()),
+    //         condition: Some(
+    //             span_op_conditions.clone()
+    //                 & resource_condition.clone()
+    //                 & RuleCondition::gt("span.data.http\\.response_content_length", 0),
+    //         ),
+    //         tags: Default::default(),
+    //     },
+    //     MetricSpec {
+    //         category: DataCategory::Span,
+    //         mri: "d:spans/http.decoded_response_content_length@byte".into(),
+    //         field: Some("span.data.http\\.decoded_response_content_length".into()),
+    //         condition: Some(
+    //             span_op_conditions.clone()
+    //                 & resource_condition.clone()
+    //                 & RuleCondition::gt("span.data.http\\.decoded_response_content_length", 0),
+    //         ),
+    //         tags: Default::default(),
+    //     },
+    //     MetricSpec {
+    //         category: DataCategory::Span,
+    //         mri: "d:spans/http.response_transfer_size@byte".into(),
+    //         field: Some("span.data.http\\.response_transfer_size".into()),
+    //         condition: Some(
+    //             span_op_conditions.clone()
+    //                 & resource_condition.clone()
+    //                 & RuleCondition::gt("span.data.http\\.response_transfer_size", 0),
+    //         ),
+    //         tags: Default::default(),
+    //     },
+    //     MetricSpec {
+    //         category: DataCategory::Span,
+    //         mri: "c:spans/count_per_op@none".into(),
+    //         field: None,
+    //         condition: Some(duration_condition.clone()),
+    //         tags: ["category", "op", "system"]
+    //             .map(|key| TagSpec {
+    //                 key: format!("span.{key}"),
+    //                 field: Some(format!("span.sentry_tags.{key}")),
+    //                 value: None,
+    //                 condition: None,
+    //             })
+    //             .into(),
+    //     },
+    // ]);
 
     config.tags.extend([
         TagMapping {
@@ -238,125 +238,296 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         },
     ]);
 
-    let module_enabled = RuleCondition::never(); // TODO
-    let is_mobile = module_enabled & RuleCondition::never(); // TODO
+    // / NEW /////
+    let mobile_condition = RuleCondition::eq("span.sentry_tags.mobile", "true");
     config.metrics.extend([
         MetricSpec {
             category: DataCategory::Span,
             mri: "d:spans/exclusive_time_light@millisecond".into(),
             field: Some("span.exclusive_time".into()),
-            condition: Some(module_enabled),
+            condition: Some(span_op_conditions.clone() & duration_condition.clone()),
             tags: vec![
                 Tag::with_key("environment")
                     .from_field("sentry_tags.environment")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("transaction.method")
                     .from_field("sentry_tags.transaction.method")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("transaction.op")
                     .from_field("sentry_tags.transaction.op")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.action")
                     .from_field("sentry_tags.action")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.category")
                     .from_field("sentry_tags.category")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.description")
                     .from_field("sentry_tags.description")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.domain")
                     .from_field("sentry_tags.domain")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.group")
                     .from_field("sentry_tags.group")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.module")
                     .from_field("sentry_tags.module")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.op")
                     .from_field("sentry_tags.op")
-                    .when(module_enabled),
+                    .always(),
+                Tag::with_key("span.status")
+                    .from_field("span.status") // from top-level field
+                    .always(),
                 Tag::with_key("span.status_code")
                     .from_field("sentry_tags.status_code")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.system")
                     .from_field("sentry_tags.system")
-                    .when(module_enabled),
+                    .always(),
                 // Mobile:
                 Tag::with_key("device.class")
                     .from_field("span.sentry_tags.device.class")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
                 Tag::with_key("release")
                     .from_field("span.sentry_tags.release")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
                 Tag::with_key("span.main_thread")
                     .from_field("span.sentry_tags.main_thread")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
             ],
         },
         MetricSpec {
             category: DataCategory::Span,
             mri: "d:spans/exclusive_time@millisecond".into(),
             field: Some("span.exclusive_time".into()),
-            condition: Some(module_enabled),
+            condition: Some(span_op_conditions.clone() & duration_condition.clone()),
             tags: vec![
                 // Common tags:
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("transaction.method")
                     .from_field("span.sentry_tags.transaction.method")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("transaction.op")
                     .from_field("span.sentry_tags.transaction.op")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.action")
                     .from_field("span.sentry_tags.action")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.category")
                     .from_field("span.sentry_tags.category")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.description")
                     .from_field("span.sentry_tags.description")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.domain")
                     .from_field("span.sentry_tags.domain")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.group")
                     .from_field("span.sentry_tags.group")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.module")
                     .from_field("span.sentry_tags.module")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.status_code")
                     .from_field("span.sentry_tags.status_code")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("span.system")
                     .from_field("span.sentry_tags.system")
-                    .when(module_enabled),
+                    .always(),
                 Tag::with_key("transaction")
                     .from_field("span.sentry_tags.transaction")
-                    .when(module_enabled),
+                    .always(),
                 // Mobile:
                 Tag::with_key("device.class")
                     .from_field("span.sentry_tags.device.class")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
                 Tag::with_key("release")
                     .from_field("span.sentry_tags.release")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
                 Tag::with_key("ttfd")
                     .from_field("span.sentry_tags.ttfd")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
                 Tag::with_key("ttid")
                     .from_field("span.sentry_tags.ttid")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
                 Tag::with_key("span.main_thread")
                     .from_field("span.sentry_tags.main_thread")
-                    .when(is_mobile),
+                    .when(mobile_condition.clone()),
+                // Resource module:
+                Tag::with_key("file_extension")
+                    .from_field("span.sentry_tags.file_extension")
+                    .when(resource_condition.clone()),
+                Tag::with_key("resource.render_blocking_status")
+                    .from_field("span.sentry_tags.resource.render_blocking_status")
+                    .when(resource_condition.clone()),
+            ],
+        },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "d:spans/http.response_content_length@byte".into(),
+            field: Some("span.data.http\\.response_content_length".into()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone().clone()
+                    & RuleCondition::gt("span.data.http\\.response_content_length", 0),
+            ),
+            tags: vec![
+                Tag::with_key("environment")
+                    .from_field("span.sentry_tags.environment")
+                    .when(resource_condition.clone()),
+                Tag::with_key("file_extension")
+                    .from_field("span.sentry_tags.file_extension")
+                    .when(resource_condition.clone()),
+                Tag::with_key("resource.render_blocking_status")
+                    .from_field("span.sentry_tags.resource.render_blocking_status")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.domain")
+                    .from_field("span.sentry_tags.domain")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .when(resource_condition.clone()),
+                Tag::with_key("transaction")
+                    .from_field("span.sentry_tags")
+                    .when(resource_condition.clone()),
+            ],
+        },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "d:spans/http.response_content_length@byte".into(),
+            field: Some("span.data.http\\.response_content_length".into()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone()
+                    & RuleCondition::gt("span.data.http\\.response_content_length", 0),
+            ),
+            tags: vec![
+                Tag::with_key("environment")
+                    .from_field("span.sentry_tags.environment")
+                    .when(resource_condition.clone()),
+                Tag::with_key("file_extension")
+                    .from_field("span.sentry_tags.file_extension")
+                    .when(resource_condition.clone()),
+                Tag::with_key("resource.render_blocking_status")
+                    .from_field("span.sentry_tags.resource.render_blocking_status")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.domain")
+                    .from_field("span.sentry_tags.domain")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .when(resource_condition.clone()),
+                Tag::with_key("transaction")
+                    .from_field("span.sentry_tags")
+                    .when(resource_condition.clone()),
+            ],
+        },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "d:spans/http.decoded_response_content_length@byte".into(),
+            field: Some("span.data.http\\.decoded_response_content_length".into()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone()
+                    & RuleCondition::gt("span.data.http\\.decoded_response_content_length", 0),
+            ),
+            tags: vec![
+                Tag::with_key("environment")
+                    .from_field("span.sentry_tags.environment")
+                    .when(resource_condition.clone()),
+                Tag::with_key("file_extension")
+                    .from_field("span.sentry_tags.file_extension")
+                    .when(resource_condition.clone()),
+                Tag::with_key("resource.render_blocking_status")
+                    .from_field("span.sentry_tags.resource.render_blocking_status")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.domain")
+                    .from_field("span.sentry_tags.domain")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .when(resource_condition.clone()),
+                Tag::with_key("transaction")
+                    .from_field("span.sentry_tags")
+                    .when(resource_condition.clone()),
+            ],
+        },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "d:spans/http.response_transfer_size@byte".into(),
+            field: Some("span.data.http\\.response_transfer_size".into()),
+            condition: Some(
+                span_op_conditions.clone()
+                    & resource_condition.clone()
+                    & RuleCondition::gt("span.data.http\\.response_transfer_size", 0),
+            ),
+            tags: vec![
+                Tag::with_key("environment")
+                    .from_field("span.sentry_tags.environment")
+                    .when(resource_condition.clone()),
+                Tag::with_key("file_extension")
+                    .from_field("span.sentry_tags.file_extension")
+                    .when(resource_condition.clone()),
+                Tag::with_key("resource.render_blocking_status")
+                    .from_field("span.sentry_tags.resource.render_blocking_status")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.domain")
+                    .from_field("span.sentry_tags.domain")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .when(resource_condition.clone()),
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .when(resource_condition.clone()),
+                Tag::with_key("transaction")
+                    .from_field("span.sentry_tags")
+                    .when(resource_condition.clone()),
+            ],
+        },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "c:spans/count_per_op@none".into(),
+            field: None,
+            condition: Some(duration_condition.clone()),
+            tags: vec![
+                Tag::with_key("category")
+                    .from_field("span.sentry_tags.category")
+                    .always(),
+                Tag::with_key("op")
+                    .from_field("span.sentry_tags.op")
+                    .always(),
+                Tag::with_key("system")
+                    .from_field("span.sentry_tags.system")
+                    .always(),
             ],
         },
     ]);

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -80,70 +80,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
     config.metrics.extend([
         MetricSpec {
             category: DataCategory::Span,
-            mri: "d:spans/exclusive_time_light@millisecond".into(),
-            field: Some("span.exclusive_time".into()),
-            condition: Some(span_op_conditions.clone() & duration_condition.clone()),
-            tags: vec![
-                Tag::with_key("environment")
-                    .from_field("sentry_tags.environment")
-                    .always(),
-                Tag::with_key("transaction.method")
-                    .from_field("sentry_tags.transaction.method")
-                    .always(),
-                Tag::with_key("transaction.op")
-                    .from_field("sentry_tags.transaction.op")
-                    .always(),
-                Tag::with_key("span.action")
-                    .from_field("sentry_tags.action")
-                    .always(),
-                Tag::with_key("span.category")
-                    .from_field("sentry_tags.category")
-                    .always(),
-                Tag::with_key("span.description")
-                    .from_field("sentry_tags.description")
-                    .always(),
-                Tag::with_key("span.domain")
-                    .from_field("sentry_tags.domain")
-                    .always(),
-                Tag::with_key("span.group")
-                    .from_field("sentry_tags.group")
-                    .always(),
-                Tag::with_key("span.module")
-                    .from_field("sentry_tags.module")
-                    .always(),
-                Tag::with_key("span.op")
-                    .from_field("sentry_tags.op")
-                    .always(),
-                Tag::with_key("span.status")
-                    .from_field("span.status") // from top-level field
-                    .always(),
-                Tag::with_key("span.status_code")
-                    .from_field("sentry_tags.status_code")
-                    .always(),
-                Tag::with_key("span.system")
-                    .from_field("sentry_tags.system")
-                    .always(),
-                // Mobile:
-                Tag::with_key("device.class")
-                    .from_field("span.sentry_tags.device.class")
-                    .when(mobile_condition.clone()),
-                Tag::with_key("os.name") // TODO: might not be needed on both `exclusive_time` metrics
-                    .from_field("span.sentry_tags.os.name")
-                    .when(mobile_condition.clone()),
-                Tag::with_key("release")
-                    .from_field("span.sentry_tags.release")
-                    .when(mobile_condition.clone()),
-                // Resource module:
-                Tag::with_key("file_extension")
-                    .from_field("span.sentry_tags.file_extension")
-                    .when(resource_condition.clone()),
-                Tag::with_key("resource.render_blocking_status")
-                    .from_field("span.sentry_tags.resource.render_blocking_status")
-                    .when(resource_condition.clone()),
-            ],
-        },
-        MetricSpec {
-            category: DataCategory::Span,
             mri: "d:spans/exclusive_time@millisecond".into(),
             field: Some("span.exclusive_time".into()),
             condition: Some(span_op_conditions.clone() & duration_condition.clone()),
@@ -178,6 +114,9 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                     .always(),
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
+                    .always(),
+                Tag::with_key("span.status")
+                    .from_field("span.status") // from top-level field
                     .always(),
                 Tag::with_key("span.status_code")
                     .from_field("span.sentry_tags.status_code")
@@ -218,37 +157,65 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         },
         MetricSpec {
             category: DataCategory::Span,
-            mri: "d:spans/http.response_content_length@byte".into(),
-            field: Some("span.data.http\\.response_content_length".into()),
-            condition: Some(
-                span_op_conditions.clone()
-                    & resource_condition.clone().clone()
-                    & RuleCondition::gt("span.data.http\\.response_content_length", 0),
-            ),
+            mri: "d:spans/exclusive_time_light@millisecond".into(),
+            field: Some("span.exclusive_time".into()),
+            condition: Some(span_op_conditions.clone() & duration_condition.clone()),
             tags: vec![
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
-                    .when(resource_condition.clone()),
+                    .always(),
+                Tag::with_key("transaction.method")
+                    .from_field("span.sentry_tags.transaction.method")
+                    .always(),
+                Tag::with_key("transaction.op")
+                    .from_field("span.sentry_tags.transaction.op")
+                    .always(),
+                Tag::with_key("span.action")
+                    .from_field("span.sentry_tags.action")
+                    .always(),
+                Tag::with_key("span.category")
+                    .from_field("span.sentry_tags.category")
+                    .always(),
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .always(),
+                Tag::with_key("span.domain")
+                    .from_field("span.sentry_tags.domain")
+                    .always(),
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .always(),
+                Tag::with_key("span.module")
+                    .from_field("span.sentry_tags.module")
+                    .always(),
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .always(),
+                Tag::with_key("span.status")
+                    .from_field("span.status") // from top-level field
+                    .always(),
+                Tag::with_key("span.status_code")
+                    .from_field("span.sentry_tags.status_code")
+                    .always(),
+                Tag::with_key("span.system")
+                    .from_field("span.sentry_tags.system")
+                    .always(),
+                // Mobile:
+                Tag::with_key("device.class")
+                    .from_field("span.sentry_tags.device.class")
+                    .when(mobile_condition.clone()),
+                Tag::with_key("os.name") // TODO: might not be needed on both `exclusive_time` metrics
+                    .from_field("span.sentry_tags.os.name")
+                    .when(mobile_condition.clone()),
+                Tag::with_key("release")
+                    .from_field("span.sentry_tags.release")
+                    .when(mobile_condition.clone()),
+                // Resource module:
                 Tag::with_key("file_extension")
                     .from_field("span.sentry_tags.file_extension")
                     .when(resource_condition.clone()),
                 Tag::with_key("resource.render_blocking_status")
                     .from_field("span.sentry_tags.resource.render_blocking_status")
-                    .when(resource_condition.clone()),
-                Tag::with_key("span.description")
-                    .from_field("span.sentry_tags.description")
-                    .when(resource_condition.clone()),
-                Tag::with_key("span.domain")
-                    .from_field("span.sentry_tags.domain")
-                    .when(resource_condition.clone()),
-                Tag::with_key("span.group")
-                    .from_field("span.sentry_tags.group")
-                    .when(resource_condition.clone()),
-                Tag::with_key("span.op")
-                    .from_field("span.sentry_tags.op")
-                    .when(resource_condition.clone()),
-                Tag::with_key("transaction")
-                    .from_field("span.sentry_tags")
                     .when(resource_condition.clone()),
             ],
         },
@@ -264,28 +231,28 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             tags: vec![
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("file_extension")
                     .from_field("span.sentry_tags.file_extension")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("resource.render_blocking_status")
                     .from_field("span.sentry_tags.resource.render_blocking_status")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.description")
                     .from_field("span.sentry_tags.description")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.domain")
                     .from_field("span.sentry_tags.domain")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.group")
                     .from_field("span.sentry_tags.group")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("transaction")
-                    .from_field("span.sentry_tags")
-                    .when(resource_condition.clone()),
+                    .from_field("span.sentry_tags.transaction")
+                    .always(), // already guarded by condition on metric
             ],
         },
         MetricSpec {
@@ -300,28 +267,28 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             tags: vec![
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("file_extension")
                     .from_field("span.sentry_tags.file_extension")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("resource.render_blocking_status")
                     .from_field("span.sentry_tags.resource.render_blocking_status")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.description")
                     .from_field("span.sentry_tags.description")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.domain")
                     .from_field("span.sentry_tags.domain")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.group")
                     .from_field("span.sentry_tags.group")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("transaction")
-                    .from_field("span.sentry_tags")
-                    .when(resource_condition.clone()),
+                    .from_field("span.sentry_tags.transaction")
+                    .always(), // already guarded by condition on metric
             ],
         },
         MetricSpec {
@@ -336,28 +303,28 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             tags: vec![
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("file_extension")
                     .from_field("span.sentry_tags.file_extension")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("resource.render_blocking_status")
                     .from_field("span.sentry_tags.resource.render_blocking_status")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.description")
                     .from_field("span.sentry_tags.description")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.domain")
                     .from_field("span.sentry_tags.domain")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.group")
                     .from_field("span.sentry_tags.group")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
-                    .when(resource_condition.clone()),
+                    .always(), // already guarded by condition on metric
                 Tag::with_key("transaction")
-                    .from_field("span.sentry_tags")
-                    .when(resource_condition.clone()),
+                    .from_field("span.sentry_tags.transaction")
+                    .always(), // already guarded by condition on metric
             ],
         },
         MetricSpec {
@@ -366,13 +333,13 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             field: None,
             condition: Some(duration_condition.clone()),
             tags: vec![
-                Tag::with_key("category")
+                Tag::with_key("span.category")
                     .from_field("span.sentry_tags.category")
                     .always(),
-                Tag::with_key("op")
+                Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
                     .always(),
-                Tag::with_key("system")
+                Tag::with_key("span.system")
                     .from_field("span.sentry_tags.system")
                     .always(),
             ],

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -341,10 +341,12 @@ pub struct Tag {
 }
 
 impl Tag {
+    /// Prepares a tag with a given tag name.
     pub fn with_key(key: impl Into<String>) -> Self {
-        Self { key }
+        Self { key: key.into() }
     }
 
+    /// Defines the field from which the tag value gets its data.
     pub fn from_field(self, field_name: impl Into<String>) -> TagWithSource {
         let Self { key } = self;
         TagWithSource {
@@ -354,6 +356,7 @@ impl Tag {
         }
     }
 
+    /// Defines what value to set for a tag.
     pub fn with_value(self, value: impl Into<String>) -> TagWithSource {
         let Self { key } = self;
         TagWithSource {
@@ -364,6 +367,9 @@ impl Tag {
     }
 }
 
+/// Intermediate result of the tag spec builder.
+///
+/// Can be transformed into `[TagSpec]`.
 pub struct TagWithSource {
     key: String,
     field: Option<String>,
@@ -371,6 +377,7 @@ pub struct TagWithSource {
 }
 
 impl TagWithSource {
+    /// Defines a tag that is extracted unconditionally.
     pub fn always(self) -> TagSpec {
         let Self { key, field, value } = self;
         TagSpec {
@@ -381,6 +388,7 @@ impl TagWithSource {
         }
     }
 
+    /// Defines a tag that is extracted under the given condition.
     pub fn when(self, condition: RuleCondition) -> TagSpec {
         let Self { key, field, value } = self;
         TagSpec {

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -335,6 +335,63 @@ impl TagSpec {
     }
 }
 
+/// Builder for [`TagSpec`].
+pub struct Tag {
+    key: String,
+}
+
+impl Tag {
+    pub fn with_key(key: impl Into<String>) -> Self {
+        Self { key }
+    }
+
+    pub fn from_field(self, field_name: impl Into<String>) -> TagWithSource {
+        let Self { key } = self;
+        TagWithSource {
+            key,
+            field: Some(field_name.into()),
+            value: None,
+        }
+    }
+
+    pub fn with_value(self, value: impl Into<String>) -> TagWithSource {
+        let Self { key } = self;
+        TagWithSource {
+            key,
+            field: None,
+            value: Some(value.into()),
+        }
+    }
+}
+
+pub struct TagWithSource {
+    key: String,
+    field: Option<String>,
+    value: Option<String>,
+}
+
+impl TagWithSource {
+    pub fn always(self) -> TagSpec {
+        let Self { key, field, value } = self;
+        TagSpec {
+            key,
+            field,
+            value,
+            condition: None,
+        }
+    }
+
+    pub fn when(self, condition: RuleCondition) -> TagSpec {
+        let Self { key, field, value } = self;
+        TagSpec {
+            key,
+            field,
+            value,
+            condition: Some(condition),
+        }
+    }
+}
+
 /// Specifies how to obtain the value of a tag in [`TagSpec`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum TagSource<'a> {

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -35,7 +35,7 @@ pub fn parse_query(
         .unwrap_or_else(|| Box::new(GenericDialect {}));
     let dialect = DialectWithParameters(dialect);
 
-    dbg!(sqlparser::parser::Parser::parse_sql(&dialect, query))
+    sqlparser::parser::Parser::parse_sql(&dialect, query)
 }
 
 /// Tries to parse a series of SQL queries into an AST and normalize it.

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -35,7 +35,7 @@ pub fn parse_query(
         .unwrap_or_else(|| Box::new(GenericDialect {}));
     let dialect = DialectWithParameters(dialect);
 
-    sqlparser::parser::Parser::parse_sql(&dialect, query)
+    dbg!(sqlparser::parser::Parser::parse_sql(&dialect, query))
 }
 
 /// Tries to parse a series of SQL queries into an AST and normalize it.


### PR DESCRIPTION
List every tag for every metric explicitly. This nonfunctional change is the first step towards more selective tagging (tag only when you need it, and only on the metrics that actually need it).

ref: https://github.com/getsentry/team-ingest/issues/252

#skip-changelog