### PR TITLE
ref(cardinality): Do not lookup scoped cache for every update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,6 +3491,7 @@ version = "24.1.1"
 dependencies = [
  "criterion",
  "hashbrown 0.13.2",
+ "parking_lot",
  "relay-base-schema",
  "relay-common",
  "relay-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hash32 = "0.3.1"
 hashbrown = "0.13.2"
 itertools = "0.10.5"
 once_cell = "1.13.1"
+parking_lot = "0.12.1"
 rand = "0.8.5"
 regex = "1.10.2"
 serde = { version = "1.0.159", features = ["derive"] }

--- a/relay-cardinality/Cargo.toml
+++ b/relay-cardinality/Cargo.toml
@@ -16,8 +16,9 @@ redis = ["relay-redis/impl"]
 
 [dependencies]
 hashbrown = { workspace = true }
-relay-common = { path = "../relay-common" }
+parking_lot = { workspace = true }
 relay-base-schema = { path = "../relay-base-schema" }
+relay-common = { path = "../relay-common" }
 relay-log = { path = "../relay-log" }
 relay-redis = { path = "../relay-redis" }
 relay-statsd = { path = "../relay-statsd" }

--- a/relay-statsd/Cargo.toml
+++ b/relay-statsd/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 cadence = "0.29.0"
 crossbeam-channel = "0.5.6"
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 rand = { workspace = true }
 relay-log = { path = "../relay-log" }
 


### PR DESCRIPTION
Previously every `accept` call to insert a hash into the cache would lookup the scoped cache again. Using parking lot we can store an owned reference to the `ScopedCache`.

We're already using `parking_lot` elsewhere in Relay (directly and indirectly), it also get's rid of the lock poisoning and it is generally more performant than the std locks. 

#skip-changelog