### PR TITLE
ref(metrics): Require finite floats in metric values

### DIFF
--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -65,7 +65,7 @@ fn bench_insert_and_flush(c: &mut Criterion) {
         timestamp: UnixTimestamp::now(),
         width: 0,
         name: "c:transactions/foo@none".to_owned(),
-        value: BucketValue::counter(42.),
+        value: BucketValue::counter(42.).unwrap(),
         tags: BTreeMap::new(),
     };
 

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -457,7 +457,7 @@ mod tests {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
             name: "c:transactions/foo".to_owned(),
-            value: BucketValue::counter(42.),
+            value: BucketValue::counter(42.).unwrap(),
             tags: BTreeMap::new(),
         }
     }

--- a/relay-server/src/actors/processor.rs
+++ b/relay-server/src/actors/processor.rs
@@ -2680,7 +2680,7 @@ mod tests {
                 tags,
             };
 
-            let metric: Bucket = measurement.into_metric(UnixTimestamp::now());
+            let metric: Bucket = measurement.into_metric(UnixTimestamp::now()).unwrap();
             metric.name.len() - unit.to_string().len() - name.len()
         };
         assert_eq!(

--- a/relay-server/src/actors/project.rs
+++ b/relay-server/src/actors/project.rs
@@ -1287,7 +1287,7 @@ mod tests {
         Bucket {
             name: "d:transactions/foo".to_string(),
             width: 0,
-            value: BucketValue::counter(1.0),
+            value: BucketValue::counter(1.0).unwrap(),
             timestamp: UnixTimestamp::now(),
             tags: Default::default(),
         }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -131,12 +131,12 @@ fn read_metric_value(
         MetricType::Counter => BucketValue::counter(match field {
             Some(field) => instance.get_value(field)?.as_f64()?,
             None => 1.0,
-        }),
+        })?,
         MetricType::Distribution => {
-            BucketValue::distribution(instance.get_value(field?)?.as_f64()?)
+            BucketValue::distribution(instance.get_value(field?)?.as_f64()?)?
         }
         MetricType::Set => BucketValue::set_from_str(instance.get_value(field?)?.as_str()?),
-        MetricType::Gauge => BucketValue::gauge(instance.get_value(field?)?.as_f64()?),
+        MetricType::Gauge => BucketValue::gauge(instance.get_value(field?)?.as_f64()?)?,
     })
 }
 

--- a/relay-server/src/metrics_extraction/mod.rs
+++ b/relay-server/src/metrics_extraction/mod.rs
@@ -7,5 +7,5 @@ pub mod sessions;
 pub mod transactions;
 
 pub trait IntoMetric {
-    fn into_metric(self, timestamp: UnixTimestamp) -> Bucket;
+    fn into_metric(self, timestamp: UnixTimestamp) -> Option<Bucket>;
 }

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -51,80 +51,80 @@ pub fn extract_session_metrics<T: SessionLike>(
     // Always capture with "init" tag for the first session update of a session. This is used
     // for adoption and as baseline for crash rates.
     if session.total_count() > 0 {
-        target.push(
-            SessionMetric::Session {
-                counter: session.total_count() as f64,
-                tags: SessionSessionTags {
-                    status: "init".to_string(),
-                    common_tags: common_tags.clone(),
-                },
-            }
-            .into_metric(timestamp),
-        );
+        let session_metric = SessionMetric::Session {
+            counter: session.total_count() as f64,
+            tags: SessionSessionTags {
+                status: "init".to_string(),
+                common_tags: common_tags.clone(),
+            },
+        };
+        if let Some(metric) = session_metric.into_metric(timestamp) {
+            target.push(metric);
+        }
     }
 
     // Mark the session as errored, which includes fatal sessions.
     if let Some(errors) = session.all_errors() {
-        target.push(match errors {
+        let session_metric = match errors {
             SessionErrored::Individual(session_id) => SessionMetric::Error {
                 session_id,
                 tags: common_tags.clone(),
-            }
-            .into_metric(timestamp),
-
+            },
             SessionErrored::Aggregated(count) => SessionMetric::Session {
                 counter: count as f64,
                 tags: SessionSessionTags {
                     status: "errored_preaggr".to_string(),
                     common_tags: common_tags.clone(),
                 },
-            }
-            .into_metric(timestamp),
-        });
+            },
+        };
+        if let Some(metric) = session_metric.into_metric(timestamp) {
+            target.push(metric);
+        }
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
-            target.push(
-                SessionMetric::User {
-                    distinct_id: distinct_id.clone(),
-                    tags: SessionUserTags {
-                        status: Some(SessionStatus::Errored),
-                        abnormal_mechanism: None,
-                        common_tags: common_tags.clone(),
-                    },
-                }
-                .into_metric(timestamp),
-            );
+            let session_metric = SessionMetric::User {
+                distinct_id: distinct_id.clone(),
+                tags: SessionUserTags {
+                    status: Some(SessionStatus::Errored),
+                    abnormal_mechanism: None,
+                    common_tags: common_tags.clone(),
+                },
+            };
+            if let Some(metric) = session_metric.into_metric(timestamp) {
+                target.push(metric);
+            }
         }
     } else if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
         // For session updates without errors, we collect the user without a session.status tag.
         // To get the number of healthy users (i.e. users without a single errored session), query
         // |users| - |users{session.status:errored}|
