### PR TITLE
feat(inbound filters): Add iOS chrome translation filter

### DIFF
--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -45,20 +45,12 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         # See https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/
         can't\saccess\sdead\sobject|
         # Crypocurrency related extension errors
-        Cannot\sredefine\sproperty:\s(solana|ethereum)
-    "#,
-    )
-    .expect("Invalid browser extensions filter (Exec Vals) Regex")
-});
-
-static IOS_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?ix)
-        # Translation errors in Chrome on iOS
+        Cannot\sredefine\sproperty:\s(solana|ethereum)|
+        # Translation service errors in Chrome on iOS
         undefined\sis\snot\san\sobject\s\(evaluating\s'a.L'\)
     "#,
     )
-    .expect("Invalid browser extensions filter (iOS Vals) Regex")
+    .expect("Invalid browser extensions filter (Exec Vals) Regex")
 });
 
 static EXTENSION_EXC_SOURCES: Lazy<Regex> = Lazy::new(|| {
@@ -92,13 +84,6 @@ pub fn matches(event: &Event) -> bool {
     if let Some(ex_val) = get_exception_value(event) {
         if EXTENSION_EXC_VALUES.is_match(ex_val) {
             return true;
-        }
-        // Filtering for iOS based chrome trasnlation errors
-        if let Some(os_name) = event.tag_value("os.name") {
-            // Using iOS instead of device.name because it can be iPad or iPhone
-            if os_name == "iOS" && IOS_EXC_VALUES.is_match(ex_val) {
-                return true;
-            }
         }
     }
     if let Some(ex_source) = get_exception_source(event) {
@@ -150,7 +135,7 @@ fn get_exception_source(event: &Event) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use relay_event_schema::protocol::{
-        Frame, JsonLenientString, PairList, RawStacktrace, Stacktrace, TagEntry, Tags, Values,
+        Frame, JsonLenientString, RawStacktrace, Stacktrace, Values,
     };
     use relay_protocol::Annotated;
 
@@ -204,20 +189,6 @@ mod tests {
         };
 
         get_event_with_exception(ex)
-    }
-
-    fn get_event_with_exception_value_and_os_name(val: &str, os_name: &str) -> Event {
-        let event = get_event_with_exception_value(val);
-
-        let tags = vec![Annotated::new(TagEntry(
-            Annotated::new("os.name".to_string()),
-            Annotated::new(os_name.to_string()),
-        ))];
-
-        Event {
-            tags: Annotated::new(Tags(PairList::from(tags))),
-            ..event
-        }
     }
 
     #[test]
@@ -295,6 +266,7 @@ mod tests {
             "TypeError: can't access dead object because dead stuff smells bad",
             "Cannot redefine property: solana",
             "Cannot redefine property: ethereum",
+            "undefined is not an object (evaluating 'a.L')",
         ];
 
         for exc_value in &exceptions {
@@ -321,21 +293,6 @@ mod tests {
                 filter_result,
                 Ok(()),
                 "Event filter although the source or value are ok "
-            )
-        }
-    }
-
-    #[test]
-    fn test_filter_ios_specific_extensions() {
-        let exceptions = ["undefined is not an object (evaluating 'a.L')"];
-
-        for exc_value in &exceptions {
-            let event = get_event_with_exception_value_and_os_name(exc_value, "iOS");
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
-            assert_ne!(
-                filter_result,
-                Ok(()),
-                "iOS Event filter not recognizing events with known value '{exc_value}'"
             )
         }
     }


### PR DESCRIPTION
Filters out `TypeError: undefined is not an object (evaluating 'a.L')` errors that come from Chrome on iOS.

See this notion doc for more details https://www.notion.so/sentry/TypeError-undefined-is-not-an-object-evaluating-a-L-b7a96303a7aa4d2fbbfc18e0ddb1468b TLDR:
- Poorly grouped google translation related errors
- Very large number of these errors especially in projects that are static sites with mobile users using translation services
- The errors are not actionable

here's an example in our own projects https://sentry.sentry.io/issues/5053303600/

#skip-changelog