### PR TITLE
feat(inbound filters): Add googletag browser extension filter

### DIFF
--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -44,7 +44,7 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         # Firefox message when an extension tries to modify a no-longer-existing DOM node
         # See https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/
         can't\saccess\sdead\sobject|
-        # Crypocurrency related extension errors solana|ethereum
+        # Cryptocurrency related extension errors solana|ethereum
         # Googletag is also very similar, caused by adblockers
         Cannot\sredefine\sproperty:\s(solana|ethereum|googletag)|
         # Translation service errors in Chrome on iOS

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -44,8 +44,9 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         # Firefox message when an extension tries to modify a no-longer-existing DOM node
         # See https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/
         can't\saccess\sdead\sobject|
-        # Crypocurrency related extension errors
-        Cannot\sredefine\sproperty:\s(solana|ethereum)|
+        # Crypocurrency related extension errors solana|ethereum
+        # Googletag is also very similar, caused by adblockers
+        Cannot\sredefine\sproperty:\s(solana|ethereum|googletag)|
         # Translation service errors in Chrome on iOS
         undefined\sis\snot\san\sobject\s\(evaluating\s'a.L'\)
     "#,
@@ -266,6 +267,7 @@ mod tests {
             "TypeError: can't access dead object because dead stuff smells bad",
             "Cannot redefine property: solana",
             "Cannot redefine property: ethereum",
+            "Cannot redefine property: googletag",
             "undefined is not an object (evaluating 'a.L')",
         ];
 


### PR DESCRIPTION
An error similar to the solana/ethereum filter in #3231. This PR adds `Cannot redefine property: googletag` which is caused by adblockers injecting their own object into the page.

I've added a few redash queries to this notion doc https://www.notion.so/sentry/Cannot-redefine-property-googletag-13e1569e1ac54bb6b5731691222a7bc7

here's an example issue from the docs project https://sentry.sentry.io/issues/4814129167/

#skip-changelog