### PR TITLE
chore(spool): Add buffer messsage processing timer

### DIFF
--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -343,6 +343,12 @@ pub enum RelayTimers {
     ///
     ///  - `message`: The type of message that was processed.
     ProcessMessageDuration,
+    /// Timing in milliseconds for processing a message in the buffer service.
+    ///
+    /// This metric is tagged with:
+    ///
+    ///  - `message`: The type of message that was processed.
+    BufferMessageProcessDuration,
 }
 
 impl TimerMetric for RelayTimers {
@@ -378,6 +384,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::ReplayRecordingProcessing => "replay.recording.process",
             RelayTimers::GlobalConfigRequestDuration => "global_config.requests.duration",
             RelayTimers::ProcessMessageDuration => "processor.message.duration",
+            RelayTimers::BufferMessageProcessDuration => "buffer.message.duration",
         }
     }
 }


### PR DESCRIPTION
Add timer for the duration of the incoming message processing in the buffer service. 

This should show us how much time it take to process each incoming message in the service, which in return helps to fine tune the service itself. 

related to: https://github.com/getsentry/team-ingest/issues/267


#skip-changelog