### PR TITLE
ref(store): Split buckets directly for kafka

### DIFF
--- a/relay-server/src/actors/store.rs
+++ b/relay-server/src/actors/store.rs
@@ -15,7 +15,7 @@ use relay_event_schema::protocol::{
 };
 use relay_kafka::{ClientError, KafkaClient, KafkaTopic, Message};
 use relay_metrics::{
-    Bucket, BucketViewValue, BucketsView, MetricNamespace, MetricResourceIdentifier,
+    Bucket, BucketView, BucketViewValue, MetricNamespace, MetricResourceIdentifier,
 };
 use relay_quotas::Scoping;
 use relay_statsd::metric;
@@ -301,10 +301,13 @@ impl StoreService {
         let mut error = None;
 
         for bucket in buckets {
-            // Create a local bucket view to avoid splitting buckets unnecessarily. Since we produce
-            // each bucket separately, we only need to split buckets that exceed the size, but not
-            // batches.
-            for view in BucketsView::new(&[bucket]).by_size(batch_size).flatten() {
+            let mut remaining = Some(BucketView::new(&bucket));
+
+            while let Some(current) = remaining.take() {
+                let (Some(view), next) = current.split(batch_size, Some(batch_size)) else {
+                    break;
+                };
+
                 let message = MetricKafkaMessage {
                     org_id: scoping.organization_id,
                     project_id: scoping.project_id,
@@ -319,6 +322,8 @@ impl StoreService {
                     error.get_or_insert(e);
                     dropped += utils::extract_metric_quantities([view], mode);
                 }
+
+                remaining = next;
             }
         }
 


### PR DESCRIPTION
Minor refactor that changes how buckets are split before producing them to Kafka. Previously, the store service constructed a `BucketsView` with a single bucket, that it then splits and iterates. As the `BucketView` now has a direct split method, we can skip the iterator and split the view directly.

#skip-changelog