### PR TITLE
feat(processor): Introduce first step state wrapper

### DIFF
--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -7,7 +7,8 @@ use relay_pii::PiiAttachmentsProcessor;
 use relay_statsd::metric;
 
 use crate::envelope::{AttachmentType, ContentType};
-use crate::services::processor::state::ProcessedState;
+use crate::services::processor::state::{ProcessedState, ScrubAttachementState};
+#[cfg(feature = "processing")]
 use crate::services::processor::ProcessEnvelopeState;
 use crate::statsd::RelayTimers;
 
@@ -51,7 +52,8 @@ pub fn create_placeholders<G: EventProcessing>(
 /// This only applies the new PII rules that explicitly select `ValueType::Binary` or one of the
 /// attachment types. When special attachments are detected, these are scrubbed with custom
 /// logic; otherwise the entire attachment is treated as a single binary blob.
-pub fn scrub<G>(mut state: ProcessEnvelopeState<G>) -> ProcessedState<G> {
+pub fn scrub<G>(state: ScrubAttachementState<G>) -> ProcessedState<G> {
+    let mut state = state.inner();
     let envelope = state.managed_envelope.envelope_mut();
     if let Some(ref config) = state.project_state.config.pii_config {
         let minidump = envelope

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -7,6 +7,7 @@ use relay_pii::PiiAttachmentsProcessor;
 use relay_statsd::metric;
 
 use crate::envelope::{AttachmentType, ContentType};
+use crate::services::processor::state::ProcessedState;
 use crate::services::processor::ProcessEnvelopeState;
 use crate::statsd::RelayTimers;
 
@@ -50,7 +51,7 @@ pub fn create_placeholders<G: EventProcessing>(
 /// This only applies the new PII rules that explicitly select `ValueType::Binary` or one of the
 /// attachment types. When special attachments are detected, these are scrubbed with custom
 /// logic; otherwise the entire attachment is treated as a single binary blob.
-pub fn scrub<G>(mut state: ProcessEnvelopeState<G>) -> ProcessEnvelopeState<G> {
+pub fn scrub<G>(mut state: ProcessEnvelopeState<G>) -> ProcessedState<G> {
     let envelope = state.managed_envelope.envelope_mut();
     if let Some(ref config) = state.project_state.config.pii_config {
         let minidump = envelope
@@ -96,5 +97,5 @@ pub fn scrub<G>(mut state: ProcessEnvelopeState<G>) -> ProcessEnvelopeState<G> {
             item.set_payload(content_type, payload);
         }
     }
-    state
+    ProcessedState::new(state)
 }

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -25,9 +25,7 @@ use {
 ///
 /// If the event payload was empty before, it is created.
 #[cfg(feature = "processing")]
-pub fn create_placeholders<G: EventProcessing>(
-    mut state: ProcessEnvelopeState<G>,
-) -> ProcessEnvelopeState<G> {
+pub fn create_placeholders<G: EventProcessing>(state: &mut ProcessEnvelopeState<G>) {
     let envelope = state.managed_envelope.envelope();
     let minidump_attachment =
         envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
@@ -43,8 +41,6 @@ pub fn create_placeholders<G: EventProcessing>(
         state.metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
         utils::process_apple_crash_report(event, &item.payload());
     }
-
-    state
 }
 
 /// Apply data privacy rules to attachments in the envelope.

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -513,12 +513,12 @@ mod tests {
         // None represents no TransactionMetricsConfig, DS will not be run
         let state = get_state(None);
         let state = run(FilterState::new(state), &config);
-        assert!(state.sampling_should_drop());
+        assert!(state.inner().sampling_result.should_keep());
 
         // Current version is 1, so it won't run DS if it's outdated
         let state = get_state(Some(0));
         let state = run(FilterState::new(state), &config);
-        assert!(state.sampling_should_drop());
+        assert!(state.inner().sampling_result.should_keep());
 
         // Dynamic sampling is run, as the transactionmetrics version is up to date.
         let state = get_state(Some(1));

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -11,6 +11,8 @@ use relay_protocol::Annotated;
 
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::services::outcome::{DiscardReason, Outcome};
+#[cfg(feature = "processing")]
+use crate::services::processor::state::EnforcedQuotasState;
 use crate::services::processor::{ProcessEnvelopeState, TransactionGroup};
 use crate::utils::ItemAction;
 
@@ -75,29 +77,35 @@ pub fn transfer_id(
 /// Processes profiles and set the profile ID in the profile context on the transaction if successful.
 #[cfg(feature = "processing")]
 pub fn process<'a>(
-    mut state: ProcessEnvelopeState<'a, TransactionGroup>,
+    mut enforced_state: EnforcedQuotasState<'a, TransactionGroup>,
     config: &'_ Config,
 ) -> ProcessEnvelopeState<'a, TransactionGroup> {
-    let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
+    let profiling_enabled = enforced_state
+        .state
+        .project_state
+        .has_feature(Feature::Profiling);
     let mut found_profile_id = None;
-    state.managed_envelope.retain_items(|item| match item.ty() {
-        ItemType::Profile => {
-            if !profiling_enabled {
-                return ItemAction::DropSilently;
+    enforced_state
+        .state
+        .managed_envelope
+        .retain_items(|item| match item.ty() {
+            ItemType::Profile => {
+                if !profiling_enabled {
+                    return ItemAction::DropSilently;
+                }
+                // If we don't have an event at this stage, we need to drop the profile.
+                let Some(event) = enforced_state.state.event.value() else {
+                    return ItemAction::DropSilently;
+                };
+                let (profile_id, action) = expand_profile(item, event, config);
+                found_profile_id = profile_id;
+                action
             }
-            // If we don't have an event at this stage, we need to drop the profile.
-            let Some(event) = state.event.value() else {
-                return ItemAction::DropSilently;
-            };
-            let (profile_id, action) = expand_profile(item, event, config);
-            found_profile_id = profile_id;
-            action
-        }
-        _ => ItemAction::Keep,
-    });
+            _ => ItemAction::Keep,
+        });
     if found_profile_id.is_none() {
         // Remove profile context from event.
-        if let Some(event) = state.event.value_mut() {
+        if let Some(event) = enforced_state.state.event.value_mut() {
             if event.ty.value() == Some(&EventType::Transaction) {
                 if let Some(contexts) = event.contexts.value_mut() {
                     contexts.remove::<ProfileContext>();
@@ -106,7 +114,7 @@ pub fn process<'a>(
         }
     }
 
-    state
+    enforced_state.inner()
 }
 
 /// Transfers transaction metadata to profile and check its size.

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -17,6 +17,7 @@ use relay_statsd::metric;
 
 use crate::envelope::{ContentType, ItemType};
 use crate::services::outcome::{DiscardReason, Outcome};
+use crate::services::processor::state::EnforceQuotasState;
 use crate::services::processor::{
     ProcessEnvelopeState, ProcessError, ProcessingError, ReplayGroup,
 };
@@ -27,7 +28,7 @@ use crate::utils::ItemAction;
 pub fn process<'a>(
     mut state: ProcessEnvelopeState<'a, ReplayGroup>,
     config: &'_ Config,
-) -> Result<ProcessEnvelopeState<'a, ReplayGroup>, ProcessError<'a, ReplayGroup>> {
+) -> Result<EnforceQuotasState<'a, ReplayGroup>, ProcessError<'a, ReplayGroup>> {
     let project_state = state.project_state.clone();
     let replays_enabled = project_state.has_feature(Feature::SessionReplay);
     let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
@@ -125,7 +126,7 @@ pub fn process<'a>(
         _ => ItemAction::Keep,
     });
 
-    Ok(state)
+    Ok(EnforceQuotasState::new(state))
 }
 
 /// Validates, normalizes, and scrubs PII from a replay event.

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -14,6 +14,7 @@ use relay_metrics::Bucket;
 use relay_statsd::metric;
 
 use crate::envelope::{ContentType, Item, ItemType};
+use crate::services::processor::state::EnforceQuotasState;
 use crate::services::processor::{ProcessEnvelopeState, SessionGroup, MINIMUM_CLOCK_DRIFT};
 use crate::statsd::RelayTimers;
 use crate::utils::ItemAction;
@@ -25,7 +26,7 @@ use crate::utils::ItemAction;
 pub fn process<'a>(
     mut state: ProcessEnvelopeState<'a, SessionGroup>,
     config: &'_ Config,
-) -> ProcessEnvelopeState<'a, SessionGroup> {
+) -> EnforceQuotasState<'a, SessionGroup> {
     let received = state.managed_envelope.received_at();
     let extracted_metrics = &mut state.extracted_metrics.project_metrics;
     let metrics_config = state.project_state.config().session_metrics;
@@ -67,7 +68,7 @@ pub fn process<'a>(
         }
     });
 
-    state
+    EnforceQuotasState::new(state)
 }
 
 /// Returns Ok(true) if attributes were modified.

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -22,7 +22,10 @@ use crate::utils::ItemAction;
 ///
 /// Both are removed from the envelope if they contain invalid JSON or if their timestamps
 /// are out of range after clock drift correction.
-pub fn process(state: &mut ProcessEnvelopeState<SessionGroup>, config: &Config) {
+pub fn process<'a>(
+    mut state: ProcessEnvelopeState<'a, SessionGroup>,
+    config: &'_ Config,
+) -> ProcessEnvelopeState<'a, SessionGroup> {
     let received = state.managed_envelope.received_at();
     let extracted_metrics = &mut state.extracted_metrics.project_metrics;
     let metrics_config = state.project_state.config().session_metrics;
@@ -63,6 +66,8 @@ pub fn process(state: &mut ProcessEnvelopeState<SessionGroup>, config: &Config) 
             ItemAction::DropSilently // sessions never log outcomes.
         }
     });
