### PR TITLE
ref(normalization): Split validation and normalization

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -7,16 +7,11 @@ use std::collections::BTreeSet;
 
 use std::hash::{Hash, Hasher};
 use std::mem;
-use std::ops::Range;
 
-use chrono::{DateTime, Duration, Utc};
 use relay_base_schema::metrics::{
     can_be_valid_metric_name, DurationUnit, FractionUnit, MetricUnit,
 };
-use relay_common::time::UnixTimestamp;
-use relay_event_schema::processor::{
-    self, MaxChars, ProcessingAction, ProcessingResult, ProcessingState, Processor,
-};
+use relay_event_schema::processor::{self, MaxChars, ProcessingAction, ProcessingState, Processor};
 use relay_event_schema::protocol::{
     AsPair, Context, ContextInner, Contexts, DeviceClass, Event, EventType, Exception, Headers,
     IpAddr, Level, LogEntry, Measurement, Measurements, NelContext, Request, SpanAttribute,
@@ -27,12 +22,11 @@ use smallvec::SmallVec;
 
 use crate::normalize::request;
 use crate::span::tag_extraction::{self, extract_span_tags};
-use crate::timestamp::TimestampProcessor;
 use crate::utils::{self, MAX_DURATION_MOBILE_MS};
 use crate::{
     breakdowns, mechanism, schema, span, stacktrace, transactions, trimming, user_agent,
-    BreakdownsConfig, ClockDriftProcessor, DynamicMeasurementsConfig, GeoIpLookup,
-    PerformanceScoreConfig, RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig,
+    BreakdownsConfig, DynamicMeasurementsConfig, GeoIpLookup, PerformanceScoreConfig,
+    RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig,
 };
 
 /// Configuration for [`normalize_event`].
@@ -50,27 +44,6 @@ pub struct NormalizationConfig<'a> {
     /// information should the event payload contain no such data. If no client hints are present,
     /// normalization falls back to the user agent.
     pub user_agent: RawUserAgentInfo<&'a str>,
-
-    /// The time at which the event was received in this Relay.
-    ///
-    /// This timestamp is persisted into the event payload.
-    pub received_at: Option<DateTime<Utc>>,
-
-    /// The maximum amount of seconds an event can be dated in the past.
-    ///
-    /// If the event's timestamp is older, the received timestamp is assumed.
-    pub max_secs_in_past: Option<i64>,
-
-    /// The maximum amount of seconds an event can be predated into the future.
-    ///
-    /// If the event's timestamp lies further into the future, the received timestamp is assumed.
-    pub max_secs_in_future: Option<i64>,
-
-    /// Timestamp range in which a transaction must end.
-    ///
-    /// Transactions that finish outside of this range are considered invalid.
-    /// This check is skipped if no range is provided.
-    pub transaction_range: Option<Range<UnixTimestamp>>,
 
     /// The maximum length for names of custom measurements.
     ///
@@ -138,10 +111,6 @@ impl<'a> Default for NormalizationConfig<'a> {
         Self {
             client_ip: Default::default(),
             user_agent: Default::default(),
-            received_at: Default::default(),
-            max_secs_in_past: Default::default(),
-            max_secs_in_future: Default::default(),
-            transaction_range: Default::default(),
             max_name_and_unit_len: Default::default(),
             breakdowns_config: Default::default(),
             normalize_user_agent: Default::default(),
@@ -160,56 +129,40 @@ impl<'a> Default for NormalizationConfig<'a> {
     }
 }
 
-/// Normalizes an event, rejecting it if necessary.
+/// Normalizes an event.
 ///
 /// Normalization consists of applying a series of transformations on the event
 /// payload based on the given configuration.
 ///
 /// The returned [`ProcessingResult`] indicates whether the passed event should
 /// be ingested or dropped.
-pub fn normalize_event(
-    event: &mut Annotated<Event>,
-    config: &NormalizationConfig,
-) -> ProcessingResult {
+pub fn normalize_event(event: &mut Annotated<Event>, config: &NormalizationConfig) {
     let Annotated(Some(ref mut event), ref mut meta) = event else {
-        return Ok(());
+        return;
     };
 
     let is_renormalize = config.is_renormalize;
 
     if !is_renormalize {
-        normalize(event, meta, config)?;
+        normalize(event, meta, config);
     }
-
-    Ok(())
 }
 
 /// Normalizes the given event based on the given config.
 ///
 /// The returned [`ProcessingResult`] indicates whether the passed event should
 /// be ingested or dropped.
-fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -> ProcessingResult {
-    // Validate and normalize transaction
+fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
+    // Normalize the transaction.
     // (internally noops for non-transaction events).
     // TODO: Parts of this processor should probably be a filter so we
     // can revert some changes to ProcessingAction)
-    let mut transactions_processor = transactions::TransactionsProcessor::new(
-        config.transaction_name_config.clone(),
-        config.transaction_range.clone(),
-    );
-    transactions_processor.process_event(event, meta, ProcessingState::root())?;
+    let mut transactions_processor =
+        transactions::TransactionsProcessor::new(config.transaction_name_config.clone());
+    let _ = transactions_processor.process_event(event, meta, ProcessingState::root());
 
     // Check for required and non-empty values
     let _ = schema::SchemaProcessor.process_event(event, meta, ProcessingState::root());
-
-    normalize_timestamps(
-        event,
-        meta,
-        config.received_at,
-        config.max_secs_in_past,
-        config.max_secs_in_future,
-    ); // Timestamps are core in the metrics extraction
-    TimestampProcessor.process_event(event, meta, ProcessingState::root())?;
 
     // Process security reports first to ensure all props.
     normalize_security_report(event, config.client_ip, &config.user_agent);
@@ -302,8 +255,6 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) -
         let _ =
             trimming::TrimmingProcessor::new().process_event(event, meta, ProcessingState::root());
     }
-
-    Ok(())
 }
 
 /// Backfills the client IP address on for the NEL reports.
@@ -466,64 +417,6 @@ fn normalize_platform_and_level(event: &mut Event) {
         Some(EventType::Transaction) => Level::Info,
         _ => Level::Error,
     });
