### PR TITLE
ref: Remove dbg! calls

### DIFF
--- a/relay-pii/src/minidumps.rs
+++ b/relay-pii/src/minidumps.rs
@@ -583,10 +583,6 @@ mod tests {
         assert_eq!(main.debug_file().unwrap(), "crash");
 
         let modules = scrubber.other_modules(Which::Original);
-        for module in modules.iter() {
-            dbg!(module.code_file());
-            dbg!(module.debug_file());
-        }
         for module in modules {
             assert!(
                 module.code_file().matches('/').count() > 1,

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -1019,8 +1019,7 @@ mod tests {
                         "{formatted_selector}": ["@anything:remove"]
                     }}
                 }}
-                "##,
-                formatted_selector = dbg!(formatted_selector),
+                "##
             ))
             .unwrap();
 


### PR DESCRIPTION
Remove all `dbg!` calls from the code base.

#skip-changelog