### PR TITLE
fix(spans): Deny SAVEPOINT related queries from span metrics ingestion

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -29,8 +29,11 @@ const MOBILE_OPS: &[&str] = &[
 /// A list of span descriptions that indicate top-level app start spans.
 const APP_START_ROOT_SPAN_DESCRIPTIONS: &[&str] = &["Cold Start", "Warm Start"];
 
-/// A list of patterns found in MongoDB queries
+/// A list of patterns found in MongoDB queries.
 const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
+
+/// A list of PG queries we don't want to support.
+const DISABLE_SOME_PG_QUERIES: &[&str] = &["* SAVEPOINT *"];
 
 /// A list of patterns for resource span ops we'd like to ingest.
 const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css", "resource.img"];
@@ -66,7 +69,8 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
     let is_db = RuleCondition::eq("span.sentry_tags.category", "db")
         & !(RuleCondition::eq("span.system", "mongodb")
             | RuleCondition::glob("span.op", DISABLED_DATABASES)
-            | RuleCondition::glob("span.description", MONGODB_QUERIES));
+            | RuleCondition::glob("span.description", MONGODB_QUERIES)
+            | RuleCondition::glob("span.description", DISABLE_SOME_PG_QUERIES));
     let is_resource = RuleCondition::glob("span.op", RESOURCE_SPAN_OPS);
 
     let is_mobile_op = RuleCondition::glob("span.op", MOBILE_OPS);

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -33,7 +33,7 @@ const APP_START_ROOT_SPAN_DESCRIPTIONS: &[&str] = &["Cold Start", "Warm Start"];
 const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
 
 /// A list of PG queries we don't want to support.
-const DISABLE_SOME_PG_QUERIES: &[&str] = &["* SAVEPOINT *"];
+const DISABLE_SOME_PG_QUERIES: &[&str] = &["*SAVEPOINT*"];
 
 /// A list of patterns for resource span ops we'd like to ingest.
 const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css", "resource.img"];

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1032,6 +1032,36 @@ mod tests {
                         "url.scheme": "https"
                     },
                     "hash": "e2fae740cccd3789"
+                },
+                {
+                    "description": "SAVEPOINT \"s140665103034112_x630\"",
+                    "op": "db",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok"
+                },
+                {
+                    "description": "RELEASE SAVEPOINT \"s140665103034112_x630\"",
+                    "op": "db",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok"
+                },
+                {
+                    "description": "ROLLBACK TO SAVEPOINT \"s140665103034112_x630\"",
+                    "op": "db",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok"
                 }
             ]
         }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -597,44 +597,6 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
-            "span.description": "SAVEPOINT %s",
-            "span.group": "3f955cbde39e04b9",
-            "span.op": "db",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
-            "span.description": "SAVEPOINT %s",
-            "span.group": "3f955cbde39e04b9",
-            "span.op": "db",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
         name: "c:spans/count_per_op@none",
         value: Counter(
             1.0,
@@ -1123,6 +1085,42 @@ expression: metrics
         tags: {
             "span.category": "resource",
             "span.op": "resource.script",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "c:spans/count_per_op@none",
+        value: Counter(
+            1.0,
+        ),
+        tags: {
+            "span.category": "db",
+            "span.op": "db",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "c:spans/count_per_op@none",
+        value: Counter(
+            1.0,
+        ),
+        tags: {
+            "span.category": "db",
+            "span.op": "db",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "c:spans/count_per_op@none",
+        value: Counter(
+            1.0,
+        ),
+        tags: {
+            "span.category": "db",
+            "span.op": "db",
         },
     },
 ]

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -597,44 +597,6 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
-            "span.description": "SAVEPOINT %s",
-            "span.group": "3f955cbde39e04b9",
-            "span.op": "db",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
-            "span.description": "SAVEPOINT %s",
-            "span.group": "3f955cbde39e04b9",
-            "span.op": "db",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
         name: "c:spans/count_per_op@none",
         value: Counter(
             1.0,


### PR DESCRIPTION
We're seeing a ton of cardinality on span metrics linked to savepoint queries. They producing 1 million group every 6h and need to be blocked fast before we can fix that.

```
RELEASE SAVEPOINT "s140665103034112_x630"
RELEASE SAVEPOINT "s140591383963392_x77"
RELEASE SAVEPOINT "s140542268667648_x417"
RELEASE SAVEPOINT "s140661210720000_x911"
RELEASE SAVEPOINT "s140500644386560_x444"
RELEASE SAVEPOINT "s140122209109760_x599"
RELEASE SAVEPOINT "s139670792959744_x936"
RELEASE SAVEPOINT "s140696442873600_x16"
RELEASE SAVEPOINT "s139889190348544_x280"
RELEASE SAVEPOINT "s139672353216256_x604"
```

#skip-changelog