### PR TITLE
ref(normalization): Move LegacyProcessor to normalization

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -24,7 +24,7 @@ use crate::normalize::request;
 use crate::span::tag_extraction::{self, extract_span_tags};
 use crate::utils::{self, MAX_DURATION_MOBILE_MS};
 use crate::{
-    breakdowns, mechanism, schema, span, stacktrace, transactions, trimming, user_agent,
+    breakdowns, legacy, mechanism, schema, span, stacktrace, transactions, trimming, user_agent,
     BreakdownsConfig, DynamicMeasurementsConfig, GeoIpLookup, PerformanceScoreConfig,
     RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig,
 };
@@ -139,6 +139,9 @@ pub fn normalize_event(event: &mut Annotated<Event>, config: &NormalizationConfi
     };
 
     let is_renormalize = config.is_renormalize;
+
+    // Convert legacy data structures to current format
+    let _ = legacy::LegacyProcessor.process_event(event, meta, ProcessingState::root());
 
     if !is_renormalize {
         normalize(event, meta, config);

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -201,9 +201,6 @@ impl<'a> Processor for StoreProcessor<'a> {
         let is_renormalize = self.config.is_renormalize.unwrap_or(false);
         let remove_other = self.config.remove_other.unwrap_or(!is_renormalize);
 
-        // Convert legacy data structures to current format
-        legacy::LegacyProcessor.process_event(event, meta, state)?;
-
         if !is_renormalize {
             // Normalize data in all interfaces
             self.normalize.process_event(event, meta, state)?;


### PR DESCRIPTION
As we move towards the goal of removing `StoreProcessor` and merging its functionality into the new normalization, this PR moves the first step: `LegacyProcessor`. This is not a breaking change, as `normalize_event` always runs before `StoreProcessor`, including in [librelay](https://github.com/getsentry/relay/blob/0e7b0d022c49f20cd0c48c676ea7a4a86a1e590d/relay-cabi/src/processing.rs#L152).

#skip-changelog