### PR TITLE
chore(spans): Upgrade sqlparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Drop spans ending outside the valid timestamp range. ([#3013](https://github.com/getsentry/relay/pull/3013))
 - Extract INP metrics from spans. ([#2969](https://github.com/getsentry/relay/pull/2969), [#3041](https://github.com/getsentry/relay/pull/3041))
 - Add ability to rate limit metric buckets by namespace. ([#2941](https://github.com/getsentry/relay/pull/2941))
+- Upgrade sqlparser to 0.43.1.([#3057](https://github.com/getsentry/relay/pull/3057))
 
 ## 24.1.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,8 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.37.0"
-source = "git+https://github.com/getsentry/sqlparser-rs.git?rev=0bb7ec6ce661ecfc468f647fd1003b7839d37fa6#0bb7ec6ce661ecfc468f647fd1003b7839d37fa6"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95c4bae5aba7cd30bd506f7140026ade63cff5afd778af8854026f9606bf5d4"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -4849,12 +4850,13 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.1.1"
-source = "git+https://github.com/getsentry/sqlparser-rs.git?rev=0bb7ec6ce661ecfc468f647fd1003b7839d37fa6#0bb7ec6ce661ecfc468f647fd1003b7839d37fa6"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -30,7 +30,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7.1"
 smallvec = { workspace = true }
-# Use a fork of sqlparser until https://github.com/sqlparser-rs/sqlparser-rs/pull/1065 gets merged:
 sqlparser = { version = "0.43.1", features = ["visitor"] }
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -31,9 +31,7 @@ serde_json = { workspace = true }
 serde_urlencoded = "0.7.1"
 smallvec = { workspace = true }
 # Use a fork of sqlparser until https://github.com/sqlparser-rs/sqlparser-rs/pull/1065 gets merged:
-sqlparser = { git = "https://github.com/getsentry/sqlparser-rs.git", rev = "0bb7ec6ce661ecfc468f647fd1003b7839d37fa6", features = [
-    "visitor",
-] }
+sqlparser = { version = "0.43.1", features = ["visitor"] }
 thiserror = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -383,7 +383,7 @@ mod tests {
     scrub_sql_test!(
         strip_prefixes_mysql_generic,
         r#"SELECT `table`.`foo`, count(*) from `table` WHERE sku = %s"#,
-        r#"SELECT foo, count(*) from table WHERE sku = %s"#
+        r#"SELECT foo, count(*) FROM table WHERE sku = %s"#
     );
 
     scrub_sql_test_with_dialect!(
@@ -581,7 +581,7 @@ mod tests {
     scrub_sql_test!(
         values_multi,
         "INSERT INTO a (b, c, d, e) VALuES (%s, %s, %s, %s), (%s, %s, %s, %s), (%s, %s, %s, %s) ON CONFLICT DO NOTHING",
-        "INSERT INTO a (..) VALUES (%s)  ON CONFLICT DO NOTHING"
+        "INSERT INTO a (..) VALUES (%s) ON CONFLICT DO NOTHING"
     );
 
     scrub_sql_test!(
@@ -876,13 +876,10 @@ mod tests {
     );
 
     scrub_sql_test_with_dialect!(
-        dont_fallback_to_regex,
+        replace_into,
         "mysql",
-        // sqlparser cannot parse REPLACE INTO. If we know that
-        // a query is MySQL, we should give up rather than try to scrub
-        // with regex
         r#"REPLACE INTO `foo` (`a`) VALUES ("abcd1234")"#,
-        "REPLACE INTO foo (a) VALUES (%s)"
+        "REPLACE INTO foo (..) VALUES (%s)"
     );
 
     scrub_sql_test!(

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -217,10 +217,10 @@ impl VisitorMut for NormalizeVisitor {
                 Self::simplify_table_alias(alias);
             }
             TableFactor::JsonTable { columns, alias, .. } => {
-                for col in columns {
-                    Self::scrub_name(&mut col.name);
-                    Self::simplify_table_alias(alias);
+                for column in columns {
+                    Self::scrub_name(&mut column.name);
                 }
+                Self::simplify_table_alias(alias);
             }
             TableFactor::Unpivot {
                 value,


### PR DESCRIPTION
The `sqlparser` lib has been on a fork since https://github.com/getsentry/relay/pull/2846. We can now go back to the official version because https://github.com/sqlparser-rs/sqlparser-rs/pull/1065 has been merged & released.

ref: https://github.com/getsentry/team-ingest/issues/272