### PR TITLE
feat(server): Drop transactions in a spans-only world

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -47,6 +47,10 @@ pub enum Feature {
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
     IngestUnsampledProfiles,
 
+    /// Discard transactions in a spans-only world.
+    #[serde(rename = "projects:discard-transaction")]
+    DiscardTransaction,
+
     /// Deprecated, still forwarded for older downstream Relays.
     #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]
     Deprecated1,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1346,8 +1346,12 @@ impl EnvelopeProcessorService {
                     event::scrub(state)?;
                     if_processing!(self.inner.config, {
                         span::extract_from_event(state);
-                        span::maybe_discard_transaction(state);
                     });
+                }
+
+                span::maybe_discard_transaction(state);
+
+                if state.has_event() {
                     event::serialize(state)?;
                 }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1349,7 +1349,9 @@ impl EnvelopeProcessorService {
                     });
                 }
 
-                span::maybe_discard_transaction(state);
+                if_processing!(self.inner.config, {
+                    span::maybe_discard_transaction(state);
+                });
 
                 if state.has_event() {
                     event::serialize(state)?;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1344,10 +1344,11 @@ impl EnvelopeProcessorService {
 
                 if state.has_event() {
                     event::scrub(state)?;
-                    event::serialize(state)?;
                     if_processing!(self.inner.config, {
                         span::extract_from_event(state);
+                        span::maybe_discard_transaction(state);
                     });
+                    event::serialize(state)?;
                 }
 
                 attachment::scrub(state);

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -15,7 +15,7 @@ use relay_event_schema::protocol::{
     OtelContext, RelayInfo, SecurityReportType, Timestamp, Values,
 };
 use relay_pii::PiiProcessor;
-use relay_protocol::{Annotated, Array, FromValue, Object, Value};
+use relay_protocol::{Annotated, Array, Empty, FromValue, Object, Value};
 use relay_quotas::DataCategory;
 use relay_statsd::metric;
 use serde_json::Value as SerdeValue;
@@ -332,6 +332,11 @@ pub fn scrub<G: EventProcessing>(
 pub fn serialize<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
 ) -> Result<(), ProcessingError> {
+    if state.event.is_empty() {
+        relay_log::error!("Cannot serialize empty event");
+        return Ok(());
+    }
+
     let data = metric!(timer(RelayTimers::EventProcessingSerialization), {
         state
             .event

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -239,6 +239,15 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
     }
 }
 
+/// Removes the transaction in case the project has made the transition to spans-only.
+pub fn maybe_discard_transaction(state: &mut ProcessEnvelopeState<TransactionGroup>) {
+    if state.event_type() == Some(EventType::Transaction)
+        && state.project_state.has_feature(Feature::DiscardTransaction)
+    {
+        state.remove_event();
+        state.managed_envelope.update();
+    }
+}
 /// Config needed to normalize a standalone span.
 #[derive(Clone, Debug)]
 struct NormalizeSpanConfig<'a> {

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -331,7 +331,7 @@ impl ManagedEnvelope {
         self
     }
 
-    /// Removes event item(s) and log an outcome.
+    /// Removes event item(s) and logs an outcome.
     ///
     /// Note: This function relies on the envelope summary being correct.
     pub fn reject_event(&mut self, outcome: Outcome) {

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1333,12 +1333,16 @@ def test_invalid_project_id(mini_sentry, relay):
     pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
 
 
+@pytest.mark.parametrize("discard_transaction", [False, True])
 def test_span_extraction(
     mini_sentry,
     relay_with_processing,
     spans_consumer,
+    transactions_consumer,
+    discard_transaction,
 ):
     spans_consumer = spans_consumer()
+    transactions_consumer = transactions_consumer()
 
     relay = relay_with_processing()
     project_id = 42
@@ -1347,6 +1351,8 @@ def test_span_extraction(
         "projects:span-metrics-extraction",
         "projects:span-metrics-extraction-all-modules",
     ]
+    if discard_transaction:
+        project_config["config"]["features"].append("projects:discard-transaction")
 
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
     end = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=1)
@@ -1365,6 +1371,13 @@ def test_span_extraction(
     ]
 
     relay.send_event(project_id, event)
+
+    if discard_transaction:
+        result = transactions_consumer.poll(timeout=2.0)
+        assert result is None
+    else:
+        received_event, _ = transactions_consumer.get_event(timeout=2.0)
+        assert received_event["event_id"] == event["event_id"]
 
     child_span = spans_consumer.get_span()
     del child_span["received"]


### PR DESCRIPTION
To test what our Performance product looks like without transactions (spans only), add the ability to drop transactions in Relay. The feature flag will only be enabled for a single experimental project for the time being.

This PR re-applies https://github.com/getsentry/relay/pull/3165, and fixes the bug that caused empty events to end up on the errors topic.

#skip-changelog