### PR TITLE
feat(app-start): Add app_start_type to duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 - Add `raw_domain` tag to indexed spans. ([#2975](https://github.com/getsentry/relay/pull/2975))
 - Obtain `span.domain` field from the span data's `url.scheme` and `server.address` properties when applicable. ([#2975](https://github.com/getsentry/relay/pull/2975))
 - Do not truncate simplified SQL expressions. ([#3003](https://github.com/getsentry/relay/pull/3003))
-- Add `app_start_type` as self time tag for app start spans. ([#3027](https://github.com/getsentry/relay/pull/3027))
-- Add `app_start_type` to duration. ([#3066](https://github.com/getsentry/relay/pull/3066))
+- Add `app_start_type` as a tag for self time and duration for app start spans. ([#3027](https://github.com/getsentry/relay/pull/3027)), ([#3066](https://github.com/getsentry/relay/pull/3066))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Obtain `span.domain` field from the span data's `url.scheme` and `server.address` properties when applicable. ([#2975](https://github.com/getsentry/relay/pull/2975))
 - Do not truncate simplified SQL expressions. ([#3003](https://github.com/getsentry/relay/pull/3003))
 - Add `app_start_type` as self time tag for app start spans. ([#3027](https://github.com/getsentry/relay/pull/3027))
+- Add `app_start_type` to duration. ([#3066](https://github.com/getsentry/relay/pull/3066))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -406,6 +406,9 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
                     .always(), // already guarded by condition on metric
+                Tag::with_key("app_start_type")
+                    .from_field("span.sentry_tags.app_start_type")
+                    .always(), // already guarded by condition on metric
             ],
         },
         MetricSpec {

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -497,6 +497,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 ],
             ),
             tags: {
+                "app_start_type": "warm",
                 "device.class": "1",
                 "os.name": "iOS",
                 "release": "1.2.3",


### PR DESCRIPTION
This field is required for querying on the spans indexed dataset for a table that surfaces segment spans by start type.