### PR TITLE
fix(spans): Scrub RELEASE SAVEPOINT statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Fix regression in SQL query scrubbing. ([#3091](https://github.com/getsentry/relay/pull/3091))
+
 **Features**:
 
 - Add protobuf support for ingesting OpenTelemetry spans and use official `opentelemetry-proto` generated structs. ([#3044](https://github.com/getsentry/relay/pull/3044))

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -29,11 +29,8 @@ const MOBILE_OPS: &[&str] = &[
 /// A list of span descriptions that indicate top-level app start spans.
 const APP_START_ROOT_SPAN_DESCRIPTIONS: &[&str] = &["Cold Start", "Warm Start"];
 
-/// A list of patterns found in MongoDB queries.
+/// A list of patterns found in MongoDB queries
 const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
-
-/// A list of PG queries we don't want to support.
-const DISABLE_SOME_PG_QUERIES: &[&str] = &["*SAVEPOINT*"];
 
 /// A list of patterns for resource span ops we'd like to ingest.
 const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css", "resource.img"];
@@ -69,8 +66,7 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
     let is_db = RuleCondition::eq("span.sentry_tags.category", "db")
         & !(RuleCondition::eq("span.system", "mongodb")
             | RuleCondition::glob("span.op", DISABLED_DATABASES)
-            | RuleCondition::glob("span.description", MONGODB_QUERIES)
-            | RuleCondition::glob("span.description", DISABLE_SOME_PG_QUERIES));
+            | RuleCondition::glob("span.description", MONGODB_QUERIES));
     let is_resource = RuleCondition::glob("span.op", RESOURCE_SPAN_OPS);
 
     let is_mobile_op = RuleCondition::glob("span.op", MOBILE_OPS);

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -29,7 +29,7 @@ const MOBILE_OPS: &[&str] = &[
 /// A list of span descriptions that indicate top-level app start spans.
 const APP_START_ROOT_SPAN_DESCRIPTIONS: &[&str] = &["Cold Start", "Warm Start"];
 
-/// A list of patterns found in MongoDB queries
+/// A list of patterns found in MongoDB queries.
 const MONGODB_QUERIES: &[&str] = &["*\"$*", "{*", "*({*", "*[{*"];
 
 /// A list of patterns for resource span ops we'd like to ingest.

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -319,6 +319,38 @@ mod tests {
     );
 
     scrub_sql_test!(
+        savepoint_mysql,
+        r#"SaVePoInT "double_quoted_identifier""#,
+        "SAVEPOINT %s"
+    );
+
+    scrub_sql_test_with_dialect!(
+        savepoint_mysql_informed,
+        "mysql",
+        r#"SaVePoInT "double_quoted_identifier""#,
+        "SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        release_savepoint,
+        r#"ReLease SaVePoInT name"#,
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        release_savepoint_mysql,
+        r#"ReLease SaVePoInT "double_quoted_identifier""#,
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test_with_dialect!(
+        release_savepoint_mysql_informed,
+        "mysql",
+        r#"ReLease SaVePoInT "double_quoted_identifier""#,
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
         declare_cursor,
         "DECLARE curs2 CURSOR FOR SELECT * FROM t1",
         "DECLARE %s CURSOR FOR SELECT * FROM t1"

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -351,6 +351,66 @@ mod tests {
     );
 
     scrub_sql_test!(
+        release_savepoint_uppercase,
+        "RELEASE SAVEPOINT unquoted_identifier",
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        release_savepoint_uppercase_semicolon,
+        "RELEASE SAVEPOINT unquoted_identifier;",
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        release_savepoint_lowercase,
+        "release savepoint unquoted_identifier",
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        release_savepoint_quoted,
+        "RELEASE SAVEPOINT 'single_quoted_identifier'",
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        release_savepoint_quoted_backtick,
+        "RELEASE SAVEPOINT `backtick_quoted_identifier`",
+        "RELEASE SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        rollback_savepoint_uppercase,
+        "ROLLBACK TO SAVEPOINT unquoted_identifier",
+        "ROLLBACK TO SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        rollback_savepoint_uppercase_semicolon,
+        "ROLLBACK TO SAVEPOINT unquoted_identifier;",
+        "ROLLBACK TO SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        rollback_savepoint_lowercase,
+        "rollback to savepoint unquoted_identifier",
+        "ROLLBACK TO SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        rollback_savepoint_quoted,
+        "ROLLBACK TO SAVEPOINT 'single_quoted_identifier'",
+        "ROLLBACK TO SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
+        rollback_savepoint_quoted_backtick,
+        "ROLLBACK TO SAVEPOINT `backtick_quoted_identifier`",
+        "ROLLBACK TO SAVEPOINT %s"
+    );
+
+    scrub_sql_test!(
         declare_cursor,
         "DECLARE curs2 CURSOR FOR SELECT * FROM t1",
         "DECLARE %s CURSOR FOR SELECT * FROM t1"

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -386,7 +386,8 @@ impl VisitorMut for NormalizeVisitor {
                 }
             }
             // `SAVEPOINT foo` becomes `SAVEPOINT %s`.
-            Statement::Savepoint { name } => Self::erase_name(name),
+            Statement::Savepoint { name } => Self::erase_name(dbg!(name)),
+            Statement::ReleaseSavepoint { name } => Self::erase_name(dbg!(name)),
             Statement::Declare { name, query, .. } => {
                 Self::erase_name(name);
                 self.transform_query(query);
@@ -492,7 +493,6 @@ impl VisitorMut for NormalizeVisitor {
                     }
                 }
             }
-
             _ => {}
         }
 

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -397,8 +397,8 @@ impl VisitorMut for NormalizeVisitor {
                 }
             }
             // `SAVEPOINT foo` becomes `SAVEPOINT %s`.
-            Statement::Savepoint { name } => Self::erase_name(dbg!(name)),
-            Statement::ReleaseSavepoint { name } => Self::erase_name(dbg!(name)),
+            Statement::Savepoint { name } => Self::erase_name(name),
+            Statement::ReleaseSavepoint { name } => Self::erase_name(name),
             Statement::Declare { name, query, .. } => {
                 Self::erase_name(name);
                 self.transform_query(query);
@@ -414,7 +414,7 @@ impl VisitorMut for NormalizeVisitor {
             }
             Statement::Close { cursor } => match cursor {
                 CloseCursor::All => {}
-                CloseCursor::Specific { name } => Self::scrub_name(name),
+                CloseCursor::Specific { name } => Self::erase_name(name),
             },
             Statement::AlterTable {
                 name, operations, ..
@@ -608,7 +608,7 @@ impl VisitorMut for NormalizeVisitor {
             Statement::Commit { .. } => {}
             Statement::Rollback { savepoint, .. } => {
                 if let Some(savepoint) = savepoint {
-                    Self::scrub_name(savepoint);
+                    Self::erase_name(savepoint);
                 }
             }
             Statement::CreateSchema { .. } => {}

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -195,10 +195,10 @@ impl NormalizeVisitor {
 impl VisitorMut for NormalizeVisitor {
     type Break = ();
 
-    // fn pre_visit_relation(&mut self, relation: &mut ObjectName) -> ControlFlow<Self::Break> {
-    //     Self::simplify_compound_identifier(&mut relation.0);
-    //     ControlFlow::Continue(())
-    // }
+    fn pre_visit_relation(&mut self, relation: &mut ObjectName) -> ControlFlow<Self::Break> {
+        Self::simplify_compound_identifier(&mut relation.0);
+        ControlFlow::Continue(())
+    }
 
     fn pre_visit_table_factor(
         &mut self,
@@ -671,11 +671,6 @@ impl VisitorMut for NormalizeVisitor {
             Statement::UnlockTables => {}
         }
 
-        ControlFlow::Continue(())
-    }
-
-    fn post_visit_relation(&mut self, relation: &mut ObjectName) -> ControlFlow<Self::Break> {
-        Self::simplify_compound_identifier(&mut relation.0);
         ControlFlow::Continue(())
     }
 }

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -386,8 +386,12 @@ impl VisitorMut for NormalizeVisitor {
                 }
             }
             // `SAVEPOINT foo` becomes `SAVEPOINT %s`.
-            Statement::Savepoint { name } => Self::erase_name(dbg!(name)),
-            Statement::ReleaseSavepoint { name } => Self::erase_name(dbg!(name)),
+            Statement::Savepoint { name } => Self::erase_name(name),
+            Statement::ReleaseSavepoint { name } => Self::erase_name(name),
+            Statement::Rollback {
+                savepoint: Some(savepoint),
+                ..
+            } => Self::erase_name(savepoint),
             Statement::Declare { name, query, .. } => {
                 Self::erase_name(name);
                 self.transform_query(query);

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1032,36 +1032,6 @@ mod tests {
                         "url.scheme": "https"
                     },
                     "hash": "e2fae740cccd3789"
-                },
-                {
-                    "description": "SAVEPOINT \"s140665103034112_x630\"",
-                    "op": "db",
-                    "parent_span_id": "8f5a2b8768cafb4e",
-                    "span_id": "bb7af8b99e95af5f",
-                    "start_timestamp": 1597976300.0000000,
-                    "timestamp": 1597976302.0000000,
-                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
-                    "status": "ok"
-                },
-                {
-                    "description": "RELEASE SAVEPOINT \"s140665103034112_x630\"",
-                    "op": "db",
-                    "parent_span_id": "8f5a2b8768cafb4e",
-                    "span_id": "bb7af8b99e95af5f",
-                    "start_timestamp": 1597976300.0000000,
-                    "timestamp": 1597976302.0000000,
-                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
-                    "status": "ok"
-                },
-                {
-                    "description": "ROLLBACK TO SAVEPOINT \"s140665103034112_x630\"",
-                    "op": "db",
-                    "parent_span_id": "8f5a2b8768cafb4e",
-                    "span_id": "bb7af8b99e95af5f",
-                    "start_timestamp": 1597976300.0000000,
-                    "timestamp": 1597976302.0000000,
-                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
-                    "status": "ok"
                 }
             ]
         }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -597,6 +597,44 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
+        name: "d:spans/exclusive_time@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.action": "SAVEPOINT",
+            "span.category": "db",
+            "span.description": "SAVEPOINT %s",
+            "span.group": "3f955cbde39e04b9",
+            "span.op": "db",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.method": "POST",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "d:spans/exclusive_time_light@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.action": "SAVEPOINT",
+            "span.category": "db",
+            "span.description": "SAVEPOINT %s",
+            "span.group": "3f955cbde39e04b9",
+            "span.op": "db",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "c:spans/count_per_op@none",
         value: Counter(
             1.0,
@@ -1085,42 +1123,6 @@ expression: metrics
         tags: {
             "span.category": "resource",
             "span.op": "resource.script",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: "c:spans/count_per_op@none",
-        value: Counter(
-            1.0,
-        ),
-        tags: {
-            "span.category": "db",
-            "span.op": "db",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: "c:spans/count_per_op@none",
-        value: Counter(
-            1.0,
-        ),
-        tags: {
-            "span.category": "db",
-            "span.op": "db",
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: "c:spans/count_per_op@none",
-        value: Counter(
-            1.0,
-        ),
-        tags: {
-            "span.category": "db",
-            "span.op": "db",
         },
     },
 ]

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_all_modules.snap
@@ -597,6 +597,44 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
+        name: "d:spans/exclusive_time@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.action": "SAVEPOINT",
+            "span.category": "db",
+            "span.description": "SAVEPOINT %s",
+            "span.group": "3f955cbde39e04b9",
+            "span.op": "db",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.method": "POST",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: "d:spans/exclusive_time_light@millisecond",
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.action": "SAVEPOINT",
+            "span.category": "db",
+            "span.description": "SAVEPOINT %s",
+            "span.group": "3f955cbde39e04b9",
+            "span.op": "db",
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
         name: "c:spans/count_per_op@none",
         value: Counter(
             1.0,


### PR DESCRIPTION
sqlparser improved parsing capabilities, which made us rely on the fallback scrubber less. Unfortunately, In the case of savepoints, the fallback scrubber caught more than the parser-based scrubber.

Reverts https://github.com/getsentry/relay/pull/3083
Fixes https://github.com/getsentry/relay/issues/3085