### PR TITLE
build: Migrate all dependencies to workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,6 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -5555,7 +5554,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.3",
  "tokio-macros",
- "tracing",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,30 +17,161 @@ debug = true
 dbg_macro = "warn"
 
 [workspace.dependencies]
+relay-auth = { path = "relay-auth" }
+relay-aws-extension = { path = "relay-aws-extension" }
+relay-base-schema = { path = "relay-base-schema" }
+relay-cardinality = { path = "relay-cardinality" }
+relay-cogs = { path = "relay-cogs" }
+relay-common = { path = "relay-common" }
+relay-config = { path = "relay-config" }
+relay-crash = { path = "relay-crash" }
+relay-dynamic-config = { path = "relay-dynamic-config" }
+relay-event-normalization = { path = "relay-event-normalization" }
+relay-event-schema = { path = "relay-event-schema" }
+relay-ffi = { path = "relay-ffi" }
+relay-ffi-macros = { path = "relay-ffi-macros" }
+relay-filter = { path = "relay-filter" }
+relay-kafka = { path = "relay-kafka" }
+relay-log = { path = "relay-log" }
+relay-metrics = { path = "relay-metrics" }
+relay-monitors = { path = "relay-monitors" }
+relay-pii = { path = "relay-pii" }
+relay-profiling = { path = "relay-profiling" }
+relay-protocol = { path = "relay-protocol" }
+relay-quotas = { path = "relay-quotas" }
+relay-redis = { path = "relay-redis" }
+relay-replays = { path = "relay-replays" }
+relay-sampling = { path = "relay-sampling" }
+relay-server = { path = "relay-server" }
+relay-spans = { path = "relay-spans" }
+relay-statsd = { path = "relay-statsd" }
+relay-system = { path = "relay-system" }
+relay-ua = { path = "relay-ua" }
+relay-test = { path = "relay-test" }
+relay-protocol-derive = { path = "relay-protocol-derive" }
+relay-event-derive = { path = "relay-event-derive" }
+relay-jsonschema-derive = { path = "relay-jsonschema-derive" }
+
+android_trace_log = { version = "0.3.0", features = ["serde"] }
+ansi-to-html = "0.1.3"
 anyhow = "1.0.66"
-chrono = { version = "0.4.31", default-features = false, features = [
-    "std",
-    "serde",
-] }
+assert-json-diff = "2.0.2"
+axum = "0.6.20"
+axum-extra = "0.7.7"
+axum-server = "0.4.7"
+backoff = "0.4.0"
+bindgen = "0.64.0"
+brotli = "3.3.4"
+bytecount = "0.6.0"
+bytes = "1.4.0"
+cadence = "0.29.0"
+chrono = { version = "0.4.31", default-features = false, features = ["std", "serde"] }
 clap = { version = "4.4.6" }
+clap_complete = "4.1.1"
+cmake = "0.1.46"
+console = "0.15.5"
+cookie = "0.17.0"
 criterion = "0.5"
+crossbeam-channel = "0.5.6"
+data-encoding = "2.5.0"
+debugid = "0.8.0"
+dialoguer = "0.10.0"
+dynfmt = "0.1.4"
+ed25519-dalek = "2.0.0"
+enumset = "1.0.4"
+flate2 = "1.0.19"
+fnv = "1.0.7"
 futures = { version = "0.3", default-features = false, features = ["std"] }
-insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
+globset = "0.4.5"
+gloo-console = "0.3.0"
+gloo-net = "0.4.0"
 hash32 = "0.3.1"
 hashbrown = "0.14.3"
+hex = "0.4.3"
+hmac = "0.12.1"
+hostname = "0.3.1"
+human-size = "0.4.1"
 indexmap = "2.2.5"
+insta = { version = "1.31.0", features = ["json", "redactions", "ron"] }
+instant = "0.1.12"
+ipnetwork = "0.20.0"
 itertools = "0.10.5"
+json-forensics = "0.1.1"
+lru = "0.9.0"
+maxminddb = "0.23.0"
+md5 = "0.7.0"
+mime = "0.3.16"
+mime_guess = "2.0.4"
+minidump = "0.15.2"
+multer = "2.0.4"
+num-traits = "0.2.12"
+num_cpus = "1.13.0"
 once_cell = "1.13.1"
+opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"}
 parking_lot = "0.12.1"
+path-slash = "0.2.1"
+pest = "2.1.3"
+pest_derive = "2.1.0"
+pretty-hex = "0.3.0"
+proc-macro2 = "1.0.8"
+quote = "1.0.2"
+r2d2 = "0.8.10"
 rand = "0.8.5"
+rand_pcg = "0.3.1"
+rdkafka = "0.29.0"
+rdkafka-sys = "4.3.0"
+redis = "0.23.1"
 regex = "1.10.2"
-serde = { version = "1.0.159", features = ["derive", "rc"] }
-serde_json = "1.0.93"
-serde_yaml = "0.9.17"
+reqwasm = "0.5.0"
+reqwest = "0.11.1"
+rmp-serde = "1.1.1"
+rust-embed = "8.0.0"
 schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }
