### PR TITLE
fix(normalization): Normalize timestamps before TimestampProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug fixes**:
+
+- Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2851](https://github.com/getsentry/relay/issues/2851))
+
 **Internal**:
 
 - Use a Lua script and in-memory cache for the cardinality limiting to reduce load on Redis. ([#2849](https://github.com/getsentry/relay/pull/2849))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug fixes**:
 
-- Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2851](https://github.com/getsentry/relay/issues/2851))
+- Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2878](https://github.com/getsentry/relay/pull/2878))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - This release requires Python 3.9 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.8.
-- Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2851](https://github.com/getsentry/relay/issues/2851))
+- Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2878](https://github.com/getsentry/relay/pull/2878))
 
 ## 0.8.39
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 This release requires Python 3.9 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.8.
 
+- Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2851](https://github.com/getsentry/relay/issues/2851))
+
 ## 0.8.39
 
 - Add `_metrics_summary` as temporary key on `Event` for a DDM experiment. ([#2757](https://github.com/getsentry/relay/pull/2757))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-This release requires Python 3.9 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.8.
-
+- This release requires Python 3.9 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.8.
 - Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2851](https://github.com/getsentry/relay/issues/2851))
 
 ## 0.8.39

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2344,20 +2344,24 @@ mod tests {
 
     #[test]
     fn test_reject_stale_transactions_after_timestamp_normalization() {
+        let now = Utc::now();
         let config = NormalizationConfig {
-            received_at: Some(Utc::now()),
+            received_at: Some(now),
             max_secs_in_past: Some(2),
             max_secs_in_future: Some(1),
             ..Default::default()
         };
 
-        let json = r#"{
-  "event_id": "52df9022835246eeb317dbd739ccd059",
-  "transaction": "clockdrift is not enough to accept me :(",
-  "start_timestamp": -62135811111,
-  "timestamp": 1697711111
-}"#;
-        let mut event = Annotated::<Event>::from_json(json).unwrap();
+        let json = format!(
+            r#"{{
+          "event_id": "52df9022835246eeb317dbd739ccd059",
+          "transaction": "clockdrift is not enough to accept me :(",
+          "start_timestamp": -62135811111,
+          "timestamp": {}
+        }}"#,
+            now.timestamp()
+        );
+        let mut event = Annotated::<Event>::from_json(json.as_str()).unwrap();
 
         assert_eq!(
             normalize_event(&mut event, &config)

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2322,6 +2322,8 @@ mod tests {
         "###);
     }
 
+    /// Test that timestamp normalization updates a transaction's timestamps to
+    /// be acceptable, when both timestamps are similarly stale.
     #[test]
     fn test_accept_recent_transactions_with_stale_timestamps() {
         let config = NormalizationConfig {
@@ -2333,7 +2335,7 @@ mod tests {
 
         let json = r#"{
   "event_id": "52df9022835246eeb317dbd739ccd059",
-  "transaction": "i have an stale timestamp, but im recent!",
+  "transaction": "I have a stale timestamp, but I'm recent!",
   "start_timestamp": -2,
   "timestamp": -1
 }"#;
@@ -2342,6 +2344,11 @@ mod tests {
         assert!(normalize_event(&mut event, &config).is_ok());
     }
 
+    /// Test that transactions are rejected as invalid when timestamp normalization isn't enough.
+    ///
+    /// When the end timestamp is recent but the start timestamp is stale, timestamp normalization
+    /// will fix the timestamps based on the end timestamp. The start timestamp will be more recent,
+    /// but not recent enough for the transaction to be accepted. The transaction will be rejected.
     #[test]
     fn test_reject_stale_transactions_after_timestamp_normalization() {
         let now = Utc::now();


### PR DESCRIPTION
This PR moves timestamp normalization to happen before running the `TimestampProcessor` during event normalization.

`TimestampProcessor` rejects events with stale timestamps. However, it's possible that the clock in a network isn't up-to-date and events are sent with a stale timestamp even if they are just generated, resulting in Relay rejecting these events. The timestamp normalization step solves the clock issue but must happen before validation.

Fixes https://github.com/getsentry/relay/issues/2851.