### PR TITLE
ref: Coerce all Thread IDs to integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Internal**:
 
 - Set the span op on segments. ([#3082](https://github.com/getsentry/relay/pull/3082))
+- Coerce all Thread IDs to integers. ([#3102](https://github.com/getsentry/relay/pull/3102))
 
 ## 24.1.2
 

--- a/relay-event-schema/src/protocol/exception.rs
+++ b/relay-event-schema/src/protocol/exception.rs
@@ -93,7 +93,7 @@ mod tests {
             ty: Annotated::new("mytype".to_string()),
             value: Annotated::new("myvalue".to_string().into()),
             module: Annotated::new("mymodule".to_string()),
-            thread_id: Annotated::new(ThreadId::Int(42)),
+            thread_id: Annotated::new(ThreadId(42)),
             other: {
                 let mut map = Map::new();
                 map.insert(

--- a/relay-event-schema/src/protocol/stacktrace.rs
+++ b/relay-event-schema/src/protocol/stacktrace.rs
@@ -601,7 +601,7 @@ mod tests {
                 address: Annotated::new("0x07d7437b".to_string()),
                 package_name: Annotated::new("io.sentry.samples".to_string()),
                 class_name: Annotated::new("MainActivity".to_string()),
-                thread_id: Annotated::new(ThreadId::Int(7)),
+                thread_id: Annotated::new(ThreadId(7)),
                 other: Default::default(),
             }),
             other: {

--- a/relay-event-schema/src/protocol/thread.rs
+++ b/relay-event-schema/src/protocol/thread.rs
@@ -233,14 +233,7 @@ mod tests {
     #[test]
     fn test_thread_id() {
         assert_eq!(
-            ThreadId::String("testing".into()),
-            Annotated::<ThreadId>::from_json("\"testing\"")
-                .unwrap()
-                .0
-                .unwrap()
-        );
-        assert_eq!(
-            ThreadId::String("42".into()),
+            ThreadId(42),
             Annotated::<ThreadId>::from_json("\"42\"")
                 .unwrap()
                 .0

--- a/relay-event-schema/src/protocol/thread.rs
+++ b/relay-event-schema/src/protocol/thread.rs
@@ -247,7 +247,7 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(
-            ThreadId::Int(42),
+            ThreadId(42),
             Annotated::<ThreadId>::from_json("42").unwrap().0.unwrap()
         );
     }
@@ -265,7 +265,7 @@ mod tests {
   "other": "value"
 }"#;
         let thread = Annotated::new(Thread {
-            id: Annotated::new(ThreadId::Int(42)),
+            id: Annotated::new(ThreadId(42)),
             name: Annotated::new("myname".to_string()),
             stacktrace: Annotated::empty(),
             raw_stacktrace: Annotated::empty(),
@@ -324,7 +324,7 @@ mod tests {
   "other": "value"
 }"#;
         let thread = Annotated::new(Thread {
-            id: Annotated::new(ThreadId::Int(42)),
+            id: Annotated::new(ThreadId(42)),
             name: Annotated::new("myname".to_string()),
             stacktrace: Annotated::empty(),
             raw_stacktrace: Annotated::empty(),
@@ -341,7 +341,7 @@ mod tests {
                         address: Annotated::empty(),
                         package_name: Annotated::new("io.sentry.samples".to_string()),
                         class_name: Annotated::new("MainActivity".to_string()),
-                        thread_id: Annotated::new(ThreadId::Int(7)),
+                        thread_id: Annotated::new(ThreadId(7)),
                         other: Default::default(),
                     }),
                 );
@@ -352,7 +352,7 @@ mod tests {
                         address: Annotated::empty(),
                         package_name: Annotated::new("android.database.sqlite".to_string()),
                         class_name: Annotated::new("SQLiteConnection".to_string()),
-                        thread_id: Annotated::new(ThreadId::Int(2)),
+                        thread_id: Annotated::new(ThreadId(2)),
                         other: Default::default(),
                     }),
                 );

--- a/relay-event-schema/src/protocol/thread.rs
+++ b/relay-event-schema/src/protocol/thread.rs
@@ -13,7 +13,7 @@ use crate::protocol::{RawStacktrace, Stacktrace};
 /// Thread IDs can come in either as strings or integers. Strings are silently coerced to integers.
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, IntoValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-pub struct ThreadId(u64);
+pub struct ThreadId(pub u64);
 
 impl FromValue for ThreadId {
     fn from_value(value: Annotated<Value>) -> Annotated<Self> {

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -3591,15 +3591,12 @@ expression: "relay_event_schema::protocol::event_json_schema()"
       ]
     },
     "ThreadId": {
-      "description": " Represents a thread id.",
+      "description": " Represents a thread ID.\n\n Thread IDs can come in either as strings or integers. Strings are silently coerced to integers.",
       "anyOf": [
         {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
-        },
-        {
-          "type": "string"
         }
       ]
     },


### PR DESCRIPTION
While porting the Snuba consumers to Rust, I saw that thread IDs could
be strings. This isn't really aligned with how it's typed in our
frontend, typed in symbolicator, and appears to subvert user
expectations as well: https://github.com/getsentry/sentry-go/issues/767

It seems easiest to restrict the output type and silently coerce
strings to integers. This also gets rid of weird artifacts like people
sending in random (non-numerical) strings which is currently allowed