+sentry = "0.31.7"
+sentry-core = "0.31.7"
+sentry-kafka-schemas = { version = "0.1.64", default-features = false }
+sentry-release-parser = { version = "1.3.2", default-features = false }
+sentry-types = "0.31.3"
+sentry_usage_accountant = { version = "0.1.0", default-features = false }
+serde = { version = "1.0.159", features = ["derive", "rc"] }
+serde-transcode = "1.1.1"
+serde_bytes = "0.11"
+serde_json = "1.0.93"
+serde_path_to_error = "0.1.14"
+serde_repr = "0.1.16"
+serde_test = "1.0.125"
+serde_urlencoded = "0.7.1"
+serde_yaml = "0.9.17"
+sha1 = "0.10.5"
+sha2 = "0.10.6"
 similar-asserts = "1.4.2"
 smallvec = { version = "1.11.2", features = ["serde"] }
+sqlparser = { git = "https://github.com/getsentry/sqlparser-rs", rev = "1bfe51c3db3e5b6bda4f52c56860af378d8ec2d3" }
+sqlx = { version = "0.7.3", default-features = false }
+statsdproxy = { version = "0.1.2", default-features = false }
+symbolic-common = { version = "12.1.2", default-features = false }
+symbolic-unreal = { version = "12.1.2", default-features = false }
+syn = "1.0.14"
+syn2 = { package = "syn", version = "2.0.11"}
+synstructure = "0.12.3"
+sysinfo = { version = "0.30.7", default-features = false }
+tempfile = "3.5.0"
 thiserror = "1.0.38"
-tokio = { version = "1.28.0", features = ["macros", "sync", "tracing"] }
+tikv-jemallocator = "0.5.0"
+tokio = { version = "1.28.0", default-features = false } 
+tower = { version = "0.4.13", default-features = false }
+tower-http = { version = "0.4.0", default-features = false }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+uaparser = "0.6.0"
+unicase = "2.6.0"
 url = "2.1.1"
+utf16string = "0.2.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
+walkdir = "2.3.2"
+wasm-bindgen = "0.2.87"
+wasm-bindgen-futures = "0.4"
+web-sys = "0.3"
+yew = "0.20"
+yew-router = "0.17.0"
+zstd = "0.12.3"

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -15,13 +15,13 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-data-encoding = "2.5.0"
-ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
-hmac = "0.12.1"
+data-encoding = { workspace = true }
+ed25519-dalek = { workspace = true, features = ["rand_core"] }
+hmac = { workspace = true }
 rand = { workspace = true }
-relay-common = { path = "../relay-common" }
+relay-common = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10.6"
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/relay-aws-extension/Cargo.toml
+++ b/relay-aws-extension/Cargo.toml
@@ -13,9 +13,9 @@ publish = false
 workspace = true
 
 [dependencies]
-relay-log = { path = "../relay-log" }
-relay-system = { path = "../relay-system" }
-reqwest = { version = "0.11.1", features = ["json"] }
+relay-log = { workspace = true }
+relay-system = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/relay-base-schema/Cargo.toml
+++ b/relay-base-schema/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 
 [dependencies]
 regex = { workspace = true }
