### PR TITLE
fix(project-cache): Increase project cache worker threads

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -298,7 +298,7 @@ impl Runtimes {
     pub fn new(config: &Config) -> Self {
         Self {
             upstream: create_runtime("upstream-rt", 1),
-            project: create_runtime("project-rt", 1),
+            project: create_runtime("project-rt", 2),
             aggregator: create_runtime("aggregator-rt", 1),
             outcome: create_runtime("outcome-rt", 1),
             #[cfg(feature = "processing")]


### PR DESCRIPTION
The project cache Runtime only has a single thread. The idea is since it only ever works on a single task at a time it only needs a single thread. 

But the project cache does spawn more tasks via `tokio::spawn` in [`handle_request_update`](https://github.com/getsentry/relay/blob/c363c861ae78f2523e0d48977a0d05dd936d4697/relay-server/src/services/project_cache.rs#L643-L675) (a substantial amount), this interferes with the single thread only working on the project cache backlog.

This is a bit of a stab in the dark to fix processing delays in our dedicated project config Relays.

#skip-changelog