### PR TITLE
fix(spans): Update extraction condition for count_per_segment

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -84,7 +84,7 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
             ],
         );
 
-    let is_mobile = is_mobile_sdk & (is_mobile_op.clone() | is_screen);
+    let is_mobile = is_mobile_sdk.clone() & (is_mobile_op.clone() | is_screen);
 
     // For mobile spans, only extract duration metrics when they are below a threshold.
     let duration_condition = RuleCondition::negate(is_mobile_op.clone())
@@ -336,7 +336,7 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
             category: DataCategory::Span,
             mri: "c:spans/count_per_segment@none".into(),
             field: None,
-            condition: Some(is_mobile.clone() & duration_condition.clone()),
+            condition: Some(is_mobile_sdk.clone() & duration_condition.clone()),
             tags: vec![
                 Tag::with_key("transaction.op")
                     .from_field("span.sentry_tags.transaction.op")

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1084,6 +1084,14 @@ mod tests {
                     "start_timestamp": 1597976300.0000000,
                     "timestamp": 1597976303.0000000,
                     "trace_id": "ff62a8b040f340bda5d830223def1d81"
+                },
+                {
+                    "op": "custom.op",
+                    "description": "Custom Op",
+                    "span_id": "bd429c44b67a3eb2",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976303.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81"
                 }
             ]
         }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -125,6 +125,45 @@ expression: "(&event.value().unwrap().spans, metrics)"
             _metrics_summary: ~,
             other: {},
         },
+        Span {
+            timestamp: Timestamp(
+                2020-08-21T02:18:23Z,
+            ),
+            start_timestamp: Timestamp(
+                2020-08-21T02:18:20Z,
+            ),
+            exclusive_time: 3000.0,
+            description: "Custom Op",
+            op: "custom.op",
+            span_id: SpanId(
+                "bd429c44b67a3eb2",
+            ),
+            parent_span_id: ~,
+            trace_id: TraceId(
+                "ff62a8b040f340bda5d830223def1d81",
+            ),
+            segment_id: ~,
+            is_segment: ~,
+            status: ~,
+            tags: ~,
+            origin: ~,
+            profile_id: ~,
+            data: ~,
+            sentry_tags: {
+                "device.class": "1",
+                "mobile": "true",
+                "op": "custom.op",
+                "os.name": "iOS",
+                "release": "1.2.3",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+            received: ~,
+            measurements: ~,
+            _metrics_summary: ~,
+            other: {},
+        },
     ],
     [
         Bucket {
@@ -327,6 +366,29 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "span.description": "Cold Start",
                 "span.group": "2d675185edfeb30c",
                 "span.op": "app.start.cold",
+                "transaction": "gEt /api/:version/users/",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_op@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "span.op": "custom.op",
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: "c:spans/count_per_segment@none",
+            value: Counter(
+                1.0,
+            ),
+            tags: {
+                "release": "1.2.3",
                 "transaction": "gEt /api/:version/users/",
             },
         },


### PR DESCRIPTION
We'd like to keep a count of _all_ mobile spans so we
can determine "other". Updates the condition to not just
include the mobile span ops.

#skip-changelog