### PR TITLE
fix(spans): Accept supabase without identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Extend GPU context with data for Unreal Engine crash reports. ([#3144](https://github.com/getsentry/relay/pull/3144))
 - Parametrize transaction in dynamic sampling context. ([#3141](https://github.com/getsentry/relay/pull/3141))
-- Parse & scrub span description for supabase. ([#3153](https://github.com/getsentry/relay/pull/3153))
+- Parse & scrub span description for supabase. ([#3153](https://github.com/getsentry/relay/pull/3153), [#3156](https://github.com/getsentry/relay/pull/3156))
 
 **Bug Fixes**:
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -71,7 +71,9 @@ pub(crate) fn scrub_span_description(
                     // The description will only contain the entity queried and
                     // the query type ("User find" for example).
                     Some(description.to_owned())
-                } else if span_origin == Some("auto.db.supabase") {
+                } else if span_origin == Some("auto.db.supabase")
+                    && description.starts_with("from(")
+                {
                     // The description only contains the table name, e.g. `"from(users)`.
                     // In the future, we might want to parse `data.query` as well.
                     // See https://github.com/supabase-community/sentry-integration-js/blob/master/index.js#L259
@@ -148,10 +150,7 @@ fn scrub_core_data(string: &str) -> Option<String> {
 }
 
 fn scrub_supabase(string: &str) -> Option<String> {
-    match DB_SUPABASE_REGEX.replace_all(string, "{%s}") {
-        Cow::Owned(scrubbed) => Some(scrubbed),
-        Cow::Borrowed(_) => None,
-    }
+    Some(DB_SUPABASE_REGEX.replace_all(string, "{%s}").into())
 }
 
 fn scrub_http(string: &str) -> Option<String> {

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -366,11 +366,11 @@ pub fn extract_tags(
                 None
             }
         } else if span.origin.as_str() == Some("auto.db.supabase") {
-            scrubbed_description.as_deref().map(|s| {
-                s.trim_start_matches("from(")
-                    .trim_end_matches(')')
-                    .to_owned()
-            })
+            scrubbed_description
+                .as_deref()
+                .and_then(|s| s.strip_prefix("from("))
+                .and_then(|s| s.strip_suffix(')'))
+                .map(String::from)
         } else if span_op.starts_with("db") {
             span.description
                 .value()


### PR DESCRIPTION
Follow-up for https://github.com/getsentry/relay/pull/3153:

* Only accept `from(...)`
* Accept table names without scrubbed identifiers.