### PR TITLE
fix(spans): Do not copy parsed SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Fix regression in SQL query scrubbing. ([#3091](https://github.com/getsentry/relay/pull/3091))
 - Fix span metric ingestion for http spans. ([#3111](https://github.com/getsentry/relay/pull/3111))
 - Normalize route in trace context data field. ([#3104](https://github.com/getsentry/relay/pull/3104))
-- Limit the length of scrubbed span descriptions. ([#3115](https://github.com/getsentry/relay/pull/3115))
 
 **Features**:
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -2,7 +2,8 @@
 mod resource;
 mod sql;
 use once_cell::sync::Lazy;
-pub use sql::parse_query;
+#[cfg(test)]
+pub use sql::{scrub_queries, Mode};
 
 use std::borrow::Cow;
 use std::path::Path;

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -20,9 +20,6 @@ use crate::span::tag_extraction::HTTP_METHOD_EXTRACTOR_REGEX;
 /// Dummy URL used to parse relative URLs.
 static DUMMY_BASE_URL: Lazy<Url> = Lazy::new(|| "http://replace_me".parse().unwrap());
 
-/// Very large SQL queries may cause stack overflows in the parser, so do not attempt to parse these.
-const MAX_DESCRIPTION_LENGTH: usize = 10_000;
-
 /// Maximum length of a resource URL segment.
 ///
 /// Segments longer than this are treated as identifiers.
@@ -40,14 +37,6 @@ pub(crate) fn scrub_span_description(
     let Some(description) = span.description.as_str() else {
         return (None, None);
     };
-
-    if description.len() > MAX_DESCRIPTION_LENGTH {
-        relay_log::error!(
-            description = description,
-            "Span description too large to parse"
-        );
-        return (None, None);
-    }
 
     let data = span.data.value();
 
@@ -921,17 +910,6 @@ mod tests {
     );
 
     span_description_test!(db_prisma, "User find", "db.sql.prisma", "User find");
-
-    span_description_test!(
-        long_description_none,
-        // Do not attempt to parse very long descriptions.
-        {
-            let repeated = "+1".repeat(5000);
-            &("SELECT 1".to_string() + &repeated)
-        },
-        "db.query",
-        ""
-    );
 
     #[test]
     fn informed_sql_parser() {

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -1,6 +1,5 @@
 //! Logic for scrubbing and normalizing span descriptions that contain SQL queries.
 mod parser;
-pub use parser::parse_query;
 
 use std::borrow::Cow;
 use std::time::Instant;

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -63,7 +63,6 @@ pub fn normalize_parsed_queries(
     string: &str,
 ) -> Result<(String, Vec<Statement>), ()> {
     let mut parsed = parse_query(db_system, string).map_err(|_| ())?;
-    let original_ast = parsed.clone();
     parsed.visit(&mut NormalizeVisitor);
     parsed.visit(&mut MaxDepthVisitor::new());
 
@@ -75,7 +74,7 @@ pub fn normalize_parsed_queries(
     // Insert placeholders that the SQL serializer cannot provide.
     let replaced = concatenated.replace("___UPDATE_LHS___ = NULL", "..");
 
-    Ok((replaced, original_ast))
+    Ok((replaced, parsed))
 }
 
 /// A visitor that normalizes the SQL AST in-place.


### PR DESCRIPTION
All stack overflows after upgrading to sqlparser 0.43 occurred in `.clone()`, not during parsing (see [POP-RELAY-30P](https://sentry.my.sentry.io/organizations/sentry/issues/645286/)).

We cloned the parsed query to reuse it for table name extraction. But table name extraction should work just as well on the scrubbed query, so the clone is unnecessary.

This PR also reverts https://github.com/getsentry/relay/pull/3115.

ref: https://github.com/getsentry/team-ingest/issues/272

#skip-changelog