### PR TITLE
chore(build): Address beta lint warning and suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,9 +5986,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ smallvec = { version = "1.11.2", features = ["serde"] }
 thiserror = "1.0.38"
 tokio = { version = "1.28.0", features = ["macros", "sync", "tracing"] }
 url = "2.1.1"
-uuid = { version = "1.3.0", features = ["serde", "v4"] }
+uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/relay-ffi/src/lib.rs
+++ b/relay-ffi/src/lib.rs
@@ -113,7 +113,7 @@ use std::{fmt, panic, thread};
 pub use relay_ffi_macros::catch_unwind;
 
 thread_local! {
-    static LAST_ERROR: RefCell<Option<anyhow::Error>> = RefCell::new(None);
+    static LAST_ERROR: RefCell<Option<anyhow::Error>> = const { RefCell::new(None) };
 }
 
 fn set_last_error(err: anyhow::Error) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1141,7 +1141,7 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<G>,
     ) -> Result<(), ProcessingError> {
-        if let Some(sampling_state) = state.sampling_project_state.as_ref().map(Arc::clone) {
+        if let Some(sampling_state) = state.sampling_project_state.clone() {
             state
                 .envelope_mut()
                 .parametrize_dsc_transaction(&sampling_state.config.tx_name_rules);

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -200,7 +200,7 @@ mod tests {
     /// Tests that an event is kept when there is a match and we have 100% sample rate.
     fn test_match_rules_return_keep_with_match_and_100_sample_rate() {
         let event = mocked_event(EventType::Transaction, "bar", "2.0");
-        let rules = vec![mocked_sampling_rule(1, RuleType::Transaction, 1.0)];
+        let rules = [mocked_sampling_rule(1, RuleType::Transaction, 1.0)];
         let seed = Uuid::default();
 
         let result: SamplingResult = SamplingEvaluator::new(Utc::now())
@@ -214,7 +214,7 @@ mod tests {
     /// Tests that an event is dropped when there is a match and we have 0% sample rate.
     fn test_match_rules_return_drop_with_match_and_0_sample_rate() {
         let event = mocked_event(EventType::Transaction, "bar", "2.0");
-        let rules = vec![mocked_sampling_rule(1, RuleType::Transaction, 0.0)];
+        let rules = [mocked_sampling_rule(1, RuleType::Transaction, 0.0)];
         let seed = Uuid::default();
 
         let result: SamplingResult = SamplingEvaluator::new(Utc::now())
@@ -228,7 +228,7 @@ mod tests {
     #[test]
     /// Tests that an event is kept when there is no match.
     fn test_match_rules_return_keep_with_no_match() {
-        let rules = vec![SamplingRule {
+        let rules = [SamplingRule {
             condition: RuleCondition::eq_ignore_case("event.transaction", "foo"),
             sampling_value: SamplingValue::SampleRate { value: 0.5 },
             ty: RuleType::Transaction,
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     /// Tests that an event is kept when there is a trace match and we have 100% sample rate.
     fn test_match_rules_with_traces_rules_return_keep_when_match() {
-        let rules = vec![mocked_sampling_rule(1, RuleType::Trace, 1.0)];
+        let rules = [mocked_sampling_rule(1, RuleType::Trace, 1.0)];
         let dsc = mocked_simple_dynamic_sampling_context(Some(1.0), Some("3.0"), None, None, None);
 
         let result: SamplingResult = SamplingEvaluator::new(Utc::now())


### PR DESCRIPTION
Fixing beta lint warning making sure new Rust release will be just working in Relay codebase. 

Also updating `uuid` to the newest version to address some of the errors while using `beta`. 

#skip-changelog