### PR TITLE
instr(metrics): Log error when metrics of invalid state are dropped

### DIFF
--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1131,12 +1131,18 @@ impl Project {
     ) -> Option<(Scoping, ProjectMetrics)> {
         let len = buckets.len();
         let Some(project_state) = self.valid_state() else {
-            relay_log::trace!("there is no project state: dropping {len} buckets",);
+            relay_log::error!(
+                tags.project_key = self.project_key.as_str(),
+                "there is no project state: dropping {len} buckets"
+            );
             return None;
         };
 
         let Some(scoping) = self.scoping() else {
-            relay_log::trace!("there is no scoping: dropping {len} buckets");
+            relay_log::error!(
+                tags.project_key = self.project_key.as_str(),
+                "there is no scoping: dropping {len} buckets"
+            );
             return None;
         };
 


### PR DESCRIPTION
ref: https://github.com/getsentry/relay/issues/2967

#skip-changelog