### PR TITLE
instr(kafka): Tag producer error metric with topic

### DIFF
--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -26,7 +26,10 @@ impl ProducerContext for CaptureErrorContext {
                 "failed to produce message to Kafka (delivery callback)",
             );
 
-            metric!(counter(KafkaCounters::ProcessingProduceError) += 1);
+            metric!(
+                counter(KafkaCounters::ProcessingProduceError) += 1,
+                topic = message.topic()
+            );
         }
     }
 }

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -7,6 +7,9 @@ pub enum KafkaCounters {
     /// These errors include, for example, _"MessageTooLarge"_ errors when the broker does not
     /// accept the requests over a certain size, which is usually due to invalid or inconsistent
     /// broker/producer configurations.
+    ///
+    /// This metric is tagged with:
+    ///  - `topic`: The Kafka topic being produced to.
     ProcessingProduceError,
 }
 


### PR DESCRIPTION
There is an alert based on this metric. Tagging it by topic will make the problem faster to diagnose (no need to go and check the accompanying sentry issue).

#skip-changelog