### PR TITLE
feat(inbound filters): Add cyptocurrency "cannot redefine property" to browser extension filter

### DIFF
--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -43,7 +43,9 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         webkit-masked-url:|
         # Firefox message when an extension tries to modify a no-longer-existing DOM node
         # See https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/
-        can't\saccess\sdead\sobject
+        can't\saccess\sdead\sobject|
+        # Crypocurrency related extension errors
+        Cannot\sredefine\sproperty:\s(solana|ethereum)
     "#,
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex")
@@ -260,6 +262,8 @@ mod tests {
             "Extension context invalidated",
             "useless error webkit-masked-url: please filter",
             "TypeError: can't access dead object because dead stuff smells bad",
+            "Cannot redefine property: solana",
+            "Cannot redefine property: ethereum",
         ];
 
         for exc_value in &exceptions {


### PR DESCRIPTION
These cryptocurrencies commonly have wallets that inject javascript into the page making noise. See the potential number of projects affected in redash https://redash.getsentry.net/queries/6220/source

or an issue within our own projects https://sentry.sentry.io/issues/4724125675/

#skip-changelog