### PR TITLE
ref(spans): Parse SQL only once and deduplicate errors

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -57,8 +57,6 @@ fn parse_query_inner(
 }
 
 /// Tries to parse a series of SQL queries into an AST and normalize it.
-///
-///
 pub fn normalize_parsed_queries(
     db_system: Option<&str>,
     string: &str,

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -57,8 +57,14 @@ fn parse_query_inner(
 }
 
 /// Tries to parse a series of SQL queries into an AST and normalize it.
-pub fn normalize_parsed_queries(db_system: Option<&str>, string: &str) -> Result<String, ()> {
+///
+///
+pub fn normalize_parsed_queries(
+    db_system: Option<&str>,
+    string: &str,
+) -> Result<(String, Vec<Statement>), ()> {
     let mut parsed = parse_query(db_system, string).map_err(|_| ())?;
+    let original_ast = parsed.clone();
     parsed.visit(&mut NormalizeVisitor);
     parsed.visit(&mut MaxDepthVisitor::new());
 
@@ -70,7 +76,7 @@ pub fn normalize_parsed_queries(db_system: Option<&str>, string: &str) -> Result
     // Insert placeholders that the SQL serializer cannot provide.
     let replaced = concatenated.replace("___UPDATE_LHS___ = NULL", "..");
 
-    Ok(replaced)
+    Ok((replaced, original_ast))
 }
 
 /// A visitor that normalizes the SQL AST in-place.
@@ -639,6 +645,6 @@ mod tests {
     #[test]
     fn parse_deep_expression() {
         let query = "SELECT 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1";
-        assert_eq!(normalize_parsed_queries(None, query).as_deref(), Ok("SELECT .. + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s"));
+        assert_eq!(normalize_parsed_queries(None, query).unwrap().0, "SELECT .. + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s");
     }
 }

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -732,6 +732,7 @@ mod tests {
     use relay_protocol::{get_value, Annotated};
 
     use super::*;
+    use crate::span::description::parse_query;
     use crate::{normalize_event, NormalizationConfig};
 
     #[test]


### PR DESCRIPTION
An unparsable SQL query in a span description currently causes four sentry errors:

* A panic and a manual error when we parse to scrub.
* A panic and a manual error when we parse to extract table names.

This PR

- makes `sql_tables_from_query` reuse the parsed SQL query from `scrub_span_description`,
- removes the manual error, setting necessary tags & data on the sentry scope instead.

ref: https://github.com/getsentry/team-ingest/issues/272

#skip-changelog