### PR TITLE
feat(metrics_summaries): Allow to parse null tags and filter them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Adds support for dynamic metric bucket encoding. ([#3137](https://github.com/getsentry/relay/pull/3137))
 - Use statsdproxy to pre-aggregate metrics. ([#2425](https://github.com/getsentry/relay/pull/2425))
 - Add SDK information to spans. ([#3178](https://github.com/getsentry/relay/pull/3178))
+- Filter null values from metrics summary tags. ([#3204](https://github.com/getsentry/relay/pull/3204))
 
 ## 24.2.0
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1138,6 +1138,15 @@ impl StoreService {
                     continue;
                 }
 
+                let mut filtered_tags: BTreeMap<String, String> = BTreeMap::new();
+
+                for (k, v) in tags.iter() {
+                    match v {
+                        Some(v) => filtered_tags.insert(k.into(), v.into()),
+                        _ => continue,
+                    };
+                }
+
                 // Ignore immediate errors on produce.
                 if let Err(error) = self.produce(
                     KafkaTopic::MetricsSummaries,
@@ -1157,7 +1166,7 @@ impl StoreService {
                         segment_id: segment_id.unwrap_or_default(),
                         span_id,
                         sum,
-                        tags,
+                        tags: &filtered_tags,
                         trace_id,
                     }),
                 ) {
@@ -1562,7 +1571,7 @@ struct SpanMetricsSummary {
     #[serde(default)]
     sum: Option<f64>,
     #[serde(default)]
-    tags: BTreeMap<String, String>,
+    tags: BTreeMap<String, Option<String>>,
 }
 
 type SpanMetricsSummaries = Vec<Option<SpanMetricsSummary>>;

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1926,6 +1926,7 @@ def test_span_extraction_with_ddm_missing_values(
                 "count": 4,
                 "tags": {
                     "environment": "test",
+                    "release": None,
                 },
             },
         ],


### PR DESCRIPTION
We are getting some errors around null tag values when we're trying to deserialize metrics summaries to push them to their topic.

This will allow null values to be deserialized but still filtered before they end up on the topic.