### PR TITLE
ref(server): Create reusable utils for metric outcomes

### DIFF
--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -96,12 +96,12 @@ impl<'a> BucketsView<'a> {
     }
 
     /// Iterator over all buckets in the view.
-    pub fn iter(&self) -> impl Iterator<Item = BucketView<'a>> {
+    pub fn iter(&self) -> BucketsViewIter<'a> {
         BucketsViewIter::new(self.inner, self.start, self.end)
     }
 
     /// Iterator which slices the source view into segments with an approximate size of `size_in_bytes`.
-    pub fn by_size(&self, size_in_bytes: usize) -> impl Iterator<Item = BucketsView<'a>> {
+    pub fn by_size(&self, size_in_bytes: usize) -> BucketsViewBySizeIter<'a> {
         BucketsViewBySizeIter::new(self.inner, self.start, self.end, size_in_bytes)
     }
 }
@@ -113,10 +113,19 @@ impl<'a> fmt::Debug for BucketsView<'a> {
     }
 }
 
+impl<'a> IntoIterator for &'_ BucketsView<'a> {
+    type Item = BucketView<'a>;
+    type IntoIter = BucketsViewIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 /// Iterator yielding all items contained in a [`BucketsView`].
 ///
 /// First and/or last item may be partial buckets.
-struct BucketsViewIter<'a> {
+pub struct BucketsViewIter<'a> {
     /// Source slice of buckets.
     inner: &'a [Bucket],
     /// Current index.
@@ -185,7 +194,7 @@ impl<'a> Iterator for BucketsViewIter<'a> {
 /// Iterator slicing a [`BucketsView`] into smaller views constrained by a given size in bytes.
 ///
 /// See [`estimate_size`] for how the size of a bucket is calculated.
-struct BucketsViewBySizeIter<'a> {
+pub struct BucketsViewBySizeIter<'a> {
     /// Source slice.
     inner: &'a [Bucket],
     /// Current position in the slice.
@@ -437,26 +446,9 @@ impl<'a> fmt::Debug for BucketView<'a> {
     }
 }
 
