### PR TITLE
ref(dependencies): Update `indexmap` to v2.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2204,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3741,7 +3741,7 @@ version = "24.2.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "insta",
  "relay-auth",
  "relay-base-schema",
@@ -3847,7 +3847,7 @@ dependencies = [
 name = "relay-filter"
 version = "24.2.0"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "insta",
  "ipnetwork 0.20.0",
  "once_cell",
@@ -5081,7 +5081,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.0.0",
+ "indexmap 2.2.5",
  "log",
  "memchr",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
 hash32 = "0.3.1"
 hashbrown = "0.14.3"
-indexmap = "2.0.0"
+indexmap = "2.2.5"
 itertools = "0.10.5"
 once_cell = "1.13.1"
 parking_lot = "0.12.1"


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/3161#discussion_r1507411200.

Bumps workspace's `indexmap` from `2.0.0` to `2.2.5` (latest).

Note:
- `2.2.1` introduces a [breaking change](https://github.com/indexmap-rs/indexmap/blob/master/RELEASES.md#221) that should have no impact (the struct `RawOccupiedEntryMut` is not used).

#skip-changelog