### PR TITLE
feat(server): Org rate limit per metric bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add size limits on metric related envelope items. ([#2800](https://github.com/getsentry/relay/pull/2800))
 - Include the size offending item in the size limit error message. ([#2801](https://github.com/getsentry/relay/pull/2801))
 - Add metric_bucket data category. ([#2824](https://github.com/getsentry/relay/pull/2824))
+- Org rate limit metrics per bucket. ([#2836](https://github.com/getsentry/relay/pull/2836))
 
 ## 23.11.2
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -296,16 +296,14 @@ impl Quota {
         // Check for a scope identifier constraint. If there is no constraint, this means that the
         // quota matches any scope. In case the scope is unknown, it will be coerced to the most
         // specific scope later.
-        let scope_id = match self.scope_id {
-            Some(ref scope_id) => scope_id,
-            None => return true,
+        let Some(scope_id) = self.scope_id.as_ref() else {
+            return true;
         };
 
         // Check if the scope identifier in the quota is parseable. If not, this means we cannot
         // fulfill the constraint, so the quota does not match.
-        let parsed = match scope_id.parse::<u64>() {
-            Ok(parsed) => parsed,
-            Err(_) => return false,
+        let Ok(parsed) = scope_id.parse::<u64>() else {
+            return false;
         };
 
         // At this stage, require that the scope is known since we have to fulfill the constraint.

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -27,8 +27,7 @@ use relay_metrics::{Bucket, BucketsView, MergeBuckets, MetricMeta, MetricNamespa
 use relay_pii::PiiConfigError;
 use relay_profiling::ProfileId;
 use relay_protocol::{Annotated, Value};
-
-use relay_quotas::{DataCategory, Scoping};
+use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::evaluation::{MatchedRuleIds, ReservoirCounters, ReservoirEvaluator};
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
@@ -39,8 +38,9 @@ use {
     crate::actors::project_cache::UpdateRateLimits,
     crate::utils::{EnvelopeLimiter, ItemAction, MetricsLimiter},
     relay_metrics::{Aggregator, RedisMetricMetaStore},
-    relay_quotas::{RateLimitingError, RedisRateLimiter},
+    relay_quotas::{ItemScoping, RateLimitingError, ReasonCode, RedisRateLimiter},
     relay_redis::RedisPool,
+    std::collections::BTreeMap,
     symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
 };
 
@@ -231,6 +231,23 @@ impl ExtractedMetrics {
             ));
         }
     }
+}
+
+fn source_quantities_from_buckets(
+    buckets: &BucketsView,
+    extraction_mode: ExtractionMode,
+) -> SourceQuantities {
+    buckets
+        .iter()
+        .filter_map(|bucket| extract_transaction_count(&bucket, extraction_mode))
+        .fold(SourceQuantities::default(), |acc, c| {
+            let profile_count = if c.has_profile { c.count } else { 0 };
+
+            SourceQuantities {
+                transactions: acc.transactions + c.count,
+                profiles: acc.profiles + profile_count,
+            }
+        })
 }
 
 /// A state container for envelope processing.
@@ -438,6 +455,10 @@ pub struct EncodeMetrics {
     pub scoping: Scoping,
     /// Transaction metrics extraction mode.
     pub extraction_mode: ExtractionMode,
+    /// Project state for extracting quotas.
+    pub project_state: Arc<ProjectState>,
+    /// The ratelimits belonging to the project.
+    pub rate_limits: RateLimits,
 }
 
 /// Encodes metric meta into an envelope and sends it upstream.
@@ -1172,8 +1193,6 @@ impl EnvelopeProcessorService {
     /// Check and apply rate limits to metrics buckets.
     #[cfg(feature = "processing")]
     fn handle_rate_limit_buckets(&self, message: RateLimitBuckets) {
-        use relay_quotas::ItemScoping;
-
         let RateLimitBuckets { mut bucket_limiter } = message;
 
         let scoping = *bucket_limiter.scoping();
@@ -1261,11 +1280,158 @@ impl EnvelopeProcessorService {
         }
     }
 
+    /// Records the outcomes of the dropped buckets.
+    #[cfg(feature = "processing")]
+    fn drop_buckets_with_outcomes(
+        &self,
+        reason_code: Option<ReasonCode>,
+        total_buckets: usize,
+        scoping: Scoping,
+        bucket_partitions: &BTreeMap<Option<u64>, Vec<Bucket>>,
+        mode: ExtractionMode,
+    ) {
+        let mut source_quantities = SourceQuantities::default();
+
+        for buckets in bucket_partitions.values() {
+            source_quantities += source_quantities_from_buckets(&BucketsView::new(buckets), mode);
+        }
+
+        let timestamp = Utc::now();
+
+        if source_quantities.transactions > 0 {
+            self.inner.outcome_aggregator.send(TrackOutcome {
+                timestamp,
+                scoping,
+                outcome: Outcome::RateLimited(reason_code.clone()),
+                event_id: None,
+                remote_addr: None,
+                category: DataCategory::Transaction,
+                quantity: source_quantities.transactions as u32,
+            });
+        }
+        if source_quantities.profiles > 0 {
+            self.inner.outcome_aggregator.send(TrackOutcome {
+                timestamp,
+                scoping,
+                outcome: Outcome::RateLimited(reason_code.clone()),
+                event_id: None,
+                remote_addr: None,
+                category: DataCategory::Profile,
+                quantity: source_quantities.profiles as u32,
+            });
+        }
+
+        self.inner.outcome_aggregator.send(TrackOutcome {
+            timestamp,
+            scoping,
+            outcome: Outcome::RateLimited(reason_code),
+            event_id: None,
+            remote_addr: None,
+            category: DataCategory::MetricBucket,
+            quantity: total_buckets as u32,
+        });
+    }
+
+    /// Returns `true` if the batches should be rate limited.
+    #[cfg(feature = "processing")]
+    fn rate_limit_batches(
+        &self,
+        cached_rate_limits: RateLimits,
+        scoping: Scoping,
+        bucket_partitions: &BTreeMap<Option<u64>, Vec<Bucket>>,
+        max_batch_size_bytes: usize,
+        project_state: Arc<ProjectState>,
+    ) -> bool {
+        let Some(rate_limiter) = self.inner.rate_limiter.as_ref() else {
+            return false;
+        };
+
+        let mode = {
+            let usage = match project_state.config.transaction_metrics {
+                Some(ErrorBoundary::Ok(ref c)) => c.usage_metric(),
+                _ => false,
+            };
+            ExtractionMode::from_usage(usage)
+        };
+
+        let quotas = &project_state.config.quotas;
+        let item_scoping = ItemScoping {
+            category: DataCategory::MetricBucket,
+            scoping: &scoping,
+        };
+
+        // We couldn't use the bucket length directly because batching may change the amount of buckets.
+        let total_buckets: usize = bucket_partitions
+            .values()
+            .flat_map(|buckets| {
+                // Cheap operation because there's no allocations.
+                BucketsView::new(buckets)
+                    .by_size(max_batch_size_bytes)
+                    .map(|batch| batch.len())
+            })
+            .sum();
+
+        // For limiting the amount of redis calls we make, in case we already passed the limit.
+        if cached_rate_limits
+            .check_with_quotas(quotas, item_scoping)
+            .is_limited()
+        {
+            relay_log::info!("dropping {total_buckets} buckets due to throughput ratelimit");
+            let reason_code = cached_rate_limits
+                .longest()
+                .and_then(|limit| limit.reason_code.clone());
+
+            self.drop_buckets_with_outcomes(
+                reason_code,
+                total_buckets,
+                scoping,
+                bucket_partitions,
+                mode,
+            );
+
+            return true;
+        }
+
+        // Check with redis if the throughput limit has been exceeded, while also updating
+        // the count so that other relays will be updated too.
+        match rate_limiter.is_rate_limited(quotas, item_scoping, total_buckets, false) {
+            Ok(limits) if limits.is_limited() => {
+                relay_log::info!("dropping {total_buckets} buckets due to throughput ratelimit");
+
+                let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
+                self.drop_buckets_with_outcomes(
+                    reason_code,
+                    total_buckets,
+                    scoping,
+                    bucket_partitions,
+                    mode,
+                );
+
+                self.inner
+                    .project_cache
+                    .send(UpdateRateLimits::new(scoping.project_key, limits));
+
+                return true;
+            }
+            Ok(_) => {} // not ratelimited
+            Err(e) => {
+                relay_log::error!(
+                    error = &e as &dyn std::error::Error,
+                    "failed to check redis rate limits"
+                );
+            }
+        }
+
+        false
+    }
+
     fn handle_encode_metrics(&self, message: EncodeMetrics) {
         let EncodeMetrics {
             buckets,
             scoping,
             extraction_mode,
+            project_state: _project_state,
+            rate_limits: _cached_rate_limits,
         } = message;
 
         let partitions = self.inner.config.metrics_partitions();
@@ -1274,8 +1440,20 @@ impl EnvelopeProcessorService {
         let upstream = self.inner.config.upstream_descriptor();
         let dsn = PartialDsn::outbound(&scoping, upstream);
 
-        for (partition_key, buckets) in partition_buckets(scoping.project_key, buckets, partitions)
-        {
+        let bucket_partitions = partition_buckets(scoping.project_key, buckets, partitions);
+
+        #[cfg(feature = "processing")]
+        if self.rate_limit_batches(
+            _cached_rate_limits,
+            scoping,
+            &bucket_partitions,
+            max_batch_size_bytes,
+            _project_state,
+        ) {
+            return;
+        }
+
+        for (partition_key, buckets) in bucket_partitions {
             let mut num_batches = 0;
 
             for batch in BucketsView::new(&buckets).by_size(max_batch_size_bytes) {
@@ -1409,18 +1587,7 @@ impl Service for EnvelopeProcessorService {
 }
 
 fn create_metrics_item(buckets: &BucketsView<'_>, extraction_mode: ExtractionMode) -> Item {
-    let source_quantities = buckets
-        .iter()
-        .filter_map(|bucket| extract_transaction_count(&bucket, extraction_mode))
-        .fold(SourceQuantities::default(), |acc, c| {
-            let profile_count = if c.has_profile { c.count } else { 0 };
-
-            SourceQuantities {
-                transactions: acc.transactions + c.count,
-                profiles: acc.profiles + profile_count,
-            }
-        });
-
+    let source_quantities = source_quantities_from_buckets(buckets, extraction_mode);
     let mut item = Item::new(ItemType::MetricBuckets);
     item.set_source_quantities(source_quantities);
     item.set_payload(ContentType::Json, serde_json::to_vec(&buckets).unwrap());

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1407,11 +1407,7 @@ impl EnvelopeProcessorService {
         }
 
         #[cfg(feature = "processing")]
-        {
-            let Some(rate_limiter) = self.inner.rate_limiter.as_ref() else {
-                return false;
-            };
-
+        if let Some(rate_limiter) = self.inner.rate_limiter.as_ref() {
             // Check with redis if the throughput limit has been exceeded, while also updating
             // the count so that other relays will be updated too.
             match rate_limiter.is_rate_limited(quotas, item_scoping, total_buckets, false) {
@@ -1443,7 +1439,7 @@ impl EnvelopeProcessorService {
                     );
                 }
             }
-        }
+        };
 
         false
     }
@@ -1475,8 +1471,8 @@ impl EnvelopeProcessorService {
             buckets,
             scoping,
             extraction_mode,
-            project_state: _project_state,
-            rate_limits: _cached_rate_limits,
+            project_state,
+            rate_limits: cached_rate_limits,
             enable_cardinality_limiter,
         } = message;
 
@@ -1504,11 +1500,11 @@ impl EnvelopeProcessorService {
         let bucket_partitions = partition_buckets(scoping.project_key, buckets, partitions);
 
         if self.rate_limit_batches(
-            _cached_rate_limits,
+            cached_rate_limits,
             scoping,
             &bucket_partitions,
             max_batch_size_bytes,
-            _project_state,
+            project_state,
         ) {
             return;
         }

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -1138,6 +1138,8 @@ impl Project {
                 buckets,
                 scoping,
                 extraction_mode,
+                project_state,
+                rate_limits: self.rate_limits.clone(),
             });
         }
     }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -34,6 +34,7 @@ use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Write};
+use std::ops::AddAssign;
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -530,6 +531,13 @@ pub struct SourceQuantities {
     pub transactions: usize,
     /// Profile quantity.
     pub profiles: usize,
+}
+
+impl AddAssign for SourceQuantities {
+    fn add_assign(&mut self, other: Self) {
+        self.transactions += other.transactions;
+        self.profiles += other.profiles;
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -172,6 +172,7 @@ impl<Q: AsRef<Vec<Quota>>> MetricsLimiter<Q> {
     fn drop_with_outcome(&mut self, outcome: Outcome, outcome_aggregator: Addr<TrackOutcome>) {
         // Drop transaction buckets:
         let metrics = std::mem::take(&mut self.metrics);
+        let timestamp = Utc::now();
 
         self.metrics = metrics
             .into_iter()
@@ -183,7 +184,6 @@ impl<Q: AsRef<Vec<Quota>>> MetricsLimiter<Q> {
 
         // Track outcome for the transaction metrics we dropped here:
         if self.transaction_count > 0 {
-            let timestamp = UnixTimestamp::now().as_datetime().unwrap_or_else(Utc::now);
             outcome_aggregator.send(TrackOutcome {
                 timestamp,
                 scoping: self.scoping,

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -211,22 +211,22 @@ def category_value(category):
 
 
 class OutcomesConsumer(ConsumerBase):
-    def _poll_all(self):
+    def _poll_all(self, timeout):
         while True:
-            outcome = self.poll()
+            outcome = self.poll(timeout)
             if outcome is None:
                 return
             else:
                 yield outcome
 
-    def get_outcomes(self):
-        outcomes = list(self._poll_all())
+    def get_outcomes(self, timeout=None):
+        outcomes = list(self._poll_all(timeout))
         for outcome in outcomes:
             assert outcome.error() is None
         return [json.loads(outcome.value()) for outcome in outcomes]
 
-    def get_outcome(self):
-        outcomes = self.get_outcomes()
+    def get_outcome(self, timeout=None):
+        outcomes = self.get_outcomes(timeout)
         assert len(outcomes) > 0, "No outcomes were consumed"
         assert len(outcomes) == 1, "More than one outcome was consumed"
         return outcomes[0]

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -497,7 +497,6 @@ def test_processing_quotas(
             assert event["logentry"]["formatted"] == "application / http.error"
         else:
             assert event["logentry"]["formatted"] == f"otherkey{i}"
-    assert False
 
 
 def test_sends_metric_bucket_outcome(

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -567,13 +567,10 @@ def test_rate_limit_metric_bucket(
     projectconfig = mini_sentry.add_full_project_config(project_id)
     mini_sentry.add_dsn_key_to_project(project_id)
 
-    public_keys = mini_sentry.get_dsn_public_key_configs(project_id)
-    key_id = public_keys[0]["numericId"]
     projectconfig["config"]["quotas"] = [
         {
             "id": f"test_rate_limiting_{uuid.uuid4().hex}",
-            "scope": "key",
-            "scopeId": str(key_id),
+            "scope": "organization",
             "categories": ["metric_bucket"],
             "limit": metric_bucket_limit,
             "window": 86400,

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -514,7 +514,7 @@ def test_sends_metric_bucket_outcome(
                 "bucket_interval": 1,
                 "initial_delay": 0,
                 "debounce_delay": 0,
-                "flush_interval": 1,
+                "flush_interval": 0,
             },
         }
     )
@@ -535,9 +535,8 @@ def test_sends_metric_bucket_outcome(
     metrics_payload = f"transactions/foo:42|c\nbar@second:17|c|T{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
 
-    sleep(1)
+    outcome = outcomes_consumer.get_outcome(timeout=3)
 
-    outcome = outcomes_consumer.get_outcome()
     assert outcome["category"] == 15
     assert outcome["quantity"] == 1
 


### PR DESCRIPTION
part of: https://github.com/getsentry/relay/issues/2716

in order to protect our kafka metric consumers, we want to have a way of rate limiting based on the amount of buckets, as that's what decides the load placed on our kafka topics.

We are starting out with just the org throughput limits but will be expanded upon further as outlined in the linked epic.

This is a re-revert of https://github.com/getsentry/relay/pull/2758 (reverted in https://github.com/getsentry/relay/pull/2821).