### PR TITLE
feat(profiling): add namespace for profile metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add SDK information to spans. ([#3178](https://github.com/getsentry/relay/pull/3178))
 - Filter null values from metrics summary tags. ([#3204](https://github.com/getsentry/relay/pull/3204))
 - Emit a usage metric for every span seen. ([#3209](https://github.com/getsentry/relay/pull/3209))
+- Add namespace for profile metrics. ([#3229](https://github.com/getsentry/relay/pull/3229))
 
 ## 24.2.0
 

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -112,6 +112,8 @@ pub enum MetricNamespace {
     Transactions,
     /// Metrics extracted from spans.
     Spans,
+    /// Metrics extracted from profile functions.
+    Profiles,
     /// User-defined metrics directly sent by SDKs and applications.
     Custom,
     /// An unknown and unsupported metric.
@@ -133,6 +135,7 @@ impl MetricNamespace {
             MetricNamespace::Sessions => "sessions",
             MetricNamespace::Transactions => "transactions",
             MetricNamespace::Spans => "spans",
+            MetricNamespace::Profiles => "profiles",
             MetricNamespace::Custom => "custom",
             MetricNamespace::Unsupported => "unsupported",
         }
@@ -147,6 +150,7 @@ impl std::str::FromStr for MetricNamespace {
             "sessions" => Ok(Self::Sessions),
             "transactions" => Ok(Self::Transactions),
             "spans" => Ok(Self::Spans),
+            "profiles" => Ok(Self::Profiles),
             "custom" => Ok(Self::Custom),
             _ => Ok(Self::Unsupported),
         }

--- a/relay-cogs/src/lib.rs
+++ b/relay-cogs/src/lib.rs
@@ -135,6 +135,8 @@ pub enum AppFeature {
     MetricsTransactions,
     /// Metrics in the spans namespace.
     MetricsSpans,
+    /// Metrics in the profiles namespace.
+    MetricsProfiles,
     /// Metrics in the sessions namespace.
     MetricsSessions,
     /// Metrics in the custom namespace.
@@ -163,6 +165,7 @@ impl AppFeature {
             Self::MetricMeta => "metric_meta",
             Self::MetricsTransactions => "metrics_transactions",
             Self::MetricsSpans => "metrics_spans",
+            Self::MetricsProfiles => "metrics_profiles",
             Self::MetricsSessions => "metrics_sessions",
             Self::MetricsCustom => "metrics_custom",
             Self::MetricsUnsupported => "metrics_unsupported",

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -94,13 +94,22 @@ pub struct Options {
     )]
     pub profile_metrics_sample_rate: f32,
 
-    /// Kill switch for shutting down profile metrics
+    /// Kill switch for shutting down unsampled_profile metrics
     #[serde(
         rename = "profiling.profile_metrics.unsampled_profiles.enabled",
         deserialize_with = "default_on_error",
         skip_serializing_if = "is_default"
     )]
     pub unsampled_profiles_enabled: bool,
+
+    /// Kill switch for shutting down profile function metrics
+    /// ingestion in the generic-metrics platform
+    #[serde(
+        rename = "profiling.generic_metrics.functions_ingestion.enabled",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub profiles_function_generic_metrics_enabled: bool,
 
     /// Kill switch for controlling the cardinality limiter.
     #[serde(

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -169,6 +169,7 @@ pub struct MetricBucketEncodings {
     sessions: MetricEncoding,
     transactions: MetricEncoding,
     spans: MetricEncoding,
+    profiles: MetricEncoding,
     custom: MetricEncoding,
     unsupported: MetricEncoding,
 }
@@ -180,6 +181,7 @@ impl MetricBucketEncodings {
             MetricNamespace::Sessions => self.sessions,
             MetricNamespace::Transactions => self.transactions,
             MetricNamespace::Spans => self.spans,
+            MetricNamespace::Profiles => self.profiles,
             MetricNamespace::Custom => self.custom,
             MetricNamespace::Unsupported => self.unsupported,
         }

--- a/relay-metrics/src/cogs.rs
+++ b/relay-metrics/src/cogs.rs
@@ -38,6 +38,7 @@ fn to_app_feature(ns: MetricNamespace) -> AppFeature {
         MetricNamespace::Sessions => AppFeature::MetricsSessions,
         MetricNamespace::Transactions => AppFeature::MetricsTransactions,
         MetricNamespace::Spans => AppFeature::MetricsSpans,
+        MetricNamespace::Profiles => AppFeature::MetricsProfiles,
         MetricNamespace::Custom => AppFeature::MetricsCustom,
         MetricNamespace::Unsupported => AppFeature::MetricsUnsupported,
     }

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1246,6 +1246,7 @@ fn is_metric_namespace_valid(state: &ProjectState, namespace: &MetricNamespace) 
             state.has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent)
                 || state.has_feature(Feature::StandaloneSpanIngestion)
         }
+        MetricNamespace::Profiles => true,
         MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
         MetricNamespace::Unsupported => false,
     }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -769,12 +769,6 @@ impl StoreService {
                     .options
                     .profiles_function_generic_metrics_enabled
                 {
-                    relay_log::with_scope(
-                        |scope| scope.set_extra("metric_message.name", message.name.into()),
-                        || {
-                            relay_log::error!("store service dropping profiles metric usecase: currently disabled")
-                        },
-                    );
                     return Ok(());
                 }
                 KafkaTopic::MetricsGeneric

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -762,6 +762,23 @@ impl StoreService {
                 );
                 return Ok(());
             }
+            MetricNamespace::Profiles => {
+                if !self
+                    .global_config
+                    .current()
+                    .options
+                    .profiles_function_generic_metrics_enabled
+                {
+                    relay_log::with_scope(
+                        |scope| scope.set_extra("metric_message.name", message.name.into()),
+                        || {
+                            relay_log::error!("store service dropping profiles metric usecase: currently disabled")
+                        },
+                    );
+                    return Ok(());
+                }
+                KafkaTopic::MetricsGeneric
+            }
             _ => KafkaTopic::MetricsGeneric,
         };
         let headers = BTreeMap::from([("namespace".to_string(), namespace.to_string())]);

--- a/relay-server/src/utils/metric_stats.rs
+++ b/relay-server/src/utils/metric_stats.rs
@@ -12,6 +12,7 @@ pub struct MetricStats {
     custom: Stat,
     sessions: Stat,
     spans: Stat,
+    profiles: Stat,
     transactions: Stat,
     unsupported: Stat,
 }
@@ -60,6 +61,7 @@ impl MetricStats {
             MetricNamespace::Sessions => &mut self.sessions,
             MetricNamespace::Transactions => &mut self.transactions,
             MetricNamespace::Spans => &mut self.spans,
+            MetricNamespace::Profiles => &mut self.profiles,
             MetricNamespace::Custom => &mut self.custom,
             MetricNamespace::Unsupported => &mut self.unsupported,
         }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -2062,7 +2062,7 @@ def test_profiles_metrics(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
 
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"profiles/foo:42|c|T{timestamp}\profiles/bar:17|c|T{timestamp}"
+    metrics_payload = f"profiles/foo:42|c|T{timestamp}\nprofiles/bar:17|c|T{timestamp}"
 
     relay.send_metrics(project_id, metrics_payload)
 


### PR DESCRIPTION
Sentry PR that added the `profles` use case: https://github.com/getsentry/sentry/pull/65152/files