-relay-common = { path = "../relay-common" }
-relay-protocol = { path = "../relay-protocol" }
+relay-common = { workspace = true }
+relay-protocol = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -18,21 +18,21 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 chrono = { workspace = true }
-json-forensics = { version = "0.1.1" }
-lru = "0.9.0"
+json-forensics = { workspace = true }
+lru = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
-relay-auth = { path = "../relay-auth" }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-common = { path = "../relay-common" }
-relay-dynamic-config = { path = "../relay-dynamic-config" }
-relay-event-normalization = { path = "../relay-event-normalization" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-ffi = { path = "../relay-ffi" }
-relay-pii = { path = "../relay-pii" }
-relay-protocol = { path = "../relay-protocol" }
-relay-sampling = { path = "../relay-sampling" }
-sentry-release-parser = { version = "1.3.2", features = ["serde"] }
+relay-auth = { workspace = true }
+relay-base-schema = { workspace = true }
+relay-common = { workspace = true }
+relay-dynamic-config = { workspace = true }
+relay-event-normalization = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-ffi = { workspace = true }
+relay-pii = { workspace = true }
+relay-protocol = { workspace = true }
+relay-sampling = { workspace = true }
+sentry-release-parser = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/relay-cardinality/Cargo.toml
+++ b/relay-cardinality/Cargo.toml
@@ -20,11 +20,11 @@ workspace = true
 [dependencies]
 hashbrown = { workspace = true }
 parking_lot = { workspace = true }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-common = { path = "../relay-common" }
-relay-log = { path = "../relay-log" }
-relay-redis = { path = "../relay-redis" }
-relay-statsd = { path = "../relay-statsd" }
+relay-base-schema = { workspace = true }
+relay-common = { workspace = true }
+relay-log = { workspace = true }
+relay-redis = { workspace = true }
+relay-statsd = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -14,13 +14,13 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-globset = "0.4.5"
-lru = "0.9.0"
+globset = { workspace = true }
+lru = { workspace = true }
 once_cell = { workspace = true }
-parking_lot = "0.12.1"
+parking_lot = { workspace = true }
 regex = { workspace = true }
-sentry-types = "0.31.3"
+sentry-types = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-serde_test = "1.0.125"
+serde_test = { workspace = true }

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -18,14 +18,14 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-human-size = "0.4.1"
-num_cpus = "1.13.0"
-relay-auth = { path = "../relay-auth" }
-relay-common = { path = "../relay-common" }
-relay-kafka = { path = "../relay-kafka" }
-relay-log = { path = "../relay-log", features = ["init"] }
-relay-metrics = { path = "../relay-metrics" }
-relay-redis = { path = "../relay-redis" }
+human-size = { workspace = true }
+num_cpus = { workspace = true }
+relay-auth = { workspace = true }
+relay-common = { workspace = true }
+relay-kafka = { workspace = true }
+relay-log = { workspace = true, features = ["init"] }
+relay-metrics = { workspace = true }
+relay-redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/relay-crash/Cargo.toml
+++ b/relay-crash/Cargo.toml
@@ -16,5 +16,5 @@ workspace = true
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.64.0"
-cmake = { version = "0.1.46" }
+bindgen = { workspace = true }
+cmake = { workspace = true }

--- a/relay-dashboard/Cargo.toml
+++ b/relay-dashboard/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-ansi-to-html = "0.1.3"
-futures = "0.3.28"
-instant = { version = "0.1.12", features = ["wasm-bindgen"] }
-gloo-console = "0.3.0"
-gloo-net = "0.4.0"
-once_cell = "1.18.0"
-reqwasm = { version = "0.5.0" }
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Window", "Document", "Location"] }
-tokio = { version = "1.28.0", features = ["sync"] }
-yew = { version = "0.20", features = ["csr"] }
-yew-router = "0.17.0"
+ansi-to-html = { workspace = true }
+futures = { workspace = true }
+instant = { workspace = true, features = ["wasm-bindgen"] }
+gloo-console = { workspace = true }
+gloo-net = { workspace = true }
+once_cell = { workspace = true }
+reqwasm = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["Window", "Document", "Location"] }
+tokio = { workspace = true, features = ["sync"] }
+yew = { workspace = true, features = ["csr"] }
+yew-router = { workspace = true }

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -17,18 +17,18 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-assert-json-diff = "2.0.2"
-relay-auth = { path = "../relay-auth" }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-cardinality = { path = "../relay-cardinality" }
-relay-common = { path = "../relay-common" }
-relay-event-normalization = { path = "../relay-event-normalization" }
-relay-filter = { path = "../relay-filter" }
-relay-log = { path = "../relay-log" }
-relay-pii = { path = "../relay-pii" }
-relay-protocol = { path = "../relay-protocol" }
-relay-quotas = { path = "../relay-quotas" }
-relay-sampling = { path = "../relay-sampling" }
+assert-json-diff = { workspace = true }
+relay-auth = { workspace = true }
+relay-base-schema = { workspace = true }
+relay-cardinality = { workspace = true }
+relay-common = { workspace = true }
+relay-event-normalization = { workspace = true }
+relay-filter = { workspace = true }
+relay-log = { workspace = true }
+relay-pii = { workspace = true }
+relay-protocol = { workspace = true }
+relay-quotas = { workspace = true }
+relay-sampling = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }

--- a/relay-event-derive/Cargo.toml
+++ b/relay-event-derive/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 workspace = true
 
 [dependencies]
-quote = "1.0.2"
-syn = "1.0.14"
-synstructure = "0.12.3"
-proc-macro2 = "1.0.8"
+quote = { workspace = true }
+syn = { workspace = true }
+synstructure = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -13,30 +13,27 @@ publish = false
 workspace = true
 
 [dependencies]
-bytecount = "0.6.0"
+bytecount = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
-dynfmt = { version = "0.1.4", features = ["python", "curly"] }
+dynfmt = { workspace = true, features = ["python", "curly"] }
 itertools = { workspace = true }
