### PR TITLE
feat(metric-stats): Add metric stats namespace

### DIFF
--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -116,6 +116,10 @@ pub enum MetricNamespace {
     Profiles,
     /// User-defined metrics directly sent by SDKs and applications.
     Custom,
+    /// Metric stats.
+    ///
+    /// Metrics about metrics.
+    MetricStats,
     /// An unknown and unsupported metric.
     ///
     /// Metrics that Relay either doesn't know or recognize the namespace of will be dropped before
@@ -129,6 +133,19 @@ pub enum MetricNamespace {
 }
 
 impl MetricNamespace {
+    /// Returns all namespaces/variants of this enum.
+    pub fn all() -> [Self; 7] {
+        [
+            MetricNamespace::Sessions,
+            MetricNamespace::Transactions,
+            MetricNamespace::Spans,
+            MetricNamespace::Profiles,
+            MetricNamespace::Custom,
+            MetricNamespace::MetricStats,
+            MetricNamespace::Unsupported,
+        ]
+    }
+
     /// Returns the string representation for this metric type.
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -137,6 +154,7 @@ impl MetricNamespace {
             MetricNamespace::Spans => "spans",
             MetricNamespace::Profiles => "profiles",
             MetricNamespace::Custom => "custom",
+            MetricNamespace::MetricStats => "metric_stats",
             MetricNamespace::Unsupported => "unsupported",
         }
     }
@@ -152,6 +170,7 @@ impl std::str::FromStr for MetricNamespace {
             "spans" => Ok(Self::Spans),
             "profiles" => Ok(Self::Profiles),
             "custom" => Ok(Self::Custom),
+            "metric_stats" => Ok(Self::MetricStats),
             _ => Ok(Self::Unsupported),
         }
     }
@@ -335,6 +354,16 @@ mod tests {
     fn test_sizeof_unit() {
         assert_eq!(std::mem::size_of::<MetricUnit>(), 16);
         assert_eq!(std::mem::align_of::<MetricUnit>(), 1);
+    }
+
+    #[test]
+    fn test_metric_namespaces_conversion() {
+        for namespace in MetricNamespace::all() {
+            assert_eq!(
+                namespace,
+                namespace.as_str().parse::<MetricNamespace>().unwrap()
+            );
+        }
     }
 
     #[test]

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -119,7 +119,7 @@ pub enum MetricNamespace {
     /// Metric stats.
     ///
     /// Metrics about metrics.
-    MetricStats,
+    Stats,
     /// An unknown and unsupported metric.
     ///
     /// Metrics that Relay either doesn't know or recognize the namespace of will be dropped before
@@ -141,7 +141,7 @@ impl MetricNamespace {
             MetricNamespace::Spans,
             MetricNamespace::Profiles,
             MetricNamespace::Custom,
-            MetricNamespace::MetricStats,
+            MetricNamespace::Stats,
             MetricNamespace::Unsupported,
         ]
     }
@@ -154,7 +154,7 @@ impl MetricNamespace {
             MetricNamespace::Spans => "spans",
             MetricNamespace::Profiles => "profiles",
             MetricNamespace::Custom => "custom",
-            MetricNamespace::MetricStats => "metric_stats",
+            MetricNamespace::Stats => "metric_stats",
             MetricNamespace::Unsupported => "unsupported",
         }
     }
@@ -170,7 +170,7 @@ impl std::str::FromStr for MetricNamespace {
             "spans" => Ok(Self::Spans),
             "profiles" => Ok(Self::Profiles),
             "custom" => Ok(Self::Custom),
-            "metric_stats" => Ok(Self::MetricStats),
+            "metric_stats" => Ok(Self::Stats),
             _ => Ok(Self::Unsupported),
         }
     }

