### PR TITLE
chore(csp): Filter out unsupported report types

### DIFF
--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -1130,6 +1130,7 @@ pub enum SecurityReportType {
     ExpectCt,
     ExpectStaple,
     Hpkp,
+    Unsupported,
 }
 
 impl SecurityReportType {
@@ -1155,6 +1156,8 @@ impl SecurityReportType {
             Some(SecurityReportType::Csp)
         } else if let Some(CspViolationType::CspViolation) = helper.ty {
             Some(SecurityReportType::Csp)
+        } else if let Some(CspViolationType::Other) = helper.ty {
+            Some(SecurityReportType::Unsupported)
         } else if helper.known_pins.is_some() {
             Some(SecurityReportType::Hpkp)
         } else if helper.expect_staple_report.is_some() {

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -189,13 +189,13 @@ struct CspRaw {
     effective_directive: Option<String>,
     #[serde(
         default = "CspRaw::default_blocked_uri",
-        alias = "blockedUrl",
+        alias = "blockedURL",
         alias = "blocked-uri"
     )]
     blocked_uri: String,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        alias = "documentUrl",
+        alias = "documentURL",
         alias = "document-uri"
     )]
     document_uri: Option<String>,

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -59,11 +59,9 @@ impl SecurityReportParams {
 
         if let Ok(items) = variant {
             for item in items {
-                let data = Bytes::from(item.to_owned().to_string());
-                if is_supported_type(&data) {
-                    let report_item = Self::create_security_item(&query, data);
-                    envelope.add_item(report_item);
-                }
+                let report_item =
+                    Self::create_security_item(&query, Bytes::from(item.to_owned().to_string()));
+                envelope.add_item(report_item);
             }
         } else {
             let report_item = Self::create_security_item(&query, body);
@@ -72,21 +70,6 @@ impl SecurityReportParams {
 
         Ok(envelope)
     }
-}
-
-/// Check if the report type is supported.
-///
-/// Note: use only for the reports sent through the Reporting Api.
-fn is_supported_type(data: &[u8]) -> bool {
-    #[derive(Deserialize)]
-    #[serde(rename_all = "kebab-case")]
-    #[serde(tag = "type")]
-    enum SecurityReportVariant {
-        CspViolation,
-    }
-
-    let helper: Option<SecurityReportVariant> = serde_json::from_slice(data).ok();
-    helper.is_some()
 }
 
 fn is_security_mime(mime: Mime) -> bool {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -413,6 +413,9 @@ pub enum ProcessingError {
     #[error("invalid security report type: {0:?}")]
     InvalidSecurityType(Bytes),
 
+    #[error("unsupported security report type")]
+    UnsupportedSecurityType,
+
     #[error("invalid security report")]
     InvalidSecurityReport(#[source] serde_json::Error),
 
@@ -453,6 +456,7 @@ impl ProcessingError {
                 Some(Outcome::Invalid(DiscardReason::SecurityReportType))
             }
             Self::InvalidSecurityReport(_) => Some(Outcome::Invalid(DiscardReason::SecurityReport)),
+            Self::UnsupportedSecurityType => Some(Outcome::Filtered(FilterStatKey::InvalidCsp)),
             Self::InvalidNelReport(_) => Some(Outcome::Invalid(DiscardReason::InvalidJson)),
             Self::InvalidTransaction => Some(Outcome::Invalid(DiscardReason::InvalidTransaction)),
             Self::InvalidTimestamp => Some(Outcome::Invalid(DiscardReason::Timestamp)),

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -558,11 +558,7 @@ fn event_from_security_report(
             EventType::ExpectStaple,
         ),
         SecurityReportType::Hpkp => (Hpkp::apply_to_event(data, &mut event), EventType::Hpkp),
-        SecurityReportType::Unsupported => {
-            return Err(ProcessingError::EventFiltered(
-                relay_filter::FilterStatKey::InvalidCsp,
-            ))
-        }
+        SecurityReportType::Unsupported => return Err(ProcessingError::UnsupportedSecurityType),
     };
 
     if let Err(json_error) = apply_result {

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -547,11 +547,22 @@ fn event_from_security_report(
         return Err(ProcessingError::InvalidSecurityType(bytes));
     };
 
-    let apply_result = match report_type {
-        SecurityReportType::Csp => Csp::apply_to_event(data, &mut event),
-        SecurityReportType::ExpectCt => ExpectCt::apply_to_event(data, &mut event),
-        SecurityReportType::ExpectStaple => ExpectStaple::apply_to_event(data, &mut event),
-        SecurityReportType::Hpkp => Hpkp::apply_to_event(data, &mut event),
+    let (apply_result, event_type) = match report_type {
+        SecurityReportType::Csp => (Csp::apply_to_event(data, &mut event), EventType::Csp),
+        SecurityReportType::ExpectCt => (
+            ExpectCt::apply_to_event(data, &mut event),
+            EventType::ExpectCt,
+        ),
+        SecurityReportType::ExpectStaple => (
+            ExpectStaple::apply_to_event(data, &mut event),
+            EventType::ExpectStaple,
+        ),
+        SecurityReportType::Hpkp => (Hpkp::apply_to_event(data, &mut event), EventType::Hpkp),
+        SecurityReportType::Unsupported => {
+            return Err(ProcessingError::EventFiltered(
+                relay_filter::FilterStatKey::InvalidCsp,
+            ))
+        }
     };
 
     if let Err(json_error) = apply_result {
@@ -585,12 +596,7 @@ fn event_from_security_report(
 
     // Explicitly set the event type. This is required so that a `Security` item can be created
     // instead of a regular `Event` item.
-    event.ty = Annotated::new(match report_type {
-        SecurityReportType::Csp => EventType::Csp,
-        SecurityReportType::ExpectCt => EventType::ExpectCt,
-        SecurityReportType::ExpectStaple => EventType::ExpectStaple,
-        SecurityReportType::Hpkp => EventType::Hpkp,
-    });
+    event.ty = Annotated::new(event_type);
 
     Ok((Annotated::new(event), len))
 }

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -103,10 +103,12 @@ pub fn extract<G: EventProcessing>(
         relay_log::trace!("processing security report");
         sample_rates = item.take_sample_rates();
         event_from_security_report(item, envelope.meta()).map_err(|error| {
-            relay_log::error!(
-                error = &error as &dyn Error,
-                "failed to extract security report"
-            );
+            if !matches!(error, ProcessingError::UnsupportedSecurityType) {
+                relay_log::error!(
+                    error = &error as &dyn Error,
+                    "failed to extract security report"
+                );
+            }
             error
         })?
     } else if let Some(item) = nel_item {

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -210,26 +210,17 @@ def test_deprication_reports_with_processing(
         },
     ]
 
-    try:
-        relay.send_security_report(
-            project_id=proj_id,
-            content_type="application/reports+json; charset=utf-8",
-            payload=reports,
-            release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
-            environment="production",
-        )
+    relay.send_security_report(
+        project_id=proj_id,
+        content_type="application/reports+json; charset=utf-8",
+        payload=reports,
+        release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
+        environment="production",
+    )
 
-        events = []
-        event, _ = events_consumer.get_event()
-        events.append(event)
-
-        # We will discard the unsupported "deprecation" report type.
-        assert len(mini_sentry.test_failures) > 0
-        assert {str(e) for _, e in mini_sentry.test_failures} == {
-            "Relay sent us event: failed to extract security report: unsupported security report type",
-        }
-    finally:
-        mini_sentry.test_failures.clear()
+    events = []
+    event, _ = events_consumer.get_event()
+    events.append(event)
 
     events_consumer.assert_empty()
     assert len(events), 1

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -226,8 +226,7 @@ def test_deprication_reports_with_processing(
         # We will discard the unsupported "deprecation" report type.
         assert len(mini_sentry.test_failures) > 0
         assert {str(e) for _, e in mini_sentry.test_failures} == {
-            "Relay sent us event: failed to extract security report: event filtered with reason: InvalidCsp",
-            "Relay sent us event: dropped envelope: internal error",
+            "Relay sent us event: failed to extract security report: unsupported security report type",
         }
     finally:
         mini_sentry.test_failures.clear()

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -210,17 +210,27 @@ def test_deprication_reports_with_processing(
         },
     ]
 
-    relay.send_security_report(
-        project_id=proj_id,
-        content_type="application/reports+json; charset=utf-8",
-        payload=reports,
-        release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
-        environment="production",
-    )
+    try:
+        relay.send_security_report(
+            project_id=proj_id,
+            content_type="application/reports+json; charset=utf-8",
+            payload=reports,
+            release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
+            environment="production",
+        )
 
-    events = []
-    event, _ = events_consumer.get_event()
-    events.append(event)
+        events = []
+        event, _ = events_consumer.get_event()
+        events.append(event)
+
+        # We will discard the unsupported "deprecation" report type.
+        assert len(mini_sentry.test_failures) > 0
+        assert {str(e) for _, e in mini_sentry.test_failures} == {
+            "Relay sent us event: failed to extract security report: event filtered with reason: InvalidCsp",
+            "Relay sent us event: dropped envelope: internal error",
+        }
+    finally:
+        mini_sentry.test_failures.clear()
 
     events_consumer.assert_empty()
     assert len(events), 1

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -157,9 +157,73 @@ def test_csp_violation_reports_with_processing(
     events.append(event)
     event, _ = events_consumer.get_event()
     events.append(event)
-    events_consumer.assert_empty()
 
+    events_consumer.assert_empty()
+    assert len(events), 2
     assert any(d for d in events if d["csp"]["disposition"] == "enforce")
+    assert any(d for d in events if d["csp"]["disposition"] == "report")
+
+
+def test_deprication_reports_with_processing(
+    mini_sentry,
+    relay_with_processing,
+    events_consumer,
+):
+    # UA parsing introduces higher latency in debug mode
+    events_consumer = events_consumer(timeout=10)
+
+    proj_id = 42
+    relay = relay_with_processing()
+    mini_sentry.add_full_project_config(proj_id)
+
+    reports = [
+        {
+            "age": 0,
+            "body": {
+                "blockedURL": "https://example.com/tst/media/7_del.png",
+                "disposition": "report",
+                "documentURL": "https://example.com/tst/test_frame.php?ID=229&hash=da964209653e467d337313e51876e27d",
+                "effectiveDirective": "img-src",
+                "lineNumber": 9,
+                "originalPolicy": "default-src 'none'; report-to endpoint-csp;",
+                "referrer": "https://example.com/test229/",
+                "sourceFile": "https://example.com/tst/test_frame.php?ID=229&hash=da964209653e467d337313e51876e27d",
+                "statusCode": 0,
+            },
+            "type": "csp-violation",
+            "url": "https://example.com/tst/test_frame.php?ID=229&hash=da964209653e467d337313e51876e27d",
+            "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+        },
+        {
+            "type": "deprecation",
+            "age": 10,
+            "url": "https://example.com/",
+            "user_agent": "BarBrowser/98.0 (Mozilla/5.0 compatiblish)",
+            "body": {
+                "id": "websql",
+                "anticipatedRemoval": "1/1/2020",
+                "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
+                "sourceFile": "https://example.com/index.js",
+                "lineNumber": 1234,
+                "columnNumber": 42,
+            },
+        },
+    ]
+
+    relay.send_security_report(
+        project_id=proj_id,
+        content_type="application/reports+json; charset=utf-8",
+        payload=reports,
+        release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
+        environment="production",
+    )
+
+    events = []
+    event, _ = events_consumer.get_event()
+    events.append(event)
+
+    events_consumer.assert_empty()
+    assert len(events), 1
     assert any(d for d in events if d["csp"]["disposition"] == "report")
 
 


### PR DESCRIPTION
In case if the default report group defined and used for CSP reports (with Reporting Api), browser also will use that group for sending `deprecation` [reports](https://wicg.github.io/deprecation-reporting/), which we do not support and should filter them out. 

followup for #3293 #3277 

#skip-changelog