### PR TITLE
fix(build): Add additional dependencies to the release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV RUST_TOOLCHAIN_VERSION=${RUST_TOOLCHAIN_VERSION}
 RUN yum -y update \
   && yum -y install centos-release-scl epel-release \
   # install a modern compiler toolchain
-  && yum -y install cmake3 devtoolset-10 git \
+  && yum -y install cmake3 devtoolset-10 git perl-core openssl openssl-devel pkgconfig libatomic \
   # below required for sentry-native
   llvm-toolset-7.0-clang-devel \
   && yum clean all \


### PR DESCRIPTION
Adding addition dependencies into the `Dockerfile` used by the release build to make sure Relay can be built with new openssl dependencies. 


Current release build is failing: https://github.com/getsentry/relay/actions/runs/7224869848/job/19690242007

Related #2785 

#skip-changelog