### PR TITLE
fix(normalization): Skip validation on renormalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Forward metrics in proxy mode. ([#3106](https://github.com/getsentry/relay/pull/3106))
 - Do not PII-scrub code locations by default. ([#3116](https://github.com/getsentry/relay/pull/3116))
 - Accept transactions with unfinished spans. ([#3162](https://github.com/getsentry/relay/pull/3162))
+- Don't run validation on renormalization, and don't normalize spans from librelay calls. ([#3214](https://github.com/getsentry/relay/pull/3214))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Don't run validation on renormalization, and don't normalize spans. ([#3214](https://github.com/getsentry/relay/pull/3214))
+
 ## 0.8.46
 
 - This release requires Python 3.10 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.9.

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         geoip_lookup: None, // only supported in relay
         enable_trimming: config.enable_trimming.unwrap_or_default(),
         measurements: None,
-        normalize_spans: false,
+        normalize_spans: config.normalize_spans,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -117,11 +117,13 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         received_at: config.received_at,
         max_secs_in_past: config.max_secs_in_past,
         max_secs_in_future: config.max_secs_in_future,
+        is_renormalize: config.is_renormalize.unwrap_or(false),
     };
     validate_event_timestamps(&mut event, &event_validation_config)?;
 
     let tx_validation_config = TransactionValidationConfig {
         timestamp_range: None, // only supported in relay
+        is_renormalize: config.is_renormalize.unwrap_or(false),
     };
     validate_transaction(&mut event, &tx_validation_config)?;
 
@@ -144,6 +146,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         geoip_lookup: None, // only supported in relay
         enable_trimming: config.enable_trimming.unwrap_or_default(),
         measurements: None,
+        normalize_spans: false,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -117,13 +117,13 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         received_at: config.received_at,
         max_secs_in_past: config.max_secs_in_past,
         max_secs_in_future: config.max_secs_in_future,
-        is_renormalize: config.is_renormalize.unwrap_or(false),
+        is_validated: config.is_renormalize.unwrap_or(false),
     };
     validate_event_timestamps(&mut event, &event_validation_config)?;
 
     let tx_validation_config = TransactionValidationConfig {
         timestamp_range: None, // only supported in relay
-        is_renormalize: config.is_renormalize.unwrap_or(false),
+        is_validated: config.is_renormalize.unwrap_or(false),
     };
     validate_transaction(&mut event, &tx_validation_config)?;
 

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -158,6 +158,13 @@ pub struct StoreConfig {
     ///
     /// It is persisted into the event payload for correlation.
     pub replay_id: Option<Uuid>,
+
+    /// Controls whether spans should be normalized (e.g. normalizing the exclusive time).
+    ///
+    /// To normalize spans in [`crate::normalize_event`], `is_renormalize` must
+    /// be disabled _and_ `normalize_spans` enabled in
+    /// [`crate::NormalizationConfig`].
+    pub normalize_spans: bool,
 }
 
 /// The processor that normalizes events for processing and storage.

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1477,7 +1477,7 @@ mod tests {
                 received_at,
                 max_secs_in_past,
                 max_secs_in_future,
-                is_renormalize: false,
+                is_validated: false,
             },
         )
         .unwrap();
@@ -1538,7 +1538,7 @@ mod tests {
                 received_at,
                 max_secs_in_past,
                 max_secs_in_future,
-                is_renormalize: false,
+                is_validated: false,
             },
         )
         .unwrap();

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1477,6 +1477,7 @@ mod tests {
                 received_at,
                 max_secs_in_past,
                 max_secs_in_future,
+                is_renormalize: false,
             },
         )
         .unwrap();
@@ -1537,6 +1538,7 @@ mod tests {
                 received_at,
                 max_secs_in_past,
                 max_secs_in_future,
+                is_renormalize: false,
             },
         )
         .unwrap();

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -19,6 +19,9 @@ pub struct TransactionValidationConfig {
     /// Transactions that finish outside this range are invalid. The check is
     /// skipped if no range is provided.
     pub timestamp_range: Option<Range<UnixTimestamp>>,
+
+    /// Controls whether the event has been validated before, in which case disables validation.
+    pub is_renormalize: bool,
 }
 
 /// Validates a transaction.
@@ -35,6 +38,10 @@ pub fn validate_transaction(
     event: &mut Annotated<Event>,
     config: &TransactionValidationConfig,
 ) -> ProcessingResult {
+    if config.is_renormalize {
+        return Ok(());
+    }
+
     let Annotated(Some(ref mut event), ref _meta) = event else {
         return Ok(());
     };
@@ -237,6 +244,9 @@ pub struct EventValidationConfig {
     ///
     /// If the event's timestamp lies further into the future, the received timestamp is assumed.
     pub max_secs_in_future: Option<i64>,
+
+    /// Controls whether the event has been validated before, in which case disables validation.
+    pub is_renormalize: bool,
 }
 
 /// Validates the timestamp values of an event, after performing minimal timestamp normalization.
@@ -259,6 +269,10 @@ pub fn validate_event_timestamps(
     event: &mut Annotated<Event>,
     config: &EventValidationConfig,
 ) -> ProcessingResult {
+    if config.is_renormalize {
+        return Ok(());
+    }
+
     let Annotated(Some(ref mut event), ref mut meta) = event else {
         return Ok(());
     };
@@ -397,6 +411,7 @@ mod tests {
                 &mut event,
                 &TransactionValidationConfig {
                     timestamp_range: Some(UnixTimestamp::now()..UnixTimestamp::now()),
+                    is_renormalize: false
                 }
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -436,7 +451,8 @@ mod tests {
             validate_transaction(
                 &mut event,
                 &TransactionValidationConfig {
-                    timestamp_range: None
+                    timestamp_range: None,
+                    is_renormalize: false
                 }
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -461,7 +477,8 @@ mod tests {
             validate_transaction(
                 &mut event,
                 &TransactionValidationConfig {
-                    timestamp_range: None
+                    timestamp_range: None,
+                    is_renormalize: false
                 }
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -710,6 +727,7 @@ mod tests {
             received_at: Some(Utc::now()),
             max_secs_in_past: Some(2),
             max_secs_in_future: Some(1),
+            is_renormalize: false,
         };
 
         let json = r#"{
@@ -735,6 +753,7 @@ mod tests {
             received_at: Some(now),
             max_secs_in_past: Some(2),
             max_secs_in_future: Some(1),
+            is_renormalize: false,
         };
 
         let json = format!(
@@ -824,6 +843,7 @@ mod tests {
                 received_at: Some(Utc::now()),
                 max_secs_in_past: Some(2),
                 max_secs_in_future: Some(1),
+                is_renormalize: false,
             },
         )
         .unwrap();
@@ -834,5 +854,46 @@ mod tests {
         let span = get_value!(spans[0]!);
 
         assert_eq!(span.timestamp.value(), event.timestamp.value());
+    }
+
+    #[test]
+    fn test_skip_transaction_validation_on_renormalization() {
+        let json = r#"{
+  "event_id": "52df9022835246eeb317dbd739ccd059",
+  "type": "transaction",
+  "transaction": "I'm invalid because I don't have any timestamps!"
+}"#;
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+
+        assert!(validate_transaction(&mut event, &TransactionValidationConfig::default()).is_err());
+        assert!(validate_transaction(
+            &mut event,
+            &TransactionValidationConfig {
+                is_renormalize: true,
+                ..Default::default()
+            }
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_skip_event_timestamp_validation_on_renormalization() {
+        let json = r#"{
+  "event_id": "52df9022835246eeb317dbd739ccd059",
+  "transaction": "completely outdated transaction",
+  "start_timestamp": -2,
+  "timestamp": -1
+}"#;
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+
+        assert!(validate_event_timestamps(&mut event, &EventValidationConfig::default()).is_err());
+        assert!(validate_event_timestamps(
+            &mut event,
+            &EventValidationConfig {
+                is_renormalize: true,
+                ..Default::default()
+            }
+        )
+        .is_ok());
     }
 }

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -21,7 +21,11 @@ pub struct TransactionValidationConfig {
     pub timestamp_range: Option<Range<UnixTimestamp>>,
 
     /// Controls whether the event has been validated before, in which case disables validation.
-    pub is_renormalize: bool,
+    ///
+    /// By default, `is_validated` is disabled and transaction validation is run.
+    ///
+    /// Similar to `is_renormalize` for normalization, `sentry_relay` may configure this value.
+    pub is_validated: bool,
 }
 
 /// Validates a transaction.
@@ -38,7 +42,7 @@ pub fn validate_transaction(
     event: &mut Annotated<Event>,
     config: &TransactionValidationConfig,
 ) -> ProcessingResult {
-    if config.is_renormalize {
+    if config.is_validated {
         return Ok(());
     }
 
@@ -246,7 +250,11 @@ pub struct EventValidationConfig {
     pub max_secs_in_future: Option<i64>,
 
     /// Controls whether the event has been validated before, in which case disables validation.
-    pub is_renormalize: bool,
+    ///
+    /// By default, `is_validated` is disabled and event validation is run.
+    ///
+    /// Similar to `is_renormalize` for normalization, `sentry_relay` may configure this value.
+    pub is_validated: bool,
 }
 
 /// Validates the timestamp values of an event, after performing minimal timestamp normalization.
@@ -269,7 +277,7 @@ pub fn validate_event_timestamps(
     event: &mut Annotated<Event>,
     config: &EventValidationConfig,
 ) -> ProcessingResult {
-    if config.is_renormalize {
+    if config.is_validated {
         return Ok(());
     }
 
@@ -411,7 +419,7 @@ mod tests {
                 &mut event,
                 &TransactionValidationConfig {
                     timestamp_range: Some(UnixTimestamp::now()..UnixTimestamp::now()),
-                    is_renormalize: false
+                    is_validated: false
                 }
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -452,7 +460,7 @@ mod tests {
                 &mut event,
                 &TransactionValidationConfig {
                     timestamp_range: None,
-                    is_renormalize: false
+                    is_validated: false
                 }
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -478,7 +486,7 @@ mod tests {
                 &mut event,
                 &TransactionValidationConfig {
                     timestamp_range: None,
-                    is_renormalize: false
+                    is_validated: false
                 }
             ),
             Err(ProcessingAction::InvalidTransaction(
@@ -727,7 +735,7 @@ mod tests {
             received_at: Some(Utc::now()),
             max_secs_in_past: Some(2),
             max_secs_in_future: Some(1),
-            is_renormalize: false,
+            is_validated: false,
         };
 
         let json = r#"{
@@ -753,7 +761,7 @@ mod tests {
             received_at: Some(now),
             max_secs_in_past: Some(2),
             max_secs_in_future: Some(1),
-            is_renormalize: false,
+            is_validated: false,
         };
 
         let json = format!(
@@ -843,7 +851,7 @@ mod tests {
                 received_at: Some(Utc::now()),
                 max_secs_in_past: Some(2),
                 max_secs_in_future: Some(1),
-                is_renormalize: false,
+                is_validated: false,
             },
         )
         .unwrap();
@@ -869,7 +877,7 @@ mod tests {
         assert!(validate_transaction(
             &mut event,
             &TransactionValidationConfig {
-                is_renormalize: true,
+                is_validated: true,
                 ..Default::default()
             }
         )
@@ -890,7 +898,7 @@ mod tests {
         assert!(validate_event_timestamps(
             &mut event,
             &EventValidationConfig {
-                is_renormalize: true,
+                is_validated: true,
                 ..Default::default()
             }
         )

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1184,11 +1184,13 @@ impl EnvelopeProcessorService {
                 timestamp_range: Some(
                     AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
                 ),
+                is_renormalize: false,
             };
             let event_validation_config = EventValidationConfig {
                 received_at: Some(state.managed_envelope.received_at()),
                 max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
                 max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
+                is_renormalize: false,
             };
             let normalization_config = NormalizationConfig {
                 client_ip: client_ipaddr.as_ref(),
@@ -1226,6 +1228,7 @@ impl EnvelopeProcessorService {
                     state.project_state.config().measurements.as_ref(),
                     global_config.measurements.as_ref(),
                 )),
+                normalize_spans: true,
             };
 
             metric!(timer(RelayTimers::EventProcessingLightNormalization), {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1184,13 +1184,13 @@ impl EnvelopeProcessorService {
                 timestamp_range: Some(
                     AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
                 ),
-                is_renormalize: false,
+                is_validated: false,
             };
             let event_validation_config = EventValidationConfig {
                 received_at: Some(state.managed_envelope.received_at()),
                 max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
                 max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
-                is_renormalize: false,
+                is_validated: false,
             };
             let normalization_config = NormalizationConfig {
                 client_ip: client_ipaddr.as_ref(),

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -407,6 +407,7 @@ pub fn store<G: EventProcessing>(
         client_sample_rate: envelope.dsc().and_then(|ctx| ctx.sample_rate),
         replay_id: envelope.dsc().and_then(|ctx| ctx.replay_id),
         client_hints: envelope.meta().client_hints().to_owned(),
+        normalize_spans: false, // noop
     };
 
     let mut store_processor = StoreProcessor::new(store_config);


### PR DESCRIPTION
Previous normalization PRs run validation from librelay calls. However, some `sentry` tests run full normalization in librelay on partial (i.e. invalid) payloads, and running validation makes plenty of tests fail (see https://github.com/getsentry/sentry/pull/66134).

Similarly, many `sentry` tests expect span normalization to never happen. After spending significant time "fixing"* some tests, it'd require me even more time to "fix" the remaining ones as it requires a deeper understanding of other features/codebases. Thus, I'm reintroducing `normalize_spans` to disable span normalization (mostly exclusive time computation) from librelay calls and unblock the librelay release.

*Note: "fixing" a test means using data relay outputs from normalization. This doesn't align with other assumptions made in the tests, nor modifications to the event payload in the rest of the event processing pipeline.

### Future work
- Consider span normalization a regular step in event normalization behind the `is_renormalize` flag, removing the `normalize_spans` flag.