### PR TITLE
fix(python): Add description content type

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -108,6 +108,7 @@ setup(
     author_email="hello@sentry.io",
     description="A python library to access sentry relay functionality.",
     long_description=readme,
+    long_description_content_type="text/markdown",
     include_package_data=True,
     package_data={"sentry_relay": ["py.typed", "_lowlevel.pyi"]},
     zip_safe=False,


### PR DESCRIPTION
This will fix:
```
  twine: ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
  twine:          'description-content-type' must be one of ['text/plain',
  twine:          'text/markdown', 'text/x-rst'], not ''. See
  twine:          https://packaging.python.org/specifications/core-metadata for more
  twine:          information.
```

#skip-changelog