### PR TITLE
ref(normalization): Move frames to normalization

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -529,7 +529,7 @@ fn normalize_event_stacktrace(event: &mut Event) {
     let Annotated(Some(stacktrace), meta) = &mut event.stacktrace else {
         return;
     };
-    stacktrace::process_stacktrace(&mut stacktrace.0, meta);
+    stacktrace::normalize_stacktrace(&mut stacktrace.0, meta);
 }
 
 /// Normalizes the stack traces in an event's exceptions, in `event.exceptions.stacktraces`.
@@ -547,7 +547,7 @@ fn normalize_exception_stacktraces(event: &mut Event) {
             continue;
         };
         if let Annotated(Some(stacktrace), meta) = &mut exception.stacktrace {
-            stacktrace::process_stacktrace(&mut stacktrace.0, meta);
+            stacktrace::normalize_stacktrace(&mut stacktrace.0, meta);
         }
     }
 }
@@ -567,7 +567,7 @@ fn normalize_thread_stacktraces(event: &mut Event) {
             continue;
         };
         if let Annotated(Some(stacktrace), meta) = &mut thread.stacktrace {
-            stacktrace::process_stacktrace(&mut stacktrace.0, meta);
+            stacktrace::normalize_stacktrace(&mut stacktrace.0, meta);
         }
     }
 }


### PR DESCRIPTION
Move frame normalization from StoreNormalization to normalization. This brings us one step closer to removing StoreNormalization.

This PR also changes the name `process_stacktrace` -> `normalize_stacktrace`. "Process" has a specific meaning with processors, which are not used here and could generate some confusion, and "normalize" aligns with the naming used in all normalization steps.

#skip-changelog