### PR TITLE
ref(cardinality): Use cardinality limits from project config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Internal**:
 
 - Implement quota system for cardinality limiter. ([#2972](https://github.com/getsentry/relay/pull/2972))
+- Use cardinality limits from project config instead of Relay config. ([#2990](https://github.com/getsentry/relay/pull/2990))
 - Proactively move on-disk spool to memory. ([#2949](https://github.com/getsentry/relay/pull/2949))
 - Default missing `Event.platform` and `Event.level` fields during light normalization. ([#2961](https://github.com/getsentry/relay/pull/2961))
 - Copy event measurements to span & normalize span measurements. ([#2953](https://github.com/getsentry/relay/pull/2953))

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1282,42 +1282,9 @@ pub struct GeoIpConfig {
 }
 
 /// Cardinality Limiter configuration options.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(default)]
-pub struct CardinalityLimiter {
-    /// The number of seconds to apply the limit to.
-    ///
-    /// Defaults to: 1 hour.
-    pub window_seconds: u64,
-    /// A number between 1 and `window_seconds`. Since `window_seconds` is a
-    /// sliding window, configure what the granularity of that window is.
-    ///
-    /// If this is equal to `window_seconds`, the quota resets to 0 every
-    /// `window_seconds`.  If this is a very small number, the window slides
-    /// "more smoothly" at the expense of having much more redis keys.
-    ///
-    /// The number of redis keys required to enforce a quota is `window_seconds /
-    /// granularity_seconds`.
-    ///
-    /// Defaults to: 10 minutes.
-    pub granularity_seconds: u64,
-    /// Cardinality limit per bucket.
-    ///
-    /// The current bucket scope is comprised of organization and namespace.
-    ///
-    /// Defaults to: 10_000.
-    pub limit: u64,
-}
-
-impl Default for CardinalityLimiter {
-    fn default() -> Self {
-        Self {
-            window_seconds: 3600,
-            granularity_seconds: 600,
-            limit: 10_000,
-        }
-    }
-}
+pub struct CardinalityLimiter {}
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct ConfigValues {
@@ -2168,21 +2135,6 @@ impl Config {
     /// Maximum rate limit to report to clients in seconds.
     pub fn max_rate_limit(&self) -> Option<u64> {
         self.values.processing.max_rate_limit.map(u32::into)
-    }
-
-    /// Cardinality limit per org and namespace.
-    pub fn cardinality_limit(&self) -> u64 {
-        self.values.cardinality_limiter.limit
-    }
-
-    /// Sliding window size to enforce cardinality limit.
-    pub fn cardinality_limiter_window(&self) -> u64 {
-        self.values.cardinality_limiter.window_seconds
-    }
-
-    /// Granularity of the sliding window to enforce cardinality limit.
-    pub fn cardinality_limiter_granularity(&self) -> u64 {
-        self.values.cardinality_limiter.granularity_seconds
     }
 
     /// Creates an [`AggregatorConfig`] that is compatible with every other aggregator.

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use relay_base_schema::project::{ProjectId, ProjectKey};
+#[cfg(feature = "processing")]
+use relay_cardinality::CardinalityLimit;
 use relay_config::Config;
 use relay_dynamic_config::{ErrorBoundary, Feature, LimitedProjectConfig, Metrics, ProjectConfig};
 use relay_filter::matches_any_origin;
@@ -286,6 +288,15 @@ impl ProjectState {
     /// Returns quotas declared in this project state.
     pub fn get_quotas(&self) -> &[Quota] {
         self.config.quotas.as_slice()
+    }
+
+    /// Returns cardinality limits declared in this project state.
+    #[cfg(feature = "processing")]
+    pub fn get_cardinality_limits(&self) -> &[CardinalityLimit] {
+        match self.config.metrics {
+            ErrorBoundary::Ok(ref m) => m.cardinality_limits.as_slice(),
+            _ => &[],
+        }
     }
 
     /// Returns `Err` if the project is known to be invalid or disabled.

--- a/tests/integration/test_cardinality_limiter.py
+++ b/tests/integration/test_cardinality_limiter.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timezone
+
+from .test_metrics import metrics_by_name
+
+TEST_CONFIG = {
+    "aggregator": {
+        "bucket_interval": 1,
+        "initial_delay": 0,
+        "debounce_delay": 0,
+        "shift_key": "none",
+    }
+}
+
+
+def metrics_by_namespace(metrics_consumer, count, timeout=None):
+    metrics = metrics_by_name(metrics_consumer, count, timeout)
+
+    result = dict()
+    for metric, headers in metrics["headers"].items():
+        namespace = dict(headers)["namespace"].decode("utf-8")
+        result.setdefault(namespace, []).append(metric)
+
+    return result
+
+
+def add_project_config(mini_sentry, project_id, cardinality_limits=None):
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:custom-metrics",
+        "organizations:relay-cardinality-limiter",
+    ]
+    project_config["config"]["metrics"] = {
+        "cardinalityLimits": cardinality_limits or []
+    }
+
+
+def test_cardinality_limits(mini_sentry, relay_with_processing, metrics_consumer):
+    relay = relay_with_processing(options=TEST_CONFIG)
+    metrics_consumer = metrics_consumer()
+
+    project_id = 42
+    cardinality_limits = [
+        {
+            "id": "transactions",
+            "window": {"windowSeconds": 3600, "granularitySeconds": 600},
+            "limit": 1,
+            "scope": "organization",
+            "namespace": "transactions",
+        },
+        {
+            "id": "custom",
+            "window": {"windowSeconds": 3600, "granularitySeconds": 600},
+            "limit": 2,
+            "scope": "organization",
+            "namespace": "custom",
+        },
+    ]
+
+    add_project_config(mini_sentry, project_id, cardinality_limits)
+
+    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
+    metrics_payload = "\n".join(
+        [
+            "transactions/foo@second:12|c",
+            "transactions/bar@second:23|c",
+            "sessions/foo@second:12|c",
+            "foo@second:12|c",
+            "bar@second:23|c",
+            f"baz@second:17|c|T{timestamp}",
+        ]
+    )
+    relay.send_metrics(project_id, metrics_payload)
+
+    metrics = metrics_by_namespace(metrics_consumer, 4)
+    assert len(metrics["custom"]) == 2
+    assert len(metrics["sessions"]) == 1
+    assert len(metrics["transactions"]) == 1


### PR DESCRIPTION
Reads the cardinality config from the project config instead of generating them from the Relay config.

Sentry side implemented in: https://github.com/getsentry/sentry/pull/63562