### PR TITLE
instr(kafka): platform tag

### DIFF
--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1955,6 +1955,7 @@ mod tests {
                 received: ~,
                 measurements: ~,
                 _metrics_summary: ~,
+                platform: ~,
                 other: {},
             },
         ]
@@ -1998,6 +1999,7 @@ mod tests {
                 received: ~,
                 measurements: ~,
                 _metrics_summary: ~,
+                platform: ~,
                 other: {},
             },
         ]
@@ -2041,6 +2043,7 @@ mod tests {
                 received: ~,
                 measurements: ~,
                 _metrics_summary: ~,
+                platform: ~,
                 other: {},
             },
         ]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -489,6 +489,7 @@ mod tests {
                     ],
                 },
             ),
+            platform: ~,
             other: {},
         }
         "###);

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -91,6 +91,12 @@ pub struct Span {
     #[metastructure(skip_serialization = "empty")]
     pub _metrics_summary: Annotated<MetricsSummary>,
 
+    /// Platform identifier.
+    ///
+    /// See [`Event::platform`].
+    #[metastructure(skip_serialization = "empty")]
+    pub platform: Annotated<String>,
+
     // TODO remove retain when the api stabilizes
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
@@ -107,6 +113,7 @@ impl From<&Event> for Span {
             start_timestamp: event.start_timestamp.clone(),
             timestamp: event.timestamp.clone(),
             measurements: event.measurements.clone(),
+            platform: event.platform.clone(),
             ..Default::default()
         };
 

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -43,6 +43,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
         Span {
@@ -83,6 +84,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
         Span {
@@ -126,6 +128,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
         Span {
@@ -166,6 +169,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
         Span {
@@ -208,6 +212,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
         Span {
@@ -250,6 +255,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
         Span {
@@ -315,6 +321,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
             received: ~,
             measurements: ~,
             _metrics_summary: ~,
+            platform: ~,
             other: {},
         },
     ],

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -654,6 +654,7 @@ mod tests {
                 received: ~,
                 measurements: ~,
                 _metrics_summary: ~,
+                platform: ~,
                 other: {},
             },
         ]

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -207,6 +207,7 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
                 new_span.is_segment = Annotated::new(false);
                 new_span.received = transaction_span.received.clone();
                 new_span.segment_id = transaction_span.segment_id.clone();
+                new_span.platform = transaction_span.platform.clone();
 
                 // If a profile is associated with the transaction, also associate it with its
                 // child spans.

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -15,7 +15,7 @@ use relay_common::time::{instant_to_date_time, UnixTimestamp};
 use relay_config::Config;
 use relay_dynamic_config::MetricEncoding;
 use relay_event_schema::protocol::{
-    self, EventId, SessionAggregates, SessionStatus, SessionUpdate,
+    self, EventId, SessionAggregates, SessionStatus, SessionUpdate, VALID_PLATFORMS,
 };
 
 use relay_kafka::{ClientError, KafkaClient, KafkaTopic, Message};
@@ -968,6 +968,7 @@ impl StoreService {
 
         let is_segment = span.is_segment;
         let has_parent = span.parent_span_id.is_some();
+        let platform = VALID_PLATFORMS.iter().find(|p| *p == &span.platform);
 
         self.produce(
             KafkaTopic::Spans,
@@ -988,6 +989,7 @@ impl StoreService {
         metric!(
             counter(RelayCounters::ProcessingMessageProduced) += 1,
             event_type = "span",
+            platform = platform.unwrap_or(&""),
             is_segment = bool_to_str(is_segment),
             has_parent = bool_to_str(has_parent),
         );
@@ -1461,6 +1463,9 @@ struct SpanKafkaMessage<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     tags: Option<&'a RawValue>,
     trace_id: &'a str,
+
+    #[serde(borrow, default, skip_serializing)]
+    platform: Cow<'a, str>, // We only use this for logging for now
 }
 
 #[derive(Debug, Deserialize)]

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -542,6 +542,7 @@ pub enum RelayCounters {
     ///  - `namespace` (only for metrics): The namespace that the metric belongs to.
     ///  - `is_segment` (only for event_type span): `true` the span is the root of a segment.
     ///  - `has_parent` (only for event_type span): `false` if the span is the root of a trace.
+    ///  - `platform` (only for event_type span): The platform from which the span was spent.
     ///
     /// The message types can be:
     ///


### PR DESCRIPTION
Add a `platform` tag to the metric that counts span Kafka messages. We can remove this tag again once the investigation is done.

#skip-changelog