### PR TITLE
fix(spans): Deduplicate more repeated conditions

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -727,6 +727,18 @@ mod tests {
     );
 
     scrub_sql_test!(
+        duplicate_conditions_left,
+        r#"SELECT * FROM t WHERE a = %s OR a = %s OR b = %s"#,
+        "SELECT * FROM t WHERE a = %s OR b = %s"
+    );
+
+    scrub_sql_test!(
+        duplicate_conditions_right,
+        r#"SELECT * FROM t WHERE a = %s OR b = %s OR b = %s"#,
+        "SELECT * FROM t WHERE a = %s OR b = %s"
+    );
+
+    scrub_sql_test!(
         non_duplicate_conditions,
         r#"SELECT *
         FROM a


### PR DESCRIPTION
https://github.com/getsentry/relay/issues/2929 partially scrubbed repeated conditions in SQL queries, but it did not consider the case where the repeated operands of an `OR` or `AND` operation are not siblings (see tree in code comments).

#skip-changelog

