### PR TITLE
test(flaky): Fix flaky test 'test_span_ingestion'

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1647,7 +1647,7 @@ def test_span_ingestion(
     ]
 
     metrics = [metric for (metric, _headers) in metrics_consumer.get_metrics()]
-    metrics.sort(key=lambda m: (m["name"], sorted(m["tags"].items())))
+    metrics.sort(key=lambda m: (m["name"], sorted(m["tags"].items()), m["timestamp"]))
     for metric in metrics:
         try:
             metric["value"].sort()


### PR DESCRIPTION
Seems like the results are sorted but the same metrics with different timestamp are not sorted.

Fixes: https://github.com/getsentry/relay/issues/2996

#skip-changelog