### PR TITLE
ref(log): Strip trace and debug logs from release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add possiblity to block metrics or their tags with glob-patterns. ([#2954](https://github.com/getsentry/relay/pull/2954), [#2973](https://github.com/getsentry/relay/pull/2973))
 - Forward profiles of non-sampled transactions. ([#2940](https://github.com/getsentry/relay/pull/2940))
 - Enable throttled periodic unspool of the buffered envelopes. ([#2993](https://github.com/getsentry/relay/pull/2993))
+- Strip trace and debug logs from release builds. ([#3011](https://github.com/getsentry/relay/pull/3011))
 
 **Bug Fixes**:
 

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", default-features = false, features = [
 ], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-tracing = "0.1.37"
+tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",
     "json",


### PR DESCRIPTION
Strips all trace and debug logs from a release build.

This has the downside that debugging a release build (docker container) may become harder. So maybe not worth it.