--- a/relay-cogs/src/lib.rs
+++ b/relay-cogs/src/lib.rs
@@ -142,7 +142,7 @@ pub enum AppFeature {
     /// Metrics in the custom namespace.
     MetricsCustom,
     /// Metrics in the `metric_stats` namespace.
-    MetricsMetricStats,
+    MetricsStats,
     /// Metrics in the unsupported namespace.
     ///
     /// This is usually not emitted, since metrics in the unsupported
@@ -170,7 +170,7 @@ impl AppFeature {
             Self::MetricsProfiles => "metrics_profiles",
             Self::MetricsSessions => "metrics_sessions",
             Self::MetricsCustom => "metrics_custom",
-            Self::MetricsMetricStats => "metrics_metric_stats",
+            Self::MetricsStats => "metrics_metric_stats",
             Self::MetricsUnsupported => "metrics_unsupported",
         }
     }

--- a/relay-cogs/src/lib.rs
+++ b/relay-cogs/src/lib.rs
@@ -141,6 +141,8 @@ pub enum AppFeature {
     MetricsSessions,
     /// Metrics in the custom namespace.
     MetricsCustom,
+    /// Metrics in the `metric_stats` namespace.
+    MetricsMetricStats,
     /// Metrics in the unsupported namespace.
     ///
     /// This is usually not emitted, since metrics in the unsupported
@@ -168,6 +170,7 @@ impl AppFeature {
             Self::MetricsProfiles => "metrics_profiles",
             Self::MetricsSessions => "metrics_sessions",
             Self::MetricsCustom => "metrics_custom",
+            Self::MetricsMetricStats => "metrics_metric_stats",
             Self::MetricsUnsupported => "metrics_unsupported",
         }
     }

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -197,7 +197,7 @@ impl BucketEncodings {
             MetricNamespace::Spans => self.spans,
             MetricNamespace::Profiles => self.profiles,
             MetricNamespace::Custom => self.custom,
-            MetricNamespace::MetricStats => self.metric_stats,
+            MetricNamespace::Stats => self.metric_stats,
             // Always force the legacy encoding for sessions,
             // sessions are not part of the generic metrics platform with different
             // consumer which are not (yet) updated to support the new data.

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -186,6 +186,7 @@ pub struct BucketEncodings {
     spans: BucketEncoding,
     profiles: BucketEncoding,
     custom: BucketEncoding,
+    metric_stats: BucketEncoding,
 }
 
 impl BucketEncodings {
@@ -196,6 +197,7 @@ impl BucketEncodings {
             MetricNamespace::Spans => self.spans,
             MetricNamespace::Profiles => self.profiles,
             MetricNamespace::Custom => self.custom,
+            MetricNamespace::MetricStats => self.metric_stats,
             // Always force the legacy encoding for sessions,
             // sessions are not part of the generic metrics platform with different
             // consumer which are not (yet) updated to support the new data.
@@ -231,6 +233,7 @@ where
                 spans: encoding,
                 profiles: encoding,
                 custom: encoding,
+                metric_stats: encoding,
             })
         }
 
@@ -424,7 +427,8 @@ mod tests {
                 transactions: BucketEncoding::Legacy,
                 spans: BucketEncoding::Legacy,
                 profiles: BucketEncoding::Legacy,
-                custom: BucketEncoding::Legacy
+                custom: BucketEncoding::Legacy,
+                metric_stats: BucketEncoding::Legacy,
             }
         );
         assert_eq!(
@@ -433,7 +437,8 @@ mod tests {
                 transactions: BucketEncoding::Zstd,
                 spans: BucketEncoding::Zstd,
                 profiles: BucketEncoding::Zstd,
-                custom: BucketEncoding::Zstd
+                custom: BucketEncoding::Zstd,
+                metric_stats: BucketEncoding::Zstd,
             }
         );
     }
@@ -445,6 +450,7 @@ mod tests {
             spans: BucketEncoding::Zstd,
             profiles: BucketEncoding::Base64,
             custom: BucketEncoding::Zstd,
+            metric_stats: BucketEncoding::Base64,
         };
         let s = serde_json::to_string(&original).unwrap();
         let s = format!(

--- a/relay-metrics/src/cogs.rs
+++ b/relay-metrics/src/cogs.rs
@@ -40,7 +40,7 @@ fn to_app_feature(ns: MetricNamespace) -> AppFeature {
         MetricNamespace::Spans => AppFeature::MetricsSpans,
         MetricNamespace::Profiles => AppFeature::MetricsProfiles,
         MetricNamespace::Custom => AppFeature::MetricsCustom,
-        MetricNamespace::MetricStats => AppFeature::MetricsMetricStats,
+        MetricNamespace::Stats => AppFeature::MetricsStats,
         MetricNamespace::Unsupported => AppFeature::MetricsUnsupported,
     }
 }