+
+    state
 }
 
 /// Returns Ok(true) if attributes were modified.

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -10,7 +10,7 @@ mod processing;
 #[cfg(feature = "processing")]
 pub use processing::*;
 
-pub fn filter(state: &mut ProcessEnvelopeState<SpanGroup>) {
+pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> ProcessEnvelopeState<SpanGroup> {
     let standalone_span_ingestion_enabled = state
         .project_state
         .has_feature(Feature::StandaloneSpanIngestion);
@@ -25,4 +25,5 @@ pub fn filter(state: &mut ProcessEnvelopeState<SpanGroup>) {
         }
         _ => ItemAction::Keep,
     });
+    state
 }

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -2,6 +2,7 @@
 
 use relay_dynamic_config::Feature;
 
+use crate::services::processor::state::FilterState;
 use crate::services::processor::SpanGroup;
 use crate::{envelope::ItemType, services::processor::ProcessEnvelopeState, utils::ItemAction};
 
@@ -10,7 +11,7 @@ mod processing;
 #[cfg(feature = "processing")]
 pub use processing::*;
 
-pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> ProcessEnvelopeState<SpanGroup> {
+pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> FilterState<SpanGroup> {
     let standalone_span_ingestion_enabled = state
         .project_state
         .has_feature(Feature::StandaloneSpanIngestion);
@@ -25,5 +26,6 @@ pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> ProcessEnvelopeStat
         }
         _ => ItemAction::Keep,
     });