-}
-
-/// Validates the timestamp range and sets a default value.
-fn normalize_timestamps(
-    event: &mut Event,
-    meta: &mut Meta,
-    received_at: Option<DateTime<Utc>>,
-    max_secs_in_past: Option<i64>,
-    max_secs_in_future: Option<i64>,
-) {
-    let received_at = received_at.unwrap_or_else(Utc::now);
-
-    let mut sent_at = None;
-    let mut error_kind = ErrorKind::ClockDrift;
-
-    let _ = processor::apply(&mut event.timestamp, |timestamp, _meta| {
-        if let Some(secs) = max_secs_in_future {
-            if *timestamp > received_at + Duration::seconds(secs) {
-                error_kind = ErrorKind::FutureTimestamp;
-                sent_at = Some(*timestamp);
-                return Ok(());
-            }
-        }
-
-        if let Some(secs) = max_secs_in_past {
-            if *timestamp < received_at - Duration::seconds(secs) {
-                error_kind = ErrorKind::PastTimestamp;
-                sent_at = Some(*timestamp);
-                return Ok(());
-            }
-        }
-
-        Ok(())
-    });
-
-    let _ = ClockDriftProcessor::new(sent_at.map(|ts| ts.into_inner()), received_at)
-        .error_kind(error_kind)
-        .process_event(event, meta, ProcessingState::root());
-
-    // Apply this after clock drift correction, otherwise we will malform it.
-    event.received = Annotated::new(received_at.into());
-
-    if event.timestamp.value().is_none() {
-        event.timestamp.set_value(Some(received_at.into()));
-    }
-
-    let _ = processor::apply(&mut event.time_spent, |time_spent, _| {
-        validate_bounded_integer_field(*time_spent)
-    });
-}
-
-/// Validate fields that go into a `sentry.models.BoundedIntegerField`.
-fn validate_bounded_integer_field(value: u64) -> ProcessingResult {
-    if value < 2_147_483_647 {
-        Ok(())
-    } else {
-        Err(ProcessingAction::DeleteValueHard)
-    }
 }
 
 struct DedupCache(SmallVec<[u64; 16]>);
@@ -2496,62 +2389,6 @@ mod tests {
           },
         }
         "###);
