### PR TITLE
ref(cardinality): Clean old values from cardinality cache

### DIFF
--- a/relay-cardinality/benches/redis_impl.rs
+++ b/relay-cardinality/benches/redis_impl.rs
@@ -1,10 +1,13 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::{
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
 
 use criterion::{BatchSize, BenchmarkId, Criterion};
 use relay_base_schema::{metrics::MetricNamespace, project::ProjectId};
 use relay_cardinality::{
     limiter::{Entry, EntryId, Limiter, Rejections, Scoping},
-    CardinalityLimit, CardinalityScope, RedisSetLimiter, SlidingWindow,
+    CardinalityLimit, CardinalityScope, RedisSetLimiter, RedisSetLimiterOptions, SlidingWindow,
 };
 use relay_redis::{redis, RedisConfigOptions, RedisPool};
 
@@ -23,7 +26,12 @@ fn build_limiter(redis: RedisPool, reset_redis: bool) -> RedisSetLimiter {
         redis::cmd("FLUSHALL").execute(&mut connection);
     }
 
-    RedisSetLimiter::new(redis)
+    RedisSetLimiter::new(
+        RedisSetLimiterOptions {
+            cache_vacuum_interval: Duration::from_secs(180),
+        },
+        redis,
+    )
 }
 
 struct NoopRejections;

--- a/relay-cardinality/src/lib.rs
+++ b/relay-cardinality/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::config::*;
 pub use self::error::*;
 pub use self::limiter::{CardinalityItem, CardinalityLimits, Scoping};
 #[cfg(feature = "redis")]
-pub use self::redis::RedisSetLimiter;
+pub use self::redis::{RedisSetLimiter, RedisSetLimiterOptions};
 pub use self::window::SlidingWindow;
 
 /// Redis Set based cardinality limiter.

--- a/relay-cardinality/src/redis/mod.rs
+++ b/relay-cardinality/src/redis/mod.rs
@@ -4,4 +4,4 @@ mod script;
 
 use self::limiter::*;
 
-pub use self::limiter::RedisSetLimiter;
+pub use self::limiter::{RedisSetLimiter, RedisSetLimiterOptions};

--- a/relay-cardinality/src/statsd.rs
+++ b/relay-cardinality/src/statsd.rs
@@ -26,6 +26,9 @@ pub enum CardinalityLimiterCounters {
     ///  - `id`: The id of the enforced limit.
     #[cfg(feature = "redis")]
     RedisCacheMiss,
+    /// Amount of entries removed from the cache via periodic cleanups.
+    #[cfg(feature = "redis")]
+    RedisCacheVacuum,
 }
 
 impl CounterMetric for CardinalityLimiterCounters {
@@ -39,6 +42,8 @@ impl CounterMetric for CardinalityLimiterCounters {
             Self::RedisCacheHit => "cardinality.limiter.redis.cache_hit",
             #[cfg(feature = "redis")]
             Self::RedisCacheMiss => "cardinality.limiter.redis.cache_miss",
+            #[cfg(feature = "redis")]
+            Self::RedisCacheVacuum => "cardinality.limiter.redis.cache_vacuum",
         }
     }
 }
@@ -52,6 +57,10 @@ pub enum CardinalityLimiterTimers {
     ///  - `id`: The id of the enforced limit.
     #[cfg(feature = "redis")]
     Redis,
+    /// Timer tracking the amount of time spent removing expired values
+    /// from the cardinality cache.
+    #[cfg(feature = "redis")]
+    CacheVacuum,
 }
 
 impl TimerMetric for CardinalityLimiterTimers {
@@ -60,6 +69,10 @@ impl TimerMetric for CardinalityLimiterTimers {
             CardinalityLimiterTimers::CardinalityLimiter => "cardinality.limiter.duration",
             #[cfg(feature = "redis")]
             CardinalityLimiterTimers::Redis => "cardinality.limiter.redis.duration",
+            #[cfg(feature = "redis")]
+            CardinalityLimiterTimers::CacheVacuum => {
+                "cardinality.limiter.redis.cache_vacuum.duration"
+            }
         }
     }
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1282,9 +1282,24 @@ pub struct GeoIpConfig {
 }
 
 /// Cardinality Limiter configuration options.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
-pub struct CardinalityLimiter {}
+pub struct CardinalityLimiter {
+    /// Cache vacuum interval in seconds for the in memory cache.
+    ///
+    /// The cache will scan for expired values based on this interval.
+    ///
+    /// Defaults to 180 seconds, 3 minutes.
+    pub cache_vacuum_interval: u64,
+}
+
+impl Default for CardinalityLimiter {
+    fn default() -> Self {
+        Self {
+            cache_vacuum_interval: 180,
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct ConfigValues {
@@ -2135,6 +2150,13 @@ impl Config {
     /// Maximum rate limit to report to clients in seconds.
     pub fn max_rate_limit(&self) -> Option<u64> {
         self.values.processing.max_rate_limit.map(u32::into)
+    }
+
+    /// Cache vacuum interval for the cardinality limiter in memory cache.
+    ///
+    /// The cache will scan for expired values based on this interval.
+    pub fn cardinality_limiter_cache_vacuum_interval(&self) -> Duration {
+        Duration::from_secs(self.values.cardinality_limiter.cache_vacuum_interval)
     }
 
     /// Creates an [`AggregatorConfig`] that is compatible with every other aggregator.


### PR DESCRIPTION
Old values may retain in cache when there are no longer arriving updates for these scopes. Periodically remove expired values from the cache.

#skip-changelog