### PR TITLE
ref(crons): Rename DataCategory::MONITOR -> DataCategory::MonitorCheckIn

### DIFF
--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -42,7 +42,7 @@ pub enum DataCategory {
     /// contrast, `transaction` only guarantees that metrics have been accepted for the transaction.
     TransactionIndexed = 9,
     /// Monitor check-ins.
-    Monitor = 10,
+    MonitorCheckIn = 10,
     /// Indexed Profile
     ///
     /// This is the category for indexed profiles that will be stored later.
@@ -91,7 +91,9 @@ impl DataCategory {
             "replay" => Self::Replay,
             "transaction_processed" => Self::TransactionProcessed,
             "transaction_indexed" => Self::TransactionIndexed,
-            "monitor" => Self::Monitor,
+            // TODO(epurkhiser): May be removed once we validate this data category is not in use.
+            "monitor" => Self::MonitorCheckIn,
+            "monitor_checkin" => Self::MonitorCheckIn,
             "span" => Self::Span,
             "monitor_seat" => Self::MonitorSeat,
             "feedback" => Self::UserReportV2,
@@ -115,7 +117,7 @@ impl DataCategory {
             Self::Replay => "replay",
             Self::TransactionProcessed => "transaction_processed",
             Self::TransactionIndexed => "transaction_indexed",
-            Self::Monitor => "monitor",
+            Self::MonitorCheckIn => "monitor_checkin",
             Self::Span => "span",
             Self::MonitorSeat => "monitor_seat",
             Self::UserReportV2 => "feedback",

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -110,7 +110,7 @@ impl CategoryUnit {
             | DataCategory::TransactionIndexed
             | DataCategory::Span
             | DataCategory::MonitorSeat
-            | DataCategory::Monitor
+            | DataCategory::MonitorCheckIn
             | DataCategory::MetricBucket
             | DataCategory::UserReportV2 => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -606,7 +606,7 @@ impl Item {
             }),
             ItemType::ReplayEvent | ItemType::ReplayRecording => Some(DataCategory::Replay),
             ItemType::ClientReport => None,
-            ItemType::CheckIn => Some(DataCategory::Monitor),
+            ItemType::CheckIn => Some(DataCategory::MonitorCheckIn),
             ItemType::Unknown(_) => None,
             ItemType::Span => None,     // No outcomes, for now
             ItemType::OtelSpan => None, // No outcomes, for now

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -597,10 +597,10 @@ where
         }
 
         if summary.checkin_quantity > 0 {
-            let item_scoping = scoping.item(DataCategory::Monitor);
+            let item_scoping = scoping.item(DataCategory::MonitorCheckIn);
             let checkin_limits = (self.check)(item_scoping, summary.checkin_quantity)?;
             enforcement.check_ins = CategoryLimit::new(
-                DataCategory::Monitor,
+                DataCategory::MonitorCheckIn,
                 summary.checkin_quantity,
                 checkin_limits.longest(),
             );
@@ -990,14 +990,17 @@ mod tests {
         let mut envelope = envelope![CheckIn];
         let config = ProjectConfig::default();
 
-        let mut mock = MockLimiter::default().deny(DataCategory::Monitor);
+        let mut mock = MockLimiter::default().deny(DataCategory::MonitorCheckIn);
         let (enforcement, limits) = EnvelopeLimiter::new(Some(&config), |s, q| mock.check(s, q))
             .enforce(&mut envelope, &scoping())
             .unwrap();
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 0);
-        assert_eq!(mock.called, BTreeMap::from([(DataCategory::Monitor, 1)]));
+        assert_eq!(
+            mock.called,
+            BTreeMap::from([(DataCategory::MonitorCheckIn, 1)])
+        );
 
         let outcomes = enforcement
             .get_outcomes(&envelope, &scoping())
@@ -1005,7 +1008,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             outcomes,
-            vec![(Outcome::RateLimited(None), DataCategory::Monitor, 1)]
+            vec![(Outcome::RateLimited(None), DataCategory::MonitorCheckIn, 1)]
         )
     }
 


### PR DESCRIPTION
Before we start using this everywhere let's fix this naming so we don't
have to deal with this being confusing for the rest of time.

#skip-changelog