### PR TITLE
fix(spans): Parse quotes in MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - In on-demand metric extraction, use the normalized URL instead of raw URLs sent by SDKs. This bug prevented metrics for certain dashboard queries from being extracted. ([#2819](https://github.com/getsentry/relay/pull/2819))
 - Ignore whitespaces when parsing user reports. ([#2798](https://github.com/getsentry/relay/pull/2798))
+- Fix parsing bug for SQL queries. ([#2846](https://github.com/getsentry/relay/pull/2846))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,8 +4826,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ae05a8250b968a3f7db93155a84d68b2e6cea1583949af5ca5b5170c76c075"
+source = "git+https://github.com/getsentry/sqlparser-rs.git?rev=0bb7ec6ce661ecfc468f647fd1003b7839d37fa6#0bb7ec6ce661ecfc468f647fd1003b7839d37fa6"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -4836,8 +4835,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55fe75cb4a364c7f7ae06c7dbbc8d84bddd85d6cdf9975963c3935bc1991761e"
+source = "git+https://github.com/getsentry/sqlparser-rs.git?rev=0bb7ec6ce661ecfc468f647fd1003b7839d37fa6#0bb7ec6ce661ecfc468f647fd1003b7839d37fa6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -30,7 +30,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7.1"
 smallvec = { workspace = true }
-sqlparser = { version = "0.37.0", features = ["visitor"] }
+# Use a fork of sqlparser until https://github.com/sqlparser-rs/sqlparser-rs/pull/1065 gets merged:
+sqlparser = { git = "https://github.com/getsentry/sqlparser-rs.git", rev = "0bb7ec6ce661ecfc468f647fd1003b7839d37fa6", features = [
+    "visitor",
+] }
 thiserror = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -617,6 +617,28 @@ mod tests {
         "DELETE FROM some_table WHERE id IN (%s)"
     );
 
+    scrub_sql_test!(escape_quote, r#"SELECT 'Wayne\'s World'"#, "SELECT %s");
+
+    scrub_sql_test!(
+        escape_double_quote,
+        r#"SELECT '{"json": "yes"}'"#,
+        "SELECT %s"
+    );
+
+    scrub_sql_test_with_dialect!(
+        mysql_escape_quote,
+        "mysql",
+        r#"SELECT "Wayne's World"#,
+        "SELECT %s"
+    );
+
+    scrub_sql_test_with_dialect!(
+        mysql_escape_double_quote,
+        "mysql",
+        r#"SELECT "{\"json\": \"yes\"}""#,
+        "SELECT %s"
+    );
+
     scrub_sql_test!(
         bytesa,
         r#"SELECT "t"."x", "t"."arr"::bytea, "t"."c" WHERE "t"."id" IN (%s, %s)"#,

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -628,7 +628,7 @@ mod tests {
     scrub_sql_test_with_dialect!(
         mysql_escape_quote,
         "mysql",
-        r#"SELECT "Wayne's World"#,
+        r#"SELECT "Wayne's World""#,
         "SELECT %s"
     );
 

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -429,6 +429,10 @@ impl DialectWithParameters {
 }
 
 impl Dialect for DialectWithParameters {
+    fn dialect(&self) -> std::any::TypeId {
+        self.0.dialect()
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         Self::PARAMETERS.contains(ch) || self.0.is_identifier_start(ch)
     }


### PR DESCRIPTION
Some of the dialect-specific parsing logic did not apply because we use a wrapped dialect `DialectWithParameters`, which has the wrong `type_id()`.

Until https://github.com/sqlparser-rs/sqlparser-rs/pull/1065 gets merged, use a fork of `sqlparser` to make `DialectWithParameters` behave like the underlying dialect.

ref: https://github.com/getsentry/relay/issues/2847