### PR TITLE
feat(replays): Log event-id on replay-event (de)serialization failure

### DIFF
--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -69,6 +69,7 @@ pub fn process(
             ItemType::ReplayEvent => {
                 match handle_replay_event_item(
                     item.payload(),
+                    &event_id,
                     project_config,
                     client_addr,
                     user_agent,
@@ -120,6 +121,7 @@ pub fn process(
 
 fn handle_replay_event_item(
     payload: Bytes,
+    event_id: &Option<EventId>,
     config: &ProjectConfig,
     client_ip: Option<IpAddr>,
     user_agent: &RawUserAgentInfo<&str>,
@@ -128,12 +130,18 @@ fn handle_replay_event_item(
         Ok(replay) => match replay.to_json() {
             Ok(json) => Ok(json.into_bytes().into()),
             Err(error) => {
-                relay_log::error!(error = &error as &dyn Error, "failed to serialize replay");
+                relay_log::error!(
+                    error = &error as &dyn Error,
+                    "failed to serialize replay: {event_id:?}"
+                );
                 Ok(payload)
             }
         },
         Err(error) => {
-            relay_log::warn!(error = &error as &dyn Error, "invalid replay event");
+            relay_log::warn!(
+                error = &error as &dyn Error,
+                "invalid replay event: {event_id:?}"
+            );
             Err(Outcome::Invalid(match error {
                 ReplayError::NoContent => DiscardReason::InvalidReplayEventNoPayload,
                 ReplayError::CouldNotScrub(_) => DiscardReason::InvalidReplayEventPii,
@@ -242,7 +250,8 @@ fn handle_replay_video_item(
     };
 
     // Process as a replay-event envelope item.
-    let replay_event = handle_replay_event_item(replay_event, config, client_ip, user_agent)?;
+    let replay_event =
+        handle_replay_event_item(replay_event, event_id, config, client_ip, user_agent)?;
 
     // Process as a replay-recording envelope item.
     let replay_recording =

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -132,7 +132,8 @@ fn handle_replay_event_item(
             Err(error) => {
                 relay_log::error!(
                     error = &error as &dyn Error,
-                    "failed to serialize replay: {event_id:?}"
+                    ?event_id,
+                    "failed to serialize replay"
                 );
                 Ok(payload)
             }
@@ -140,7 +141,8 @@ fn handle_replay_event_item(
         Err(error) => {
             relay_log::warn!(
                 error = &error as &dyn Error,
-                "invalid replay event: {event_id:?}"
+                ?event_id,
+                "invalid replay event"
             );
             Err(Outcome::Invalid(match error {
                 ReplayError::NoContent => DiscardReason::InvalidReplayEventNoPayload,


### PR DESCRIPTION
Closes: https://github.com/getsentry/relay/issues/3219

#skip-changelog