### PR TITLE
ref(axum): Enables http compression for responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Parse & scrub span description for supabase. ([#3153](https://github.com/getsentry/relay/pull/3153), [#3156](https://github.com/getsentry/relay/pull/3156))
 - Introduce generic filters in global configs. ([#3161](https://github.com/getsentry/relay/pull/3161))
 - Individual cardinality limits can now be set into passive mode and not be enforced. ([#3199](https://github.com/getsentry/relay/pull/3199))
+- Enable HTTP compression for all APIs. ([#3233](https://github.com/getsentry/relay/pull/3233))
+
 
 **Bug Fixes**:
 

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -117,6 +117,9 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower = { version = "0.4.13", default-features = false }
 tower-http = { version = "0.4.0", default-features = false, features = [
     "catch-panic",
+    "compression-br",
+    "compression-deflate",
+    "compression-gzip",
     "cors",
     "decompression-br",
     "decompression-deflate",

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -9,6 +9,7 @@ use relay_config::Config;
 use relay_log::tower::{NewSentryLayer, SentryHttpLayer};
 use relay_system::{Controller, Service, Shutdown};
 use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
 
 use crate::constants;
@@ -84,7 +85,8 @@ impl Service for HttpServer {
             .layer(middlewares::trace_http_layer())
             .layer(HandleErrorLayer::new(middlewares::decompression_error))
             .map_request(middlewares::remove_empty_encoding)
-            .layer(RequestDecompressionLayer::new());
+            .layer(RequestDecompressionLayer::new())
+            .layer(CompressionLayer::new());
 
         let router = crate::endpoints::routes(service.config())
             .layer(middleware)


### PR DESCRIPTION
Project configs are big and apparently not compressed.

Manually verified this by adding a new endpoint that returns a few kib of data and running curl against it: `curl -H "Accept-Encoding: gzip, deflate, br" -i http://127.0.0.1:3001/test/`