### PR TITLE
ci: Update upload-artifact and download-artifact actions

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -33,7 +33,7 @@ jobs:
           zip relay-Linux-x86_64-debug.zip relay.debug
           mv relay relay-Linux-x86_64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: target/x86_64-unknown-linux-gnu/release/relay-Linux-x86_64*
@@ -61,7 +61,7 @@ jobs:
           mv relay relay-Darwin-x86_64
           zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: target/release/relay-Darwin-x86_64*
@@ -88,7 +88,7 @@ jobs:
           7z a relay-Windows-x86_64-pdb.zip relay.pdb
           mv relay.exe relay-Windows-x86_64.exe
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: target/release/relay-Windows-x86_64*

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           TARGET: ${{ matrix.build-arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: py/dist/*
@@ -80,7 +80,7 @@ jobs:
           # consumed by cargo and setup.py to obtain the target dir
           CARGO_BUILD_TARGET: ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: py/dist/*
@@ -102,7 +102,7 @@ jobs:
         run: python setup.py sdist --format=zip
         working-directory: py
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: py/dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         run: docker save -o ${{ matrix.image_name }}-docker-image.tgz $IMG_VERSIONED
 
       - name: Upload Docker Image to Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 1
           name: ${{ matrix.image_name }}-docker-image
@@ -271,7 +271,7 @@ jobs:
 
     steps:
       - name: Download Docker Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.image_name }}-docker-image
 
@@ -432,7 +432,7 @@ jobs:
           symbolicator: true
 
       - name: Download Docker Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: relay-docker-image
 


### PR DESCRIPTION
Update Github actions.

Supersedes https://github.com/getsentry/relay/pull/2860 and https://github.com/getsentry/relay/pull/2859


#skip-changelog