### PR TITLE
build(deps): Bump unsafe-libyaml from 0.2.5 to 0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,9 +5664,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "ureq"


### PR DESCRIPTION
Update dependencies:
- `unsafe-libyaml` bump `0.2.5` -> `0.2.10`


supersedes https://github.com/getsentry/relay/pull/2891

#skip-changelog