-    }
-
-    /// Test that timestamp normalization updates a transaction's timestamps to
-    /// be acceptable, when both timestamps are similarly stale.
-    #[test]
-    fn test_accept_recent_transactions_with_stale_timestamps() {
-        let config = NormalizationConfig {
-            received_at: Some(Utc::now()),
-            max_secs_in_past: Some(2),
-            max_secs_in_future: Some(1),
-            ..Default::default()
-        };
-
-        let json = r#"{
-  "event_id": "52df9022835246eeb317dbd739ccd059",
-  "transaction": "I have a stale timestamp, but I'm recent!",
-  "start_timestamp": -2,
-  "timestamp": -1
-}"#;
-        let mut event = Annotated::<Event>::from_json(json).unwrap();
-
-        assert!(normalize_event(&mut event, &config).is_ok());
-    }
-
-    /// Test that transactions are rejected as invalid when timestamp normalization isn't enough.
-    ///
-    /// When the end timestamp is recent but the start timestamp is stale, timestamp normalization
-    /// will fix the timestamps based on the end timestamp. The start timestamp will be more recent,
-    /// but not recent enough for the transaction to be accepted. The transaction will be rejected.
-    #[test]
-    fn test_reject_stale_transactions_after_timestamp_normalization() {
-        let now = Utc::now();
-        let config = NormalizationConfig {
-            received_at: Some(now),
-            max_secs_in_past: Some(2),
-            max_secs_in_future: Some(1),
-            ..Default::default()
-        };
-
-        let json = format!(
-            r#"{{
-          "event_id": "52df9022835246eeb317dbd739ccd059",
-          "transaction": "clockdrift is not enough to accept me :(",
-          "start_timestamp": -62135811111,
-          "timestamp": {}
-        }}"#,
-            now.timestamp()
-        );
-        let mut event = Annotated::<Event>::from_json(json.as_str()).unwrap();
-
-        assert_eq!(
-            normalize_event(&mut event, &config)
-                .unwrap_err()
-                .to_string(),
-            "invalid transaction event: timestamp is too stale"
-        );
     }
 
     #[test]

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -133,9 +133,6 @@ impl<'a> Default for NormalizationConfig<'a> {
 ///
 /// Normalization consists of applying a series of transformations on the event
 /// payload based on the given configuration.
-///
-/// The returned [`ProcessingResult`] indicates whether the passed event should
-/// be ingested or dropped.
 pub fn normalize_event(event: &mut Annotated<Event>, config: &NormalizationConfig) {
     let Annotated(Some(ref mut event), ref mut meta) = event else {
         return;
@@ -149,9 +146,6 @@ pub fn normalize_event(event: &mut Annotated<Event>, config: &NormalizationConfi
 }
 
 /// Normalizes the given event based on the given config.
-///
-/// The returned [`ProcessingResult`] indicates whether the passed event should
-/// be ingested or dropped.
 fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     // Normalize the transaction.
     // (internally noops for non-transaction events).

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -33,7 +33,12 @@ mod statsd;
 mod timestamp;
 mod transactions;
 mod trimming;
+mod validation;
 
+pub use validation::{
+    validate_event_timestamps, validate_span, validate_transaction, EventValidationConfig,
+    TransactionValidationConfig,
+};
 pub mod replay;
 pub use event::{normalize_event, normalize_measurements, NormalizationConfig};
 pub use normalize::breakdowns::*;

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -709,7 +709,10 @@ mod tests {
     use std::collections::BTreeMap;
     use uuid::Uuid;
 
-    use crate::{normalize_event, NormalizationConfig};
+    use crate::{
+        normalize_event, validate_event_timestamps, validate_transaction, EventValidationConfig,
+        NormalizationConfig, TransactionValidationConfig,
+    };
 
     use super::*;
 
@@ -887,7 +890,7 @@ mod tests {
 
         let config = StoreConfig::default();
         let mut processor = StoreNormalizeProcessor::new(Arc::new(config), None);
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
 
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -915,7 +918,7 @@ mod tests {
 
         let config = StoreConfig::default();
         let mut processor = StoreNormalizeProcessor::new(Arc::new(config), None);
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(Annotated::empty(), event.value().unwrap().user);
@@ -941,8 +944,7 @@ mod tests {
                 client_ip: Some(&ip_address),
                 ..Default::default()
             },
-        )
-        .unwrap();
+        );
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let ip_addr = get_value!(event.user.ip_address!);
@@ -973,8 +975,7 @@ mod tests {
                 client_ip: Some(&ip_address),
                 ..Default::default()
             },
-        )
-        .unwrap();
+        );
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let user = get_value!(event.user!);
@@ -1002,8 +1003,7 @@ mod tests {
                 client_ip: Some(&ip_address),
                 ..Default::default()
             },
-        )
-        .unwrap();
+        );
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let user = get_value!(event.user!);
@@ -1015,7 +1015,7 @@ mod tests {
     fn test_event_level_defaulted() {
         let processor = &mut StoreNormalizeProcessor::default();
         let mut event = Annotated::new(Event::default());
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, processor, ProcessingState::root()).unwrap();
         assert_eq!(get_value!(event.level), Some(&Level::Error));
     }
@@ -1041,7 +1041,7 @@ mod tests {
             },
             ..Event::default()
         });
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, processor, ProcessingState::root()).unwrap();
         assert_eq!(get_value!(event.level), Some(&Level::Info));
     }
@@ -1057,7 +1057,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let event = event.value().unwrap();
@@ -1078,7 +1078,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let event = event.value().unwrap();
@@ -1095,7 +1095,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
         assert_eq!(get_value!(event.environment), None);
     }
