### PR TITLE
feat(app-start): Collect dynamically loaded library count and size metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Validate error_id and trace_id vectors in replay deserializer. ([#2931](https://github.com/getsentry/relay/pull/2931))
 - Add a data category for indexed spans. ([#2937](https://github.com/getsentry/relay/pull/2937))
 - Add nested Android app start span ops to span ingestion ([#2927](https://github.com/getsentry/relay/pull/2927))
+- Add size and count metrics for dynamically loaded libraries on app start spans ([#2938](https://github.com/getsentry/relay/pull/2938))
 
 ## 23.12.1
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -383,5 +383,39 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
                     .always(), // already guarded by condition on metric
             ],
         },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "c:spans/count_dynamically_loaded_libraries@none".into(),
+            field: Some("span.measurements.count_dynamically_loaded_libraries".into()),
+            condition: Some(
+                duration_condition.clone() & is_mobile.clone() & app_start_condition.clone(),
+            ),
+            tags: vec![
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("transaction")
+                    .from_field("span.sentry_tags.transaction")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("device.class")
+                    .from_field("span.sentry_tags.device.class")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("release")
+                    .from_field("span.sentry_tags.release")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("os.name")
+                    .from_field("span.sentry_tags.os.name")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("environment")
+                    .from_field("span.sentry_tags.environment")
+                    .always(), // already guarded by condition on metric
+            ],
+        },
     ]
 }

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -385,8 +385,42 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
         },
         MetricSpec {
             category: DataCategory::Span,
-            mri: "c:spans/count_dynamically_loaded_libraries@none".into(),
-            field: Some("span.measurements.count_dynamically_loaded_libraries".into()),
+            mri: "c:spans/dynamically_loaded_libraries_count@none".into(),
+            field: Some("span.measurements.dynamically_loaded_libraries_count".into()),
+            condition: Some(
+                duration_condition.clone() & is_mobile.clone() & app_start_condition.clone(),
+            ),
+            tags: vec![
+                Tag::with_key("span.op")
+                    .from_field("span.sentry_tags.op")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("span.description")
+                    .from_field("span.sentry_tags.description")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("span.group")
+                    .from_field("span.sentry_tags.group")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("transaction")
+                    .from_field("span.sentry_tags.transaction")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("device.class")
+                    .from_field("span.sentry_tags.device.class")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("release")
+                    .from_field("span.sentry_tags.release")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("os.name")
+                    .from_field("span.sentry_tags.os.name")
+                    .always(), // already guarded by condition on metric
+                Tag::with_key("environment")
+                    .from_field("span.sentry_tags.environment")
+                    .always(), // already guarded by condition on metric
+            ],
+        },
+        MetricSpec {
+            category: DataCategory::Span,
+            mri: "c:spans/dynamically_loaded_libraries_size@byte".into(),
+            field: Some("span.measurements.dynamically_loaded_libraries_size".into()),
             condition: Some(
                 duration_condition.clone() & is_mobile.clone() & app_start_condition.clone(),
             ),

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -159,6 +159,8 @@ impl Getter for Span {
                     val.into()
                 } else if let Some(key) = path.strip_prefix("sentry_tags.") {
                     self.sentry_tags.value()?.get(key)?.as_str()?.into()
+                } else if let Some(key) = path.strip_prefix("measurements.") {
+                    self.measurements.value()?.get_value(key)?.into()
                 } else {
                     return None;
                 }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -121,7 +121,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "ttid": "ttid",
             },
             received: ~,
-            measurements: ~,
+            measurements: Measurements(
+                {},
+            ),
             _metrics_summary: ~,
             other: {},
         },


### PR DESCRIPTION
App start transactions are being modified to send the dynamically loaded libraries.

From this we want to capture a count of loaded libraries as well as the size of the libraries.
We chose counter implementations because there isn't a need to represent this using
percentiles, min, or max. The calculation for average can be done in the backend by
dividing the values by the count of events.

For this implementation I added the metric to the measurements field and has to
add some code to retrieve measurements in the span Getter

TODO:
- [ ] Determine which tags I need to collect for these metrics and update the MetricSpecs
- [ ] Find out which DebugImage types are applicable and whether or not there are different access paths for `image_size`
- [x] CHANGELOG.md entry