### PR TITLE
fix(spans): Scrub double-quoted strings in fallback mode

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -43,6 +43,17 @@ static NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
+/// For MySQL, also look for double quoted strings.
+static DOUBLE_QUOTED_STRING_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?xi)
+        # Capture double-quoted strings, including the remaining substring if `\'` is found.
+        ((?-x)(?P<single_quoted_strs>N?"(?:\\"|[^"])*(?:"|$)(::\w+(\[\]?)?)?))
+        "#,
+    )
+    .unwrap()
+});
+
 /// Removes extra whitespace and newlines.
 static WHITESPACE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\s*\n\s*)|(\s\s+)").unwrap());
 
@@ -133,21 +144,37 @@ fn scrub_queries_inner(db_system: Option<&str>, string: &str) -> (Option<String>
 
     let mut string = Cow::from(string.trim());
 
-    for (regex, replacement) in [
-        (&COMMENTS, "\n"),
-        (&INLINE_COMMENTS, ""),
-        (&NORMALIZER_REGEX, "$pre%s"),
-        (&WHITESPACE, " "),
-        (&PARENS, "$pre$post"),
-        (&COLLAPSE_PLACEHOLDERS, "$pre%s$post"),
-        (&STRIP_QUOTES, "$entity_name"),
-        (&COLLAPSE_ENTITIES, "$entity_name"),
-        (&COLLAPSE_COLUMNS, "$pre..$post"),
-    ] {
-        let replaced = regex.replace_all(&string, replacement);
-        if let Cow::Owned(s) = replaced {
+    if let Cow::Owned(s) = COMMENTS.replace_all(&string, "\n") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = INLINE_COMMENTS.replace_all(&string, "") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = NORMALIZER_REGEX.replace_all(&string, "$pre%s") {
+        string = Cow::Owned(s);
+    }
+    if db_system == Some("mysql") {
+        if let Cow::Owned(s) = DOUBLE_QUOTED_STRING_REGEX.replace_all(&string, "%s") {
             string = Cow::Owned(s);
         }
+    }
+    if let Cow::Owned(s) = WHITESPACE.replace_all(&string, " ") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = PARENS.replace_all(&string, "$pre$post") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = COLLAPSE_PLACEHOLDERS.replace_all(&string, "$pre%s$post") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = STRIP_QUOTES.replace_all(&string, "$entity_name") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = COLLAPSE_ENTITIES.replace_all(&string, "$entity_name") {
+        string = Cow::Owned(s);
+    }
+    if let Cow::Owned(s) = COLLAPSE_COLUMNS.replace_all(&string, "$pre..$post") {
+        string = Cow::Owned(s);
     }
 
     let result = match string {
@@ -766,6 +793,16 @@ mod tests {
         fallback_hex,
         r#"SELECT {ts '2023-12-24 23:59'}, 0x123456789AbCdEf"#,
         "SELECT %s, %s"
+    );
+
+    scrub_sql_test_with_dialect!(
+        dont_fallback_to_regex,
+        "mysql",
+        // sqlparser cannot parse REPLACE INTO. If we know that
+        // a query is MySQL, we should give up rather than try to scrub
+        // with regex
+        r#"REPLACE INTO `foo` (`a`) VALUES ("abcd1234")"#,
+        "REPLACE INTO foo (a) VALUES (%s)"
     );
 
     scrub_sql_test!(


### PR DESCRIPTION
Double quotes delimit identifiers (for example, column names) in most dialects, but in MySQL they can be also used for string values. When a query cannot be parsed for whatever reason, our fallback regex scrubber should remove these strings as it does for other dialects.

#skip-changelog