### PR TITLE
chore(spool): Tunining for unspool operation

### DIFF
--- a/relay-server/src/utils/buffer.rs
+++ b/relay-server/src/utils/buffer.rs
@@ -43,7 +43,8 @@ impl BufferGuard {
             inner,
             capacity,
             high_watermark: 0.8,
-            low_watermark: 0.5,
+            // Keep the low limit under 40%.
+            low_watermark: 0.40,
         }
     }
 


### PR DESCRIPTION
Followup unspool tuning:
* lower the limit for the low watermark - make sure we stop unspooling before half of the permits are acquired
* request unspool for smaller batches  - instead of sending all the keys to spooler and try to unspool them, batch the request in 2000 queued keys per request, which should slow down unspool a little bit and also avoid overwhelming the envelope processor service
  


fix: https://github.com/getsentry/team-ingest/issues/267

#skip-changelog