### PR TITLE
ref(deploy): Add new PoP regional clusters to the deployment pipeline

### DIFF
--- a/gocd/templates/libs/relay-pops.libsonnet
+++ b/gocd/templates/libs/relay-pops.libsonnet
@@ -11,6 +11,10 @@ local region_pops = {
     'us-pop-2',
     'us-pop-3',
     'us-pop-4',
+    'us-pop-regional-1',
+    'us-pop-regional-2',
+    'us-pop-regional-3',
+    'us-pop-regional-4',
   ],
 };
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adding new regional PoP clusters to the deployment pipeline. These clusters will eventually replace the current single-zone clusters.

Depends on https://github.com/getsentry/devinfra-deployment-service/pull/513

#skip-changelog


