### PR TITLE
feat(spans): Parse supabase span descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Extend GPU context with data for Unreal Engine crash reports. ([#3144](https://github.com/getsentry/relay/pull/3144))
 - Parametrize transaction in dynamic sampling context. ([#3141](https://github.com/getsentry/relay/pull/3141))
+- Parse & scrub span description for supabase. ([#3153](https://github.com/getsentry/relay/pull/3153))
 
 **Bug Fixes**:
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn scrub_span_description(
                     if let sql::Mode::Parsed(ast) = mode {
                         parsed_sql = Some(ast);
                     }
-                    dbg!(scrubbed)
+                    scrubbed
                 }
             }
             ("resource", ty) => scrub_resource(ty, description),

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -72,6 +72,9 @@ pub(crate) fn scrub_span_description(
                     // the query type ("User find" for example).
                     Some(description.to_owned())
                 } else if span_origin == Some("auto.db.supabase") {
+                    // The description only contains the table name, e.g. `"from(users)`.
+                    // In the future, we might want to parse `data.query` as well.
+                    // See https://github.com/supabase-community/sentry-integration-js/blob/master/index.js#L259
                     scrub_supabase(description)
                 } else {
                     let (scrubbed, mode) = sql::scrub_queries(db_system, description);
@@ -921,13 +924,6 @@ mod tests {
     );
 
     span_description_test!(db_prisma, "User find", "db.sql.prisma", "User find");
-
-    span_description_test!(
-        db_supabase,
-        "from(my_table)",
-        "db.auto.supabase",
-        "from(my_table)"
-    );
 
     #[test]
     fn informed_sql_parser() {

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1440,7 +1440,13 @@ LIMIT 1
         let json = r#"{
             "description": "from(my_table00)",
             "op": "db.select",
-            "origin": "auto.db.supabase"
+            "origin": "auto.db.supabase",
+            "data": {
+                "query": [
+                    "select(*,other(*))",
+                    "in(something, (value1,value2))"
+                ]
+            }
         }"#;
 
         let span = Annotated::<Span>::from_json(json)

--- a/relay-event-normalization/src/regexes.rs
+++ b/relay-event-normalization/src/regexes.rs
@@ -81,3 +81,17 @@ pub static RESOURCE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 pub static DB_SQL_TRANSACTION_CORE_DATA_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?P<int>\d+)").unwrap());
+
+pub static DB_SUPABASE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?xi)
+        # UUIDs.
+        (?P<uuid>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}) |
+        # Hexadecimal strings with more than 5 digits.
+        (?P<hex>[a-f0-9]{5}[a-f0-9]+) |
+        # Integer IDs with more than one digit.
+        (?P<int>\d\d+)
+        ",
+    )
+    .unwrap()
+});


### PR DESCRIPTION
The description only contains the table name, e.g. `"from(users)"`.
In the future, we might want to parse `data.query` as well.

See https://github.com/supabase-community/sentry-integration-js/blob/bae59de7e86c916d9396e2e2de55e6ac17e646d6/index.js#L259