### PR TITLE
feat(server): Send metrics via the global endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Use a Lua script and in-memory cache for the cardinality limiting to reduce load on Redis. ([#2849](https://github.com/getsentry/relay/pull/2849))
 - Extract metrics for file spans. ([#2874](https://github.com/getsentry/relay/pull/2874))
 - Add an internal endpoint that allows Relays to submit metrics from multiple projects in a single request. ([#2869](https://github.com/getsentry/relay/pull/2869))
+- Introduce the configuration option `http.global_metrics`. When enabled, Relay submits metric buckets not through regular project-scoped Envelopes, but instead through the global endpoint. When this Relay serves a high number of projects, this can reduce the overall request volume. ([#2902](https://github.com/getsentry/relay/pull/2902))
 - Emit a `processor.message.duration` metric to assess the throughput of the internal CPU pool. ([#2877](https://github.com/getsentry/relay/pull/2877))
 
 ## 23.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,6 +3921,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "flate2",
+ "fnv",
  "futures",
  "hash32",
  "hashbrown 0.13.2",

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -124,13 +124,6 @@ pub enum MetricHistograms {
     ///    time period (`false`) or after the initial delay has expired (`true`).
     BucketsDelay,
 
-    ///
-    /// Distribution of flush buckets over partition keys.
-    ///
-    /// The distribution of buckets should be even.
-    /// If it is not, this metric should expose it.
-    PartitionKeys,
-
     /// Distribution of invalid bucket timestamps observed, relative to the time of observation.
     ///
     /// This is a temporary metric to better understand why we see so many invalid timestamp errors.
@@ -143,7 +136,6 @@ impl HistogramMetric for MetricHistograms {
             Self::BucketsFlushed => "metrics.buckets.flushed",
             Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
             Self::BucketsDelay => "metrics.buckets.delay",
-            Self::PartitionKeys => "metrics.buckets.partition_keys",
             Self::InvalidBucketTimestamp => "metrics.buckets.invalid_timestamp",
         }
     }

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -15,6 +15,11 @@ use crate::BucketValue;
 /// and buckets larger will be split up.
 const BUCKET_SPLIT_FACTOR: usize = 32;
 
+/// The base size of a serialized bucket in bytes.
+///
+/// This is the size of a bucket's fixed fields in JSON format, excluding the value and tags.
+const BUCKET_SIZE: usize = 50;
+
 /// The average size of values when serialized.
 const AVG_VALUE_SIZE: usize = 8;
 
@@ -429,7 +434,7 @@ impl<'a> BucketView<'a> {
     /// Note that this does not match the exact size of the serialized payload. Instead, the size is
     /// approximated through tags and a static overhead.
     fn estimated_base_size(&self) -> usize {
-        50 + self.name().len() + aggregator::tags_cost(self.tags())
+        BUCKET_SIZE + self.name().len() + aggregator::tags_cost(self.tags())
     }
 
     /// Estimates the number of bytes needed to serialize the bucket.

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -276,14 +276,10 @@ impl<'a> Iterator for BucketsViewBySizeIter<'a> {
                 }
                 SplitDecision::MoveToNextBatch => break,
                 SplitDecision::Split(at) => {
-                    // Only certain buckets can be split, if the bucket can't be split,
-                    // move it to the next batch.
-                    if bucket.can_split() {
-                        self.current = Index {
-                            slice: self.current.slice,
-                            bucket: self.current.bucket + at,
-                        };
-                    }
+                    self.current = Index {
+                        slice: self.current.slice,
+                        bucket: self.current.bucket + at,
+                    };
                     break;
                 }
             }
@@ -332,6 +328,7 @@ impl<'a> Serialize for BucketsView<'a> {
 /// ```
 ///
 /// A view can be split again into multiple smaller views.
+#[derive(Clone)]
 pub struct BucketView<'a> {
     /// The source bucket.
     inner: &'a Bucket,
@@ -425,6 +422,46 @@ impl<'a> BucketView<'a> {
 
         self.range = range;
         Some(self)
+    }
+
+    /// Estimates the number of bytes needed to serialize the bucket without value.
+    ///
+    /// Note that this does not match the exact size of the serialized payload. Instead, the size is
+    /// approximated through tags and a static overhead.
+    fn estimated_base_size(&self) -> usize {
+        50 + self.name().len() + aggregator::tags_cost(self.tags())
+    }
+
+    /// Estimates the number of bytes needed to serialize the bucket.
+    ///
+    /// Note that this does not match the exact size of the serialized payload. Instead, the size is
+    /// approximated through the number of contained values, assuming an average size of serialized
+    /// values.
+    pub fn estimated_size(&self) -> usize {
+        self.estimated_base_size() + self.len() * AVG_VALUE_SIZE
+    }
+
+    /// Calculates a split for this bucket if its estimated serialization size exceeds a threshold.
+    ///
+    /// There are three possible return values:
+    ///  - `(Some, None)` if the bucket fits entirely into the size budget. There is no split.
+    ///  - `(None, Some)` if the size budget cannot even hold the bucket name and tags. There is no
+    ///    split, the entire bucket is moved.
+    ///  - `(Some, Some)` if the bucket fits partially. Remaining values are moved into a new bucket
+    ///    with all other information cloned.
+    ///
+    /// This is an approximate function. The bucket is not actually serialized, but rather its
+    /// footprint is estimated through the number of data points contained. See
+    /// [`estimated_size`](Self::estimated_size) for more information.
+    pub fn split(self, size: usize, max_size: Option<usize>) -> (Option<Self>, Option<Self>) {
+        match split_at(&self, size, max_size.unwrap_or(0) / BUCKET_SPLIT_FACTOR) {
+            SplitDecision::BucketFits(_) => (Some(self), None),
+            SplitDecision::MoveToNextBatch => (None, Some(self)),
+            SplitDecision::Split(at) => {
+                let Range { start, end } = self.range.clone();
+                (self.clone().select(start..at), self.select(at..end))
+            }
+        }
     }
 
     /// Whether the bucket can be split into multiple.
@@ -624,14 +661,18 @@ enum SplitDecision {
 /// `estimate_size` for more information.
 fn split_at(bucket: &BucketView<'_>, max_size: usize, min_split_size: usize) -> SplitDecision {
     // If there's enough space for the entire bucket, do not perform a split.
-    let bucket_size = estimate_size(bucket);
+    let bucket_size = bucket.estimated_size();
     if max_size >= bucket_size {
         return SplitDecision::BucketFits(bucket_size);
     }
 
+    if !bucket.can_split() {
+        return SplitDecision::MoveToNextBatch;
+    }
+
     // If the bucket key can't even fit into the remaining length, move the entire bucket into
     // the right-hand side.
-    let own_size = estimate_base_size(bucket);
+    let own_size = bucket.estimated_base_size();
     if max_size < (own_size + AVG_VALUE_SIZE) {
         // split_at must not be zero
         return SplitDecision::MoveToNextBatch;
@@ -644,25 +685,7 @@ fn split_at(bucket: &BucketView<'_>, max_size: usize, min_split_size: usize) -> 
     // Perform a split with the remaining space after adding the key. We assume an average
     // length of 8 bytes per value and compute the number of items fitting into the left side.
     let split_at = (max_size - own_size) / AVG_VALUE_SIZE;
-
     SplitDecision::Split(split_at)
-}
-
-/// Estimates the number of bytes needed to serialize the bucket without value.
-///
-/// Note that this does not match the exact size of the serialized payload. Instead, the size is
-/// approximated through tags and a static overhead.
-fn estimate_base_size(bucket: &BucketView<'_>) -> usize {
-    50 + bucket.name().len() + aggregator::tags_cost(bucket.tags())
-}
-
-/// Estimates the number of bytes needed to serialize the bucket.
-///
-/// Note that this does not match the exact size of the serialized payload. Instead, the size is
-/// approximated through the number of contained values, assuming an average size of serialized
-/// values.
-fn estimate_size(bucket: &BucketView<'_>) -> usize {
-    estimate_base_size(bucket) + bucket.len() * AVG_VALUE_SIZE
 }
 
 #[cfg(test)]
@@ -919,7 +942,7 @@ b3:42:75|s"#;
             .by_size(100)
             .map(|bv| {
                 let len: usize = bv.iter().map(|b| b.len()).sum();
-                let size: usize = bv.iter().map(|b| estimate_size(&b)).sum();
+                let size: usize = bv.iter().map(|b| b.estimated_size()).sum();
                 (len, size)
             })
             .collect::<Vec<_>>();
@@ -945,7 +968,7 @@ b3:42:75|s"#;
             .by_size(250)
             .map(|bv| {
                 let len: usize = bv.iter().map(|b| b.len()).sum();
-                let size: usize = bv.iter().map(|b| estimate_size(&b)).sum();
+                let size: usize = bv.iter().map(|b| b.estimated_size()).sum();
                 (len, size)
             })
             .collect::<Vec<_>>();
@@ -971,7 +994,7 @@ b3:42:75|s"#;
             .by_size(500)
             .map(|bv| {
                 let len: usize = bv.iter().map(|b| b.len()).sum();
-                let size: usize = bv.iter().map(|b| estimate_size(&b)).sum();
+                let size: usize = bv.iter().map(|b| b.estimated_size()).sum();
                 (len, size)
             })
             .collect::<Vec<_>>();

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -50,6 +50,7 @@ bytes = { version = "1.4.0" }
 chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"
+fnv = "1.0.7"
 futures = { workspace = true }
 hash32 = { workspace = true }
 hashbrown = { workspace = true }
@@ -95,7 +96,7 @@ rmp-serde = "1.1.1"
 rust-embed = { version = "8.0.0", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-smallvec = { workspace = true, features = ["drain_filter"]  }
+smallvec = { workspace = true, features = ["drain_filter"] }
 sqlx = { version = "0.7.0", features = [
     "macros",
     "migrate",

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
+use std::future::Future;
 use std::io::Write;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -10,6 +12,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
+use fnv::FnvHasher;
 use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding};
@@ -22,9 +25,8 @@ use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo};
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::{Event, EventType, IpAddr, Metrics, NetworkReportError};
 use relay_filter::FilterStatKey;
-use relay_metrics::aggregator::partition_buckets;
 use relay_metrics::aggregator::AggregatorConfig;
-use relay_metrics::{Bucket, BucketsView, MergeBuckets, MetricMeta, MetricNamespace};
+use relay_metrics::{Bucket, BucketView, BucketsView, MergeBuckets, MetricMeta, MetricNamespace};
 use relay_pii::PiiConfigError;
 use relay_profiling::ProfileId;
 use relay_protocol::{Annotated, Value};
@@ -32,6 +34,7 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_sampling::evaluation::{MatchedRuleIds, ReservoirCounters, ReservoirEvaluator};
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
+use reqwest::header;
 use tokio::sync::Semaphore;
 
 #[cfg(feature = "processing")]
@@ -51,9 +54,10 @@ use crate::actors::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::actors::project::ProjectState;
 use crate::actors::project_cache::{AddMetricMeta, ProjectCache};
 use crate::actors::test_store::TestStore;
-use crate::actors::upstream::{SendRequest, UpstreamRelay};
-use crate::envelope::{ContentType, Envelope, Item, ItemType};
+use crate::actors::upstream::{SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError};
+use crate::envelope::{ContentType, Envelope, Item, ItemType, SourceQuantities};
 use crate::extractors::{PartialDsn, RequestMeta};
+use crate::http;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::metrics_extraction::transactions::{ExtractedMetrics, TransactionExtractor};
 use crate::service::ServiceError;
@@ -1314,36 +1318,9 @@ impl EnvelopeProcessorService {
         }
     }
 
-    fn encode_envelope_body(
-        body: Bytes,
-        http_encoding: HttpEncoding,
-    ) -> Result<Bytes, std::io::Error> {
-        let envelope_body: Vec<u8> = match http_encoding {
-            HttpEncoding::Identity => return Ok(body),
-            HttpEncoding::Deflate => {
-                let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-                encoder.write_all(body.as_ref())?;
-                encoder.finish()?
-            }
-            HttpEncoding::Gzip => {
-                let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-                encoder.write_all(body.as_ref())?;
-                encoder.finish()?
-            }
-            HttpEncoding::Br => {
-                // Use default buffer size (via 0), medium quality (5), and the default lgwin (22).
-                let mut encoder = BrotliEncoder::new(Vec::new(), 0, 5, 22);
-                encoder.write_all(body.as_ref())?;
-                encoder.into_inner()
-            }
-        };
-
-        Ok(envelope_body.into())
-    }
-
     fn handle_encode_envelope(&self, message: EncodeEnvelope) {
         let mut request = message.request;
-        match Self::encode_envelope_body(request.envelope_body, request.http_encoding) {
+        match encode_payload(request.envelope_body, request.http_encoding) {
             Err(e) => {
                 request
                     .response_sender
@@ -1485,7 +1462,6 @@ impl EnvelopeProcessorService {
     /// access to the central Redis instance. Cached rate limits are applied in the project cache
     /// already.
     fn encode_metrics_envelope(&self, message: EncodeMetrics) {
-        let partition_count = self.inner.config.metrics_partitions();
         let batch_size = self.inner.config.metrics_max_batch_size_bytes();
         let upstream = self.inner.config.upstream_descriptor();
 
@@ -1495,17 +1471,30 @@ impl EnvelopeProcessorService {
                 project_state,
             } = message;
 
+            let project_key = scoping.project_key;
+            let dsn = PartialDsn::outbound(&scoping, upstream);
             let mode = match project_state.config.transaction_metrics {
                 Some(ErrorBoundary::Ok(ref c)) if c.usage_metric() => ExtractionMode::Usage,
                 _ => ExtractionMode::Duration,
             };
 
-            let dsn = PartialDsn::outbound(&scoping, upstream);
-            let partitions = partition_buckets(scoping.project_key, buckets, partition_count);
+            let partitions = if let Some(count) = self.inner.config.metrics_partitions() {
+                let mut partitions: BTreeMap<Option<u64>, Vec<Bucket>> = BTreeMap::new();
+                for bucket in buckets {
+                    let partition_key = partition_key(project_key, &bucket, Some(count));
+                    partitions.entry(partition_key).or_default().push(bucket);
+                }
+                partitions
+            } else {
+                BTreeMap::from([(None, buckets)])
+            };
 
             for (partition_key, buckets) in partitions {
-                let mut num_batches = 0;
+                if let Some(key) = partition_key {
+                    relay_statsd::metric!(histogram(RelayHistograms::PartitionKeys) = key);
+                }
 
+                let mut num_batches = 0;
                 for batch in BucketsView::new(&buckets).by_size(batch_size) {
                     let mut envelope =
                         Envelope::from_request(None, RequestMeta::outbound(dsn.clone()));
@@ -1540,6 +1529,77 @@ impl EnvelopeProcessorService {
         }
     }
 
+    fn send_global_partition(&self, key: Option<u64>, partition: &mut Partition<'_>) {
+        if partition.is_empty() {
+            return;
+        }
+
+        let (payload, quantities) = partition.take_parts();
+
+        // TODO: Benchmark streaming encoding.
+        let http_encoding = self.inner.config.http_encoding();
+        let payload = match encode_payload(payload, http_encoding) {
+            Ok(payload) => payload,
+            Err(error) => {
+                let error = &error as &dyn std::error::Error;
+                relay_log::error!(error, "failed to encode metrics payload");
+                return;
+            }
+        };
+
+        let request = SendMetricsRequest {
+            partition_key: key.map(|k| k.to_string()),
+            payload,
+            quantities,
+            outcome_aggregator: self.inner.outcome_aggregator.clone(),
+            http_encoding,
+        };
+
+        self.inner.upstream_relay.send(SendRequest(request));
+    }
+
+    fn encode_metrics_global(&self, message: EncodeMetrics) {
+        let partition_count = self.inner.config.metrics_partitions();
+        let batch_size = self.inner.config.metrics_max_batch_size_bytes();
+
+        let mut partitions = BTreeMap::new();
+
+        for (scoping, message) in &message.scopes {
+            let ProjectMetrics {
+                buckets,
+                project_state,
+            } = message;
+
+            let mode = match project_state.config.transaction_metrics {
+                Some(ErrorBoundary::Ok(ref c)) if c.usage_metric() => ExtractionMode::Usage,
+                _ => ExtractionMode::Duration,
+            };
+
+            for bucket in buckets {
+                let partition_key = partition_key(scoping.project_key, bucket, partition_count);
+
+                let mut remaining = Some(BucketView::new(bucket));
+                while let Some(bucket) = remaining.take() {
+                    let partition = partitions
+                        .entry(partition_key)
+                        .or_insert_with(|| Partition::new(batch_size, mode));
+
+                    if let Some(next) = partition.insert(bucket, *scoping) {
+                        // A part of the bucket could not be inserted. Take the partition and submit
+                        // it immediately. Repeat until the final part was inserted. This should
+                        // always result in a request, otherwise we would enter an endless loop.
+                        self.send_global_partition(partition_key, partition);
+                        remaining = Some(next);
+                    }
+                }
+            }
+        }
+
+        for (partition_key, mut partition) in partitions {
+            self.send_global_partition(partition_key, &mut partition);
+        }
+    }
+
     fn handle_encode_metrics(&self, message: EncodeMetrics) {
         #[cfg(feature = "processing")]
         if self.inner.config.processing_enabled() {
@@ -1548,7 +1608,11 @@ impl EnvelopeProcessorService {
             }
         }
 
-        self.encode_metrics_envelope(message)
+        if self.inner.config.http_global_metrics() {
+            self.encode_metrics_global(message)
+        } else {
+            self.encode_metrics_envelope(message)
+        }
     }
 
     fn handle_encode_metric_meta(&self, message: EncodeMetricMeta) {
@@ -1652,6 +1716,160 @@ impl Service for EnvelopeProcessorService {
                 }
             }
         });
+    }
+}
+
+fn encode_payload(body: Bytes, http_encoding: HttpEncoding) -> Result<Bytes, std::io::Error> {
+    let envelope_body: Vec<u8> = match http_encoding {
+        HttpEncoding::Identity => return Ok(body),
+        HttpEncoding::Deflate => {
+            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(body.as_ref())?;
+            encoder.finish()?
+        }
+        HttpEncoding::Gzip => {
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(body.as_ref())?;
+            encoder.finish()?
+        }
+        HttpEncoding::Br => {
+            // Use default buffer size (via 0), medium quality (5), and the default lgwin (22).
+            let mut encoder = BrotliEncoder::new(Vec::new(), 0, 5, 22);
+            encoder.write_all(body.as_ref())?;
+            encoder.into_inner()
+        }
+    };
+
+    Ok(envelope_body.into())
+}
+
+fn partition_key(project_key: ProjectKey, bucket: &Bucket, partitions: Option<u64>) -> Option<u64> {
+    use std::hash::{Hash, Hasher};
+
+    let partitions = partitions?;
+    let key = (project_key, bucket.timestamp, &bucket.name, &bucket.tags);
+
+    let mut hasher = FnvHasher::default();
+    key.hash(&mut hasher);
+    Some(hasher.finish() % partitions)
+}
+
+#[derive(Debug)]
+struct Partition<'a> {
+    max_size: usize,
+    remaining: usize,
+    views: HashMap<ProjectKey, Vec<BucketView<'a>>>,
+    quantities: Vec<(Scoping, SourceQuantities)>,
+    mode: ExtractionMode,
+}
+
+impl<'a> Partition<'a> {
+    pub fn new(size: usize, mode: ExtractionMode) -> Self {
+        Self {
+            max_size: size,
+            remaining: size,
+            views: HashMap::new(),
+            quantities: Vec::new(),
+            mode,
+        }
+    }
+
+    fn insert(&mut self, bucket: BucketView<'a>, scoping: Scoping) -> Option<BucketView<'a>> {
+        let (current, next) = bucket.split(self.remaining, Some(self.max_size));
+
+        if let Some(current) = current {
+            self.remaining -= current.estimated_size();
+            let quantities = utils::extract_metric_quantities([current.clone()], self.mode);
+            self.quantities.push((scoping, quantities));
+            self.views
+                .entry(scoping.project_key)
+                .or_default()
+                .push(current);
+        }
+
+        next
+    }
+
+    fn is_empty(&self) -> bool {
+        self.views.is_empty()
+    }
+
+    fn take_parts(&mut self) -> (Bytes, Vec<(Scoping, SourceQuantities)>) {
+        let payload = serde_json::to_vec(&self.views).unwrap().into();
+        let quantities = self.quantities.clone();
+
+        self.views.clear();
+        self.quantities.clear();
+        self.remaining = self.max_size;
+
+        (payload, quantities)
+    }
+}
+
+#[derive(Debug)]
+struct SendMetricsRequest {
+    partition_key: Option<String>,
+    payload: Bytes,
+    http_encoding: HttpEncoding,
+    quantities: Vec<(Scoping, SourceQuantities)>,
+    outcome_aggregator: Addr<TrackOutcome>,
+}
+
+impl UpstreamRequest for SendMetricsRequest {
+    fn set_relay_id(&self) -> bool {
+        true
+    }
+
+    fn sign(&self) -> bool {
+        true
+    }
+
+    fn method(&self) -> reqwest::Method {
+        reqwest::Method::POST
+    }
+
+    fn path(&self) -> std::borrow::Cow<'_, str> {
+        "/api/0/relays/metrics/".into()
+    }
+
+    fn route(&self) -> &'static str {
+        "global_metrics"
+    }
+
+    fn build(&mut self, builder: &mut http::RequestBuilder) -> Result<(), http::HttpError> {
+        builder
+            .content_encoding(self.http_encoding)
+            .header(header::CONTENT_TYPE, b"application/json")
+            .header_opt("X-Sentry-Relay-Shard", self.partition_key.as_ref())
+            .body(self.payload.clone());
+
+        Ok(())
+    }
+
+    fn respond(
+        self: Box<Self>,
+        result: Result<http::Response, UpstreamRequestError>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> {
+        Box::pin(async {
+            match result {
+                Ok(mut response) => {
+                    response.consume().await.ok();
+                }
+                // Request did not arrive, we are responsible for outcomes.
+                Err(error) if !error.is_received() => {
+                    for (scoping, quantities) in self.quantities {
+                        utils::reject_metrics(
+                            &self.outcome_aggregator,
+                            quantities,
+                            scoping,
+                            Outcome::Invalid(DiscardReason::Internal),
+                        );
+                    }
+                }
+                // Upstream is responsible to log outcomes.
+                Err(_received) => (),
+            }
+        })
     }
 }
 

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -1883,8 +1883,8 @@ impl UpstreamRequest for SendMetricsRequest {
     fn build(&mut self, builder: &mut http::RequestBuilder) -> Result<(), http::HttpError> {
         builder
             .content_encoding(self.http_encoding)
-            .header(header::CONTENT_TYPE, b"application/json")
             .header_opt("X-Sentry-Relay-Shard", self.partition_key.as_ref())
+            .header(header::CONTENT_TYPE, b"application/json")
             .body(self.payload.clone());
 
         Ok(())

--- a/relay-server/src/endpoints/batch_metrics.rs
+++ b/relay-server/src/endpoints/batch_metrics.rs
@@ -1,6 +1,5 @@
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use relay_config::EmitOutcomes;
 use serde::{Deserialize, Serialize};
 
 use crate::actors::processor::ProcessBatchedMetrics;
@@ -15,7 +14,7 @@ pub async fn handle(
     start_time: StartTime,
     body: SignedBytes,
 ) -> impl IntoResponse {
-    if !body.relay.internal || state.config().emit_outcomes() != EmitOutcomes::AsOutcomes {
+    if !body.relay.internal {
         return StatusCode::FORBIDDEN.into_response();
     }
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -46,28 +46,22 @@ pub struct Request(pub reqwest::Request);
 
 pub struct RequestBuilder {
     builder: Option<reqwest::RequestBuilder>,
-    body: Option<Bytes>,
 }
 
 impl RequestBuilder {
     pub fn reqwest(builder: reqwest::RequestBuilder) -> Self {
         RequestBuilder {
             builder: Some(builder),
-            body: None,
         }
     }
 
     pub fn finish(self) -> Result<Request, HttpError> {
-        let mut builder = self.builder.unwrap();
-        if let Some(body) = self.body {
-            builder = builder.body(body);
-        }
-        Ok(Request(builder.build()?))
+        Ok(Request(self.builder.unwrap().build()?))
     }
 
     fn build<F>(&mut self, f: F) -> &mut Self
     where
-        F: FnMut(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+        F: FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
     {
         self.builder = self.builder.take().map(f);
         self
@@ -98,12 +92,7 @@ impl RequestBuilder {
     }
 
     pub fn body(&mut self, body: Bytes) -> &mut Self {
-        self.body = Some(body);
-        self
-    }
-
-    pub fn get_body(&self) -> Option<&[u8]> {
-        self.body.as_deref()
+        self.build(|builder| builder.body(body))
     }
 }
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -56,6 +56,8 @@ impl RequestBuilder {
     }
 
     pub fn finish(self) -> Result<Request, HttpError> {
+        // The builder is not optional, instead the option is used inside `build` so that it can be
+        // moved temporarily. Therefore, the `unwrap` here is infallible.
         Ok(Request(self.builder.unwrap().build()?))
     }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -158,6 +158,12 @@ pub enum RelayHistograms {
     /// Size of queries (projectconfig queries, i.e. the request payload, not the response) sent by
     /// Relay over HTTP in bytes.
     UpstreamEnvelopeBodySize,
+
+    /// Distribution of flush buckets over partition keys.
+    ///
+    /// The distribution of buckets should be even.
+    /// If it is not, this metric should expose it.
+    PartitionKeys,
 }
 
 impl HistogramMetric for RelayHistograms {
@@ -188,6 +194,7 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::UpstreamRetries => "upstream.retries",
             RelayHistograms::UpstreamQueryBodySize => "upstream.query.body_size",
             RelayHistograms::UpstreamEnvelopeBodySize => "upstream.envelope.body_size",
+            RelayHistograms::PartitionKeys => "metrics.buckets.partition_keys",
         }
     }
 }

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -403,7 +403,7 @@ def mini_sentry(request):  # noqa
         assert encoding == "gzip", "Relay should always compress store requests"
         data = gzip.decompress(flask_request.data)
 
-        metrics_batch = json.loads(data)
+        metrics_batch = json.loads(data)["buckets"]
         sentry.captured_metrics.put(metrics_batch)
         return jsonify({})
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -199,8 +199,93 @@ def test_metrics_max_batch_size(mini_sentry, relay, max_batch_size, expected_eve
         mini_sentry.captured_events.get(timeout=1)
 
 
+def test_global_metrics(mini_sentry, relay):
+    relay = relay(
+        mini_sentry, options={"http": {"global_metrics": True}, **TEST_CONFIG}
+    )
+
+    project_id = 42
+    config = mini_sentry.add_basic_project_config(project_id)
+    public_key = config["publicKeys"][0]["publicKey"]
+
+    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
+    metrics_payload = f"transactions/foo:42|c\ntransactions/bar:17|c|T{timestamp}"
+    relay.send_metrics(project_id, metrics_payload)
+
+    metrics_batch = mini_sentry.captured_metrics.get(timeout=5)
+    assert mini_sentry.captured_metrics.qsize() == 0  # we had only one batch
+
+    metrics = sorted(metrics_batch[public_key], key=lambda x: x["name"])
+
+    assert metrics == [
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:transactions/bar@none",
+            "value": 17.0,
+            "type": "c",
+        },
+        {
+            "timestamp": timestamp,
+            "width": 1,
+            "name": "c:transactions/foo@none",
+            "value": 42.0,
+            "type": "c",
+        },
+    ]
+
+
 def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_consumer):
     relay = relay_with_processing(options=TEST_CONFIG)
+    metrics_consumer = metrics_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = ["organizations:custom-metrics"]
+
+    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
+    metrics_payload = f"transactions/foo:42|c\nbar@second:17|c|T{timestamp}"
+    relay.send_metrics(project_id, metrics_payload)
+
+    metrics = metrics_by_name(metrics_consumer, 2)
+
+    assert metrics["headers"]["c:transactions/foo@none"] == [
+        ("namespace", b"transactions")
+    ]
+    assert metrics["c:transactions/foo@none"] == {
+        "org_id": 1,
+        "project_id": project_id,
+        "retention_days": 90,
+        "name": "c:transactions/foo@none",
+        "tags": {},
+        "value": 42.0,
+        "type": "c",
+        "timestamp": timestamp,
+    }
+
+    assert metrics["headers"]["c:custom/bar@second"] == [("namespace", b"custom")]
+    assert metrics["c:custom/bar@second"] == {
+        "org_id": 1,
+        "project_id": project_id,
+        "retention_days": 90,
+        "name": "c:custom/bar@second",
+        "tags": {},
+        "value": 17.0,
+        "type": "c",
+        "timestamp": timestamp,
+    }
+
+
+def test_global_metrics_with_processing(
+    mini_sentry, relay, relay_with_processing, metrics_consumer
+):
+    # Set up a relay chain where the outer relay has global metrics enabled
+    # and forwards to a processing Relay.
+    processing_relay = relay_with_processing(options=TEST_CONFIG)
+    relay = relay(
+        processing_relay, options={"http": {"global_metrics": True}, **TEST_CONFIG}
+    )
+
     metrics_consumer = metrics_consumer()
 
     project_id = 42


### PR DESCRIPTION
Introduces an option `http.global_metrics`. When enabled and not in
processing mode, Relay sends metrics to the global batch endpoint at
`/api/0/relays/metrics/` instead of envelopes. This endpoint allows for
batched submission of metrics from multiple projects, which should
reduce the overall number of requests.

### Bug Fixes

This change contains additional bug fixes that were discoverd during
implementation:

- The batch metrics endpoint no longer requires the `emit_outcomes`
  outcomes flag to be set. This was invalid copy & paste from the
  outcomes endpoint.
- Requests with HTTP encoding received a signature computed from the
  compressed body. However, Relay requires the signature on the
  uncompressed body.

### Details

Building the request occurs in the `EnvelopeProcessor` in place of
building envelopes in the following steps:

1.  Iterate buckets from all projects and stream them into partitions.
2.  While collecting, check the size of the partition. As soon as a
    partition reaches the batch size limit, flush the partition eagerly.
    Buckets at the border may be split.
3.  At the end flush all remaining partitions with data.
4.  To flush a partition, JSON-encode the list of buckets and optionally
    apply HTTP encoding (compression).
5.  Submit the `SendMetricsRequest` with the payload and outcome
    metadata directly to the upstream.
6.  In the response callback, log outcomes directly. Therefore, the
    request does not have to be awaited.

In processing mode, Relay still produces to Kafka. The configuration
option does not have an effect in processing mode.

A note on stability: This endpoint and functionality is meant for
operation at scale within a distributed Sentry installation. At this
moment, it is not recommended to enable this option for external Relays.

### Tasks

- [x] PR description
- [x] Changelog entry with option
- [x] Integration test
- [x] Doc comments
- [x] **BUG**: Batch metrics endpoint checks outcomes flag
- [x] **BUG**: Invalid signature applied to compressed requests

### Possible Improvements

The changes in this PR allow for further optimization and changes. In
order to keep the scope of this PR to a necessary minimum, these have
not been included yet:

- Submit regular envelopes directly from the `EnvelopeProcessor`,
  avoiding the roundtrip through the `EnvelopeManager`. This also avoids
  a redundant call back to compress envelopes in the processor, should
  HTTP encoding be enabled.
- Improve handling of the `ExtractionMode`. It can be accessed more
  conveniently through a getter. Additionally, it resides on project
  config where it should actually be included in global config.
  Currently it is being passed around in excess.