### PR TITLE
feat(server): Kafka SSL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Parse & scrub span description for supabase. ([#3153](https://github.com/getsentry/relay/pull/3153), [#3156](https://github.com/getsentry/relay/pull/3156))
 - Introduce generic filters in global configs. ([#3161](https://github.com/getsentry/relay/pull/3161))
 - Individual cardinality limits can now be set into passive mode and not be enforced. ([#3199](https://github.com/getsentry/relay/pull/3199))
+- Allow enabling SSL for Kafka. ([#3232](https://github.com/getsentry/relay/pull/3232))
 
 **Bug Fixes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,14 +3479,15 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+1.9.2"
+version = "4.7.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d222a401698c7f2010e3967353eae566d9934dcda49c29910da922414ab4e3f4"
+checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
 dependencies = [
  "cmake",
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../LICENSE.md"
 publish = false
 
 [dependencies]
-rdkafka = { version = "0.29.0", optional = true, features = ["tracing"] }
+rdkafka = { version = "0.29.0", optional = true, features = ["tracing", "ssl"] }
 rdkafka-sys = { version = "4.3.0", optional = true }
 relay-log = { path = "../relay-log", optional = true }
 relay-statsd = { path = "../relay-statsd", optional = true }

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -2297,3 +2297,9 @@ def test_span_ingestion_with_performance_scores(
             },
         },
     ]
+
+
+def test_kafka_ssl(relay_with_processing):
+    relay_with_processing(
+        options={"kafka_config": [{"name": "ssl.key.password", "value": "foo"}]}
+    )


### PR DESCRIPTION
Previous attempts of compiling SSL support for Kafka failed on macOS (see [comment](https://github.com/getsentry/relay/issues/1361#issuecomment-1199120293)). Now it seems to work.