### PR TITLE
fix(spans): Apply max. SQL expression depth after simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Avoid producing `null` values in metric data. These values were the result of Infinity or NaN values extracted from event data. The values are now discarded during extraction. ([#2958](https://github.com/getsentry/relay/pull/2958))
 - Fix processing of user reports. ([#2981](https://github.com/getsentry/relay/pull/2981), [#2984](https://github.com/getsentry/relay/pull/2984))
 - Fetch project config when metrics are received. ([#2987](https://github.com/getsentry/relay/pull/2987))
+- Do not truncate simplified SQL expressions. ([#3003](https://github.com/getsentry/relay/pull/3003))
 
 ## 24.1.0
 

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -190,7 +190,7 @@ mod tests {
     use super::*;
 
     macro_rules! scrub_sql_test {
-        ($name:ident, $description_in:literal, $output:literal) => {
+        ($name:ident, $description_in:expr, $output:literal) => {
             #[test]
             fn $name() {
                 let scrubbed = scrub_queries(None, $description_in);
@@ -723,6 +723,16 @@ mod tests {
             OR (a.id = %s OR a.org = %s)
             OR (a.id = %s OR a.org = %s)
         )"#,
+        "SELECT * FROM a WHERE status = %s OR (id = %s OR org = %s)"
+    );
+
+    scrub_sql_test!(
+        duplicate_conditions_or_long,
+        {
+            let repeated = ["(a.id = %s OR a.org = %s)"].repeat(64);
+            let repeated = itertools::join(repeated, " OR ");
+            format!("SELECT * FROM a WHERE a.status = %s OR {repeated}").as_str()
+        },
         "SELECT * FROM a WHERE status = %s OR (id = %s OR org = %s)"
     );
 

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -452,7 +452,7 @@ fn take_expr(expr: &mut Expr) -> Expr {
     swapped
 }
 
-/// Remove parentheses for equal operators, e.g. `(a OR b) OR c`.
+/// Removes parentheses for equal operators, e.g. `(a OR b) OR c`.
 ///
 /// Only use this function on operations which have the
 /// [associative property](https://en.wikipedia.org/wiki/Associative_property).


### PR DESCRIPTION
Repeating OR/AND conditions are collapsed, but if the maximum query depth is reached, the limit is applied before we can collapse it. This leads to scrubbed queries like:

```sql
WHERE ((.. OR (..) OR (.. = %s AND b = %s) OR (a = %s AND b = %s))
```

Fix by splitting the query visitor into two steps (first normalize, then reduce depth).

This PR also removes redundant parentheses around binary operations (e.g. `a OR (b OR c)`).

ref: [internal issue](https://www.notion.so/sentry/Collapse-identical-OR-conditions-in-queries-40786f8cddb145e398e8ad2d5eb66522)