### PR TITLE
ref(config): Separate relays and projectupstream batch interval configs

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -904,8 +904,10 @@ struct Cache {
     envelope_buffer_size: u32,
     /// The cache timeout for non-existing entries.
     miss_expiry: u32,
-    /// The buffer timeout for batched queries before sending them upstream in ms.
+    /// The buffer timeout for batched project config queries before sending them upstream in ms.
     batch_interval: u32,
+    /// The buffer timeout for batched queries of downstream relays, in ms and defaults to 100ms.
+    downstream_relays_batch_interval: u32,
     /// The maximum number of project configs to fetch from Sentry at once. Defaults to 500.
     ///
     /// `cache.batch_interval` controls how quickly batches are sent, this controls the batch size.
@@ -927,8 +929,9 @@ impl Default for Cache {
             relay_expiry: 3600,   // 1 hour
             envelope_expiry: 600, // 10 minutes
             envelope_buffer_size: 1000,
-            miss_expiry: 60,     // 1 minute
-            batch_interval: 100, // 100ms
+            miss_expiry: 60,                       // 1 minute
+            batch_interval: 100,                   // 100ms
+            downstream_relays_batch_interval: 100, // 100ms
             batch_size: 500,
             file_interval: 10,                // 10 seconds
             eviction_interval: 60,            // 60 seconds
@@ -1884,10 +1887,15 @@ impl Config {
         Duration::from_secs(self.values.cache.project_grace_period.into())
     }
 
-    /// Returns the number of seconds during which batchable queries are collected before sending
-    /// them in a single request.
+    /// Returns the duration in which batchable project config queries are
+    /// collected before sending them in a single request.
     pub fn query_batch_interval(&self) -> Duration {
         Duration::from_millis(self.values.cache.batch_interval.into())
+    }
+
+    /// Returns the duration in which downstream relays are requested from upstream.
+    pub fn downstream_relays_batch_interval(&self) -> Duration {
+        Duration::from_millis(self.values.cache.downstream_relays_batch_interval.into())
     }
 
     /// Returns the interval in seconds in which local project configurations should be reloaded.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -906,7 +906,7 @@ struct Cache {
     miss_expiry: u32,
     /// The buffer timeout for batched project config queries before sending them upstream in ms.
     batch_interval: u32,
-    /// The buffer timeout for batched queries of downstream relays, in ms and defaults to 100ms.
+    /// The buffer timeout for batched queries of downstream relays in ms. Defaults to 100ms.
     downstream_relays_batch_interval: u32,
     /// The maximum number of project configs to fetch from Sentry at once. Defaults to 500.
     ///

--- a/relay-server/src/services/relays.rs
+++ b/relay-server/src/services/relays.rs
@@ -215,7 +215,7 @@ impl RelayCacheService {
     /// If previous queries succeeded, this will be the general batch interval. Additionally, an
     /// exponentially increasing backoff is used for retrying the upstream request.
     fn next_backoff(&mut self) -> Duration {
-        self.config.query_batch_interval() + self.backoff.next_backoff()
+        self.config.downstream_relays_batch_interval() + self.backoff.next_backoff()
     }
 
     /// Schedules a batched upstream query with exponential backoff.


### PR DESCRIPTION
This PR adds a new config `cache.downstream_relays_batch_interval` to separate it from `cache.batch_interval`.

`cache.batch_interval` is currently used for both the project upstream service and the relay cache service, making it impossible to update the configured value of one without updating the other.

## Background

As Sentry offers a wider and deeper feature set, the project config computation time has [increased](https://app.datadoghq.com/s/FH6-Y3/7sw-38r-w6x) significantly. Relays still make very frequent requests, requiring [more attempts](https://app.datadoghq.com/s/FH6-Y3/spt-htf-zah) to fetch a project config. The number of requests impacts the upstream relay unnecessarily as not that many requests are needed. In order to reduce the frequency, and increase the batch interval, without impacting other areas, the config must be split into two.

### Related issues

- https://github.com/getsentry/team-ingest/issues/285
- https://github.com/getsentry/team-ingest/issues/287

#skip-changelog
