### PR TITLE
fix(gocd): Fixing check scripts and relay-pop pipeline name

### DIFF
--- a/gocd/templates/bash/check-sentry-errors.sh
+++ b/gocd/templates/bash/check-sentry-errors.sh
@@ -15,7 +15,7 @@ for i in "${!project_ids[@]}"; do
   /devinfra/scripts/checks/sentry/release_error_events.py \
     --project-id="${project_ids[i]}" \
     --project-slug="${project_slugs[i]}" \
-    --release="relay@${GO_REVISION_GETSENTRY_REPO}" \
+    --release="relay@${GO_REVISION_RELAY_REPO}" \
     --duration=5 \
     --error-events-limit="${ERROR_LIMIT}" \
     --dry-run="${DRY_RUN}" \

--- a/gocd/templates/bash/check-sentry-new-errors.sh
+++ b/gocd/templates/bash/check-sentry-new-errors.sh
@@ -14,7 +14,7 @@ for i in "${!project_ids[@]}"; do
   /devinfra/scripts/checks/sentry/release_new_issues.py \
     --project-id="${project_ids[i]}" \
     --project-slug="${project_slugs[i]}" \
-    --release="relay@${GO_REVISION_GETSENTRY_REPO}" \
+    --release="relay@${GO_REVISION_RELAY_REPO}" \
     --new-issues-limit=0 \
     --dry-run="${DRY_RUN}" \
     --single-tenant="${SENTRY_SINGLE_TENANT}" \

--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -3,7 +3,6 @@ local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libs
 
 local canary_region_pops = {
   de: [],
-  // TODO: Check that these are right
   us: ['us-pop-1', 'us-pop-regional-1'],
 };
 

--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -3,7 +3,7 @@ local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libs
 
 local canary_region_pops = {
   de: [],
-  us: ['us-pop-1', 'us-pop-regional-1'],
+  us: ['us-pop-1', 'us-pop-2'],
 };
 
 local region_pops = {

--- a/gocd/templates/pops.jsonnet
+++ b/gocd/templates/pops.jsonnet
@@ -5,7 +5,7 @@ local pops = import './pipelines/pops.libsonnet';
 local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
 
 local pipedream_config = {
-  name: 'relay-pops',
+  name: 'relay-pop',
   auto_deploy: false,
   materials: {
     relay_repo: {


### PR DESCRIPTION
Noticed a few small typos after merging #3131, this doesn't impact the existing deployment pipeline, just the new ones.

#skip-changelog