### PR TITLE
ref(cardinality): Log Sentry errors for cardinality limits

### DIFF
--- a/relay-cardinality/benches/redis_impl.rs
+++ b/relay-cardinality/benches/redis_impl.rs
@@ -36,8 +36,8 @@ fn build_limiter(redis: RedisPool, reset_redis: bool) -> RedisSetLimiter {
 
 struct NoopRejections;
 
-impl Rejections for NoopRejections {
-    fn reject(&mut self, _entry_id: EntryId) {}
+impl<'a> Rejections<'a> for NoopRejections {
+    fn reject(&mut self, _limit_id: &'a str, _entry_id: EntryId) {}
 }
 
 #[derive(Debug)]

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -20,9 +20,9 @@ pub struct Scoping {
 }
 
 /// Accumulator of all cardinality limiter rejections.
-pub trait Rejections {
+pub trait Rejections<'a> {
     /// Called for ever [`Entry`] which was rejected from the [`Limiter`].
-    fn reject(&mut self, entry_id: EntryId);
+    fn reject(&mut self, limit_id: &'a str, entry_id: EntryId);
 }
 
 /// Limiter responsible to enforce limits.
@@ -30,16 +30,16 @@ pub trait Limiter {
     /// Verifies cardinality limits.
     ///
     /// Returns an iterator containing only accepted entries.
-    fn check_cardinality_limits<E, R>(
+    fn check_cardinality_limits<'a, E, R>(
         &self,
         scoping: Scoping,
-        limits: &[CardinalityLimit],
+        limits: &'a [CardinalityLimit],
         entries: E,
         rejections: &mut R,
     ) -> Result<()>
     where
         E: IntoIterator<Item = Entry>,
-        R: Rejections;
+        R: Rejections<'a>;
 }
 
 /// Unit of operation for the cardinality limiter.
@@ -100,18 +100,18 @@ impl<T: Limiter> CardinalityLimiter<T> {
     /// Checks cardinality limits of a list of buckets.
     ///
     /// Returns an iterator of all buckets that have been accepted.
-    pub fn check_cardinality_limits<I: CardinalityItem>(
+    pub fn check_cardinality_limits<'a, I: CardinalityItem>(
         &self,
         scoping: Scoping,
-        limits: &[CardinalityLimit],
+        limits: &'a [CardinalityLimit],
         items: Vec<I>,
-    ) -> Result<CardinalityLimits<I>, (Vec<I>, Error)> {
+    ) -> Result<CardinalityLimits<'a, I>, (Vec<I>, Error)> {
         metric!(timer(CardinalityLimiterTimers::CardinalityLimiter), {
             let entries = items.iter().enumerate().filter_map(|(id, item)| {
                 Some(Entry::new(EntryId(id), item.namespace()?, item.to_hash()))
             });
 
-            let mut rejections = RejectedIds::default();
+            let mut rejections = RejectionTracker::default();
             if let Err(err) =
                 self.limiter
                     .check_cardinality_limits(scoping, limits, entries, &mut rejections)
@@ -119,11 +119,11 @@ impl<T: Limiter> CardinalityLimiter<T> {
                 return Err((items, err));
             }
 
-            if !rejections.0.is_empty() {
+            if !rejections.entries.is_empty() {
                 relay_log::debug!(
                     scoping = ?scoping,
                     "rejected {} metrics due to cardinality limit",
-                    rejections.0.len(),
+                    rejections.entries.len(),
                 );
             }
 
@@ -136,28 +136,44 @@ impl<T: Limiter> CardinalityLimiter<T> {
 ///
 /// The result can be used directly by [`CardinalityLimits`].
 #[derive(Debug, Default)]
-struct RejectedIds(HashSet<usize>);
+struct RejectionTracker<'a> {
+    limits: HashSet<&'a str>,
+    entries: HashSet<usize>,
+}
 
-impl Rejections for RejectedIds {
+impl<'a> Rejections<'a> for RejectionTracker<'a> {
     #[inline(always)]
-    fn reject(&mut self, entry_id: EntryId) {
-        self.0.insert(entry_id.0);
+    fn reject(&mut self, limit_id: &'a str, entry_id: EntryId) {
+        self.limits.insert(limit_id);
+        self.entries.insert(entry_id.0);
     }
 }
 
 /// Result of [`CardinalityLimiter::check_cardinality_limits`].
 #[derive(Debug)]
-pub struct CardinalityLimits<T> {
+pub struct CardinalityLimits<'a, T> {
     source: Vec<T>,
     rejections: HashSet<usize>,
+    limits: HashSet<&'a str>,
 }
 
-impl<T> CardinalityLimits<T> {
-    fn new(source: Vec<T>, rejections: RejectedIds) -> Self {
+impl<'a, T> CardinalityLimits<'a, T> {
+    fn new(source: Vec<T>, rejections: RejectionTracker<'a>) -> Self {
         Self {
             source,
-            rejections: rejections.0,
+            rejections: rejections.entries,
+            limits: rejections.limits,
         }
+    }
+
+    /// Wether any items are rejected.
+    pub fn has_rejections(&self) -> bool {
+        !self.rejections.is_empty()
+    }
+
+    /// Returns all id's of cardinality limits which were exceeded.
+    pub fn enforced_limits(&self) -> &HashSet<&'a str> {
+        &self.limits
     }
 
     /// Recovers the original list of items passed to the cardinality limiter.
@@ -259,21 +275,27 @@ mod tests {
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: HashSet::from([0, 1, 3]),
+            limits: HashSet::new(),
         };
         assert_rejected(&limits, ['a', 'b', 'd']);
+        assert!(limits.has_rejections());
         assert_eq!(limits.into_accepted(), vec!['c', 'e']);
 
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: HashSet::from([]),
+            limits: HashSet::new(),
         };
         assert_rejected(&limits, []);
+        assert!(!limits.has_rejections());
         assert_eq!(limits.into_accepted(), vec!['a', 'b', 'c', 'd', 'e']);
 
         let limits = CardinalityLimits {
             source: vec!['a', 'b', 'c', 'd', 'e'],
             rejections: HashSet::from([0, 1, 2, 3, 4]),
+            limits: HashSet::new(),
         };
+        assert!(limits.has_rejections());
         assert_rejected(&limits, ['a', 'b', 'c', 'd', 'e']);
         assert!(limits.into_accepted().is_empty());
     }
@@ -283,19 +305,19 @@ mod tests {
         struct RejectAllLimiter;
 
         impl Limiter for RejectAllLimiter {
-            fn check_cardinality_limits<I, T>(
+            fn check_cardinality_limits<'a, I, T>(
                 &self,
                 _scoping: Scoping,
-                _limits: &[CardinalityLimit],
+                _limits: &'a [CardinalityLimit],
                 entries: I,
                 outcomes: &mut T,
             ) -> Result<()>
             where
                 I: IntoIterator<Item = Entry>,
-                T: Rejections,
+                T: Rejections<'a>,
             {
                 for entry in entries {
-                    outcomes.reject(entry.id);
+                    outcomes.reject("test", entry.id);
                 }
 
                 Ok(())
@@ -304,10 +326,11 @@ mod tests {
 
         let limiter = CardinalityLimiter::new(RejectAllLimiter);
 
+        let limits = build_limits();
         let result = limiter
             .check_cardinality_limits(
                 build_scoping(),
-                &build_limits(),
+                &limits,
                 vec![
                     Item::new(0, MetricNamespace::Transactions),
                     Item::new(1, MetricNamespace::Transactions),
@@ -315,6 +338,7 @@ mod tests {
             )
             .unwrap();
 
+        assert_eq!(result.enforced_limits(), &HashSet::from(["test"]));
         assert!(result.into_accepted().is_empty());
     }
 
@@ -323,16 +347,16 @@ mod tests {
         struct AcceptAllLimiter;
 
         impl Limiter for AcceptAllLimiter {
-            fn check_cardinality_limits<I, T>(
+            fn check_cardinality_limits<'a, I, T>(
                 &self,
                 _scoping: Scoping,
-                _limits: &[CardinalityLimit],
+                _limits: &'a [CardinalityLimit],
                 _entries: I,
                 _outcomes: &mut T,
             ) -> Result<()>
             where
                 I: IntoIterator<Item = Entry>,
-                T: Rejections,
+                T: Rejections<'a>,
             {
                 Ok(())
             }
@@ -344,8 +368,9 @@ mod tests {
             Item::new(0, MetricNamespace::Transactions),
             Item::new(1, MetricNamespace::Spans),
         ];
+        let limits = build_limits();
         let result = limiter
-            .check_cardinality_limits(build_scoping(), &build_limits(), items.clone())
+            .check_cardinality_limits(build_scoping(), &limits, items.clone())
             .unwrap();
 
         assert_eq!(result.into_accepted(), items);
@@ -356,7 +381,7 @@ mod tests {
         struct RejectEvenLimiter;
 
         impl Limiter for RejectEvenLimiter {
-            fn check_cardinality_limits<I, T>(
+            fn check_cardinality_limits<'a, I, T>(
                 &self,
                 scoping: Scoping,
                 limits: &[CardinalityLimit],
@@ -365,14 +390,14 @@ mod tests {
             ) -> Result<()>
             where
                 I: IntoIterator<Item = Entry>,
-                T: Rejections,
+                T: Rejections<'a>,
             {
                 assert_eq!(scoping, build_scoping());
                 assert_eq!(limits, &build_limits());
 
                 for entry in entries {
                     if entry.id.0 % 2 == 0 {
-                        outcomes.reject(entry.id);
+                        outcomes.reject("test", entry.id);
                     }
                 }
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -166,7 +166,7 @@ impl<'a, T> CardinalityLimits<'a, T> {
         }
     }
 
-    /// Whether any items are rejected.
+    /// Returns `true` if any items have been rejected.
     pub fn has_rejections(&self) -> bool {
         !self.rejections.is_empty()
     }

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -166,7 +166,7 @@ impl<'a, T> CardinalityLimits<'a, T> {
         }
     }
 
-    /// Wether any items are rejected.
+    /// Whether any items are rejected.
     pub fn has_rejections(&self) -> bool {
         !self.rejections.is_empty()
     }

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -100,16 +100,16 @@ impl RedisSetLimiter {
 }
 
 impl Limiter for RedisSetLimiter {
-    fn check_cardinality_limits<E, R>(
+    fn check_cardinality_limits<'a, E, R>(
         &self,
         scoping: Scoping,
-        limits: &[CardinalityLimit],
+        limits: &'a [CardinalityLimit],
         entries: E,
         rejections: &mut R,
     ) -> Result<()>
     where
         E: IntoIterator<Item = Entry>,
-        R: Rejections,
+        R: Rejections<'a>,
     {
         let timestamp = UnixTimestamp::now();
         // Allows to fast forward time in tests.
@@ -134,7 +134,7 @@ impl Limiter for RedisSetLimiter {
                     }
                     CacheOutcome::Rejected => {
                         // Rejected, add it to the rejected list and move on.
-                        rejections.reject(entry.id);
+                        rejections.reject(state.id, entry.id);
                         state.cache_hit();
                         state.rejected();
                     }
@@ -166,7 +166,7 @@ impl Limiter for RedisSetLimiter {
             let mut cache = self.cache.update(state.scope, timestamp); // Acquire a write lock.
             for (entry, status) in results {
                 if status.is_rejected() {
-                    rejections.reject(entry.id);
+                    rejections.reject(state.id, entry.id);
                     state.rejected();
                 } else {
                     cache.accept(entry.hash);
@@ -403,8 +403,8 @@ mod tests {
     #[derive(Debug, Default, PartialEq, Eq)]
     struct Rejections(HashSet<EntryId>);
 
-    impl super::Rejections for Rejections {
-        fn reject(&mut self, entry_id: EntryId) {
+    impl<'a> super::Rejections<'a> for Rejections {
+        fn reject(&mut self, _limit_id: &'a str, entry_id: EntryId) {
             self.0.insert(entry_id);
         }
     }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1291,12 +1291,21 @@ pub struct CardinalityLimiter {
     ///
     /// Defaults to 180 seconds, 3 minutes.
     pub cache_vacuum_interval: u64,
+
+    /// Sample rate for Cardinality Limiter Sentry errors.
+    ///
+    /// Rate needs to be between `0.0` and `1.0`.
+    /// If set to `1.0` all cardinality limiter rejections will be logged as a Sentry error.
+    ///
+    /// Defaults to 1% (0.01).
+    pub error_sample_rate: f32,
 }
 
 impl Default for CardinalityLimiter {
     fn default() -> Self {
         Self {
             cache_vacuum_interval: 180,
+            error_sample_rate: 0.01,
         }
     }
 }
@@ -2157,6 +2166,11 @@ impl Config {
     /// The cache will scan for expired values based on this interval.
     pub fn cardinality_limiter_cache_vacuum_interval(&self) -> Duration {
         Duration::from_secs(self.values.cardinality_limiter.cache_vacuum_interval)
+    }
+
+    /// Sample rate for Cardinality Limiter Sentry errors.
+    pub fn cardinality_limiter_error_sample_rate(&self) -> f32 {
+        self.values.cardinality_limiter.error_sample_rate
     }
 
     /// Creates an [`AggregatorConfig`] that is compatible with every other aggregator.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1291,21 +1291,12 @@ pub struct CardinalityLimiter {
     ///
     /// Defaults to 180 seconds, 3 minutes.
     pub cache_vacuum_interval: u64,
-
-    /// Sample rate for Cardinality Limiter Sentry errors.
-    ///
-    /// Rate needs to be between `0.0` and `1.0`.
-    /// If set to `1.0` all cardinality limiter rejections will be logged as a Sentry error.
-    ///
-    /// Defaults to 1% (0.01).
-    pub error_sample_rate: f32,
 }
 
 impl Default for CardinalityLimiter {
     fn default() -> Self {
         Self {
             cache_vacuum_interval: 180,
-            error_sample_rate: 0.01,
         }
     }
 }
@@ -2166,11 +2157,6 @@ impl Config {
     /// The cache will scan for expired values based on this interval.
     pub fn cardinality_limiter_cache_vacuum_interval(&self) -> Duration {
         Duration::from_secs(self.values.cardinality_limiter.cache_vacuum_interval)
-    }
-
-    /// Sample rate for Cardinality Limiter Sentry errors.
-    pub fn cardinality_limiter_error_sample_rate(&self) -> f32 {
-        self.values.cardinality_limiter.error_sample_rate
     }
 
     /// Creates an [`AggregatorConfig`] that is compatible with every other aggregator.

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -38,11 +38,6 @@ impl GlobalConfig {
             Ok(None)
         }
     }
-
-    /// Returns the [`Options::cardinality_limiter_mode`] option.
-    pub fn cardinality_limiter_mode(&self) -> CardinalityLimiterMode {
-        self.options.cardinality_limiter_mode
-    }
 }
 
 /// All options passed down from Sentry to Relay.
@@ -78,6 +73,16 @@ pub struct Options {
         skip_serializing_if = "is_default"
     )]
     pub cardinality_limiter_mode: CardinalityLimiterMode,
+
+    /// Sample rate for Cardinality Limiter Sentry errors.
+    ///
+    /// Rate needs to be between `0.0` and `1.0`.
+    /// If set to `1.0` all cardinality limiter rejections will be logged as a Sentry error.
+    #[serde(
+        rename = "relay.cardinality-limiter.error-sample-rate",
+        skip_serializing_if = "is_default"
+    )]
+    pub cardinality_limiter_error_sample_rate: f32,
 
     /// Kill switch for disabling the span usage metric.
     ///

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2262,7 +2262,7 @@ impl UpstreamRequest for SendEnvelope {
     }
 }
 
-/// Returns a boolean wether the current item should be sampled or discarded
+/// Returns a boolean whether the current item should be sampled or discarded
 /// using the passed `rate` (0 <= rate <= 1).
 #[cfg(feature = "processing")]
 fn sample(rate: f32) -> bool {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2262,8 +2262,9 @@ impl UpstreamRequest for SendEnvelope {
     }
 }
 
-/// Returns a boolean whether the current item should be sampled or discarded
-/// using the passed `rate` (0 <= rate <= 1).
+/// Returns `true` if the current item should be sampled.
+///
+/// The passed `rate` is expected to be `0 <= rate <= 1`.
 #[cfg(feature = "processing")]
 fn sample(rate: f32) -> bool {
     (rate >= 1.0) || (rate > 0.0 && rand::random::<f32>() < rate)


### PR DESCRIPTION
To also track which namespace/limit was affected, this PR also adds a hashset of limit IDs to the cardinality limiter return value.

#skip-changelog