### PR TITLE
feat(quotas): Add ability to use namespace in non-global quotas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add protobuf support for ingesting OpenTelemetry spans and use official `opentelemetry-proto` generated structs. ([#3044](https://github.com/getsentry/relay/pull/3044))
 
+**Internal**
+
+- Add ability to use namespace in non-global quotas. ([#3090](https://github.com/getsentry/relay/pull/3090))
 
 ## 24.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add protobuf support for ingesting OpenTelemetry spans and use official `opentelemetry-proto` generated structs. ([#3044](https://github.com/getsentry/relay/pull/3044))
 
-**Internal**
+**Internal**:
 
 - Add ability to use namespace in non-global quotas. ([#3090](https://github.com/getsentry/relay/pull/3090))
 - Set the span op on segments. ([#3082](https://github.com/getsentry/relay/pull/3082))

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -140,10 +140,11 @@ impl<'a> RedisQuota<'a> {
         let org = self.scoping.organization_id;
 
         format!(
-            "quota:{id}{{{org}}}{subscope}:{slot}",
+            "quota:{id}{{{org}}}{subscope}{namespace}:{slot}",
             id = self.prefix,
             org = org,
             subscope = OptionalDisplay(subscope),
+            namespace = OptionalDisplay(self.namespace),
             slot = self.slot(),
         )
     }

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -385,7 +385,7 @@ mod tests {
         );
     }
 
-    /// Tests that a quota with and without namespace are counted differently.
+    /// Tests that a quota with and without namespace are counted separately.
     #[test]
     fn test_non_global_namespace_quota() {
         let id = format!("test_simple_quota_{}", uuid::Uuid::new_v4());

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -388,10 +388,9 @@ mod tests {
     /// Tests that a quota with and without namespace are counted separately.
     #[test]
     fn test_non_global_namespace_quota() {
-        let id = format!("test_simple_quota_{}", uuid::Uuid::new_v4());
         let get_quota = |namespace: Option<MetricNamespace>| -> Quota {
             Quota {
-                id: Some(id.clone()),
+                id: Some(format!("test_simple_quota_{}", uuid::Uuid::new_v4())),
                 categories: DataCategories::new(),
                 scope: QuotaScope::Organization,
                 scope_id: None,


### PR DESCRIPTION
https://github.com/getsentry/relay/issues/2716

With this PR, we can also use namespace in non-global quotas. 

The reason for this PR was the requirement to be able to ratelimit based on namespace per org, but in reality it's pretty flexible so we can do namespace per project as well. 