### PR TITLE
fix(normalize): Do not divide by zero in perf scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**:
 
 - Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2878](https://github.com/getsentry/relay/pull/2878))
+- Resolve a division by zero in performance score computation that leads to dropped metrics for transactions. ([#2911](https://github.com/getsentry/relay/pull/2911))
 
 **Internal**:
 


### PR DESCRIPTION
Resolve a division by zero in performance score computation that leads to dropped metrics for transactions. This could occur if either all components are optional, or the weight of all components is `0`.

Potential fix for [SNUBA-426](https://sentry.sentry.io/issues/4747328935/)
Ref https://github.com/getsentry/relay/issues/2910