### PR TITLE
ref(metrics): Use item type variant name for stats

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -329,7 +329,7 @@ pub async fn handle_envelope(
     for item in envelope.items() {
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
-            item_type = item.ty().as_str()
+            item_type = item.ty().name()
         )
     }
 

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -145,7 +145,7 @@ impl ItemType {
 
     /// Returns the variant name of the item type.
     ///
-    /// Unlike [`as_str`] this returns an unknown value as `unknown`.
+    /// Unlike [`Self::as_str`] this returns an unknown value as `unknown`.
     pub fn name(&self) -> &'static str {
         match self {
             Self::Event => "event",
@@ -1451,6 +1451,16 @@ mod tests {
         item.set_source_quantities(source_quantities);
 
         assert_eq!(item.source_quantities(), Some(source_quantities));
+    }
+
+    #[test]
+    fn test_item_type_names() {
+        assert_eq!(ItemType::Span.name(), "span");
+        assert_eq!(ItemType::Unknown("test".to_owned()).name(), "unknown");
+        assert_eq!(ItemType::Span.as_str(), "span");
+        assert_eq!(ItemType::Unknown("test".to_owned()).as_str(), "test");
+        assert_eq!(&ItemType::Span.to_string(), "span");
+        assert_eq!(&ItemType::Unknown("test".to_owned()).to_string(), "test");
     }
 
     #[test]

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -143,7 +143,10 @@ impl ItemType {
         }
     }
 
-    pub fn as_str(&self) -> &str {
+    /// Returns the variant name of the item type.
+    ///
+    /// Unlike [`as_str`] this returns an unknown value as `unknown`.
+    pub fn name(&self) -> &'static str {
         match self {
             Self::Event => "event",
             Self::Transaction => "transaction",
@@ -167,7 +170,15 @@ impl ItemType {
             Self::CheckIn => "check_in",
             Self::Span => "span",
             Self::OtelSpan => "otel_span",
+            Self::Unknown(_) => "unknown",
+        }
+    }
+
+    /// Returns the item type as a string.
+    pub fn as_str(&self) -> &str {
+        match self {
             Self::Unknown(ref s) => s,
+            _ => self.name(),
         }
     }
 }


### PR DESCRIPTION
Followup for #3096 - Addresses [Joris' comment](https://github.com/getsentry/relay/pull/3096#discussion_r1486387704)

#skip-changelog