### PR TITLE
ref(server): Separate methods for encoding metrics

### DIFF
--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -528,22 +528,14 @@ pub enum BucketViewValue<'a> {
     Gauge(GaugeValue),
 }
 
-impl<'a> From<&BucketViewValue<'a>> for BucketValue {
-    fn from(value: &BucketViewValue<'a>) -> Self {
+impl<'a> From<&'a BucketValue> for BucketViewValue<'a> {
+    fn from(value: &'a BucketValue) -> Self {
         match value {
-            BucketViewValue::Counter(c) => BucketValue::Counter(*c),
-            BucketViewValue::Distribution(d) => {
-                BucketValue::Distribution(d.iter().copied().collect())
-            }
-            BucketViewValue::Set(s) => BucketValue::Set(s.iter().copied().collect()),
-            BucketViewValue::Gauge(g) => BucketValue::Gauge(*g),
+            BucketValue::Counter(c) => BucketViewValue::Counter(*c),
+            BucketValue::Distribution(d) => BucketViewValue::Distribution(d),
+            BucketValue::Set(s) => BucketViewValue::Set(SetView::new(s, 0..s.len())),
+            BucketValue::Gauge(g) => BucketViewValue::Gauge(*g),
         }
-    }
-}
-
-impl<'a> From<BucketViewValue<'a>> for BucketValue {
-    fn from(value: BucketViewValue<'a>) -> Self {
-        BucketValue::from(&value)
     }
 }
 

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -212,7 +212,7 @@ impl EnvelopeManagerService {
         partition_key: Option<u64>,
     ) -> Result<(), SendEnvelopeError> {
         #[cfg(feature = "processing")]
-        {
+        if self.config.processing_enabled() {
             if let Some(store_forwarder) = self.store_forwarder.clone() {
                 relay_log::trace!("sending envelope to kafka");
                 let future = store_forwarder.send(StoreEnvelope {

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -199,6 +199,7 @@ impl EnvelopeManagerService {
             project_cache,
             test_store,
             upstream_relay,
+            #[cfg(feature = "processing")]
             store_forwarder,
         }
     }

--- a/relay-server/src/actors/envelopes.rs
+++ b/relay-server/src/actors/envelopes.rs
@@ -191,6 +191,7 @@ impl EnvelopeManagerService {
         project_cache: Addr<ProjectCache>,
         test_store: Addr<TestStore>,
         upstream_relay: Addr<UpstreamRelay>,
+        #[cfg(feature = "processing")] store_forwarder: Option<Addr<Store>>,
     ) -> Self {
         Self {
             config,
@@ -198,15 +199,8 @@ impl EnvelopeManagerService {
             project_cache,
             test_store,
             upstream_relay,
-            #[cfg(feature = "processing")]
-            store_forwarder: None,
+            store_forwarder,
         }
-    }
-
-    /// Configures a store forwarder to produce Envelopes to Kafka.
-    #[cfg(feature = "processing")]
-    pub fn set_store_forwarder(&mut self, addr: Addr<Store>) {
-        self.store_forwarder = Some(addr);
     }
 
     /// Sends an envelope to the upstream or Kafka.

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1513,8 +1513,10 @@ impl EnvelopeProcessorService {
 
     fn handle_encode_metrics(&self, message: EncodeMetrics) {
         #[cfg(feature = "processing")]
-        if let Some(ref store_forwarder) = self.inner.store_forwarder {
-            return self.encode_metrics_processing(message, store_forwarder);
+        if self.inner.config.processing_enabled() {
+            if let Some(ref store_forwarder) = self.inner.store_forwarder {
+                return self.encode_metrics_processing(message, store_forwarder);
+            }
         }
 
         self.encode_metrics_envelope(message)

--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -82,7 +82,7 @@ pub struct StoreEnvelope {
     pub scoping: Scoping,
 }
 
-/// TODO
+/// Publishes a list of [`Bucket`]s to the Sentry core application through Kafka topics.
 #[derive(Clone, Debug)]
 pub struct StoreMetrics {
     pub buckets: Vec<Bucket>,

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -124,6 +124,8 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
         test_store,
         #[cfg(feature = "processing")]
         _aggregator,
+        #[cfg(feature = "processing")]
+        None,
     )
 }
 


### PR DESCRIPTION
This introduces two methods for flushing metric buckets:

1. The version for external and PoP Relays that performs partitioning,
   batching, and sends envelopes.
2. The version for processing Relays that performs cardinality limiting,
   rate limiting, and sends kafka messages directly. Batching occurs in
   the store forwarder.

To submit metric buckets to kafka more efficiently, there's a new
message `StoreMetrics` that can take in-memory buckets. It splits
buckets internally so that the caller doesn't have to take care of that
anymore. This is a fire-and-forget message that does not require the
caller to await the result.

The `StoreForwarder` therefore is now responsible to log outcomes for
metric buckets that cannot be produced.

#skip-changelog