### PR TITLE
feat(stats-detectors): Add transaction.op to duration light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use a Lua script and in-memory cache for the cardinality limiting to reduce load on Redis. ([#2849](https://github.com/getsentry/relay/pull/2849))
 - Add an internal endpoint that allows Relays to submit metrics from multiple projects in a single request. ([#2869](https://github.com/getsentry/relay/pull/2869))
 - Emit a `processor.message.duration` metric to assess the throughput of the internal CPU pool. ([#2877](https://github.com/getsentry/relay/pull/2877))
+- Add `transaction.op` to the duration light metric. ([#2881](https://github.com/getsentry/relay/pull/2881))
 
 ## 23.12.0
 

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -129,9 +129,10 @@ fn track_transaction_name_stats(event: &Event) {
 }
 
 /// These are the tags that are added to extracted low cardinality metrics.
-fn extract_light_transaction_tags(event: &Event) -> LightTransactionTags {
+fn extract_light_transaction_tags(tags: &CommonTags) -> LightTransactionTags {
     LightTransactionTags {
-        transaction: get_transaction_name(event),
+        transaction_op: tags.0.get(&CommonTag::TransactionOp).cloned(),
+        transaction: tags.0.get(&CommonTag::Transaction).cloned(),
     }
 }
 
@@ -272,7 +273,7 @@ impl TransactionExtractor<'_> {
 
         track_transaction_name_stats(event);
         let tags = extract_universal_tags(event, self.config);
-        let light_tags = extract_light_transaction_tags(event);
+        let light_tags = extract_light_transaction_tags(&tags);
 
         // Measurements
         let measurement_names: BTreeSet<_> = event
@@ -803,6 +804,7 @@ mod tests {
                 ),
                 tags: {
                     "transaction": "gEt /api/:version/users/",
+                    "transaction.op": "mYOp",
                 },
             },
             Bucket {

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -142,12 +142,16 @@ impl From<TransactionDurationTags> for BTreeMap<String, String> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct LightTransactionTags {
+    pub transaction_op: Option<String>,
     pub transaction: Option<String>,
 }
 
 impl From<LightTransactionTags> for BTreeMap<String, String> {
     fn from(tags: LightTransactionTags) -> Self {
         let mut map = BTreeMap::new();
+        if let Some(transaction_op) = tags.transaction_op {
+            map.insert(CommonTag::TransactionOp.to_string(), transaction_op);
+        }
         if let Some(transaction) = tags.transaction {
             map.insert(CommonTag::Transaction.to_string(), transaction);
         }


### PR DESCRIPTION
We actually need to extract transaction.op as well since some transactions can have the same name but different ops.