### PR TITLE
fix(health): Switch to sysinfo fork for correct cgroup v2 mem limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5392,9 +5392,8 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
+version = "0.30.6"
+source = "git+https://github.com/getsentry/sysinfo.git?rev=2fe6093#2fe60934273f56f6d8995486dd162309784dde4b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -111,7 +111,7 @@ symbolic-common = { version = "12.1.2", optional = true, default-features = fals
 symbolic-unreal = { version = "12.1.2", optional = true, default-features = false, features = [
     "serde",
 ] }
-sysinfo = "0.30"
+sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "2fe6093" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower = { version = "0.4.13", default-features = false }


### PR DESCRIPTION
The memory health check is broken for cgroup v2, see https://github.com/GuillaumeGomez/sysinfo/issues/1219

Switches to a fork until the upstream issue is fixed.

#skip-changelog