### PR TITLE
Revert "chore(spool): Add periodic check for in-memory buffer with additional metrics"

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -813,11 +813,6 @@ fn spool_envelopes_max_connections() -> u32 {
     20
 }
 
-/// Defaualt period for garbage collection in the spooler.
-fn spool_envelopes_check_interval() -> u64 {
-    60
-}
-
 /// Persistent buffering configuration for incoming envelopes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvelopeSpool {
@@ -841,11 +836,6 @@ pub struct EnvelopeSpool {
     /// This is a hard upper bound and defaults to 524288000 bytes (500MB).
     #[serde(default = "spool_envelopes_max_memory_size")]
     max_memory_size: ByteSize,
-
-    /// The interval for the internal check to run and issue specific to the spooler metrics and
-    /// errors.
-    #[serde(default = "spool_envelopes_check_interval")]
-    check_interval: u64,
 }
 
 impl Default for EnvelopeSpool {
@@ -856,7 +846,6 @@ impl Default for EnvelopeSpool {
             min_connections: spool_envelopes_min_connections(),
             max_disk_size: spool_envelopes_max_disk_size(),
             max_memory_size: spool_envelopes_max_memory_size(),
-            check_interval: spool_envelopes_check_interval(),
         }
     }
 }
@@ -1940,11 +1929,6 @@ impl Config {
     /// The maximum size of the memory buffer, in bytes.
     pub fn spool_envelopes_max_memory_size(&self) -> usize {
         self.values.spool.envelopes.max_memory_size.as_bytes()
-    }
-
-    /// The interval to run the check.
-    pub fn spool_envelopes_check_interval(&self) -> Duration {
-        Duration::from_secs(self.values.spool.envelopes.check_interval)
     }
 
     /// Returns the maximum size of an event payload in bytes.

--- a/relay-server/src/actors/spooler/mod.rs
+++ b/relay-server/src/actors/spooler/mod.rs
@@ -29,8 +29,6 @@
 //!
 //! Current on-disk spool implementation uses SQLite as a storage.
 
-static NUMBER_OF_ENVELOPES_PER_KEY: usize = 1000;
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::path::Path;
@@ -253,25 +251,6 @@ impl InMemory {
     /// Returns the number of envelopes in the memory buffer.
     fn count(&self) -> usize {
         self.buffer.values().map(|v| v.len()).sum()
-    }
-
-    /// Runs the check for in-memory buffer and emits the metrics and/or errors.
-    fn check(&self) {
-        let count = self.buffer.keys().len();
-        relay_statsd::metric!(gauge(RelayGauges::BufferProjectsMemoryCount) = count as u64);
-
-        // Go over the buffered envelopes and check if any of the keys exceeds the threshold.
-        for (key, values) in &self.buffer {
-            let number_of_envelopes = values.len();
-            if number_of_envelopes > NUMBER_OF_ENVELOPES_PER_KEY {
-                relay_log::error!(
-                    tags.own_key = %key.own_key,
-                    tags.sampling_key = %key.sampling_key,
-                    count = number_of_envelopes,
-                    "Number of envelopes per key in memory exceeds the threshold"
-                );
-            }
-        }
     }
 
     /// Removes envelopes from the in-memory buffer.
@@ -956,20 +935,6 @@ impl BufferService {
         disk.spool(buffer).await?;
         Ok(())
     }
-
-    /// Handles the check of the envelopes buffer.
-    ///
-    /// Note: currently the check runs only on the in-memory buffer to track if there is "hot"
-    /// projects keys which are always have too many envelopes in the queue.
-    fn handle_check(&mut self) {
-        let (BufferState::Memory(ref mut ram) | BufferState::MemoryFileStandby { ref mut ram, .. }) =
-            self.state
-        else {
-            return;
-        };
-
-        ram.check();
-    }
 }
 
 impl Service for BufferService {
@@ -978,13 +943,11 @@ impl Service for BufferService {
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
             let mut shutdown = Controller::shutdown_handle();
-            let mut ticker = tokio::time::interval(self.config.spool_envelopes_check_interval());
 
             loop {
                 tokio::select! {
                     biased;
 
-                    _ = ticker.tick() => self.handle_check(),
                     Some(message) = rx.recv() => {
                         if let Err(err) = self.handle_message(message).await {
                             relay_log::error!(

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -20,8 +20,6 @@ pub enum RelayGauges {
     ///
     /// The disk buffer size can be configured with `spool.envelopes.max_disk_size`.
     BufferEnvelopesDiskCount,
-    /// The current count of the keys in the "in-memory" buffer.
-    BufferProjectsMemoryCount,
 }
 
 impl GaugeMetric for RelayGauges {
@@ -31,7 +29,6 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",
-            RelayGauges::BufferProjectsMemoryCount => "buffer.projects_mem_count",
         }
     }
 }
@@ -424,6 +421,7 @@ pub enum RelayCounters {
     BufferEnvelopesWritten,
     /// Number of _envelopes_ the envelope buffer reads back from disk.
     BufferEnvelopesRead,
+    ///
     /// Number of outcomes and reasons for rejected Envelopes.
     ///
     /// This metric is tagged with:


### PR DESCRIPTION
Reverts getsentry/relay#2742

This was temporary checks and no longer needed. 

#skip-changelog