### PR TITLE
feat(spans): Allow resource.img spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Allow ingestion of metrics summary on spans. ([#2823](https://github.com/getsentry/relay/pull/2823))
 - Add metric_bucket data category. ([#2824](https://github.com/getsentry/relay/pull/2824))
 - Org rate limit metrics per bucket. ([#2836](https://github.com/getsentry/relay/pull/2836))
-- Keep only domain and extension for image resource span grouping. ([#2826](https://github.com/getsentry/relay/pull/2826))
+- Emit image resource spans, grouped by domain and extension. ([#2826](https://github.com/getsentry/relay/pull/2826), [#2855](https://github.com/getsentry/relay/pull/2855))
 
 ## 23.11.2
 

--- a/relay-server/src/actors/processor/span/processing.rs
+++ b/relay-server/src/actors/processor/span/processing.rs
@@ -314,16 +314,17 @@ fn is_allowed(span: &Span) -> bool {
         .unwrap_or_default();
     op.contains("resource.script")
         || op.contains("resource.css")
+        || op == "resource.img"
         || op == "http.client"
         || op.starts_with("app.")
         || op.starts_with("ui.load")
         || op.starts_with("file")
-        || op.starts_with("db")
+        || (op.starts_with("db")
             && !(op.contains("clickhouse")
                 || op.contains("mongodb")
                 || op.contains("redis")
                 || op.contains("compiler"))
-            && !(op == "db.sql.query" && (description.contains("\"$") || system == "mongodb"))
+            && !(op == "db.sql.query" && (description.contains("\"$") || system == "mongodb")))
 }
 
 /// We do not extract or ingest spans with missing fields if those fields are required on the Kafka topic.


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/2826 introduced grouping `resource.img` spans by domain + extension, allowing us to enable span metrics for this op. Now also enable `resource.img` for the spans dataset.