### PR TITLE
ref(global-config): Don't fail on deserialization issues in global config options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ dependencies = [
  "relay-common",
  "relay-event-normalization",
  "relay-filter",
+ "relay-log",
  "relay-pii",
  "relay-protocol",
  "relay-quotas",

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -19,8 +19,9 @@ relay-auth = { path = "../relay-auth" }
 relay-base-schema = { path = "../relay-base-schema" }
 relay-cardinality = { path = "../relay-cardinality" }
 relay-common = { path = "../relay-common" }
-relay-filter = { path = "../relay-filter" }
 relay-event-normalization = { path = "../relay-event-normalization" }
+relay-filter = { path = "../relay-filter" }
+relay-log = { path = "../relay-log" }
 relay-pii = { path = "../relay-pii" }
 relay-protocol  = { path = "../relay-protocol" }
 relay-quotas = { path = "../relay-quotas" }


### PR DESCRIPTION
Currently one broken option will take down Relay, and it is way too easy to accidentally configure the wrong option in the options automator.

This PR changes the behaviour to just use a default value when deserialization fails and logs an error.

#skip-changelog