### PR TITLE
feat(spans): Remove unused transaction tag from resource metrics

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -286,9 +286,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
                     .always(), // already guarded by condition on metric
-                Tag::with_key("transaction")
-                    .from_field("span.sentry_tags.transaction")
-                    .always(), // already guarded by condition on metric
             ],
         },
         MetricSpec {
@@ -321,9 +318,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
                     .always(), // already guarded by condition on metric
                 Tag::with_key("span.op")
                     .from_field("span.sentry_tags.op")
-                    .always(), // already guarded by condition on metric
-                Tag::with_key("transaction")
-                    .from_field("span.sentry_tags.transaction")
                     .always(), // already guarded by condition on metric
             ],
         },

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -1603,7 +1603,6 @@ expression: metrics
             "span.domain": "*.domain.com",
             "span.group": "d744fa0716ef1142",
             "span.op": "resource.css",
-            "transaction": "gEt /api/:version/users/",
         },
     },
     Bucket {
@@ -1623,7 +1622,6 @@ expression: metrics
             "span.domain": "*.domain.com",
             "span.group": "d744fa0716ef1142",
             "span.op": "resource.css",
-            "transaction": "gEt /api/:version/users/",
         },
     },
     Bucket {

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -1608,7 +1608,6 @@ expression: metrics
             "span.domain": "*.domain.com",
             "span.group": "7f402250846262be",
             "span.op": "resource.css",
-            "transaction": "gEt /api/:version/users/",
         },
     },
     Bucket {
@@ -1628,7 +1627,6 @@ expression: metrics
             "span.domain": "*.domain.com",
             "span.group": "7f402250846262be",
             "span.op": "resource.css",
-            "transaction": "gEt /api/:version/users/",
         },
     },
     Bucket {


### PR DESCRIPTION
We currently set the high cardinality `transaction` tag on all of the resource size metrics:

- `http.response_content_length` (encoded size)
- `http.decoded_response_content_length`
- `http.response_transfer_size`

However, we only show `http.response_content_length` split by transaction in the UI, so for now the tag can be removed on the other two metrics.

#skip-changelog