### PR TITLE
Use centralized SA for GCR image pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.SENTRY_GCP_PROD_WORKLOAD_IDENTITY_POOL }}
+          workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
           service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
 
       - name: "Set up Cloud SDK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,8 +282,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: projects/345757944225/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-          service_account: github-actions-gcr@sentryio.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.SENTRY_GCP_PROD_WORKLOAD_IDENTITY_POOL }}
+          service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"


### PR DESCRIPTION
#skip-changelog