### PR TITLE
fix(pii): Enable PII scrubbing in logentry.params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Add automatic PII scrubbing to `logentry.params`. ([#2956](https://github.com/getsentry/relay/pull/2956))
+
 ## 24.1.0
 
 **Features**:

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add automatic PII scrubbing to `logentry.params`. ([#2956](https://github.com/getsentry/relay/pull/2956))
+
 ## 0.8.41
 
 - This release requires Python 3.9 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.8.

--- a/relay-event-schema/src/protocol/logentry.rs
+++ b/relay-event-schema/src/protocol/logentry.rs
@@ -50,7 +50,7 @@ pub struct LogEntry {
 
     /// Parameters to be interpolated into the log message. This can be an array of positional
     /// parameters as well as a mapping of named arguments to their values.
-    #[metastructure(bag_size = "medium")]
+    #[metastructure(bag_size = "medium", pii = "true")]
     pub params: Annotated<Value>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -469,10 +469,12 @@ mod tests {
     use insta::assert_debug_snapshot;
     use relay_event_schema::processor::process_value;
     use relay_event_schema::protocol::{
-        Addr, Breadcrumb, DebugImage, DebugMeta, Event, ExtraValue, Headers, LogEntry,
+        Addr, Breadcrumb, DebugImage, DebugMeta, Event, ExtraValue, Headers, LogEntry, Message,
         NativeDebugImage, Request, Span, TagEntry, Tags, TraceContext,
     };
-    use relay_protocol::{assert_annotated_snapshot, Annotated, FromValue, Object, Value};
+    use relay_protocol::{
+        assert_annotated_snapshot, get_value, Annotated, FromValue, Object, Value,
+    };
 
     use super::*;
     use crate::{DataScrubbingConfig, PiiConfig, ReplaceRedaction};
@@ -1524,5 +1526,52 @@ mod tests {
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
         assert_debug_snapshot!(&data);
+    }
+
+    #[test]
+    fn test_logentry_params_scrubbed() {
+        let config = serde_json::from_str::<PiiConfig>(
+            r##"
+                {
+                    "applications": {
+                        "$string": ["@anything:remove"]
+                    }
+                }
+                "##,
+        )
+        .unwrap();
+
+        let mut event = Annotated::new(Event {
+            logentry: Annotated::new(LogEntry {
+                message: Annotated::new(Message::from("failed to parse report id=%s".to_owned())),
+                formatted: Annotated::new("failed to parse report id=1".to_string().into()),
+                params: Annotated::new(Value::Array(vec![Annotated::new(Value::String(
+                    "12345".to_owned(),
+                ))])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let mut processor = PiiProcessor::new(config.compiled());
+        process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+        let params = get_value!(event.logentry.params!);
+        assert_debug_snapshot!(params, @r#"Array(
+    [
+        Meta {
+            remarks: [
+                Remark {
+                    ty: Removed,
+                    rule_id: "@anything:remove",
+                    range: None,
+                },
+            ],
+            errors: [],
+            original_length: None,
+            original_value: None,
+        },
+    ],
+)"#);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/relay/issues/2920.

Currently, a `logentry`'s formatted message may be scrubbed but the values still exist in the parameters. This PR adds scrubbing to the parameters so that all values are scrubbed.