### PR TITLE
chore(beta): Address new beta lints

### DIFF
--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -98,7 +98,7 @@
 //! at the beginning of test method. It enables test mode of the logger and customizes log levels
 //! for the current crate.
 //!
-//! ```
+//! ```ignore
 //! #[test]
 //! fn test_something() {
 //!     relay_log::init_test!();

--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -98,7 +98,7 @@
 //! at the beginning of test method. It enables test mode of the logger and customizes log levels
 //! for the current crate.
 //!
-//! ```ignore
+//! ```no_run
 //! #[test]
 //! fn test_something() {
 //!     relay_log::init_test!();

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
 //! #[test]
 //! fn my_test() {
 //!     relay_test::setup();

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```ignore
 //! #[test]
 //! fn my_test() {
 //!     relay_test::setup();


### PR DESCRIPTION
This [lint](https://rust-lang.github.io/rust-clippy/master/index.html#/test_attr_in_doctest) is producing warning (error in our case).  
Let's `ignore` the doc tests with `#[test]` attribute, in our case those used just as an example. 

#skip-changelog