### PR TITLE
Extend GPU context with data for Unreal Engine crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Extend GPU context with data for Unreal Engine crash reports. ([#3144](https://github.com/getsentry/relay/pull/3144))
+
 **Bug Fixes**:
 
 - Forward metrics in proxy mode. ([#3106](https://github.com/getsentry/relay/pull/3106))

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
@@ -15,7 +15,12 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "type": "device"
     },
     "gpu": {
-      "name": "Parallels Display Adapter (WDDM)",
+      "name": "NVIDIA GeForce RTX 4060 Laptop GPU",
+      "version": "551.52",
+      "id": "28E0",
+      "vendor_name": "NVIDIA",
+      "api_type": "D3D12",
+      "graphics_shader_level": "SM5",
       "type": "gpu"
     },
     "os": {
@@ -29,7 +34,8 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       },
       "memory_stats_total_virtual": 140737488224256,
       "misc_cpu_brand": "Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz",
-      "misc_cpu_vendor": "GenuineIntel"
+      "misc_cpu_vendor": "GenuineIntel",
+      "misc_primary_gpu_brand": "Parallels Display Adapter (WDDM)"
     }
   },
   "sdk": {

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -212,9 +212,38 @@ fn merge_unreal_context(event: &mut Event, context: Unreal4Context) {
         os_context.name = Annotated::new(os_major);
     }
 
-    if let Some(gpu_brand) = runtime_props.misc_primary_gpu_brand.take() {
+    // See https://github.com/EpicGames/UnrealEngine/blob/5.3.2-release/Engine/Source/Runtime/RHI/Private/DynamicRHI.cpp#L368-L376
+    if let Some(adapter_name) = context.engine_data.get("RHI.AdapterName") {
+        let gpu_context = contexts.get_or_default::<GpuContext>();
+        gpu_context.name = Annotated::new(adapter_name.into());
+    } else if let Some(gpu_brand) = runtime_props.misc_primary_gpu_brand.take() {
         let gpu_context = contexts.get_or_default::<GpuContext>();
         gpu_context.name = Annotated::new(gpu_brand);
+    }
+
+    if let Some(device_id) = context.engine_data.get("RHI.DeviceId") {
+        let gpu_context = contexts.get_or_default::<GpuContext>();
+        gpu_context.id = Annotated::new(Value::String(device_id.into()));
+    }
+
+    if let Some(feature_level) = context.engine_data.get("RHI.FeatureLevel") {
+        let gpu_context = contexts.get_or_default::<GpuContext>();
+        gpu_context.graphics_shader_level = Annotated::new(feature_level.into());
+    }
+
+    if let Some(vendor_name) = context.engine_data.get("RHI.GPUVendor") {
+        let gpu_context = contexts.get_or_default::<GpuContext>();
+        gpu_context.vendor_name = Annotated::new(vendor_name.into());
+    }
+
+    if let Some(driver_version) = context.engine_data.get("RHI.UserDriverVersion") {
+        let gpu_context = contexts.get_or_default::<GpuContext>();
+        gpu_context.version = Annotated::new(driver_version.into());
+    }
+
+    if let Some(rhi_name) = context.engine_data.get("RHI.RHIName") {
+        let gpu_context = contexts.get_or_default::<GpuContext>();
+        gpu_context.api_type = Annotated::new(rhi_name.into());
     }
 
     if runtime_props.is_assert.unwrap_or(false) {
@@ -338,6 +367,27 @@ mod tests {
 		<Modules>\\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
 \\Mac\Home\Desktop\WindowsNoEditor\Engine\Binaries\ThirdParty\PhysX3\Win64\VS2015\PxFoundationPROFILE_x64.dll</Modules>
 	</RuntimeProperties>
+	<EngineData>
+		<MatchingDPStatus>WindowsNo errors</MatchingDPStatus>
+		<RHI.IntegratedGPU>false</RHI.IntegratedGPU>
+		<RHI.DriverDenylisted>false</RHI.DriverDenylisted>
+		<RHI.D3DDebug>false</RHI.D3DDebug>
+		<RHI.Breadcrumbs>true</RHI.Breadcrumbs>
+		<RHI.DRED>true</RHI.DRED>
+		<RHI.DREDMarkersOnly>false</RHI.DREDMarkersOnly>
+		<RHI.DREDContext>true</RHI.DREDContext>
+		<RHI.Aftermath>true</RHI.Aftermath>
+		<RHI.RHIName>D3D12</RHI.RHIName>
+		<RHI.AdapterName>NVIDIA GeForce RTX 4060 Laptop GPU</RHI.AdapterName>
+		<RHI.UserDriverVersion>551.52</RHI.UserDriverVersion>
+		<RHI.InternalDriverVersion>31.0.15.5152</RHI.InternalDriverVersion>
+		<RHI.DriverDate>2-7-2024</RHI.DriverDate>
+		<RHI.FeatureLevel>SM5</RHI.FeatureLevel>
+		<RHI.GPUVendor>NVIDIA</RHI.GPUVendor>
+		<RHI.DeviceId>28E0</RHI.DeviceId>
+		<DeviceProfile.Name>Windows</DeviceProfile.Name>
+		<Platform.AppHasFocus>true</Platform.AppHasFocus>
+	</EngineData>
 	<PlatformProperties>
 		<PlatformIsRunningWindows>1</PlatformIsRunningWindows>
 		<PlatformCallbackResult>0</PlatformCallbackResult>


### PR DESCRIPTION
1. This commit replaces primary GPU with the one that is actually used for rendering. These two may be different for laptops. Fixes https://github.com/getsentry/sentry/issues/27498
2. This commit adds other available data:
  * Numeric DeviceID
  * Used feature level (SM5, SM6, etc)
  * GPU vendor name
  * GPU driver version
  * RHI type that is used (Metal, Vulkan, DX11, etc)




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
