### PR TITLE
fix(test): Wait for http error

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -477,6 +477,7 @@ def test_processing_quotas(
         with pytest.raises(HTTPError) as excinfo:
             # Failed: DID NOT RAISE <class 'requests.exceptions.HTTPError'>
             relay.send_event(project_id, transform({"message": "rate_limited"}))
+            sleep(0.2)
         headers = excinfo.value.response.headers
 
         retry_after = headers["retry-after"]


### PR DESCRIPTION
This one I could not reproduce locally at all. 

But my guess is that we have to wait a little bit longer after sending the event in order to receive the response.

fix: https://github.com/getsentry/relay/issues/3037

#skip-changelog