### PR TITLE
ref(metrics): Change flush into a cross-project message

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -757,6 +757,13 @@ struct Http {
     ///  - `gzip` (default): Compression using gzip.
     ///  - `br`: Compression using the brotli algorithm.
     encoding: HttpEncoding,
+    /// Submit metrics globally through a shared endpoint.
+    ///
+    /// As opposed to regular envelopes which are sent to an endpoint inferred from the project's
+    /// DSN, this submits metrics to the global endpoint with Relay authentication.
+    ///
+    /// This option does not have any effect on processing mode.
+    global_metrics: bool,
 }
 
 impl Default for Http {
@@ -771,6 +778,7 @@ impl Default for Http {
             retry_delay: default_retry_delay(),
             project_failure_interval: default_project_failure_interval(),
             encoding: HttpEncoding::Gzip,
+            global_metrics: false,
         }
     }
 }
@@ -1720,6 +1728,11 @@ impl Config {
     /// Content encoding of upstream requests.
     pub fn http_encoding(&self) -> HttpEncoding {
         self.values.http.encoding
+    }
+
+    /// Returns whether metrics should be sent globally through a shared endpoint.
+    pub fn http_global_metrics(&self) -> bool {
+        self.values.http.global_metrics
     }
 
     /// Returns whether this Relay should emit outcomes.

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -273,7 +273,6 @@ impl AggregatorService {
 
         relay_log::trace!("flushing {} projects to receiver", buckets.len());
 
-        // TODO(ja): Check if we want to log this somewhere else
         let mut total_bucket_count = 0u64;
         for buckets in buckets.values() {
             let bucket_count = buckets.len() as u64;

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use relay_base_schema::project::ProjectKey;
@@ -206,10 +207,8 @@ pub struct BucketCountInquiry;
 ///   failed buckets. They will be merged back into the aggregator and flushed at a later time.
 #[derive(Clone, Debug)]
 pub struct FlushBuckets {
-    /// The project key.
-    pub project_key: ProjectKey,
     /// The buckets to be flushed.
-    pub buckets: Vec<Bucket>,
+    pub buckets: HashMap<ProjectKey, Vec<Bucket>>,
 }
 
 enum AggregatorState {
@@ -265,37 +264,35 @@ impl AggregatorService {
     ///
     /// If `force` is true, flush all buckets unconditionally and do not attempt to merge back.
     fn try_flush(&mut self) {
-        let flush_buckets = {
-            let force_flush = matches!(&self.state, AggregatorState::ShuttingDown);
-            self.aggregator.pop_flush_buckets(force_flush)
-        };
+        let force_flush = matches!(&self.state, AggregatorState::ShuttingDown);
+        let buckets = self.aggregator.pop_flush_buckets(force_flush);
 
-        if flush_buckets.is_empty() {
+        if buckets.is_empty() {
             return;
         }
 
-        relay_log::trace!("flushing {} projects to receiver", flush_buckets.len());
+        relay_log::trace!("flushing {} projects to receiver", buckets.len());
 
+        // TODO(ja): Check if we want to log this somewhere else
         let mut total_bucket_count = 0u64;
-        for (project_key, buckets) in flush_buckets.into_iter() {
+        for buckets in buckets.values() {
             let bucket_count = buckets.len() as u64;
+            total_bucket_count += bucket_count;
+
             relay_statsd::metric!(
                 histogram(MetricHistograms::BucketsFlushedPerProject) = bucket_count,
                 aggregator = self.aggregator.name(),
             );
-            total_bucket_count += bucket_count;
-
-            if let Some(ref receiver) = self.receiver {
-                receiver.send(FlushBuckets {
-                    project_key,
-                    buckets,
-                });
-            }
         }
+
         relay_statsd::metric!(
             histogram(MetricHistograms::BucketsFlushed) = total_bucket_count,
             aggregator = self.aggregator.name(),
         );
+
+        if let Some(ref receiver) = self.receiver {
+            receiver.send(FlushBuckets { buckets })
+        }
     }
 
     fn handle_merge_buckets(&mut self, msg: MergeBuckets) {
@@ -431,7 +428,8 @@ mod tests {
     }
 
     impl TestReceiver {
-        fn add_buckets(&self, buckets: Vec<Bucket>) {
+        fn add_buckets(&self, buckets: HashMap<ProjectKey, Vec<Bucket>>) {
+            let buckets = buckets.into_values().flatten();
             self.data.write().unwrap().buckets.extend(buckets);
         }
 

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use tokio::time::Instant;
 use crate::actors::envelopes::EnvelopeManager;
 use crate::actors::global_config::{self, GlobalConfigManager, Subscribe};
 use crate::actors::outcome::{DiscardReason, TrackOutcome};
-use crate::actors::processor::{EnvelopeProcessor, ProcessEnvelope};
+use crate::actors::processor::{EncodeMetrics, EnvelopeProcessor, ProcessEnvelope};
 use crate::actors::project::{Project, ProjectSender, ProjectState};
 use crate::actors::project_local::{LocalProjectSource, LocalProjectSourceService};
 #[cfg(feature = "processing")]
@@ -883,11 +883,18 @@ impl ProjectCacheBroker {
     }
 
     fn handle_flush_buckets(&mut self, message: FlushBuckets) {
-        let envelope_processor = self.services.envelope_processor.clone();
-        let outcome_aggregator = self.services.outcome_aggregator.clone();
+        let mut output = HashMap::new();
+        for (project_key, buckets) in message.buckets {
+            let outcome_aggregator = self.services.outcome_aggregator.clone();
+            let project = self.get_or_create_project(project_key);
+            if let Some(b) = project.check_buckets(outcome_aggregator, buckets) {
+                output.insert(project_key, b);
+            }
+        }
 
-        self.get_or_create_project(message.project_key)
-            .flush_buckets(envelope_processor, outcome_aggregator, message.buckets);
+        self.services
+            .envelope_processor
+            .send(EncodeMetrics { buckets: output })
     }
 
     fn handle_buffer_index(&mut self, message: UpdateBufferIndex) {

--- a/relay-server/src/actors/project_cache.rs
+++ b/relay-server/src/actors/project_cache.rs
@@ -887,14 +887,14 @@ impl ProjectCacheBroker {
         for (project_key, buckets) in message.buckets {
             let outcome_aggregator = self.services.outcome_aggregator.clone();
             let project = self.get_or_create_project(project_key);
-            if let Some(b) = project.check_buckets(outcome_aggregator, buckets) {
-                output.insert(project_key, b);
+            if let Some((scoping, b)) = project.check_buckets(outcome_aggregator, buckets) {
+                output.insert(scoping, b);
             }
         }
 
         self.services
             .envelope_processor
-            .send(EncodeMetrics { buckets: output })
+            .send(EncodeMetrics { scopes: output })
     }
 
     fn handle_buffer_index(&mut self, message: UpdateBufferIndex) {


### PR DESCRIPTION
The metrics aggregator service now flushes the buckets of all projects
in a single `FlushBuckets` message. Previously, this message was emitted
separately for every project.

This change allows the processor to batch buckets from multiple projects
into a single request. This change is not yet included in this PR and
will be added in a follow-up.

#skip-changelog