### PR TITLE
test(metrics): Fix flaky test_metrics

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -173,7 +173,9 @@ def test_metrics(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"transactions/foo:42|c\ntransactions/bar:17|c|T{timestamp}"
+    metrics_payload = (
+        f"transactions/foo:42|c|T{timestamp}\ntransactions/bar:17|c|T{timestamp}"
+    )
     relay.send_metrics(project_id, metrics_payload)
 
     envelope = mini_sentry.captured_events.get(timeout=3)
@@ -184,6 +186,7 @@ def test_metrics(mini_sentry, relay):
 
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
+
     assert received_metrics == [
         {
             "timestamp": timestamp,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -186,7 +186,6 @@ def test_metrics(mini_sentry, relay):
 
     received_metrics = json.loads(metrics_item.get_bytes().decode())
     received_metrics = sorted(received_metrics, key=lambda x: x["name"])
-
     assert received_metrics == [
         {
             "timestamp": timestamp,


### PR DESCRIPTION
Adding the missing timestamp into the metric bucket seems to fix it, similar to https://github.com/getsentry/relay/pull/3138.

Resolves https://github.com/getsentry/relay/issues/2865.

#skip-changelog