### PR TITLE
fix(csp): Add `reports+json` content type support

### DIFF
--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -84,6 +84,7 @@ fn is_security_mime(mime: Mime) -> bool {
             | ("application", "expect-ct-report", None)
             | ("application", "expect-ct-report", Some("json"))
             | ("application", "expect-staple-report", None)
+            | ("application", "reports", Some("json"))
     )
 }
 

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -146,7 +146,7 @@ def test_csp_violation_reports_with_processing(
 
     relay.send_security_report(
         project_id=proj_id,
-        content_type="application/json; charset=utf-8",
+        content_type="application/reports+json; charset=utf-8",
         payload=reports,
         release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
         environment="production",


### PR DESCRIPTION
Reporting API uses `application/reports+json` content type. So the `csp-report` endpoint should support it for us to be able to ingest new `csp-violation` type.

Followup for https://github.com/getsentry/relay/pull/3277

Prerequisite for https://github.com/getsentry/sentry-docs/pull/9514

#skip-changelog