### PR TITLE
ref(metrics): Implement MetricName newtype with optimized namespace access

### DIFF
--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -349,6 +349,131 @@ impl BucketValue {
     }
 }
 
+/// The name of a metric.
+///
+/// Optimized string represenation of a metric name, the contained name
+/// does not need to be valid MRI, but usually is.
+///
+/// The metric name can be efficiently cloned.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MetricName(Arc<str>);
+
+impl MetricName {
+    /// Extracts the namespace from a well formed MRI.
+    ///
+    /// Returns [`MetricNamespace::Unsupported`] if the metric name is not a well formed MRI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relay_metrics::{MetricName, MetricNamespace};
+    ///
+    /// let name = MetricName::from("foo");
+    /// assert_eq!(name.namespace(), MetricNamespace::Unsupported);
+    ///
+    /// let name = MetricName::from("c:custom/foo@none");
+    /// assert_eq!(name.namespace(), MetricNamespace::Custom);
+    /// ```
+    pub fn namespace(&self) -> MetricNamespace {
+        self.try_namespace().unwrap_or(MetricNamespace::Unsupported)
+    }
+
+    /// Extracts the namespace from a well formed MRI.
+    ///
+    /// If the contained metric name is not a well formed MRI this function returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relay_metrics::{MetricName, MetricNamespace};
+    ///
+    /// let name = MetricName::from("foo");
+    /// assert!(name.try_namespace().is_none());
+    ///
+    /// let name = MetricName::from("c:custom/foo@none");
+    /// assert_eq!(name.try_namespace(), Some(MetricNamespace::Custom));
+    /// ```
+    pub fn try_namespace(&self) -> Option<MetricNamespace> {
+        // A well formed MRI is always in the format `<type>:<namespace>/<name>[@<unit>]`,
+        // `<type>` is always a single ascii character.
+        //
+        // Skip the first two ascii characters and extract the namespace.
+        let maybe_namespace = self.0.get(2..)?.split('/').next()?;
+
+        MetricNamespace::all()
+            .into_iter()
+            .find(|namespace| maybe_namespace == namespace.as_str())
+    }
+}
+
+impl PartialEq<str> for MetricName {
+    fn eq(&self, other: &str) -> bool {
+        self.0.as_ref() == other
+    }
+}
+
+impl fmt::Display for MetricName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<String> for MetricName {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Arc<str>> for MetricName {
+    fn from(value: Arc<str>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for MetricName {
+    fn from(value: &str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl std::ops::Deref for MetricName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl AsRef<str> for MetricName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl std::borrow::Borrow<str> for MetricName {
+    fn borrow(&self) -> &str {
+        self.0.borrow()
+    }
+}
+
+impl Serialize for MetricName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for MetricName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer).map(Self)
+    }
+}
+
 /// Parses a list of counter values separated by colons and sums them up.
 fn parse_counter(string: &str) -> Option<CounterType> {
     let mut sum = CounterType::default();
@@ -552,7 +677,7 @@ pub struct Bucket {
     /// custom/endpoint.hits:1|c
     /// custom/endpoint.duration@millisecond:21.5|d
     /// ```
-    pub name: Arc<str>,
+    pub name: MetricName,
 
     /// The type and aggregated values of this bucket.
     ///
@@ -614,11 +739,6 @@ pub struct Bucket {
 }
 
 impl Bucket {
-    /// Returns the [`MetricNamespace`] of the bucket.
-    pub fn parse_namespace(&self) -> Result<MetricNamespace, ParseMetricError> {
-        MetricResourceIdentifier::parse(&self.name).map(|mri| mri.namespace)
-    }
-
     /// Parses a statsd-compatible payload.
     ///
     /// ```text
@@ -722,19 +842,7 @@ impl Bucket {
 
 impl CardinalityItem for Bucket {
     fn namespace(&self) -> Option<MetricNamespace> {
-        let mri = match MetricResourceIdentifier::parse(&self.name) {
-            Err(error) => {
-                relay_log::debug!(
-                    error = &error as &dyn std::error::Error,
-                    metric = self.name.as_ref(),
-                    "rejecting metric with invalid MRI"
-                );
-                return None;
-            }
-            Ok(mri) => mri,
-        };
-
-        Some(mri.namespace)
+        self.name.try_namespace()
     }
 
     fn to_hash(&self) -> u32 {
@@ -906,7 +1014,9 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp(4711),
             width: 0,
-            name: "c:transactions/foo@none",
+            name: MetricName(
+                "c:transactions/foo@none",
+            ),
             value: Counter(
                 42.0,
             ),
@@ -935,7 +1045,9 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp(4711),
             width: 0,
-            name: "d:transactions/foo@none",
+            name: MetricName(
+                "d:transactions/foo@none",
+            ),
             value: Distribution(
                 [
                     17.5,
@@ -984,7 +1096,9 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp(4711),
             width: 0,
-            name: "s:transactions/foo@none",
+            name: MetricName(
+                "s:transactions/foo@none",
+            ),
             value: Set(
                 {
                     4267882815,
@@ -1037,7 +1151,9 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp(4711),
             width: 0,
-            name: "g:transactions/foo@none",
+            name: MetricName(
+                "g:transactions/foo@none",
+            ),
             value: Gauge(
                 GaugeValue {
                     last: 42.0,
@@ -1064,7 +1180,9 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp(4711),
             width: 0,
-            name: "g:transactions/foo@none",
+            name: MetricName(
+                "g:transactions/foo@none",
+            ),
             value: Gauge(
                 GaugeValue {
                     last: 25.0,
@@ -1091,7 +1209,9 @@ mod tests {
         Bucket {
             timestamp: UnixTimestamp(4711),
             width: 0,
-            name: "c:custom/foo@none",
+            name: MetricName(
+                "c:custom/foo@none",
+            ),
             value: Counter(
                 42.0,
             ),
@@ -1265,7 +1385,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
                 width: 10,
-                name: "endpoint.response_time",
+                name: MetricName(
+                    "endpoint.response_time",
+                ),
                 value: Distribution(
                     [
                         36.0,
@@ -1303,7 +1425,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1615889440),
                 width: 10,
-                name: "endpoint.hits",
+                name: MetricName(
+                    "endpoint.hits",
+                ),
                 value: Counter(
                     4.0,
                 ),

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -349,13 +349,13 @@ impl BucketValue {
     }
 }
 
-/// The name of a metric.
+/// Optimized string represenation of a metric name
 ///
-/// Optimized string represenation of a metric name, the contained name
-/// does not need to be valid MRI, but usually is.
+/// The contained name does not need to be valid MRI, but it usually is.
 ///
 /// The metric name can be efficiently cloned.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
 pub struct MetricName(Arc<str>);
 
 impl MetricName {
@@ -369,6 +369,8 @@ impl MetricName {
     /// use relay_metrics::{MetricName, MetricNamespace};
     ///
     /// let name = MetricName::from("foo");
+    /// assert_eq!(name.namespace(), MetricNamespace::Unsupported);
+    /// let name = MetricName::from("c:custom_oops/foo@none");
     /// assert_eq!(name.namespace(), MetricNamespace::Unsupported);
     ///
     /// let name = MetricName::from("c:custom/foo@none");
@@ -389,9 +391,12 @@ impl MetricName {
     ///
     /// let name = MetricName::from("foo");
     /// assert!(name.try_namespace().is_none());
+    /// let name = MetricName::from("c:custom_oops/foo@none");
+    /// assert!(name.try_namespace().is_none());
     ///
     /// let name = MetricName::from("c:custom/foo@none");
     /// assert_eq!(name.try_namespace(), Some(MetricNamespace::Custom));
+    ///
     /// ```
     pub fn try_namespace(&self) -> Option<MetricNamespace> {
         // A well formed MRI is always in the format `<type>:<namespace>/<name>[@<unit>]`,
@@ -453,24 +458,6 @@ impl AsRef<str> for MetricName {
 impl std::borrow::Borrow<str> for MetricName {
     fn borrow(&self) -> &str {
         self.0.borrow()
-    }
-}
-
-impl Serialize for MetricName {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for MetricName {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer).map(Self)
     }
 }
 

--- a/relay-metrics/src/cogs.rs
+++ b/relay-metrics/src/cogs.rs
@@ -1,9 +1,8 @@
 //! COGS related metric utilities.
 
-use relay_base_schema::metrics::{MetricNamespace, MetricResourceIdentifier};
 use relay_cogs::{AppFeature, FeatureWeights};
 
-use crate::{Bucket, BucketView};
+use crate::{Bucket, BucketView, MetricNamespace};
 
 /// COGS estimator based on the estimated size of each bucket in bytes.
 pub struct BySize<'a>(pub &'a [Bucket]);
@@ -30,7 +29,7 @@ where
     let mut b = FeatureWeights::builder();
 
     for bucket in buckets.into_iter() {
-        b.add_weight(to_app_feature(namespace(bucket)), f(bucket));
+        b.add_weight(to_app_feature(bucket.name.namespace()), f(bucket));
     }
 
     b.build()
@@ -46,10 +45,4 @@ fn to_app_feature(ns: MetricNamespace) -> AppFeature {
         MetricNamespace::Stats => AppFeature::MetricsStats,
         MetricNamespace::Unsupported => AppFeature::MetricsUnsupported,
     }
-}
-
-fn namespace(bucket: &Bucket) -> MetricNamespace {
-    MetricResourceIdentifier::parse(&bucket.name)
-        .map(|mri| mri.namespace)
-        .unwrap_or(MetricNamespace::Unsupported)
 }

--- a/relay-metrics/src/router.rs
+++ b/relay-metrics/src/router.rs
@@ -8,10 +8,7 @@ use relay_system::{Addr, NoResponse, Recipient, Service};
 use serde::{Deserialize, Serialize};
 
 use crate::aggregatorservice::{AggregatorService, FlushBuckets};
-use crate::{
-    AcceptsMetrics, Aggregator, AggregatorServiceConfig, MergeBuckets, MetricNamespace,
-    MetricResourceIdentifier,
-};
+use crate::{AcceptsMetrics, Aggregator, AggregatorServiceConfig, MergeBuckets, MetricNamespace};
 
 /// Contains an [`AggregatorServiceConfig`] for a specific scope.
 ///
@@ -145,11 +142,10 @@ impl StartedRouter {
     }
 
     fn handle_merge_buckets(&mut self, message: MergeBuckets) {
-        let metrics_by_namespace = message.buckets.into_iter().group_by(|bucket| {
-            MetricResourceIdentifier::parse(&bucket.name)
-                .map(|mri| mri.namespace)
-                .ok()
-        });
+        let metrics_by_namespace = message
+            .buckets
+            .into_iter()
+            .group_by(|bucket| bucket.name.try_namespace());
 
         // TODO: Parse MRI only once, move validation from Aggregator here.
         for (namespace, group) in metrics_by_namespace.into_iter() {

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -3,12 +3,12 @@ use serde::ser::{SerializeMap, SerializeSeq};
 use serde::Serialize;
 
 use crate::{
-    aggregator, BucketMetadata, CounterType, DistributionType, GaugeValue, SetType, SetValue,
+    aggregator, BucketMetadata, CounterType, DistributionType, GaugeValue, MetricName, SetType,
+    SetValue,
 };
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Range;
-use std::sync::Arc;
 
 use crate::bucket::Bucket;
 use crate::BucketValue;
@@ -373,15 +373,8 @@ impl<'a> BucketView<'a> {
     /// Name of the bucket.
     ///
     /// See also: [`Bucket::name`]
-    pub fn name(&self) -> &'a str {
+    pub fn name(&self) -> &'a MetricName {
         &self.inner.name
-    }
-
-    /// Returns the name of the bucket.
-    ///
-    /// Caller holds shared ownership of the string.
-    pub fn clone_name(&self) -> Arc<str> {
-        Arc::clone(&self.inner.name)
     }
 
     /// Value of the bucket view.

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, OnceLock};
 
 use relay_config::Config;
-use relay_metrics::{
-    Aggregator, Bucket, BucketValue, MergeBuckets, MetricResourceIdentifier, UnixTimestamp,
-};
+use relay_metrics::{Aggregator, Bucket, BucketValue, MergeBuckets, MetricName, UnixTimestamp};
 use relay_quotas::Scoping;
 use relay_system::Addr;
 
@@ -12,10 +10,12 @@ use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::Outcome;
 use crate::utils::is_rolled_out;
 
-fn volume_metric_mri() -> Arc<str> {
-    static VOLUME_METRIC_MRI: OnceLock<Arc<str>> = OnceLock::new();
+fn volume_metric_mri() -> MetricName {
+    static VOLUME_METRIC_MRI: OnceLock<MetricName> = OnceLock::new();
 
-    Arc::clone(VOLUME_METRIC_MRI.get_or_init(|| "c:metric_stats/volume@none".into()))
+    VOLUME_METRIC_MRI
+        .get_or_init(|| "c:metric_stats/volume@none".into())
+        .clone()
 }
 
 /// Tracks stats about metrics.
@@ -82,9 +82,7 @@ impl MetricStats {
             return None;
         }
 
-        let namespace = MetricResourceIdentifier::parse(&bucket.name)
-            .ok()?
-            .namespace;
+        let namespace = bucket.name.namespace();
         if !namespace.has_metric_stats() {
             return None;
         }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -189,7 +189,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "c:transactions/counter@none",
+                name: MetricName(
+                    "c:transactions/counter@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -229,7 +231,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "d:transactions/duration@none",
+                name: MetricName(
+                    "d:transactions/duration@none",
+                ),
                 value: Distribution(
                     [
                         2000.0,
@@ -273,7 +277,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "s:transactions/users@none",
+                name: MetricName(
+                    "s:transactions/users@none",
+                ),
                 value: Set(
                     {
                         943162418,
@@ -329,7 +335,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "c:transactions/counter@none",
+                name: MetricName(
+                    "c:transactions/counter@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -386,7 +394,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "c:transactions/counter@none",
+                name: MetricName(
+                    "c:transactions/counter@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -445,7 +455,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "c:transactions/counter@none",
+                name: MetricName(
+                    "c:transactions/counter@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -512,7 +524,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1597976302),
                 width: 0,
-                name: "d:transactions/measurements.valid@none",
+                name: MetricName(
+                    "d:transactions/measurements.valid@none",
+                ),
                 value: Distribution(
                     [
                         1.0,

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -479,7 +479,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084960),
                 width: 0,
-                name: "c:sessions/session@none",
+                name: MetricName(
+                    "c:sessions/session@none",
+                ),
                 value: Counter(
                     135.0,
                 ),
@@ -496,7 +498,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084960),
                 width: 0,
-                name: "c:sessions/session@none",
+                name: MetricName(
+                    "c:sessions/session@none",
+                ),
                 value: Counter(
                     12.0,
                 ),
@@ -513,7 +517,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084960),
                 width: 0,
-                name: "c:sessions/session@none",
+                name: MetricName(
+                    "c:sessions/session@none",
+                ),
                 value: Counter(
                     5.0,
                 ),
@@ -530,7 +536,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084960),
                 width: 0,
-                name: "c:sessions/session@none",
+                name: MetricName(
+                    "c:sessions/session@none",
+                ),
                 value: Counter(
                     7.0,
                 ),
@@ -547,7 +555,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084961),
                 width: 0,
-                name: "c:sessions/session@none",
+                name: MetricName(
+                    "c:sessions/session@none",
+                ),
                 value: Counter(
                     15.0,
                 ),
@@ -564,7 +574,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084961),
                 width: 0,
-                name: "c:sessions/session@none",
+                name: MetricName(
+                    "c:sessions/session@none",
+                ),
                 value: Counter(
                     3.0,
                 ),
@@ -581,7 +593,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1581084961),
                 width: 0,
-                name: "s:sessions/user@none",
+                name: MetricName(
+                    "s:sessions/user@none",
+                ),
                 value: Set(
                     {
                         3097475539,

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -6,7 +6,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1619420400),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -18,7 +20,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1619420400),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 59000.0,
@@ -37,7 +41,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1619420400),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -51,7 +57,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -63,7 +71,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -82,7 +92,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -97,7 +109,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -109,7 +123,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -133,7 +149,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -154,7 +172,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -169,7 +189,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -181,7 +203,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -205,7 +229,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -226,7 +252,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -241,7 +269,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -253,7 +283,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -277,7 +309,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -298,7 +332,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -313,7 +349,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -325,7 +363,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -348,7 +388,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -368,7 +410,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -383,7 +427,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -395,7 +441,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -419,7 +467,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -440,7 +490,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -455,7 +507,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -467,7 +521,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -491,7 +547,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -512,7 +570,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -527,7 +587,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -539,7 +601,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -564,7 +628,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -586,7 +652,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -601,7 +669,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -613,7 +683,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -638,7 +710,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -660,7 +734,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -675,7 +751,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -687,7 +765,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -712,7 +792,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -734,7 +816,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -749,7 +833,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -761,7 +847,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -786,7 +874,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -808,7 +898,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -823,7 +915,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -835,7 +929,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -860,7 +956,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -882,7 +980,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -897,7 +997,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -909,7 +1011,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -934,7 +1038,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -956,7 +1062,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -972,7 +1080,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -984,7 +1094,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1009,7 +1121,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1031,7 +1145,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1046,7 +1162,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1058,7 +1176,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1081,7 +1201,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1101,7 +1223,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1117,7 +1241,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1129,7 +1255,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1154,7 +1282,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1176,7 +1306,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1192,7 +1324,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1204,7 +1338,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1227,7 +1363,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1247,7 +1385,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1262,7 +1402,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1274,7 +1416,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1299,7 +1443,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1321,7 +1467,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1337,7 +1485,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1349,7 +1499,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1374,7 +1526,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1396,7 +1550,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1412,7 +1568,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1424,7 +1582,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1447,7 +1607,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1467,7 +1629,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1483,7 +1647,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1495,7 +1661,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1518,7 +1686,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1538,7 +1708,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1554,7 +1726,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1566,7 +1740,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1590,7 +1766,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1611,7 +1789,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1627,7 +1807,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1639,7 +1821,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1658,7 +1842,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1673,7 +1859,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1685,7 +1873,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1709,7 +1899,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1730,7 +1922,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1745,7 +1939,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1757,7 +1953,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1781,7 +1979,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1802,7 +2002,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1817,7 +2019,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1829,7 +2033,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1853,7 +2059,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1874,7 +2082,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1889,7 +2099,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1901,7 +2113,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1925,7 +2139,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1947,7 +2163,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1962,7 +2180,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -1974,7 +2194,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -1993,7 +2215,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2009,7 +2233,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2021,7 +2247,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2044,7 +2272,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2064,7 +2294,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2080,7 +2312,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2092,7 +2326,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2111,7 +2347,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2126,7 +2364,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2138,7 +2378,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2161,7 +2403,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2181,7 +2425,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2197,7 +2443,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2209,7 +2457,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2231,7 +2481,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2250,7 +2502,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2266,7 +2520,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1695255152),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2278,7 +2534,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1695255152),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 15833.532095,
@@ -2297,7 +2555,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1695255152),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2311,7 +2571,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1695255136),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2323,7 +2585,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1695255136),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 1668.516159,
@@ -2342,7 +2606,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1695255136),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2357,7 +2623,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2369,7 +2637,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -2394,7 +2664,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -2417,7 +2689,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_content_length@byte",
+        name: MetricName(
+            "d:spans/http.response_content_length@byte",
+        ),
         value: Distribution(
             [
                 36170.0,
@@ -2440,7 +2714,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.decoded_response_content_length@byte",
+        name: MetricName(
+            "d:spans/http.decoded_response_content_length@byte",
+        ),
         value: Distribution(
             [
                 128950.0,
@@ -2462,7 +2738,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_transfer_size@byte",
+        name: MetricName(
+            "d:spans/http.response_transfer_size@byte",
+        ),
         value: Distribution(
             [
                 36470.0,
@@ -2484,7 +2762,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2499,7 +2779,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2511,7 +2793,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -2536,7 +2820,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -2559,7 +2845,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_content_length@byte",
+        name: MetricName(
+            "d:spans/http.response_content_length@byte",
+        ),
         value: Distribution(
             [
                 36170.0,
@@ -2582,7 +2870,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.decoded_response_content_length@byte",
+        name: MetricName(
+            "d:spans/http.decoded_response_content_length@byte",
+        ),
         value: Distribution(
             [
                 128950.0,
@@ -2604,7 +2894,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_transfer_size@byte",
+        name: MetricName(
+            "d:spans/http.response_transfer_size@byte",
+        ),
         value: Distribution(
             [
                 36470.0,
@@ -2626,7 +2918,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2641,7 +2935,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2653,7 +2949,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2672,7 +2970,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2687,7 +2987,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2699,7 +3001,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2723,7 +3027,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2744,7 +3050,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2759,7 +3067,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2771,7 +3081,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2795,7 +3107,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2816,7 +3130,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2831,7 +3147,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2843,7 +3161,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2867,7 +3187,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2888,7 +3210,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2903,7 +3227,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2915,7 +3241,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2938,7 +3266,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -2958,7 +3288,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2973,7 +3305,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -2985,7 +3319,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3009,7 +3345,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3030,7 +3368,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3045,7 +3385,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3057,7 +3399,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3082,7 +3426,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3104,7 +3450,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3119,7 +3467,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3131,7 +3481,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3156,7 +3508,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3178,7 +3532,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3193,7 +3549,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3205,7 +3563,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3230,7 +3590,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3252,7 +3614,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3267,7 +3631,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3279,7 +3645,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3304,7 +3672,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3326,7 +3696,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3341,7 +3713,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3353,7 +3727,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3378,7 +3754,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3400,7 +3778,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3415,7 +3795,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3427,7 +3809,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3452,7 +3836,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3474,7 +3860,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3490,7 +3878,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3502,7 +3892,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3527,7 +3919,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3549,7 +3943,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3564,7 +3960,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3576,7 +3974,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3599,7 +3999,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3619,7 +4021,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3635,7 +4039,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3647,7 +4053,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3672,7 +4080,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3694,7 +4104,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3710,7 +4122,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3722,7 +4136,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3745,7 +4161,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3765,7 +4183,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3780,7 +4200,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3792,7 +4214,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3817,7 +4241,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3839,7 +4265,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3855,7 +4283,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3867,7 +4297,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3892,7 +4324,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3914,7 +4348,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3930,7 +4366,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -3942,7 +4380,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3965,7 +4405,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -3985,7 +4427,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4001,7 +4445,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4013,7 +4459,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4036,7 +4484,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4056,7 +4506,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4072,7 +4524,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4084,7 +4538,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4108,7 +4564,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4129,7 +4587,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4145,7 +4605,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4157,7 +4619,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4176,7 +4640,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4191,7 +4657,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4203,7 +4671,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4227,7 +4697,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4248,7 +4720,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4263,7 +4737,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4275,7 +4751,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4299,7 +4777,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4320,7 +4800,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4335,7 +4817,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4347,7 +4831,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4371,7 +4857,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4392,7 +4880,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4407,7 +4897,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4419,7 +4911,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4442,7 +4936,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4463,7 +4959,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4478,7 +4976,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4490,7 +4990,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4514,7 +5016,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 2000.0,
@@ -4536,7 +5040,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4551,7 +5057,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4563,7 +5071,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -4588,7 +5098,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -4611,7 +5123,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_content_length@byte",
+        name: MetricName(
+            "d:spans/http.response_content_length@byte",
+        ),
         value: Distribution(
             [
                 36170.0,
@@ -4634,7 +5148,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.decoded_response_content_length@byte",
+        name: MetricName(
+            "d:spans/http.decoded_response_content_length@byte",
+        ),
         value: Distribution(
             [
                 128950.0,
@@ -4656,7 +5172,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/http.response_transfer_size@byte",
+        name: MetricName(
+            "d:spans/http.response_transfer_size@byte",
+        ),
         value: Distribution(
             [
                 36470.0,
@@ -4678,7 +5196,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4693,7 +5213,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4705,7 +5227,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -4727,7 +5251,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 477.800131,
@@ -4747,7 +5273,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1694732408),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4762,7 +5290,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1702474613),
         width: 0,
-        name: "c:spans/usage@none",
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
         value: Counter(
             1.0,
         ),
@@ -4774,7 +5304,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1702474613),
         width: 0,
-        name: "d:spans/exclusive_time@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
         value: Distribution(
             [
                 32.000065,
@@ -4793,7 +5325,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1702474613),
         width: 0,
-        name: "d:spans/exclusive_time_light@millisecond",
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
         value: Distribution(
             [
                 32.000065,
@@ -4811,7 +5345,9 @@ expression: metrics
     Bucket {
         timestamp: UnixTimestamp(1702474613),
         width: 0,
-        name: "c:spans/count_per_op@none",
+        name: MetricName(
+            "c:spans/count_per_op@none",
+        ),
         value: Counter(
             1.0,
         ),

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -425,7 +425,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1619420400),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -437,7 +439,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1619420400),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     59000.0,
@@ -454,7 +458,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1619420400),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -468,7 +474,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1619420400),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -483,7 +491,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976302),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -495,7 +505,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976302),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     2000.0,
@@ -519,7 +531,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976302),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     2000.0,
@@ -539,7 +553,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976302),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -554,7 +570,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976302),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -569,7 +587,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -581,7 +601,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -604,7 +626,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -623,7 +647,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -637,7 +663,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -652,7 +680,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -664,7 +694,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -690,7 +722,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -712,7 +746,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -727,7 +763,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -742,7 +780,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/duration@millisecond",
+            name: MetricName(
+                "d:spans/duration@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -765,7 +805,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -777,7 +819,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -794,7 +838,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -808,7 +854,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -823,7 +871,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -835,7 +885,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -860,7 +912,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -881,7 +935,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -895,7 +951,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -910,7 +968,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -922,7 +982,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -947,7 +1009,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -968,7 +1032,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -982,7 +1048,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -997,7 +1065,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -1009,7 +1079,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -1034,7 +1106,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -1055,7 +1129,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -1069,7 +1145,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -1084,7 +1162,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/usage@none",
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -1096,7 +1176,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -1119,7 +1201,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "d:spans/exclusive_time_light@millisecond",
+            name: MetricName(
+                "d:spans/exclusive_time_light@millisecond",
+            ),
             value: Distribution(
                 [
                     3000.0,
@@ -1138,7 +1222,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_op@none",
+            name: MetricName(
+                "c:spans/count_per_op@none",
+            ),
             value: Counter(
                 1.0,
             ),
@@ -1152,7 +1238,9 @@ expression: "(&event.value().unwrap().spans, metrics)"
         Bucket {
             timestamp: UnixTimestamp(1597976303),
             width: 0,
-            name: "c:spans/count_per_segment@none",
+            name: MetricName(
+                "c:spans/count_per_segment@none",
+            ),
             value: Counter(
                 1.0,
             ),

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -670,7 +670,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.foo@none",
+                name: MetricName(
+                    "d:transactions/measurements.foo@none",
+                ),
                 value: Distribution(
                     [
                         420.69,
@@ -697,7 +699,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.lcp@millisecond",
+                name: MetricName(
+                    "d:transactions/measurements.lcp@millisecond",
+                ),
                 value: Distribution(
                     [
                         3000.0,
@@ -725,7 +729,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.score.lcp@ratio",
+                name: MetricName(
+                    "d:transactions/measurements.score.lcp@ratio",
+                ),
                 value: Distribution(
                     [
                         0.0,
@@ -747,7 +753,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.score.total@ratio",
+                name: MetricName(
+                    "d:transactions/measurements.score.total@ratio",
+                ),
                 value: Distribution(
                     [
                         0.0,
@@ -769,7 +777,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.score.weight.lcp@ratio",
+                name: MetricName(
+                    "d:transactions/measurements.score.weight.lcp@ratio",
+                ),
                 value: Distribution(
                     [
                         1.0,
@@ -791,7 +801,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond",
+                name: MetricName(
+                    "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond",
+                ),
                 value: Distribution(
                     [
                         2000.0,
@@ -818,7 +830,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "c:transactions/usage@none",
+                name: MetricName(
+                    "c:transactions/usage@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -830,7 +844,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration@millisecond",
+                name: MetricName(
+                    "d:transactions/duration@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -857,7 +873,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration_light@millisecond",
+                name: MetricName(
+                    "d:transactions/duration_light@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -874,7 +892,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "s:transactions/user@none",
+                name: MetricName(
+                    "s:transactions/user@none",
+                ),
                 value: Set(
                     {
                         933084975,
@@ -942,7 +962,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.fcp@millisecond",
+                name: MetricName(
+                    "d:transactions/measurements.fcp@millisecond",
+                ),
                 value: Distribution(
                     [
                         1.1,
@@ -961,7 +983,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.foo@none",
+                name: MetricName(
+                    "d:transactions/measurements.foo@none",
+                ),
                 value: Distribution(
                     [
                         8.8,
@@ -979,7 +1003,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.stall_count@none",
+                name: MetricName(
+                    "d:transactions/measurements.stall_count@none",
+                ),
                 value: Distribution(
                     [
                         3.3,
@@ -997,7 +1023,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "c:transactions/usage@none",
+                name: MetricName(
+                    "c:transactions/usage@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -1009,7 +1037,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration@millisecond",
+                name: MetricName(
+                    "d:transactions/duration@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -1027,7 +1057,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration_light@millisecond",
+                name: MetricName(
+                    "d:transactions/duration_light@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -1081,7 +1113,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.fcp@second",
+                name: MetricName(
+                    "d:transactions/measurements.fcp@second",
+                ),
                 value: Distribution(
                     [
                         1.1,
@@ -1100,7 +1134,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/measurements.lcp@none",
+                name: MetricName(
+                    "d:transactions/measurements.lcp@none",
+                ),
                 value: Distribution(
                     [
                         2.2,
@@ -1119,7 +1155,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "c:transactions/usage@none",
+                name: MetricName(
+                    "c:transactions/usage@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -1131,7 +1169,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration@millisecond",
+                name: MetricName(
+                    "d:transactions/duration@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -1149,7 +1189,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration_light@millisecond",
+                name: MetricName(
+                    "d:transactions/duration_light@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -1277,7 +1319,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/measurements.a_custom1@none",
+                name: MetricName(
+                    "d:transactions/measurements.a_custom1@none",
+                ),
                 value: Distribution(
                     [
                         41.0,
@@ -1295,7 +1339,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/measurements.fcp@millisecond",
+                name: MetricName(
+                    "d:transactions/measurements.fcp@millisecond",
+                ),
                 value: Distribution(
                     [
                         0.123,
@@ -1314,7 +1360,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/measurements.g_custom2@second",
+                name: MetricName(
+                    "d:transactions/measurements.g_custom2@second",
+                ),
                 value: Distribution(
                     [
                         42.0,
@@ -1332,7 +1380,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "c:transactions/usage@none",
+                name: MetricName(
+                    "c:transactions/usage@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -1344,7 +1394,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/duration@millisecond",
+                name: MetricName(
+                    "d:transactions/duration@millisecond",
+                ),
                 value: Distribution(
                     [
                         2000.0,
@@ -1362,7 +1414,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/duration_light@millisecond",
+                name: MetricName(
+                    "d:transactions/duration_light@millisecond",
+                ),
                 value: Distribution(
                     [
                         2000.0,
@@ -1513,7 +1567,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "c:transactions/usage@none",
+                name: MetricName(
+                    "c:transactions/usage@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -1525,7 +1581,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration@millisecond",
+                name: MetricName(
+                    "d:transactions/duration@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -1543,7 +1601,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "d:transactions/duration_light@millisecond",
+                name: MetricName(
+                    "d:transactions/duration_light@millisecond",
+                ),
                 value: Distribution(
                     [
                         59000.0,
@@ -1671,7 +1731,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420400),
                 width: 0,
-                name: "c:transactions/count_per_root_project@none",
+                name: MetricName(
+                    "c:transactions/count_per_root_project@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -1938,16 +2000,36 @@ mod tests {
 
         insta::assert_debug_snapshot!(metrics_names, @r###"
         [
-            "d:transactions/measurements.frames_frozen@none",
-            "d:transactions/measurements.frames_frozen_rate@ratio",
-            "d:transactions/measurements.frames_slow@none",
-            "d:transactions/measurements.frames_slow_rate@ratio",
-            "d:transactions/measurements.frames_total@none",
-            "d:transactions/measurements.stall_percentage@ratio",
-            "d:transactions/measurements.stall_total_time@millisecond",
-            "c:transactions/usage@none",
-            "d:transactions/duration@millisecond",
-            "d:transactions/duration_light@millisecond",
+            MetricName(
+                "d:transactions/measurements.frames_frozen@none",
+            ),
+            MetricName(
+                "d:transactions/measurements.frames_frozen_rate@ratio",
+            ),
+            MetricName(
+                "d:transactions/measurements.frames_slow@none",
+            ),
+            MetricName(
+                "d:transactions/measurements.frames_slow_rate@ratio",
+            ),
+            MetricName(
+                "d:transactions/measurements.frames_total@none",
+            ),
+            MetricName(
+                "d:transactions/measurements.stall_percentage@ratio",
+            ),
+            MetricName(
+                "d:transactions/measurements.stall_total_time@millisecond",
+            ),
+            MetricName(
+                "c:transactions/usage@none",
+            ),
+            MetricName(
+                "d:transactions/duration@millisecond",
+            ),
+            MetricName(
+                "d:transactions/duration_light@millisecond",
+            ),
         ]
         "###);
     }
@@ -2009,7 +2091,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/measurements.lcp@millisecond",
+                name: MetricName(
+                    "d:transactions/measurements.lcp@millisecond",
+                ),
                 value: Distribution(
                     [
                         41.0,
@@ -2026,7 +2110,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "c:transactions/usage@none",
+                name: MetricName(
+                    "c:transactions/usage@none",
+                ),
                 value: Counter(
                     1.0,
                 ),
@@ -2038,7 +2124,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/duration@millisecond",
+                name: MetricName(
+                    "d:transactions/duration@millisecond",
+                ),
                 value: Distribution(
                     [
                         2000.0,
@@ -2055,7 +2143,9 @@ mod tests {
             Bucket {
                 timestamp: UnixTimestamp(1619420402),
                 width: 0,
-                name: "d:transactions/duration_light@millisecond",
+                name: MetricName(
+                    "d:transactions/duration_light@millisecond",
+                ),
                 value: Distribution(
                     [
                         2000.0,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2005,7 +2005,7 @@ impl EnvelopeProcessorService {
 
         let buckets_by_ns: HashMap<MetricNamespace, Vec<Bucket>> = buckets
             .into_iter()
-            .filter_map(|bucket| Some((bucket.parse_namespace().ok()?, bucket)))
+            .filter_map(|bucket| Some((bucket.name.try_namespace()?, bucket)))
             .into_group_map();
 
         buckets_by_ns

--- a/relay-server/src/utils/bucket_encoding.rs
+++ b/relay-server/src/utils/bucket_encoding.rs
@@ -1,9 +1,7 @@
 use std::io;
 
 use relay_dynamic_config::{BucketEncoding, GlobalConfig};
-use relay_metrics::{
-    Bucket, BucketValue, FiniteF64, MetricNamespace, MetricResourceIdentifier, SetView,
-};
+use relay_metrics::{Bucket, BucketValue, FiniteF64, MetricNamespace, SetView};
 use serde::Serialize;
 
 static BASE64: data_encoding::Encoding = data_encoding::BASE64;
@@ -30,9 +28,7 @@ impl<'a> BucketEncoder<'a> {
     /// afterwards the bucket can be split into multiple smaller views
     /// and encoded one by one.
     pub fn prepare(&self, bucket: &mut Bucket) -> MetricNamespace {
-        let namespace = MetricResourceIdentifier::parse(&bucket.name)
-            .map(|mri| mri.namespace)
-            .unwrap_or(MetricNamespace::Unsupported);
+        let namespace = bucket.name.namespace();
 
         if let BucketValue::Distribution(ref mut distribution) = bucket.value {
             let enc = self.global_config.options.metric_bucket_dist_encodings;


### PR DESCRIPTION
Wrap the metric name in a newtype and allow easy and fast access to the namespace instead of always re-parsing with `MetricResourceIdentifier`.

#skip-changelog