### PR TITLE
chore(spool): Enable periodic unspool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Copy event measurements to span & normalize span measurements. ([#2953](https://github.com/getsentry/relay/pull/2953))
 - Add `allow_negative` to `BuiltinMeasurementKey`. Filter out negative BuiltinMeasurements if `allow_negative` is false. ([#2982](https://github.com/getsentry/relay/pull/2982))
 - Add possiblity to block metrics or their tags with glob-patterns. ([#2954](https://github.com/getsentry/relay/pull/2954), [#2973](https://github.com/getsentry/relay/pull/2973))
-- Enable periodic unspool of the buffered envelopes. ([#2993](https://github.com/getsentry/relay/pull/2993))
+- Enable throttled periodic unspool of the buffered envelopes. ([#2993](https://github.com/getsentry/relay/pull/2993))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@
 - Proactively move on-disk spool to memory. ([#2949](https://github.com/getsentry/relay/pull/2949))
 - Default missing `Event.platform` and `Event.level` fields during light normalization. ([#2961](https://github.com/getsentry/relay/pull/2961))
 - Copy event measurements to span & normalize span measurements. ([#2953](https://github.com/getsentry/relay/pull/2953))
-- Add possiblity to block metrics with glob-patterns. ([#2954](https://github.com/getsentry/relay/pull/2954))
-- Enable periodic unspool of the buffered envelopes. ([#2993](https://github.com/getsentry/relay/pull/2993))
 - Add possiblity to block metrics or their tags with glob-patterns. ([#2954](https://github.com/getsentry/relay/pull/2954), [#2973](https://github.com/getsentry/relay/pull/2973))
+- Enable periodic unspool of the buffered envelopes. ([#2993](https://github.com/getsentry/relay/pull/2993))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Default missing `Event.platform` and `Event.level` fields during light normalization. ([#2961](https://github.com/getsentry/relay/pull/2961))
 - Copy event measurements to span & normalize span measurements. ([#2953](https://github.com/getsentry/relay/pull/2953))
 - Add possiblity to block metrics with glob-patterns. ([#2954](https://github.com/getsentry/relay/pull/2954))
+- Enable periodic unspool of the buffered envelopes. ([#2993](https://github.com/getsentry/relay/pull/2993))
 
 **Bug Fixes**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -854,7 +854,7 @@ pub struct EnvelopeSpool {
     /// This is a hard upper bound and defaults to 524288000 bytes (500MB).
     #[serde(default = "spool_envelopes_max_memory_size")]
     max_memory_size: ByteSize,
-    /// The internal in milliseconds to trigger unspool.
+    /// The interval in milliseconds to trigger unspool.
     #[serde(default = "spool_envelopes_unspool_interval")]
     unspool_interval: u64,
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -826,6 +826,11 @@ fn spool_envelopes_max_connections() -> u32 {
     20
 }
 
+/// Default interval to unspool buffered envelopes, 100ms.
+fn spool_envelopes_unspool_interval() -> u64 {
+    100
+}
+
 /// Persistent buffering configuration for incoming envelopes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvelopeSpool {
@@ -849,6 +854,9 @@ pub struct EnvelopeSpool {
     /// This is a hard upper bound and defaults to 524288000 bytes (500MB).
     #[serde(default = "spool_envelopes_max_memory_size")]
     max_memory_size: ByteSize,
+    /// The internal in milliseconds to trigger unspool.
+    #[serde(default = "spool_envelopes_unspool_interval")]
+    unspool_interval: u64,
 }
 
 impl Default for EnvelopeSpool {
@@ -859,6 +867,7 @@ impl Default for EnvelopeSpool {
             min_connections: spool_envelopes_min_connections(),
             max_disk_size: spool_envelopes_max_disk_size(),
             max_memory_size: spool_envelopes_max_memory_size(),
+            unspool_interval: spool_envelopes_unspool_interval(), // 100ms
         }
     }
 }
@@ -1934,6 +1943,11 @@ impl Config {
     /// Minimum number of connections to create to buffer file.
     pub fn spool_envelopes_min_connections(&self) -> u32 {
         self.values.spool.envelopes.min_connections
+    }
+
+    /// Unspool interval in milliseconds.
+    pub fn spool_envelopes_unspool_interval(&self) -> Duration {
+        Duration::from_millis(self.values.spool.envelopes.unspool_interval)
     }
 
     /// The maximum size of the buffer, in bytes.

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -899,8 +899,8 @@ impl ProjectCacheBroker {
         }
     }
 
-    /// Iterates the buffer index and tries to unspool the envelopes if the project state is still
-    /// valid.
+    /// Iterates the buffer index and tries to unspool the envelopes for projects with a valid
+    /// state.
     ///
     /// This makes sure we always moving the unspool forward, even if we do not fetch the project
     /// states updates, but still can process data based on the existing cache.
@@ -923,8 +923,7 @@ impl ProjectCacheBroker {
                     .get_cached_state(self.services.project_cache.clone(), false)
                     .is_some()
             }) {
-                // Do *not* attempt to unspool if there are more permits are assigned than low
-                // watermark indicates.
+                // Do *not* attempt to unspool if the assigned permits over low watermark.
                 if !self.buffer_guard.is_below_low_watermark() {
                     self.schedule_unspool();
                     return;
@@ -1275,7 +1274,7 @@ mod tests {
         envelopes.pop().unwrap();
         assert_eq!(buffer_guard.available(), 1);
 
-        // Till now we should have enqueued 5 envleopes and dequeued only 1, it means the index is
+        // Till now we should have enqueued 5 envelopes and dequeued only 1, it means the index is
         // still populated with same keys and values.
         assert_eq!(broker.index.keys().len(), 1);
         assert_eq!(broker.index.values().count(), 1);

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -98,9 +98,11 @@ pub fn new_envelope<T: Into<String>>(with_dsc: bool, transaction_name: T) -> Box
 }
 
 pub fn empty_envelope() -> Box<Envelope> {
-    let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
-        .parse()
-        .unwrap();
+    empty_envelope_with_dsn("e12d836b15bb49d7bbf99e64295d995b")
+}
+
+pub fn empty_envelope_with_dsn(dsn: &str) -> Box<Envelope> {
+    let dsn = format!("https://{dsn}:@sentry.io/42").parse().unwrap();
 
     let mut envelope = Envelope::from_request(Some(EventId::new()), RequestMeta::new(dsn));
     envelope.add_item(Item::new(ItemType::Event));

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -127,6 +127,10 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
                     "flush_interval": 0,
                 },
             },
+            "spool": {
+                # Unspool as quickly as possible
+                "envelopes": {"unspool_interval": 1},
+            },
         }
 
         if static_relays is not None:

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -491,7 +491,7 @@ def test_processing_quotas(
             relay.send_event(
                 project_id, transform({"message": f"otherkey{i}"}), dsn_key_idx=1
             )
-        event, _ = events_consumer.get_event()
+        event, _ = events_consumer.get_event(timeout=5)
 
         if event_type == "nel":
             assert event["logentry"]["formatted"] == "application / http.error"


### PR DESCRIPTION
Currently in order to trigger unspool of buffered envelopes the new project state update must be received from the upstream, which sometimes can take longer time.

To make unspool action a bit more predictable let's enable periodic unspool initiated by project cache. This way:
* spool service does not have to know when to unspool
* spool service just has to serve the request and communicate back the results 
* project cache will take care of the initiating the action and only queue the envelopes when certain criteria are met


part of: https://github.com/getsentry/team-ingest/issues/267
