### PR TITLE
ref: Warn about dbg macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ debug = false
 # panic and error stack traces to Sentry.
 debug = true
 
+[workspace.lints.clippy]
+dbg_macro = "warn"
+
 [workspace.dependencies]
 anyhow = "1.0.66"
 chrono = { version = "0.4.31", default-features = false, features = [

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -10,6 +10,9 @@ license-file = "../LICENSE.md"
 publish = false
 build = "build.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono = { workspace = true }
 data-encoding = "2.5.0"

--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 relay-log = { path = "../relay-log" }
 relay-system = { path = "../relay-system" }

--- a/relay-base-schema/Cargo.toml
+++ b/relay-base-schema/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 regex = { workspace = true }
 relay-common = { path = "../relay-common" }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 chrono = { workspace = true }

--- a/relay-cardinality/Cargo.toml
+++ b/relay-cardinality/Cargo.toml
@@ -14,6 +14,9 @@ autobenches = false
 default = []
 redis = ["relay-redis/impl"]
 
+[lints]
+workspace = true
+
 [dependencies]
 hashbrown = { workspace = true }
 parking_lot = { workspace = true }

--- a/relay-cogs/Cargo.toml
+++ b/relay-cogs/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 license-file = "../LICENSE"
 publish = false
 autobenches = false
+
+[lints]
+workspace = true

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono = { workspace = true }
 globset = "0.4.5"

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -13,6 +13,9 @@ publish = false
 default = []
 processing = []
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 human-size = "0.4.1"

--- a/relay-crash/Cargo.toml
+++ b/relay-crash/Cargo.toml
@@ -10,6 +10,9 @@ build = "build.rs"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 
 [build-dependencies]

--- a/relay-dashboard/Cargo.toml
+++ b/relay-dashboard/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 ansi-to-html = "0.1.3"
 futures = "0.3.28"

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [features]
 default = []
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 assert-json-diff = "2.0.2"

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -33,7 +33,7 @@ impl Metrics {
     pub fn is_empty(&self) -> bool {
         self.cardinality_limits.is_empty()
             && self.denied_names.is_empty()
-            && self.denied_tags.is_empty()
+            && dbg!(self.denied_tags.is_empty())
     }
 }
 

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -33,7 +33,7 @@ impl Metrics {
     pub fn is_empty(&self) -> bool {
         self.cardinality_limits.is_empty()
             && self.denied_names.is_empty()
-            && dbg!(self.denied_tags.is_empty())
+            && self.denied_tags.is_empty()
     }
 }
 

--- a/relay-event-derive/Cargo.toml
+++ b/relay-event-derive/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 quote = "1.0.2"
 syn = "1.0.14"

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bytecount = "0.6.0"
 chrono = { workspace = true, features = ["clock"] }

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bytecount = "0.6.0"
 chrono = { workspace = true, features = ["clock"] }

--- a/relay-ffi-macros/Cargo.toml
+++ b/relay-ffi-macros/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 syn = { version = "1.0.39", features = ["fold", "full"] }
 quote = "1.0.6"

--- a/relay-ffi/Cargo.toml
+++ b/relay-ffi/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 relay-ffi-macros = { path = "../relay-ffi-macros" }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 ipnetwork = "0.20.0"
 once_cell = { workspace = true }

--- a/relay-jsonschema-derive/Cargo.toml
+++ b/relay-jsonschema-derive/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 quote = "1.0.2"
 syn = "1.0.14"

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 rdkafka = { version = "0.29.0", optional = true, features = ["tracing", "ssl"] }
 rdkafka-sys = { version = "4.3.0", optional = true }

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -10,6 +10,9 @@ license-file = "../LICENSE.md"
 publish = false
 build = "build.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono = { workspace = true, features = ["clock"], optional = true }
 console = { version = "0.15.5", optional = true }

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 redis = ["relay-redis/impl"]
 

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 once_cell = { workspace = true }
 regex = { workspace = true }

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 hmac = "0.12.1"
 minidump = "0.15.2"

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 android_trace_log = { version = "0.3.0", features = ["serde"] }
 chrono = { workspace = true }

--- a/relay-protocol-derive/Cargo.toml
+++ b/relay-protocol-derive/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 quote = "1.0.2"
 syn = "1.0.14"

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 num-traits = "0.2.12"
 relay-common = { path = "../relay-common" }

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -13,6 +13,9 @@ publish = false
 default = []
 redis = ["dep:thiserror", "dep:relay-log", "relay-redis/impl"]
 
+[lints]
+workspace = true
+
 [dependencies]
 hashbrown = { workspace = true }
 relay-base-schema = { path = "../relay-base-schema" }

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 r2d2 = { version = "0.8.10", optional = true }
 redis = { version = "0.23.1", optional = true, features = [

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { version = "1.4.0" }
 flate2 = "1.0.19"

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -13,6 +13,9 @@ publish = false
 default = []
 redis = ["dep:anyhow", "relay-redis/impl"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -32,6 +32,9 @@ processing = [
     "relay-sampling/redis",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 serde_path_to_error = "0.1.14"

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -318,7 +318,7 @@ impl<Q: AsRef<Vec<Quota>>> MetricsLimiter<Q> {
                     outcome_aggregator.send(TrackOutcome {
                         timestamp,
                         scoping: self.scoping,
-                        outcome: dbg!(outcome.clone()),
+                        outcome: outcome.clone(),
                         event_id: None,
                         remote_addr: None,
                         category: DataCategory::Transaction,

--- a/relay-spans/Cargo.toml
+++ b/relay-spans/Cargo.toml
@@ -9,11 +9,18 @@ edition = "2021"
 license-file = "../LICENSE"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 enumset = "1.0.4"
 once_cell.workspace = true
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14", features = ["gen-tonic", "with-serde", "trace"] }
+opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14", features = [
+    "gen-tonic",
+    "with-serde",
+    "trace",
+] }
 relay-event-schema = { path = "../relay-event-schema" }
 relay-protocol = { path = "../relay-protocol" }
 serde.workspace = true

--- a/relay-statsd/Cargo.toml
+++ b/relay-statsd/Cargo.toml
@@ -9,13 +9,18 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 cadence = "0.29.0"
 crossbeam-channel = "0.5.6"
 parking_lot = { workspace = true }
 rand = { workspace = true }
 relay-log = { path = "../relay-log" }
-statsdproxy = { version = "0.1.2", features = ["cadence-adapter"], default-features = false }
+statsdproxy = { version = "0.1.2", features = [
+    "cadence-adapter",
+], default-features = false }
 
 [features]
 default = []

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 futures = { workspace = true }
 once_cell = { workspace = true }

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 relay-log = { path = "../relay-log", features = ["test"] }
 relay-system = { path = "../relay-system" }

--- a/relay-ua/Cargo.toml
+++ b/relay-ua/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 once_cell = { workspace = true }
 uaparser = { version = "0.6.0" }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -15,6 +15,9 @@ default = []
 processing = ["relay-server/processing"]
 crash-handler = ["relay-log/crash-handler"]
 
+[lints]
+workspace = true
+
 # Direct dependencies of the main application in `src/`
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
* Introduce a workspace lint to warn about `dbg!` usage.
* Enable workspace lints in all crates.

#skip-changelog