### PR TITLE
chore(spooler): Change default connection pool to 1 connection

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -823,12 +823,12 @@ fn spool_envelopes_max_disk_size() -> ByteSize {
 
 /// Default for min connections to keep open in the pool.
 fn spool_envelopes_min_connections() -> u32 {
-    10
+    1
 }
 
 /// Default for max connections to keep open in the pool.
 fn spool_envelopes_max_connections() -> u32 {
-    20
+    1
 }
 
 /// Default interval to unspool buffered envelopes, 100ms.


### PR DESCRIPTION
This sets the sqlite connections pool to use max only 1 connection with DB file.

Since we're processing only 1 message at a time right now, we do not really need to have many connections open and maintained at the same time. Which also will allow us to debug any weird looking issues behaviour if that can happen.

related to https://github.com/getsentry/ops/pull/9509

#skip-changelog