### PR TITLE
ref(metrics): Change bucket name to Arc<str>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.13.1"
 parking_lot = "0.12.1"
 rand = "0.8.5"
 regex = "1.10.2"
-serde = { version = "1.0.159", features = ["derive"] }
+serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde_json = "1.0.93"
 serde_yaml = "0.9.17"
 schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }

--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -31,7 +31,7 @@ impl MetricInput {
             let key_id = i % self.num_project_keys;
             let metric_name = format!("c:transactions/foo{}", i % self.num_metric_names);
             let mut bucket = self.bucket.clone();
-            bucket.name = metric_name;
+            bucket.name = metric_name.into();
             let key = ProjectKey::parse(&format!("{key_id:0width$x}", width = 32)).unwrap();
             rv.push((key, bucket));
         }
@@ -64,7 +64,7 @@ fn bench_insert_and_flush(c: &mut Criterion) {
     let counter = Bucket {
         timestamp: UnixTimestamp::now(),
         width: 0,
-        name: "c:transactions/foo@none".to_owned(),
+        name: "c:transactions/foo@none".into(),
         value: BucketValue::counter(42.into()),
         tags: BTreeMap::new(),
         metadata: Default::default(),

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::hash::Hasher;
 use std::iter::FromIterator;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, mem};
 
@@ -38,7 +39,7 @@ impl From<AggregateMetricsErrorKind> for AggregateMetricsError {
 enum AggregateMetricsErrorKind {
     /// A metric bucket had invalid characters in the metric name.
     #[error("found invalid characters: {0}")]
-    InvalidCharacters(String),
+    InvalidCharacters(Arc<str>),
     /// A metric bucket had an unknown namespace in the metric name.
     #[error("found unsupported namespace: {0}")]
     UnsupportedNamespace(MetricNamespace),
@@ -50,7 +51,7 @@ enum AggregateMetricsErrorKind {
     InvalidTypes,
     /// A metric bucket had a too long string (metric name or a tag key/value).
     #[error("found invalid string: {0}")]
-    InvalidStringLength(String),
+    InvalidStringLength(Arc<str>),
     /// A metric bucket is too large for the global bytes limit.
     #[error("total metrics limit exceeded")]
     TotalLimitExceeded,
@@ -63,7 +64,7 @@ enum AggregateMetricsErrorKind {
 struct BucketKey {
     project_key: ProjectKey,
     timestamp: UnixTimestamp,
-    metric_name: String,
+    metric_name: Arc<str>,
     tags: BTreeMap<String, String>,
 }
 
@@ -82,7 +83,7 @@ impl BucketKey {
     /// Note that this does not necessarily match the exact memory footprint of the key,
     /// because data structures have a memory overhead.
     fn cost(&self) -> usize {
-        mem::size_of::<Self>() + self.metric_name.capacity() + tags_cost(&self.tags)
+        mem::size_of::<Self>() + self.metric_name.len() + tags_cost(&self.tags)
     }
 
     /// Returns the namespace of this bucket.
@@ -645,7 +646,7 @@ impl Aggregator {
                     "bucket.project_key",
                     key.project_key.as_str().to_owned().into(),
                 );
-                scope.set_extra("bucket.metric_name", key.metric_name.into());
+                scope.set_extra("bucket.metric_name", key.metric_name.to_string().into());
             });
             return Err(err);
         }
@@ -663,16 +664,14 @@ impl Aggregator {
                     );
                 }
 
-                let mut metric_name = mri.to_string();
-                // do this so cost tracking still works accurately.
-                metric_name.shrink_to_fit();
-                metric_name
+                mri.to_string().into()
             }
             Err(_) => {
                 relay_log::debug!("invalid metric name {:?}", &key.metric_name);
-                return Err(
-                    AggregateMetricsErrorKind::InvalidCharacters(key.metric_name.clone()).into(),
-                );
+                return Err(AggregateMetricsErrorKind::InvalidCharacters(Arc::clone(
+                    &key.metric_name,
+                ))
+                .into());
             }
         };
 
