### PR TITLE
feat(server): Drop transactions in an only-spans world

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -47,6 +47,10 @@ pub enum Feature {
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
     IngestUnsampledProfiles,
 
+    /// Discard transactions in a spans-only world.
+    #[serde(rename = "projects:discard-transaction")]
+    DiscardTransaction,
+
     /// Deprecated, still forwarded for older downstream Relays.
     #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]
     Deprecated1,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1297,11 +1297,11 @@ impl EnvelopeProcessorService {
 
         if state.has_event() {
             event::scrub(state)?;
-            event::serialize(state)?;
             if_processing!(self.inner.config, {
                 span::extract_from_event(state);
-                span::maybe_remove_event(state);
+                span::maybe_discard_transaction(state);
             });
+            event::serialize(state)?;
         }
 
         attachment::scrub(state);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1300,6 +1300,7 @@ impl EnvelopeProcessorService {
             event::serialize(state)?;
             if_processing!(self.inner.config, {
                 span::extract_from_event(state);
+                span::maybe_remove_event(state);
             });
         }
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -237,7 +237,8 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
     }
 }
 
-pub fn maybe_remove_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
+/// Removes the transaction in case the project has made the transition to spans-only.
+pub fn maybe_discard_transaction(state: &mut ProcessEnvelopeState<TransactionGroup>) {
     if state.event_type() == Some(EventType::Transaction)
         && state.project_state.has_feature(Feature::DiscardTransaction)
     {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -237,6 +237,14 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
     }
 }
 
+pub fn maybe_remove_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
+    if state.event_type() == Some(EventType::Transaction)
+        && state.project_state.has_feature(Feature::DiscardTransaction)
+    {
+        state.remove_event();
+        state.managed_envelope.update();
+    }
+}
 /// Config needed to normalize a standalone span.
 #[derive(Clone, Debug)]
 struct NormalizeSpanConfig<'a> {

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -63,9 +63,9 @@ def processing_config(get_topic_name):
         if not processing.get("redis"):
             processing["redis"] = "redis://127.0.0.1"
 
-        processing["projectconfig_cache_prefix"] = (
-            f"relay-test-relayconfig-{uuid.uuid4()}"
-        )
+        processing[
+            "projectconfig_cache_prefix"
+        ] = f"relay-test-relayconfig-{uuid.uuid4()}"
 
         return options
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -180,9 +180,7 @@ class ConsumerBase:
         self.test_producer.produce(self.topic_name, message)
         self.test_producer.flush(timeout=5)
 
-        print(timeout)
         rv = self.poll(timeout=timeout)
-        print(rv)
         assert rv.error() is None
         assert rv.value() == message, rv.value()
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -63,9 +63,9 @@ def processing_config(get_topic_name):
         if not processing.get("redis"):
             processing["redis"] = "redis://127.0.0.1"
 
-        processing[
-            "projectconfig_cache_prefix"
-        ] = f"relay-test-relayconfig-{uuid.uuid4()}"
+        processing["projectconfig_cache_prefix"] = (
+            f"relay-test-relayconfig-{uuid.uuid4()}"
+        )
 
         return options
 
@@ -180,7 +180,9 @@ class ConsumerBase:
         self.test_producer.produce(self.topic_name, message)
         self.test_producer.flush(timeout=5)
 
+        print(timeout)
         rv = self.poll(timeout=timeout)
+        print(rv)
         assert rv.error() is None
         assert rv.value() == message, rv.value()
 


### PR DESCRIPTION
To test what our Performance product looks like without transactions (spans only), add the ability to drop transactions in Relay. The feature flag will only be enabled for a single experimental project for the time being.

#skip-changelog