### PR TITLE
test(metrics): Increase timeout for transactions test

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -972,7 +972,7 @@ def test_transaction_metrics(
 
         return
 
-    metrics = metrics_by_name(metrics_consumer, 7)
+    metrics = metrics_by_name(metrics_consumer, 7, timeout=6)
     common = {
         "timestamp": int(timestamp.timestamp()),
         "org_id": 1,


### PR DESCRIPTION
The Relay logs show no differences to a successful run, in the end of the logs you can see that Relay emits 7 different metrics into the topic but yet the assertion fails with that there is a message missing. Seems like a spurious failure (Kafka being slow?), increased the timeout as a best effort fix (does not slow down tests, it's just for the error case).

Closes: #2898

#skip-changelog
