### PR TITLE
fix(spans): Change default topic to push directly to Snuba in development

### DIFF
--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -151,7 +151,7 @@ impl Default for TopicAssignments {
             replay_events: "ingest-replay-events".to_owned().into(),
             replay_recordings: "ingest-replay-recordings".to_owned().into(),
             monitors: "ingest-monitors".to_owned().into(),
-            spans: "ingest-spans".to_owned().into(),
+            spans: "snuba-spans".to_owned().into(),
         }
     }
 }


### PR DESCRIPTION
We changed to push directly to Snuba in production but this config was defaulting to pushing to the topic for the Sentry consumer. This will push spans to the right topic in development so we can get them ingested by the Snuba consumer.

#skip-changelog