### PR TITLE
test(spooler): Fix healthcheck flaky test

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -653,7 +653,7 @@ impl BufferState {
         }
     }
 
-    /// Becomes a different state, depdending on the current state and the current conditions of
+    /// Becomes a different state, depending on the current state and the current conditions of
     /// underlying spool.
     async fn transition(self, config: &Arc<Config>) -> Self {
         match self {

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -114,26 +114,7 @@ def test_readiness_disk_spool(mini_sentry, relay):
         mini_sentry.add_full_project_config(project_key)
         # Set the broken config, so we won't be able to dequeue the envelopes.
         config = mini_sentry.project_configs[project_key]["config"]
-        ds = config.setdefault("sampling", {})
-        ds.setdefault("version", 2)
-        ds.setdefault("rules", []).append(
-            {
-                "condition": {
-                    "op": "and",
-                    "inner": [
-                        {"op": "glob", "name": "releases", "value": ["1.1.1", "1.1.2"]}
-                    ],
-                },
-                "samplingValue": {"strategy": "sampleRate", "value": 0.7},
-                "type": "trace",
-                "id": 1,
-                "timeRange": {
-                    "start": "2022-10-10T00:00:00.000000Z",
-                    "end": "2022-10-20T00:00:00.000000Z",
-                },
-                "decayingFn": {"function": "linear", "decayedSampleRate": 0.9},
-            }
-        )
+        config["quotas"] = None
 
         relay_config = {
             "spool": {


### PR DESCRIPTION
The test attempted to have a broken config to not dequeue envelopes, in a key with an `ErrorBoundary`. This PR sets a broken config in a key without an `ErrorBoundary` to make effective the no-dequeuing.

### Why was it flaky?

The config was not effectively broken for Relay due to the `ErrorBoundary`, thus Relay attempted dequeuing.

As the test sets a maximum of 0 for the memory and disk, Relay considers these always full, and transitions between `MemoryFileStandby` (memory+file) and `Disk` states constantly. In combination with the above, a race condition happens: if Tokio runs spooler jobs first, Relay will have time to make two state transitions and end up at `MemoryFileStandby` for handling the last health readiness check; but Relay will only transition once if Tokio runs the project cache jobs first.

`MemoryFileStandby` and `Disk` handle readiness checks differently: `Disk` reports ready if the disk is not full, but other states always report ready even if the memory is full too. (see https://github.com/getsentry/relay/issues/2896)

Resolves https://github.com/getsentry/relay/issues/2883.

#skip-changelog