### PR TITLE
feat(spans): Set all span tags on transaction span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-**Features**
+**Features**:
 
 - Add support for Reporting API for CSP reports ([#3277](https://github.com/getsentry/relay/pull/3277))
 - Extract op and description while converting opentelemetry spans to sentry spans. ([#3287](https://github.com/getsentry/relay/pull/3287))
@@ -16,6 +16,8 @@
 - Implement volume metric stats. ([#3281](https://github.com/getsentry/relay/pull/3281))
 - Scrub transactions before enforcing quotas. ([#3248](https://github.com/getsentry/relay/pull/3248))
 - Kafka topic config supports default topic names as keys. ([#3282](https://github.com/getsentry/relay/pull/3282))
+- Set all span tags on the transaction span. ([#3310](https://github.com/getsentry/relay/pull/3310))
+
 
 ## 24.3.0
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -22,7 +22,7 @@ use relay_protocol::{Annotated, Empty, Error, ErrorKind, Meta, Object, Value};
 use smallvec::SmallVec;
 
 use crate::normalize::request;
-use crate::span::tag_extraction::{self, extract_span_tags};
+use crate::span::tag_extraction;
 use crate::utils::{self, get_event_user_tag, MAX_DURATION_MOBILE_MS};
 use crate::{
     breakdowns, legacy, mechanism, schema, span, stacktrace, transactions, trimming, user_agent,
@@ -244,12 +244,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     }
 
     if config.enrich_spans {
-        extract_span_tags(
-            event,
-            &tag_extraction::Config {
-                max_tag_value_size: config.max_tag_value_length,
-            },
-        );
+        tag_extraction::extract_span_tags_from_event(event, config.max_tag_value_length);
     }
 }
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -22,7 +22,7 @@ use relay_protocol::{Annotated, Empty, Error, ErrorKind, Meta, Object, Value};
 use smallvec::SmallVec;
 
 use crate::normalize::request;
-use crate::span::tag_extraction;
+use crate::span::tag_extraction::{self, extract_span_tags_from_event};
 use crate::utils::{self, get_event_user_tag, MAX_DURATION_MOBILE_MS};
 use crate::{
     breakdowns, legacy, mechanism, schema, span, stacktrace, transactions, trimming, user_agent,
@@ -244,7 +244,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     }
 
     if config.enrich_spans {
-        tag_extraction::extract_span_tags_from_event(event, config.max_tag_value_length);
+        extract_span_tags_from_event(event, config.max_tag_value_length);
     }
 }
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -22,7 +22,7 @@ use relay_protocol::{Annotated, Empty, Error, ErrorKind, Meta, Object, Value};
 use smallvec::SmallVec;
 
 use crate::normalize::request;
-use crate::span::tag_extraction::{self, extract_span_tags_from_event};
+use crate::span::tag_extraction::extract_span_tags_from_event;
 use crate::utils::{self, get_event_user_tag, MAX_DURATION_MOBILE_MS};
 use crate::{
     breakdowns, legacy, mechanism, schema, span, stacktrace, transactions, trimming, user_agent,

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -154,7 +154,7 @@ pub(crate) fn extract_span_tags_from_event(event: &mut Event, max_tag_value_size
     event.spans = spans;
 }
 
-/// Extracts tags and measurements from event and spans and materializes them.
+/// Extracts tags and measurements from event and spans and materializes them into the spans.
 ///
 /// Tags longer than `max_tag_value_size` bytes will be truncated.
 pub fn extract_span_tags(event: &Event, spans: &mut [Annotated<Span>], max_tag_value_size: usize) {

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -145,6 +145,7 @@ impl std::fmt::Display for RenderBlockingStatus {
 ///
 /// Tags longer than `max_tag_value_size` bytes will be truncated.
 pub(crate) fn extract_span_tags_from_event(event: &mut Event, max_tag_value_size: usize) {
+    // Temporarily take ownership to pass both an event reference and a mutable span reference to `extract_span_tags`.
     let mut spans = std::mem::take(&mut event.spans);
     let Some(spans_vec) = spans.value_mut() else {
         return;

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -141,14 +141,27 @@ impl std::fmt::Display for RenderBlockingStatus {
     }
 }
 
-/// Configuration for span tag extraction.
-pub struct Config {
-    /// The maximum allowed size of tag values in bytes. Longer values will be cropped.
-    pub max_tag_value_size: usize,
+/// Wrapper for [`extract_span_tags`].
+///
+/// Tags longer than `max_tag_value_size` bytes will be truncated.
+pub(crate) fn extract_span_tags_from_event(event: &mut Event, max_tag_value_size: usize) {
+    let spans = &mut event.spans;
+    let Some(spans_vec) = spans.value_mut() else {
+        return;
+    };
+    extract_span_tags(event, spans_vec.as_mut_slice(), max_tag_value_size);
 }
 
-/// Extracts tags from event and spans and materializes them into `span.data`.
-pub(crate) fn extract_span_tags(event: &mut Event, config: &Config) {
+trait SpanIter<'a>: Iterator<Item = &'a mut Span> + std::clone::Clone {}
+
+/// Extracts tags and measurements from event and spans and materializes them.
+///
+/// Tags longer than `max_tag_value_size` bytes will be truncated.
+pub fn extract_span_tags<'a>(
+    event: &Event,
+    spans: &mut [Annotated<Span>],
+    max_tag_value_size: usize,
+) {
     // TODO: To prevent differences between metrics and payloads, we should not extract tags here
     // when they have already been extracted by a downstream relay.
     let shared_tags = extract_shared_tags(event);
@@ -157,19 +170,15 @@ pub(crate) fn extract_span_tags(event: &mut Event, config: &Config) {
         .is_some_and(|v| v.as_str() == "true");
     let start_type = is_mobile.then(|| get_event_start_type(event)).flatten();
 
-    let Some(spans) = event.spans.value_mut() else {
-        return;
-    };
-
     let ttid = timestamp_by_op(spans, "ui.load.initial_display");
     let ttfd = timestamp_by_op(spans, "ui.load.full_display");
 
     for span in spans {
-        let Some(span) = span.value_mut().as_mut() else {
+        let Some(span) = span.value_mut() else {
             continue;
         };
 
-        let tags = extract_tags(span, config, ttid, ttfd, is_mobile, start_type);
+        let tags = extract_tags(span, max_tag_value_size, ttid, ttfd, is_mobile, start_type);
 
         span.sentry_tags = Annotated::new(
             shared_tags
@@ -185,7 +194,7 @@ pub(crate) fn extract_span_tags(event: &mut Event, config: &Config) {
 }
 
 /// Extracts tags shared by every span.
-pub fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
+fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
     let mut tags = BTreeMap::new();
 
     if let Some(release) = event.release.as_str() {
@@ -266,7 +275,7 @@ pub fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
 /// and rely on Sentry conventions and heuristics.
 pub fn extract_tags(
     span: &Span,
-    config: &Config,
+    max_tag_value_size: usize,
     initial_display: Option<Timestamp>,
     full_display: Option<Timestamp>,
     is_mobile: bool,
@@ -410,7 +419,7 @@ pub fn extract_tags(
             span_group.truncate(16);
             span_tags.insert(SpanTagKey::Group, span_group);
 
-            let truncated = truncate_string(scrubbed_desc, config.max_tag_value_size);
+            let truncated = truncate_string(scrubbed_desc, max_tag_value_size);
             if span_op.starts_with("resource.") {
                 if let Some(ext) = truncated
                     .rsplit('/')
@@ -593,10 +602,10 @@ pub fn extract_measurements(span: &mut Span) {
 /// Finds first matching span and get its timestamp.
 ///
 /// Used to get time-to-initial/full-display times.
-fn timestamp_by_op(spans: &[Annotated<Span>], op: &str) -> Option<Timestamp> {
+fn timestamp_by_op(spans: &mut [Annotated<Span>], op: &str) -> Option<Timestamp> {
     spans
-        .iter()
-        .filter_map(Annotated::value)
+        .iter_mut()
+        .filter_map(|a| a.value_mut().as_mut())
         .find(|span| span.op.as_str() == Some(op))
         .and_then(|span| span.timestamp.value().copied())
 }
@@ -1076,12 +1085,7 @@ LIMIT 1
             .into_value()
             .unwrap();
 
-        extract_span_tags(
-            &mut event,
-            &Config {
-                max_tag_value_size: 200,
-            },
-        );
+        extract_span_tags_from_event(&mut event, 200);
 
         let spans = event.spans.value().unwrap();
 
@@ -1143,12 +1147,7 @@ LIMIT 1
             .into_value()
             .unwrap();
 
-        extract_span_tags(
-            &mut event,
-            &Config {
-                max_tag_value_size: 200,
-            },
-        );
+        extract_span_tags_from_event(&mut event, 200);
 
         let span = &event.spans.value().unwrap()[0];
 
@@ -1266,12 +1265,7 @@ LIMIT 1
             .into_value()
             .unwrap();
 
-        extract_span_tags(
-            &mut event,
-            &Config {
-                max_tag_value_size: 200,
-            },
-        );
+        extract_span_tags_from_event(&mut event, 200);
 
         let span_1 = &event.spans.value().unwrap()[0];
         let span_2 = &event.spans.value().unwrap()[1];
@@ -1362,12 +1356,7 @@ LIMIT 1
             .into_value()
             .unwrap();
 
-        extract_span_tags(
-            &mut event,
-            &Config {
-                max_tag_value_size: 200,
-            },
-        );
+        extract_span_tags_from_event(&mut event, 200);
 
         let span = &event.spans.value().unwrap()[0];
 
@@ -1424,12 +1413,7 @@ LIMIT 1
             .into_value()
             .unwrap();
 
-        extract_span_tags(
-            &mut event,
-            &Config {
-                max_tag_value_size: 200,
-            },
-        );
+        extract_span_tags_from_event(&mut event, 200);
 
         let span = &event.spans.value().unwrap()[0];
         let tags = span.value().unwrap().sentry_tags.value().unwrap();
@@ -1457,16 +1441,7 @@ LIMIT 1
             .unwrap()
             .into_value()
             .unwrap();
-        let tags = extract_tags(
-            &span,
-            &Config {
-                max_tag_value_size: 200,
-            },
-            None,
-            None,
-            false,
-            None,
-        );
+        let tags = extract_tags(&span, 200, None, None, false, None);
 
         assert_eq!(
             tags.get(&SpanTagKey::BrowserName),
@@ -1493,16 +1468,7 @@ LIMIT 1
             .unwrap();
         span.description.set_value(Some(description.into()));
 
-        extract_tags(
-            &span,
-            &Config {
-                max_tag_value_size: 200,
-            },
-            None,
-            None,
-            false,
-            None,
-        )
+        extract_tags(&span, 200, None, None, false, None)
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -154,8 +154,6 @@ pub(crate) fn extract_span_tags_from_event(event: &mut Event, max_tag_value_size
     event.spans = spans;
 }
 
-trait SpanIter<'a>: Iterator<Item = &'a mut Span> + std::clone::Clone {}
-
 /// Extracts tags and measurements from event and spans and materializes them.
 ///
 /// Tags longer than `max_tag_value_size` bytes will be truncated.
@@ -600,10 +598,10 @@ pub fn extract_measurements(span: &mut Span) {
 /// Finds first matching span and get its timestamp.
 ///
 /// Used to get time-to-initial/full-display times.
-fn timestamp_by_op(spans: &mut [Annotated<Span>], op: &str) -> Option<Timestamp> {
+fn timestamp_by_op(spans: &[Annotated<Span>], op: &str) -> Option<Timestamp> {
     spans
-        .iter_mut()
-        .filter_map(|a| a.value_mut().as_mut())
+        .iter()
+        .filter_map(Annotated::value)
         .find(|span| span.op.as_str() == Some(op))
         .and_then(|span| span.timestamp.value().copied())
 }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -52,8 +52,9 @@ pub fn extract_metrics(
     let mut metrics = generic::extract_metrics(event, config);
 
     relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {
-        let transaction_span = extract_transaction_span(event, max_tag_value_size);
-        metrics.extend(generic::extract_metrics(&transaction_span, config));
+        if let Some(transaction_span) = extract_transaction_span(event, max_tag_value_size) {
+            metrics.extend(generic::extract_metrics(&transaction_span, config));
+        }
 
         if let Some(spans) = event.spans.value() {
             for annotated_span in spans {

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -71,6 +71,7 @@ pub fn extract_metrics(
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, Utc};
+    use insta::assert_debug_snapshot;
     use relay_dynamic_config::{Feature, FeatureSet, ProjectConfig};
     use relay_event_normalization::{normalize_event, NormalizationConfig};
     use relay_event_schema::protocol::Timestamp;
@@ -1457,9 +1458,12 @@ mod tests {
                 "type": "transaction",
                 "timestamp": "2021-04-26T08:00:05+0100",
                 "start_timestamp": "2021-04-26T08:00:00+0100",
+                "transaction": "my_transaction",
                 "contexts": {
                     "trace": {
-                        "op": "db.query"
+                        "exclusive_time": 5000.0,
+                        "op": "db.query",
+                        "status": "ok"
                     }
                 }
             }
@@ -1478,9 +1482,24 @@ mod tests {
         let config = project.metric_extraction.ok().unwrap();
         let metrics = extract_metrics(event.value().unwrap(), &config, 200);
 
-        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics.len(), 4);
         assert_eq!(&*metrics[0].name, "c:spans/usage@none");
-        assert_eq!(&*metrics[1].name, "c:spans/count_per_op@none");
-        assert_eq!(&*metrics[1].tags["span.op"], "db.query");
+
+        assert_eq!(&*metrics[1].name, "d:spans/exclusive_time@millisecond");
+        assert_debug_snapshot!(metrics[1].tags, @r###"
+        {
+            "span.category": "db",
+            "span.op": "db.query",
+            "transaction": "my_transaction",
+            "transaction.op": "db.query",
+        }
+        "###);
+        assert_eq!(
+            &*metrics[2].name,
+            "d:spans/exclusive_time_light@millisecond"
+        );
+
+        assert_eq!(&*metrics[3].name, "c:spans/count_per_op@none");
+        assert_eq!(&*metrics[3].tags["span.op"], "db.query");
     }
 }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -48,7 +48,7 @@ pub fn extract_metrics(event: &Event, config: &MetricExtractionConfig) -> Vec<Bu
     let mut metrics = generic::extract_metrics(event, config);
 
     relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {
-        let transaction_span = extract_transaction_span(event);
+        let transaction_span = extract_transaction_span(event, todo!());
         metrics.extend(generic::extract_metrics(&transaction_span, config));
 
         if let Some(spans) = event.spans.value() {

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -30,7 +30,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.op": "mYOp",
+            "span.op": "myop",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
         },
@@ -48,7 +48,7 @@ expression: metrics
             1.0,
         ),
         tags: {
-            "span.op": "mYOp",
+            "span.op": "myop",
         },
         metadata: BucketMetadata {
             merges: 1,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1357,7 +1357,7 @@ impl EnvelopeProcessorService {
                 if state.has_event() {
                     event::scrub(state)?;
                     if_processing!(self.inner.config, {
-                        span::extract_from_event(state);
+                        span::extract_from_event(state, &self.inner.config);
                     });
                 }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1140,7 +1140,14 @@ impl EnvelopeProcessorService {
             }
 
             if let Some(config) = config {
-                let metrics = crate::metrics_extraction::event::extract_metrics(event, config);
+                let metrics = crate::metrics_extraction::event::extract_metrics(
+                    event,
+                    config,
+                    self.inner
+                        .config
+                        .aggregator_config_for(MetricNamespace::Spans)
+                        .max_tag_value_length,
+                );
                 state.event_metrics_extracted |= !metrics.is_empty();
                 state.extracted_metrics.project_metrics.extend(metrics);
             }

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -31,21 +31,10 @@ pub fn filter(state: &mut ProcessEnvelopeState<SpanGroup>) {
 }
 
 /// Creates a span from the transaction and applies tag extraction on it.
-pub fn extract_transaction_span(event: &Event) -> Span {
-    let mut transaction_span: Span = event.into();
+pub fn extract_transaction_span(event: &Event, max_tag_value_size: usize) -> Span {
+    let mut spans = [Span::from(event).into()];
 
-    let mut shared_tags = tag_extraction::extract_shared_tags(event);
-    if let Some(span_op) = transaction_span.op.value() {
-        shared_tags.insert(tag_extraction::SpanTagKey::SpanOp, span_op.to_owned());
-    }
+    tag_extraction::extract_span_tags(&event, &mut spans, max_tag_value_size);
 
-    transaction_span.sentry_tags = Annotated::new(
-        shared_tags
-            .clone()
-            .into_iter()
-            .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v)))
-            .collect(),
-    );
-
-    transaction_span
+    spans[0]
 }

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -3,7 +3,6 @@
 use relay_dynamic_config::Feature;
 use relay_event_normalization::span::tag_extraction;
 use relay_event_schema::protocol::{Event, Span};
-use relay_protocol::Annotated;
 
 use crate::services::processor::SpanGroup;
 use crate::{envelope::ItemType, services::processor::ProcessEnvelopeState, utils::ItemAction};
@@ -34,7 +33,7 @@ pub fn filter(state: &mut ProcessEnvelopeState<SpanGroup>) {
 pub fn extract_transaction_span(event: &Event, max_tag_value_size: usize) -> Span {
     let mut spans = [Span::from(event).into()];
 
-    tag_extraction::extract_span_tags(&event, &mut spans, max_tag_value_size);
+    tag_extraction::extract_span_tags(event, &mut spans, max_tag_value_size);
 
-    spans[0]
+    spans.into_iter().next().unwrap().into_value().unwrap() // TODO
 }

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -3,6 +3,7 @@
 use relay_dynamic_config::Feature;
 use relay_event_normalization::span::tag_extraction;
 use relay_event_schema::protocol::{Event, Span};
+use relay_protocol::Annotated;
 
 use crate::services::processor::SpanGroup;
 use crate::{envelope::ItemType, services::processor::ProcessEnvelopeState, utils::ItemAction};
@@ -30,10 +31,12 @@ pub fn filter(state: &mut ProcessEnvelopeState<SpanGroup>) {
 }
 
 /// Creates a span from the transaction and applies tag extraction on it.
-pub fn extract_transaction_span(event: &Event, max_tag_value_size: usize) -> Span {
+///
+/// Returns `None` when [`tag_extraction::extract_span_tags`] clears the span, which it shouldn't.
+pub fn extract_transaction_span(event: &Event, max_tag_value_size: usize) -> Option<Span> {
     let mut spans = [Span::from(event).into()];
 
     tag_extraction::extract_span_tags(event, &mut spans, max_tag_value_size);
 
-    spans.into_iter().next().unwrap().into_value().unwrap() // TODO
+    spans.into_iter().next().and_then(Annotated::into_value)
 }

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -194,12 +194,14 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>, co
         return;
     };
 
-    let transaction_span = extract_transaction_span(
+    let Some(transaction_span) = extract_transaction_span(
         event,
         config
             .aggregator_config_for(MetricNamespace::Spans)
             .max_tag_value_length,
-    );
+    ) else {
+        return;
+    };
     // Add child spans as envelope items.
     if let Some(child_spans) = event.spans.value() {
         for span in child_spans {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -143,7 +143,7 @@ pub fn process(
     });
 }
 
-pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
+pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>, config: &Config) {
     // Only extract spans from transactions (not errors).
     if state.event_type() != Some(EventType::Transaction) {
         return;
@@ -194,8 +194,14 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>) {
         return;
     };
 
-    let transaction_span = extract_transaction_span(event);
-
+    let Annotated(Some(transaction_span), _meta) = extract_transaction_span(
+        event,
+        config
+            .aggregator_config_for(MetricNamespace::Spans)
+            .max_tag_value_length,
+    ) else {
+        return;
+    };
     // Add child spans as envelope items.
     if let Some(child_spans) = event.spans.value() {
         for span in child_spans {
@@ -368,9 +374,8 @@ fn normalize(
     }
 
     // Tag extraction:
-    let config = tag_extraction::Config { max_tag_value_size };
     let is_mobile = false; // TODO: find a way to determine is_mobile from a standalone span.
-    let tags = tag_extraction::extract_tags(span, &config, None, None, is_mobile, None);
+    let tags = tag_extraction::extract_tags(span, max_tag_value_size, None, None, is_mobile, None);
     span.sentry_tags = Annotated::new(
         tags.into_iter()
             .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v)))

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -194,14 +194,12 @@ pub fn extract_from_event(state: &mut ProcessEnvelopeState<TransactionGroup>, co
         return;
     };
 
-    let Annotated(Some(transaction_span), _meta) = extract_transaction_span(
+    let transaction_span = extract_transaction_span(
         event,
         config
             .aggregator_config_for(MetricNamespace::Spans)
             .max_tag_value_length,
-    ) else {
-        return;
-    };
+    );
     // Add child spans as envelope items.
     if let Some(child_spans) = event.spans.value() {
         for span in child_spans {


### PR DESCRIPTION
Previously, only span tags extracted from the transaction itself were added to the transaction span. With this PR, tags that are derived from the transaction span are set as well.

ref: https://github.com/getsentry/relay/issues/2494