### PR TITLE
instr(server): topic name as tag

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -519,7 +519,8 @@ impl StoreService {
     ) -> Result<(), StoreError> {
         relay_log::trace!("Sending kafka message of type {}", message.variant());
 
-        self.producer
+        let topic_name = self
+            .producer
             .client
             .send_message(topic, organization_id, &message)?;
 
@@ -530,6 +531,7 @@ impl StoreService {
                 metric!(
                     counter(RelayCounters::ProcessingMessageProduced) += 1,
                     event_type = message.variant(),
+                    topic = topic_name,
                     metric_type = metric.value.variant(),
                     metric_encoding = metric.value.encoding().unwrap_or(""),
                 );
@@ -542,9 +544,11 @@ impl StoreService {
                 metric!(
                     counter(RelayCounters::ProcessingMessageProduced) += 1,
                     event_type = message.variant(),
+                    topic = topic_name,
                     platform = platform.unwrap_or(&""),
                     is_segment = bool_to_str(is_segment),
                     has_parent = bool_to_str(has_parent),
+                    topic = topic_name,
                 );
             }
             KafkaMessage::ReplayRecordingNotChunked(replay) => {
@@ -553,6 +557,7 @@ impl StoreService {
                 metric!(
                     counter(RelayCounters::ProcessingMessageProduced) += 1,
                     event_type = message.variant(),
+                    topic = topic_name,
                     has_video = bool_to_str(has_video),
                 );
             }
@@ -560,6 +565,7 @@ impl StoreService {
                 metric!(
                     counter(RelayCounters::ProcessingMessageProduced) += 1,
                     event_type = message.variant(),
+                    topic = topic_name,
                 );
             }
         }


### PR DESCRIPTION
This will allow us to match `ProcessingMessageProduced` and `ProcessingProduceError` by topic. Neither the `event_type` nor the `KafkaTopic` type match the actual topic name 1:1, because the `ShardedProducer` can have multiple topic names for a single `KafkaTopic`.

#skip-changelog