### PR TITLE
fix(gocd): Moving comment to fix GoCD script parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ gocd: ## Build GoCD pipelines
 	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
 	@ cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./relay.jsonnet
 	@ cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./pops.jsonnet
-	@ cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./relay.jsonnet
+	@ cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./processing.jsonnet
 	@ cd ./gocd/generated-pipelines && find . -type f \( -name '*.yaml' \) -print0 | xargs -n 1 -0 yq -p json -o yaml -i
 .PHONY: gocd
 

--- a/gocd/templates/bash/check-sentry-errors.sh
+++ b/gocd/templates/bash/check-sentry-errors.sh
@@ -13,6 +13,9 @@
 #                    match, and we need the service to get the release name
 #   SENTRY_SINGLE_TENANT: When single-tenant is 'true' this script will use the sentry-st organization instead of sentry
 #   SKIP_CANARY_CHECKS: Whether to skip checks entirely (true/false)
+#
+# Since Processing and PoPs can be deployed independently, we don't fail if
+# we can't find a release as it may not exist yet
 
 # shellcheck disable=SC2206
 projects=(${SENTRY_PROJECTS})
@@ -26,8 +29,6 @@ for project in "${projects[@]}"; do
   release_name=$(./relay/scripts/get-sentry-release-name "${GO_REVISION_RELAY_REPO}" "${service}")
   if [ -z "${release_name}" ]; then
     echo "Failed to get the release name for ${service} at ${GO_REVISION_RELAY_REPO}"
-    # Since Processing and PoPs can be deployed independently, we shouldn't fail if
-    # we can't find a release as it may not exist yet
     continue
   fi
 

--- a/gocd/templates/bash/check-sentry-new-errors.sh
+++ b/gocd/templates/bash/check-sentry-new-errors.sh
@@ -12,6 +12,9 @@
 #                    match, and we need the service to get the release name
 #   SENTRY_SINGLE_TENANT: When single-tenant is 'true' this script will use the sentry-st organization instead of sentry
 #   SKIP_CANARY_CHECKS: Whether to skip checks entirely (true/false)
+#
+# Since Processing and PoPs can be deployed independently, we don't fail if
+# we can't find a release as it may not exist yet
 
 # shellcheck disable=SC2206
 projects=(${SENTRY_PROJECTS})
@@ -25,8 +28,7 @@ for project in "${projects[@]}"; do
   release_name=$(./relay/scripts/get-sentry-release-name "${GO_REVISION_RELAY_REPO}" "${service}")
   if [ -z "${release_name}" ]; then
     echo "Failed to get the release name for ${service} at ${GO_REVISION_RELAY_REPO}"
-    # Since Processing and PoPs can be deployed independently, we shouldn't fail if
-    # we can't find a release as it may not exist yet
+
     continue
   fi
 


### PR DESCRIPTION
This PR addresses an issue with GoCD's handling of inline comments in scripts. GoCD requires `#` characters to either denote a variable or be prefixed with an additional `#` character. Because comments in scripts are quite common, we have added a utility that automatically adds an additional `#`, but it is quite naive and doesn't understand nested comments. As a result, I decided to move the nested comment up to the top for the time being to unblock progress.

#skip-changelog