-    state
+
+    FilterState::new(state)
 }

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -2,7 +2,7 @@
 
 use relay_dynamic_config::Feature;
 
-use crate::services::processor::state::FilterState;
+use crate::services::processor::state::FilterSpanState;
 use crate::services::processor::SpanGroup;
 use crate::{envelope::ItemType, services::processor::ProcessEnvelopeState, utils::ItemAction};
 
@@ -11,7 +11,7 @@ mod processing;
 #[cfg(feature = "processing")]
 pub use processing::*;
 
-pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> FilterState<SpanGroup> {
+pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> FilterSpanState<SpanGroup> {
     let standalone_span_ingestion_enabled = state
         .project_state
         .has_feature(Feature::StandaloneSpanIngestion);
@@ -27,5 +27,5 @@ pub fn filter(mut state: ProcessEnvelopeState<SpanGroup>) -> FilterState<SpanGro
         _ => ItemAction::Keep,
     });
 
-    FilterState::new(state)
+    FilterSpanState::new(state)
 }

--- a/relay-server/src/services/processor/state.rs
+++ b/relay-server/src/services/processor/state.rs
@@ -19,22 +19,76 @@ macro_rules! state_type {
     };
 }
 
-#[cfg(feature = "processing")]
-state_type!(EnforcedQuotasState);
+state_type!(EnforceQuotasState);
+state_type!(EnforcedQuotastate);
+state_type!(ScrubAttachementState);
 state_type!(ProcessedState);
