### PR TITLE
docs(metrics): allow empty space character in metrics tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add quotas to global config. ([#3086](https://github.com/getsentry/relay/pull/3086))
 - Adds support for dynamic metric bucket encoding. ([#3137](https://github.com/getsentry/relay/pull/3137))
 - Use statsdproxy to pre-aggregate metrics. ([#2425](https://github.com/getsentry/relay/pull/2425))
+- Fix docs about allowed space characther in the metric tags values ([#3174](https://github.com/getsentry/relay/pull/3174))
 
 ## 24.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 - Add quotas to global config. ([#3086](https://github.com/getsentry/relay/pull/3086))
 - Adds support for dynamic metric bucket encoding. ([#3137](https://github.com/getsentry/relay/pull/3137))
 - Use statsdproxy to pre-aggregate metrics. ([#2425](https://github.com/getsentry/relay/pull/2425))
-- Fix docs about allowed space characther in the metric tags values ([#3174](https://github.com/getsentry/relay/pull/3174))
 
 ## 24.2.0
 

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -593,7 +593,7 @@ pub struct Bucket {
     ///
     /// Tag keys are restricted to ASCII characters and must match the regular expression
     /// `/[a-zA-Z0-9_/.-]+/`. Tag values can contain unicode characters and must match the regular
-    /// expression `/[\w\d_:/@.{}\[\]$-]+/`.
+    /// expression `/[\w\d\s_:/@.{}\[\]$-]+/`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
catching up with https://github.com/getsentry/develop/pull/1171

#skip-changelog