### PR TITLE
fix(spans): Fall back to regex scrubber for long queries

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -54,7 +54,10 @@ fn parse_query_inner(
         .unwrap_or_else(|| Box::new(GenericDialect {}));
     let dialect = DialectWithParameters(dialect);
 
-    sqlparser::parser::Parser::parse_sql(&dialect, query)
+    sqlparser::parser::Parser::new(&dialect)
+        .with_recursion_limit(1)
+        .try_with_sql(query)?
+        .parse_statements()
 }
 
 /// Tries to parse a series of SQL queries into an AST and normalize it.

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -54,10 +54,7 @@ fn parse_query_inner(
         .unwrap_or_else(|| Box::new(GenericDialect {}));
     let dialect = DialectWithParameters(dialect);
 
-    sqlparser::parser::Parser::new(&dialect)
-        .with_recursion_limit(1)
-        .try_with_sql(query)?
-        .parse_statements()
+    sqlparser::parser::Parser::parse_sql(&dialect, query)
 }
 
 /// Tries to parse a series of SQL queries into an AST and normalize it.

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -562,7 +562,7 @@ fn timestamp_by_op(spans: &[Annotated<Span>], op: &str) -> Option<Timestamp> {
 /// If the string is short, it remains unchanged. If it's long, this method
 /// truncates it to the maximum allowed size and sets the last character to
 /// `*`.
-fn truncate_string(mut string: String, max_bytes: usize) -> String {
+pub fn truncate_string(mut string: String, max_bytes: usize) -> String {
     if string.len() <= max_bytes {
         return string;
     }


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/3115 erased the span group for SQL queries longer than 10000 bytes, but this threshold is surpassed so frequently that it might break product experience.

Instead of not grouping the span at all, truncate it and fall back to regex scrubbers. 