### PR TITLE
instr(spans): Tag kafka metric with is_segment / has_parent

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -983,7 +983,9 @@ impl StoreService {
 
         metric!(
             counter(RelayCounters::ProcessingMessageProduced) += 1,
-            event_type = "span"
+            event_type = "span",
+            is_segment = bool_to_str(span.is_segment),
+            has_parent = bool_to_str(span.parent_span_id.is_some()),
         );
 
         Ok(())
@@ -1626,6 +1628,14 @@ impl Message for KafkaMessage<'_> {
 /// Slow items must be routed to the `Attachments` topic.
 fn is_slow_item(item: &Item) -> bool {
     item.ty() == &ItemType::Attachment || item.ty() == &ItemType::UserReport
+}
+
+fn bool_to_str(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
 }
 
 #[cfg(test)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -965,6 +965,9 @@ impl StoreService {
 
         self.produce_metrics_summary(scoping, item, &span);
 
+        let is_segment = span.is_segment;
+        let has_parent = span.parent_span_id.is_some();
+
         self.produce(
             KafkaTopic::Spans,
             scoping.organization_id,
@@ -984,8 +987,8 @@ impl StoreService {
         metric!(
             counter(RelayCounters::ProcessingMessageProduced) += 1,
             event_type = "span",
-            is_segment = bool_to_str(span.is_segment),
-            has_parent = bool_to_str(span.parent_span_id.is_some()),
+            is_segment = bool_to_str(is_segment),
+            has_parent = bool_to_str(has_parent),
         );
 
         Ok(())

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -533,6 +533,8 @@ pub enum RelayCounters {
     ///
     /// This metric is tagged with:
     ///  - `event_type`: The kind of message produced to Kafka.
+    ///  - `is_segment` (only for event_type span): `true` the span is the root of a segment.
+    ///  - `has_parent` (only for event_type span): `false` if the span is the root of a trace.
     ///
     /// The message types can be:
     ///

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -84,6 +84,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
     let trace_id = hex::encode(trace_id);
     let parent_span_id = hex::encode(parent_span_id);
 
+    // TODO: This is wrong, a segment could still have a parent in the trace.
     let segment_id = if parent_span_id.is_empty() {
         Annotated::new(SpanId(span_id.clone()))
     } else {
@@ -144,6 +145,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
             (otel_span.end_time_unix_nano - otel_span.start_time_unix_nano) as f64 / 1e6f64;
     }
 
+    // TODO: This is wrong, a segment could still have a parent in the trace.
     let is_segment = parent_span_id.is_empty().into();
 
     EventSpan {


### PR DESCRIPTION
For spans, tag the statsd metric that we emit for produced Kafka messages with `is_segment` and `has_parent`. 100% of transaction spans are currently converted to standalone spans, so this should give us an accurate estimate of the ratio of spans vs. segments (=transactions) vs. traces.

#skip-changelog