### PR TITLE
chore(processor): Remove legacy processe state function

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -460,15 +460,6 @@ impl<'a> ProcessEnvelopeState<'a> {
         self.managed_envelope.envelope_mut()
     }
 
-    /// Returns whether any item in the envelope creates an event in any relay.
-    ///
-    /// This is used to branch into the processing pipeline. If this function returns false, only
-    /// rate limits are executed. If this function returns true, an event is created either in the
-    /// current relay or in an upstream processing relay.
-    fn creates_event(&self) -> bool {
-        self.envelope().items().any(Item::creates_event)
-    }
-
     /// Returns true if there is an event in the processing state.
     ///
     /// The event was previously removed from the Envelope. This returns false if there was an
@@ -1288,86 +1279,6 @@ impl EnvelopeProcessorService {
         Ok(())
     }
 
-    /// Legacy implementation of the `process_state` function, which is used for all
-    /// unknown [`ProcessingGroup`] variant.
-    ///
-    /// Note: this will be removed once we are confident in the new implementation and make sure
-    /// that all the groups properly covered.
-    fn process_state_legacy(
-        &self,
-        state: &mut ProcessEnvelopeState,
-    ) -> Result<(), ProcessingError> {
-        session::process(state, &self.inner.config);
-        report::process_client_reports(
-            state,
-            &self.inner.config,
-            self.inner.outcome_aggregator.clone(),
-        );
-        report::process_user_reports(state);
-        replay::process(state, &self.inner.config)?;
-        profile::filter(state);
-        span::filter(state);
-
-        if state.creates_event() {
-            // Some envelopes only create events in processing relays; for example, unreal events.
-            // This makes it possible to get in this code block while not really having an event in
-            // the envelope.
-
-            if_processing!(self.inner.config, {
-                unreal::expand(state, &self.inner.config)?;
-            });
-
-            event::extract(state, &self.inner.config)?;
-            profile::transfer_id(state);
-
-            if_processing!(self.inner.config, {
-                unreal::process(state)?;
-                attachment::create_placeholders(state);
-            });
-
-            event::finalize(state, &self.inner.config)?;
-            self.light_normalize_event(state)?;
-            dynamic_sampling::normalize(state);
-            event::filter(state)?;
-            dynamic_sampling::run(state, &self.inner.config);
-
-            // We avoid extracting metrics if we are not sampling the event while in non-processing
-            // relays, in order to synchronize rate limits on indexed and processed transactions.
-            if self.inner.config.processing_enabled() || state.sampling_result.should_drop() {
-                self.extract_metrics(state)?;
-            }
-
-            dynamic_sampling::sample_envelope_items(state);
-
-            if_processing!(self.inner.config, {
-                event::store(state, &self.inner.config, self.inner.geoip_lookup.as_ref())?;
-            });
-        }
-
-        if_processing!(self.inner.config, {
-            self.enforce_quotas(state)?;
-            profile::process(state, &self.inner.config);
-            self.process_check_ins(state);
-            span::process(
-                state,
-                self.inner.config.clone(),
-                self.inner.global_config.current().measurements.as_ref(),
-            );
-        });
-
-        if state.has_event() {
-            event::scrub(state)?;
-            event::serialize(state)?;
-            if_processing!(self.inner.config, {
-                span::extract_from_event(state);
-            });
-        }
-
-        attachment::scrub(state);
-
-        Ok(())
-    }
-
     fn process_state(&self, state: &mut ProcessEnvelopeState) -> Result<(), ProcessingError> {
         // Get the group from the managed envelope context, and if it's not set, try to guess it
         // from the contents of the envelope.
@@ -1391,9 +1302,6 @@ impl EnvelopeProcessorService {
                     items = ?state.envelope().items().next().map(Item::ty),
                     "Could not identify the processing group based on the envelope's items"
                 );
-
-                // Call the legacy implementation of the `process_state` function.
-                self.process_state_legacy(state)?;
             }
             // Leave this group unchanged.
             //

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -284,7 +284,12 @@ mod tests {
         let (outcome_aggregator, test_store) = testutils::processor_services();
 
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
+            envelope: ManagedEnvelope::standalone(
+                envelope,
+                outcome_aggregator,
+                test_store,
+                ProcessingGroup::Transaction,
+            ),
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state,
             reservoir_counters: ReservoirCounters::default(),

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -188,8 +188,14 @@ mod tests {
         let mut project_state = ProjectState::allowed();
         project_state.config.features.0.insert(Feature::Profiling);
 
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
+        assert_eq!(envelopes.len(), 1);
+
+        let (group, envelope) = envelopes.pop().unwrap();
+        let envelope = ManagedEnvelope::standalone(envelope, Addr::dummy(), Addr::dummy(), group);
+
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, Addr::dummy(), Addr::dummy()),
+            envelope,
             project_state: Arc::new(project_state),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
@@ -252,13 +258,12 @@ mod tests {
         let mut project_state = ProjectState::allowed();
         project_state.config.features.0.insert(Feature::Profiling);
 
-        let envelopes = ProcessingGroup::split_envelope(*envelope);
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
         assert_eq!(envelopes.len(), 1);
 
-        let (group, envelope) = envelopes.first().unwrap();
-        let mut envelope =
-            ManagedEnvelope::standalone(envelope.clone(), Addr::dummy(), Addr::dummy());
-        envelope.set_processing_group(*group);
+        let (group, envelope) = envelopes.pop().unwrap();
+        let envelope =
+            ManagedEnvelope::standalone(envelope.clone(), Addr::dummy(), Addr::dummy(), group);
 
         let message = ProcessEnvelope {
             envelope,

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -310,8 +310,13 @@ mod tests {
             item
         });
 
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
+        assert_eq!(envelopes.len(), 1);
+        let (group, envelope) = envelopes.pop().unwrap();
+
+        let envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store, group);
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
+            envelope,
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
@@ -359,8 +364,13 @@ mod tests {
             item
         });
 
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
+        assert_eq!(envelopes.len(), 1);
+        let (group, envelope) = envelopes.pop().unwrap();
+        let envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store, group);
+
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
+            envelope,
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
@@ -416,8 +426,13 @@ mod tests {
             item
         });
 
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
+        assert_eq!(envelopes.len(), 1);
+
+        let (group, envelope) = envelopes.pop().unwrap();
+        let envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store, group);
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
+            envelope,
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),
@@ -450,9 +465,12 @@ mod tests {
             item
         });
 
