### PR TITLE
fix(cogs): Emit micros instead of millis

### DIFF
--- a/relay-server/src/services/cogs.rs
+++ b/relay-server/src/services/cogs.rs
@@ -78,7 +78,7 @@ impl CogsService {
 
         let (amount, unit) = match measurement.value {
             relay_cogs::Value::Time(duration) => (
-                duration.as_millis().try_into().unwrap_or(u64::MAX),
+                duration.as_micros().try_into().unwrap_or(u64::MAX),
                 UsageUnit::Milliseconds,
             ),
         };

--- a/tests/integration/test_cogs.py
+++ b/tests/integration/test_cogs.py
@@ -24,5 +24,5 @@ def test_cogs_simple(mini_sentry, relay_with_processing, cogs_consumer):
     assert m["app_feature"] == "errors"
     assert m["usage_unit"] == "milliseconds"
     assert (
-        m["amount"] < 1000
+        m["amount"] < 1000 * 1000
     )  # If processing this error takes a second, we have a problem ...


### PR DESCRIPTION
Fixes: https://github.com/getsentry/relay/issues/3253

#skip-changelog