### PR TITLE
fix(cardinality): Fix cardinality cache, introduce stronger typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,7 @@ dependencies = [
  "criterion",
  "hashbrown 0.13.2",
  "relay-base-schema",
+ "relay-common",
  "relay-log",
  "relay-redis",
  "relay-statsd",

--- a/relay-cardinality/Cargo.toml
+++ b/relay-cardinality/Cargo.toml
@@ -16,6 +16,7 @@ redis = ["relay-redis/impl"]
 
 [dependencies]
 hashbrown = { workspace = true }
+relay-common = { path = "../relay-common" }
 relay-base-schema = { path = "../relay-base-schema" }
 relay-log = { path = "../relay-log" }
 relay-redis = { path = "../relay-redis" }

--- a/relay-cardinality/src/cache.rs
+++ b/relay-cardinality/src/cache.rs
@@ -1,10 +1,14 @@
+use std::fmt;
 use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use relay_common::time::UnixTimestamp;
+
 use crate::redis::QuotaScoping;
+use crate::window::Slot;
 
 /// Cached outcome, wether the item can be accepted, rejected or the cache has no information about
 /// this hash.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CacheOutcome {
     /// Hash accepted by cache.
     Accepted,
@@ -27,7 +31,7 @@ impl Cache {
     ///
     /// All operations done on the handle share the same lock. To release the lock
     /// the returned [`CacheRead`] must be dropped.
-    pub fn read(&self, timestamp: u64) -> CacheRead<'_> {
+    pub fn read(&self, timestamp: UnixTimestamp) -> CacheRead<'_> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         CacheRead::new(inner, timestamp)
     }
@@ -36,21 +40,30 @@ impl Cache {
     ///
     /// All operations done on the handle share the same lock. To release the lock
     /// the returned [`CacheUpdate`] must be dropped.
-    pub fn update(&self, scope: QuotaScoping, slot: u64) -> CacheUpdate<'_> {
+    pub fn update(&self, scope: QuotaScoping, timestamp: UnixTimestamp) -> CacheUpdate<'_> {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
 
-        // If the slot is older don't do anything and give up the lock early.
-        if slot < inner.current_slot {
+        let slot = scope.window.active_slot(timestamp);
+        let cache = inner.cache.entry(scope).or_default();
+
+        // If the slot is older, don't do anything and give up the lock early.
+        if slot < cache.current_slot {
             return CacheUpdate::noop();
         }
 
-        // If the slot is newer then the current slot, reset the cache to the new slot.
-        if slot > inner.current_slot {
-            inner.current_slot = slot;
-            inner.cache.clear();
+        // If the slot is newer than the current slot, reset the cache to the new slot.
+        if slot > cache.current_slot {
+            cache.reset(slot);
         }
 
         CacheUpdate::new(inner, scope)
+    }
+}
+
+impl fmt::Debug for Cache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        f.debug_tuple("Cache").field(&inner.cache).finish()
     }
 }
 
