### PR TITLE
fix(docs): specify that metrics tags and timestamp are optional

### DIFF
--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -448,7 +448,7 @@ fn parse_timestamp(string: &str) -> Option<UnixTimestamp> {
 /// # Submission Protocol
 ///
 /// ```text
-/// <name>[@unit]:<value>[:<value>...]|<type>|#<tag_key>:<tag_value>,<tag>|T<timestamp>
+/// <name>[@unit]:<value>[:<value>...]|<type>[|#<tag_key>:<tag_value>,<tag>][|T<timestamp>]
 /// ```
 ///
 /// See the [field documentation](Bucket#fields) for more information on the components. An example


### PR DESCRIPTION
#skip-changelog