### PR TITLE
ref(cardinality): Store hashes in Redis as bytes instead of itoa

### DIFF
--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -96,7 +96,7 @@ impl CardinalityScript {
 
         let mut num_hashes = 0;
         for hash in hashes {
-            invocation.arg(hash);
+            invocation.arg(&hash.to_le_bytes());
             num_hashes += 1;
         }
 


### PR DESCRIPTION
Currently hashes in Redis are stored as a string, converted via `itoa`, which takes about 10 bytes for a 4 byte integer. Store the hashes as raw bytes instead.

This introduces a Redis key version, since the stored values will not be compatible with old values, to ensure that the cardinality limiter is reset and not rejecting all values until the sliding window resets.

#skip-changelog