### PR TITLE
feat(cardinality): Create outcomes for cardinality limited metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Validate error_id and trace_id vectors in replay deserializer. ([#2931](https://github.com/getsentry/relay/pull/2931))
 - Add a data category for indexed spans. ([#2937](https://github.com/getsentry/relay/pull/2937))
 - Add nested Android app start span ops to span ingestion ([#2927](https://github.com/getsentry/relay/pull/2927))
+- Create rate limited outcomes for cardinality limited metrics ([#2947](https://github.com/getsentry/relay/pull/2947))
 
 ## 23.12.1
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -207,7 +207,6 @@ mod tests {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([0, 1, 3]),
         };
-        dbg!(limits.rejected().collect::<Vec<_>>());
         assert!(limits.rejected().eq(['a', 'b', 'd'].iter()));
         assert_eq!(limits.into_accepted(), vec!['c', 'e']);
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -207,21 +207,27 @@ mod tests {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([0, 1, 3]),
         };
-        assert!(limits.rejected().eq(['a', 'b', 'd'].iter()));
+        assert_eq!(
+            limits.rejected().copied().collect::<Vec<_>>(),
+            vec!['a', 'b', 'd']
+        );
         assert_eq!(limits.into_accepted(), vec!['c', 'e']);
 
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([]),
         };
-        assert!(limits.rejected().eq([].iter()));
+        assert_eq!(limits.rejected().copied().collect::<Vec<_>>(), vec![]);
         assert_eq!(limits.into_accepted(), vec!['a', 'b', 'c', 'd', 'e']);
 
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([0, 1, 2, 3, 4]),
         };
-        assert!(limits.rejected().eq(['a', 'b', 'c', 'd', 'e'].iter()));
+        assert_eq!(
+            limits.rejected().copied().collect::<Vec<_>>(),
+            vec!['a', 'b', 'c', 'd', 'e']
+        );
         assert!(limits.into_accepted().is_empty());
     }
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -203,31 +203,36 @@ mod tests {
 
     #[test]
     fn test_accepted() {
+        // Workaround for windows which requires an absurd amount of type annotations here.
+        fn assert_rejected(
+            limits: &CardinalityLimits<char>,
+            expected: impl IntoIterator<Item = char>,
+        ) {
+            assert_eq!(
+                limits.rejected().copied().collect::<Vec<char>>(),
+                expected.into_iter().collect::<Vec<char>>(),
+            );
+        }
+
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([0, 1, 3]),
         };
-        assert_eq!(
-            limits.rejected().copied().collect::<Vec<char>>(),
-            vec!['a', 'b', 'd']
-        );
+        assert_rejected(&limits, ['a', 'b', 'd']);
         assert_eq!(limits.into_accepted(), vec!['c', 'e']);
 
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([]),
         };
-        assert_eq!(limits.rejected().copied().collect::<Vec<char>>(), vec![]);
+        assert_rejected(&limits, []);
         assert_eq!(limits.into_accepted(), vec!['a', 'b', 'c', 'd', 'e']);
 
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([0, 1, 2, 3, 4]),
         };
-        assert_eq!(
-            limits.rejected().copied().collect::<Vec<char>>(),
-            vec!['a', 'b', 'c', 'd', 'e']
-        );
+        assert_rejected(&limits, ['a', 'b', 'c', 'd', 'e']);
         assert!(limits.into_accepted().is_empty());
     }
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -208,7 +208,7 @@ mod tests {
             rejections: BTreeSet::from([0, 1, 3]),
         };
         assert_eq!(
-            limits.rejected().copied().collect::<Vec<_>>(),
+            limits.rejected().copied().collect::<Vec<char>>(),
             vec!['a', 'b', 'd']
         );
         assert_eq!(limits.into_accepted(), vec!['c', 'e']);
@@ -217,7 +217,7 @@ mod tests {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: BTreeSet::from([]),
         };
-        assert_eq!(limits.rejected().copied().collect::<Vec<_>>(), vec![]);
+        assert_eq!(limits.rejected().copied().collect::<Vec<char>>(), vec![]);
         assert_eq!(limits.into_accepted(), vec!['a', 'b', 'c', 'd', 'e']);
 
         let limits = CardinalityLimits {
@@ -225,7 +225,7 @@ mod tests {
             rejections: BTreeSet::from([0, 1, 2, 3, 4]),
         };
         assert_eq!(
-            limits.rejected().copied().collect::<Vec<_>>(),
+            limits.rejected().copied().collect::<Vec<char>>(),
             vec!['a', 'b', 'c', 'd', 'e']
         );
         assert!(limits.into_accepted().is_empty());

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -184,6 +184,7 @@ impl Outcome {
         match self {
             Outcome::Filtered(_) | Outcome::FilteredSampling(_) => OutcomeId::FILTERED,
             Outcome::RateLimited(_) => OutcomeId::RATE_LIMITED,
+            #[cfg(feature = "processing")]
             Outcome::CardinalityLimited => OutcomeId::RATE_LIMITED,
             Outcome::Invalid(_) => OutcomeId::INVALID,
             Outcome::Abuse => OutcomeId::ABUSE,
@@ -202,6 +203,7 @@ impl Outcome {
             Outcome::RateLimited(code_opt) => code_opt
                 .as_ref()
                 .map(|code| Cow::Owned(code.as_str().into())),
+            #[cfg(feature = "processing")]
             Outcome::CardinalityLimited => Some(Cow::Borrowed("cardinality_limited")),
             Outcome::ClientDiscard(ref discard_reason) => Some(Cow::Borrowed(discard_reason)),
             Outcome::Abuse => None,
@@ -233,6 +235,7 @@ impl fmt::Display for Outcome {
             Outcome::FilteredSampling(rule_ids) => write!(f, "sampling rule {rule_ids}"),
             Outcome::RateLimited(None) => write!(f, "rate limited"),
             Outcome::RateLimited(Some(reason)) => write!(f, "rate limited with reason {reason}"),
+            #[cfg(feature = "processing")]
             Outcome::CardinalityLimited => write!(f, "cardinality limited"),
             Outcome::Invalid(DiscardReason::Internal) => write!(f, "internal error"),
             Outcome::Invalid(reason) => write!(f, "invalid data ({reason})"),

--- a/relay-server/src/actors/outcome.rs
+++ b/relay-server/src/actors/outcome.rs
@@ -163,6 +163,10 @@ pub enum Outcome {
     /// The event has been rate limited.
     RateLimited(Option<ReasonCode>),
 
+    /// The event/metric has been cardinality limited.
+    #[cfg(feature = "processing")]
+    CardinalityLimited,
+
     /// The event has been discarded because of invalid data.
     Invalid(DiscardReason),
 
@@ -180,6 +184,7 @@ impl Outcome {
         match self {
             Outcome::Filtered(_) | Outcome::FilteredSampling(_) => OutcomeId::FILTERED,
             Outcome::RateLimited(_) => OutcomeId::RATE_LIMITED,
+            Outcome::CardinalityLimited => OutcomeId::RATE_LIMITED,
             Outcome::Invalid(_) => OutcomeId::INVALID,
             Outcome::Abuse => OutcomeId::ABUSE,
             Outcome::ClientDiscard(_) => OutcomeId::CLIENT_DISCARD,
@@ -197,6 +202,7 @@ impl Outcome {
             Outcome::RateLimited(code_opt) => code_opt
                 .as_ref()
                 .map(|code| Cow::Owned(code.as_str().into())),
+            Outcome::CardinalityLimited => Some(Cow::Borrowed("cardinality_limited")),
             Outcome::ClientDiscard(ref discard_reason) => Some(Cow::Borrowed(discard_reason)),
             Outcome::Abuse => None,
             Outcome::Accepted => None,
@@ -227,6 +233,7 @@ impl fmt::Display for Outcome {
             Outcome::FilteredSampling(rule_ids) => write!(f, "sampling rule {rule_ids}"),
             Outcome::RateLimited(None) => write!(f, "rate limited"),
             Outcome::RateLimited(Some(reason)) => write!(f, "rate limited with reason {reason}"),
+            Outcome::CardinalityLimited => write!(f, "cardinality limited"),
             Outcome::Invalid(DiscardReason::Internal) => write!(f, "internal error"),
             Outcome::Invalid(reason) => write!(f, "invalid data ({reason})"),
             Outcome::Abuse => write!(f, "abuse limit reached"),


### PR DESCRIPTION
Creates rate limited outcomes for cardinality limited items.

Maybe we should introduce a new outcome id for the cardinality limiter instead?