### PR TITLE
fix(sysinfo): Sysinfo fixed cgroups, remove fork from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5392,15 +5392,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.6"
-source = "git+https://github.com/getsentry/sysinfo.git?rev=2fe6093#2fe60934273f56f6d8995486dd162309784dde4b"
+version = "0.30.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "windows",
 ]
 

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -111,7 +111,7 @@ symbolic-common = { version = "12.1.2", optional = true, default-features = fals
 symbolic-unreal = { version = "12.1.2", optional = true, default-features = false, features = [
     "serde",
 ] }
-sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "2fe6093" }
+sysinfo = { version = "0.30.7", default-features = false }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower = { version = "0.4.13", default-features = false }


### PR DESCRIPTION
We no longer need the fork, they released a new version with our fix applied.

Also disabled default features, by default it enables the multithreaded feature, which uses rayon. We don't want/need/use that, since we only query memory stats.

#skip-changelog