### PR TITLE
ref(store): Remove produce_metrics

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -193,14 +193,14 @@ impl StoreService {
 
     fn store_envelope(
         &self,
-        envelope: Box<Envelope>,
+        mut envelope: Box<Envelope>,
         start_time: Instant,
         scoping: Scoping,
     ) -> Result<(), StoreError> {
         let retention = envelope.retention();
         let client = envelope.meta().client();
         let event_id = envelope.event_id();
-        let event_item = envelope.take_item_by(|item| {
+        let event_item = envelope.as_mut().take_item_by(|item| {
             matches!(
                 item.ty(),
                 ItemType::Event
@@ -330,7 +330,7 @@ impl StoreService {
         let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
 
         let kafka_messages = Self::extract_kafka_messages_for_event(
-            event_item,
+            event_item.as_ref(),
             event_id.ok_or(StoreError::NoEventId)?,
             scoping,
             start_time,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -200,7 +200,7 @@ impl StoreService {
         let retention = envelope.retention();
         let client = envelope.meta().client();
         let event_id = envelope.event_id();
-        let event_item = envelope.get_item_by(|item| {
+        let event_item = envelope.take_item_by(|item| {
             matches!(
                 item.ty(),
                 ItemType::Event

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -198,7 +198,6 @@ impl StoreService {
         scoping: Scoping,
     ) -> Result<(), StoreError> {
         let retention = envelope.retention();
-        let client = envelope.meta().client();
         let event_id = envelope.event_id();
         let event_item = envelope.as_mut().take_item_by(|item| {
             matches!(
@@ -209,10 +208,11 @@ impl StoreService {
                     | ItemType::UserReportV2
             )
         });
+        let client = envelope.meta().client();
 
         let topic = if envelope.get_item_by(is_slow_item).is_some() {
             KafkaTopic::Attachments
-        } else if event_item.map(|x| x.ty()) == Some(&ItemType::Transaction) {
+        } else if event_item.as_ref().map(|x| x.ty()) == Some(&ItemType::Transaction) {
             KafkaTopic::Transactions
         } else {
             KafkaTopic::Events


### PR DESCRIPTION
This PR

1. Removes code from the store service that produced metrics for envelope items. Metrics go through the separate `StoreMetrics` message now.
2. Logs an error for any unexpected envelope item that reaches the store services. This will prevent us from silently dropping items in the future. Long-term, we should use a different format than the envelope to communicate with the store service.

#skip-changelog