### PR TITLE
ref(healthcheck): Instrument healthcheck code path

### DIFF
--- a/relay-server/src/endpoints/health_check.rs
+++ b/relay-server/src/endpoints/health_check.rs
@@ -4,9 +4,11 @@ use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Serialize;
+use tokio::time::Instant;
 
 use crate::service::ServiceState;
-use crate::services::health_check::IsHealthy;
+use crate::services::health_check::{IsHealthy, IsHealthyWrapper};
+use crate::statsd::RelayTimers;
 
 #[derive(Serialize)]
 struct Status {
@@ -14,7 +16,16 @@ struct Status {
 }
 
 pub async fn handle(state: ServiceState, Path(kind): Path<IsHealthy>) -> impl IntoResponse {
-    match state.health_check().send(kind).await {
+    let received = Instant::now();
+
+    let wrapper = IsHealthyWrapper { kind, received };
+    let result = state.health_check().send(wrapper).await;
+
+    relay_statsd::metric!(
+        timer(RelayTimers::HealthcheckEndpointCheckDuration) = received.elapsed(),
+        kind = kind.variant()
+    );
+    match result {
         Ok(true) => (StatusCode::OK, axum::Json(Status { is_healthy: true })),
         _ => (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -359,6 +359,29 @@ pub enum RelayTimers {
     ///
     ///  - `message`: The type of message that was processed.
     BufferMessageProcessDuration,
+    /// Timing in milliseconds for responding a healthcheck message.
+    ///
+    /// This metric is tagged with:
+    /// - `kind`: The kind of healthcheck message.
+    HealthcheckEndpointCheckDuration,
+    /// Timing in milliseconds for the delay for the healthcheck endpoint to get the message.
+    HealthcheckServiceReceivedDelay,
+    /// Timing in milliseconds for the duration of the healthcheck service to respond to a message.
+    ///
+    /// This metric is tagged with:
+    /// - `kind`: The kind of healthcheck message.
+    HealthcheckServiceHandleDuration,
+    /// Timing in milliseconds for the duration the healthcheck service waits for a spool health.
+    HealthcheckServiceProjectcacheResponseDuration,
+    /// Timing in milliseconds for the delay for the project cache service to receive a spool health.
+    ProjectCacheReceivedDelay,
+    /// Timing in milliseconds for the delay of the spooler to receive a health message.
+    SpoolerHealthReceivedDelay,
+    /// Timing in milliseconds for the delay of the spooler to handle the health duration.
+    ///
+    /// This metric is tagged with:
+    /// - `variant`: The spooler state.
+    SpoolerHealthDuration,
 }
 
 impl TimerMetric for RelayTimers {
@@ -396,6 +419,15 @@ impl TimerMetric for RelayTimers {
             RelayTimers::ProcessMessageDuration => "processor.message.duration",
             RelayTimers::ProjectCacheMessageDuration => "project_cache.message.duration",
             RelayTimers::BufferMessageProcessDuration => "buffer.message.duration",
+            RelayTimers::HealthcheckEndpointCheckDuration => "health_check.endpoint.duration",
+            RelayTimers::HealthcheckServiceReceivedDelay => "health_check.service.received.delay",
+            RelayTimers::HealthcheckServiceHandleDuration => "health_check.service.handle.duration",
+            RelayTimers::HealthcheckServiceProjectcacheResponseDuration => {
+                "health_check.service.project_cache.duration"
+            }
+            RelayTimers::ProjectCacheReceivedDelay => "project_cache.received.delay",
+            RelayTimers::SpoolerHealthReceivedDelay => "spooler.received.delay",
+            RelayTimers::SpoolerHealthDuration => "spooler.health.duration",
         }
     }
 }


### PR DESCRIPTION
This PR adds various metrics around the code path for a health check. We're seeing some health checks being slower than expected, and these metrics should provide visibility. Once the root cause is identified and addressed, we'll evaluate what metrics are worth keeping and which should be removed.

#skip-changelog