### PR TITLE
feat(app-start): Add Android app start-related spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Make Kafka spans compatible with the Snuba span schema. ([#2917](https://github.com/getsentry/relay/pull/2917), [#2926](https://github.com/getsentry/relay/pull/2926))
 - Only extract span metrics / tags when they are needed. ([#2907](https://github.com/getsentry/relay/pull/2907), [#2923](https://github.com/getsentry/relay/pull/2923))
 - Normalize metric resource identifiers in `event._metrics_summary` and `span._metrics_summary`. ([#2914](https://github.com/getsentry/relay/pull/2914))
+- Add nested Android app start span ops to span ingestion ([#2906](https://github.com/getsentry/relay/pull/2906))
 
 ## 23.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Make Kafka spans compatible with the Snuba span schema. ([#2917](https://github.com/getsentry/relay/pull/2917), [#2926](https://github.com/getsentry/relay/pull/2926))
 - Only extract span metrics / tags when they are needed. ([#2907](https://github.com/getsentry/relay/pull/2907), [#2923](https://github.com/getsentry/relay/pull/2923))
 - Normalize metric resource identifiers in `event._metrics_summary` and `span._metrics_summary`. ([#2914](https://github.com/getsentry/relay/pull/2914))
-- Add nested Android app start span ops to span ingestion ([#2906](https://github.com/getsentry/relay/pull/2906))
+- Add nested Android app start span ops to span ingestion ([#2927](https://github.com/getsentry/relay/pull/2927))
 
 ## 23.12.1
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -61,12 +61,12 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
 
 /// Metrics with tags applied as required.
 fn span_metrics(is_extract_all: bool) -> impl IntoIterator<Item = MetricSpec> {
-    let flagged_mobile_ops = if is_extract_all {
-        let mut new_mobile_ops = MOBILE_OPS.to_vec();
-        new_mobile_ops.extend(["contentprovider.load", "application.load", "activity.load"]);
-        new_mobile_ops
-    } else {
-        MOBILE_OPS.to_vec()
+    let flagged_mobile_ops = {
+        let mut ops = MOBILE_OPS.to_vec();
+        if is_extract_all {
+            ops.extend(["contentprovider.load", "application.load", "activity.load"]);
+        }
+        ops
     };
 
     let is_db = RuleCondition::eq("span.sentry_tags.category", "db")

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -18,7 +18,13 @@ const DISABLED_DATABASES: &[&str] = &[
 ];
 
 /// A list of `span.op` patterns we want to enable for mobile.
-const MOBILE_OPS: &[&str] = &["app.*", "ui.load*"];
+const MOBILE_OPS: &[&str] = &[
+    "app.*",
+    "ui.load*",
+    "contentprovider.load",
+    "application.load",
+    "activity.load",
+];
 
 /// A list of span descriptions that indicate top-level app start spans.
 const APP_START_ROOT_SPAN_DESCRIPTIONS: &[&str] = &["Cold Start", "Warm Start"];

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -82,6 +82,26 @@ pub(crate) fn scrub_span_description(span: &Span) -> Option<String> {
                 // They are low-cardinality.
                 Some(description.to_owned())
             }
+            ("contentprovider", "load") => {
+                // `contentprovider.load` spans contain paths of third party framework components
+                // and their onCreate method such as
+                // `io.sentry.android.core.SentryPerformanceProvider.onCreate`, which
+                // _should_ be low-cardinality, on the order of 10s per project.
+                Some(description.to_owned())
+            }
+            ("application", "load") => {
+                // `application.load` spans contain paths of app components and their
+                // onCreate method such as
+                // `io.sentry.samples.android.MyApplication.onCreate`, which _should_ be
+                // low-cardinality.
+                Some(description.to_owned())
+            }
+            ("activity", "load") => {
+                // `activity.load` spans contain paths of app components and their onCreate/onStart
+                // method such as `io.sentry.samples.android.MainActivity.onCreate`, which
+                // _should_ be low-cardinality, less than 10 per project.
+                Some(description.to_owned())
+            }
             ("file", _) => scrub_file(description),
             _ => None,
         })
@@ -681,6 +701,27 @@ mod tests {
         "ListAppViewController",
         "ui.load",
         "ListAppViewController"
+    );
+
+    span_description_test!(
+        contentprovider_load,
+        "io.sentry.android.core.SentryPerformanceProvider.onCreate",
+        "contentprovider.load",
+        "io.sentry.android.core.SentryPerformanceProvider.onCreate"
+    );
+
+    span_description_test!(
+        application_load,
+        "io.sentry.samples.android.MyApplication.onCreate",
+        "application.load",
+        "io.sentry.samples.android.MyApplication.onCreate"
+    );
+
+    span_description_test!(
+        activity_load,
+        "io.sentry.samples.android.MainActivity.onCreate",
+        "activity.load",
+        "io.sentry.samples.android.MainActivity.onCreate"
     );
 
     span_description_test!(

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1084,6 +1084,30 @@ mod tests {
                     "start_timestamp": 1597976300.0000000,
                     "timestamp": 1597976303.0000000,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81"
+                },
+                {
+                    "op": "contentprovider.load",
+                    "description": "io.sentry.android.core.SentryPerformanceProvider.onCreate",
+                    "span_id": "bd429c44b67a3eb2",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976303.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81"
+                },
+                {
+                    "op": "application.load",
+                    "description": "io.sentry.samples.android.MyApplication.onCreate",
+                    "span_id": "bd429c44b67a3eb2",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976303.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81"
+                },
+                {
+                    "op": "activity.load",
+                    "description": "io.sentry.samples.android.MainActivity.onCreate",
+                    "span_id": "bd429c44b67a3eb2",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976303.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81"
                 }
             ]
         }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -125,6 +125,129 @@ expression: "(&event.value().unwrap().spans, metrics)"
             _metrics_summary: ~,
             other: {},
         },
+        Span {
+            timestamp: Timestamp(
+                2020-08-21T02:18:23Z,
+            ),
+            start_timestamp: Timestamp(
+                2020-08-21T02:18:20Z,
+            ),
+            exclusive_time: 3000.0,
+            description: "io.sentry.android.core.SentryPerformanceProvider.onCreate",
+            op: "contentprovider.load",
+            span_id: SpanId(
+                "bd429c44b67a3eb2",
+            ),
+            parent_span_id: ~,
+            trace_id: TraceId(
+                "ff62a8b040f340bda5d830223def1d81",
+            ),
+            segment_id: ~,
+            is_segment: ~,
+            status: ~,
+            tags: ~,
+            origin: ~,
+            profile_id: ~,
+            data: ~,
+            sentry_tags: {
+                "description": "io.sentry.android.core.SentryPerformanceProvider.onCreate",
+                "device.class": "1",
+                "group": "cfb484dec50a18c9",
+                "mobile": "true",
+                "op": "contentprovider.load",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+            received: ~,
+            measurements: ~,
+            _metrics_summary: ~,
+            other: {},
+        },
+        Span {
+            timestamp: Timestamp(
+                2020-08-21T02:18:23Z,
+            ),
+            start_timestamp: Timestamp(
+                2020-08-21T02:18:20Z,
+            ),
+            exclusive_time: 3000.0,
+            description: "io.sentry.samples.android.MyApplication.onCreate",
+            op: "application.load",
+            span_id: SpanId(
+                "bd429c44b67a3eb2",
+            ),
+            parent_span_id: ~,
+            trace_id: TraceId(
+                "ff62a8b040f340bda5d830223def1d81",
+            ),
+            segment_id: ~,
+            is_segment: ~,
+            status: ~,
+            tags: ~,
+            origin: ~,
+            profile_id: ~,
+            data: ~,
+            sentry_tags: {
+                "description": "io.sentry.samples.android.MyApplication.onCreate",
+                "device.class": "1",
+                "group": "a928f42bab6aff5b",
+                "mobile": "true",
+                "op": "application.load",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+            received: ~,
+            measurements: ~,
+            _metrics_summary: ~,
+            other: {},
+        },
+        Span {
+            timestamp: Timestamp(
+                2020-08-21T02:18:23Z,
+            ),
+            start_timestamp: Timestamp(
+                2020-08-21T02:18:20Z,
+            ),
+            exclusive_time: 3000.0,
+            description: "io.sentry.samples.android.MainActivity.onCreate",
+            op: "activity.load",
+            span_id: SpanId(
+                "bd429c44b67a3eb2",
+            ),
+            parent_span_id: ~,
+            trace_id: TraceId(
+                "ff62a8b040f340bda5d830223def1d81",
+            ),
+            segment_id: ~,
+            is_segment: ~,
+            status: ~,
+            tags: ~,
+            origin: ~,
+            profile_id: ~,
+            data: ~,
+            sentry_tags: {
+                "description": "io.sentry.samples.android.MainActivity.onCreate",
+                "device.class": "1",
+                "group": "6d931be5b5897006",
+                "mobile": "true",
+                "op": "activity.load",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+            received: ~,
+            measurements: ~,
+            _metrics_summary: ~,
+            other: {},
+        },
     ],
     [
         Bucket {
@@ -327,6 +450,192 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "span.description": "Cold Start",
                 "span.group": "2d675185edfeb30c",
                 "span.op": "app.start.cold",
+                "transaction": "gEt /api/:version/users/",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.description": "io.sentry.android.core.SentryPerformanceProvider.onCreate",
+                "span.group": "cfb484dec50a18c9",
+                "span.op": "contentprovider.load",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time_light@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.description": "io.sentry.android.core.SentryPerformanceProvider.onCreate",
+                "span.group": "cfb484dec50a18c9",
+                "span.op": "contentprovider.load",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_op@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "span.op": "contentprovider.load",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_segment@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.description": "io.sentry.samples.android.MyApplication.onCreate",
+                "span.group": "a928f42bab6aff5b",
+                "span.op": "application.load",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time_light@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.description": "io.sentry.samples.android.MyApplication.onCreate",
+                "span.group": "a928f42bab6aff5b",
+                "span.op": "application.load",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_op@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "span.op": "application.load",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_segment@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.description": "io.sentry.samples.android.MainActivity.onCreate",
+                "span.group": "6d931be5b5897006",
+                "span.op": "activity.load",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "d:spans/exclusive_time_light@millisecond",
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "device.class": "1",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "span.description": "io.sentry.samples.android.MainActivity.onCreate",
+                "span.group": "6d931be5b5897006",
+                "span.op": "activity.load",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_op@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "span.op": "activity.load",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_segment@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "release": "1.2.3",
                 "transaction": "gEt /api/:version/users/",
             },
         },


### PR DESCRIPTION
These spans are nested operations under the app.start.* spans on Android. Start collecting them for the Sentry product so we have some data before moving into the default config.

Note: This only adds the application portion of the spans. We are currently awaiting a new span that tracks the system portion of the app start and I will add that as another span op afterwards.

These spans are listed out [here](https://www.notion.so/sentry/70c42197962a41198992ae89383ceb57?v=af03325d6d3e4168bdb13bd3269fe3f1&pvs=4) for further information: 