### PR TITLE
ref(cardinality): Drop timestamp from metrics partition for better caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Internal**:
 
 - Emit a usage metric for total spans. ([#3007](https://github.com/getsentry/relay/pull/3007))
+- Drop timestamp from metrics partition. ([#3025](https://github.com/getsentry/relay/pull/3025))
 
 ## 24.1.1
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2228,7 +2228,7 @@ fn partition_key(project_key: ProjectKey, bucket: &Bucket, partitions: Option<u6
     use std::hash::{Hash, Hasher};
 
     let partitions = partitions?.max(1);
-    let key = (project_key, bucket.timestamp, &bucket.name, &bucket.tags);
+    let key = (project_key, &bucket.name, &bucket.tags);
 
     let mut hasher = FnvHasher::default();
     key.hash(&mut hasher);

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -128,7 +128,7 @@ def test_metrics_backdated(mini_sentry, relay):
 
 @pytest.mark.parametrize(
     "metrics_partitions,expected_header",
-    [(None, None), (0, "0"), (1, "0"), (128, "34")],
+    [(None, None), (0, "0"), (1, "0"), (128, "17")],
 )
 def test_metrics_partition_key(mini_sentry, relay, metrics_partitions, expected_header):
     forever = 100 * 365 * 24 * 60 * 60  # *almost forever


### PR DESCRIPTION
Removes timestamp from partition key, to increase cardinality cache efficiency.

Closes: #3010