### PR TITLE
chore(logging): Add support to "off" for logging level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,7 @@ dependencies = [
  "chrono",
  "console",
  "once_cell",
+ "relay-common",
  "relay-crash",
  "sentry",
  "sentry-core",

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 chrono = { workspace = true, features = ["clock"], optional = true }
 console = { version = "0.15.5", optional = true }
 once_cell = { version = "1.13.1", optional = true }
+relay-common = { path = "../relay-common" }
 relay-crash = { path = "../relay-crash", optional = true }
 sentry = { version = "0.31.7", features = [
     "debug-images",

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
 use std::env;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use relay_common::impl_str_serde;
 use sentry::types::Dsn;
 use serde::{Deserialize, Serialize};
-use tracing::{level_filters::LevelFilter, Level as TracingLevel};
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{prelude::*, EnvFilter, Layer};
 
 #[cfg(feature = "dashboard")]
@@ -63,8 +64,7 @@ impl Display for LevelParseError {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Clone, Copy, Debug)]
 pub enum Level {
     Error,
     Warn,
@@ -73,6 +73,8 @@ pub enum Level {
     Trace,
     Off,
 }
+
+impl_str_serde!(Level, "The logging level.");
 
 impl Level {
     /// Returns the tracing [`LevelFilter`].
@@ -84,18 +86,6 @@ impl Level {
             Level::Debug => LevelFilter::DEBUG,
             Level::Trace => LevelFilter::TRACE,
             Level::Off => LevelFilter::OFF,
-        }
-    }
-
-    /// Returns the tracing logging [`tracing::Level`].
-    pub fn level(&self) -> TracingLevel {
-        match self {
-            Level::Error => TracingLevel::ERROR,
-            Level::Warn => TracingLevel::WARN,
-            Level::Info => TracingLevel::INFO,
-            Level::Debug => TracingLevel::DEBUG,
-            Level::Trace => TracingLevel::TRACE,
-            Level::Off => TracingLevel::ERROR,
         }
     }
 }

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -75,6 +75,7 @@ pub enum Level {
 }
 
 impl Level {
+    /// Returns the tracing [`LevelFilter`].
     pub fn level_filter(&self) -> LevelFilter {
         match self {
             Level::Error => LevelFilter::ERROR,
@@ -86,6 +87,7 @@ impl Level {
         }
     }
 
+    /// Returns the tracing logging [`tracing::Level`].
     pub fn level(&self) -> TracingLevel {
         match self {
             Level::Error => TracingLevel::ERROR,
@@ -149,7 +151,7 @@ pub struct LogConfig {
 }
 
 impl LogConfig {
-    /// Returns the string representation of the level
+    /// Returns the tracing [`LevelFilter`].
     pub fn level_filter(&self) -> LevelFilter {
         self.level.level_filter()
     }

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -78,7 +78,7 @@ impl_str_serde!(Level, "The logging level.");
 
 impl Level {
     /// Returns the tracing [`LevelFilter`].
-    pub fn level_filter(&self) -> LevelFilter {
+    pub const fn level_filter(&self) -> LevelFilter {
         match self {
             Level::Error => LevelFilter::ERROR,
             Level::Warn => LevelFilter::WARN,
@@ -142,7 +142,7 @@ pub struct LogConfig {
 
 impl LogConfig {
     /// Returns the tracing [`LevelFilter`].
-    pub fn level_filter(&self) -> LevelFilter {
+    pub const fn level_filter(&self) -> LevelFilter {
         self.level.level_filter()
     }
 }


### PR DESCRIPTION
Support all the logging levels mentioned in the docs https://docs.sentry.io/product/relay/options/#logging

This change basically addresses the support for `"off"` level.

fix: https://github.com/getsentry/relay/issues/3051

#skip-changelog