### PR TITLE
instr(server): Add namespace tag to kafka metrics-metric

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -721,7 +721,8 @@ impl StoreService {
         )?;
         metric!(
             counter(RelayCounters::ProcessingMessageProduced) += 1,
-            event_type = "metric"
+            event_type = "metric",
+            namespace = namespace.as_str()
         );
         Ok(())
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -539,6 +539,7 @@ pub enum RelayCounters {
     ///
     /// This metric is tagged with:
     ///  - `event_type`: The kind of message produced to Kafka.
+    ///  - `namespace` (only for metrics): The namespace that the metric belongs to.
     ///  - `is_segment` (only for event_type span): `true` the span is the root of a segment.
     ///  - `has_parent` (only for event_type span): `false` if the span is the root of a trace.
     ///


### PR DESCRIPTION
We now have the ability to limit metrics by namespace. To choose the right limit it would be helpful to see how often the different namespace are used. 

#skip-changelog