### PR TITLE
ref(cardinality): Remove no longer necessary feature flag

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -37,9 +37,6 @@ pub enum Feature {
     /// Enable metric metadata.
     #[serde(rename = "organizations:metric-meta")]
     MetricMeta,
-    /// Enable the Relay cardinality limiter.
-    #[serde(rename = "organizations:relay-cardinality-limiter")]
-    CardinalityLimiter,
     /// Enable processing and extracting data from profiles that would normally be dropped by dynamic sampling.
     ///
     /// This is required for [slowest function aggregation](https://github.com/getsentry/snuba/blob/b5311b404a6bd73a9e1997a46d38e7df88e5f391/snuba/snuba_migrations/functions/0001_functions.py#L209-L256). The profile payload will be dropped on the sentry side.

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1840,16 +1840,14 @@ impl EnvelopeProcessorService {
 
         for (scoping, message) in message.scopes {
             let ProjectMetrics {
-                mut buckets,
+                buckets,
                 project_state,
             } = message;
 
             let mode = project_state.get_extraction_mode();
             let limits = project_state.get_cardinality_limits();
 
-            if project_state.has_feature(Feature::CardinalityLimiter) {
-                buckets = self.cardinality_limit_buckets(scoping, limits, buckets, mode);
-            }
+            let buckets = self.cardinality_limit_buckets(scoping, limits, buckets, mode);
 
             let buckets = self.rate_limit_buckets_by_namespace(
                 scoping,

--- a/tests/integration/test_cardinality_limiter.py
+++ b/tests/integration/test_cardinality_limiter.py
@@ -27,10 +27,7 @@ def metrics_by_namespace(metrics_consumer, count, timeout=None):
 
 def add_project_config(mini_sentry, project_id, cardinality_limits=None):
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "organizations:custom-metrics",
-        "organizations:relay-cardinality-limiter",
-    ]
+    project_config["config"]["features"] = ["organizations:custom-metrics"]
     project_config["config"]["metrics"] = {
         "cardinalityLimits": cardinality_limits or []
     }


### PR DESCRIPTION
Cardinality limits are now exposed via project config, and Sentry already does the feature flag check [there](https://github.com/getsentry/sentry/blob/master/src/sentry/relay/config/__init__.py#L204) -> we can remove the feature flag handling from Relay.

The feature flag was also only used by processing Relays, we don't have to consider compatibility here.

Should be merged together with https://github.com/getsentry/relay/pull/3067 but is not necessary.

#skip-changelog