### PR TITLE
fix(gocd): Fixing sentry checks by ensuring they use the right release

### DIFF
--- a/gocd/templates/bash/check-sentry-errors.sh
+++ b/gocd/templates/bash/check-sentry-errors.sh
@@ -1,21 +1,38 @@
 #!/bin/bash
 
+# Check Sentry for errors in the last 5 minutes for a given release (from GO_REVISION_RELAY_REPO)
+#
+# Required environment variables:
+#   DRY_RUN: When dry-run is 'true' this script will not fail if the checks indicate an issue
+#   ERROR_LIMIT: The number of error events to permit before failing
+#   GO_REVISION_RELAY_REPO: Git commit hash (provided by GoCD)
+#   SENTRY_AUTH_TOKEN: Sentry auth token (https://sentry.io/settings/account/api/auth-tokens/) (required by devinfra/scripts/checks/sentry/release_error_events.py)
+#   SENTRY_BASE: Sentry base API URL (e.g. https://sentry.io/api/0)
+#   SENTRY_PROJECTS: A space-separated list of <project_id>:<project_slug>:<service> tuples
+#   SENTRY_SINGLE_TENANT: When single-tenant is 'true' this script will use the sentry-st organization instead of sentry
+#   SKIP_CANARY_CHECKS: Whether to skip checks entirely (true/false)
+
 # shellcheck disable=SC2206
-project_ids=(${SENTRY_PROJECT_IDS})
-# shellcheck disable=SC2206
-project_slugs=(${SENTRY_PROJECTS})
+projects=(${SENTRY_PROJECTS})
 
+for project in "${projects[@]}"; do
+  IFS=':' read -r -a project_info <<<"$project"
+  project_id="${project_info[0]}"
+  project_slug="${project_info[1]}"
+  service="${project_info[2]}"
 