-maxminddb = "0.23.0"
-md5 = "0.7.0"
+maxminddb = { workspace = true }
+md5 = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-common = { path = "../relay-common" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-log = { path = "../relay-log" }
-relay-protocol = { path = "../relay-protocol" }
-relay-statsd = { path = "../relay-statsd" }
-relay-ua = { path = "../relay-ua" }
-sentry-release-parser = "1.3.2"
+relay-base-schema = { workspace = true }
+relay-common = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-log = { workspace = true }
+relay-protocol = { workspace = true }
+relay-statsd = { workspace = true }
+relay-ua = { workspace = true }
+sentry-release-parser = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_urlencoded = "0.7.1"
+serde_urlencoded = { workspace = true }
 smallvec = { workspace = true }
-# Temporary fix until https://github.com/sqlparser-rs/sqlparser-rs/pull/1140 is merged.
-sqlparser = { git = "https://github.com/getsentry/sqlparser-rs", rev = "1bfe51c3db3e5b6bda4f52c56860af378d8ec2d3", features = [
-    "visitor",
-] }
+sqlparser = { workspace = true, features = ["visitor"] }
 
 thiserror = { workspace = true }
 url = { workspace = true }
@@ -44,7 +41,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-relay-protocol = { path = "../relay-protocol", features = ["test"] }
+relay-protocol = { workspace = true, features = ["test"] }
 similar-asserts = { workspace = true }
 
 [features]

--- a/relay-event-schema/Cargo.toml
+++ b/relay-event-schema/Cargo.toml
@@ -13,18 +13,18 @@ publish = false
 workspace = true
 
 [dependencies]
-bytecount = "0.6.0"
+bytecount = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
-cookie = { version = "0.17.0", features = ["percent-encode"] }
-debugid = { version = "0.8.0", features = ["serde"] }
-enumset = "1.0.4"
-relay-common = { path = "../relay-common" }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-event-derive = { path = "../relay-event-derive" }
-relay-jsonschema-derive = { path = "../relay-jsonschema-derive", optional = true }
-relay-protocol = { path = "../relay-protocol", features = ["derive"] }
+cookie = { workspace = true, features = ["percent-encode"] }
+debugid = { workspace = true, features = ["serde"] }
+enumset = { workspace = true }
+relay-common = { workspace = true }
+relay-base-schema = { workspace = true }
+relay-event-derive = { workspace = true }
+relay-jsonschema-derive = { workspace = true, optional = true }
+relay-protocol = { workspace = true, features = ["derive"] }
 schemars = { workspace = true, optional = true }
-sentry-release-parser = "1.3.2"
+sentry-release-parser = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -33,7 +33,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-relay-protocol = { path = "../relay-protocol", features = ["test"] }
+relay-protocol = { workspace = true, features = ["test"] }
 similar-asserts = { workspace = true }
 
 [features]

--- a/relay-ffi-macros/Cargo.toml
+++ b/relay-ffi-macros/Cargo.toml
@@ -16,5 +16,5 @@ proc-macro = true
 workspace = true
 
 [dependencies]
-syn = { version = "1.0.39", features = ["fold", "full"] }
-quote = "1.0.6"
+syn = { workspace = true, features = ["fold", "full"] }
+quote = { workspace = true }

--- a/relay-ffi/Cargo.toml
+++ b/relay-ffi/Cargo.toml
@@ -14,4 +14,4 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-relay-ffi-macros = { path = "../relay-ffi-macros" }
+relay-ffi-macros = { workspace = true }

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -13,14 +13,14 @@ publish = false
 workspace = true
 
 [dependencies]
-ipnetwork = "0.20.0"
+ipnetwork = { workspace = true }
 once_cell = { workspace = true }
 indexmap = { workspace = true }
 regex = { workspace = true }
-relay-common = { path = "../relay-common" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-protocol = { path = "../relay-protocol" }
-relay-ua = { path = "../relay-ua" }
+relay-common = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-protocol = { workspace = true }
+relay-ua = { workspace = true }
 serde = { workspace = true }
 url = { workspace = true }
 

--- a/relay-jsonschema-derive/Cargo.toml
+++ b/relay-jsonschema-derive/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 workspace = true
 
 [dependencies]
-quote = "1.0.2"
-syn = "1.0.14"
-synstructure = "0.12.3"
-proc-macro2 = "1.0.8"
+quote = { workspace = true }
+syn = { workspace = true }
+synstructure = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -13,15 +13,15 @@ publish = false
 workspace = true
 
 [dependencies]
-rdkafka = { version = "0.29.0", optional = true, features = ["tracing", "ssl"] }
-rdkafka-sys = { version = "4.3.0", optional = true }
-relay-log = { path = "../relay-log", optional = true }
-relay-statsd = { path = "../relay-statsd", optional = true }
-rmp-serde = { version = "1.1.1", optional = true }
+rdkafka = { workspace = true, optional = true, features = ["tracing", "ssl"] }
+rdkafka-sys = { workspace = true, optional = true }
+relay-log = { workspace = true, optional = true }
+relay-statsd = { workspace = true, optional = true }
+rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
-sentry-kafka-schemas = { version = "0.1.64", default_features = false, optional = true }
+sentry-kafka-schemas = { workspace = true, default_features = false, optional = true }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -15,23 +15,21 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true, features = ["clock"], optional = true }
-console = { version = "0.15.5", optional = true }
-once_cell = { version = "1.13.1", optional = true }
-relay-common = { path = "../relay-common" }
-relay-crash = { path = "../relay-crash", optional = true }
-sentry = { version = "0.31.7", features = [
+console = { workspace = true, optional = true }
+once_cell = { workspace = true, optional = true }
+relay-common = { workspace = true }
+relay-crash = { workspace = true, optional = true }
+sentry = { workspace = true, features = [
     "debug-images",
     "tower-axum-matched-path",
     "tracing",
 ], optional = true }
-sentry-core = { version = "0.31.7" }
-tokio = { version = "1", default-features = false, features = [
-    "sync",
-], optional = true }
+sentry-core = { workspace = true }
+tokio = { workspace = true, default-features = false, features = ["sync"], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = [
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "json",
     "time",

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -16,20 +16,20 @@ workspace = true
 redis = ["relay-redis/impl"]
 
 [dependencies]
-bytecount = "0.6.0"
+bytecount = { workspace = true }
 chrono = { workspace = true }
-fnv = "1.0.7"
+fnv = { workspace = true }
 hash32 = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-cardinality = { path = "../relay-cardinality" }
-relay-cogs = { path = "../relay-cogs" }
-relay-common = { path = "../relay-common" }
-relay-log = { path = "../relay-log" }
-relay-redis = { path = "../relay-redis", optional = true }
-relay-statsd = { path = "../relay-statsd" }
-relay-system = { path = "../relay-system" }
+relay-base-schema = { workspace = true }
+relay-cardinality = { workspace = true }
+relay-cogs = { workspace = true }
+relay-common = { workspace = true }
+relay-log = { workspace = true }
+relay-redis = { workspace = true, optional = true }
+relay-statsd = { workspace = true }
+relay-system = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
@@ -40,8 +40,8 @@ tokio = { workspace = true, features = ["time"] }
 criterion = { workspace = true }
 insta = { workspace = true }
 rand = { workspace = true }
-relay-statsd = { path = "../relay-statsd", features = ["test"] }
-relay-test = { path = "../relay-test" }
+relay-statsd = { workspace = true, features = ["test"] }
+relay-test = { workspace = true }
 similar-asserts = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/relay-monitors/Cargo.toml
+++ b/relay-monitors/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 once_cell = { workspace = true }
 regex = { workspace = true }
-relay-base-schema = { path = "../relay-base-schema" }
+relay-base-schema = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -13,27 +13,27 @@ publish = false
 workspace = true
 
 [dependencies]
-hmac = "0.12.1"
-minidump = "0.15.2"
+hmac = { workspace = true }
+minidump = { workspace = true }
 once_cell = { workspace = true }
-pest = "2.1.3"
-pest_derive = "2.1.0"
+pest = { workspace = true }
+pest_derive = { workspace = true }
 regex = { workspace = true }
-relay-common = { path = "../relay-common" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-log = { path = "../relay-log" }
-relay-protocol = { path = "../relay-protocol" }
+relay-common = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-log = { workspace = true }
+relay-protocol = { workspace = true }
 serde = { workspace = true }
-sha1 = "0.10.5"
+sha1 = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
-utf16string = "0.2.0"
+utf16string = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
 itertools = { workspace = true }
-pretty-hex = "0.3.0"
-relay-protocol = { path = "../relay-protocol", features = ["test"] }
+pretty-hex = { workspace = true }
+relay-protocol = { workspace = true, features = ["test"] }
 serde_json = { workspace = true }
 similar-asserts = { workspace = true }
 

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -13,19 +13,19 @@ publish = false
 workspace = true
 
 [dependencies]
-android_trace_log = { version = "0.3.0", features = ["serde"] }
+android_trace_log = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
-data-encoding = "2.3.3"
+data-encoding = { workspace = true }
 itertools = { workspace = true }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-log = { path = "../relay-log" }
-relay-protocol = { path = "../relay-protocol" }
+relay-base-schema = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-log = { workspace = true }
+relay-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_path_to_error = "0.1.14"
+serde_path_to_error = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-serde_test = "1.0.125"
+serde_test = { workspace = true }

--- a/relay-protocol-derive/Cargo.toml
+++ b/relay-protocol-derive/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 workspace = true
 
 [dependencies]
-quote = "1.0.2"
-syn = "1.0.14"
-synstructure = "0.12.3"
-proc-macro2 = "1.0.8"
+quote = { workspace = true }
+syn = { workspace = true }
+synstructure = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/relay-protocol/Cargo.toml
+++ b/relay-protocol/Cargo.toml
@@ -13,15 +13,15 @@ publish = false
 workspace = true
 
 [dependencies]
-num-traits = "0.2.12"
-relay-common = { path = "../relay-common" }
-relay-protocol-derive = { path = "../relay-protocol-derive", optional = true }
+num-traits = { workspace = true }
+relay-common = { workspace = true }
+relay-protocol-derive = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
 uuid = { workspace = true }
-unicase = "2.6.0"
+unicase = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-quotas/Cargo.toml
+++ b/relay-quotas/Cargo.toml
@@ -18,10 +18,10 @@ workspace = true
 
 [dependencies]
 hashbrown = { workspace = true }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-common = { path = "../relay-common" }
-relay-log = { path = "../relay-log", optional = true }
-relay-redis = { path = "../relay-redis", optional = true }
+relay-base-schema = { workspace = true }
+relay-common = { workspace = true }
+relay-log = { workspace = true, optional = true }
+relay-redis = { workspace = true, optional = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true, optional = true }

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 workspace = true
 
 [dependencies]
-r2d2 = { version = "0.8.10", optional = true }
-redis = { version = "0.23.1", optional = true, features = [
+r2d2 = { workspace = true, optional = true }
+redis = { workspace = true, optional = true, features = [
     "cluster",
     "r2d2",
     "tls-native-tls",

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -13,20 +13,20 @@ publish = false
 workspace = true
 
 [dependencies]
-bytes = { version = "1.4.0" }
-flate2 = "1.0.19"
+bytes = { workspace = true }
+flate2 = { workspace = true }
 once_cell = { workspace = true }
-relay-common = { path = "../relay-common" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-log = { path = "../relay-log" }
-relay-pii = { path = "../relay-pii" }
-relay-protocol = { path = "../relay-protocol" }
+relay-common = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-log = { workspace = true }
+relay-pii = { workspace = true }
+relay-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
-serde-transcode = "1.1.1"
+serde-transcode = { workspace = true }
 
 [dev-dependencies]
-assert-json-diff = "2.0.2"
+assert-json-diff = { workspace = true }
 criterion = { workspace = true }
 insta = { workspace = true }
 

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -20,15 +20,15 @@ workspace = true
 anyhow = { workspace = true, optional = true }
 chrono = { workspace = true }
 rand = { workspace = true }
-rand_pcg = "0.3.1"
-relay-base-schema = { path = "../relay-base-schema" }
-relay-common = { path = "../relay-common" }
-relay-log = { path = "../relay-log" }
-relay-protocol = { path = "../relay-protocol" }
-relay-redis = { path = "../relay-redis", optional = true }
+rand_pcg = { workspace = true }
+relay-base-schema = { workspace = true }
+relay-common = { workspace = true }
+relay-log = { workspace = true }
+relay-protocol = { workspace = true }
+relay-redis = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-unicase = "2.6.0"
+unicase = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -37,88 +37,88 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-serde_path_to_error = "0.1.14"
-axum = { version = "0.6.20", features = [
+serde_path_to_error = { workspace = true }
+axum = { workspace = true, features = [
     "headers",
     "macros",
     "matched-path",
     "multipart",
     "tracing",
 ] }
-axum-server = "0.4.7"
-backoff = "0.4.0"
-brotli = "3.3.4"
-bytecount = "0.6.0"
-bytes = { version = "1.4.0", features = ["serde"] }
+axum-server = { workspace = true }
+backoff = { workspace = true }
+brotli = { workspace = true }
+bytecount = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["clock"] }
-data-encoding = "2.5.0"
-flate2 = "1.0.19"
-fnv = "1.0.7"
+data-encoding = { workspace = true }
+flate2 = { workspace = true }
+fnv = { workspace = true }
 futures = { workspace = true }
 hash32 = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-json-forensics = { version = "0.1.1" }
-mime = "0.3.16"
-mime_guess = { version = "2.0.4", optional = true }
-minidump = { version = "0.15.2", optional = true }
-multer = "2.0.4"
+json-forensics = { workspace = true }
+mime = { workspace = true }
+mime_guess = { workspace = true, optional = true }
+minidump = { workspace = true, optional = true }
+multer = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
-relay-auth = { path = "../relay-auth" }
-relay-aws-extension = { path = "../relay-aws-extension" }
-relay-base-schema = { path = "../relay-base-schema" }
-relay-cardinality = { path = "../relay-cardinality" }
-relay-cogs = { path = "../relay-cogs" }
-relay-common = { path = "../relay-common" }
-relay-config = { path = "../relay-config" }
-relay-dynamic-config = { path = "../relay-dynamic-config" }
-relay-event-normalization = { path = "../relay-event-normalization" }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-filter = { path = "../relay-filter" }
-relay-kafka = { path = "../relay-kafka", optional = true }
-relay-log = { path = "../relay-log", features = ["sentry"] }
-relay-metrics = { path = "../relay-metrics" }
-relay-monitors = { path = "../relay-monitors" }
-relay-pii = { path = "../relay-pii" }
-relay-profiling = { path = "../relay-profiling" }
-relay-protocol = { path = "../relay-protocol" }
-relay-quotas = { path = "../relay-quotas" }
-relay-redis = { path = "../relay-redis" }
-relay-replays = { path = "../relay-replays" }
-relay-sampling = { path = "../relay-sampling" }
-relay-spans = { path = "../relay-spans" }
-relay-statsd = { path = "../relay-statsd" }
-relay-system = { path = "../relay-system" }
-reqwest = { version = "0.11.1", features = [
+relay-auth = { workspace = true }
+relay-aws-extension = { workspace = true }
+relay-base-schema = { workspace = true }
+relay-cardinality = { workspace = true }
+relay-cogs = { workspace = true }
+relay-common = { workspace = true }
+relay-config = { workspace = true }
+relay-dynamic-config = { workspace = true }
+relay-event-normalization = { workspace = true }
+relay-event-schema = { workspace = true }
+relay-filter = { workspace = true }
+relay-kafka = { workspace = true, optional = true }
+relay-log = { workspace = true, features = ["sentry"] }
+relay-metrics = { workspace = true }
+relay-monitors = { workspace = true }
+relay-pii = { workspace = true }
+relay-profiling = { workspace = true }
+relay-protocol = { workspace = true }
+relay-quotas = { workspace = true }
+relay-redis = { workspace = true }
+relay-replays = { workspace = true }
+relay-sampling = { workspace = true }
+relay-spans = { workspace = true }
+relay-statsd = { workspace = true }
+relay-system = { workspace = true }
+reqwest = { workspace = true, features = [
     "gzip",
     "stream",
     "trust-dns",
     "native-tls-vendored",
 ] }
-rmp-serde = "1.1.1"
-rust-embed = { version = "8.0.0", optional = true }
-sentry_usage_accountant = { version = "0.1.0", default-features = false }
+rmp-serde = { workspace = true }
+rust-embed = { workspace = true, optional = true }
+sentry_usage_accountant = { workspace = true, default-features = false }
 serde = { workspace = true }
-serde_bytes = "0.11"
+serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true, features = ["drain_filter"] }
-sqlx = { version = "0.7.3", features = [
+sqlx = { workspace = true, features = [
     "macros",
     "migrate",
     "sqlite",
     "runtime-tokio",
 ], default-features = false }
-symbolic-common = { version = "12.1.2", optional = true, default-features = false }
-symbolic-unreal = { version = "12.1.2", optional = true, default-features = false, features = [
+symbolic-common = { workspace = true, optional = true, default-features = false }
+symbolic-unreal = { workspace = true, optional = true, default-features = false, features = [
     "serde",
 ] }
-sysinfo = { version = "0.30.7", default-features = false }
+sysinfo = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-tower = { version = "0.4.13", default-features = false }
-tower-http = { version = "0.4.0", default-features = false, features = [
+tower = { workspace = true, default-features = false }
+tower-http = { workspace = true, default-features = false, features = [
     "catch-panic",
     "compression-br",
     "compression-deflate",
@@ -132,16 +132,16 @@ tower-http = { version = "0.4.0", default-features = false, features = [
 ] }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v5"] }
-zstd = { version = "0.12.3", optional = true }
-axum-extra = { version = "0.7.7", features = ["protobuf"] }
+zstd = { workspace = true, optional = true }
+axum-extra = { workspace = true, features = ["protobuf"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ['test-util'] }
 insta = { workspace = true }
-relay-event-schema = { path = "../relay-event-schema", features = [
+relay-event-schema = { workspace = true, features = [
     "jsonschema",
 ] }
-relay-protocol = { path = "../relay-protocol", features = ["test"] }
-relay-test = { path = "../relay-test" }
+relay-protocol = { workspace = true, features = ["test"] }
+relay-test = { workspace = true }
 similar-asserts = { workspace = true }
-tempfile = "3.5.0"
+tempfile = { workspace = true }

--- a/relay-spans/Cargo.toml
+++ b/relay-spans/Cargo.toml
@@ -13,17 +13,13 @@ publish = false
 workspace = true
 
 [dependencies]
-chrono.workspace = true
-enumset = "1.0.4"
-once_cell.workspace = true
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14", features = [
-    "gen-tonic",
-    "with-serde",
-    "trace",
-] }
-relay-event-schema = { path = "../relay-event-schema" }
-relay-protocol = { path = "../relay-protocol" }
-serde.workspace = true
-serde_json.workspace = true
-serde_repr = "0.1.16"
-hex = "0.4.3"
+chrono = { workspace = true }
+enumset = { workspace = true }
+hex = { workspace = true }
+once_cell = { workspace = true }
+opentelemetry-proto = { workspace = true, features = ["gen-tonic", "with-serde", "trace"] }
+relay-event-schema = { workspace = true }
+relay-protocol = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_repr = { workspace = true }

--- a/relay-statsd/Cargo.toml
+++ b/relay-statsd/Cargo.toml
@@ -13,14 +13,12 @@ publish = false
 workspace = true
 
 [dependencies]
-cadence = "0.29.0"
-crossbeam-channel = "0.5.6"
+cadence = { workspace = true }
+crossbeam-channel = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
-relay-log = { path = "../relay-log" }
-statsdproxy = { version = "0.1.2", features = [
-    "cadence-adapter",
-], default-features = false }
+relay-log = { workspace = true }
+statsdproxy = { workspace = true, features = ["cadence-adapter"], default-features = false }
 
 [features]
 default = []

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -15,10 +15,10 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 once_cell = { workspace = true }
-relay-log = { path = "../relay-log" }
-relay-statsd = { path = "../relay-statsd" }
+relay-log = { workspace = true }
+relay-statsd = { workspace = true }
 tokio = { workspace = true, features = ["rt", "signal"] }
 
 [dev-dependencies]
-relay-statsd = { path = "../relay-statsd", features = ["test"] }
+relay-statsd = { workspace = true, features = ["test"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/relay-test/Cargo.toml
+++ b/relay-test/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 workspace = true
 
 [dependencies]
-relay-log = { path = "../relay-log", features = ["test"] }
-relay-system = { path = "../relay-system" }
+relay-log = { workspace = true, features = ["test"] }
+relay-system = { workspace = true }
 tokio = { workspace = true }

--- a/relay-ua/Cargo.toml
+++ b/relay-ua/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 once_cell = { workspace = true }
-uaparser = { version = "0.6.0" }
+uaparser = { workspace = true }
 
 [features]
 default = []

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -22,15 +22,15 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["env", "wrap_help"] }
-clap_complete = "4.1.1"
-dialoguer = "0.10.0"
-hostname = "0.3.1"
+clap_complete = { workspace = true }
+dialoguer = { workspace = true }
+hostname = { workspace = true }
 once_cell = { workspace = true }
-relay-config = { path = "../relay-config" }
-relay-log = { path = "../relay-log", features = ["init"] }
-relay-server = { path = "../relay-server" }
-relay-statsd = { path = "../relay-statsd" }
+relay-config = { workspace = true }
+relay-log = { workspace = true, features = ["init"] }
+relay-server = { workspace = true }
+relay-statsd = { workspace = true }
 uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemallocator = { version = "0.5.0", features = ["background_threads"] }
+tikv-jemallocator = { workspace = true, features = ["background_threads"] }

--- a/tools/document-metrics/Cargo.toml
+++ b/tools/document-metrics/Cargo.toml
@@ -14,7 +14,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-syn = { version = "1.0.39", features = ["full"] }
+syn = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/tools/document-pii/Cargo.toml
+++ b/tools/document-pii/Cargo.toml
@@ -11,14 +11,14 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-path-slash = "0.2.1"
-proc-macro2 = "1.0.54"
-quote = "1.0.26"
+path-slash = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-syn = { version = "2.0.11", features = ["visit", "full", "extra-traits"] }
-walkdir = "2.3.2"
+syn2 = { workspace = true, features = ["visit", "full", "extra-traits"] }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/tools/document-pii/src/main.rs
+++ b/tools/document-pii/src/main.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 
 use clap::{command, Parser};
 use serde::Serialize;
-use syn::ItemEnum;
-use syn::ItemStruct;
+use syn2::ItemEnum;
+use syn2::ItemStruct;
 use walkdir::WalkDir;
 
 use crate::item_collector::AstItemCollector;

--- a/tools/document-pii/src/pii_finder.rs
+++ b/tools/document-pii/src/pii_finder.rs
@@ -8,8 +8,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use anyhow::anyhow;
 use proc_macro2::TokenTree;
-use syn::visit::Visit;
-use syn::{Attribute, Field, ItemEnum, ItemStruct, Meta, Path, Type, TypePath};
+use syn2::visit::Visit;
+use syn2::{Attribute, Field, ItemEnum, ItemStruct, Meta, Path, Type, TypePath};
 
 use crate::EnumOrStruct;
 
@@ -232,9 +232,9 @@ fn get_field_types(path: &Path, segments: &mut BTreeSet<String>) {
         let mut ident = first_segment.ident.to_string();
 
         // Recursion on AngleBracketed args is necessary for nested generic types
-        if let syn::PathArguments::AngleBracketed(angle_bracketed) = &first_segment.arguments {
+        if let syn2::PathArguments::AngleBracketed(angle_bracketed) = &first_segment.arguments {
             for generic_arg in angle_bracketed.args.iter() {
-                if let syn::GenericArgument::Type(Type::Path(path)) = generic_arg {
+                if let syn2::GenericArgument::Type(Type::Path(path)) = generic_arg {
                     get_field_types(&path.path, segments);
                 }
             }

--- a/tools/generate-schema/Cargo.toml
+++ b/tools/generate-schema/Cargo.toml
@@ -11,7 +11,5 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-relay-event-schema = { path = "../../relay-event-schema", features = [
-    "jsonschema",
-] }
+relay-event-schema = { workspace = true, features = ["jsonschema"] }
 serde_json = { workspace = true }

--- a/tools/process-event/Cargo.toml
+++ b/tools/process-event/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-relay-event-schema = { path = "../../relay-event-schema" }
-relay-pii = { path = "../../relay-pii" }
-relay-protocol = { path = "../../relay-protocol" }
-relay-event-normalization = { path = "../../relay-event-normalization" }
+relay-event-schema = { workspace = true }
+relay-pii = { workspace = true }
+relay-protocol = { workspace = true }
+relay-event-normalization = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/scrub-minidump/Cargo.toml
+++ b/tools/scrub-minidump/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-relay-pii = { path = "../../relay-pii" }
+relay-pii = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Migrates all dependencies to workspace dependencies without updating versions or other changes (apart from sorting).

#skip-changelog