### PR TITLE
ref(server): Improve request body and signature handling

### DIFF
--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1332,11 +1332,11 @@ impl EnvelopeProcessorService {
     }
 
     fn encode_envelope_body(
-        body: Vec<u8>,
+        body: Bytes,
         http_encoding: HttpEncoding,
-    ) -> Result<Vec<u8>, std::io::Error> {
-        let envelope_body = match http_encoding {
-            HttpEncoding::Identity => body,
+    ) -> Result<Bytes, std::io::Error> {
+        let envelope_body: Vec<u8> = match http_encoding {
+            HttpEncoding::Identity => return Ok(body),
             HttpEncoding::Deflate => {
                 let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
                 encoder.write_all(body.as_ref())?;
@@ -1354,7 +1354,8 @@ impl EnvelopeProcessorService {
                 encoder.into_inner()
             }
         };
-        Ok(envelope_body)
+
+        Ok(envelope_body.into())
     }
 
     fn handle_encode_envelope(&self, message: EncodeEnvelope) {

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -314,6 +314,12 @@ pub trait UpstreamRequest: Send + Sync + fmt::Debug {
     fn route(&self) -> &'static str;
 
     /// Callback to apply configuration to the request.
+    ///
+    /// This hook is called at least once before `build`. It can be used to include additional
+    /// properties from Relay's config in the Request before it is sent or handled if during request
+    /// creation time the configuration is not available.
+    ///
+    /// This method is optional and defaults to a no-op.
     fn configure(&mut self, _config: &Config) {}
 
     /// Callback to build the outgoing web request.

--- a/relay-server/src/actors/upstream.rs
+++ b/relay-server/src/actors/upstream.rs
@@ -297,6 +297,12 @@ pub trait UpstreamRequest: Send + Sync + fmt::Debug {
         true
     }
 
+    /// Add the `X-Sentry-Relay-Signature` header to the outgoing request.
+    ///
+    /// This requires configuration of the Relay's credentials. If the credentials are not
+    /// configured, the request will fail with [`UpstreamRequestError::NoCredentials`].
+    ///
+    /// Defaults to `false`.
     fn sign(&self) -> bool {
         false
     }

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -72,7 +72,6 @@ impl IntoResponse for ForwardError {
                 }
                 HttpError::Io(_) => StatusCode::BAD_GATEWAY.into_response(),
                 HttpError::Json(_) => StatusCode::BAD_REQUEST.into_response(),
-                HttpError::NoCredentials => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             },
             UpstreamRequestError::SendFailed(e) => {
                 if e.is_timeout() {

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -20,8 +20,6 @@ use serde::de::DeserializeOwned;
 pub enum HttpError {
     #[error("payload too large")]
     Overflow,
-    #[error("attempted to send upstream request without credentials configured")]
-    NoCredentials,
     #[error("could not send request")]
     Reqwest(#[from] reqwest::Error),
     #[error("failed to stream payload")]
@@ -40,7 +38,6 @@ impl HttpError {
             Self::Reqwest(error) => error.is_timeout(),
             Self::Json(_) => false,
             HttpError::Overflow => false,
-            HttpError::NoCredentials => false,
         }
     }
 }

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -65,11 +65,11 @@ impl RequestBuilder {
         Ok(Request(builder.build()?))
     }
 
-    fn build<F>(&mut self, mut f: F) -> &mut Self
+    fn build<F>(&mut self, f: F) -> &mut Self
     where
         F: FnMut(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
     {
-        self.builder = Some(f(self.builder.take().unwrap()));
+        self.builder = self.builder.take().map(f);
         self
     }
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -97,8 +97,8 @@ impl RequestBuilder {
         self.header_opt("content-encoding", encoding.name())
     }
 
-    pub fn body<B: Into<Bytes>>(&mut self, body: B) -> &mut Self {
-        self.body = Some(body.into());
+    pub fn body(&mut self, body: Bytes) -> &mut Self {
+        self.body = Some(body);
         self
     }
 


### PR DESCRIPTION
Changes the signature of `UpstreamRequest` so that any request can be
configured to be signed now. Before, this was possible only for query
requests. The `UpstreamRequest` trait now has a `sign() -> bool` method
that returns whether or not a signature should be applied.

Along with this, there are changes to the request builder to make it
more ergonomic for the common use case:

- The builder uses interior mutability instead of moving now.
- `RequestBuilder` now takes `Into<Bytes>` as body, which allows for
  more efficient retries. However, it is still the responsibility of the
  request to ensure bytes are cloned. This is because usually we want
  expensive serialization operations outside of the Upstream's runtime.
- The `build()` function no longer receives the config, as this was
  needed just for internal query requests.
- The `build()` function does not need to finish the request, this is
  done by the upstream now.
- `HttpError::NoCredentials` has been removed. This was a hack to allow
  emitting this error from the build callback, but this is no longer
  required.

#skip-changelog