### PR TITLE
fix(spans): Gate span metric extraction on the feature flag

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -41,7 +41,10 @@ const RESOURCE_SPAN_OPS: &[&str] = &["resource.script", "resource.css", "resourc
 /// This requires the `SpanMetricsExtraction` feature. This feature should be set to `false` if the
 /// default should no longer be placed.
 pub fn add_span_metrics(project_config: &mut ProjectConfig) {
-    if !project_config.features.has(Feature::SpanMetricsExtraction) {
+    if !project_config
+        .features
+        .has(Feature::ExtractSpansAndSpanMetricsFromEvent)
+    {
         return;
     }
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -27,7 +27,7 @@ pub enum Feature {
     DeviceClassSynthesis,
     /// Enables metric extraction from spans.
     #[serde(rename = "projects:span-metrics-extraction")]
-    SpanMetricsExtraction,
+    ExtractSpansAndSpanMetricsFromEvent,
     /// Allow ingestion of metrics in the "custom" namespace.
     #[serde(rename = "organizations:custom-metrics")]
     CustomMetrics,

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -976,7 +976,9 @@ mod tests {
         "#;
 
         let mut event = Annotated::from_json(json).unwrap();
-        let features = FeatureSet(BTreeSet::from([Feature::SpanMetricsExtraction]));
+        let features = FeatureSet(BTreeSet::from([
+            Feature::ExtractSpansAndSpanMetricsFromEvent,
+        ]));
 
         // Normalize first, to make sure that all things are correct as in the real pipeline:
         normalize_event(
@@ -1111,7 +1113,9 @@ mod tests {
 
         // Create a project config with the relevant feature flag. Sanitize to fill defaults.
         let mut project = ProjectConfig {
-            features: [Feature::SpanMetricsExtraction].into_iter().collect(),
+            features: [Feature::ExtractSpansAndSpanMetricsFromEvent]
+                .into_iter()
+                .collect(),
             ..ProjectConfig::default()
         };
         project.sanitize();
@@ -1170,7 +1174,9 @@ mod tests {
 
         // Create a project config with the relevant feature flag. Sanitize to fill defaults.
         let mut project = ProjectConfig {
-            features: [Feature::SpanMetricsExtraction].into_iter().collect(),
+            features: [Feature::ExtractSpansAndSpanMetricsFromEvent]
+                .into_iter()
+                .collect(),
             ..ProjectConfig::default()
         };
         project.sanitize();
@@ -1204,7 +1210,9 @@ mod tests {
 
         // Create a project config with the relevant feature flag. Sanitize to fill defaults.
         let mut project = ProjectConfig {
-            features: [Feature::SpanMetricsExtraction].into_iter().collect(),
+            features: [Feature::ExtractSpansAndSpanMetricsFromEvent]
+                .into_iter()
+                .collect(),
             ..ProjectConfig::default()
         };
         project.sanitize();
@@ -1235,7 +1243,10 @@ mod tests {
     /// Helper function for span metric extraction tests.
     fn extract_span_metrics(span: &Span) -> Vec<Bucket> {
         let mut config = ProjectConfig::default();
-        config.features.0.insert(Feature::SpanMetricsExtraction);
+        config
+            .features
+            .0
+            .insert(Feature::ExtractSpansAndSpanMetricsFromEvent);
         config.sanitize(); // apply defaults for span extraction
 
         let extraction_config = config.metric_extraction.ok().unwrap();

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1212,7 +1212,7 @@ impl EnvelopeProcessorService {
                     .has_feature(Feature::DeviceClassSynthesis),
                 enrich_spans: state
                     .project_state
-                    .has_feature(Feature::SpanMetricsExtraction),
+                    .has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent),
                 max_tag_value_length: self
                     .inner
                     .config

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -148,6 +148,13 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
         return;
     };
 
+    if !state
+        .project_state
+        .has_feature(Feature::SpanMetricsExtraction)
+    {
+        return;
+    }
+
     let mut add_span = |span: Annotated<Span>| {
         let span = match validate(span) {
             Ok(span) => span,
@@ -180,63 +187,50 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
         state.managed_envelope.envelope_mut().add_item(item);
     };
 
-    let span_metrics_extraction_enabled = state
-        .project_state
-        .has_feature(Feature::SpanMetricsExtraction);
-    let custom_metrics_enabled = state.project_state.has_feature(Feature::CustomMetrics);
-
     let Some(event) = state.event.value() else {
         return;
     };
 
-    let extract_transaction_span = span_metrics_extraction_enabled
-        || (custom_metrics_enabled && !event._metrics_summary.is_empty());
-    let extract_child_spans = span_metrics_extraction_enabled;
-
     // Extract transaction as a span.
     let mut transaction_span: Span = event.into();
 
-    if extract_child_spans {
-        // Add child spans as envelope items.
-        if let Some(child_spans) = event.spans.value() {
-            for span in child_spans {
-                let Some(inner_span) = span.value() else {
-                    continue;
-                };
-                // HACK: clone the span to set the segment_id. This should happen
-                // as part of normalization once standalone spans reach wider adoption.
-                let mut new_span = inner_span.clone();
-                new_span.is_segment = Annotated::new(false);
-                new_span.received = transaction_span.received.clone();
-                new_span.segment_id = transaction_span.segment_id.clone();
-                new_span.platform = transaction_span.platform.clone();
+    // Add child spans as envelope items.
+    if let Some(child_spans) = event.spans.value() {
+        for span in child_spans {
+            let Some(inner_span) = span.value() else {
+                continue;
+            };
+            // HACK: clone the span to set the segment_id. This should happen
+            // as part of normalization once standalone spans reach wider adoption.
+            let mut new_span = inner_span.clone();
+            new_span.is_segment = Annotated::new(false);
+            new_span.received = transaction_span.received.clone();
+            new_span.segment_id = transaction_span.segment_id.clone();
+            new_span.platform = transaction_span.platform.clone();
 
-                // If a profile is associated with the transaction, also associate it with its
-                // child spans.
-                new_span.profile_id = transaction_span.profile_id.clone();
+            // If a profile is associated with the transaction, also associate it with its
+            // child spans.
+            new_span.profile_id = transaction_span.profile_id.clone();
 
-                add_span(Annotated::new(new_span));
-            }
+            add_span(Annotated::new(new_span));
         }
     }
 
-    if extract_transaction_span {
-        // Extract tags to add to this span as well
-        let mut shared_tags = tag_extraction::extract_shared_tags(event);
+    // Extract tags to add to this span as well
+    let mut shared_tags = tag_extraction::extract_shared_tags(event);
 
-        if let Some(span_op) = transaction_span.op.value() {
-            shared_tags.insert(tag_extraction::SpanTagKey::SpanOp, span_op.to_owned());
-        }
-
-        transaction_span.sentry_tags = Annotated::new(
-            shared_tags
-                .clone()
-                .into_iter()
-                .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v)))
-                .collect(),
-        );
-        add_span(transaction_span.into());
+    if let Some(span_op) = transaction_span.op.value() {
+        shared_tags.insert(tag_extraction::SpanTagKey::SpanOp, span_op.to_owned());
     }
+
+    transaction_span.sentry_tags = Annotated::new(
+        shared_tags
+            .clone()
+            .into_iter()
+            .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v)))
+            .collect(),
+    );
+    add_span(transaction_span.into());
 }
 
 /// Config needed to normalize a standalone span.

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -150,7 +150,7 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
 
     if !state
         .project_state
-        .has_feature(Feature::SpanMetricsExtraction)
+        .has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent)
     {
         return;
     }

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1242,7 +1242,10 @@ fn is_metric_namespace_valid(state: &ProjectState, namespace: &MetricNamespace) 
     match namespace {
         MetricNamespace::Sessions => true,
         MetricNamespace::Transactions => true,
-        MetricNamespace::Spans => state.has_feature(Feature::SpanMetricsExtraction),
+        MetricNamespace::Spans => {
+            state.has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent)
+                || state.has_feature(Feature::StandaloneSpanIngestion)
+        }
         MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
         MetricNamespace::Unsupported => false,
     }

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1845,6 +1845,7 @@ def test_span_extraction_with_metrics_summary(
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["features"] = [
         "organizations:custom-metrics",
+        "projects:span-metrics-extraction",
     ]
 
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
@@ -1915,6 +1916,7 @@ def test_span_extraction_with_ddm_missing_values(
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["features"] = [
         "organizations:custom-metrics",
+        "projects:span-metrics-extraction",
     ]
 
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1904,6 +1904,45 @@ def test_span_extraction_with_metrics_summary(
     assert metrics_summary["mri"] == mri
 
 
+def test_span_no_extraction_with_metrics_summary(
+    mini_sentry,
+    relay_with_processing,
+    spans_consumer,
+    metrics_summaries_consumer,
+):
+    spans_consumer = spans_consumer()
+    metrics_summaries_consumer = metrics_summaries_consumer()
+
+    relay = relay_with_processing()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:custom-metrics",
+    ]
+
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    mri = "c:spans/some_metric@none"
+    metrics_summary = {
+        mri: [
+            {
+                "min": 1.0,
+                "max": 2.0,
+                "sum": 3.0,
+                "count": 4,
+                "tags": {
+                    "environment": "test",
+                },
+            },
+        ],
+    }
+    event["_metrics_summary"] = metrics_summary
+
+    relay.send_event(project_id, event)
+
+    spans_consumer.assert_empty()
+    metrics_summaries_consumer.assert_empty()
+
+
 def test_span_extraction_with_ddm_missing_values(
     mini_sentry,
     relay_with_processing,


### PR DESCRIPTION
For a while, we were not ingesting all spans but we still wanted to ingest metrics summaries and the related spans.

Now we're ingesting all spans, we want to make sure it's still gated properly (only active for AM2 plans and above). This will stop ingesting segments and the related metrics summaries for AM1 customers.

#skip-changelog