### PR TITLE
feat(spans): De-duplicate SQL conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Group db spans with repeating logical conditions together. ([#2929](https://github.com/getsentry/relay/pull/2929))
+
 **Bug Fixes**:
 
 - Normalize event timestamps before validating them, fixing cases where Relay would drop valid events with reason "invalid_transaction". ([#2878](https://github.com/getsentry/relay/pull/2878))

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -704,12 +704,12 @@ mod tests {
         FROM a
         WHERE a.status = %s
         AND (
-        (a.id = %s AND a.org = %s)
-        OR (a.id = %s AND a.org = %s)
-        OR (a.id = %s AND a.org = %s)
-        OR (a.id = %s AND a.org = %s)
+            (a.id = %s AND a.org = %s)
+            OR (a.id = %s AND a.org = %s)
+            OR (a.id = %s AND a.org = %s)
+            OR (a.id = %s AND a.org = %s)
         )"#,
-        "SELECT * FROM a WHERE status = %s AND ((a.id = %s AND a.org = %s) OR ..)"
+        "SELECT * FROM a WHERE status = %s AND ((id = %s AND org = %s))"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -713,6 +713,32 @@ mod tests {
     );
 
     scrub_sql_test!(
+        duplicate_conditions_or,
+        r#"SELECT *
+        FROM a
+        WHERE a.status = %s
+        OR (
+            (a.id = %s OR a.org = %s)
+            OR (a.id = %s OR a.org = %s)
+            OR (a.id = %s OR a.org = %s)
+            OR (a.id = %s OR a.org = %s)
+        )"#,
+        "SELECT * FROM a WHERE status = %s OR ((id = %s OR org = %s))"
+    );
+
+    scrub_sql_test!(
+        non_duplicate_conditions,
+        r#"SELECT *
+        FROM a
+        WHERE a.status = %s
+        AND (
+            (a.id = %s AND a.org2 = %s)
+            OR (a.id = %s AND a.org = %s)
+        )"#,
+        "SELECT * FROM a WHERE status = %s AND ((id = %s AND org2 = %s) OR (id = %s AND org = %s))"
+    );
+
+    scrub_sql_test!(
         unique_alias,
         "SELECT pg_advisory_unlock(%s, %s) AS t0123456789abcdef",
         "SELECT pg_advisory_unlock(%s, %s)"

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -709,7 +709,7 @@ mod tests {
             OR (a.id = %s AND a.org = %s)
             OR (a.id = %s AND a.org = %s)
         )"#,
-        "SELECT * FROM a WHERE status = %s AND ((id = %s AND org = %s))"
+        "SELECT * FROM a WHERE status = %s AND (id = %s AND org = %s)"
     );
 
     scrub_sql_test!(
@@ -723,7 +723,7 @@ mod tests {
             OR (a.id = %s OR a.org = %s)
             OR (a.id = %s OR a.org = %s)
         )"#,
-        "SELECT * FROM a WHERE status = %s OR ((id = %s OR org = %s))"
+        "SELECT * FROM a WHERE status = %s OR (id = %s OR org = %s)"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -699,6 +699,20 @@ mod tests {
     );
 
     scrub_sql_test!(
+        duplicate_conditions,
+        r#"SELECT *
+        FROM a
+        WHERE a.status = %s
+        AND (
+        (a.id = %s AND a.org = %s)
+        OR (a.id = %s AND a.org = %s)
+        OR (a.id = %s AND a.org = %s)
+        OR (a.id = %s AND a.org = %s)
+        )"#,
+        "SELECT * FROM a WHERE status = %s AND ((a.id = %s AND a.org = %s) OR ..)"
+    );
+
+    scrub_sql_test!(
         unique_alias,
         "SELECT pg_advisory_unlock(%s, %s) AS t0123456789abcdef",
         "SELECT pg_advisory_unlock(%s, %s)"

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -211,8 +211,8 @@ mod tests {
 
     scrub_sql_test!(
         various_parameterized_ins_percentage,
-        "SELECT count() FROM table1 WHERE id IN (%s, %s) AND id IN (%s, %s, %s)",
-        "SELECT count() FROM table1 WHERE id IN (%s) AND id IN (%s)"
+        "SELECT count() FROM table1 WHERE id1 IN (%s, %s) AND id2 IN (%s, %s, %s)",
+        "SELECT count() FROM table1 WHERE id1 IN (%s) AND id2 IN (%s)"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -275,24 +275,15 @@ impl VisitorMut for NormalizeVisitor {
                 *expr = swapped;
             }
             Expr::BinaryOp {
-                left,
+                ref mut left,
                 op: BinaryOperator::Or, // TODO: And
-                right,
+                ref right,
             } => {
-                while let Expr::Nested(boxed_expr) = right.as_mut() {
-                    if let Expr::BinaryOp {
-                        left: right_left,
-                        op: right_op,
-                        right: ref mut right_right,
-                    } = boxed_expr.as_mut()
-                    {
-                        if right_op == &BinaryOperator::Or && right_left == left {
-                            *right = right_right.clone();
-                            right = right_right;
-                        }
-                        continue;
-                    }
-                    break;
+                let is_equal = left == right;
+                if is_equal {
+                    let mut swapped = Expr::Value(Value::Null);
+                    std::mem::swap(&mut swapped, left.as_mut());
+                    *expr = swapped;
                 }
             }
             _ => (),

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -1,6 +1,5 @@
 //! Logic for parsing SQL queries and manipulating the resulting Abstract Syntax Tree.
 use std::borrow::Cow;
-use std::mem::swap;
 use std::ops::ControlFlow;
 
 use itertools::Itertools;

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -276,10 +276,24 @@ impl VisitorMut for NormalizeVisitor {
             }
             Expr::BinaryOp {
                 left,
-                op: BinaryOperator::And,
+                op: BinaryOperator::Or, // TODO: And
                 right,
             } => {
-                dbg!(left, right);
+                while let Expr::Nested(boxed_expr) = right.as_mut() {
+                    if let Expr::BinaryOp {
+                        left: right_left,
+                        op: right_op,
+                        right: ref mut right_right,
+                    } = boxed_expr.as_mut()
+                    {
+                        if right_op == &BinaryOperator::Or && right_left == left {
+                            *right = right_right.clone();
+                            right = right_right;
+                        }
+                        continue;
+                    }
+                    break;
+                }
             }
             _ => (),
         }

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -276,7 +276,7 @@ impl VisitorMut for NormalizeVisitor {
             }
             Expr::BinaryOp {
                 ref mut left,
-                op: BinaryOperator::Or, // TODO: And
+                op: BinaryOperator::Or | BinaryOperator::And,
                 ref right,
             } => {
                 let is_equal = left == right;


### PR DESCRIPTION
SQL queries are sometimes generated with dynamic conditions (`.. OR .. OR .. OR ..`). After parameter scrubbing, these operands look the same, for example `id = %s OR id = %s OR id = %s`. In this case, simplify the condition to `id = %s`. 

ref: [internal issue](https://www.notion.so/sentry/Collapse-identical-OR-conditions-in-queries-40786f8cddb145e398e8ad2d5eb66522)