### PR TITLE
ref(health): Report memory stats via metrics

### DIFF
--- a/relay-server/src/services/health_check.rs
+++ b/relay-server/src/services/health_check.rs
@@ -124,6 +124,9 @@ impl HealthCheckService {
                 .memory()
         };
 
+        metric!(gauge(RelayGauges::SystemMemoryUsed) = memory.used);
+        metric!(gauge(RelayGauges::SystemMemoryTotal) = memory.total);
+
         if memory.used_percent() >= self.config.health_max_memory_watermark_percent() {
             relay_log::error!(
                 "Not enough memory, {} / {} ({:.2}% >= {:.2}%)",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -20,6 +20,14 @@ pub enum RelayGauges {
     ///
     /// The disk buffer size can be configured with `spool.envelopes.max_disk_size`.
     BufferEnvelopesDiskCount,
+    /// The currently used memory by the entire system.
+    ///
+    /// Relay uses the same value for its memory health check.
+    SystemMemoryUsed,
+    /// The total system memory.
+    ///
+    /// Relay uses the same value for its memory health check.
+    SystemMemoryTotal,
 }
 
 impl GaugeMetric for RelayGauges {
@@ -29,6 +37,8 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::ProjectCacheGarbageQueueSize => "project_cache.garbage.queue_size",
             RelayGauges::BufferEnvelopesMemoryCount => "buffer.envelopes_mem_count",
             RelayGauges::BufferEnvelopesDiskCount => "buffer.envelopes_disk_count",
+            RelayGauges::SystemMemoryUsed => "health.system_memory.used",
+            RelayGauges::SystemMemoryTotal => "health.system_memory.total",
         }
     }
 }


### PR DESCRIPTION
As discussed in #3217, at least temporarily for debugging purposes to see if our measurements are correct.

cc @beezz @gi0baro 

#skip-changelog