@@ -1111,7 +1111,7 @@ mod tests {
             ..StoreConfig::default()
         };
         let mut processor = StoreNormalizeProcessor::new(Arc::new(config), None);
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let event = event.value().unwrap();
@@ -1134,7 +1134,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let environment = get_path!(event.environment!);
@@ -1159,7 +1159,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let release = get_path!(event.release!);
@@ -1192,7 +1192,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(get_value!(event.site), None);
@@ -1246,7 +1246,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(get_value!(event.tags!).len(), 1);
@@ -1273,7 +1273,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1324,7 +1324,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         // should keep the first occurrence of every tag
@@ -1364,7 +1364,7 @@ mod tests {
             ..StoreConfig::default()
         };
         let mut processor = StoreNormalizeProcessor::new(Arc::new(config), None);
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let event = event.value().unwrap();
@@ -1418,7 +1418,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1516,7 +1516,7 @@ mod tests {
     });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1548,7 +1548,7 @@ mod tests {
         let mut event = Annotated::<Event>::from_json(json).unwrap();
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let dist = &event.value().unwrap().dist;
@@ -1583,7 +1583,7 @@ mod tests {
         });
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1612,7 +1612,7 @@ mod tests {
             None,
         );
 
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(
@@ -1634,7 +1634,8 @@ mod tests {
 
         let mut processor = StoreNormalizeProcessor::default();
 
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_eq!(get_value!(event.received!), get_value!(event.timestamp!));
@@ -1660,7 +1661,8 @@ mod tests {
             None,
         );
 
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
@@ -1706,7 +1708,7 @@ mod tests {
         let mut event = Annotated::<Event>::from_json(json).unwrap();
 
         let mut processor = StoreNormalizeProcessor::default();
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         assert_json_snapshot!(SerializableAnnotated(&event), {".received" => "[received]"}, @r#"
@@ -1763,16 +1765,17 @@ mod tests {
             }),
             None,
         );
-        normalize_event(
+        validate_transaction(&event, &TransactionValidationConfig::default()).unwrap();
+        validate_event_timestamps(
             &mut event,
-            &NormalizationConfig {
+            &EventValidationConfig {
                 received_at,
                 max_secs_in_past,
                 max_secs_in_future,
-                ..Default::default()
             },
         )
         .unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
@@ -1825,16 +1828,16 @@ mod tests {
             }),
             None,
         );
-        normalize_event(
+        validate_event_timestamps(
             &mut event,
-            &NormalizationConfig {
+            &EventValidationConfig {
                 received_at,
                 max_secs_in_past,
                 max_secs_in_future,
-                ..Default::default()
             },
         )
         .unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
@@ -2041,19 +2044,19 @@ mod tests {
             event
         }
 
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         let first = remove_received_from_event(&mut event.clone())
             .to_json()
             .unwrap();
         // Expected some fields (such as timestamps) exist after first light normalization.
 
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         let second = remove_received_from_event(&mut event.clone())
             .to_json()
             .unwrap();
         assert_eq!(&first, &second, "idempotency check failed");
 
-        normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+        normalize_event(&mut event, &NormalizationConfig::default());
         let third = remove_received_from_event(&mut event.clone())
             .to_json()
             .unwrap();
@@ -2114,7 +2117,8 @@ mod tests {
                 .spans
                 .set_value(Some(vec![Annotated::<Span>::from_json(span).unwrap()]));
 
-            let res = normalize_event(&mut modified_event, &NormalizationConfig::default());
+            let res =
+                validate_transaction(&modified_event, &TransactionValidationConfig::default());
 
             assert!(res.is_err(), "{span:?}");
         }
@@ -2132,15 +2136,13 @@ mod tests {
         )
         .unwrap();
 
-        let result = normalize_event(
+        normalize_event(
             &mut event,
             &NormalizationConfig {
                 is_renormalize: true,
                 ..Default::default()
             },
         );
-
-        assert!(result.is_ok());
 
         assert_debug_snapshot!(event.value().unwrap().tags, @r#"
         Tags(
@@ -2196,8 +2198,7 @@ mod tests {
                 geoip_lookup: Some(&lookup),
                 ..Default::default()
             },
-        )
-        .unwrap();
+        );
 
         // Extract user's geo information after normalization.
         let user_geo = event
@@ -2508,20 +2509,5 @@ mod tests {
           }
         }
         "###);
-    }
-
-    #[test]
-    fn test_reject_stale_transaction() {
-        let json = r#"{
-  "event_id": "52df9022835246eeb317dbd739ccd059",
-  "start_timestamp": -2,
-  "timestamp": -1
-}"#;
-        let mut transaction = Annotated::<Event>::from_json(json).unwrap();
-        let res = normalize_event(&mut transaction, &NormalizationConfig::default());
-        assert_eq!(
-            res.unwrap_err().to_string(),
-            "invalid transaction event: timestamp is too stale"
-        );
     }
 }

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -651,10 +651,7 @@ mod tests {
     use relay_protocol::Annotated;
 
     use super::*;
-    use crate::{
-        normalize_event, validate_event_timestamps, validate_transaction, EventValidationConfig,
-        NormalizationConfig, TransactionValidationConfig,
-    };
+    use crate::{normalize_event, NormalizationConfig};
 
     #[test]
     fn test_truncate_string_no_panic() {
@@ -721,13 +718,6 @@ mod tests {
                         });
                     }
                 }