@@ -910,7 +909,7 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
-            name: "c:transactions/foo".to_owned(),
+            name: "c:transactions/foo".into(),
             value: BucketValue::counter(42.into()),
             tags: BTreeMap::new(),
             metadata: BucketMetadata::new(),
@@ -984,11 +983,11 @@ mod tests {
         // When this test fails, it means that the cost model has changed.
         // Check dimensionality limits.
         let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
-        let name = "12345".to_owned();
+        let metric_name = "12345".into();
         let bucket_key = BucketKey {
-            project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: name,
+            project_key,
+            metric_name,
             tags: BTreeMap::from([
                 ("hello".to_owned(), "world".to_owned()),
                 ("answer".to_owned(), "42".to_owned()),
@@ -996,7 +995,7 @@ mod tests {
         };
         assert_eq!(
             bucket_key.cost(),
-            88 + // BucketKey
+            80 + // BucketKey
             5 + // name
             (5 + 5 + 6 + 2) // tags
         );
@@ -1155,7 +1154,7 @@ mod tests {
         let bucket = Bucket {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
-            name: "c:transactions/foo@none".to_owned(),
+            name: "c:transactions/foo@none".into(),
             value: BucketValue::counter(42.into()),
             tags: BTreeMap::new(),
             metadata: BucketMetadata::new(),
@@ -1163,7 +1162,7 @@ mod tests {
         let bucket_key = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/foo@none".to_owned(),
+            metric_name: "c:transactions/foo@none".into(),
             tags: BTreeMap::new(),
         };
         let fixed_cost = bucket_key.cost() + mem::size_of::<BucketValue>();
@@ -1209,7 +1208,7 @@ mod tests {
         ] {
             let mut bucket = bucket.clone();
             bucket.value = metric_value;
-            bucket.name = metric_name.to_string();
+            bucket.name = metric_name.into();
 
             let current_cost = aggregator.cost_tracker.total_cost;
             aggregator.merge(project_key, bucket, None).unwrap();
@@ -1303,7 +1302,7 @@ mod tests {
         let bucket_key = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/hergus.bergus".to_owned(),
+            metric_name: "c:transactions/hergus.bergus".into(),
             tags: {
                 let mut tags = BTreeMap::new();
                 // There are some SDKs which mess up content encodings, and interpret the raw bytes
@@ -1336,7 +1335,7 @@ mod tests {
         );
         assert_eq!(bucket_key.tags.get("another\0garbage"), None);
 
-        bucket_key.metric_name = "hergus\0bergus".to_owned();
+        bucket_key.metric_name = "hergus\0bergus".into();
         Aggregator::validate_bucket_key(bucket_key, &test_config()).unwrap_err();
     }
 
@@ -1348,7 +1347,7 @@ mod tests {
         let short_metric = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/a_short_metric".to_owned(),
+            metric_name: "c:transactions/a_short_metric".into(),
             tags: BTreeMap::new(),
         };
         assert!(Aggregator::validate_bucket_key(short_metric, &test_config()).is_ok());
@@ -1356,7 +1355,7 @@ mod tests {
         let long_metric = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/long_name_a_very_long_name_its_super_long_really_but_like_super_long_probably_the_longest_name_youve_seen_and_even_the_longest_name_ever_its_extremly_long_i_cant_tell_how_long_it_is_because_i_dont_have_that_many_fingers_thus_i_cant_count_the_many_characters_this_long_name_is".to_owned(),
+            metric_name: "c:transactions/long_name_a_very_long_name_its_super_long_really_but_like_super_long_probably_the_longest_name_youve_seen_and_even_the_longest_name_ever_its_extremly_long_i_cant_tell_how_long_it_is_because_i_dont_have_that_many_fingers_thus_i_cant_count_the_many_characters_this_long_name_is".into(),
             tags: BTreeMap::new(),
         };
         let validation = Aggregator::validate_bucket_key(long_metric, &test_config());
@@ -1371,7 +1370,7 @@ mod tests {
         let short_metric_long_tag_key = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/a_short_metric_with_long_tag_key".to_owned(),
+            metric_name: "c:transactions/a_short_metric_with_long_tag_key".into(),
             tags: BTreeMap::from([("i_run_out_of_creativity_so_here_we_go_Lorem_Ipsum_is_simply_dummy_text_of_the_printing_and_typesetting_industry_Lorem_Ipsum_has_been_the_industrys_standard_dummy_text_ever_since_the_1500s_when_an_unknown_printer_took_a_galley_of_type_and_scrambled_it_to_make_a_type_specimen_book".into(), "tag_value".into())]),
         };
         let validation =
@@ -1381,7 +1380,7 @@ mod tests {
         let short_metric_long_tag_value = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/a_short_metric_with_long_tag_value".to_owned(),
+            metric_name: "c:transactions/a_short_metric_with_long_tag_value".into(),
             tags: BTreeMap::from([("tag_key".into(), "i_run_out_of_creativity_so_here_we_go_Lorem_Ipsum_is_simply_dummy_text_of_the_printing_and_typesetting_industry_Lorem_Ipsum_has_been_the_industrys_standard_dummy_text_ever_since_the_1500s_when_an_unknown_printer_took_a_galley_of_type_and_scrambled_it_to_make_a_type_specimen_book".into())]),
         };
         let validation =
@@ -1399,7 +1398,7 @@ mod tests {
         let short_metric = BucketKey {
             project_key,
             timestamp: UnixTimestamp::now(),
-            metric_name: "c:transactions/a_short_metric".to_owned(),
+            metric_name: "c:transactions/a_short_metric".into(),
             tags: BTreeMap::from([("foo".into(), tag_value.clone())]),
         };
         let validated_bucket = Aggregator::validate_metric_tags(short_metric, &test_config());
@@ -1411,7 +1410,7 @@ mod tests {
         let bucket = Bucket {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
-            name: "c:transactions/foo".to_owned(),
+            name: "c:transactions/foo".into(),
             value: BucketValue::counter(42.into()),
             tags: BTreeMap::new(),
             metadata: BucketMetadata::new(),
@@ -1442,7 +1441,7 @@ mod tests {
         let bucket = Bucket {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
-            name: "c:transactions/foo".to_owned(),
+            name: "c:transactions/foo".into(),
             value: BucketValue::counter(42.into()),
             tags: BTreeMap::new(),
             metadata: BucketMetadata::new(),

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -475,7 +475,7 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp::from_secs(999994711),
             width: 0,
-            name: "c:transactions/foo".to_owned(),
+            name: "c:transactions/foo".into(),
             value: BucketValue::counter(42.into()),
             tags: BTreeMap::new(),
             metadata: BucketMetadata::new(),

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1208,10 +1208,10 @@ mod tests {
         // exclusive_time metrics:
         assert!(metrics
             .iter()
-            .any(|b| b.name == "d:spans/exclusive_time@millisecond"));
+            .any(|b| &*b.name == "d:spans/exclusive_time@millisecond"));
         assert!(metrics
             .iter()
-            .any(|b| b.name == "d:spans/exclusive_time_light@millisecond"));
+            .any(|b| &*b.name == "d:spans/exclusive_time_light@millisecond"));
     }
 
     #[test]
@@ -1242,7 +1242,7 @@ mod tests {
 
         let usage_metrics = metrics
             .into_iter()
-            .filter(|b| b.name == "c:spans/usage@none")
+            .filter(|b| &*b.name == "c:spans/usage@none")
             .collect::<Vec<_>>();
 
         let expected_usage = 8; // We count all spans received by Relay
@@ -1283,7 +1283,7 @@ mod tests {
     fn test_app_start_cold_inlier() {
         let metrics = extract_span_metrics_mobile("app.start.cold", 180000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec![
                 "c:spans/usage@none",
                 "d:spans/exclusive_time@millisecond",
@@ -1298,7 +1298,7 @@ mod tests {
     fn test_app_start_cold_outlier() {
         let metrics = extract_span_metrics_mobile("app.start.cold", 181000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec!["c:spans/usage@none"]
         );
     }
@@ -1307,7 +1307,7 @@ mod tests {
     fn test_app_start_warm_inlier() {
         let metrics = extract_span_metrics_mobile("app.start.warm", 180000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec![
                 "c:spans/usage@none",
                 "d:spans/exclusive_time@millisecond",
@@ -1322,7 +1322,7 @@ mod tests {
     fn test_app_start_warm_outlier() {
         let metrics = extract_span_metrics_mobile("app.start.warm", 181000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec!["c:spans/usage@none"]
         );
     }
@@ -1331,7 +1331,7 @@ mod tests {
     fn test_ui_load_initial_display_inlier() {
         let metrics = extract_span_metrics_mobile("ui.load.initial_display", 180000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec![
                 "c:spans/usage@none",
                 "d:spans/exclusive_time@millisecond",
@@ -1346,7 +1346,7 @@ mod tests {
     fn test_ui_load_initial_display_outlier() {
         let metrics = extract_span_metrics_mobile("ui.load.initial_display", 181000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec!["c:spans/usage@none"]
         );
     }
@@ -1355,7 +1355,7 @@ mod tests {
     fn test_ui_load_full_display_inlier() {
         let metrics = extract_span_metrics_mobile("ui.load.full_display", 180000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec![
                 "c:spans/usage@none",
                 "d:spans/exclusive_time@millisecond",
@@ -1370,7 +1370,7 @@ mod tests {
     fn test_ui_load_full_display_outlier() {
         let metrics = extract_span_metrics_mobile("ui.load.full_display", 181000.0);
         assert_eq!(
-            metrics.iter().map(|m| &m.name).collect::<Vec<_>>(),
+            metrics.iter().map(|m| &*m.name).collect::<Vec<_>>(),
             vec!["c:spans/usage@none"]
         );
     }
@@ -1395,7 +1395,7 @@ mod tests {
 
         assert!(!metrics.is_empty());
         for metric in metrics {
-            if metric.name == "d:spans/exclusive_time@millisecond" {
+            if &*metric.name == "d:spans/exclusive_time@millisecond" {
                 assert_eq!(metric.tag("ttid"), Some("ttid"));
                 assert_eq!(metric.tag("ttfd"), Some("ttfd"));
             } else {
@@ -1437,7 +1437,7 @@ mod tests {
             "d:spans/webvital.score.total@ratio",
             "d:spans/webvital.score.weight.inp@ratio",
         ] {
-            assert!(metrics.iter().any(|b| b.name == mri));
+            assert!(metrics.iter().any(|b| &*b.name == mri));
         }
     }
 }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -57,7 +57,7 @@ where
         };
 
         metrics.push(Bucket {
-            name: mri.to_string(),
+            name: mri.to_string().into(),
             width: 0,
             value,
             timestamp,

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -238,7 +238,7 @@ mod tests {
 
         let session_metric = &metrics[0];
         assert_eq!(session_metric.timestamp, started());
-        assert_eq!(session_metric.name, "c:sessions/session@none");
+        assert_eq!(&*session_metric.name, "c:sessions/session@none");
         assert!(matches!(session_metric.value, BucketValue::Counter(_)));
         assert_eq!(session_metric.tags["session.status"], "init");
         assert_eq!(session_metric.tags["release"], "1.0.0");
@@ -315,13 +315,13 @@ mod tests {
 
             let session_metric = &metrics[expected_metrics - 2];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(session_metric.name, "s:sessions/error@none");
+            assert_eq!(&*session_metric.name, "s:sessions/error@none");
             assert!(matches!(session_metric.value, BucketValue::Set(_)));
             assert_eq!(session_metric.tags.len(), 1); // Only the release tag
 
             let user_metric = &metrics[expected_metrics - 1];
             assert_eq!(user_metric.timestamp, started());
-            assert_eq!(user_metric.name, "s:sessions/user@none");
+            assert_eq!(&*user_metric.name, "s:sessions/user@none");
             assert!(matches!(user_metric.value, BucketValue::Set(_)));
             assert_eq!(user_metric.tags["session.status"], "errored");
             assert_eq!(user_metric.tags["release"], "1.0.0");
@@ -350,13 +350,13 @@ mod tests {
 
         assert_eq!(metrics.len(), 4);
 
-        assert_eq!(metrics[0].name, "s:sessions/error@none");
-        assert_eq!(metrics[1].name, "s:sessions/user@none");
+        assert_eq!(&*metrics[0].name, "s:sessions/error@none");
+        assert_eq!(&*metrics[1].name, "s:sessions/user@none");
         assert_eq!(metrics[1].tags["session.status"], "errored");
 
         let session_metric = &metrics[2];
         assert_eq!(session_metric.timestamp, started());
-        assert_eq!(session_metric.name, "c:sessions/session@none");
+        assert_eq!(&*session_metric.name, "c:sessions/session@none");
         assert!(matches!(session_metric.value, BucketValue::Counter(_)));
         assert_eq!(session_metric.tags["session.status"], "crashed");
 

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -246,7 +246,7 @@ mod tests {
 
         let user_metric = &metrics[1];
         assert_eq!(user_metric.timestamp, started());
-        assert_eq!(user_metric.name, "s:sessions/user@none");
+        assert_eq!(&*user_metric.name, "s:sessions/user@none");
         assert!(matches!(user_metric.value, BucketValue::Set(_)));
         assert!(!user_metric.tags.contains_key("session.status"));
         assert_eq!(user_metric.tags["release"], "1.0.0");
@@ -275,7 +275,7 @@ mod tests {
         // A none-initial update which is not errored/crashed/abnormal will only emit a user metric.
         assert_eq!(metrics.len(), 1);
         let user_metric = &metrics[0];
-        assert_eq!(user_metric.name, "s:sessions/user@none");
+        assert_eq!(&*user_metric.name, "s:sessions/user@none");
         assert!(matches!(user_metric.value, BucketValue::Set(_)));
         assert!(!user_metric.tags.contains_key("session.status"));
     }
@@ -362,7 +362,7 @@ mod tests {
 
         let user_metric = &metrics[3];
         assert_eq!(user_metric.timestamp, started());
-        assert_eq!(user_metric.name, "s:sessions/user@none");
+        assert_eq!(&*user_metric.name, "s:sessions/user@none");
         assert!(matches!(user_metric.value, BucketValue::Set(_)));
         assert_eq!(user_metric.tags["session.status"], "crashed");
     }
@@ -401,13 +401,13 @@ mod tests {
 
             assert_eq!(metrics.len(), 4);
 
-            assert_eq!(metrics[0].name, "s:sessions/error@none");
-            assert_eq!(metrics[1].name, "s:sessions/user@none");
+            assert_eq!(&*metrics[0].name, "s:sessions/error@none");
+            assert_eq!(&*metrics[1].name, "s:sessions/user@none");
             assert_eq!(metrics[1].tags["session.status"], "errored");
 
             let session_metric = &metrics[2];
             assert_eq!(session_metric.timestamp, started());
-            assert_eq!(session_metric.name, "c:sessions/session@none");
+            assert_eq!(&*session_metric.name, "c:sessions/session@none");
             assert!(matches!(session_metric.value, BucketValue::Counter(_)));
             assert_eq!(session_metric.tags["session.status"], "abnormal");
 
@@ -417,7 +417,7 @@ mod tests {
 
             let user_metric = &metrics[3];
             assert_eq!(user_metric.timestamp, started());
-            assert_eq!(user_metric.name, "s:sessions/user@none");
+            assert_eq!(&*user_metric.name, "s:sessions/user@none");
             assert!(matches!(user_metric.value, BucketValue::Set(_)));
             assert_eq!(user_metric.tags["session.status"], "abnormal");
 

--- a/relay-server/src/metrics_extraction/sessions/types.rs
+++ b/relay-server/src/metrics_extraction/sessions/types.rs
@@ -122,7 +122,7 @@ impl IntoMetric for SessionMetric {
         Bucket {
             timestamp,
             width: 0,
-            name: mri.to_string(),
+            name: mri.to_string().into(),
             value,
             tags,
             metadata: BucketMetadata::new(),

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -1192,10 +1192,13 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| &*m.name == "d:transactions/duration@millisecond")
             .unwrap();
 
-        assert_eq!(duration_metric.name, "d:transactions/duration@millisecond");
+        assert_eq!(
+            &*duration_metric.name,
+            "d:transactions/duration@millisecond"
+        );
         assert_eq!(
             duration_metric.value,
             BucketValue::distribution(59000.into())

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -1396,7 +1396,7 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| &*m.name == "d:transactions/duration@millisecond")
             .unwrap();
 
         assert_eq!(
@@ -1435,7 +1435,7 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| &*m.name == "d:transactions/duration@millisecond")
             .unwrap();
 
         assert_eq!(
@@ -1624,7 +1624,7 @@ mod tests {
         let duration_metric = extracted
             .project_metrics
             .iter()
-            .find(|m| m.name == "d:transactions/duration@millisecond")
+            .find(|m| &*m.name == "d:transactions/duration@millisecond")
             .unwrap();
 
         duration_metric.tags.get("transaction").cloned()

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -117,7 +117,7 @@ impl IntoMetric for TransactionMetric {
         Bucket {
             timestamp,
             width: 0,
-            name: mri.to_string(),
+            name: mri.to_string().into(),
             value,
             tags,
             metadata: BucketMetadata::new(),

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2911,7 +2911,7 @@ mod tests {
 
             let project_metrics = ProjectMetrics {
                 buckets: vec![Bucket {
-                    name: "d:transactions/bar".to_string(),
+                    name: "d:transactions/bar".into(),
                     value: BucketValue::Counter(relay_metrics::FiniteF64::new(1.0).unwrap()),
                     timestamp: UnixTimestamp::now(),
                     tags: Default::default(),

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -350,7 +350,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".into(),
                 tags: Default::default(),
                 value: BucketValue::distribution(123.into()),
                 metadata: Default::default(),
@@ -359,7 +359,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".into(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(456.into()),
                 metadata: Default::default(),
@@ -368,7 +368,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".into(),
                 tags: Default::default(),
                 value: BucketValue::counter(1.into()),
                 metadata: Default::default(),
@@ -377,7 +377,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".into(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::counter(1.into()),
                 metadata: Default::default(),
@@ -386,7 +386,7 @@ mod tests {
                 // unrelated metric
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "something_else".to_string(),
+                name: "something_else".into(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(123.into()),
                 metadata: Default::default(),
@@ -444,7 +444,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".into(),
                 tags: Default::default(),
                 value: BucketValue::distribution(123.into()),
                 metadata: Default::default(),
@@ -453,7 +453,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "d:transactions/duration@millisecond".to_string(),
+                name: "d:transactions/duration@millisecond".into(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(456.into()),
                 metadata: Default::default(),
@@ -462,7 +462,7 @@ mod tests {
                 // transaction without profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".into(),
                 tags: Default::default(),
                 value: BucketValue::counter(1.into()),
                 metadata: Default::default(),
@@ -471,7 +471,7 @@ mod tests {
                 // transaction with profile
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "c:transactions/usage@none".to_string(),
+                name: "c:transactions/usage@none".into(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::counter(1.into()),
                 metadata: Default::default(),
@@ -480,7 +480,7 @@ mod tests {
                 // unrelated metric
                 timestamp: UnixTimestamp::now(),
                 width: 0,
-                name: "something_else".to_string(),
+                name: "something_else".into(),
                 tags: [("has_profile".to_string(), "true".to_string())].into(),
                 value: BucketValue::distribution(123.into()),
                 metadata: Default::default(),


### PR DESCRIPTION
The bucket name is immutable and in serveral places it is being cloned. Instead of using a String and pruning the capacity (which wasn't always done) we can instead use an immutable variant which allows for cheap clones instead.

In a follow-up we can replace metrics created by Relay with a single `Arc` instance instead of creating the mri everytime.
 
#skip-changelog