-impl From<&BucketView<'_>> for Bucket {
-    fn from(value: &BucketView<'_>) -> Self {
-        // short circuit, it's the entire bucket
-        if value.is_full_bucket() {
-            return value.inner.clone();
-        }
-
-        Bucket {
-            timestamp: value.inner.timestamp,
-            width: value.inner.width,
-            name: value.inner.name.clone(),
-            value: value.value().into(),
-            tags: value.inner.tags.clone(),
-        }
-    }
-}
-
-impl From<BucketView<'_>> for Bucket {
-    fn from(value: BucketView<'_>) -> Self {
-        Bucket::from(&value)
+impl<'a> From<&'a Bucket> for BucketView<'a> {
+    fn from(value: &'a Bucket) -> Self {
+        BucketView::new(value)
     }
 }
 

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -193,7 +193,7 @@ impl<'a> Iterator for BucketsViewIter<'a> {
 
 /// Iterator slicing a [`BucketsView`] into smaller views constrained by a given size in bytes.
 ///
-/// See [`estimate_size`] for how the size of a bucket is calculated.
+// See [`estimate_size`] for how the size of a bucket is calculated.
 pub struct BucketsViewBySizeIter<'a> {
     /// Source slice.
     inner: &'a [Bucket],

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -531,6 +531,8 @@ pub struct SourceQuantities {
     pub transactions: usize,
     /// Profile quantity.
     pub profiles: usize,
+    /// Total number of buckets.
+    pub buckets: usize,
 }
 
 impl AddAssign for SourceQuantities {

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -142,7 +142,7 @@ impl ExtractionMode {
     }
 }
 
-/// Return value of [`extract_transaction_count`], containing the extracted
+/// Return value of [`count_metric_bucket`], containing the extracted
 /// count of transactions and wether they have associated profiles.
 #[derive(Debug, Clone, Copy)]
 struct TransactionCount {

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -145,7 +145,7 @@ impl ExtractionMode {
 /// Return value of [`extract_transaction_count`], containing the extracted
 /// count of transactions and wether they have associated profiles.
 #[derive(Debug, Clone, Copy)]
-pub struct TransactionCount {
+struct TransactionCount {
     /// Number of transactions.
     pub count: usize,
     /// Whether the transactions have associated profiles.

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -8,6 +8,7 @@ use relay_quotas::{DataCategory, ItemScoping, Quota, RateLimits, Scoping};
 use relay_system::Addr;
 
 use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
+use crate::envelope::SourceQuantities;
 
 /// Contains all data necessary to rate limit metrics or metrics buckets.
 #[derive(Debug)]
@@ -36,7 +37,7 @@ pub struct MetricsLimiter<Q: AsRef<Vec<Quota>> = Vec<Quota>> {
 
 const PROFILE_TAG: &str = "has_profile";
 
-/// Extracts the transaction count from a metric.
+/// Extracts quota information from a metric.
 ///
 /// If the metric was extracted from a or multiple transaction, it returns the amount
 /// of datapoints contained in the bucket.
@@ -44,10 +45,7 @@ const PROFILE_TAG: &str = "has_profile";
 /// Additionally tracks whether the transactions also contained profiling information.
 ///
 /// Returns `None` if the metric was not extracted from transactions.
-pub fn extract_transaction_count(
-    metric: &BucketView<'_>,
-    mode: ExtractionMode,
-) -> Option<TransactionCount> {
+fn count_metric_bucket(metric: BucketView<'_>, mode: ExtractionMode) -> Option<TransactionCount> {
     let mri = match MetricResourceIdentifier::parse(metric.name()) {
         Ok(mri) => mri,
         Err(_) => {
@@ -71,6 +69,54 @@ pub fn extract_transaction_count(
         && metric.tag(PROFILE_TAG) == Some("true");
 
     Some(TransactionCount { count, has_profile })
+}
+
+/// Extracts quota information from a list of metric buckets.
+pub fn extract_metric_quantities<'a, I, V>(buckets: I, mode: ExtractionMode) -> SourceQuantities
+where
+    I: IntoIterator<Item = V>,
+    BucketView<'a>: From<V>,
+{
+    let mut quantities = SourceQuantities::default();
+
+    for bucket in buckets {
+        quantities.buckets += 1;
+        if let Some(count) = count_metric_bucket(bucket.into(), mode) {
+            quantities.transactions += count.count;
+            if count.has_profile {
+                quantities.profiles += count.count;
+            }
+        }
+    }
+
+    quantities
+}
+
+pub fn reject_metrics(
+    addr: Addr<TrackOutcome>,
+    quantities: SourceQuantities,
+    scoping: Scoping,
+    outcome: Outcome,
+) {
+    let timestamp = Utc::now();
+
+    let categories = [
+        (DataCategory::Transaction, quantities.transactions as u32),
+        (DataCategory::Profile, quantities.profiles as u32),
+        (DataCategory::MetricBucket, quantities.buckets as u32),
+    ];
+
+    for (category, quantity) in categories {
+        addr.send(TrackOutcome {
+            timestamp,
+            scoping,
+            outcome: outcome.clone(),
+            event_id: None,
+            remote_addr: None,
+            category,
+            quantity,
+        });
+    }
 }
 
 /// Wether to extract transaction and profile count based on the usage or duration metric.
@@ -118,7 +164,7 @@ impl<Q: AsRef<Vec<Quota>>> MetricsLimiter<Q> {
     ) -> Result<Self, Vec<Bucket>> {
         let counts: Vec<_> = buckets
             .iter()
-            .map(|metric| extract_transaction_count(&BucketView::new(metric), mode))
+            .map(|metric| count_metric_bucket(BucketView::new(metric), mode))
             .collect();
 
         // Accumulate the total transaction count and profile count

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -107,15 +107,17 @@ pub fn reject_metrics(
     ];
 
     for (category, quantity) in categories {
-        addr.send(TrackOutcome {
-            timestamp,
-            scoping,
-            outcome: outcome.clone(),
-            event_id: None,
-            remote_addr: None,
-            category,
-            quantity,
-        });
+        if quantity > 0 {
+            addr.send(TrackOutcome {
+                timestamp,
+                scoping,
+                outcome: outcome.clone(),
+                event_id: None,
+                remote_addr: None,
+                category,
+                quantity,
+            });
+        }
     }
 }
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1271,6 +1271,7 @@ mod tests {
         item.set_source_quantities(SourceQuantities {
             transactions: 5,
             profiles: 2,
+            buckets: 5,
         });
         envelope.add_item(item);
 
@@ -1278,6 +1279,7 @@ mod tests {
         item.set_source_quantities(SourceQuantities {
             transactions: 2,
             profiles: 0,
+            buckets: 3,
         });
         envelope.add_item(item);
 


### PR DESCRIPTION
Moves utilities to collect `SourceQuantities` from metrics as well as logging
outcomes from `SourceQuantities` into a reusable place, so that we can check and
enforce rate limits outside of the processor.

This PR also fixes two issues with metric rate limiting:
- Emit the correct reason code for cached rate limits. Before, this would emit
  the reason code of the longest quota independently of whether that quota
  matched.
- Lower the log level for rate limited buckets to DEBUG

#skip-changelog

