### PR TITLE
instr(server): Log project key for dropped envelopes

### DIFF
--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -328,6 +328,7 @@ impl ManagedEnvelope {
                 let summary = &self.context.summary;
 
                 relay_log::error!(
+                    tags.project_key = self.scoping().project_key.to_string(),
                     tags.has_attachments = summary.attachment_quantity > 0,
                     tags.has_sessions = summary.session_quantity > 0,
                     tags.has_profiles = summary.profile_quantity > 0,


### PR DESCRIPTION
This should help us figure out how many projects are affected by data loss, and whether it is only internal projects.

#skip-changelog
