### PR TITLE
fix(spans): Max description length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix regression in SQL query scrubbing. ([#3091](https://github.com/getsentry/relay/pull/3091))
 - Normalize route in trace context data field. ([#3104](https://github.com/getsentry/relay/pull/3104))
+- Limit the length of scrubbed span descriptions. ([#3115](https://github.com/getsentry/relay/pull/3115))
 
 **Features**:
 


### PR DESCRIPTION
Do not attempt to parse very long span description.

This should prevent stack overflows in the SQL parser.

We could also limit the length of the description field by setting a `bag_size` attribute on it. Unfortunately, the `TrimmingProcessor` runs after other normalization steps, so it would not help in this case.

ref: https://github.com/getsentry/team-ingest/issues/272