@@ -59,25 +72,23 @@ impl Cache {
 /// Holds a cache read lock, the lock is released on drop.
 pub struct CacheRead<'a> {
     inner: RwLockReadGuard<'a, Inner>,
-    timestamp: u64,
+    timestamp: UnixTimestamp,
 }
 
 /// Internal state for [`CacheRead`].
 impl<'a> CacheRead<'a> {
     /// Creates a new [`CacheRead`] which reads from the cache.
-    fn new(inner: RwLockReadGuard<'a, Inner>, timestamp: u64) -> Self {
+    fn new(inner: RwLockReadGuard<'a, Inner>, timestamp: UnixTimestamp) -> Self {
         Self { inner, timestamp }
     }
 
     pub fn check(&self, scope: QuotaScoping, hash: u32, limit: u64) -> CacheOutcome {
-        if scope.window.active_slot(self.timestamp) < self.inner.current_slot {
+        let Some(cache) = self.inner.cache.get(&scope) else {
             return CacheOutcome::Unknown;
-        }
+        };
 
-        self.inner
-            .cache
-            .get(&scope)
-            .map_or(CacheOutcome::Unknown, |s| s.check(hash, limit))
+        let slot = scope.window.active_slot(self.timestamp);
+        cache.check(slot, hash, limit)
     }
 }
 
@@ -110,7 +121,9 @@ impl<'a> CacheUpdate<'a> {
     /// item as accepted.
     pub fn accept(&mut self, hash: u32) {
         if let CacheUpdateInner::Cache { inner, key } = &mut self.0 {
-            inner.cache.entry(*key).or_default().insert(hash);
+            if let Some(cache) = inner.cache.get_mut(key) {
+                cache.insert(hash);
+            }
         }
     }
 }
@@ -119,22 +132,26 @@ impl<'a> CacheUpdate<'a> {
 #[derive(Debug, Default)]
 struct Inner {
     cache: hashbrown::HashMap<QuotaScoping, ScopedCache>,
-    current_slot: u64,
 }
 
 /// Scope specific information of the cache.
 #[derive(Debug, Default)]
-struct ScopedCache(
+struct ScopedCache {
     // Uses hashbrown for a faster hasher `ahash`, benchmarks show about 10% speedup.
-    hashbrown::HashSet<u32>,
-);
+    hashes: hashbrown::HashSet<u32>,
+    current_slot: Slot,
+}
 
 impl ScopedCache {
-    fn check(&self, hash: u32, limit: u64) -> CacheOutcome {
-        if self.0.contains(&hash) {
+    fn check(&self, slot: Slot, hash: u32, limit: u64) -> CacheOutcome {
+        if slot != self.current_slot {
+            return CacheOutcome::Unknown;
+        }
+
+        if self.hashes.contains(&hash) {
             // Local cache copy contains the hash -> accept it straight away
             CacheOutcome::Accepted
-        } else if self.0.len() as u64 >= limit {
+        } else if self.hashes.len() as u64 >= limit {
             // We have more or the same amount of items in the local cache as the cardinality
             // limit -> this new item/hash is rejected.
             CacheOutcome::Rejected
@@ -145,6 +162,127 @@ impl ScopedCache {
     }
 
     fn insert(&mut self, hash: u32) {
-        self.0.insert(hash);
+        self.hashes.insert(hash);
+    }
+
+    fn reset(&mut self, slot: Slot) {
+        self.current_slot = slot;
+        self.hashes.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::SlidingWindow;
+
+    use super::*;
+
+    #[test]
+    fn test_cache() {
+        let cache = Cache::default();
+
+        let scope = QuotaScoping {
+            window: SlidingWindow {
+                window_seconds: 100,
+                granularity_seconds: 10,
+            },
+            namespace: None,
+            organization_id: None,
+            project_id: None,
+        };
+        let now = UnixTimestamp::now();
+        let future = now + Duration::from_secs(scope.window.granularity_seconds + 1);
+
+        {
+            let cache = cache.read(now);
+            assert_eq!(cache.check(scope, 1, 1), CacheOutcome::Unknown);
+        }
+
+        {
+            let mut cache = cache.update(scope, now);
+            cache.accept(1);
+            cache.accept(2);
+        }
+
+        {
+            let r1 = cache.read(now);
+            // All in cache, no matter the limit.
+            assert_eq!(r1.check(scope, 1, 1), CacheOutcome::Accepted);
+            assert_eq!(r1.check(scope, 1, 2), CacheOutcome::Accepted);
+            assert_eq!(r1.check(scope, 2, 1), CacheOutcome::Accepted);
+
+            // Not in cache, depends on limit and amount of items in the cache.
+            assert_eq!(r1.check(scope, 3, 3), CacheOutcome::Unknown);
+            assert_eq!(r1.check(scope, 3, 2), CacheOutcome::Rejected);
+
+            // Read concurrently from a future slot.
+            let r2 = cache.read(future);
+            assert_eq!(r2.check(scope, 1, 1), CacheOutcome::Unknown);
+            assert_eq!(r2.check(scope, 2, 2), CacheOutcome::Unknown);
+        }
+
+        {
+            // Move the cache into the future.
+            let mut cache = cache.update(scope, future);
+            cache.accept(1);
+        }
+
+        {
+            let future = cache.read(future);
+            // The future only contains `1`.
+            assert_eq!(future.check(scope, 1, 1), CacheOutcome::Accepted);
+            assert_eq!(future.check(scope, 2, 1), CacheOutcome::Rejected);
+
+            let past = cache.read(now);
+            // The cache has no information about the past.
+            assert_eq!(past.check(scope, 1, 1), CacheOutcome::Unknown);
+            assert_eq!(past.check(scope, 2, 1), CacheOutcome::Unknown);
+            assert_eq!(past.check(scope, 3, 99), CacheOutcome::Unknown);
+        }
+    }
+
+    #[test]
+    fn test_cache_different_scopings() {
+        let cache = Cache::default();
+
+        let scope1 = QuotaScoping {
+            window: SlidingWindow {
+                window_seconds: 100,
+                granularity_seconds: 10,
+            },
+            namespace: None,
+            organization_id: None,
+            project_id: None,
+        };
+        let scope2 = QuotaScoping {
+            organization_id: Some(100),
+            ..scope1
+        };
+        let now = UnixTimestamp::now();
+
+        {
+            let mut cache = cache.update(scope1, now);
+            cache.accept(1);
+        }
+
+        {
+            let mut cache = cache.update(scope2, now);
+            cache.accept(1);
+            cache.accept(2);
+        }
+
+        {
+            let cache = cache.read(now);
+            assert_eq!(cache.check(scope1, 1, 99), CacheOutcome::Accepted);
+            assert_eq!(cache.check(scope1, 2, 99), CacheOutcome::Unknown);
+            assert_eq!(cache.check(scope1, 3, 99), CacheOutcome::Unknown);
+            assert_eq!(cache.check(scope2, 3, 1), CacheOutcome::Rejected);
+            assert_eq!(cache.check(scope2, 1, 99), CacheOutcome::Accepted);
+            assert_eq!(cache.check(scope2, 2, 99), CacheOutcome::Accepted);
+            assert_eq!(cache.check(scope2, 3, 99), CacheOutcome::Unknown);
+            assert_eq!(cache.check(scope2, 3, 2), CacheOutcome::Rejected);
+        }
     }
 }

--- a/relay-cardinality/src/redis.rs
+++ b/relay-cardinality/src/redis.rs
@@ -215,7 +215,6 @@ impl QuotaScoping {
         let organization_id = self.organization_id.unwrap_or(0);
         let project_id = self.project_id.map(|p| p.value()).unwrap_or(0);
         let namespace = self.namespace.map(|ns| ns.as_str()).unwrap_or("");
-        let slot = slot.0;
 
         format!("{KEY_PREFIX}:scope-{{{organization_id}-{project_id}-{namespace}}}-{slot}")
     }

--- a/relay-cardinality/src/window.rs
+++ b/relay-cardinality/src/window.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use relay_common::time::UnixTimestamp;
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +51,13 @@ impl SlidingWindow {
 
 /// A single slot from a [`SlidingWindow`].
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Slot(pub u64);
+pub struct Slot(u64);
+
+impl fmt::Display for Slot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/relay-cardinality/src/window.rs
+++ b/relay-cardinality/src/window.rs
@@ -1,3 +1,4 @@
+use relay_common::time::UnixTimestamp;
 use serde::{Deserialize, Serialize};
 
 /// A sliding window.
@@ -33,20 +34,27 @@ impl SlidingWindow {
     /// * `request_timestamp / self.granularity_seconds - 2`
     /// * `request_timestamp / self.granularity_seconds - 3`
     /// * ...
-    pub fn iter(&self, timestamp: u64) -> impl Iterator<Item = u64> {
-        let value = timestamp / self.granularity_seconds;
+    pub fn iter(&self, timestamp: UnixTimestamp) -> impl Iterator<Item = Slot> {
+        let value = timestamp.as_secs() / self.granularity_seconds;
         (0..self.window_seconds / self.granularity_seconds)
             .map(move |i| value.saturating_sub(i + 1))
+            .map(Slot)
     }
 
     /// The active bucket is the oldest active granule.
-    pub fn active_slot(&self, timestamp: u64) -> u64 {
-        self.iter(timestamp).last().unwrap_or(0)
+    pub fn active_slot(&self, timestamp: UnixTimestamp) -> Slot {
+        self.iter(timestamp).last().unwrap_or(Slot(0))
     }
 }
 
+/// A single slot from a [`SlidingWindow`].
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Slot(pub u64);
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -56,20 +64,31 @@ mod tests {
             granularity_seconds: 720,
         };
 
-        let timestamp = 1701775000;
+        let timestamp = UnixTimestamp::from_secs(1701775000);
         let r = window.iter(timestamp).collect::<Vec<_>>();
         assert_eq!(
             r.len() as u64,
             window.window_seconds / window.granularity_seconds
         );
-        assert_eq!(r, vec![2363575, 2363574, 2363573, 2363572, 2363571]);
+        assert_eq!(
+            r,
+            vec![
+                Slot(2363575),
+                Slot(2363574),
+                Slot(2363573),
+                Slot(2363572),
+                Slot(2363571)
+            ]
+        );
         assert_eq!(window.active_slot(timestamp), *r.last().unwrap());
 
-        let r2 = window.iter(timestamp + 10).collect::<Vec<_>>();
+        let r2 = window
+            .iter(timestamp + Duration::from_secs(10))
+            .collect::<Vec<_>>();
         assert_eq!(r2, r);
 
         let r3 = window
-            .iter(timestamp + window.granularity_seconds)
+            .iter(timestamp + Duration::from_secs(window.granularity_seconds))
             .collect::<Vec<_>>();
         assert_ne!(r3, r);
     }


### PR DESCRIPTION
The cache incorrectly compared timestamps to slots, this was not caught because both used `u64`. To prevent future mistakes like this we're strongly typing `UnixTimestamp` and `Slot` now.

I also added new tests for the cache to catch these issues in the future.

#skip-changelog