-if [ ${##project_ids[@]} -ne ${##project_slugs[@]} ]; then
-  echo "Error: SENTRY_PROJECT_IDS and SENTRY_PROJECTS must have the same number of elements"
-  exit 1
-fi
+  release_name=$(./relay/scripts/get-sentry-release-name "${GO_REVISION_RELAY_REPO}" "${service}")
+  if [ -z "${release_name}" ]; then
+    echo "Failed to get the release name for ${service} at ${GO_REVISION_RELAY_REPO}"
+    # Since Processing and PoPs can be deployed independently, we shouldn't fail if
+    # we can't find a release as it may not exist yet
+    continue
+  fi
 
-for i in "${!project_ids[@]}"; do
   /devinfra/scripts/checks/sentry/release_error_events.py \
-    --project-id="${project_ids[i]}" \
-    --project-slug="${project_slugs[i]}" \
-    --release="relay@${GO_REVISION_RELAY_REPO}" \
+    --project-id="${project_id}" \
+    --project-slug="${project_slug}" \
+    --release="${release_name}" \
     --duration=5 \
     --error-events-limit="${ERROR_LIMIT}" \
     --dry-run="${DRY_RUN}" \

--- a/gocd/templates/bash/check-sentry-errors.sh
+++ b/gocd/templates/bash/check-sentry-errors.sh
@@ -9,6 +9,8 @@
 #   SENTRY_AUTH_TOKEN: Sentry auth token (https://sentry.io/settings/account/api/auth-tokens/) (required by devinfra/scripts/checks/sentry/release_error_events.py)
 #   SENTRY_BASE: Sentry base API URL (e.g. https://sentry.io/api/0)
 #   SENTRY_PROJECTS: A space-separated list of <project_id>:<project_slug>:<service> tuples
+#                    The reason for this is because project_slug and service do not always
+#                    match, and we need the service to get the release name
 #   SENTRY_SINGLE_TENANT: When single-tenant is 'true' this script will use the sentry-st organization instead of sentry
 #   SKIP_CANARY_CHECKS: Whether to skip checks entirely (true/false)
 

--- a/gocd/templates/bash/check-sentry-new-errors.sh
+++ b/gocd/templates/bash/check-sentry-new-errors.sh
@@ -8,6 +8,8 @@
 #   SENTRY_AUTH_TOKEN: Sentry auth token (https://sentry.io/settings/account/api/auth-tokens/) (required by devinfra/scripts/checks/sentry/release_new_issues.py)
 #   SENTRY_BASE: Sentry base API URL (e.g. https://sentry.io/api/0)
 #   SENTRY_PROJECTS: A space-separated list of <project_id>:<project_slug>:<service> tuples
+#                    The reason for this is because project_slug and service do not always
+#                    match, and we need the service to get the release name
 #   SENTRY_SINGLE_TENANT: When single-tenant is 'true' this script will use the sentry-st organization instead of sentry
 #   SKIP_CANARY_CHECKS: Whether to skip checks entirely (true/false)
 

--- a/gocd/templates/bash/check-sentry-new-errors.sh
+++ b/gocd/templates/bash/check-sentry-new-errors.sh
@@ -1,20 +1,37 @@
 #!/bin/bash
 
-# shellcheck disable=SC2206
-project_ids=(${SENTRY_PROJECT_IDS})
-# shellcheck disable=SC2206
-project_slugs=(${SENTRY_PROJECTS})
+# Check Sentry for new errors that occured for the first time in a given release (from GO_REVISION_RELAY_REPO)
+#
+# Required environment variables:
+#   DRY_RUN: When dry-run is 'true' this script will not fail if the checks indicate an issue
+#   GO_REVISION_RELAY_REPO: Git commit hash (provided by GoCD)
+#   SENTRY_AUTH_TOKEN: Sentry auth token (https://sentry.io/settings/account/api/auth-tokens/) (required by devinfra/scripts/checks/sentry/release_new_issues.py)
+#   SENTRY_BASE: Sentry base API URL (e.g. https://sentry.io/api/0)
+#   SENTRY_PROJECTS: A space-separated list of <project_id>:<project_slug>:<service> tuples
+#   SENTRY_SINGLE_TENANT: When single-tenant is 'true' this script will use the sentry-st organization instead of sentry
+#   SKIP_CANARY_CHECKS: Whether to skip checks entirely (true/false)
 
-if [ ${##project_ids[@]} -ne ${##project_slugs[@]} ]; then
-  echo "Error: SENTRY_PROJECT_IDS and SENTRY_PROJECTS must have the same number of elements"
-  exit 1
-fi
+# shellcheck disable=SC2206
+projects=(${SENTRY_PROJECTS})
 
-for i in "${!project_ids[@]}"; do
+for project in "${projects[@]}"; do
+  IFS=':' read -r -a project_info <<<"$project"
+  project_id="${project_info[0]}"
+  project_slug="${project_info[1]}"
+  service="${project_info[2]}"
+
+  release_name=$(./relay/scripts/get-sentry-release-name "${GO_REVISION_RELAY_REPO}" "${service}")
+  if [ -z "${release_name}" ]; then
+    echo "Failed to get the release name for ${service} at ${GO_REVISION_RELAY_REPO}"
+    # Since Processing and PoPs can be deployed independently, we shouldn't fail if
+    # we can't find a release as it may not exist yet
+    continue
+  fi
+
   /devinfra/scripts/checks/sentry/release_new_issues.py \
-    --project-id="${project_ids[i]}" \
-    --project-slug="${project_slugs[i]}" \
-    --release="relay@${GO_REVISION_RELAY_REPO}" \
+    --project-id="${project_id}" \
+    --project-slug="${project_slug}" \
+    --release="${release_name}" \
     --new-issues-limit=0 \
     --dry-run="${DRY_RUN}" \
     --single-tenant="${SENTRY_SINGLE_TENANT}" \

--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -40,8 +40,8 @@ local soak_time(region) =
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
                 DATADOG_MONITOR_IDS: '137575470 22592147 27804625 22634395 22635255',
-                SENTRY_PROJECTS: if region == 's4s' then 'sentry-for-sentry' else 'pop-relay relay',
-                SENTRY_PROJECT_IDS: if region == 's4s' then '1513938' else '9 4',
+                // Sentry projects to check for errors <project_id>:<project_slug>:<service>
+                SENTRY_PROJECTS: if region == 's4s' then '1513938:sentry-for-sentry:relay' else '9:pop-relay:relay-pop 4:relay:relay',
                 SENTRY_SINGLE_TENANT: if region == 's4s' then 'true' else 'false',
                 SENTRY_BASE: if region == 's4s' then 'https://sentry.io/api/0' else 'https://sentry.my.sentry.io/api/0',
                 // TODO: Set a proper error limit
@@ -49,7 +49,6 @@ local soak_time(region) =
                 PAUSE_MESSAGE: 'Detecting issues in the deployment. Pausing pipeline.',
                 // TODO: Switch dry run to false once we're confident in the soak time
                 DRY_RUN: 'true',
-                SKIP_CANARY_CHECKS: 'false',
               },
               elastic_profile_id: 'relay-pop',
               tasks: [
@@ -81,8 +80,8 @@ local deploy_pop_canary_job(region) =
       DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
       // Datadog monitor IDs for the canary deployment
       DATADOG_MONITOR_IDS: '137575470 22592147 27804625 22634395 22635255',
-      SENTRY_PROJECTS: 'pop-relay relay',
-      SENTRY_PROJECT_IDS: '9 4',
+      // Sentry projects to check for errors <project_id>:<project_slug>:<service>
+      SENTRY_PROJECTS: '9:pop-relay:relay-pop 4:relay:relay',
       SENTRY_SINGLE_TENANT: 'false',
       SENTRY_BASE: 'https://sentry.my.sentry.io/api/0',
       // TODO: Set a proper error limit
@@ -90,7 +89,6 @@ local deploy_pop_canary_job(region) =
       PAUSE_MESSAGE: 'Pausing pipeline due to canary failure.',
       // TODO: Switch dry run to false once we're confident in the soak time
       DRY_RUN: 'true',
-      SKIP_CANARY_CHECKS: 'false',
     },
     tasks: [
       gocdtasks.script(importstr '../bash/deploy-pop-canary.sh'),
@@ -218,6 +216,7 @@ local deployment_stages(region) =
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
+    SKIP_CANARY_CHECKS: false,
   },
   group: 'relay-pops-next',
   lock_behavior: 'unlockWhenFinished',

--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -35,9 +35,7 @@ local soak_time(region) =
               environment_variables: {
                 SENTRY_REGION: region,
                 GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-                // Temporary; self-service encrypted secrets aren't implemented yet.
-                // This should really be rotated to an internal integration token.
-                SENTRY_AUTH_TOKEN: if region == 's4s' then '{{SECRET:[devinfra-temp][relay_sentry_st_auth_token]}}' else '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+                SENTRY_AUTH_TOKEN: if region == 's4s' then '{{SECRET:[devinfra-sentryst][token]}}' else '{{SECRET:[devinfra-sentrymysentry][token]}}',
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
@@ -77,9 +75,7 @@ local deploy_pop_canary_job(region) =
     environment_variables: {
       SENTRY_REGION: region,
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-      // Temporary; self-service encrypted secrets aren't implemented yet.
-      // This should really be rotated to an internal integration token.
-      SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+      SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentrymysentry][token]}}',
       DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
       DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
       // Datadog monitor IDs for the canary deployment

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -13,9 +13,7 @@ local soak_time(region) =
               environment_variables: {
                 SENTRY_REGION: region,
                 GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-                // Temporary; self-service encrypted secrets aren't implemented yet.
-                // This should really be rotated to an internal integration token.
-                SENTRY_AUTH_TOKEN: if region == 's4s' then '{{SECRET:[devinfra-temp][relay_sentry_st_auth_token]}}' else '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+                SENTRY_AUTH_TOKEN: if region == 's4s' then '{{SECRET:[devinfra-sentryst][token]}}' else '{{SECRET:[devinfra-sentrymysentry][token]}}',
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
@@ -77,9 +75,7 @@ local deploy_canary(region) =
               environment_variables: {
                 SENTRY_REGION: region,
                 GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-                // Temporary; self-service encrypted secrets aren't implemented yet.
-                // This should really be rotated to an internal integration token.
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}',
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentrymysentry][token]}}',
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the canary deployment

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -17,10 +17,9 @@ local soak_time(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
-                // TODO: Add the monitor IDs
                 DATADOG_MONITOR_IDS: '137566884 14146876 137619914 14030245',
-                SENTRY_PROJECTS: if region == 's4s' then 'sentry-for-sentry' else 'relay pop-relay',
-                SENTRY_PROJECT_IDS: if region == 's4s' then '1513938' else '4 9',
+                // Sentry projects to check for errors <project_id>:<project_slug>:<service>
+                SENTRY_PROJECTS: if region == 's4s' then '1513938:sentry-for-sentry:relay' else '4:relay:relay 9:pop-relay:relay-pop',
                 SENTRY_SINGLE_TENANT: if region == 's4s' then 'true' else 'false',
                 SENTRY_BASE: if region == 's4s' then 'https://sentry.io/api/0' else 'https://sentry.my.sentry.io/api/0',
                 // TODO: Set a proper error limit
@@ -28,7 +27,6 @@ local soak_time(region) =
                 PAUSE_MESSAGE: 'Detecting issues in the deployment. Pausing pipeline.',
                 // TODO: Switch dry run to false once we're confident in the soak time
                 DRY_RUN: 'true',
-                SKIP_CANARY_CHECKS: 'false',
               },
               elastic_profile_id: 'relay',
               tasks: [
@@ -82,8 +80,8 @@ local deploy_canary(region) =
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the canary deployment
                 DATADOG_MONITOR_IDS: '137566884 14146876 137619914 14030245',
-                SENTRY_PROJECTS: 'relay pop-relay',
-                SENTRY_PROJECT_IDS: '4 9',
+                // Sentry projects to check for errors <project_id>:<project_slug>:<service>
+                SENTRY_PROJECTS: '4:relay:relay 9:pop-relay:relay-pop',
                 SENTRY_SINGLE_TENANT: 'false',
                 SENTRY_BASE: 'https://sentry.my.sentry.io/api/0',
                 // TODO: Set a proper error limit
@@ -91,7 +89,6 @@ local deploy_canary(region) =
                 PAUSE_MESSAGE: 'Pausing pipeline due to canary failure.',
                 // TODO: Switch dry run to false once we're confident in the canary
                 DRY_RUN: 'true',
-                SKIP_CANARY_CHECKS: 'false',
               },
               tasks: [
                 gocdtasks.script(importstr '../bash/deploy-processing-canary.sh'),
@@ -146,6 +143,7 @@ local deploy_primary(region) = [
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
+    SKIP_CANARY_CHECKS: false,
   },
   group: 'relay-next',
   lock_behavior: 'unlockWhenFinished',

--- a/scripts/get-sentry-release-name
+++ b/scripts/get-sentry-release-name
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Script: get the Sentry release name (e.g. "relay@1.0.0+1234abcd...")
+#
+# Positional arguments:
+#   $1: Release version (commit SHA)
+#   $2: Name of the release (default: relay)
+set -eu
+
+REVISION="${1:-}"
+NAME="${2:-relay}"
+
+if [ -z "${REVISION}" ]; then
+  echo 'No revision specified' && exit 1
+fi
+
+# Don't fail if the release name doesn't exist (e.g. if the release hasn't been created yet)
+RELEASE=$(gsutil cat "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/release-name") || true
+
+echo "${RELEASE}"


### PR DESCRIPTION
This change stems from the realization that Relay doesn't simply use the SHA when creating a release, but also the version. As a result, the complexity of the scripts had to increase a bit to accommodate this.

Things worth mentioning:
* Since the Sentry project for PoPs is pop-relay, but the service is referred to as relay-pop in google storage, we needed another env var to represent the service rather than using the sentry-project's name.
* Due to there being three env vars that each contain multiple, space-delimited inputs, I felt it was worthwhile to combine them into tuples to mitigate confusion.
* To get the release name, I use the revision and service name to search google storage for the corresponding release name. If there is an easier way, please let me know.
* I realized that since Processing and PoP's pipelines are independent there is no guarantee that they will be deployed at the same time or will even be in sync (though they ideally should be). As a result, using the other service's Sentry release as a signal could be problematic, especially if the pipelines are not kept in sync. One step I took to help alleviate this issue is not cause the check to fail if a given release name is not found.
* Similar to the point directly above, assuming we use Sentry releases as signals from both services, the longer the period between their respective deploys, the more likely it is that a new error will occur and thus cause the new error check to fail. The new error check was originally designed to be run shortly after a deploy goes out since a new error occurring in that short time period is often indicative of a problematic change. As a result, the longer the release has been live before we check, the less useful this signal becomes. While this is not inherently problematic, it is something to consider when it comes to how best we should use these pipelines.


#skip-changelog