### PR TITLE
fix: Normalize route path in trace context data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Fix regression in SQL query scrubbing. ([#3091](https://github.com/getsentry/relay/pull/3091))
+- Normalize route in trace context data field. ([#3104](https://github.com/getsentry/relay/pull/3104))
 
 **Features**:
 

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -203,7 +203,7 @@ impl FromValue for Route {
             }
             Annotated(None, meta) => Annotated(None, meta),
             Annotated(Some(value), mut meta) => {
-                meta.add_error(Error::expected("route"));
+                meta.add_error(Error::expected("route expected to be an object"));
                 meta.set_original_value(Some(value));
                 Annotated(None, meta)
             }

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -153,9 +153,12 @@ pub struct Data {
 }
 
 /// The route in the application, set by React Native SDK.
-#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[derive(Clone, Debug, Default, PartialEq, Empty, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct Route {
+    /// The name of the route.
+    #[metastructure(pii = "maybe", skip_serialization = "empty")]
+    name: Annotated<String>,
     /// Parameters assigned to this route.
     #[metastructure(pii = "true", skip_serialization = "empty", bag_size = "medium")]
     params: Annotated<Object<Value>>,
@@ -168,6 +171,44 @@ pub struct Route {
         skip_serialization = "empty"
     )]
     pub other: Object<Value>,
+}
+
+impl FromValue for Route {
+    fn from_value(value: Annotated<Value>) -> Annotated<Self>
+    where
+        Self: Sized,
+    {
+        match value {
+            Annotated(Some(Value::String(name)), meta) => Annotated(
+                Some(Route {
+                    name: Annotated::new(name),
+                    ..Default::default()
+                }),
+                meta,
+            ),
+            Annotated(Some(Value::Object(mut values)), meta) => {
+                let mut route: Route = Default::default();
+                if let Some(Annotated(Some(Value::String(name)), _)) = values.remove("name") {
+                    route.name = Annotated::new(name);
+                }
+                if let Some(Annotated(Some(Value::Object(params)), _)) = values.remove("params") {
+                    route.params = Annotated::new(params);
+                }
+
+                if !values.is_empty() {
+                    route.other = values;
+                }
+
+                Annotated(Some(route), meta)
+            }
+            Annotated(None, meta) => Annotated(None, meta),
+            Annotated(Some(value), mut meta) => {
+                meta.add_error(Error::expected("route"));
+                meta.set_original_value(Some(value));
+                Annotated(None, meta)
+            }
+        }
+    }
 }
 
 impl super::DefaultContext for TraceContext {
@@ -219,10 +260,11 @@ mod tests {
   "origin": "auto.http",
   "data": {
     "route": {
+      "name": "/users",
       "params": {
         "tok": "test"
       },
-      "path": "/path"
+      "custom_field": "something"
     }
   },
   "other": "value",
@@ -239,6 +281,7 @@ mod tests {
             origin: Annotated::new("auto.http".to_owned()),
             data: Annotated::new(Data {
                 route: Annotated::new(Route {
+                    name: Annotated::new("/users".into()),
                     params: Annotated::new({
                         let mut map = Object::new();
                         map.insert(
@@ -250,8 +293,8 @@ mod tests {
                     other: {
                         let mut map = Object::new();
                         map.insert(
-                            "path".to_string(),
-                            Annotated::new(Value::String("/path".into())),
+                            "custom_field".into(),
+                            Annotated::new(Value::String("something".into())),
                         );
                         map
                     },
@@ -283,6 +326,32 @@ mod tests {
         let context = Annotated::new(Context::Trace(Box::new(TraceContext {
             trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
             span_id: Annotated::new(SpanId("fa90fdead5f74052".into())),
+            ..Default::default()
+        })));
+
+        assert_eq!(context, Annotated::from_json(json).unwrap());
+    }
+
+    #[test]
+    fn test_trace_context_with_routes() {
+        let json = r#"{
+  "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
+  "span_id": "FA90FDEAD5F74052",
+  "type": "trace",
+  "data": {
+    "route": "HomeRoute"
+  }
+}"#;
+        let context = Annotated::new(Context::Trace(Box::new(TraceContext {
+            trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+            span_id: Annotated::new(SpanId("fa90fdead5f74052".into())),
+            data: Annotated::new(Data {
+                route: Annotated::new(Route {
+                    name: Annotated::new("HomeRoute".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
             ..Default::default()
         })));
 

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -3255,6 +3255,14 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         {
           "type": "object",
           "properties": {
+            "name": {
+              "description": " The name of the route.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "params": {
               "description": " Parameters assigned to this route.",
               "default": null,


### PR DESCRIPTION
Relay expects for `contexts.trace.data.route` to be a route, but some SDKs sent the string (for route names) in `route` and we want to handle this and normalize the data into the know types structure. 

This PR introduces the customer `FromValue` trait implementation for `Route` to handle:
* incoming object
* incoming string for `contexts.trace.data.route` field



fix: [#3000](https://github.com/getsentry/relay/issues/3000)