### PR TITLE
feat(spans): Discard transaction metrics with discard-transaction

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1128,10 +1128,11 @@ impl EnvelopeProcessorService {
                 state.extracted_metrics.project_metrics.extend(metrics);
             }
 
-            match state.project_state.config.transaction_metrics {
-                Some(ErrorBoundary::Ok(ref tx_config))
-                    if tx_config.is_enabled()
-                        && !state.project_state.has_feature(Feature::DiscardTransaction) =>
+            if let Some(ErrorBoundary::Ok(ref tx_config)) =
+                state.project_state.config.transaction_metrics
+            {
+                if tx_config.is_enabled()
+                    && !state.project_state.has_feature(Feature::DiscardTransaction)
                 {
                     let transaction_from_dsc = state
                         .managed_envelope
@@ -1150,7 +1151,6 @@ impl EnvelopeProcessorService {
                     state.extracted_metrics.extend(extractor.extract(event)?);
                     state.event_metrics_extracted |= true;
                 }
-                _ => (),
             }
 
             if state.event_metrics_extracted {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1129,7 +1129,10 @@ impl EnvelopeProcessorService {
             }
 
             match state.project_state.config.transaction_metrics {
-                Some(ErrorBoundary::Ok(ref tx_config)) if tx_config.is_enabled() => {
+                Some(ErrorBoundary::Ok(ref tx_config))
+                    if tx_config.is_enabled()
+                        && !state.project_state.has_feature(Feature::DiscardTransaction) =>
+                {
                     let transaction_from_dsc = state
                         .managed_envelope
                         .envelope()

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -327,7 +327,7 @@ impl StoreService {
         }
 
         let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
-        relay_log::error!(event_id = ?event_id, "foo");
+
         let kafka_messages = Self::extract_kafka_messages_for_event(
             event_item,
             event_id.ok_or(StoreError::NoEventId)?,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -327,7 +327,7 @@ impl StoreService {
         }
 
         let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
-
+        relay_log::error!(event_id = ?event_id, "foo");
         let kafka_messages = Self::extract_kafka_messages_for_event(
             event_item,
             event_id.ok_or(StoreError::NoEventId)?,


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/3213: With the `discard-transaction` feature flag, do not extract transaction metrics.

#skip-changelog