-
-                // Validate and normalize first, to make sure that all things
-                // are correct as in the real pipeline:
-                let res = validate_transaction(&mut event, &TransactionValidationConfig::default());
-                assert!(res.is_ok());
-                let res = validate_event_timestamps(&mut event, &EventValidationConfig::default());
-                assert!(res.is_ok());
 
                 normalize_event(
                     &mut event,

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -1,0 +1,724 @@
+use std::ops::Range;
+
+use chrono::{DateTime, Duration, Utc};
+use relay_base_schema::events::EventType;
+use relay_common::time::UnixTimestamp;
+use relay_event_schema::processor::{
+    self, ProcessingAction, ProcessingResult, ProcessingState, Processor,
+};
+use relay_event_schema::protocol::{Event, Span, TraceContext};
+use relay_protocol::{Annotated, ErrorKind, Meta};
+
+use crate::{ClockDriftProcessor, TimestampProcessor};
+
+/// Configuration for [`validate_transaction`].
+#[derive(Debug, Default)]
+pub struct TransactionValidationConfig {
+    /// Timestamp range in which a transaction must end.
+    ///
+    /// Transactions that finish outside this range are invalid. The check is
+    /// skipped if no range is provided.
+    pub timestamp_range: Option<Range<UnixTimestamp>>,
+}
+
+/// Validates a transaction.
+///
+/// Validation consists of performing multiple checks on the payload, based on
+/// the given configuration. Noop for non-transaction events.
+///
+/// The returned [`ProcessingResult`] indicates whether the passed transaction
+/// is invalid and thus should be dropped.
+///
+/// Note: this function does not validate a transaction's timestamp values are
+/// up-to-date, [`validate_event_timestamps`] should be used for that.
+pub fn validate_transaction(
+    event: &Annotated<Event>,
+    config: &TransactionValidationConfig,
+) -> ProcessingResult {
+    let Annotated(Some(ref event), ref _meta) = event else {
+        return Ok(());
+    };
+    if event.ty.value() != Some(&EventType::Transaction) {
+        return Ok(());
+    }
+
+    validate_transaction_timestamps(event, config)?;
+    validate_trace_context(event)?;
+    validate_spans(event)?;
+
+    Ok(())
+}
+
+/// Returns whether the transacion's start and end timestamps are both set and start <= end.
+fn validate_transaction_timestamps(
+    transaction_event: &Event,
+    config: &TransactionValidationConfig,
+) -> ProcessingResult {
+    match (
+        transaction_event.start_timestamp.value(),
+        transaction_event.timestamp.value(),
+    ) {
+        (Some(start), Some(end)) => {
+            if end < start {
+                return Err(ProcessingAction::InvalidTransaction(
+                    "end timestamp is smaller than start timestamp",
+                ));
+            }
+
+            if let Some(ref range) = config.timestamp_range {
+                let Some(timestamp) = UnixTimestamp::from_datetime(end.into_inner()) else {
+                    return Err(ProcessingAction::InvalidTransaction(
+                        "invalid unix timestamp",
+                    ));
+                };
+                if !range.contains(&timestamp) {
+                    return Err(ProcessingAction::InvalidTransaction(
+                        "timestamp is out of the valid range for metrics",
+                    ));
+                }
+            }
+
+            Ok(())
+        }
+        (_, None) => Err(ProcessingAction::InvalidTransaction(
+            "timestamp hard-required for transaction events",
+        )),
+        // XXX: Maybe copy timestamp over?
+        (None, _) => Err(ProcessingAction::InvalidTransaction(
+            "start_timestamp hard-required for transaction events",
+        )),
+    }
+}
+
+/// Validates the trace context in a transaction.
+///
+/// A [`ProcessingResult`] error is returned if the context is not valid. The
+/// context is valid if the trace context meets the following conditions:
+/// - It exists.
+/// - It has a trace id.
+/// - It has a span id.
+fn validate_trace_context(transaction: &Event) -> ProcessingResult {
+    let Some(trace_context) = transaction.context::<TraceContext>() else {
+        return Err(ProcessingAction::InvalidTransaction(
+            "missing valid trace context",
+        ));
+    };
+
+    if trace_context.trace_id.value().is_none() {
+        return Err(ProcessingAction::InvalidTransaction(
+            "trace context is missing trace_id",
+        ));
+    }
+
+    if trace_context.span_id.value().is_none() {
+        return Err(ProcessingAction::InvalidTransaction(
+            "trace context is missing span_id",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validates the spans in the transaction.
+///
+/// A [`ProcessingResult`] error is returned if there's an invalid span. For
+/// span validity, see [`validate_span`].
+fn validate_spans(transaction: &Event) -> ProcessingResult {
+    let Some(spans) = transaction.spans.value() else {
+        return Ok(());
+    };
+
+    for span in spans {
+        if let Some(span) = span.value() {
+            validate_span(span)?;
+        } else {
+            return Err(ProcessingAction::InvalidTransaction(
+                "spans must be valid in transaction event",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates a span.
+///
+/// A [`ProcessingResult`] error is returned when the span is invalid. A span is
+/// valid if all the following conditions are met:
+/// - A start timestamp exists.
+/// - An end timestamp exists.
+/// - Start timestamp must be no later than end timestamp.
+/// - A trace id exists.
+/// - A span id exists.
+pub fn validate_span(span: &Span) -> ProcessingResult {
+    match (span.start_timestamp.value(), span.timestamp.value()) {
+        (Some(start), Some(end)) => {
+            if end < start {
+                return Err(ProcessingAction::InvalidTransaction(
+                    "end timestamp in span is smaller than start timestamp",
+                ));
+            }
+        }
+        (_, None) => {
+            // XXX: Maybe do the same as event.timestamp?
+            return Err(ProcessingAction::InvalidTransaction(
+                "span is missing timestamp",
+            ));
+        }
+        (None, _) => {
+            // XXX: Maybe copy timestamp over?
+            return Err(ProcessingAction::InvalidTransaction(
+                "span is missing start_timestamp",
+            ));
+        }
+    }
+
+    if span.trace_id.value().is_none() {
+        return Err(ProcessingAction::InvalidTransaction(
+            "span is missing trace_id",
+        ));
+    }
+
+    if span.span_id.value().is_none() {
+        return Err(ProcessingAction::InvalidTransaction(
+            "span is missing span_id",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Configuration for [`validate_event_timestamps`].
+#[derive(Debug, Default)]
+pub struct EventValidationConfig {
+    /// The time at which the event was received in this Relay.
+    ///
+    /// This timestamp is persisted into the event payload.
+    pub received_at: Option<DateTime<Utc>>,
+
+    /// The maximum amount of seconds an event can be dated in the past.
+    ///
+    /// If the event's timestamp is older, the received timestamp is assumed.
+    pub max_secs_in_past: Option<i64>,
+
+    /// The maximum amount of seconds an event can be predated into the future.
+    ///
+    /// If the event's timestamp lies further into the future, the received timestamp is assumed.
+    pub max_secs_in_future: Option<i64>,
+}
+
+/// Validates the timestamp values of an event, after performing minimal timestamp normalization.
+///
+/// A minimal normalization is performed on an event's timestamps before
+/// checking for validity, like clock drift correction. This normalization
+/// depends on the given configuration.
+///
+/// Validation is checked individually on timestamps. Use
+/// [`validate_transaction`] to perform additional transaction-specific checks.
+///
+/// The returned [`ProcessingResult`] indicates whether the event is invalid and
+/// thus should be dropped.
+///
+/// Normalization changes should not be performed during validation, unless
+/// strictly required. Consider adding placing the normalization in
+/// [`crate::event::normalize_event`].
+pub fn validate_event_timestamps(
+    event: &mut Annotated<Event>,
+    config: &EventValidationConfig,
+) -> ProcessingResult {
+    let Annotated(Some(ref mut event), ref mut meta) = event else {
+        return Ok(());
+    };
+
+    //  timestamp processor is required in validation, and requires the clockdrift changes
+    normalize_timestamps(
+        event,
+        meta,
+        config.received_at,
+        config.max_secs_in_past,
+        config.max_secs_in_future,
+    ); // Timestamps are core in the metrics extraction
+    TimestampProcessor.process_event(event, meta, ProcessingState::root())?;
+
+    Ok(())
+}
+
+/// Validates the timestamp range and sets a default value.
+fn normalize_timestamps(
+    event: &mut Event,
+    meta: &mut Meta,
+    received_at: Option<DateTime<Utc>>,
+    max_secs_in_past: Option<i64>,
+    max_secs_in_future: Option<i64>,
+) {
+    let received_at = received_at.unwrap_or_else(Utc::now);
+
+    let mut sent_at = None;
+    let mut error_kind = ErrorKind::ClockDrift;
+
+    let _ = processor::apply(&mut event.timestamp, |timestamp, _meta| {
+        if let Some(secs) = max_secs_in_future {
+            if *timestamp > received_at + Duration::seconds(secs) {
+                error_kind = ErrorKind::FutureTimestamp;
+                sent_at = Some(*timestamp);
+                return Ok(());
+            }
+        }
+
+        if let Some(secs) = max_secs_in_past {
+            if *timestamp < received_at - Duration::seconds(secs) {
+                error_kind = ErrorKind::PastTimestamp;
+                sent_at = Some(*timestamp);
+                return Ok(());
+            }
+        }
+
+        Ok(())
+    });
+
+    let _ = ClockDriftProcessor::new(sent_at.map(|ts| ts.into_inner()), received_at)
+        .error_kind(error_kind)
+        .process_event(event, meta, ProcessingState::root());
+
+    // Apply this after clock drift correction, otherwise we will malform it.
+    event.received = Annotated::new(received_at.into());
+
+    if event.timestamp.value().is_none() {
+        event.timestamp.set_value(Some(received_at.into()));
+    }
+
+    let _ = processor::apply(&mut event.time_spent, |time_spent, _| {
+        validate_bounded_integer_field(*time_spent)
+    });
+}
+
+/// Validate fields that go into a `sentry.models.BoundedIntegerField`.
+fn validate_bounded_integer_field(value: u64) -> ProcessingResult {
+    if value < 2_147_483_647 {
+        Ok(())
+    } else {
+        Err(ProcessingAction::DeleteValueHard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use relay_event_schema::protocol::{Contexts, SpanId, TraceId};
+    use relay_protocol::Object;
+
+    use super::*;
+
+    fn new_test_event() -> Annotated<Event> {
+        let start = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 10).unwrap();
+        Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            transaction: Annotated::new("/".to_owned()),
+            start_timestamp: Annotated::new(start.into()),
+            timestamp: Annotated::new(end.into()),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                    op: Annotated::new("http.server".to_owned()),
+                    ..Default::default()
+                });
+                Annotated::new(contexts)
+            },
+            spans: Annotated::new(vec![Annotated::new(Span {
+                start_timestamp: Annotated::new(start.into()),
+                timestamp: Annotated::new(end.into()),
+                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                op: Annotated::new("db.statement".to_owned()),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_discards_when_missing_timestamp() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "timestamp hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_when_timestamp_out_of_range() {
+        let event = new_test_event();
+
+        assert!(matches!(
+            validate_transaction(
+                &event,
+                &TransactionValidationConfig {
+                    timestamp_range: Some(UnixTimestamp::now()..UnixTimestamp::now()),
+                }
+            ),
+            Err(ProcessingAction::InvalidTransaction(
+                "timestamp is out of the valid range for metrics"
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_discards_when_missing_start_timestamp() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "start_timestamp hard-required for transaction events"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_contexts_map() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(
+                &event,
+                &TransactionValidationConfig {
+                    timestamp_range: None
+                }
+            ),
+            Err(ProcessingAction::InvalidTransaction(
+                "missing valid trace context"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_context() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: Annotated::new(Contexts::new()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(
+                &event,
+                &TransactionValidationConfig {
+                    timestamp_range: None
+                }
+            ),
+            Err(ProcessingAction::InvalidTransaction(
+                "missing valid trace context"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_null_context() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: Annotated::new(Contexts({
+                let mut contexts = Object::new();
+                contexts.insert("trace".to_owned(), Annotated::empty());
+                contexts
+            })),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "missing valid trace context"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_trace_id_in_context() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext::default());
+                Annotated::new(contexts)
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "trace context is missing trace_id"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_on_missing_span_id_in_context() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    ..Default::default()
+                });
+                Annotated::new(contexts)
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "trace context is missing span_id"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_nulled_out_span() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                    op: Annotated::new("http.server".to_owned()),
+                    ..Default::default()
+                });
+                Annotated::new(contexts)
+            },
+            spans: Annotated::new(vec![Annotated::empty()]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "spans must be valid in transaction event"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_start_timestamp() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                    op: Annotated::new("http.server".to_owned()),
+                    ..Default::default()
+                });
+                Annotated::new(contexts)
+            },
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(
+                    Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+                ),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "span is missing start_timestamp"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_trace_id() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                    op: Annotated::new("http.server".to_owned()),
+                    ..Default::default()
+                });
+                Annotated::new(contexts)
+            },
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(
+                    Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+                ),
+                start_timestamp: Annotated::new(
+                    Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+                ),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "span is missing trace_id"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_discards_transaction_event_with_span_with_missing_span_id() {
+        let event = Annotated::new(Event {
+            ty: Annotated::new(EventType::Transaction),
+            timestamp: Annotated::new(Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into()),
+            start_timestamp: Annotated::new(
+                Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+            ),
+            contexts: {
+                let mut contexts = Contexts::new();
+                contexts.add(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                    op: Annotated::new("http.server".to_owned()),
+                    ..Default::default()
+                });
+                Annotated::new(contexts)
+            },
+            spans: Annotated::new(vec![Annotated::new(Span {
+                timestamp: Annotated::new(
+                    Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+                ),
+                start_timestamp: Annotated::new(
+                    Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap().into(),
+                ),
+                trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            validate_transaction(&event, &TransactionValidationConfig::default()),
+            Err(ProcessingAction::InvalidTransaction(
+                "span is missing span_id"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_reject_stale_transaction() {
+        let json = r#"{
+  "event_id": "52df9022835246eeb317dbd739ccd059",
+  "start_timestamp": -2,
+  "timestamp": -1
+}"#;
+        let mut transaction = Annotated::<Event>::from_json(json).unwrap();
+        let res = validate_event_timestamps(&mut transaction, &EventValidationConfig::default());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "invalid transaction event: timestamp is too stale"
+        );
+    }
+
+    /// Test that timestamp normalization updates a transaction's timestamps to
+    /// be acceptable, when both timestamps are similarly stale.
+    #[test]
+    fn test_accept_recent_transactions_with_stale_timestamps() {
+        let config = EventValidationConfig {
+            received_at: Some(Utc::now()),
+            max_secs_in_past: Some(2),
+            max_secs_in_future: Some(1),
+        };
+
+        let json = r#"{
+  "event_id": "52df9022835246eeb317dbd739ccd059",
+  "transaction": "I have a stale timestamp, but I'm recent!",
+  "start_timestamp": -2,
+  "timestamp": -1
+}"#;
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+
+        assert!(validate_event_timestamps(&mut event, &config).is_ok());
+    }
+
+    /// Test that transactions are rejected as invalid when timestamp normalization isn't enough.
+    ///
+    /// When the end timestamp is recent but the start timestamp is stale, timestamp normalization
+    /// will fix the timestamps based on the end timestamp. The start timestamp will be more recent,
+    /// but not recent enough for the transaction to be accepted. The transaction will be rejected.
+    #[test]
+    fn test_reject_stale_transactions_after_timestamp_normalization() {
+        let now = Utc::now();
+        let config = EventValidationConfig {
+            received_at: Some(now),
+            max_secs_in_past: Some(2),
+            max_secs_in_future: Some(1),
+        };
+
+        let json = format!(
+            r#"{{
+          "event_id": "52df9022835246eeb317dbd739ccd059",
+          "transaction": "clockdrift is not enough to accept me :(",
+          "start_timestamp": -62135811111,
+          "timestamp": {}
+        }}"#,
+            now.timestamp()
+        );
+        let mut event = Annotated::<Event>::from_json(json.as_str()).unwrap();
+
+        assert_eq!(
+            validate_event_timestamps(&mut event, &config)
+                .unwrap_err()
+                .to_string(),
+            "invalid transaction event: timestamp is too stale"
+        );
+    }
+}

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -63,10 +63,7 @@ pub fn extract_metrics(event: &Event, config: &MetricExtractionConfig) -> Vec<Bu
 mod tests {
     use chrono::{DateTime, Utc};
     use relay_dynamic_config::{Feature, FeatureSet, ProjectConfig};
-    use relay_event_normalization::{
-        normalize_event, validate_event_timestamps, validate_transaction, EventValidationConfig,
-        NormalizationConfig, TransactionValidationConfig,
-    };
+    use relay_event_normalization::{normalize_event, NormalizationConfig};
     use relay_event_schema::protocol::Timestamp;
     use relay_protocol::Annotated;
     use std::collections::BTreeSet;
@@ -499,13 +496,6 @@ mod tests {
 
         let mut event = Annotated::from_json(json).unwrap();
         let features = FeatureSet(BTreeSet::from([Feature::SpanMetricsExtraction]));
-
-        // Validate and normalize first, to make sure that all things are correct as in the real pipeline:
-        let res = validate_transaction(&event, &TransactionValidationConfig::default());
-        assert!(res.is_ok());
-
-        let res = validate_event_timestamps(&mut event, &EventValidationConfig::default());
-        assert!(res.is_ok());
 
         normalize_event(
             &mut event,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1100,7 +1100,8 @@ impl EnvelopeProcessorService {
             };
 
             metric!(timer(RelayTimers::EventProcessingLightNormalization), {
-                validate_transaction(event, &tx_validation_config)?;
+                validate_transaction(event, &tx_validation_config)
+                    .map_err(|_| ProcessingError::InvalidTransaction)?;
                 validate_event_timestamps(event, &event_validation_config)
                     .map_err(|_| ProcessingError::InvalidTransaction)?;
                 normalize_event(event, &normalization_config);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -19,8 +19,9 @@ use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding};
 use relay_dynamic_config::{ErrorBoundary, Feature};
 use relay_event_normalization::{
-    normalize_event, ClockDriftProcessor, DynamicMeasurementsConfig, MeasurementsConfig,
-    NormalizationConfig, TransactionNameConfig,
+    normalize_event, validate_event_timestamps, validate_transaction, ClockDriftProcessor,
+    DynamicMeasurementsConfig, EventValidationConfig, MeasurementsConfig, NormalizationConfig,
+    TransactionNameConfig, TransactionValidationConfig,
 };
 use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo};
 use relay_event_schema::processor::ProcessingAction;
@@ -1049,18 +1050,22 @@ impl EnvelopeProcessorService {
         let global_config = self.inner.global_config.current();
 
         utils::log_transaction_name_metrics(&mut state.event, |event| {
-            let config = NormalizationConfig {
+            let tx_validation_config = TransactionValidationConfig {
+                timestamp_range: Some(
+                    AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
+                ),
+            };
+            let event_validation_config = EventValidationConfig {
+                received_at: Some(state.managed_envelope.received_at()),
+                max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
+                max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
+            };
+            let normalization_config = NormalizationConfig {
                 client_ip: client_ipaddr.as_ref(),
                 user_agent: RawUserAgentInfo {
                     user_agent: request_meta.user_agent(),
                     client_hints: request_meta.client_hints().as_deref(),
                 },
-                received_at: Some(state.managed_envelope.received_at()),
-                max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
-                max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
-                transaction_range: Some(
-                    AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
-                ),
                 max_name_and_unit_len: Some(
                     transaction_aggregator_config
                         .max_name_length
@@ -1095,7 +1100,11 @@ impl EnvelopeProcessorService {
             };
 
             metric!(timer(RelayTimers::EventProcessingLightNormalization), {
-                normalize_event(event, &config).map_err(|_| ProcessingError::InvalidTransaction)
+                validate_transaction(event, &tx_validation_config)?;
+                validate_event_timestamps(event, &event_validation_config)
+                    .map_err(|_| ProcessingError::InvalidTransaction)?;
+                normalize_event(event, &normalization_config);
+                Result::<(), ProcessingError>::Ok(())
             })
         })?;
 
@@ -2690,8 +2699,7 @@ mod tests {
                     ..Default::default()
                 };
                 normalize_event(event, &config)
-            })
-            .unwrap();
+            });
         })
     }
 

--- a/relay-server/tests/test_fixtures.rs
+++ b/relay-server/tests/test_fixtures.rs
@@ -1,7 +1,8 @@
 use std::fs;
 
 use relay_event_normalization::{
-    normalize_event, NormalizationConfig, StoreConfig, StoreProcessor,
+    normalize_event, validate_event_timestamps, validate_transaction, EventValidationConfig,
+    NormalizationConfig, StoreConfig, StoreProcessor, TransactionValidationConfig,
 };
 use relay_event_schema::processor::{process_value, ProcessingState};
 use relay_event_schema::protocol::Event;
@@ -71,7 +72,9 @@ macro_rules! event_snapshot {
             fn test_processing() {
                 let mut event = load_fixture();
 
-                normalize_event(&mut event, &NormalizationConfig::default()).unwrap();
+                validate_transaction(&event, &TransactionValidationConfig::default()).unwrap();
+                validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
+                normalize_event(&mut event, &NormalizationConfig::default());
 
                 let config = StoreConfig::default();
                 let mut processor = StoreProcessor::new(config, None);


### PR DESCRIPTION
This PR splits the event validation from normalization, making normalization infallible. The goal is to have two separate steps: a validation step that errors on invalid events, and an infallible normalization with the single responsibility of normalizing events. There are no functional changes in the PR.

## Design choice: a 2-step validation
Validating timestamps requires some timestamp normalization (e.g. clock drift correction), meaning the original goal of having a single validation accepting an immutable event is not easily achievable in a clean way. As a result, validation consists of two steps: a transaction validation step accepting an immutable event, and a timestamp validation step performing _minimal_ normalization. Alternatively, a small pre-validation normalization step was considered, discarded for generating too much confusion.

Further, we rely on the developer to be aware of calling the right validation function(s) and not extending the minimal normalization during validation. This has been documented in the functions.

## Future work

- Although a 2-step validation moves us closer to the goal, it's not great. This decision may be revisited as part of a larger processing pipeline changes.


#skip-changelog