### PR TITLE
Always print memory usage from readiness probe

### DIFF
--- a/relay-server/src/services/health_check.rs
+++ b/relay-server/src/services/health_check.rs
@@ -133,6 +133,14 @@ impl HealthCheckService {
                 self.config.health_max_memory_watermark_percent() * 100.0,
             );
             return Status::Unhealthy;
+        } else {
+            relay_log::info!(
+                "Memory usage report, {} / {} ({:.2}% >= {:.2}%)",
+                memory.used,
+                memory.total,
+                memory.used_percent() * 100.0,
+                self.config.health_max_memory_watermark_percent() * 100.0,
+            );
         }
 
         if memory.used > self.config.health_max_memory_watermark_bytes() {
@@ -144,6 +152,14 @@ impl HealthCheckService {
                 self.config.health_max_memory_watermark_bytes(),
             );
             return Status::Unhealthy;
+        } else {
+            relay_log::info!(
+                "Memory usage report, {} / {} ({} >= {})",
+                memory.used,
+                memory.total,
+                memory.used,
+                self.config.health_max_memory_watermark_bytes(),
+            );
         }
 
         Status::Healthy


### PR DESCRIPTION


<!-- Describe your PR here. -->

For debugging purposes, always log memory usage from the readiness probe.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