+state_type!(FilterState);
+state_type!(ExtractEventState);
+state_type!(ExtractedEventState);
+state_type!(FinalizedEventState);
+state_type!(NormalizedEventState);
 
-pub enum EnforcedOrRaw<'a, G> {
-    #[cfg(feature = "processing")]
-    EnforcedQuotasState(EnforcedQuotasState<'a, G>),
-    State(ProcessEnvelopeState<'a, G>),
+pub struct SampledState<'a, G>(ProcessEnvelopeState<'a, G>);
+
+impl<'a, G> SampledState<'a, G> {
+    pub fn new(state: ProcessEnvelopeState<'a, G>) -> SampledState<'a, G> {
+        Self(state)
+    }
+
+    pub fn inner(self) -> ProcessEnvelopeState<'a, G> {
+        self.0
+    }
+
+    pub fn sampling_should_drop(&self) -> bool {
+        self.0.sampling_result.should_drop()
+    }
 }
 
-impl<'a, G> EnforcedOrRaw<'a, G> {
-    pub fn inner(self) -> ProcessEnvelopeState<'a, G> {
-        match self {
-            #[cfg(feature = "processing")]
-            EnforcedOrRaw::EnforcedQuotasState(state) => state.inner(),
-            EnforcedOrRaw::State(state) => state,
-        }
+impl<'a, G> From<EnforceQuotasState<'a, G>> for EnforcedQuotastate<'a, G> {
+    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+        EnforcedQuotastate::new(value.inner())
+    }
+}
+
+impl<'a, G> From<EnforceQuotasState<'a, G>> for ProcessedState<'a, G> {
+    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+        ProcessedState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<EnforceQuotasState<'a, G>> for FilterState<'a, G> {
+    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+        FilterState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<EnforceQuotasState<'a, G>> for SampledState<'a, G> {
+    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+        SampledState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<FilterState<'a, G>> for EnforceQuotasState<'a, G> {
+    fn from(value: FilterState<'a, G>) -> Self {
+        EnforceQuotasState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<FilterState<'a, G>> for ProcessedState<'a, G> {
+    fn from(value: FilterState<'a, G>) -> Self {
+        ProcessedState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<FilterState<'a, G>> for ExtractEventState<'a, G> {
+    fn from(value: FilterState<'a, G>) -> Self {
+        ExtractEventState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<ScrubAttachementState<'a, G>> for ExtractEventState<'a, G> {
+    fn from(value: ScrubAttachementState<'a, G>) -> Self {
+        ExtractEventState::new(value.inner())
     }
 }

--- a/relay-server/src/services/processor/state.rs
+++ b/relay-server/src/services/processor/state.rs
@@ -1,0 +1,18 @@
+//! This module contains types and utils used in processor to decribe and support the processing pipeline.
+//!
+
+use crate::services::processor::ProcessEnvelopeState;
+
+pub struct EnforcedQuotasState<'a, G> {
+    pub state: ProcessEnvelopeState<'a, G>,
+}
+
+impl<'a, G> EnforcedQuotasState<'a, G> {
+    pub fn new(state: ProcessEnvelopeState<'a, G>) -> EnforcedQuotasState<'a, G> {
+        Self { state }
+    }
+
+    pub fn inner(self) -> ProcessEnvelopeState<'a, G> {
+        self.state
+    }
+}

--- a/relay-server/src/services/processor/state.rs
+++ b/relay-server/src/services/processor/state.rs
@@ -1,8 +1,14 @@
-//! This module contains types and utils used in processor to decribe and support the processing pipeline.
+//! This module contains types and utils used in processor to describe and support the processing pipeline.
 //!
+//! The idea is that every suitable processing step function returns the [`ProcessEnvelopeState`]
+//! into one of the defined here struct, which is accepted only the following function, this
+//! way enforcing the order the function can be executed.
+
+use std::ops::{Deref, DerefMut};
 
 use crate::services::processor::ProcessEnvelopeState;
 
+/// Simple macro to create a struct and define few default methods.
 macro_rules! state_type {
     ($name:ident) => {
         pub struct $name<'a, G>(ProcessEnvelopeState<'a, G>);
@@ -19,16 +25,115 @@ macro_rules! state_type {
     };
 }
 
-state_type!(EnforceQuotasState);
-state_type!(EnforcedQuotastate);
-state_type!(ScrubAttachementState);
-state_type!(ProcessedState);
-state_type!(FilterState);
-state_type!(ExtractEventState);
-state_type!(ExtractedEventState);
-state_type!(FinalizedEventState);
+// Returns from the `processor::light_normalize_event` function.
 state_type!(NormalizedEventState);
 
+// Only this type can be used by `processor::enforce_quotas` function.
+state_type!(EnforceQuotasState);
+
+impl<'a, G> From<FilterProfileState<'a, G>> for EnforceQuotasState<'a, G> {
+    fn from(value: FilterProfileState<'a, G>) -> Self {
+        EnforceQuotasState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<FilterSpanState<'a, G>> for EnforceQuotasState<'a, G> {
+    fn from(value: FilterSpanState<'a, G>) -> Self {
+        EnforceQuotasState::new(value.inner())
+    }
+}
+
+// This type returns from the `processor::enforce_quotas` function.
+state_type!(EnforcedQuotasState);
+
+impl<'a, G> From<EnforceQuotasState<'a, G>> for EnforcedQuotasState<'a, G> {
+    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+        EnforcedQuotasState::new(value.inner())
+    }
+}
+
+// This type is accepted only by  `attachment::scrub` function.
+state_type!(ScrubAttachementState);
+
+impl<'a, G> Deref for ScrubAttachementState<'a, G> {
+    type Target = ProcessEnvelopeState<'a, G>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, G> DerefMut for ScrubAttachementState<'a, G> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// This type is set only after all the steps are done and can be returned from the main entry
+// function.
+state_type!(ProcessedState);
+
+impl<'a, G> From<EnforceQuotasState<'a, G>> for ProcessedState<'a, G> {
+    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+        ProcessedState::new(value.inner())
+    }
+}
+
+impl<'a, G> From<FilterSpanState<'a, G>> for ProcessedState<'a, G> {
+    fn from(value: FilterSpanState<'a, G>) -> Self {
+        ProcessedState::new(value.inner())
+    }
+}
+
+// Returns from `event::filter` function.
+state_type!(FilterEventState);
+
+// Returns from the `span::filter` function.
+state_type!(FilterSpanState);
+
+// Accepted into the `event::extract` function.
+state_type!(ExtractEventState);
+
+impl<'a, G> From<FilterProfileState<'a, G>> for ExtractEventState<'a, G> {
+    fn from(value: FilterProfileState<'a, G>) -> Self {
+        ExtractEventState::new(value.inner())
+    }
+}
+
+// Returns from the `event::extract` function.
+state_type!(ExtractedEventState);
+
+impl<'a, G> Deref for ExtractedEventState<'a, G> {
+    type Target = ProcessEnvelopeState<'a, G>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, G> DerefMut for ExtractedEventState<'a, G> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// Returns from the `event::finalize` function.
+state_type!(FinalizedEventState);
+
+// Returns from the `profile::filter` function.
+state_type!(FilterProfileState);
+
+impl<'a, G> From<EnforcedQuotasState<'a, G>> for FilterProfileState<'a, G> {
+    fn from(value: EnforcedQuotasState<'a, G>) -> Self {
+        FilterProfileState::new(value.inner())
+    }
+}
+
+// Returns from the `profile::process` function.
+#[cfg(feature = "processing")]
+state_type!(ProfileProcessedState);
+
+/// Signalizes that the state was through the dynamic sampling.
 pub struct SampledState<'a, G>(ProcessEnvelopeState<'a, G>);
 
 impl<'a, G> SampledState<'a, G> {
@@ -43,52 +148,21 @@ impl<'a, G> SampledState<'a, G> {
     pub fn sampling_should_drop(&self) -> bool {
         self.0.sampling_result.should_drop()
     }
-}
 
-impl<'a, G> From<EnforceQuotasState<'a, G>> for EnforcedQuotastate<'a, G> {
-    fn from(value: EnforceQuotasState<'a, G>) -> Self {
-        EnforcedQuotastate::new(value.inner())
+    pub fn has_event(&self) -> bool {
+        self.0.has_event()
     }
 }
 
-impl<'a, G> From<EnforceQuotasState<'a, G>> for ProcessedState<'a, G> {
-    fn from(value: EnforceQuotasState<'a, G>) -> Self {
-        ProcessedState::new(value.inner())
-    }
-}
-
-impl<'a, G> From<EnforceQuotasState<'a, G>> for FilterState<'a, G> {
-    fn from(value: EnforceQuotasState<'a, G>) -> Self {
-        FilterState::new(value.inner())
-    }
-}
-
-impl<'a, G> From<EnforceQuotasState<'a, G>> for SampledState<'a, G> {
-    fn from(value: EnforceQuotasState<'a, G>) -> Self {
+impl<'a, G> From<EnforcedQuotasState<'a, G>> for SampledState<'a, G> {
+    fn from(value: EnforcedQuotasState<'a, G>) -> Self {
         SampledState::new(value.inner())
     }
 }
 
-impl<'a, G> From<FilterState<'a, G>> for EnforceQuotasState<'a, G> {
-    fn from(value: FilterState<'a, G>) -> Self {
-        EnforceQuotasState::new(value.inner())
-    }
-}
-
-impl<'a, G> From<FilterState<'a, G>> for ProcessedState<'a, G> {
-    fn from(value: FilterState<'a, G>) -> Self {
-        ProcessedState::new(value.inner())
-    }
-}
-
-impl<'a, G> From<FilterState<'a, G>> for ExtractEventState<'a, G> {
-    fn from(value: FilterState<'a, G>) -> Self {
-        ExtractEventState::new(value.inner())
-    }
-}
-
-impl<'a, G> From<ScrubAttachementState<'a, G>> for ExtractEventState<'a, G> {
-    fn from(value: ScrubAttachementState<'a, G>) -> Self {
-        ExtractEventState::new(value.inner())
+#[cfg(feature = "processing")]
+impl<'a, G> From<ProfileProcessedState<'a, G>> for SampledState<'a, G> {
+    fn from(value: ProfileProcessedState<'a, G>) -> Self {
+        SampledState::new(value.inner())
     }
 }

