### PR TITLE
fix(spans): Scrub separated UUID in table name

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -943,6 +943,12 @@ mod tests {
     );
 
     scrub_sql_test!(
+        uuid_in_table_name_with_underscores,
+        "SELECT * FROM prefix_0a234567_89ab_cdef_0123_456789ABCDEF",
+        "SELECT * FROM prefix_{%s}"
+    );
+
+    scrub_sql_test!(
         long_hex_in_table_name,
         "SELECT id FROM a11a0a11b11a11a9 LIMIT 100 OFFSET 300",
         "SELECT id FROM {%s} LIMIT %s OFFSET %s"

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -21,7 +21,16 @@ use sqlparser::dialect::{Dialect, GenericDialect};
 const MAX_EXPRESSION_DEPTH: usize = 64;
 
 /// Regex used to scrub hex IDs and multi-digit numbers from table names and other identifiers.
-static TABLE_NAME_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)[0-9a-f]{8,}|\d\d+").unwrap());
+static TABLE_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?ix)
+        [0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12} |
+        [0-9a-f]{8,} |
+        \d\d+
+        ",
+    )
+    .unwrap()
+});
 
 /// Derive the SQL dialect from `db_system` (the value obtained from `span.data.system`)
 /// and try to parse the query into an AST.


### PR DESCRIPTION
Hex-like strings greater than 7 characters were already scrubbed from SQL table names. This PR adds UUIDs with components separated by `_`.

#skip-changelog