### PR TITLE
feat(starfish): enable metrics extraction for redis spans

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -9,13 +9,7 @@ use crate::project::ProjectConfig;
 use crate::Tag;
 
 /// A list of `span.op` patterns that indicate databases that should be skipped.
-const DISABLED_DATABASES: &[&str] = &[
-    "*clickhouse*",
-    "*compile*",
-    "*mongodb*",
-    "*redis*",
-    "db.orm",
-];
+const DISABLED_DATABASES: &[&str] = &["*clickhouse*", "*compile*", "*mongodb*", "db.orm"];
 
 /// A list of `span.op` patterns we want to enable for mobile.
 const MOBILE_OPS: &[&str] = &[


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/66875

Enables metrics for redis spans that will be used within the cache module. We will be adding any necessary tags in the future PRs once any SDK changes are in place.
