### PR TITLE
feat(profiles): Add a new category to count profile chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 **Internal**:
 
 - Enable `db.redis` span metrics extraction. ([#3283](https://github.com/getsentry/relay/pull/3283))
-- Add a data category for continuous profiling. ([#3284](https://github.com/getsentry/relay/pull/3284))
+- Add data categories for continuous profiling. ([#3284](https://github.com/getsentry/relay/pull/3284), [#3303](https://github.com/getsentry/relay/pull/3303))
 - Apply rate limits to span metrics. ([#3255](https://github.com/getsentry/relay/pull/3255))
 - Extract metrics from transaction spans. ([#3273](https://github.com/getsentry/relay/pull/3273))
 - Implement volume metric stats. ([#3281](https://github.com/getsentry/relay/pull/3281))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.52
 
-- Add a data category for continuous profiling. ([#3284](https://github.com/getsentry/relay/pull/3284))
+- Add a data categories for continuous profiling. ([#3284](https://github.com/getsentry/relay/pull/3284),[#3303](https://github.com/getsentry/relay/pull/3303))
 
 ## 0.8.50
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add a data category for profile chunks. [#3303](https://github.com/getsentry/relay/pull/3303))
+
 ## 0.8.52
 
-- Add a data categories for continuous profiling. ([#3284](https://github.com/getsentry/relay/pull/3284),[#3303](https://github.com/getsentry/relay/pull/3303))
+- Add a data category for profile duration. ([#3284](https://github.com/getsentry/relay/pull/3284))
 
 ## 0.8.50
 

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -27,6 +27,7 @@ class DataCategory(IntEnum):
     METRIC_BUCKET = 15
     SPAN_INDEXED = 16
     PROFILE_DURATION = 17
+    PROFILE_CHUNK = 18
     UNKNOWN = -1
     # end generated
 

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -74,6 +74,11 @@ pub enum DataCategory {
     /// This data category is used to count the number of milliseconds we have per indexed profile chunk.
     /// We will then bill per second.
     ProfileDuration = 17,
+    /// ProfileChunk
+    ///
+    /// This is a count of profile chunks received. It will not be used for billing but will be
+    /// useful for customers to track what's being dropped.
+    ProfileChunk = 18,
     //
     // IMPORTANT: After adding a new entry to DataCategory, go to the `relay-cabi` subfolder and run
     // `make header` to regenerate the C-binding. This allows using the data category from Python.
@@ -107,6 +112,7 @@ impl DataCategory {
             "metric_bucket" => Self::MetricBucket,
             "span_indexed" => Self::SpanIndexed,
             "profile_duration" => Self::ProfileDuration,
+            "profile_chunk" => Self::ProfileChunk,
             _ => Self::Unknown,
         }
     }
@@ -133,6 +139,7 @@ impl DataCategory {
             Self::MetricBucket => "metric_bucket",
             Self::SpanIndexed => "span_indexed",
             Self::ProfileDuration => "profile_duration",
+            Self::ProfileChunk => "profile_chunk",
             Self::Unknown => "unknown",
         }
     }

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -114,6 +114,13 @@ enum RelayDataCategory {
    */
   RELAY_DATA_CATEGORY_PROFILE_DURATION = 17,
   /**
+   * ProfileChunk
+   *
+   * This is a count of profile chunks received. It will not be used for billing but will be
+   * useful for customers to track what's being dropped.
+   */
+  RELAY_DATA_CATEGORY_PROFILE_CHUNK = 18,
+  /**
    * Any other data category not known by this Relay.
    */
   RELAY_DATA_CATEGORY_UNKNOWN = -1,

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -120,7 +120,8 @@ impl CategoryUnit {
             | DataCategory::MonitorSeat
             | DataCategory::Monitor
             | DataCategory::MetricBucket
-            | DataCategory::UserReportV2 => Some(Self::Count),
+            | DataCategory::UserReportV2
+            | DataCategory::ProfileChunk => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
             DataCategory::Session => Some(Self::Batched),
             DataCategory::ProfileDuration => Some(Self::Milliseconds),


### PR DESCRIPTION
We can't track invalid profile chunks' duration because we might not be able to parse them and it's expensive in case they need to be rate-limited but we still want to track invalid outcomes for them.

The plan is to add this data category and record outcomes by count on top of the duration.