### PR TITLE
ref(normalization): Remove unused normalization returns

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -250,7 +250,8 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
             meta.add_error(ErrorKind::InvalidData);
             Err(ProcessingAction::DeleteValueSoft)
         }
-    })?;
+    })
+    .ok();
 
     // Default required attributes, even if they have errors
     normalize_logentry(&mut event.logentry, meta)?;

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -263,7 +263,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
         normalize_device_class(event);
     }
     normalize_stacktraces(event);
-    normalize_exceptions(event)?; // Browser extension filters look at the stacktrace
+    normalize_exceptions(event); // Browser extension filters look at the stacktrace
     normalize_user_agent(event, config.normalize_user_agent); // Legacy browsers filter
     normalize_measurements(
         event,
@@ -650,7 +650,7 @@ fn normalize_last_stacktrace_frame(exception: &mut Annotated<Exception>) {
     .ok();
 }
 
-fn normalize_exceptions(event: &mut Event) -> ProcessingResult {
+fn normalize_exceptions(event: &mut Event) {
     let os_hint = mechanism::OsHint::from_event(event);
 
     if let Some(exception_values) = event.exceptions.value_mut() {
@@ -674,14 +674,12 @@ fn normalize_exceptions(event: &mut Event) -> ProcessingResult {
             for exception in exceptions {
                 if let Some(exception) = exception.value_mut() {
                     if let Some(mechanism) = exception.mechanism.value_mut() {
-                        mechanism::normalize_mechanism(mechanism, os_hint)?;
+                        mechanism::normalize_mechanism(mechanism, os_hint);
                     }
                 }
             }
         }
     }
-
-    Ok(())
 }
 
 fn normalize_user_agent(_event: &mut Event, normalize_user_agent: Option<bool>) {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -274,8 +274,10 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
     normalize_breakdowns(event, config.breakdowns_config); // Breakdowns are part of the metric extraction too
 
     processor::apply(&mut event.request, |request, _| {
-        request::normalize_request(request)
-    })?;
+        request::normalize_request(request);
+        Ok(())
+    })
+    .ok();
 
     // Some contexts need to be normalized before metrics extraction takes place.
     processor::apply(&mut event.contexts, normalize_contexts)?;

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -200,7 +200,9 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
     transactions_processor.process_event(event, meta, ProcessingState::root())?;
 
     // Check for required and non-empty values
-    schema::SchemaProcessor.process_event(event, meta, ProcessingState::root())?;
+    schema::SchemaProcessor
+        .process_event(event, meta, ProcessingState::root())
+        .ok();
 
     normalize_timestamps(
         event,

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -255,7 +255,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
 
     // Default required attributes, even if they have errors
     normalize_logentry(&mut event.logentry, meta);
-    normalize_release_dist(event)?; // dist is a tag extracted along with other metrics from transactions
+    normalize_release_dist(event); // dist is a tag extracted along with other metrics from transactions
     normalize_event_tags(event)?; // Tags are added to every metric
 
     // TODO: Consider moving to store normalization
@@ -439,11 +439,11 @@ fn normalize_logentry(logentry: &mut Annotated<LogEntry>, _meta: &mut Meta) {
 }
 
 /// Ensures that the `release` and `dist` fields match up.
-fn normalize_release_dist(event: &mut Event) -> ProcessingResult {
-    normalize_dist(&mut event.dist)
+fn normalize_release_dist(event: &mut Event) {
+    normalize_dist(&mut event.dist);
 }
 
-fn normalize_dist(distribution: &mut Annotated<String>) -> ProcessingResult {
+fn normalize_dist(distribution: &mut Annotated<String>) {
     processor::apply(distribution, |dist, meta| {
         let trimmed = dist.trim();
         if trimmed.is_empty() {
@@ -456,6 +456,7 @@ fn normalize_dist(distribution: &mut Annotated<String>) -> ProcessingResult {
         }
         Ok(())
     })
+    .ok();
 }
 
 /// Validates the timestamp range and sets a default value.
@@ -1095,28 +1096,28 @@ mod tests {
     #[test]
     fn test_normalize_dist_none() {
         let mut dist = Annotated::default();
-        normalize_dist(&mut dist).unwrap();
+        normalize_dist(&mut dist);
         assert_eq!(dist.value(), None);
     }
 
     #[test]
     fn test_normalize_dist_empty() {
         let mut dist = Annotated::new("".to_string());
-        normalize_dist(&mut dist).unwrap();
+        normalize_dist(&mut dist);
         assert_eq!(dist.value(), None);
     }
 
     #[test]
     fn test_normalize_dist_trim() {
         let mut dist = Annotated::new(" foo  ".to_string());
-        normalize_dist(&mut dist).unwrap();
+        normalize_dist(&mut dist);
         assert_eq!(dist.value(), Some(&"foo".to_string()));
     }
 
     #[test]
     fn test_normalize_dist_whitespace() {
         let mut dist = Annotated::new(" ".to_owned());
-        normalize_dist(&mut dist).unwrap();
+        normalize_dist(&mut dist);
         assert_eq!(dist.value(), None);
     }
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -241,7 +241,8 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
             meta.add_error(ErrorKind::InvalidData);
             Err(ProcessingAction::DeleteValueSoft)
         }
-    })?;
+    })
+    .ok();
     processor::apply(&mut event.environment, |environment, meta| {
         if crate::validate_environment(environment).is_ok() {
             Ok(())

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -256,7 +256,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
     // Default required attributes, even if they have errors
     normalize_logentry(&mut event.logentry, meta);
     normalize_release_dist(event); // dist is a tag extracted along with other metrics from transactions
-    normalize_event_tags(event)?; // Tags are added to every metric
+    normalize_event_tags(event); // Tags are added to every metric
 
     // TODO: Consider moving to store normalization
     if config.device_class_synthesis_config {
@@ -541,7 +541,7 @@ impl DedupCache {
 }
 
 /// Removes internal tags and adds tags for well-known attributes.
-fn normalize_event_tags(event: &mut Event) -> ProcessingResult {
+fn normalize_event_tags(event: &mut Event) {
     let tags = &mut event.tags.value_mut().get_or_insert_with(Tags::default).0;
     let environment = &mut event.environment;
     if environment.is_empty() {
@@ -587,7 +587,8 @@ fn normalize_event_tags(event: &mut Event) -> ProcessingResult {
             }
 
             Ok(())
-        })?;
+        })
+        .ok();
     }
 
     let server_name = std::mem::take(&mut event.server_name);
@@ -601,8 +602,6 @@ fn normalize_event_tags(event: &mut Event) -> ProcessingResult {
         let tag_name = "site".to_string();
         tags.insert(tag_name, site);
     }
-
-    Ok(())
 }
 
 // Reads device specs (family, memory, cpu, etc) from context and sets the device.class tag to high,

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -303,7 +303,9 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
 
     if config.enable_trimming {
         // Trim large strings and databags down
-        trimming::TrimmingProcessor::new().process_event(event, meta, ProcessingState::root())?;
+        trimming::TrimmingProcessor::new()
+            .process_event(event, meta, ProcessingState::root())
+            .ok();
     }
 
     Ok(())

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -254,7 +254,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
     .ok();
 
     // Default required attributes, even if they have errors
-    normalize_logentry(&mut event.logentry, meta)?;
+    normalize_logentry(&mut event.logentry, meta);
     normalize_release_dist(event)?; // dist is a tag extracted along with other metrics from transactions
     normalize_event_tags(event)?; // Tags are added to every metric
 
@@ -431,8 +431,11 @@ fn normalize_user_geoinfo(geoip_lookup: &GeoIpLookup, user: &mut User) {
     }
 }
 
-fn normalize_logentry(logentry: &mut Annotated<LogEntry>, _meta: &mut Meta) -> ProcessingResult {
-    processor::apply(logentry, crate::logentry::normalize_logentry)
+fn normalize_logentry(logentry: &mut Annotated<LogEntry>, _meta: &mut Meta) {
+    processor::apply(logentry, |logentry, meta| {
+        crate::logentry::normalize_logentry(logentry, meta)
+    })
+    .ok();
 }
 
 /// Ensures that the `release` and `dist` fields match up.

--- a/relay-event-normalization/src/mechanism.rs
+++ b/relay-event-normalization/src/mechanism.rs
@@ -590,15 +590,14 @@ impl OsHint {
 
 /// Normalizes the exception mechanism in place.
 pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) {
-    processor::apply(&mut mechanism.help_link, |value, meta| {
+    let _ = processor::apply(&mut mechanism.help_link, |value, meta| {
         if value.starts_with("http://") || value.starts_with("https://") {
             Ok(())
         } else {
             meta.add_error(Error::expected("http URL"));
             Err(ProcessingAction::DeleteValueSoft)
         }
-    })
-    .ok();
+    });
 
     let meta = match mechanism.meta.value_mut() {
         Some(meta) => meta,

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -629,7 +629,7 @@ impl<'a> Processor for StoreNormalizeProcessor<'a> {
         meta: &mut Meta,
         _state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        crate::stacktrace::process_stacktrace(&mut stacktrace.0, meta)?;
+        crate::stacktrace::process_stacktrace(&mut stacktrace.0, meta);
         Ok(())
     }
 

--- a/relay-event-normalization/src/normalize/request.rs
+++ b/relay-event-normalization/src/normalize/request.rs
@@ -193,7 +193,7 @@ fn normalize_cookies(request: &mut Request) {
 /// - The `Content-Type` header is parsed and put into the `inferred_content_type` field.
 /// - The `Cookie` header is parsed and put into the `cookies` field.
 pub fn normalize_request(request: &mut Request) {
-    processor::apply(&mut request.method, normalize_method).ok();
+    let _ = processor::apply(&mut request.method, normalize_method);
     normalize_url(request);
     normalize_data(request);
     normalize_cookies(request);

--- a/relay-event-normalization/src/normalize/request.rs
+++ b/relay-event-normalization/src/normalize/request.rs
@@ -192,12 +192,11 @@ fn normalize_cookies(request: &mut Request) {
 /// - The data is parsed as JSON or urlencoded and put into the `data` field.
 /// - The `Content-Type` header is parsed and put into the `inferred_content_type` field.
 /// - The `Cookie` header is parsed and put into the `cookies` field.
-pub fn normalize_request(request: &mut Request) -> ProcessingResult {
-    processor::apply(&mut request.method, normalize_method)?;
+pub fn normalize_request(request: &mut Request) {
+    processor::apply(&mut request.method, normalize_method).ok();
     normalize_url(request);
     normalize_data(request);
     normalize_cookies(request);
-    Ok(())
 }
 
 #[cfg(test)]
@@ -215,7 +214,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.url.as_str(), Some("http://example.com/path"));
     }
 
@@ -227,7 +226,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.url.as_str(), Some("http://example.com/path"));
     }
 
@@ -238,7 +237,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.url.as_str(), Some("http://example.com/path..."));
     }
 
@@ -249,7 +248,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(
             request,
@@ -272,7 +271,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(
             request,
             Request {
@@ -289,7 +288,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(
             request,
@@ -312,7 +311,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(
             request,
@@ -335,7 +334,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(
             request,
@@ -361,7 +360,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(
             request.cookies,
@@ -398,7 +397,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(
             request.cookies,
@@ -419,7 +418,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(request.method.value(), None);
     }
@@ -431,7 +430,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
 
         assert_eq!(request.method.as_str(), Some("POST"));
     }
@@ -449,7 +448,7 @@ mod tests {
             Annotated::from(Value::String("bar".into())),
         );
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(
             request.inferred_content_type.as_str(),
             Some("application/json")
@@ -468,7 +467,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.inferred_content_type.as_str(), Some("text/plain"));
         assert_eq!(request.data.as_str(), Some(r#"{"foo":"b"#));
     }
@@ -480,7 +479,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.inferred_content_type.value(), None);
         assert_eq!(request.data.as_str(), Some(r#"{"foo":"b"#));
     }
@@ -498,7 +497,7 @@ mod tests {
             Annotated::from(Value::String("bar".into())),
         );
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(
             request.inferred_content_type.as_str(),
             Some("application/x-www-form-urlencoded")
@@ -513,7 +512,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.inferred_content_type.value(), None);
         assert_eq!(request.data.as_str(), Some("dGU="));
     }
@@ -525,7 +524,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.inferred_content_type.value(), None);
         assert_eq!(request.data.as_str(), Some("dA=="));
     }
@@ -537,7 +536,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.inferred_content_type.value(), None);
         assert_eq!(request.data.as_str(), Some("<?xml version=\"1.0\" ?>"));
     }
@@ -549,7 +548,7 @@ mod tests {
             ..Request::default()
         };
 
-        normalize_request(&mut request).unwrap();
+        normalize_request(&mut request);
         assert_eq!(request.inferred_content_type.value(), None);
         assert_eq!(request.data.as_str(), Some("\u{001f}1\u{0000}\u{0000}"));
     }

--- a/relay-event-normalization/src/stacktrace.rs
+++ b/relay-event-normalization/src/stacktrace.rs
@@ -21,7 +21,7 @@ pub fn process_stacktrace(stacktrace: &mut RawStacktrace, _meta: &mut Meta) {
     }
 }
 pub fn process_non_raw_frame(frame: &mut Annotated<Frame>) {
-    processor::apply(frame, |frame, _meta| {
+    let _ = processor::apply(frame, |frame, _meta| {
         if frame.abs_path.value().is_empty() {
             frame.abs_path = mem::replace(&mut frame.filename, Annotated::empty());
         }
@@ -42,8 +42,7 @@ pub fn process_non_raw_frame(frame: &mut Annotated<Frame>) {
             }
         }
         Ok(())
-    })
-    .ok();
+    });
 }
 
 #[cfg(test)]

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -50,7 +50,7 @@ impl<'r> TransactionsProcessor<'r> {
     /// Note: we add `/` at the end of the transaction name if there isn't one, to make sure that
     /// patterns like `/<something>/*/**` where we have `**` at the end are a match.
     pub fn apply_transaction_rename_rule(&self, transaction: &mut Annotated<String>) {
-        processor::apply(transaction, |transaction, meta| {
+        let _ = processor::apply(transaction, |transaction, meta| {
             let result = self.name_config.rules.iter().find_map(|rule| {
                 rule.match_and_apply(Cow::Borrowed(transaction))
                     .map(|applied_result| (rule.pattern.compiled().pattern(), applied_result))
@@ -72,8 +72,7 @@ impl<'r> TransactionsProcessor<'r> {
             }
 
             Ok(())
-        })
-        .ok();
+        });
     }
 
     /// Returns `true` if the given transaction name should be treated as a URL.
@@ -387,7 +386,7 @@ fn scrub_identifiers_with_regex(
 ) {
     let capture_names = pattern.capture_names().flatten().collect::<Vec<_>>();
 
-    processor::apply(string, |trans, meta| {
+    let _ = processor::apply(string, |trans, meta| {
         let mut caps = Vec::new();
         // Collect all the remarks if anything matches.
         for captures in pattern.captures_iter(trans) {
@@ -426,8 +425,7 @@ fn scrub_identifiers_with_regex(
             *trans = changed;
         }
         Ok(())
-    })
-    .ok();
+    });
 }
 
 /// Copies the event's end timestamp into the spans that don't have one.


### PR DESCRIPTION
This PR removes unused returns in event normalization. There are no functional changes.

Most functions that returned a `ProcessingAction` always return the `Ok` variant, not requiring significant code changes, and meaning the return is indeed not useful. The `DeleteValueHard` and `DeleteValueSoft` error variants are swallowed by the processor (including `processor::apply` calls) to add errors and remarks to `meta`, but these are [never bubbled up](https://github.com/getsentry/relay/blob/478c3ada166b108464a0971827433a8db090935e/relay-event-schema/src/processor/funcs.rs#L22-L25). The `InvalidTransaction` error variant, the [only one that's bubbled up](https://github.com/getsentry/relay/blob/478c3ada166b108464a0971827433a8db090935e/relay-event-schema/src/processor/funcs.rs#L26), is only returned by `TransactionsProcessor` and `TimestampProcessor`, and these remain unchanged.

For an easier review, each commit in the PR refactors a specific normalization step.

### Motivation

The goal is to have two separate steps: validation, validating the correctness of an event and rejecting it if it's invalid, and normalization, normalizing the payload without rejecting the event. In code, this means that the normalization function should not return a `ProcessingAction`; thus, each normalization step should not return a `ProcessingAction` either. The changes presented in this PR are required before taking the next step.

### Next steps

After this PR, only two remaining items returning a `ProcessingAction` are left: `TransactionsProcessor` and `TimestampProcessor`. The next step is to move the validation steps of these processors from normalization into a separate validation step.

#skip-changelog