-        let mut envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store);
-        envelope.set_processing_group(ProcessingGroup::Standalone);
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
+        assert_eq!(envelopes.len(), 1);
 
+        let (group, envelope) = envelopes.pop().unwrap();
+
+        let envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store, group);
         let message = ProcessEnvelope {
             envelope,
             project_state: Arc::new(ProjectState::allowed()),
@@ -496,8 +514,13 @@ mod tests {
             item
         });
 
+        let mut envelopes = ProcessingGroup::split_envelope(*envelope);
+        assert_eq!(envelopes.len(), 1);
+        let (group, envelope) = envelopes.pop().unwrap();
+        let envelope = ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store, group);
+
         let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::standalone(envelope, outcome_aggregator, test_store),
+            envelope,
             project_state: Arc::new(ProjectState::allowed()),
             sampling_project_state: None,
             reservoir_counters: ReservoirCounters::default(),

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -116,11 +116,6 @@ impl ManagedEnvelope {
     }
 
     #[cfg(test)]
-    pub fn set_processing_group(&mut self, group: ProcessingGroup) {
-        self.context.group = group
-    }
-
-    #[cfg(test)]
     pub fn untracked(
         envelope: Box<Envelope>,
         outcome_aggregator: Addr<TrackOutcome>,
@@ -148,14 +143,9 @@ impl ManagedEnvelope {
         envelope: Box<Envelope>,
         outcome_aggregator: Addr<TrackOutcome>,
         test_store: Addr<TestStore>,
+        group: ProcessingGroup,
     ) -> Self {
-        Self::new_internal(
-            envelope,
-            None,
-            outcome_aggregator,
-            test_store,
-            ProcessingGroup::Ungrouped,
-        )
+        Self::new_internal(envelope, None, outcome_aggregator, test_store, group)
     }
 
     /// Computes a managed envelope from the given envelope and binds it to the processing queue.


### PR DESCRIPTION
Remove the call to legacy `process_state` function and also the function itself. 

Running the new grouped processing pipeline for the last few weeks showed that all the events are grouped and processed. But we still have the error in `Ungrouped` branch, and will see if something is regressed. 

The changes also include:
* adding `Metrics` processing group
* using `ProcessingGroup::split_envelope` function in test and also assert that correct group is assigned for the processing
* update `ManagedEnvelope::standalone` function to also accept the `ProcessingGroup` as an argument
 

related to: #2862 https://github.com/getsentry/team-ingest/issues/253

#skip-changelog