### PR TITLE
ref(spans): Type out more data fields

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn scrub_span_description(
     let data = span.data.value();
 
     let db_system = data
-        .and_then(|v| v.get("db.system"))
+        .and_then(|data| data.db_system.value())
         .and_then(|system| system.as_str());
     let span_origin = span.origin.as_str();
 
@@ -85,7 +85,7 @@ pub(crate) fn scrub_span_description(
                 Some(description.to_owned())
             }
             ("ui", sub) if sub.starts_with("interaction.") || sub.starts_with("react.") => data
-                .and_then(|data| data.get("ui.component_name"))
+                .and_then(|data| data.ui_component_name.value())
                 .and_then(|value| value.as_str())
                 .map(String::from),
             ("app", _) => {

--- a/relay-event-normalization/src/normalize/utils.rs
+++ b/relay-event-normalization/src/normalize/utils.rs
@@ -30,10 +30,7 @@ pub fn http_status_code_from_span(span: &Span) -> Option<String> {
     if let Some(status_code) = span
         .data
         .value()
-        .and_then(|v| {
-            v.get("http.response.status_code")
-                .or_else(|| v.get("status_code"))
-        })
+        .and_then(|data| data.http_response_status_code.value())
         .and_then(|v| v.as_str())
         .map(|v| v.to_string())
     {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -175,11 +175,13 @@ impl Getter for Span {
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct SpanData {
-    /// TODO: docs
+    /// Mobile app start variant.
+    ///
+    /// Can be either "cold" or "warm".
     #[metastructure(field = "app_start_type")] // TODO: no dot?
     pub app_start_type: Annotated<Value>,
 
-    /// TODO: docs
+    /// The client's browser name.
     #[metastructure(field = "browser.name")]
     pub browser_name: Annotated<Value>,
 
@@ -202,23 +204,28 @@ pub struct SpanData {
     #[metastructure(field = "code.namespace", pii = "maybe")]
     pub code_namespace: Annotated<Value>,
 
-    /// TODO: docs
+    /// The name of the operation being executed.
+    ///
+    /// E.g. the MongoDB command name such as findAndModify, or the SQL keyword.
+    /// Based on [OpenTelemetry's call level db attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes).
     #[metastructure(field = "db.operation")]
     pub db_operation: Annotated<Value>,
 
-    /// TODO: docs
+    /// An identifier for the database management system (DBMS) product being used.
+    ///
+    /// See [OpenTelemetry docs for a list of well-known identifiers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem).
     #[metastructure(field = "db.system")]
     pub db_system: Annotated<Value>,
 
-    /// TODO: docs
+    /// The sentry environment.
     #[metastructure(field = "environment")]
     pub environment: Annotated<Value>,
 
-    /// TODO: docs
+    /// The decoded body size of the response (in bytes).
     #[metastructure(field = "http.decoded_response_content_length")]
     pub http_decoded_response_content_length: Annotated<Value>,
 
-    /// TODO: docs
+    /// The HTTP method used.
     #[metastructure(
         field = "http.request_method",
         legacy_alias = "http.method",
@@ -226,35 +233,35 @@ pub struct SpanData {
     )]
     pub http_request_method: Annotated<Value>,
 
-    /// TODO: docs
+    /// The encoded body size of the response (in bytes).
     #[metastructure(field = "http.response_content_length")]
     pub http_response_content_length: Annotated<Value>,
 
-    /// TODO: docs
+    /// The transfer size of the response (in bytes).
     #[metastructure(field = "http.response_transfer_size")]
     pub http_response_transfer_size: Annotated<Value>,
 
-    /// TODO: docs
+    /// The render blocking status of the resource.
     #[metastructure(field = "resource.render_blocking_status")]
     pub resource_render_blocking_status: Annotated<Value>,
 
-    /// TODO: docs
+    /// Name of the database host.
     #[metastructure(field = "server.address")]
     pub server_address: Annotated<Value>,
 
-    /// TODO: docs
+    /// The status HTTP response.
     #[metastructure(field = "http.response.status_code", legacy_alias = "status_code")]
     pub http_response_status_code: Annotated<Value>,
 
-    /// TODO: docs
+    /// Label identifying a thread from where the span originated.
     #[metastructure(field = "thread.name")]
     pub thread_name: Annotated<Value>,
 
-    /// TODO: docs
+    /// Name of the UI component (e.g. React).
     #[metastructure(field = "ui.component_name")]
     pub ui_component_name: Annotated<Value>,
 
-    /// TODO: docs
+    /// The URL scheme, e.g. `"https"`.
     #[metastructure(field = "url.scheme")]
     pub url_scheme: Annotated<Value>,
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -507,32 +507,46 @@ mod tests {
             .into_value()
             .unwrap();
         insta::assert_debug_snapshot!(data, @r###"
-    SpanData {
-        code_filepath: String(
-            "task.py",
-        ),
-        code_lineno: I64(
-            123,
-        ),
-        code_function: String(
-            "fn()",
-        ),
-        code_namespace: String(
-            "ns",
-        ),
-        other: {
-            "bar": String(
-                "3",
+        SpanData {
+            app_start_type: ~,
+            browser_name: ~,
+            code_filepath: String(
+                "task.py",
             ),
-            "db.system": String(
+            code_lineno: I64(
+                123,
+            ),
+            code_function: String(
+                "fn()",
+            ),
+            code_namespace: String(
+                "ns",
+            ),
+            db_operation: ~,
+            db_system: String(
                 "mysql",
             ),
-            "foo": I64(
-                2,
-            ),
-        },
-    }
-    "###);
+            environment: ~,
+            http_decoded_response_content_length: ~,
+            http_request_method: ~,
+            http_response_content_length: ~,
+            http_response_transfer_size: ~,
+            resource_render_blocking_status: ~,
+            server_address: ~,
+            http_response_status_code: ~,
+            thread_name: ~,
+            ui_component_name: ~,
+            url_scheme: ~,
+            other: {
+                "bar": String(
+                    "3",
+                ),
+                "foo": I64(
+                    2,
+                ),
+            },
+        }
+        "###);
 
         assert_eq!(data.get_value("foo"), Some(Val::U64(2)));
         assert_eq!(data.get_value("bar"), Some(Val::String("3")));

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -264,19 +264,6 @@ pub struct SpanData {
 }
 
 impl SpanData {
-    /// Setter for compatibility with [`Object`].
-    pub fn insert(&mut self, key: String, value: Annotated<Value>) {
-        match key.as_str() {
-            "code.filepath" => self.code_filepath = value,
-            "code.lineno" => self.code_lineno = value,
-            "code.function" => self.code_function = value,
-            "code.namespace" => self.code_namespace = value,
-            _ => {
-                self.other.insert(key, value);
-            }
-        }
-    }
-
     /// Gets a floating point measurement value from data.
     pub fn measurement(&self, key: &str) -> Option<f64> {
         let value = self.other.get(key)?.value()?;
@@ -496,11 +483,10 @@ mod tests {
 
         assert_eq!(span.get_value("span.duration"), Some(Val::F64(477.800131)));
     }
-}
 
-#[test]
-fn test_span_data() {
-    let data = r#"{
+    #[test]
+    fn test_span_data() {
+        let data = r#"{
         "foo": 2,
         "bar": "3",
         "db.system": "mysql",
@@ -509,11 +495,11 @@ fn test_span_data() {
         "code.function": "fn()",
         "code.namespace": "ns"
     }"#;
-    let data = Annotated::<SpanData>::from_json(data)
-        .unwrap()
-        .into_value()
-        .unwrap();
-    insta::assert_debug_snapshot!(data, @r###"
+        let data = Annotated::<SpanData>::from_json(data)
+            .unwrap()
+            .into_value()
+            .unwrap();
+        insta::assert_debug_snapshot!(data, @r###"
     SpanData {
         code_filepath: String(
             "task.py",
@@ -541,11 +527,12 @@ fn test_span_data() {
     }
     "###);
 
-    assert_eq!(data.get_value("foo"), Some(Val::U64(2)));
-    assert_eq!(data.get_value("bar"), Some(Val::String("3")));
-    assert_eq!(data.get_value("db\\.system"), Some(Val::String("mysql")));
-    assert_eq!(data.get_value("code\\.lineno"), Some(Val::U64(123)));
-    assert_eq!(data.get_value("code\\.function"), Some(Val::String("fn()")));
-    assert_eq!(data.get_value("code\\.namespace"), Some(Val::String("ns")));
-    assert_eq!(data.get_value("unknown"), None);
+        assert_eq!(data.get_value("foo"), Some(Val::U64(2)));
+        assert_eq!(data.get_value("bar"), Some(Val::String("3")));
+        assert_eq!(data.get_value("db\\.system"), Some(Val::String("mysql")));
+        assert_eq!(data.get_value("code\\.lineno"), Some(Val::U64(123)));
+        assert_eq!(data.get_value("code\\.function"), Some(Val::String("fn()")));
+        assert_eq!(data.get_value("code\\.namespace"), Some(Val::String("ns")));
+        assert_eq!(data.get_value("unknown"), None);
+    }
 }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -270,26 +270,37 @@ pub struct SpanData {
     other: Object<Value>,
 }
 
-// impl SpanData {
-//     /// Gets a floating point measurement value from data.
-//     pub fn measurement(&self, key: &str) -> Option<f64> {
-//         let value = self.other.get(key)?.value()?;
-//         Some(match value {
-//             Value::I64(n) => *n as f64,
-//             Value::U64(n) => *n as f64,
-//             Value::F64(f) => *f,
-//             _ => return None,
-//         })
-//     }
-// }
-
 impl Getter for SpanData {
     fn get_value(&self, path: &str) -> Option<Val<'_>> {
         Some(match path {
-            "code\\.filepath" => self.code_filepath.as_str()?.into(),
+            "app_start_type" => self.app_start_type.value()?.into(),
+            "browser\\.name" => self.browser_name.value()?.into(),
+            "code\\.filepath" => self.code_filepath.value()?.into(),
+            "code\\.function" => self.code_function.value()?.into(),
             "code\\.lineno" => self.code_lineno.value()?.into(),
-            "code\\.function" => self.code_function.as_str()?.into(),
-            "code\\.namespace" => self.code_namespace.as_str()?.into(),
+            "code\\.namespace" => self.code_namespace.value()?.into(),
+            "db.operation" => self.db_operation.value()?.into(),
+            "db\\.system" => self.db_system.value()?.into(),
+            "environment" => self.environment.value()?.into(),
+            "http\\.decoded_response_content_length" => {
+                self.http_decoded_response_content_length.value()?.into()
+            }
+            "http\\.request_method" | "http\\.method" | "method" => {
+                self.http_request_method.value()?.into()
+            }
+            "http\\.response_content_length" => self.http_response_content_length.value()?.into(),
+            "http\\.response_transfer_size" => self.http_response_transfer_size.value()?.into(),
+            "http\\.response.status_code" | "status_code" => {
+                self.http_response_status_code.value()?.into()
+            }
+            "resource\\.render_blocking_status" => {
+                self.resource_render_blocking_status.value()?.into()
+            }
+            "server\\.address" => self.server_address.value()?.into(),
+            "thread\\.name" => self.thread_name.value()?.into(),
+            "ui\\.component_name" => self.ui_component_name.value()?.into(),
+            "url\\.scheme" => self.url_scheme.value()?.into(),
+
             _ => {
                 let escaped = path.replace("\\.", "\0");
                 let mut path = escaped.split('.').map(|s| s.replace('\0', "."));

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -270,18 +270,18 @@ pub struct SpanData {
     other: Object<Value>,
 }
 
-impl SpanData {
-    /// Gets a floating point measurement value from data.
-    pub fn measurement(&self, key: &str) -> Option<f64> {
-        let value = self.other.get(key)?.value()?;
-        Some(match value {
-            Value::I64(n) => *n as f64,
-            Value::U64(n) => *n as f64,
-            Value::F64(f) => *f,
-            _ => return None,
-        })
-    }
-}
+// impl SpanData {
+//     /// Gets a floating point measurement value from data.
+//     pub fn measurement(&self, key: &str) -> Option<f64> {
+//         let value = self.other.get(key)?.value()?;
+//         Some(match value {
+//             Value::I64(n) => *n as f64,
+//             Value::U64(n) => *n as f64,
+//             Value::F64(f) => *f,
+//             _ => return None,
+//         })
+//     }
+// }
 
 impl Getter for SpanData {
     fn get_value(&self, path: &str) -> Option<Val<'_>> {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -175,6 +175,14 @@ impl Getter for Span {
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct SpanData {
+    /// TODO: docs
+    #[metastructure(field = "app_start_type")] // TODO: no dot?
+    pub app_start_type: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "browser.name")]
+    pub browser_name: Annotated<Value>,
+
     /// The source code file name that identifies the code unit as uniquely as possible.
     #[metastructure(field = "code.filepath", pii = "maybe")]
     pub code_filepath: Annotated<Value>,
@@ -194,23 +202,68 @@ pub struct SpanData {
     #[metastructure(field = "code.namespace", pii = "maybe")]
     pub code_namespace: Annotated<Value>,
 
+    /// TODO: docs
+    #[metastructure(field = "db.operation")]
+    pub db_operation: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "db.system")]
+    pub db_system: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "environment")]
+    pub environment: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "http.decoded_response_content_length")]
+    pub http_decoded_response_content_length: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(
+        field = "http.request_method",
+        legacy_alias = "http.method",
+        legacy_alias = "method"
+    )]
+    pub http_request_method: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "http.response_content_length")]
+    pub http_response_content_length: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "http.response_transfer_size")]
+    pub http_response_transfer_size: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "resource.render_blocking_status")]
+    pub resource_render_blocking_status: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "server.address")]
+    pub server_address: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "http.response.status_code", legacy_alias = "status_code")]
+    pub http_response_status_code: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "thread.name")]
+    pub thread_name: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "ui.component_name")]
+    pub ui_component_name: Annotated<Value>,
+
+    /// TODO: docs
+    #[metastructure(field = "url.scheme")]
+    pub url_scheme: Annotated<Value>,
+
     /// Other fields in `span.data`.
     #[metastructure(additional_properties, pii = "true", retain = "true")]
     other: Object<Value>,
 }
 
 impl SpanData {
-    /// Getter for compatibility with [`Object`].
-    pub fn get(&self, key: &str) -> Option<&Annotated<Value>> {
-        match key {
-            "code.filepath" => Some(&self.code_filepath),
-            "code.lineno" => Some(&self.code_lineno),
-            "code.function" => Some(&self.code_function),
-            "code.namespace" => Some(&self.code_namespace),
-            _ => self.other.get(key),
-        }
-    }
-
     /// Setter for compatibility with [`Object`].
     pub fn insert(&mut self, key: String, value: Annotated<Value>) {
         match key.as_str() {
@@ -222,6 +275,17 @@ impl SpanData {
                 self.other.insert(key, value);
             }
         }
+    }
+
+    /// Gets a floating point measurement value from data.
+    pub fn measurement(&self, key: &str) -> Option<f64> {
+        let value = self.other.get(key)?.value()?;
+        Some(match value {
+            Value::I64(n) => *n as f64,
+            Value::U64(n) => *n as f64,
+            Value::F64(f) => *f,
+            _ => return None,
+        })
     }
 }
 

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -276,15 +276,28 @@ expression: "(&event.value().unwrap().spans, metrics)"
             origin: ~,
             profile_id: ~,
             data: SpanData {
+                app_start_type: String(
+                    "cold",
+                ),
+                browser_name: ~,
                 code_filepath: ~,
                 code_lineno: ~,
                 code_function: ~,
                 code_namespace: ~,
-                other: {
-                    "app_start_type": String(
-                        "cold",
-                    ),
-                },
+                db_operation: ~,
+                db_system: ~,
+                environment: ~,
+                http_decoded_response_content_length: ~,
+                http_request_method: ~,
+                http_response_content_length: ~,
+                http_response_transfer_size: ~,
+                resource_render_blocking_status: ~,
+                server_address: ~,
+                http_response_status_code: ~,
+                thread_name: ~,
+                ui_component_name: ~,
+                url_scheme: ~,
+                other: {},
             },
             sentry_tags: {
                 "app_start_type": "cold",

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -341,10 +341,7 @@ fn normalize(
         .and_then(|v| v.name.value())
     {
         let data = span.data.value_mut().get_or_insert_with(SpanData::default);
-        data.insert(
-            "browser.name".into(),
-            Annotated::new(browser_name.to_owned().into()),
-        );
+        data.browser_name = Annotated::new(browser_name.to_owned().into());
     }
 
     if let Annotated(Some(ref mut measurement_values), ref mut meta) = span.measurements {

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(event_span.exclusive_time, Annotated::new(1000.0));
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         assert_eq!(
-            get_path!(annotated_span.data["environment"]),
+            get_path!(annotated_span.data.environment),
             Some(&Annotated::new("test".into()))
         );
     }

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -6,7 +6,7 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use relay_event_schema::protocol::{
     Span as EventSpan, SpanData, SpanId, SpanStatus, Timestamp, TraceId,
 };
-use relay_protocol::Annotated;
+use relay_protocol::{Annotated, FromValue, Object};
 
 use crate::otel_to_sentry_tags::OTEL_TO_SENTRY_TAGS;
 use crate::otel_trace::{status::StatusCode as OtelStatusCode, Span as OtelSpan};
@@ -67,7 +67,7 @@ fn otel_value_to_string(value: OtelValue) -> Option<String> {
 /// Transform an OtelSpan to a Sentry span.
 pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
     let mut exclusive_time_ms = 0f64;
-    let mut data = SpanData::default();
+    let mut data = Object::new();
     let start_timestamp = Utc.timestamp_nanos(otel_span.start_time_unix_nano as i64);
     let end_timestamp = Utc.timestamp_nanos(otel_span.end_time_unix_nano as i64);
     let OtelSpan {
@@ -148,7 +148,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
 
     EventSpan {
         op: op.into(),
-        data: data.into(),
+        data: SpanData::from_value(Annotated::new(data.into())),
         description: name.into(),
         exclusive_time: exclusive_time_ms.into(),
         parent_span_id: SpanId(parent_span_id).into(),


### PR DESCRIPTION
Follow up to https://github.com/getsentry/relay/pull/3116, based on discussion here: https://github.com/getsentry/relay/pull/3116#discussion_r1491069595.

> We should probably just type out all the .get() calls in our code (i.e. replace with named fields), then we can remove this method. I can do that in a follow-up PR.

#skip-changelog