### PR TITLE
ref(global-config): Introduce `GlobalConfigHandle`

### DIFF
--- a/relay-server/src/actors/processor/dynamic_sampling.rs
+++ b/relay-server/src/actors/processor/dynamic_sampling.rs
@@ -287,7 +287,6 @@ mod tests {
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state,
             reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
         };
 
         let envelope_response = processor.process(message).unwrap();
@@ -434,7 +433,6 @@ mod tests {
                 profile_id: None,
                 event_metrics_extracted: false,
                 reservoir: dummy_reservoir(),
-                global_config: Arc::default(),
             }
         };
 

--- a/relay-server/src/actors/processor/profile.rs
+++ b/relay-server/src/actors/processor/profile.rs
@@ -194,7 +194,6 @@ mod tests {
             project_state: Arc::new(project_state),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
         };
 
         let envelope_response = processor.process(message).unwrap();

--- a/relay-server/src/actors/processor/report.rs
+++ b/relay-server/src/actors/processor/report.rs
@@ -335,7 +335,6 @@ mod tests {
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
         };
 
         let envelope_response = processor.process(message).unwrap();
@@ -385,7 +384,6 @@ mod tests {
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
         };
 
         let envelope_response = processor.process(message).unwrap();
@@ -443,7 +441,6 @@ mod tests {
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
         };
 
         let envelope_response = processor.process(message).unwrap();
@@ -480,7 +477,6 @@ mod tests {
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
-            global_config: Arc::default(),
         };
 
         let envelope_response = processor.process(message).unwrap();

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -118,11 +118,12 @@ impl ServiceState {
         let outcome_aggregator =
             OutcomeAggregator::new(&config, outcome_producer.clone()).start_in(&runtimes.outcome);
 
+        let global_config = GlobalConfigService::new(config.clone(), upstream_relay.clone());
+        let global_config_handle = global_config.handle();
         // The global config service must start before dependant services are
         // started. Messages like subscription requests to the global config
         // service fail if the service is not running.
-        let global_config =
-            GlobalConfigService::new(config.clone(), upstream_relay.clone()).start();
+        let global_config = global_config.start();
 
         let (project_cache, project_cache_rx) = channel(ProjectCacheService::name());
 
@@ -143,6 +144,7 @@ impl ServiceState {
 
         EnvelopeProcessorService::new(
             config.clone(),
+            global_config_handle,
             #[cfg(feature = "processing")]
             redis_pool.clone(),
             outcome_aggregator.clone(),

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -10,6 +10,7 @@ use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 use relay_system::Addr;
 use relay_test::mock_service;
 
+use crate::actors::global_config::GlobalConfigHandle;
 use crate::actors::outcome::TrackOutcome;
 use crate::actors::processor::EnvelopeProcessorService;
 use crate::actors::project::ProjectState;
@@ -116,6 +117,7 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
 
     EnvelopeProcessorService::new(
         Arc::new(config),
+        GlobalConfigHandle::fixed(Default::default()),
         #[cfg(feature = "processing")]
         None,
         outcome_aggregator,


### PR DESCRIPTION
Make it possible to pass around an owned handle for the global config, instead of needing to query the current global config or a subscription from the global config service.

#skip-changelog