### PR TITLE
fix(normalization): Accept transactions with unfinished spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Forward metrics in proxy mode. ([#3106](https://github.com/getsentry/relay/pull/3106))
 - Do not PII-scrub code locations by default. ([#3116](https://github.com/getsentry/relay/pull/3116))
+- Accept transactions with unfinished spans. ([#3162](https://github.com/getsentry/relay/pull/3162))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - This release requires Python 3.10 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.9.
+- Fix: accept transactions with unfinished spans. ([#3162](https://github.com/getsentry/relay/pull/3162))
 
 ## 0.8.45
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -113,17 +113,17 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
     let mut event = Annotated::<Event>::from_json((*event).as_str())?;
     let config = (*processor).config();
 
-    let tx_validation_config = TransactionValidationConfig {
-        timestamp_range: None, // only supported in relay
-    };
-    validate_transaction(&event, &tx_validation_config)?;
-
     let event_validation_config = EventValidationConfig {
         received_at: config.received_at,
         max_secs_in_past: config.max_secs_in_past,
         max_secs_in_future: config.max_secs_in_future,
     };
     validate_event_timestamps(&mut event, &event_validation_config)?;
+
+    let tx_validation_config = TransactionValidationConfig {
+        timestamp_range: None, // only supported in relay
+    };
+    validate_transaction(&mut event, &tx_validation_config)?;
 
     let normalization_config = NormalizationConfig {
         client_ip: config.client_ip.as_ref(),

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1471,7 +1471,6 @@ mod tests {
             max_secs_in_future,
             ..Default::default()
         }));
-        validate_transaction(&event, &TransactionValidationConfig::default()).unwrap();
         validate_event_timestamps(
             &mut event,
             &EventValidationConfig {
@@ -1481,6 +1480,7 @@ mod tests {
             },
         )
         .unwrap();
+        validate_transaction(&mut event, &TransactionValidationConfig::default()).unwrap();
         normalize_event(&mut event, &NormalizationConfig::default());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
@@ -1821,7 +1821,7 @@ mod tests {
                 .set_value(Some(vec![Annotated::<Span>::from_json(span).unwrap()]));
 
             let res =
-                validate_transaction(&modified_event, &TransactionValidationConfig::default());
+                validate_transaction(&mut modified_event, &TransactionValidationConfig::default());
 
             assert!(res.is_err(), "{span:?}");
         }

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -833,6 +833,6 @@ mod tests {
         let spans = &event.spans;
         let span = get_value!(spans[0]!);
 
-        assert_eq!(span.timestamp, event.timestamp);
+        assert_eq!(span.timestamp.value(), event.timestamp.value());
     }
 }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -580,8 +580,8 @@ mod tests {
         .unwrap();
 
         // Validate and normalize first, to make sure that all things are correct as in the real pipeline:
-        validate_transaction(&event, &TransactionValidationConfig::default()).unwrap();
         validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
+        validate_transaction(&mut event, &TransactionValidationConfig::default()).unwrap();
 
         normalize_event(
             &mut event,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1207,9 +1207,9 @@ impl EnvelopeProcessorService {
             };
 
             metric!(timer(RelayTimers::EventProcessingLightNormalization), {
-                validate_transaction(event, &tx_validation_config)
-                    .map_err(|_| ProcessingError::InvalidTransaction)?;
                 validate_event_timestamps(event, &event_validation_config)
+                    .map_err(|_| ProcessingError::InvalidTransaction)?;
+                validate_transaction(event, &tx_validation_config)
                     .map_err(|_| ProcessingError::InvalidTransaction)?;
                 normalize_event(event, &normalization_config);
                 Result::<(), ProcessingError>::Ok(())

--- a/relay-server/tests/test_fixtures.rs
+++ b/relay-server/tests/test_fixtures.rs
@@ -72,7 +72,7 @@ macro_rules! event_snapshot {
             fn test_processing() {
                 let mut event = load_fixture();
 
-                validate_transaction(&event, &TransactionValidationConfig::default()).unwrap();
+                validate_transaction(&mut event, &TransactionValidationConfig::default()).unwrap();
                 validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
                 normalize_event(&mut event, &NormalizationConfig::default());
 

--- a/tools/process-event/src/main.rs
+++ b/tools/process-event/src/main.rs
@@ -84,9 +84,9 @@ impl Cli {
         }
 
         if self.store {
-            validate_transaction(&event, &TransactionValidationConfig::default())
-                .map_err(|e| format_err!("{e}"))?;
             validate_event_timestamps(&mut event, &EventValidationConfig::default())
+                .map_err(|e| format_err!("{e}"))?;
+            validate_transaction(&mut event, &TransactionValidationConfig::default())
                 .map_err(|e| format_err!("{e}"))?;
             normalize_event(&mut event, &NormalizationConfig::default());
             let mut processor = StoreProcessor::new(StoreConfig::default());


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-java/issues/3222.

This PR finishes all spans before validating them. This used to be the behavior before a regression was introduced [here](https://github.com/getsentry/relay/commit/90fa749f1c4af857fb0f0b78e517d0f9fed4b32a).

Additionally, event timestamp validation now runs before transaction validation. Event validation includes some timestamp normalization (like clock drift correction) that updates the event's timestamps. Normalizing a transaction's timestamps after updating a span's timestamps may result in spans being out of the transaction's range.

## Future work

- [ ] Consider having a single validation step. A single step removes the ambiguity and points of failures of running the two steps in a different order. Originally, the two steps were introduced to minimize validation on mutable references, but after this PR this is no longer the case.