### PR TITLE
ref(spans): Remove redundant feature check

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -92,11 +92,7 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
 
     let is_mobile = is_mobile_sdk.clone() & (is_mobile_op.clone() | is_screen);
 
-    let is_interaction = if is_extract_all {
-        RuleCondition::glob("span.op", "ui.interaction.*")
-    } else {
-        RuleCondition::never()
-    };
+    let is_interaction = RuleCondition::glob("span.op", "ui.interaction.*");
 
     // For mobile spans, only extract duration metrics when they are below a threshold.
     let duration_condition = RuleCondition::negate(is_mobile_op.clone())

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -18,7 +18,13 @@ const DISABLED_DATABASES: &[&str] = &[
 ];
 
 /// A list of `span.op` patterns we want to enable for mobile.
-const MOBILE_OPS: &[&str] = &["app.*", "ui.load*"];
+const MOBILE_OPS: &[&str] = &[
+    "activity.load",
+    "app.*",
+    "application.load",
+    "contentprovider.load",
+    "ui.load*",
+];
 
 /// A list of span descriptions that indicate top-level app start spans.
 const APP_START_ROOT_SPAN_DESCRIPTIONS: &[&str] = &["Cold Start", "Warm Start"];
@@ -47,11 +53,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         return;
     }
 
-    let is_extract_all = project_config
-        .features
-        .has(Feature::SpanMetricsExtractionAllModules);
-
-    config.metrics.extend(span_metrics(is_extract_all));
+    config.metrics.extend(span_metrics());
 
     config._span_metrics_extended = true;
     if config.version == 0 {
@@ -60,22 +62,14 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
 }
 
 /// Metrics with tags applied as required.
-fn span_metrics(is_extract_all: bool) -> impl IntoIterator<Item = MetricSpec> {
-    let flagged_mobile_ops = {
-        let mut ops = MOBILE_OPS.to_vec();
-        if is_extract_all {
-            ops.extend(["contentprovider.load", "application.load", "activity.load"]);
-        }
-        ops
-    };
-
+fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
     let is_db = RuleCondition::eq("span.sentry_tags.category", "db")
         & !(RuleCondition::eq("span.system", "mongodb")
             | RuleCondition::glob("span.op", DISABLED_DATABASES)
             | RuleCondition::glob("span.description", MONGODB_QUERIES));
     let is_resource = RuleCondition::glob("span.op", RESOURCE_SPAN_OPS);
 
-    let is_mobile_op = RuleCondition::glob("span.op", flagged_mobile_ops);
+    let is_mobile_op = RuleCondition::glob("span.op", MOBILE_OPS);
 
     let is_mobile_sdk = RuleCondition::eq("span.sentry_tags.mobile", "true");
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -27,9 +27,7 @@ pub enum Feature {
     /// Allow ingestion of metrics in the "custom" namespace.
     #[serde(rename = "organizations:custom-metrics")]
     CustomMetrics,
-    /// Enable extracting spans for all modules.
-    #[serde(rename = "projects:span-metrics-extraction-all-modules")]
-    SpanMetricsExtractionAllModules,
+
     /// Enable processing profiles
     #[serde(rename = "organizations:profiling")]
     Profiling,
@@ -55,6 +53,9 @@ pub enum Feature {
     /// Deprecated, still forwarded for older downstream Relays.
     #[serde(rename = "projects:span-metrics-extraction-resource")]
     Deprecated5,
+    /// Deprecated, still forwarded for older downstream Relays.
+    #[serde(rename = "projects:span-metrics-extraction-all-modules")]
+    Deprected6,
     /// Forward compatibility.
     #[serde(other)]
     Unknown,

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -71,9 +71,6 @@ pub(crate) fn scrub_span_description(span: &Span) -> Option<String> {
             ("ui", "load") => {
                 // `ui.load` spans contain component names like `ListAppViewController`, so
                 // they _should_ be low-cardinality.
-                // At the moment the metrics from this module
-                // are still filtered by the `SpanMetricsExtractionAllModules` feature, so it should
-                // be low-risk to start adding the description.
                 Some(description.to_owned())
             }
             ("app", _) => {

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -483,10 +483,7 @@ mod tests {
         "#;
 
         let mut event = Annotated::from_json(json).unwrap();
-        let features = FeatureSet(BTreeSet::from([
-            Feature::SpanMetricsExtraction,
-            Feature::SpanMetricsExtractionAllModules,
-        ]));
+        let features = FeatureSet(BTreeSet::from([Feature::SpanMetricsExtraction]));
 
         // Normalize first, to make sure that all things are correct as in the real pipeline:
         normalize_event(
@@ -1137,12 +1134,7 @@ mod tests {
 
         // Create a project config with the relevant feature flag. Sanitize to fill defaults.
         let mut project = ProjectConfig {
-            features: [
-                Feature::SpanMetricsExtraction,
-                Feature::SpanMetricsExtractionAllModules,
-            ]
-            .into_iter()
-            .collect(),
+            features: [Feature::SpanMetricsExtraction].into_iter().collect(),
             ..ProjectConfig::default()
         };
         project.sanitize();
@@ -1202,12 +1194,7 @@ mod tests {
 
         // Create a project config with the relevant feature flag. Sanitize to fill defaults.
         let mut project = ProjectConfig {
-            features: [
-                Feature::SpanMetricsExtraction,
-                Feature::SpanMetricsExtractionAllModules,
-            ]
-            .into_iter()
-            .collect(),
+            features: [Feature::SpanMetricsExtraction].into_iter().collect(),
             ..ProjectConfig::default()
         };
         project.sanitize();


### PR DESCRIPTION
This feature is now rolled out to 100% of projects on SaaS, so we can remove related check.

Using one feature flag for multiple features brings the danger of accidentally enabling a feature, so we should deprecate this one and introduce new feature flags for specific features instead.

#skip-changelog