### PR TITLE
chore(spool): Remove redundant checks

### DIFF
--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -633,11 +633,8 @@ impl ProjectCacheBroker {
             no_cache,
         );
 
-        // Schedule unspool if nothing is running at the moment.
-        if !self.buffer_unspool_backoff.started() {
-            self.buffer_unspool_backoff.reset();
-            self.schedule_unspool();
-        }
+        // Try to schedule unspool if it's not scheduled yet.
+        self.schedule_unspool();
     }
 
     fn handle_request_update(&mut self, message: RequestUpdate) {
@@ -935,8 +932,7 @@ impl ProjectCacheBroker {
             return;
         }
         // If there is nothing spooled, schedule the next check a little bit later.
-        // And do *not* attempt to unspool if the assigned permits over low watermark.
-        if self.index.is_empty() || !self.buffer_guard.is_below_low_watermark() {
+        if self.index.is_empty() {
             self.schedule_unspool();
             return;
         }


### PR DESCRIPTION
Removes the checks which are unnecessary and potentially can be harmful:

* on the merge of the new state just try to schedule new unspool and `schedule_unspool()` will check it it's need to be scheduled or it already is
* on periodic unspool do not check `!self.buffer_guard.is_below_low_watermark()` since when in on-disk spool mode, the check will be done by buffer itself and if in memory mode, we can stuck with envelopes in the memory buffer and never actually unspool those - since we anyways hold the permit, we also can just unspool and send the envelope into processor.
 
#skip-changelog