### PR TITLE
fix: Process user reports in separate group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Add automatic PII scrubbing to `logentry.params`. ([#2956](https://github.com/getsentry/relay/pull/2956))
 - Avoid producing `null` values in metric data. These values were the result of Infinity or NaN values extracted from event data. The values are now discarded during extraction. ([#2958](https://github.com/getsentry/relay/pull/2958))
+- Process user reports in separate processing group. ([#2981](https://github.com/getsentry/relay/pull/2981))
 
 ## 24.1.0
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -192,6 +192,17 @@ impl ProcessingGroup {
             ))
         }
 
+        // Extract user report and user feedback.
+        let report_items = envelope.take_items_by(|item| {
+            matches!(item.ty(), &ItemType::UserReport | &ItemType::ClientReport)
+        });
+        if !report_items.is_empty() {
+            grouped_envelopes.push((
+                ProcessingGroup::UserReport,
+                Envelope::from_parts(headers.clone(), report_items),
+            ))
+        }
+
         // Extract all the items which require an event into separate envelope.
         let require_event_items = envelope.take_items_by(Item::requires_event);
         if !require_event_items.is_empty() {
@@ -217,8 +228,6 @@ impl ProcessingGroup {
             let item_type = item.ty();
             let group = if matches!(item_type, &ItemType::CheckIn) {
                 ProcessingGroup::CheckIn
-            } else if matches!(item_type, &ItemType::UserReport | &ItemType::ClientReport) {
-                ProcessingGroup::UserReport
             } else if matches!(item_type, &ItemType::Unknown(_)) {
                 ProcessingGroup::ForwardUnknown
             } else {

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -116,6 +116,11 @@ impl ManagedEnvelope {
     }
 
     #[cfg(test)]
+    pub fn set_processing_group(&mut self, group: ProcessingGroup) {
+        self.context.group = group
+    }
+
+    #[cfg(test)]
     pub fn untracked(
         envelope: Box<Envelope>,
         outcome_aggregator: Addr<TrackOutcome>,


### PR DESCRIPTION
Process user reports in separate processing group. 

Related https://github.com/getsentry/relay/issues/2980