### PR TITLE
ref(replays): video item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,7 +4122,6 @@ dependencies = [
  "rmp-serde",
  "rust-embed",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_path_to_error",
  "similar-asserts",
@@ -4707,15 +4706,6 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,7 @@ dependencies = [
  "rmp-serde",
  "rust-embed",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serde_path_to_error",
  "similar-asserts",
@@ -4706,6 +4707,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -97,7 +97,6 @@ reqwest = { version = "0.11.1", features = [
 rmp-serde = "1.1.1"
 rust-embed = { version = "8.0.0", optional = true }
 serde = { workspace = true }
-serde_bytes = { version = "0.11.14" }
 serde_json = { workspace = true }
 smallvec = { workspace = true, features = ["drain_filter"] }
 sqlx = { version = "0.7.3", features = [

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -23,7 +23,6 @@ processing = [
     "dep:symbolic-common",
     "dep:symbolic-unreal",
     "dep:zstd",
-    "bytes/serde",
     "relay-cardinality/redis",
     "relay-config/processing",
     "relay-kafka/producer",
@@ -47,7 +46,7 @@ axum-server = "0.4.7"
 backoff = "0.4.0"
 brotli = "3.3.4"
 bytecount = "0.6.0"
-bytes = { version = "1.4.0" }
+bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.3.3"
 flate2 = "1.0.19"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -97,6 +97,7 @@ reqwest = { version = "0.11.1", features = [
 rmp-serde = "1.1.1"
 rust-embed = { version = "8.0.0", optional = true }
 serde = { workspace = true }
+serde_bytes = "0.11"
 serde_json = { workspace = true }
 smallvec = { workspace = true, features = ["drain_filter"] }
 sqlx = { version = "0.7.3", features = [

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -513,11 +513,6 @@ pub struct ItemHeaders {
     #[serde(default, skip)]
     replay_combined_payload: bool,
 
-    /// The parsed replay-event and replay-recording payloads.
-    /// NOTE: This is internal-only and not exposed into the Envelope.
-    #[serde(default, skip)]
-    replay_video_events: Option<(Vec<u8>, Vec<u8>)>,
-
     /// Contains the amount of events this item was generated and aggregated from.
     ///
     /// A [metrics buckets](`ItemType::MetricBuckets`) item contains metrics extracted and
@@ -606,7 +601,6 @@ impl Item {
                 routing_hint: None,
                 rate_limited: false,
                 replay_combined_payload: false,
-                replay_video_events: None,
                 source_quantities: None,
                 sample_rates: None,
                 other: BTreeMap::new(),
@@ -781,17 +775,6 @@ impl Item {
     /// Sets the replay_combined_payload for this item.
     pub fn set_replay_combined_payload(&mut self, combined_payload: bool) {
         self.headers.replay_combined_payload = combined_payload;
-    }
-
-    /// Returns the payload's replay video events.
-    #[cfg(feature = "processing")]
-    pub fn replay_video_events(&self) -> Option<(Vec<u8>, Vec<u8>)> {
-        self.headers.replay_video_events.clone()
-    }
-
-    /// Set the replay video events attribute for this item.
-    pub fn set_replay_video_events(&mut self, replay_event: Vec<u8>, replay_recording: Vec<u8>) {
-        self.headers.replay_video_events = Some((replay_event, replay_recording));
     }
 
     /// Sets sample rates for this item.

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -107,15 +107,17 @@ pub fn process(
             ) {
                 ProcessingAction::Drop(action) => action,
                 ProcessingAction::Keep => ItemAction::Keep,
-                ProcessingAction::Replace(video_event) => match rmp_serde::to_vec(&video_event) {
-                    Ok(payload) => {
-                        item.set_payload(ContentType::OctetStream, payload);
-                        ItemAction::Keep
+                ProcessingAction::Replace(video_event) => {
+                    match rmp_serde::to_vec_named(&video_event) {
+                        Ok(payload) => {
+                            item.set_payload(ContentType::OctetStream, payload);
+                            ItemAction::Keep
+                        }
+                        Err(_) => ItemAction::Drop(Outcome::Invalid(
+                            DiscardReason::InvalidReplayVideoEvent,
+                        )),
                     }
-                    Err(_) => {
-                        ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidReplayVideoEvent))
-                    }
-                },
+                }
             },
             _ => ItemAction::Keep,
         }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -253,7 +253,7 @@ impl StoreService {
                         item.payload(),
                         start_time,
                         retention,
-                    );
+                    )?;
                 }
                 ItemType::ReplayRecording => {
                     replay_recording = Some(item);
@@ -293,11 +293,12 @@ impl StoreService {
             //
             // The replay_video value is always specified as `None`. We do not allow separate
             // item types for `ReplayVideo` events.
+            let replay_event = replay_event.map(|rv| rv.payload());
             self.produce_replay_recording(
                 event_id,
                 scoping,
                 &recording.payload(),
-                replay_event.map(|rv| rv.payload().as_ref()),
+                replay_event.as_deref(),
                 None,
                 start_time,
                 retention,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -878,9 +878,9 @@ impl StoreService {
     ) -> Result<(), StoreError> {
         #[derive(Deserialize)]
         struct VideoEvent<'a> {
-            replay_video: &'a [u8],
             replay_event: &'a [u8],
             replay_recording: &'a [u8],
+            replay_video: &'a [u8],
         }
 
         let Ok(VideoEvent {
@@ -1212,10 +1212,27 @@ struct ReplayRecordingNotChunkedKafkaMessage<'a> {
     project_id: ProjectId,
     received: u64,
     retention_days: u16,
+    #[serde(with = "serde_bytes")]
     payload: &'a [u8],
+    #[serde(with = "serde_bytes")]
     replay_event: Option<&'a [u8]>,
+    #[serde(with = "serde_bytes")]
     replay_video: Option<&'a [u8]>,
 }
+
+// fn serialize_bytes<S: Serializer>(b: &[u8], serializer: &S) -> Result<S::Ok, S::Error> {
+//     serializer.serialize_bytes(b)
+// }
+
+// fn serialize_option_bytes<S: Serializer>(
+//     b: &Option<&[u8]>,
+//     serializer: &S,
+// ) -> Result<S::Ok, S::Error> {
+//     match b {
+//         Some(b) => serializer.serialize_bytes(b),
+//         None => serializer.serialize_none(),
+//     }
+// }
 
 /// User report for an event wrapped up in a message ready for consumption in Kafka.
 ///

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1220,20 +1220,6 @@ struct ReplayRecordingNotChunkedKafkaMessage<'a> {
     replay_video: Option<&'a [u8]>,
 }
 
-// fn serialize_bytes<S: Serializer>(b: &[u8], serializer: &S) -> Result<S::Ok, S::Error> {
-//     serializer.serialize_bytes(b)
-// }
-
-// fn serialize_option_bytes<S: Serializer>(
-//     b: &Option<&[u8]>,
-//     serializer: &S,
-// ) -> Result<S::Ok, S::Error> {
-//     match b {
-//         Some(b) => serializer.serialize_bytes(b),
-//         None => serializer.serialize_none(),
-//     }
-// }
-
 /// User report for an event wrapped up in a message ready for consumption in Kafka.
 ///
 /// Is always independent of an event and can be sent as part of any envelope.


### PR DESCRIPTION
Serialize processed replay video item back into the envelope instead of putting it on the header.

#skip-changelog