### PR TITLE
fix(metrics): Do not report dropped buckets for disabled project

### DIFF
--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1291,7 +1291,7 @@ mod tests {
         project.state = State::Cached(project_state.into());
 
         let result = project.check_buckets_inner(Addr::custom().0, vec![]);
-        assert!(matches!(result, Err(CheckBucketsError::ProjectDisabled(0))));
+        assert!(matches!(result, CheckedBuckets::ProjectDisabled(0)));
     }
 
     #[tokio::test]

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1127,6 +1127,7 @@ impl Project {
         buckets: Vec<Bucket>,
     ) -> Option<(Scoping, ProjectMetrics)> {
         let len = buckets.len();
+
         let Some(project_state) = self.valid_state() else {
             relay_log::error!(
                 tags.project_key = self.project_key.as_str(),
@@ -1134,6 +1135,11 @@ impl Project {
             );
             return None;
         };
+
+        if project_state.invalid() || project_state.disabled() {
+            relay_log::debug!("dropping {len} buckets for disabled project");
+            return None;
+        }
 
         let Some(scoping) = self.scoping() else {
             relay_log::error!(


### PR DESCRIPTION
We started reporting errors for buckets dropped after aggregation in #2989. For disabled projects, we can drop silently though.

Fixes [POP-RELAY-2ZG](https://sentry.my.sentry.io/organizations/sentry/issues/541271/), [RELAY-2NQV](https://sentry.my.sentry.io/organizations/sentry/issues/541475/).

#skip-changelog