-        target.push(
-            SessionMetric::User {
-                distinct_id: distinct_id.clone(),
-                tags: SessionUserTags {
-                    status: None,
-                    abnormal_mechanism: None,
-                    common_tags: common_tags.clone(),
-                },
-            }
-            .into_metric(timestamp),
-        )
+        let session_metric = SessionMetric::User {
+            distinct_id: distinct_id.clone(),
+            tags: SessionUserTags {
+                status: None,
+                abnormal_mechanism: None,
+                common_tags: common_tags.clone(),
+            },
+        };
+        if let Some(metric) = session_metric.into_metric(timestamp) {
+            target.push(metric);
+        }
     }
 
     // Record fatal sessions for crash rate computation. This is a strict subset of errored
     // sessions above.
     if session.abnormal_count() > 0 {
-        target.push(
-            SessionMetric::Session {
-                counter: session.abnormal_count() as f64,
-                tags: SessionSessionTags {
-                    status: "abnormal".to_string(),
-                    common_tags: common_tags.clone(),
-                },
-            }
-            .into_metric(timestamp),
-        );
+        let session_metric = SessionMetric::Session {
+            counter: session.abnormal_count() as f64,
+            tags: SessionSessionTags {
+                status: "abnormal".to_string(),
+                common_tags: common_tags.clone(),
+            },
+        };
+        if let Some(metric) = session_metric.into_metric(timestamp) {
+            target.push(metric);
+        }
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
             let abnormal_mechanism = if extract_abnormal_mechanism
@@ -134,44 +134,44 @@ pub fn extract_session_metrics<T: SessionLike>(
             } else {
                 None
             };
-            target.push(
-                SessionMetric::User {
-                    distinct_id: distinct_id.clone(),
-                    tags: SessionUserTags {
-                        status: Some(SessionStatus::Abnormal),
-                        abnormal_mechanism,
-                        common_tags: common_tags.clone(),
-                    },
-                }
-                .into_metric(timestamp),
-            )
+            let session_metric = SessionMetric::User {
+                distinct_id: distinct_id.clone(),
+                tags: SessionUserTags {
+                    status: Some(SessionStatus::Abnormal),
+                    abnormal_mechanism,
+                    common_tags: common_tags.clone(),
+                },
+            };
+            if let Some(metric) = session_metric.into_metric(timestamp) {
+                target.push(metric);
+            }
         }
     }
 
     if session.crashed_count() > 0 {
-        target.push(
-            SessionMetric::Session {
-                counter: session.crashed_count() as f64,
-                tags: SessionSessionTags {
-                    status: "crashed".to_string(),
-                    common_tags: common_tags.clone(),
-                },
-            }
-            .into_metric(timestamp),
-        );
+        let session_metric = SessionMetric::Session {
+            counter: session.crashed_count() as f64,
+            tags: SessionSessionTags {
+                status: "crashed".to_string(),
+                common_tags: common_tags.clone(),
+            },
+        };
+        if let Some(metric) = session_metric.into_metric(timestamp) {
+            target.push(metric);
+        }
 
         if let Some(distinct_id) = nil_to_none(session.distinct_id()) {
-            target.push(
-                SessionMetric::User {
-                    distinct_id: distinct_id.clone(),
-                    tags: SessionUserTags {
-                        status: Some(SessionStatus::Crashed),
-                        abnormal_mechanism: None,
-                        common_tags,
-                    },
-                }
-                .into_metric(timestamp),
-            );
+            let session_metric = SessionMetric::User {
+                distinct_id: distinct_id.clone(),
+                tags: SessionUserTags {
+                    status: Some(SessionStatus::Crashed),
+                    abnormal_mechanism: None,
+                    common_tags,
+                },
+            };
+            if let Some(metric) = session_metric.into_metric(timestamp) {
+                target.push(metric);
+            }
         }
     }
 }

