### PR TITLE
fix(spans): Emit a usage metric for every span seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Use statsdproxy to pre-aggregate metrics. ([#2425](https://github.com/getsentry/relay/pull/2425))
 - Add SDK information to spans. ([#3178](https://github.com/getsentry/relay/pull/3178))
 - Filter null values from metrics summary tags. ([#3204](https://github.com/getsentry/relay/pull/3204))
-- Emit a processed span outcome for every span seen. ([#3209](https://github.com/getsentry/relay/pull/3209))
+- Emit a usage metric for every span seen. ([#3209](https://github.com/getsentry/relay/pull/3209))
 
 ## 24.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Use statsdproxy to pre-aggregate metrics. ([#2425](https://github.com/getsentry/relay/pull/2425))
 - Add SDK information to spans. ([#3178](https://github.com/getsentry/relay/pull/3178))
 - Filter null values from metrics summary tags. ([#3204](https://github.com/getsentry/relay/pull/3204))
+- Emit a processed span outcome for every span seen. ([#3209](https://github.com/getsentry/relay/pull/3209))
 
 ## 24.2.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -131,7 +131,7 @@ fn span_metrics() -> impl IntoIterator<Item = MetricSpec> {
             category: DataCategory::Span,
             mri: "c:spans/usage@none".into(),
             field: None,
-            condition: Some(exclusive_time_light_condition.clone()),
+            condition: None,
             tags: vec![],
         },
         MetricSpec {

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1225,7 +1225,7 @@ mod tests {
             .filter(|b| b.name == "c:spans/usage@none")
             .collect::<Vec<_>>();
 
-        let expected_usage = 6; // There are 7 spans, but `custom.op` is not counted.
+        let expected_usage = 7; // We count all spans received by Relay
         assert_eq!(usage_metrics.len(), expected_usage);
         for m in usage_metrics {
             assert!(m.tags.is_empty());


### PR DESCRIPTION
We've made it so we emit a usage metric for each span we extract a metric for which in turns will be used to emit a processed span outcome.

We'd like to change this to emit a usage metric for every span we see as Relay is still processing those spans even if it's not to store derived data from them. This has some impact for billing.

As we improve the product, we anticipate to store more and more information regarding those spans and the overall cost for the customer will not change.