### PR TITLE
instr(server): Add sampling tag to post_ds metric

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1291,6 +1291,11 @@ impl EnvelopeProcessorService {
 
         metric!(
             timer(RelayTimers::TransactionProcessingAfterDynamicSampling),
+            sampling_decision = if state.sampling_result.should_keep() {
+                "keep"
+            } else {
+                "drop"
+            },
             {
                 if_processing!(self.inner.config, {
                     event::store(state, &self.inner.config)?;


### PR DESCRIPTION
Processing time after sampling should be close to zero for sampling decision "drop". This tag verifies that assumption.

#skip-changelog