--- a/relay-server/src/services/processor/unreal.rs
+++ b/relay-server/src/services/processor/unreal.rs
@@ -5,6 +5,7 @@
 use relay_config::Config;
 
 use crate::envelope::ItemType;
+use crate::services::processor::state::ExtractEventState;
 use crate::services::processor::{ErrorGroup, ProcessEnvelopeState, ProcessError, ProcessingError};
 use crate::utils;
 
@@ -21,9 +22,11 @@ use crate::utils;
 /// After this, [`crate::services::processor::EnvelopeProcessorService`] should be able to process the envelope the same
 /// way it processes any other envelopes.
 pub fn expand<'a>(
-    mut state: ProcessEnvelopeState<'a, ErrorGroup>,
+    state: ExtractEventState<'a, ErrorGroup>,
     config: &'_ Config,
-) -> Result<ProcessEnvelopeState<'a, ErrorGroup>, ProcessError<'a, ErrorGroup>> {
+) -> Result<ExtractEventState<'a, ErrorGroup>, ProcessError<'a, ErrorGroup>> {
+    let mut state = state.inner();
+
     let envelope = &mut state.envelope_mut();
 
     if let Some(item) = envelope.take_item_by(|item| item.ty() == &ItemType::UnrealReport) {
@@ -32,7 +35,7 @@ pub fn expand<'a>(
         };
     }
 
-    Ok(state)
+    Ok(ExtractEventState::new(state))
 }
 
 /// Extracts event information from an unreal context.


### PR DESCRIPTION
Introduced changes: 

* instead of passing mutable reference into all processing function - we mostly move the state and let the function own it
  * in case of error we return the state back together with error
  * in case of success the state is returned
  * most of the function accept only concrete state wrapper type and then return also either the same or different type
* introduced different states, which accepted and returned by different function, and initially predefines the order in which the functions can run
  * there are still few caveats which should be worked out, because of special behaviour in `processing` mode it's not that easy to return the proper type
  * in some cases the simple mutable reference to `ProcessEnvelopeState` still is passed around


There is no functional changes in this PR and mostly changing the signatures and return types of the functions.

related: https://github.com/getsentry/team-ingest/issues/253

#skip-changelog