--- a/relay-server/src/metrics_extraction/sessions/types.rs
+++ b/relay-server/src/metrics_extraction/sessions/types.rs
@@ -95,7 +95,7 @@ impl From<SessionSessionTags> for BTreeMap<String, String> {
 }
 
 impl IntoMetric for SessionMetric {
-    fn into_metric(self, timestamp: UnixTimestamp) -> Bucket {
+    fn into_metric(self, timestamp: UnixTimestamp) -> Option<Bucket> {
         let name = self.to_string();
 
         let (value, tags) = match self {
@@ -107,7 +107,7 @@ impl IntoMetric for SessionMetric {
                 (BucketValue::set_from_display(distinct_id), tags.into())
             }
             SessionMetric::Session { counter, tags } => {
-                (BucketValue::Counter(counter), tags.into())
+                (BucketValue::counter(counter)?, tags.into())
             }
         };
 
@@ -118,13 +118,13 @@ impl IntoMetric for SessionMetric {
             unit: MetricUnit::None,
         };
 
-        Bucket {
+        Some(Bucket {
             timestamp,
             width: 0,
             name: mri.to_string(),
             value,
             tags,
-        }
+        })
     }
 }
 

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -54,7 +54,7 @@ pub enum TransactionMetric {
 }
 
 impl IntoMetric for TransactionMetric {
-    fn into_metric(self, timestamp: UnixTimestamp) -> Bucket {
+    fn into_metric(self, timestamp: UnixTimestamp) -> Option<Bucket> {
         let namespace = MetricNamespace::Transactions;
 
         let (name, value, unit, tags) = match self {
@@ -66,31 +66,31 @@ impl IntoMetric for TransactionMetric {
             ),
             Self::Duration { unit, value, tags } => (
                 Cow::Borrowed("duration"),
-                BucketValue::distribution(value),
+                BucketValue::distribution(value)?,
                 MetricUnit::Duration(unit),
                 tags.into(),
             ),
             Self::DurationLight { unit, value, tags } => (
                 Cow::Borrowed("duration_light"),
-                BucketValue::distribution(value),
+                BucketValue::distribution(value)?,
                 MetricUnit::Duration(unit),
                 tags.into(),
             ),
             Self::Usage { tags } => (
                 Cow::Borrowed("usage"),
-                BucketValue::counter(1.0),
+                BucketValue::counter(1.0)?,
                 MetricUnit::None,
                 tags.into(),
             ),
             Self::CountPerRootProject { tags } => (
                 Cow::Borrowed("count_per_root_project"),
-                BucketValue::counter(1.0),
+                BucketValue::counter(1.0)?,
                 MetricUnit::None,
                 tags.into(),
             ),
             Self::Breakdown { name, value, tags } => (
                 Cow::Owned(format!("breakdowns.{name}")),
-                BucketValue::distribution(value),
+                BucketValue::distribution(value)?,
                 MetricUnit::Duration(DurationUnit::MilliSecond),
                 tags.into(),
             ),
@@ -101,7 +101,7 @@ impl IntoMetric for TransactionMetric {
                 tags,
             } => (
                 Cow::Owned(format!("measurements.{name}")),
-                BucketValue::distribution(value),
+                BucketValue::distribution(value)?,
                 unit,
                 tags.into(),
             ),
@@ -114,13 +114,13 @@ impl IntoMetric for TransactionMetric {
             unit,
         };
 
-        Bucket {
+        Some(Bucket {
             timestamp,
             width: 0,
             name: mri.to_string(),
             value,
             tags,
-        }
+        })
     }
 }
 

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -344,7 +344,7 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: Default::default(),
-                value: BucketValue::distribution(123.0),
+                value: BucketValue::distribution(123.0).unwrap(),
             },
             Bucket {
                 // transaction with profile
@@ -352,7 +352,7 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: BucketValue::distribution(456.0),
+                value: BucketValue::distribution(456.0).unwrap(),
             },
             Bucket {
                 // transaction without profile
@@ -360,7 +360,7 @@ mod tests {
                 width: 0,
                 name: "c:transactions/usage@none".to_string(),
                 tags: Default::default(),
-                value: BucketValue::counter(1.0),
+                value: BucketValue::counter(1.0).unwrap(),
             },
             Bucket {
                 // transaction with profile
@@ -368,7 +368,7 @@ mod tests {
                 width: 0,
                 name: "c:transactions/usage@none".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: BucketValue::counter(1.0),
+                value: BucketValue::counter(1.0).unwrap(),
             },
             Bucket {
                 // unrelated metric
@@ -376,7 +376,7 @@ mod tests {
                 width: 0,
                 name: "something_else".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: BucketValue::distribution(123.0),
+                value: BucketValue::distribution(123.0).unwrap(),
             },
         ];
         let quotas = vec![Quota {
@@ -432,7 +432,7 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: Default::default(),
-                value: BucketValue::distribution(123.0),
+                value: BucketValue::distribution(123.0).unwrap(),
             },
             Bucket {
                 // transaction with profile
@@ -440,7 +440,7 @@ mod tests {
                 width: 0,
                 name: "d:transactions/duration@millisecond".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: BucketValue::distribution(456.0),
+                value: BucketValue::distribution(456.0).unwrap(),
             },
             Bucket {
                 // transaction without profile
@@ -448,7 +448,7 @@ mod tests {
                 width: 0,
                 name: "c:transactions/usage@none".to_string(),
                 tags: Default::default(),
-                value: BucketValue::counter(1.0),
+                value: BucketValue::counter(1.0).unwrap(),
             },
             Bucket {
                 // transaction with profile
@@ -456,7 +456,7 @@ mod tests {
                 width: 0,
                 name: "c:transactions/usage@none".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: BucketValue::counter(1.0),
+                value: BucketValue::counter(1.0).unwrap(),
             },
             Bucket {
                 // unrelated metric
@@ -464,7 +464,7 @@ mod tests {
                 width: 0,
                 name: "something_else".to_string(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
-                value: BucketValue::distribution(123.0),
+                value: BucketValue::distribution(123.0).unwrap(),
             },
         ];
         let quotas = vec![Quota {


### PR DESCRIPTION
PoC how float validation would look like at runtime without a dedicated type.
Initially this was expected to be less code, but the changes to the `IntoMetric`
trait are rather verbose already.

#skip-changelog
Ref https://github.com/getsentry/relay/issues/2910
