### PR TITLE
ref(compression): Disable compression for small responses

### DIFF
--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -46,7 +46,7 @@ const KEEPALIVE_RETRIES: u32 = 5;
 /// header within this time, the connection is closed.
 const CLIENT_HEADER_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Only compress responses above this configured size.
+/// Only compress responses above this configured size, in bytes.
 ///
 /// Small responses don't benefit from compression,
 /// additionally the envelope endpoint which returns the event id

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -9,7 +9,8 @@ use relay_config::Config;
 use relay_log::tower::{NewSentryLayer, SentryHttpLayer};
 use relay_system::{Controller, Service, Shutdown};
 use tower::ServiceBuilder;
-use tower_http::compression::CompressionLayer;
+use tower_http::compression::predicate::SizeAbove;
+use tower_http::compression::{CompressionLayer, DefaultPredicate, Predicate};
 use tower_http::set_header::SetResponseHeaderLayer;
 
 use crate::constants;
@@ -45,6 +46,13 @@ const KEEPALIVE_RETRIES: u32 = 5;
 /// header within this time, the connection is closed.
 const CLIENT_HEADER_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Only compress responses above this configured size.
+///
+/// Small responses don't benefit from compression,
+/// additionally the envelope endpoint which returns the event id
+/// should not be compressed due to a bug in the Unity SDK.
+const COMPRESSION_MIN_SIZE: u16 = 128;
+
 impl HttpServer {
     pub fn new(config: Arc<Config>, service: ServiceState) -> Result<Self, ServerError> {
         // Inform the user about a removed feature.
@@ -64,6 +72,9 @@ impl Service for HttpServer {
 
     fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) {
         let Self { config, service } = self;
+
+        let compression_predicate =
+            SizeAbove::new(COMPRESSION_MIN_SIZE).and(DefaultPredicate::new());
 
         // Build the router middleware into a single service which runs _after_ routing. Service
         // builder order defines layers added first will be called first. This means:
@@ -86,7 +97,7 @@ impl Service for HttpServer {
             .layer(HandleErrorLayer::new(middlewares::decompression_error))
             .map_request(middlewares::remove_empty_encoding)
             .layer(RequestDecompressionLayer::new())
-            .layer(CompressionLayer::new());
+            .layer(CompressionLayer::new().compress_when(compression_predicate));
 
         let router = crate::endpoints::routes(service.config())
             .layer(middleware)

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -249,6 +249,7 @@ class SentryLike:
         }
         response = self.post(url, headers=headers, data=envelope.serialize())
         response.raise_for_status()
+        return response
 
     def send_session(self, project_id, payload, item_headers=None):
         envelope = Envelope()

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -11,10 +11,12 @@ def test_envelope(mini_sentry, relay_chain):
 
     envelope = Envelope()
     envelope.add_event({"message": "Hello, World!"})
-    relay.send_envelope(project_id, envelope)
+    response = relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
 
     event = mini_sentry.captured_events.get(timeout=1).get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
+    # The response should not be compressed
+    assert "content-encoding" not in response.headers
 
 
 def test_envelope_close_connection(mini_sentry, relay):

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -11,7 +11,9 @@ def test_envelope(mini_sentry, relay_chain):
 
     envelope = Envelope()
     envelope.add_event({"message": "Hello, World!"})
-    response = relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
+    response = relay.send_envelope(
+        project_id, envelope, headers={"Accept-Encoding": "gzip"}
+    )
 
     event = mini_sentry.captured_events.get(timeout=1).get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}


### PR DESCRIPTION
Unity SDKs have problems with the compression (bug) for envelope responses, we can disable the compression for small payloads which will cover the problem.

SDK fix: https://github.com/getsentry/sentry-unity/pull/1587

#skip-changelog