### PR TITLE
ref(metrics): Better align flush times with intervals

### DIFF
--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -182,6 +182,15 @@ impl fmt::Display for UnixTimestamp {
     }
 }
 
+/// Adds _whole_ seconds of the given duration to the timestamp.
+impl std::ops::Add<Duration> for UnixTimestamp {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0.saturating_add(rhs.as_secs()))
+    }
+}
+
 impl std::ops::Sub for UnixTimestamp {
     type Output = Duration;
 

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -202,9 +202,9 @@ impl AggregatorConfig {
         let now = UnixTimestamp::now();
         let backdated = initial_flush <= now;
 
-        let delay = now.as_secs() as f64 - bucket_key.timestamp.as_secs() as f64;
+        let delay = now.as_secs() as i64 - bucket_key.timestamp.as_secs() as i64;
         relay_statsd::metric!(
-            histogram(MetricHistograms::BucketsDelay) = delay,
+            histogram(MetricHistograms::BucketsDelay) = delay as f64,
             backdated = if backdated { "true" } else { "false" },
         );
 
@@ -875,7 +875,7 @@ mod tests {
             max_tag_key_length: 200,
             max_tag_value_length: 200,
             max_project_key_bucket_bytes: None,
-            ..Default::default()
+            shift_key: ShiftKey::default(),
         }
     }
 

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -859,7 +859,6 @@ impl fmt::Debug for Aggregator {
 
 #[cfg(test)]
 mod tests {
-
     use similar_asserts::assert_eq;
 
     use super::*;
@@ -1177,27 +1176,29 @@ mod tests {
             assert_eq!(total_cost, current_cost + expected_added_cost);
         }
 
-        aggregator.pop_flush_buckets(false);
+        aggregator.pop_flush_buckets(true);
         assert_eq!(aggregator.cost_tracker.total_cost, 0);
     }
 
-    // #[test]
-    // fn test_get_bucket_timestamp_overflow() {
-    //     let config = AggregatorConfig {
-    //         bucket_interval: 10,
-    //         initial_delay: 0,
-    //         debounce_delay: 0,
-    //         ..Default::default()
-    //     };
+    #[test]
+    fn test_get_bucket_timestamp_overflow() {
+        let config = AggregatorConfig {
+            bucket_interval: 10,
+            initial_delay: 0,
+            debounce_delay: 0,
+            ..Default::default()
+        };
 
-    //     assert!(matches!(
-    //         config
-    //             .get_bucket_timestamp(UnixTimestamp::from_secs(u64::MAX), 2)
-    //             .unwrap_err()
-    //             .kind,
-    //         AggregateMetricsErrorKind::InvalidTimestamp(_)
-    //     ));
-    // }
+        let aggregator = Aggregator::new(config);
+
+        assert!(matches!(
+            aggregator
+                .get_bucket_timestamp(UnixTimestamp::from_secs(u64::MAX), 2)
+                .unwrap_err()
+                .kind,
+            AggregateMetricsErrorKind::InvalidTimestamp(_)
+        ));
+    }
 
     #[test]
     fn test_get_bucket_timestamp_zero() {

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -392,7 +392,6 @@ impl MergeBuckets {
 
 #[cfg(test)]
 mod tests {
-
     use std::collections::BTreeMap;
     use std::sync::{Arc, RwLock};
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -11,7 +11,12 @@ import queue
 from .test_envelope import generate_transaction_item
 
 TEST_CONFIG = {
-    "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0}
+    "aggregator": {
+        "bucket_interval": 1,
+        "initial_delay": 0,
+        "debounce_delay": 0,
+        "shift_key": "none",
+    }
 }
 
 
@@ -138,6 +143,7 @@ def test_metrics_partition_key(mini_sentry, relay, metrics_partitions, expected_
             "max_secs_in_past": forever,
             "max_secs_in_future": forever,
             "flush_partitions": metrics_partitions,
+            "shift_key": "none",
         },
     }
     relay = relay(mini_sentry, options=relay_config)


### PR DESCRIPTION
Align the flush times of backdated metric buckets with bucket intervals
so that global flushing becomes more effective. This is done through two
changes:

1. Allow to configure `ShiftKey::None` to disable shifting of flushed
   buckets. If set to `none`, buckets from all projects are flushed at
   the same time.
2. For backdated buckets, do not use the precise current timestamp.
   Instead, round it to the current bucket interval, then add the
   debounce delay. When shifting is configured, the shift is now also
   added to backdated buckets.

Integration tests by default use `shift_key: none` now to improve their
execution time, which also helps reduce flakiness.

#skip-changelog