### PR TITLE
Revert "debug(spool): Add metrics and report an error"

### DIFF
--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -36,10 +36,9 @@ use std::error::Error;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
-use relay_base_schema::project::{ProjectId, ProjectKey};
+use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
 use relay_system::{Addr, Controller, FromMessage, Interface, Sender, Service};
 use sqlx::migrate::MigrateError;
@@ -56,7 +55,7 @@ use crate::actors::project_cache::{ProjectCache, UpdateBufferIndex};
 use crate::actors::test_store::TestStore;
 use crate::envelope::{Envelope, EnvelopeError};
 use crate::extractors::StartTime;
-use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
+use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms};
 use crate::utils::{BufferGuard, ManagedEnvelope};
 
 mod sql;
@@ -416,26 +415,9 @@ impl OnDisk {
         let received_at: i64 = row
             .try_get("received_at")
             .map_err(BufferError::FetchFailed)?;
-        let start_time_instant = StartTime::from_timestamp_millis(received_at as u64).into_inner();
+        let start_time = StartTime::from_timestamp_millis(received_at as u64);
 
-        // This metric should show how long we waited till the envelope was unspooled.
-        relay_statsd::metric!(
-            timer(RelayTimers::EnvelopeOnDiskBufferTime) = start_time_instant.elapsed()
-        );
-
-        // If an envelope stays longer than 2 hours in on-disk spool, produce an error, so we could
-        // debug what kind of envelope it is.
-        if start_time_instant.elapsed() > Duration::from_secs(7200) {
-            relay_log::error!(
-                tags.project_key = %envelope.meta().public_key(),
-                tags.project_id = %envelope.meta().project_id().unwrap_or(ProjectId::new(0)),
-                event_id = ?envelope.event_id(),
-                duration = ?start_time_instant.elapsed(),
-                "Spooled envelope spent more than 2 hours in on-disk spool"
-            );
-        }
-
-        envelope.set_start_time(start_time_instant);
+        envelope.set_start_time(start_time.into_inner());
 
         let managed_envelope = self.buffer_guard.enter(
             envelope,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -254,8 +254,6 @@ pub enum RelayTimers {
     /// Total time in milliseconds an envelope spends in Relay from the time it is received until it
     /// finishes processing and has been submitted to the upstream.
     EnvelopeTotalTime,
-    /// Total time in milliseconds an envelope spends in the Relay's on-disk buffer.
-    EnvelopeOnDiskBufferTime,
     /// Total time in milliseconds spent evicting outdated and unused projects happens.
     ProjectStateEvictionDuration,
     /// Total time in milliseconds spent fetching queued project configuration updates requests to
@@ -370,7 +368,6 @@ impl TimerMetric for RelayTimers {
             RelayTimers::EnvelopeWaitTime => "event.wait_time",
             RelayTimers::EnvelopeProcessingTime => "event.processing_time",
             RelayTimers::EnvelopeTotalTime => "event.total_time",
-            RelayTimers::EnvelopeOnDiskBufferTime => "envelope.on_disk_buffer_time",
             RelayTimers::ProjectStateEvictionDuration => "project_state.eviction.duration",
             RelayTimers::ProjectStateRequestDuration => "project_state.request.duration",
             #[cfg(feature = "processing")]


### PR DESCRIPTION
Reverts getsentry/relay#2828

This metrics is no longer needed. 

#skip-changelog