### PR TITLE
feat(spans): Extract op/description while converting otel spans to sentry spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - Add support for Reporting API for CSP reports ([#3277](https://github.com/getsentry/relay/pull/3277))
+- Extract op and description while converting opentelemetry spans to sentry spans ([#3287](https://github.com/getsentry/relay/pull/3287))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**
 
 - Add support for Reporting API for CSP reports ([#3277](https://github.com/getsentry/relay/pull/3277))
-- Extract op and description while converting opentelemetry spans to sentry spans ([#3287](https://github.com/getsentry/relay/pull/3287))
+- Extract op and description while converting opentelemetry spans to sentry spans. ([#3287](https://github.com/getsentry/relay/pull/3287))
 
 **Internal**:
 

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -169,10 +169,8 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
     // TODO: This is wrong, a segment could still have a parent in the trace.
     let is_segment = parent_span_id.is_empty().into();
 
-    if let Some(http_method) = http_method {
-        if let Some(http_route) = http_route {
-            description = format!("{} {}", http_method, http_route);
-        }
+    if let (Some(http_method), Some(http_route)) = (http_method, http_route) {
+        description = format!("{} {}", http_method, http_route);
     }
 
     EventSpan {


### PR DESCRIPTION
We need the op/description for these cases for further tag/metric extraction and for stuff to show up in the product.