### PR TITLE
fix(user_report): Treat UserReport like standalone attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - Add automatic PII scrubbing to `logentry.params`. ([#2956](https://github.com/getsentry/relay/pull/2956))
 - Avoid producing `null` values in metric data. These values were the result of Infinity or NaN values extracted from event data. The values are now discarded during extraction. ([#2958](https://github.com/getsentry/relay/pull/2958))
-- Add user reports to a correct processing group. ([#2981](https://github.com/getsentry/relay/pull/2981), [#2984](https://github.com/getsentry/relay/pull/2984))
+- Fix processing of user reports. ([#2981](https://github.com/getsentry/relay/pull/2981), [#2984](https://github.com/getsentry/relay/pull/2984))
 
 ## 24.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - Add automatic PII scrubbing to `logentry.params`. ([#2956](https://github.com/getsentry/relay/pull/2956))
 - Avoid producing `null` values in metric data. These values were the result of Infinity or NaN values extracted from event data. The values are now discarded during extraction. ([#2958](https://github.com/getsentry/relay/pull/2958))
-- Process user reports in separate processing group. ([#2981](https://github.com/getsentry/relay/pull/2981))
+- Add user reports to a correct processing group. ([#2981](https://github.com/getsentry/relay/pull/2981), [#2984](https://github.com/getsentry/relay/pull/2984))
 
 ## 24.1.0
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -110,10 +110,11 @@ pub enum ProcessingGroup {
     Error,
     /// Session events.
     Session,
-    /// Attachments which can be sent alone without any event attached to it in the current
+    /// Attachments (including UserReports) which can be sent alone without any event attached to it in the current
     /// envelope.
     StandaloneAttachment,
-    UserReport,
+    /// Outcomes.
+    ClientReport,
     Replay,
     /// Crons.
     CheckIn,
@@ -144,11 +145,16 @@ impl ProcessingGroup {
             });
         grouped_envelopes.extend(nel_envelopes);
 
-        // Extract all standalone attachments.
-        // Note: only if there is no items in the envelope which can create events.
+        // Extract all standalone attachments and reports.
+        //
+        // Note: only if there is no items in the envelope which can create events, otherwise they
+        // will be in the same envelope with all require event items.
         if !envelope.items().any(Item::creates_event) {
             let standalone_attachment_items = envelope.take_items_by(|item| {
-                matches!(item.ty(), &ItemType::Attachment | &ItemType::FormData)
+                matches!(
+                    item.ty(),
+                    &ItemType::Attachment | &ItemType::FormData | &ItemType::UserReport
+                )
             });
             if !standalone_attachment_items.is_empty() {
                 grouped_envelopes.push((
@@ -192,17 +198,6 @@ impl ProcessingGroup {
             ))
         }
 
-        // Extract user report and user feedback.
-        let report_items = envelope.take_items_by(|item| {
-            matches!(item.ty(), &ItemType::UserReport | &ItemType::ClientReport)
-        });
-        if !report_items.is_empty() {
-            grouped_envelopes.push((
-                ProcessingGroup::UserReport,
-                Envelope::from_parts(headers.clone(), report_items),
-            ))
-        }
-
         // Extract all the items which require an event into separate envelope.
         let require_event_items = envelope.take_items_by(Item::requires_event);
         if !require_event_items.is_empty() {
@@ -228,6 +223,8 @@ impl ProcessingGroup {
             let item_type = item.ty();
             let group = if matches!(item_type, &ItemType::CheckIn) {
                 ProcessingGroup::CheckIn
+            } else if matches!(item.ty(), &ItemType::ClientReport) {
+                ProcessingGroup::ClientReport
             } else if matches!(item_type, &ItemType::Unknown(_)) {
                 ProcessingGroup::ForwardUnknown
             } else {
@@ -1121,11 +1118,7 @@ impl EnvelopeProcessorService {
     /// Processes the general errors, and the items which require or create the events.
     fn process_errors(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
         // Events can also contain user reports.
-        report::process(
-            state,
-            &self.inner.config,
-            self.inner.outcome_aggregator.clone(),
-        );
+        report::process_user_reports(state);
 
         if_processing!(self.inner.config, {
             unreal::expand(state, &self.inner.config)?;
@@ -1204,11 +1197,15 @@ impl EnvelopeProcessorService {
     }
 
     /// Processes standalone attachments.
-    fn process_attachments(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
+    fn process_standalone_attachments(
+        &self,
+        state: &mut ProcessEnvelopeState,
+    ) -> Result<(), ProcessingError> {
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
         });
 
+        report::process_user_reports(state);
         attachment::scrub(state);
         Ok(())
     }
@@ -1223,7 +1220,7 @@ impl EnvelopeProcessorService {
     }
 
     /// Processes user and client reports.
-    fn process_user_reports(
+    fn process_client_reports(
         &self,
         state: &mut ProcessEnvelopeState,
     ) -> Result<(), ProcessingError> {
@@ -1231,7 +1228,7 @@ impl EnvelopeProcessorService {
             self.enforce_quotas(state)?;
         });
 
-        report::process(
+        report::process_client_reports(
             state,
             &self.inner.config,
             self.inner.outcome_aggregator.clone(),
@@ -1282,11 +1279,12 @@ impl EnvelopeProcessorService {
         state: &mut ProcessEnvelopeState,
     ) -> Result<(), ProcessingError> {
         session::process(state, &self.inner.config);
-        report::process(
+        report::process_client_reports(
             state,
             &self.inner.config,
             self.inner.outcome_aggregator.clone(),
         );
+        report::process_user_reports(state);
         replay::process(state, &self.inner.config)?;
         profile::filter(state);
         span::filter(state);
@@ -1362,8 +1360,8 @@ impl EnvelopeProcessorService {
             ProcessingGroup::Error => self.process_errors(state)?,
             ProcessingGroup::Transaction => self.process_transactions(state)?,
             ProcessingGroup::Session => self.process_sessions(state)?,
-            ProcessingGroup::StandaloneAttachment => self.process_attachments(state)?,
-            ProcessingGroup::UserReport => self.process_user_reports(state)?,
+            ProcessingGroup::StandaloneAttachment => self.process_standalone_attachments(state)?,
+            ProcessingGroup::ClientReport => self.process_client_reports(state)?,
             ProcessingGroup::Replay => self.process_replays(state)?,
             ProcessingGroup::CheckIn => self.process_checkins(state)?,
             ProcessingGroup::Span => self.process_spans(state)?,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -147,7 +147,7 @@ impl ProcessingGroup {
 
         // Extract all standalone attachments and reports.
         //
-        // Note: only if there is no items in the envelope which can create events, otherwise they
+        // Note: only if there are no items in the envelope which can create events, otherwise they
         // will be in the same envelope with all require event items.
         if !envelope.items().any(Item::creates_event) {
             let standalone_attachment_items = envelope.take_items_by(|item| {

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -451,7 +451,7 @@ mod tests {
         });
 
         let mut envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store);
-        envelope.set_processing_group(ProcessingGroup::StandaloneAttachment);
+        envelope.set_processing_group(ProcessingGroup::Standalone);
 
         let message = ProcessEnvelope {
             envelope,

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -299,6 +299,11 @@ class SentryLike:
         envelope.add_item(Item(PayloadRef(json=payload), type="feedback"))
         self.send_envelope(project_id, envelope)
 
+    def send_user_report(self, project_id, payload):
+        envelope = Envelope()
+        envelope.add_item(Item(PayloadRef(json=payload), type="user_report"))
+        self.send_envelope(project_id, envelope)
+
     def send_metrics(self, project_id, payload):
         envelope = Envelope()
         envelope.add_item(

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -374,6 +374,15 @@ class AttachmentsConsumer(EventsConsumer):
         assert v["type"] == "attachment", v["type"]
         return v
 
+    def get_user_report(self, timeout=None):
+        message = self.poll(timeout)
+        assert message is not None
+        assert message.error() is None
+
+        v = msgpack.unpackb(message.value(), raw=False, use_list=False)
+        assert v["type"] == "user_report", v["type"]
+        return v
+
 
 class ReplayRecordingsConsumer(EventsConsumer):
     def get_chunked_replay_chunk(self):

--- a/tests/integration/test_user_report.py
+++ b/tests/integration/test_user_report.py
@@ -1,0 +1,68 @@
+import json
+import uuid
+
+from sentry_sdk.envelope import Envelope, Item, PayloadRef
+
+
+def test_standalone_user_report(
+    relay_with_processing, mini_sentry, attachments_consumer
+):
+    project_id = 42
+    relay = relay_with_processing()
+    mini_sentry.add_full_project_config(project_id)
+
+    report_payload = {
+        "name": "Josh",
+        "email": "",
+        "comments": "I'm having fun",
+        "event_id": "4cec9f3e1f214073b816e0f4de5f59b1",
+    }
+
+    relay.send_user_report(
+        project_id,
+        report_payload,
+    )
+
+    attachments_consumer = attachments_consumer()
+    report = attachments_consumer.get_user_report(timeout=5)
+    assert json.loads(report["payload"]) == report_payload
+
+
+def test_user_report_with_event(
+    relay_with_processing, mini_sentry, attachments_consumer
+):
+    project_id = 42
+    relay = relay_with_processing()
+    mini_sentry.add_full_project_config(project_id)
+
+    event_id = uuid.uuid1().hex
+
+    error_payload = {
+        "event_id": event_id,
+        "message": "test",
+        "extra": {"msg_text": "test"},
+        "type": "error",
+        "environment": "production",
+        "release": "foo@1.2.3",
+    }
+
+    report_payload = {
+        "name": "Josh",
+        "email": "",
+        "comments": "I'm having fun",
+        "event_id": "4cec9f3e1f214073b816e0f4de5f59b1",
+    }
+
+    envelope = Envelope()
+    envelope.add_item(Item(PayloadRef(json=error_payload), type="event"))
+    envelope.add_item(Item(PayloadRef(json=report_payload), type="user_report"))
+
+    from pprint import pp
+
+    pp(envelope)
+
+    relay.send_envelope(project_id, envelope)
+
+    attachments_consumer = attachments_consumer()
+    report = attachments_consumer.get_user_report(timeout=5)
+    assert json.loads(report["payload"]) == report_payload

--- a/tests/integration/test_user_report.py
+++ b/tests/integration/test_user_report.py
@@ -50,7 +50,7 @@ def test_user_report_with_event(
         "name": "Josh",
         "email": "",
         "comments": "I'm having fun",
-        "event_id": "4cec9f3e1f214073b816e0f4de5f59b1",
+        "event_id": event_id,
     }
 
     envelope = Envelope()
@@ -62,3 +62,60 @@ def test_user_report_with_event(
     attachments_consumer = attachments_consumer()
     report = attachments_consumer.get_user_report(timeout=5)
     assert json.loads(report["payload"]) == report_payload
+
+
+def test_user_reports_quotas(
+    mini_sentry,
+    relay_with_processing,
+    attachments_consumer,
+    events_consumer,
+    outcomes_consumer,
+):
+    project_id = 42
+    event_id = uuid.uuid1().hex
+    relay = relay_with_processing()
+    outcomes_consumer = outcomes_consumer(timeout=10)
+    attachments_consumer = attachments_consumer()
+    events_consumer = events_consumer()
+
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["quotas"] = [
+        {
+            "id": f"test_rate_limiting_{event_id}",
+            "categories": ["error"],
+            "window": 3600,
+            "limit": 0,
+            "reasonCode": "drop_all",
+        }
+    ]
+
+    error_payload = {
+        "event_id": event_id,
+        "message": "test",
+        "extra": {"msg_text": "test"},
+        "type": "error",
+        "environment": "production",
+        "release": "foo@1.2.3",
+    }
+
+    report_payload = {
+        "name": "Josh",
+        "email": "",
+        "comments": "I'm having fun",
+        "event_id": event_id,
+    }
+
+    envelope = Envelope()
+    envelope.add_item(Item(PayloadRef(json=error_payload), type="event"))
+    envelope.add_item(Item(PayloadRef(json=report_payload), type="user_report"))
+
+    relay.send_envelope(project_id, envelope)
+
+    # Becuase of the quotas, we should drop error, and since the user_report is in the same envelope, we should also drop it.
+    attachments_consumer.assert_empty()
+    events_consumer.assert_empty()
+
+    # We must have 1 outcome with provided reason.
+    outcomes = outcomes_consumer.get_outcomes()
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "drop_all"

--- a/tests/integration/test_user_report.py
+++ b/tests/integration/test_user_report.py
@@ -57,10 +57,6 @@ def test_user_report_with_event(
     envelope.add_item(Item(PayloadRef(json=error_payload), type="event"))
     envelope.add_item(Item(PayloadRef(json=report_payload), type="user_report"))
 
-    from pprint import pp
-
-    pp(envelope)
-
     relay.send_envelope(project_id, envelope)
 
     attachments_consumer = attachments_consumer()


### PR DESCRIPTION
If the user reports are send in separate envelope from the event, we treat it like a standalone attachment.

* changed the processing grouping 
* added few tests to verify the behaviour 
* client reports are in separate processing group, since they do not require any events

fix: https://github.com/getsentry/relay/issues/2980