--- a/relay-metrics/src/cogs.rs
+++ b/relay-metrics/src/cogs.rs
@@ -40,6 +40,7 @@ fn to_app_feature(ns: MetricNamespace) -> AppFeature {
         MetricNamespace::Spans => AppFeature::MetricsSpans,
         MetricNamespace::Profiles => AppFeature::MetricsProfiles,
         MetricNamespace::Custom => AppFeature::MetricsCustom,
+        MetricNamespace::MetricStats => AppFeature::MetricsMetricStats,
         MetricNamespace::Unsupported => AppFeature::MetricsUnsupported,
     }
 }

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1248,7 +1248,7 @@ fn is_metric_namespace_valid(state: &ProjectState, namespace: &MetricNamespace) 
         }
         MetricNamespace::Profiles => true,
         MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
-        MetricNamespace::MetricStats => false,
+        MetricNamespace::Stats => false,
         MetricNamespace::Unsupported => false,
     }
 }

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1248,6 +1248,7 @@ fn is_metric_namespace_valid(state: &ProjectState, namespace: &MetricNamespace) 
         }
         MetricNamespace::Profiles => true,
         MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
+        MetricNamespace::MetricStats => false,
         MetricNamespace::Unsupported => false,
     }
 }

--- a/relay-server/src/utils/metric_stats.rs
+++ b/relay-server/src/utils/metric_stats.rs
@@ -57,7 +57,7 @@ impl MetricStats {
             MetricNamespace::Spans => &mut self.spans,
             MetricNamespace::Profiles => &mut self.profiles,
             MetricNamespace::Custom => &mut self.custom,
-            MetricNamespace::MetricStats => &mut self.metric_stats,
+            MetricNamespace::Stats => &mut self.metric_stats,
             MetricNamespace::Unsupported => &mut self.unsupported,
         }
     }

--- a/relay-server/src/utils/metric_stats.rs
+++ b/relay-server/src/utils/metric_stats.rs
@@ -14,6 +14,7 @@ pub struct MetricStats {
     spans: Stat,
     profiles: Stat,
     transactions: Stat,
+    metric_stats: Stat,
     unsupported: Stat,
 }
 
@@ -38,16 +39,9 @@ impl MetricStats {
     /// - `calls`: incremented by one for each seen namespace.
     /// - `count`: total amount of metric buckets by namespace.
     /// - `cost`: total cost of metric buckets by namespace.
-    pub fn emit(self, calls: RelayCounters, count: RelayCounters, cost: RelayCounters) {
-        let stats = [
-            (MetricNamespace::Custom, self.custom),
-            (MetricNamespace::Sessions, self.sessions),
-            (MetricNamespace::Spans, self.spans),
-            (MetricNamespace::Transactions, self.transactions),
-            (MetricNamespace::Unsupported, self.unsupported),
-        ];
-
-        for (namespace, stat) in stats {
+    pub fn emit(mut self, calls: RelayCounters, count: RelayCounters, cost: RelayCounters) {
+        for namespace in MetricNamespace::all() {
+            let stat = self.stat(namespace);
             if stat.count > 0 {
                 metric!(counter(calls) += 1, namespace = namespace.as_str());
                 metric!(counter(count) += stat.count, namespace = namespace.as_str());
@@ -63,6 +57,7 @@ impl MetricStats {
             MetricNamespace::Spans => &mut self.spans,
             MetricNamespace::Profiles => &mut self.profiles,
             MetricNamespace::Custom => &mut self.custom,
+            MetricNamespace::MetricStats => &mut self.metric_stats,
             MetricNamespace::Unsupported => &mut self.unsupported,
         }
     }


### PR DESCRIPTION
Adds the namespace, but it is still disabled, so we can make a `librelay` release for Sentry.

Epic: https://github.com/getsentry/relay/issues/3147

#skip-changelog