### PR TITLE
fix(metrics-extraction): Add defaulting of required attributes in light normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Internal**:
 
 - Proactively move on-disk spool to memory. ([#2949](https://github.com/getsentry/relay/pull/2949))
-- Default `platform` and `level` `Event` fields during light normalization. ([#2961](https://github.com/getsentry/relay/pull/2961))
+- Default missing `Event.platform` and `Event.level` fields during light normalization. ([#2961](https://github.com/getsentry/relay/pull/2961))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Proactively move on-disk spool to memory. ([#2949](https://github.com/getsentry/relay/pull/2949))
+- Default `platform` and `level` `Event` fields during light normalization. ([#2961](https://github.com/getsentry/relay/pull/2961))
 
 **Bug Fixes**:
 

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -1074,6 +1074,7 @@ mod tests {
     #[test]
     fn test_field_value_provider_event_filled() {
         let event = Event {
+            level: Annotated::new(Level::Info),
             release: Annotated::new(LenientString("1.1.1".to_owned())),
             environment: Annotated::new("prod".to_owned()),
             user: Annotated::new(User {
@@ -1145,6 +1146,8 @@ mod tests {
             }),
             ..Default::default()
         };
+
+        assert_eq!(Some(Val::String("info")), event.get_value("event.level"));
 
         assert_eq!(Some(Val::String("1.1.1")), event.get_value("event.release"));
         assert_eq!(

--- a/tests/integration/fixtures/security_report/csp.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp.no_processing.output.json
@@ -22,10 +22,12 @@
   },
   "culprit": "default-src self",
   "environment": "production",
+  "level": "error",
   "logentry": {
     "formatted": "Blocked 'default-src' from 'evilhackerscripts.com'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "request": {
     "headers": [

--- a/tests/integration/fixtures/security_report/csp_chrome.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_chrome.no_processing.output.json
@@ -23,10 +23,12 @@
   },
   "culprit": "style-src cdn.example.com",
   "environment": "production",
+  "level": "error",
   "logentry": {
     "formatted": "Blocked 'style' from 'localhost:8000'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "request": {
     "headers": [

--- a/tests/integration/fixtures/security_report/csp_chrome_blocked_asset.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_chrome_blocked_asset.no_processing.output.json
@@ -23,10 +23,12 @@
   },
   "culprit": "style-src cdn.example.com",
   "environment": "production",
+  "level": "error",
   "logentry": {
     "formatted": "Blocked 'style' from 'notlocalhost:8000'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "request": {
     "headers": [

--- a/tests/integration/fixtures/security_report/csp_firefox_blocked_asset.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_firefox_blocked_asset.no_processing.output.json
@@ -22,10 +22,12 @@
   },
   "culprit": "style-src http://cdn.example.com",
   "environment": "production",
+  "level": "error",
   "logentry": {
     "formatted": "Blocked 'style' from 'notlocalhost:8000'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "request": {
     "headers": [

--- a/tests/integration/fixtures/security_report/expect_ct.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/expect_ct.no_processing.output.json
@@ -13,10 +13,12 @@
     }
   },
   "culprit": "www.example.com",
+  "level": "error",
   "logentry": {
     "formatted": "Expect-CT failed for 'www.example.com'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "environment": "production",
   "request": {

--- a/tests/integration/fixtures/security_report/expect_staple.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/expect_staple.no_processing.output.json
@@ -13,10 +13,12 @@
     }
   },
   "culprit": "www.example.com",
+  "level": "error",
   "logentry": {
     "formatted": "Expect-Staple failed for 'www.example.com'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "environment": "production",
   "request": {

--- a/tests/integration/fixtures/security_report/hpkp.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/hpkp.no_processing.output.json
@@ -12,10 +12,12 @@
       "version": ">=10"
     }
   },
+  "level": "error",
   "logentry": {
     "formatted": "Public key pinning validation failed for 'www.example.com'"
   },
   "logger": "csp",
+  "platform": "other",
   "release": "01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
   "environment": "production",
   "request": {


### PR DESCRIPTION
This PR adds a new normalization step in the light normalization pipeline which normalizes required attributes that have no value. The need for this change arises from metrics extraction, which is run after light normalization and requires the event payload to be normalized almost entirely to perform the correct conditional extraction.