### PR TITLE
chore(trace): Add extra "data" field to the trace context

### DIFF
--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -118,6 +118,10 @@ pub struct TraceContext {
     /// This flag only applies to events with [`Error`] type that have an associated dynamic sampling context.
     pub sampled: Annotated<bool>,
 
+    /// Arbitrary additional data on a trace.
+    #[metastructure(pii = "true")]
+    pub data: Annotated<Object<Value>>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
     pub other: Object<Value>,
@@ -170,6 +174,9 @@ mod tests {
   "exclusive_time": 0.0,
   "client_sample_rate": 0.5,
   "origin": "auto.http",
+  "data": {
+    "route": "/path"
+  },
   "other": "value",
   "type": "trace"
 }"#;
@@ -182,6 +189,14 @@ mod tests {
             exclusive_time: Annotated::new(0.0),
             client_sample_rate: Annotated::new(0.5),
             origin: Annotated::new("auto.http".to_owned()),
+            data: Annotated::new({
+                let mut map = Object::new();
+                map.insert(
+                    "route".to_string(),
+                    Annotated::new(Value::String("/path".to_string())),
+                );
+                map
+            }),
             other: {
                 let mut map = Object::new();
                 map.insert(

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -119,7 +119,7 @@ pub struct TraceContext {
     pub sampled: Annotated<bool>,
 
     /// Arbitrary additional data on a trace.
-    #[metastructure(pii = "true")]
+    #[metastructure(pii = "true", skip_serialization = "empty", bag_size = "medium")]
     pub data: Annotated<Object<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.
@@ -175,7 +175,9 @@ mod tests {
   "client_sample_rate": 0.5,
   "origin": "auto.http",
   "data": {
-    "route": "/path"
+    "route": {
+      "path": "/path"
+    }
   },
   "other": "value",
   "type": "trace"
@@ -191,9 +193,14 @@ mod tests {
             origin: Annotated::new("auto.http".to_owned()),
             data: Annotated::new({
                 let mut map = Object::new();
+                let mut inner_map = Object::new();
+                inner_map.insert(
+                    "path".to_string(),
+                    Annotated::new(Value::String("/path".to_string())),
+                );
                 map.insert(
                     "route".to_string(),
-                    Annotated::new(Value::String("/path".to_string())),
+                    Annotated::new(Value::Object(inner_map)),
                 );
                 map
             }),

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__trace_route_params_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__trace_route_params_scrubbed.snap
@@ -1,0 +1,37 @@
+---
+source: relay-pii/src/processor.rs
+expression: trace_context
+---
+{
+  "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+  "span_id": "fa90fdead5f74052",
+  "data": {
+    "previousRoute": {
+      "params": {
+        "password": "[Filtered]"
+      }
+    }
+  },
+  "type": "trace",
+  "_meta": {
+    "data": {
+      "previousRoute": {
+        "params": {
+          "password": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 4
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -1005,6 +1005,41 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         }
       ]
     },
+    "Data": {
+      "description": " The arbitrary data on the trace.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "previousRoute": {
+              "description": " The previous route in the application\n\n Set by React Native SDK.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Route"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "route": {
+              "description": " The current route in the application.\n\n Set by React Native SDK.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Route"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "DebugId": {
       "type": "string"
     },
@@ -3214,6 +3249,26 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         }
       ]
     },
+    "Route": {
+      "description": " The route in the application, set by React Native SDK.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "params": {
+              "description": " Parameters assigned to this route.",
+              "default": null,
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "RuntimeContext": {
       "description": " Runtime information.\n\n Runtime context describes a runtime in more detail. Typically, this context is present in\n `contexts` multiple times if multiple runtimes are involved (for instance, if you have a\n JavaScript application running on top of JVM).",
       "anyOf": [
@@ -3582,11 +3637,14 @@ expression: "relay_event_schema::protocol::event_json_schema()"
             "data": {
               "description": " Arbitrary additional data on a trace.",
               "default": null,
-              "type": [
-                "object",
-                "null"
-              ],
-              "additionalProperties": true
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Data"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "exclusive_time": {
               "description": " The amount of time in milliseconds spent in this transaction span,\n excluding its immediate child spans.",

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -3579,6 +3579,15 @@ expression: "relay_event_schema::protocol::event_json_schema()"
               ],
               "format": "double"
             },
+            "data": {
+              "description": " Arbitrary additional data on a trace.",
+              "default": null,
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
             "exclusive_time": {
               "description": " The amount of time in milliseconds spent in this transaction span,\n excluding its immediate child spans.",
               "default": null,


### PR DESCRIPTION
Adds extra `data` field to the trace context with nested types for better schema definition. 

#skip-changelog