### PR TITLE
ref(cardinality): Optimize iterator for only rejections or all accepted

### DIFF
--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -138,6 +138,7 @@ impl<T: Limiter> CardinalityLimiter<T> {
 }
 
 /// Result of [`CardinalityLimiter::check_cardinality_limits`].
+#[derive(Debug)]
 pub struct CardinalityLimits<T> {
     source: Vec<T>,
     rejections: BTreeSet<usize>,
@@ -185,6 +186,18 @@ impl<T> Iterator for Accepted<T> {
                     return next;
                 }
             }
+        }
+    }
+
+    fn collect<B: FromIterator<Self::Item>>(mut self) -> B
+    where
+        Self: Sized,
+    {
+        // Specialize here and use the optimized collect when there are no rejections.
+        if self.rejections.peek().is_none() {
+            self.source.collect()
+        } else {
+            FromIterator::from_iter(self)
         }
     }
 }

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -160,10 +160,19 @@ pub struct Accepted<T> {
 
 impl<T> Accepted<T> {
     fn new(source: Vec<T>, rejections: BTreeSet<usize>) -> Self {
-        Self {
-            source: source.into_iter(),
-            rejections: rejections.into_iter().peekable(),
-            next_index: 0,
+        if rejections.len() == source.len() {
+            // Optimize the case where every item is rejected.
+            Self {
+                source: Vec::new().into_iter(),
+                rejections: BTreeSet::new().into_iter().peekable(),
+                next_index: 0,
+            }
+        } else {
+            Self {
+                source: source.into_iter(),
+                rejections: rejections.into_iter().peekable(),
+                next_index: 0,
+            }
         }
     }
 }

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeSet;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::iter::FusedIterator;
 
 use relay_statsd::metric;
 
@@ -210,6 +211,8 @@ impl<T> Iterator for Accepted<T> {
         }
     }
 }
+
+impl<T> FusedIterator for Accepted<T> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Optimization tested by tracking allocations via a custom allocator: https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=a512f449788d9ca8885e299045270b5d

#skip-changelog