### PR TITLE
fix(tests): Fix flaky test_global_metrics_with_processing

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -487,7 +487,9 @@ def test_global_metrics_with_processing(
     project_config["config"]["features"] = ["organizations:custom-metrics"]
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"transactions/foo:42|c\nbar@second:17|c|T{timestamp}"
+    metrics_payload = (
+        f"transactions/foo:42|c|T{timestamp}\nbar@second:17|c|T{timestamp}"
+    )
     relay.send_metrics(project_id, metrics_payload)
 
     metrics = metrics_by_name(metrics_consumer, 2)


### PR DESCRIPTION
the 'transactions/foo:42' metric didn't have a timestamp set, but we asserted that after it went through the pipeline the timestamp assigned was equal to `current time`. this usually worked because it'd get assigned iwth the `start_time` field from requestmeta, but ocasionally there'd be a second difference between `current time` when starting the test and the `current time` when it was received by relay

#skip-changelog