### PR TITLE
feat(bucket-encoding): Implements base64 and zstd encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Extend GPU context with data for Unreal Engine crash reports. ([#3144](https://github.com/getsentry/relay/pull/3144))
+- Implement base64 and zstd metric bucket encodings. ([#3218](https://github.com/getsentry/relay/pull/3218))
 - Implement COGS measurements into Relay. ([#3157](https://github.com/getsentry/relay/pull/3157))
 - Parametrize transaction in dynamic sampling context. ([#3141](https://github.com/getsentry/relay/pull/3141))
 - Adds ReplayVideo envelope-item type. ([#3105](https://github.com/getsentry/relay/pull/3105))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "bytemuck"
+version = "1.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "debugid"
@@ -4111,6 +4117,7 @@ dependencies = [
  "backoff",
  "brotli",
  "bytecount",
+ "bytemuck",
  "bytes",
  "chrono",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,12 +539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
-name = "bytemuck"
-version = "1.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4111,6 @@ dependencies = [
  "backoff",
  "brotli",
  "bytecount",
- "bytemuck",
  "bytes",
  "chrono",
  "data-encoding",

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 chrono = { workspace = true }
-data-encoding = "2.3.3"
+data-encoding = "2.5.0"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 hmac = "0.12.1"
 rand = { workspace = true }

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -182,7 +182,6 @@ pub enum CardinalityLimiterMode {
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 #[serde(default)]
 pub struct BucketEncodings {
-    sessions: BucketEncoding,
     transactions: BucketEncoding,
     spans: BucketEncoding,
     profiles: BucketEncoding,
@@ -193,12 +192,11 @@ impl BucketEncodings {
     /// Returns the configured encoding for a specific namespace.
     pub fn for_namespace(&self, namespace: MetricNamespace) -> BucketEncoding {
         match namespace {
-            MetricNamespace::Sessions => self.sessions,
             MetricNamespace::Transactions => self.transactions,
             MetricNamespace::Spans => self.spans,
             MetricNamespace::Profiles => self.profiles,
             MetricNamespace::Custom => self.custom,
-            MetricNamespace::Unsupported => BucketEncoding::default(),
+            _ => BucketEncoding::Legacy,
         }
     }
 }
@@ -225,7 +223,6 @@ where
         {
             let encoding = BucketEncoding::deserialize(de::value::StrDeserializer::new(v))?;
             Ok(BucketEncodings {
-                sessions: encoding,
                 transactions: encoding,
                 spans: encoding,
                 profiles: encoding,
@@ -420,7 +417,6 @@ mod tests {
         assert_eq!(
             o.metric_bucket_set_encodings,
             BucketEncodings {
-                sessions: BucketEncoding::Legacy,
                 transactions: BucketEncoding::Legacy,
                 spans: BucketEncoding::Legacy,
                 profiles: BucketEncoding::Legacy,
@@ -430,7 +426,6 @@ mod tests {
         assert_eq!(
             o.metric_bucket_dist_encodings,
             BucketEncodings {
-                sessions: BucketEncoding::Zstd,
                 transactions: BucketEncoding::Zstd,
                 spans: BucketEncoding::Zstd,
                 profiles: BucketEncoding::Zstd,
@@ -442,7 +437,6 @@ mod tests {
     #[test]
     fn test_metric_bucket_encodings_de_from_obj() {
         let original = BucketEncodings {
-            sessions: BucketEncoding::Legacy,
             transactions: BucketEncoding::Base64,
             spans: BucketEncoding::Zstd,
             profiles: BucketEncoding::Base64,

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -196,6 +196,10 @@ impl BucketEncodings {
             MetricNamespace::Spans => self.spans,
             MetricNamespace::Profiles => self.profiles,
             MetricNamespace::Custom => self.custom,
+            // Always force the legacy encoding for sessions,
+            // sessions are not part of the generic metrics platform with different
+            // consumer which are not (yet) updated to support the new data.
+            MetricNamespace::Sessions => BucketEncoding::Legacy,
             _ => BucketEncoding::Legacy,
         }
     }

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -217,7 +217,7 @@ where
             formatter.write_str("metric bucket encodings")
         }
 
-        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
         where
             E: de::Error,
         {

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -211,6 +211,10 @@ pub enum MetricEncoding {
     /// Uses already the dynamic value format but still encodes
     /// all values as a JSON number array.
     Array,
+    /// Auto mode.
+    ///
+    /// Relay chooses the best available encoding for distributions and sets.
+    Auto,
 }
 
 /// Returns `true` if this value is equal to `Default::default()`.

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -7,7 +7,7 @@ use relay_base_schema::metrics::MetricNamespace;
 use relay_event_normalization::MeasurementsConfig;
 use relay_filter::GenericFiltersConfig;
 use relay_quotas::Quota;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::ErrorBoundary;
@@ -140,13 +140,20 @@ pub struct Options {
     )]
     pub span_usage_metric: bool,
 
-    /// Metric bucket encoding configuration by metric namespace.
+    /// Metric bucket encoding configuration for sets by metric namespace.
     #[serde(
-        rename = "relay.metric-bucket-encodings",
-        deserialize_with = "default_on_error",
+        rename = "relay.metric-bucket-set-encodings",
+        deserialize_with = "de_metric_bucket_encodings",
         skip_serializing_if = "is_default"
     )]
-    pub metric_bucket_encodings: MetricBucketEncodings,
+    pub metric_bucket_set_encodings: BucketEncodings,
+    /// Metric bucket encoding configuration for distributions by metric namespace.
+    #[serde(
+        rename = "relay.metric-bucket-distribution-encodings",
+        deserialize_with = "de_metric_bucket_encodings",
+        skip_serializing_if = "is_default"
+    )]
+    pub metric_bucket_dist_encodings: BucketEncodings,
 
     /// All other unknown options.
     #[serde(flatten)]
@@ -170,29 +177,78 @@ pub enum CardinalityLimiterMode {
     Disabled,
 }
 
-/// Configuration container to control [`MetricEncoding`] per namespace.
+/// Configuration container to control [`BucketEncoding`] per namespace.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 #[serde(default)]
-pub struct MetricBucketEncodings {
-    sessions: MetricEncoding,
-    transactions: MetricEncoding,
-    spans: MetricEncoding,
-    profiles: MetricEncoding,
-    custom: MetricEncoding,
-    unsupported: MetricEncoding,
+pub struct BucketEncodings {
+    sessions: BucketEncoding,
+    transactions: BucketEncoding,
+    spans: BucketEncoding,
+    profiles: BucketEncoding,
+    custom: BucketEncoding,
 }
 
-impl MetricBucketEncodings {
+impl BucketEncodings {
     /// Returns the configured encoding for a specific namespace.
-    pub fn for_namespace(&self, namespace: MetricNamespace) -> MetricEncoding {
+    pub fn for_namespace(&self, namespace: MetricNamespace) -> BucketEncoding {
         match namespace {
             MetricNamespace::Sessions => self.sessions,
             MetricNamespace::Transactions => self.transactions,
             MetricNamespace::Spans => self.spans,
             MetricNamespace::Profiles => self.profiles,
             MetricNamespace::Custom => self.custom,
-            MetricNamespace::Unsupported => self.unsupported,
+            MetricNamespace::Unsupported => BucketEncoding::default(),
+        }
+    }
+}
+
+/// Deserializes individual metric encodings or all from a string.
+///
+/// Returns a default when failing to deserialize.
+fn de_metric_bucket_encodings<'de, D>(deserializer: D) -> Result<BucketEncodings, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = BucketEncodings;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("metric bucket encodings")
+        }
+
+        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let encoding = BucketEncoding::deserialize(de::value::StrDeserializer::new(v))?;
+            Ok(BucketEncodings {
+                sessions: encoding,
+                transactions: encoding,
+                spans: encoding,
+                profiles: encoding,
+                custom: encoding,
+            })
+        }
+
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            BucketEncodings::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    match deserializer.deserialize_any(Visitor) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            relay_log::error!(
+                error = %error,
+                "Error deserializing metric bucket encodings",
+            );
+            Ok(BucketEncodings::default())
         }
     }
 }
@@ -200,7 +256,7 @@ impl MetricBucketEncodings {
 /// All supported metric bucket encodings.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
-pub enum MetricEncoding {
+pub enum BucketEncoding {
     /// The default legacy encoding.
     ///
     /// A simple JSON array of numbers.
@@ -211,10 +267,14 @@ pub enum MetricEncoding {
     /// Uses already the dynamic value format but still encodes
     /// all values as a JSON number array.
     Array,
-    /// Auto mode.
+    /// Base64 encoding.
     ///
-    /// Relay chooses the best available encoding for distributions and sets.
-    Auto,
+    /// Encodes all values as Base64.
+    Base64,
+    /// Zstd.
+    ///
+    /// Compresses all values with zstd.
+    Zstd,
 }
 
 /// Returns `true` if this value is equal to `Default::default()`.
@@ -345,5 +405,59 @@ mod tests {
         let deserialized: GlobalConfig = serde_json::from_str(config).unwrap();
         let serialized = serde_json::to_string(&deserialized).unwrap();
         assert_eq!(config, &serialized);
+    }
+
+    #[test]
+    fn test_metric_bucket_encodings_de_from_str() {
+        let o: Options = serde_json::from_str(
+            r#"{
+                "relay.metric-bucket-set-encodings": "legacy",
+                "relay.metric-bucket-distribution-encodings": "zstd"
+        }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            o.metric_bucket_set_encodings,
+            BucketEncodings {
+                sessions: BucketEncoding::Legacy,
+                transactions: BucketEncoding::Legacy,
+                spans: BucketEncoding::Legacy,
+                profiles: BucketEncoding::Legacy,
+                custom: BucketEncoding::Legacy
+            }
+        );
+        assert_eq!(
+            o.metric_bucket_dist_encodings,
+            BucketEncodings {
+                sessions: BucketEncoding::Zstd,
+                transactions: BucketEncoding::Zstd,
+                spans: BucketEncoding::Zstd,
+                profiles: BucketEncoding::Zstd,
+                custom: BucketEncoding::Zstd
+            }
+        );
+    }
+
+    #[test]
+    fn test_metric_bucket_encodings_de_from_obj() {
+        let original = BucketEncodings {
+            sessions: BucketEncoding::Legacy,
+            transactions: BucketEncoding::Base64,
+            spans: BucketEncoding::Zstd,
+            profiles: BucketEncoding::Base64,
+            custom: BucketEncoding::Zstd,
+        };
+        let s = serde_json::to_string(&original).unwrap();
+        let s = format!(
+            r#"{{
+            "relay.metric-bucket-set-encodings": {s},
+            "relay.metric-bucket-distribution-encodings": {s}
+        }}"#
+        );
+
+        let o: Options = serde_json::from_str(&s).unwrap();
+        assert_eq!(o.metric_bucket_set_encodings, original);
+        assert_eq!(o.metric_bucket_dist_encodings, original);
     }
 }

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -370,7 +370,7 @@ impl<'a> BucketView<'a> {
     /// Name of the bucket.
     ///
     /// See also: [`Bucket::name`]
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         &self.inner.name
     }
 
@@ -387,14 +387,14 @@ impl<'a> BucketView<'a> {
     /// Name of the bucket.
     ///
     /// See also: [`Bucket::tags`]
-    pub fn tags(&self) -> &BTreeMap<String, String> {
+    pub fn tags(&self) -> &'a BTreeMap<String, String> {
         &self.inner.tags
     }
 
     /// Returns the value of the specified tag if it exists.
     ///
     /// See also: [`Bucket::tag()`]
-    pub fn tag(&self, name: &str) -> Option<&str> {
+    pub fn tag(&self, name: &str) -> Option<&'a str> {
         self.inner.tag(name)
     }
 

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -19,6 +19,7 @@ dashboard = [
     "relay-log/dashboard",
 ]
 processing = [
+    "dep:bytemuck",
     "dep:minidump",
     "dep:symbolic-common",
     "dep:symbolic-unreal",
@@ -46,7 +47,7 @@ axum-server = "0.4.7"
 backoff = "0.4.0"
 brotli = "3.3.4"
 bytecount = "0.6.0"
-bytemuck = { version = "1.14.3", features = ["min_const_generics"] }
+bytemuck = { version = "1.14.3", features = ["min_const_generics"], optional = true }
 bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.5.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -46,9 +46,10 @@ axum-server = "0.4.7"
 backoff = "0.4.0"
 brotli = "3.3.4"
 bytecount = "0.6.0"
+bytemuck = { version = "1.14.3", features = ["min_const_generics"] }
 bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { workspace = true, features = ["clock"] }
-data-encoding = "2.3.3"
+data-encoding = "2.5.0"
 flate2 = "1.0.19"
 fnv = "1.0.7"
 futures = { workspace = true }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -19,7 +19,6 @@ dashboard = [
     "relay-log/dashboard",
 ]
 processing = [
-    "dep:bytemuck",
     "dep:minidump",
     "dep:symbolic-common",
     "dep:symbolic-unreal",
@@ -47,7 +46,6 @@ axum-server = "0.4.7"
 backoff = "0.4.0"
 brotli = "3.3.4"
 bytecount = "0.6.0"
-bytemuck = { version = "1.14.3", features = ["min_const_generics"], optional = true }
 bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { workspace = true, features = ["clock"] }
 data-encoding = "2.5.0"

--- a/relay-server/src/utils/bucket_encoding.rs
+++ b/relay-server/src/utils/bucket_encoding.rs
@@ -1,9 +1,80 @@
-use std::io::{self, Write};
+use std::io;
 
-use relay_metrics::{FiniteF64, SetView};
+use relay_dynamic_config::{BucketEncoding, GlobalConfig};
+use relay_metrics::{
+    Bucket, BucketValue, FiniteF64, MetricNamespace, MetricResourceIdentifier, SetView,
+};
 use serde::Serialize;
 
 static BASE64: data_encoding::Encoding = data_encoding::BASE64;
+
+pub struct BucketEncoder<'a> {
+    global_config: &'a GlobalConfig,
+}
+
+impl<'a> BucketEncoder<'a> {
+    /// Creates a new bucket encoder with the provided config.
+    pub fn new(global_config: &'a GlobalConfig) -> Self {
+        Self { global_config }
+    }
+
+    /// Prepares the bucket before encoding.
+    ///
+    /// Returns the namespace extracted from the bucket.
+    ///
+    /// Some encodings need the bucket to be sorted or otherwise modified,
+    /// afterwards the bucket can be split into multiple smaller views
+    /// and encoded one by one.
+    pub fn prepare(&self, bucket: &mut Bucket) -> MetricNamespace {
+        let namespace = MetricResourceIdentifier::parse(&bucket.name)
+            .map(|mri| mri.namespace)
+            .unwrap_or(MetricNamespace::Unsupported);
+
+        if let BucketValue::Distribution(ref mut distribution) = bucket.value {
+            let enc = self.global_config.options.metric_bucket_dist_encodings;
+            let enc = enc.for_namespace(namespace);
+
+            if matches!(enc, BucketEncoding::Zstd) {
+                distribution.sort_unstable();
+            }
+        }
+
+        namespace
+    }
+
+    /// Encodes a distribution.
+    pub fn encode_distribution<'data>(
+        &self,
+        namespace: MetricNamespace,
+        dist: &'data [FiniteF64],
+    ) -> io::Result<ArrayEncoding<&'data [FiniteF64]>> {
+        let enc = self.global_config.options.metric_bucket_dist_encodings;
+        let enc = enc.for_namespace(namespace);
+        Self::do_encode(enc, dist)
+    }
+
+    /// Encodes a set.
+    pub fn encode_set<'data>(
+        &self,
+        namespace: MetricNamespace,
+        set: SetView<'data>,
+    ) -> io::Result<ArrayEncoding<SetView<'data>>> {
+        let enc = self.global_config.options.metric_bucket_set_encodings;
+        let enc = enc.for_namespace(namespace);
+        Self::do_encode(enc, set)
+    }
+
+    fn do_encode<T: Encodable>(enc: BucketEncoding, data: T) -> io::Result<ArrayEncoding<T>> {
+        match enc {
+            BucketEncoding::Legacy => Ok(ArrayEncoding::Legacy(data)),
+            BucketEncoding::Array => {
+                Ok(ArrayEncoding::Dynamic(DynamicArrayEncoding::Array { data }))
+            }
+            BucketEncoding::Base64 => base64(data),
+            BucketEncoding::Zstd => zstd(data),
+        }
+    }
+}
 
 /// Dynamic array encoding intended for distribution and set metric buckets.
 #[derive(Clone, Debug, Serialize)]
@@ -20,47 +91,14 @@ pub enum ArrayEncoding<T> {
 }
 
 impl<T> ArrayEncoding<T> {
+    /// Name of the encoding.
+    ///
+    /// Should only be used for debugging purposes.
     pub fn name(&self) -> &'static str {
         match self {
             Self::Legacy(_) => "legacy",
             Self::Dynamic(dynamic) => dynamic.format(),
         }
-    }
-
-    pub fn legacy(data: T) -> Self {
-        Self::Legacy(data)
-    }
-
-    pub fn array(data: T) -> Self {
-        Self::Dynamic(DynamicArrayEncoding::Array { data })
-    }
-
-    pub fn base64(data: SetView<'_>) -> Self {
-        let mut encoded = String::new();
-
-        let mut encoder = BASE64.new_encoder(&mut encoded);
-        for item in data.iter() {
-            encoder.append(&item.to_le_bytes());
-        }
-        encoder.finalize();
-
-        Self::Dynamic(DynamicArrayEncoding::Base64 { data: encoded })
-    }
-
-    pub fn zstd(data: &[FiniteF64]) -> io::Result<Self> {
-        let mut encoded = String::new();
-        let mut writer = zstd::Encoder::new(
-            EncoderWriteAdapter(BASE64.new_encoder(&mut encoded)),
-            zstd::DEFAULT_COMPRESSION_LEVEL,
-        )?;
-
-        for f in data {
-            writer.write_all(&f.to_f64().to_le_bytes())?;
-        }
-
-        writer.finish()?;
-
-        Ok(Self::Dynamic(DynamicArrayEncoding::Zstd { data: encoded }))
     }
 }
 
@@ -97,6 +135,34 @@ impl<T> DynamicArrayEncoding<T> {
     }
 }
 
+fn base64<T: Encodable>(data: T) -> io::Result<ArrayEncoding<T>> {
+    let mut encoded = String::new();
+
+    let mut writer = EncoderWriteAdapter(BASE64.new_encoder(&mut encoded));
+    data.write_to(&mut writer)?;
+    drop(writer);
+
+    Ok(ArrayEncoding::Dynamic(DynamicArrayEncoding::Base64 {
+        data: encoded,
+    }))
+}
+
+fn zstd<T: Encodable>(data: T) -> io::Result<ArrayEncoding<T>> {
+    let mut encoded = String::new();
+    let mut writer = zstd::Encoder::new(
+        EncoderWriteAdapter(BASE64.new_encoder(&mut encoded)),
+        zstd::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+
+    data.write_to(&mut writer)?;
+
+    writer.finish()?;
+
+    Ok(ArrayEncoding::Dynamic(DynamicArrayEncoding::Zstd {
+        data: encoded,
+    }))
+}
+
 struct EncoderWriteAdapter<'a>(pub data_encoding::Encoder<'a>);
 
 impl<'a> io::Write for EncoderWriteAdapter<'a> {
@@ -106,6 +172,30 @@ impl<'a> io::Write for EncoderWriteAdapter<'a> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+trait Encodable {
+    fn write_to(&self, writer: impl io::Write) -> io::Result<()>;
+}
+
+impl Encodable for SetView<'_> {
+    #[inline(always)]
+    fn write_to(&self, mut writer: impl io::Write) -> io::Result<()> {
+        for value in self.iter() {
+            writer.write_all(&value.to_le_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl Encodable for &[FiniteF64] {
+    #[inline(always)]
+    fn write_to(&self, mut writer: impl io::Write) -> io::Result<()> {
+        for value in self.iter() {
+            writer.write_all(&value.to_f64().to_le_bytes())?;
+        }
         Ok(())
     }
 }

--- a/relay-server/src/utils/bucket_encoding.rs
+++ b/relay-server/src/utils/bucket_encoding.rs
@@ -1,0 +1,114 @@
+use std::io;
+
+use relay_metrics::{FiniteF64, SetView};
+use serde::Serialize;
+
+static BASE64: data_encoding::Encoding = data_encoding::BASE64;
+
+/// Dynamic array encoding intended for distribution and set metric buckets.
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum ArrayEncoding<T> {
+    /// The original, legacy, encoding.
+    ///
+    /// Encodes all values as an array of numbers.
+    Legacy(T),
+    /// Dynamic encoding supporting multiple formats.
+    ///
+    /// Adds metadata and adds support for multiple different encodings.
+    Dynamic(DynamicArrayEncoding<T>),
+}
+
+impl<T> ArrayEncoding<T> {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Legacy(_) => "legacy",
+            Self::Dynamic(dynamic) => dynamic.format(),
+        }
+    }
+
+    pub fn legacy(data: T) -> Self {
+        Self::Legacy(data)
+    }
+
+    pub fn array(data: T) -> Self {
+        Self::Dynamic(DynamicArrayEncoding::Array { data })
+    }
+
+    pub fn base64(data: SetView<'_>) -> Self {
+        let mut encoded = String::new();
+
+        let mut encoder = BASE64.new_encoder(&mut encoded);
+        for item in data.iter() {
+            encoder.append(&item.to_le_bytes());
+        }
+        encoder.finalize();
+
+        Self::Dynamic(DynamicArrayEncoding::Base64 { data: encoded })
+    }
+
+    pub fn zstd(data: &[FiniteF64]) -> io::Result<Self> {
+        // Sort data for better compression results.
+        let mut data = data
+            .iter()
+            .map(|f| f.to_f64().to_le_bytes())
+            .collect::<Vec<_>>();
+        data.sort_unstable();
+
+        let mut encoded = String::new();
+
+        zstd::stream::copy_encode(
+            bytemuck::cast_slice(data.as_slice()),
+            EncoderWriteAdapter(BASE64.new_encoder(&mut encoded)),
+            zstd::DEFAULT_COMPRESSION_LEVEL,
+        )?;
+
+        Ok(Self::Dynamic(DynamicArrayEncoding::Zstd { data: encoded }))
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "format", rename_all = "lowercase")]
+pub enum DynamicArrayEncoding<T> {
+    /// Array encoding.
+    ///
+    /// Encodes all items as an array.
+    Array { data: T },
+    /// Base64 encoding.
+    ///
+    /// Converts all items to little endian byte sequences
+    /// and Base64 encodes the raw bytes.
+    Base64 { data: String },
+    /// Zstd encoding.
+    ///
+    /// Converts all items to little endian byte sequences,
+    /// compresses the data using zstd and then encodes the result
+    /// using Base64.
+    ///
+    /// Items may be sorted to achieve better compression results.
+    Zstd { data: String },
+}
+
+impl<T> DynamicArrayEncoding<T> {
+    /// Returns the serialized format name.
+    pub fn format(&self) -> &'static str {
+        match self {
+            DynamicArrayEncoding::Array { .. } => "array",
+            DynamicArrayEncoding::Base64 { .. } => "base64",
+            DynamicArrayEncoding::Zstd { .. } => "zstd",
+        }
+    }
+}
+
+struct EncoderWriteAdapter<'a>(pub data_encoding::Encoder<'a>);
+
+impl<'a> std::io::Write for EncoderWriteAdapter<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.append(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/relay-server/src/utils/bucket_encoding.rs
+++ b/relay-server/src/utils/bucket_encoding.rs
@@ -74,7 +74,7 @@ pub enum DynamicArrayEncoding<T> {
     ///
     /// Encodes all items as an array.
     Array { data: T },
-    /// Base64 encoding.
+    /// Base64 (with padding) encoding.
     ///
     /// Converts all items to little endian byte sequences
     /// and Base64 encodes the raw bytes.
@@ -83,7 +83,7 @@ pub enum DynamicArrayEncoding<T> {
     ///
     /// Converts all items to little endian byte sequences,
     /// compresses the data using zstd and then encodes the result
-    /// using Base64.
+    /// using Base64 (with padding).
     ///
     /// Items may be sorted to achieve better compression results.
     Zstd { data: String },
@@ -102,13 +102,13 @@ impl<T> DynamicArrayEncoding<T> {
 
 struct EncoderWriteAdapter<'a>(pub data_encoding::Encoder<'a>);
 
-impl<'a> std::io::Write for EncoderWriteAdapter<'a> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+impl<'a> io::Write for EncoderWriteAdapter<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.append(buf);
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 }

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod bucket_encoding;
 mod buffer;
 mod dynamic_sampling;
 mod garbage;
@@ -20,6 +21,7 @@ mod native;
 mod unreal;
 
 pub use self::api::*;
+pub use self::bucket_encoding::*;
 pub use self::buffer::*;
 pub use self::dynamic_sampling::*;
 pub use self::garbage::*;

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+#[cfg(feature = "processing")]
 mod bucket_encoding;
 mod buffer;
 mod dynamic_sampling;
@@ -21,6 +22,7 @@ mod native;
 mod unreal;
 
 pub use self::api::*;
+#[cfg(feature = "processing")]
 pub use self::bucket_encoding::*;
 pub use self::buffer::*;
 pub use self::dynamic_sampling::*;

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,13 +9,13 @@ click==8.0.4
 flake8==6.0.0
 confluent-kafka==2.1.1
 flask==2.2.2
-msgpack==1.0.4
+msgpack==1.0.7
 opentelemetry-proto==1.22.0
 pytest-localserver==0.7.0
 pytest-sentry==0.1.11
 pytest-xdist==3.0.2
 pytest==7.1.2
-PyYAML==6.0
+PyYAML==6.0.1
 redis==4.5.4
 requests==2.31.0
 sentry_sdk==1.14.0

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1818,68 +1818,6 @@ def test_block_metrics_and_tags(mini_sentry, relay, denied_names, denied_tag):
         assert False, "add new else-branch if you add another denied tag"
 
 
-@pytest.mark.parametrize("mode", [None, "legacy"])
-def test_metric_bucket_encoding_legacy(
-    mini_sentry, relay_with_processing, metrics_consumer, mode
-):
-    if mode is not None:
-        mini_sentry.global_config["options"]["relay.metric-bucket-encodings"] = {
-            "transactions": mode
-        }
-
-    metrics_consumer = metrics_consumer()
-    relay = relay_with_processing(options=TEST_CONFIG)
-
-    project_id = 42
-    mini_sentry.add_basic_project_config(project_id)
-
-    relay.send_metrics(project_id, "transactions/foo:1337|d\ntransactions/bar:42|s")
-
-    metrics = metrics_by_name(metrics_consumer, 2)
-    assert metrics["d:transactions/foo@none"]["value"] == [1337.0]
-    assert metrics["s:transactions/bar@none"]["value"] == [42.0]
-
-
-@pytest.mark.parametrize(
-    "namespace", [None, "spans", "custom", "transactions", "spans"]
-)
-def test_metric_bucket_encoding_dynamic_global_config_option(
-    mini_sentry, relay_with_processing, metrics_consumer, namespace
-):
-    if namespace is not None:
-        mini_sentry.global_config["options"]["relay.metric-bucket-encodings"] = {
-            namespace: "array"
-        }
-
-    metrics_consumer = metrics_consumer()
-    relay = relay_with_processing(options=TEST_CONFIG)
-
-    project_id = 42
-    project_config = mini_sentry.add_basic_project_config(project_id)
-    project_config["config"]["features"] = [
-        "organizations:custom-metrics",
-        "projects:span-metrics-extraction",
-    ]
-
-    metrics_payload = (
-        f"{namespace or 'custom'}/foo:1337|d\n{namespace or 'custom'}/bar:42|s"
-    )
-    relay.send_metrics(project_id, metrics_payload)
-
-    metrics = metrics_by_name(metrics_consumer, 2)
-
-    dname = f"d:{namespace or 'custom'}/foo@none"
-    sname = f"s:{namespace or 'custom'}/bar@none"
-    assert dname in metrics
-    assert sname in metrics
-    if namespace is not None:
-        assert metrics[dname]["value"] == {"format": "array", "data": [1337.0]}
-        assert metrics[sname]["value"] == {"format": "array", "data": [42.0]}
-    else:
-        assert metrics[dname]["value"] == [1337.0]
-        assert metrics[sname]["value"] == [42.0]
-
-
 @pytest.mark.parametrize("is_processing_relay", (False, True))
 @pytest.mark.parametrize(
     "global_generic_filters",

--- a/tests/integration/test_metrics_encoding.py
+++ b/tests/integration/test_metrics_encoding.py
@@ -1,0 +1,160 @@
+import pytest
+import struct
+import base64
+import zstandard as zstd
+
+
+from .test_metrics import TEST_CONFIG, metrics_by_name
+
+
+def b64_set(*values):
+    return base64.b64encode(
+        b"".join(struct.pack("<I", value) for value in values)
+    ).decode("ascii")
+
+
+def b64_dist(*values):
+    return base64.b64encode(
+        b"".join(struct.pack("<d", value) for value in values)
+    ).decode("ascii")
+
+
+def assert_zstd_set(value, *expected):
+    data = zstd_decompress(value.pop("data"))
+    assert value == {"format": "zstd"}
+
+    values = list(value[0] for value in struct.iter_unpack("<I", data))
+    assert values == list(expected)
+
+
+def assert_zstd_dist(value, *expected):
+    data = zstd_decompress(value.pop("data"))
+    assert value == {"format": "zstd"}
+
+    values = list(value[0] for value in struct.iter_unpack("<d", data))
+    assert values == list(expected)
+
+
+def zstd_decompress(data):
+    with zstd.ZstdDecompressor().stream_reader(base64.b64decode(data)) as decompressor:
+        return decompressor.read()
+
+
+@pytest.mark.parametrize("mode", [None, "legacy"])
+def test_metric_bucket_encoding_legacy(
+    mini_sentry, relay_with_processing, metrics_consumer, mode
+):
+    if mode is not None:
+        mini_sentry.global_config["options"]["relay.metric-bucket-set-encodings"] = mode
+        mini_sentry.global_config["options"][
+            "relay.metric-bucket-distribution-encodings"
+        ] = mode
+
+    metrics_consumer = metrics_consumer()
+    relay = relay_with_processing(options=TEST_CONFIG)
+
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    relay.send_metrics(project_id, "transactions/foo:1337|d\ntransactions/bar:42|s")
+
+    metrics = metrics_by_name(metrics_consumer, 2)
+    assert metrics["d:transactions/foo@none"]["value"] == [1337.0]
+    assert metrics["s:transactions/bar@none"]["value"] == [42.0]
+
+
+@pytest.mark.parametrize("namespace", [None, "spans", "custom"])
+@pytest.mark.parametrize("ty", ["set", "distribution"])
+def test_metric_bucket_encoding_dynamic_global_config_option(
+    mini_sentry, relay_with_processing, metrics_consumer, namespace, ty
+):
+    if namespace is not None:
+        mini_sentry.global_config["options"][f"relay.metric-bucket-{ty}-encodings"] = {
+            namespace: "array"
+        }
+
+    metrics_consumer = metrics_consumer()
+    relay = relay_with_processing(options=TEST_CONFIG)
+
+    project_id = 42
+    project_config = mini_sentry.add_basic_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:custom-metrics",
+        "projects:span-metrics-extraction",
+    ]
+
+    metrics_payload = (
+        f"{namespace or 'custom'}/foo:1337|d\n{namespace or 'custom'}/bar:42|s"
+    )
+    relay.send_metrics(project_id, metrics_payload)
+
+    metrics = metrics_by_name(metrics_consumer, 2)
+
+    dname = f"d:{namespace or 'custom'}/foo@none"
+    sname = f"s:{namespace or 'custom'}/bar@none"
+    assert dname in metrics
+    assert sname in metrics
+
+    if namespace is not None and ty == "distribution":
+        assert metrics[dname]["value"] == {"format": "array", "data": [1337.0]}
+    else:
+        assert metrics[dname]["value"] == [1337.0]
+
+    if namespace is not None and ty == "set":
+        assert metrics[sname]["value"] == {"format": "array", "data": [42.0]}
+    else:
+        assert metrics[sname]["value"] == [42.0]
+
+
+def test_metric_bucket_encoding_base64(
+    mini_sentry, relay_with_processing, metrics_consumer
+):
+    mini_sentry.global_config["options"].update(
+        {
+            "relay.metric-bucket-set-encodings": "base64",
+            "relay.metric-bucket-distribution-encodings": "base64",
+        }
+    )
+
+    metrics_consumer = metrics_consumer()
+    relay = relay_with_processing(options=TEST_CONFIG)
+
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    relay.send_metrics(project_id, "transactions/foo:3:1:2|d\ntransactions/bar:7:1|s")
+
+    metrics = metrics_by_name(metrics_consumer, 2)
+    assert metrics["d:transactions/foo@none"]["value"] == {
+        "format": "base64",
+        "data": b64_dist(3, 1, 2),  # values are in order
+    }
+    assert metrics["s:transactions/bar@none"]["value"] == {
+        "format": "base64",
+        "data": b64_set(1, 7),
+    }
+
+
+def test_metric_bucket_encoding_zstd(
+    mini_sentry, relay_with_processing, metrics_consumer
+):
+    mini_sentry.global_config["options"].update(
+        {
+            "relay.metric-bucket-set-encodings": "zstd",
+            "relay.metric-bucket-distribution-encodings": "zstd",
+        }
+    )
+
+    metrics_consumer = metrics_consumer()
+    relay = relay_with_processing(options=TEST_CONFIG)
+
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    relay.send_metrics(project_id, "transactions/foo:3:1:2|d\ntransactions/bar:7:1|s")
+
+    metrics = metrics_by_name(metrics_consumer, 2)
+    assert_zstd_dist(
+        metrics["d:transactions/foo@none"]["value"], 1, 2, 3
+    )  # values are sorted
+    assert_zstd_set(metrics["s:transactions/bar@none"]["value"], 1, 7)


### PR DESCRIPTION
- Implements Base64 and zstd metric bucket encodings.
- Moves all bucket encoding related logic into its own file.
- Splits the config options into two separate options to control sets from distributions separately.
- Makes it impossible for sessions to configure a bucket encoding other than `legacy`.

In a followup PR the encoding/compression of values should be moved into the processor.