### PR TITLE
chore(deps): Update hashbrown crate to 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,16 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "serde",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -73,6 +74,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -1887,14 +1894,18 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.8",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.8",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashlink"
@@ -2170,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2314,7 +2325,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48354c4c4f088714424ddf090de1ff84acc82b2f08c192d46d226ae2529a465"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.8",
  "anyhow",
  "base64 0.21.0",
  "bytecount",
@@ -3602,7 +3613,7 @@ name = "relay-cardinality"
 version = "24.1.2"
 dependencies = [
  "criterion",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "parking_lot",
  "relay-base-schema",
  "relay-common",
@@ -3855,7 +3866,7 @@ dependencies = [
  "criterion",
  "fnv",
  "hash32",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "insta",
  "itertools",
  "rand",
@@ -3966,7 +3977,7 @@ dependencies = [
 name = "relay-quotas"
 version = "24.1.2"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "insta",
  "itertools",
  "relay-base-schema",
@@ -4049,7 +4060,7 @@ dependencies = [
  "fnv",
  "futures",
  "hash32",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "insta",
  "itertools",
  "json-forensics",
@@ -4994,7 +5005,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a22fd81e9c1ad53c562edb869ff042b215d4eadefefc4784bacfbfd19835945"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.8",
  "atoi",
  "byteorder",
  "bytes",
@@ -6327,6 +6338,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ criterion = "0.5"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 hash32 = "0.3.1"
-hashbrown = "0.13.2"
+hashbrown = "0.14.3"
 itertools = "0.10.5"
 once_cell = "1.13.1"
 parking_lot = "0.12.1"

--- a/relay-cardinality/src/redis/cache.rs
+++ b/relay-cardinality/src/redis/cache.rs
@@ -150,7 +150,7 @@ impl Inner {
 
         let expired = metric!(timer(CardinalityLimiterTimers::CacheVacuum), {
             self.cache
-                .drain_filter(|scope, cache| cache.current_slot < scope.active_slot(ts))
+                .extract_if(|scope, cache| cache.current_slot < scope.active_slot(ts))
                 .count()
         });
         metric!(counter(CardinalityLimiterCounters::RedisCacheVacuum) += expired as i64);

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -482,7 +482,7 @@ impl Services {
 struct ProjectCacheBroker {
     config: Arc<Config>,
     services: Services,
-    // Need hashbrown because drain_filter is not stable in std yet.
+    // Need hashbrown because extract_if is not stable in std yet.
     projects: hashbrown::HashMap<ProjectKey, Project>,
     garbage_disposal: GarbageDisposal<Project>,
     source: ProjectSource,
@@ -547,14 +547,14 @@ impl ProjectCacheBroker {
 
         let expired = self
             .projects
-            .drain_filter(|_, entry| entry.last_updated_at() + delta <= eviction_start);
+            .extract_if(|_, entry| entry.last_updated_at() + delta <= eviction_start);
 
         // Defer dropping the projects to a dedicated thread:
         let mut count = 0;
         for (project_key, project) in expired {
             let keys = self
                 .index
-                .drain_filter(|key| key.own_key == project_key || key.sampling_key == project_key)
+                .extract_if(|key| key.own_key == project_key || key.sampling_key == project_key)
                 .collect::<BTreeSet<_>>();
 
             if !keys.is_empty() {
@@ -926,7 +926,7 @@ impl ProjectCacheBroker {
 
         let mut index = std::mem::take(&mut self.index);
         let values = index
-            .drain_filter(|key| self.is_state_valid(key))
+            .extract_if(|key| self.is_state_valid(key))
             .collect::<HashSet<_>>();
 
         if !values.is_empty() {


### PR DESCRIPTION
This upgrades `hashbrown` crate, which also introduces new [`extract_if`](https://docs.rs/hashbrown/latest/hashbrown/hash_set/struct.HashSet.html#method.extract_if)  instead of [`drain_filter`](https://docs.rs/hashbrown/0.13.2/hashbrown/hash_set/struct.HashSet.html#method.drain_filter) with better semantics and behaviour. 



#skip-changelog