### PR TITLE
feat(spans): Copies exclusive_time from span data into a top level attribute

### DIFF
--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -559,6 +559,7 @@ mod tests {
             http_response_status_code: ~,
             thread_name: ~,
             ui_component_name: ~,
+            exclusive_time: ~,
             url_scheme: ~,
             other: {
                 "bar": String(

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -272,6 +272,10 @@ pub struct SpanData {
     #[metastructure(field = "url.scheme")]
     pub url_scheme: Annotated<Value>,
 
+    /// exclusive time
+    #[metastructure(field = "exclusive_time")]
+    pub exclusive_time: Annotated<Value>,
+
     /// Other fields in `span.data`.
     #[metastructure(additional_properties, pii = "true", retain = "true")]
     other: Object<Value>,

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -559,8 +559,8 @@ mod tests {
             http_response_status_code: ~,
             thread_name: ~,
             ui_component_name: ~,
-            exclusive_time: ~,
             url_scheme: ~,
+            exclusive_time: ~,
             other: {
                 "bar": String(
                     "3",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -303,6 +303,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 thread_name: ~,
                 ui_component_name: ~,
                 url_scheme: ~,
+                exclusive_time: ~,
                 other: {},
             },
             sentry_tags: {


### PR DESCRIPTION
Takes `exclusive_time` from span data, and copies it as a top level attribute on the span.

For context, this is required because we enforce the top level `exclusive_time` attribute to be not empty when validating spans. For `otel_span`, we already do this on the `exclusive_time_ns` within the span data, but we do not do this on `span` type items (hence this pr).

#skip-changelog