### PR TITLE
instr(kafka): Emit producer metrics

### DIFF
--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -23,7 +23,7 @@ use crate::config::{KafkaConfig, KafkaParams, KafkaTopic};
 use crate::statsd::{KafkaGauges, KafkaHistograms};
 
 mod utils;
-use utils::{CaptureErrorContext, ThreadedProducer};
+use utils::{Context, ThreadedProducer};
 
 #[cfg(feature = "schemas")]
 mod schemas;
@@ -258,7 +258,7 @@ impl KafkaClientBuilder {
 
                 let producer = Arc::new(
                     client_config
-                        .create_with_context(CaptureErrorContext)
+                        .create_with_context(Context)
                         .map_err(ClientError::InvalidConfig)?,
                 );
 
@@ -285,7 +285,7 @@ impl KafkaClientBuilder {
                     }
                     let producer = Arc::new(
                         client_config
-                            .create_with_context(CaptureErrorContext)
+                            .create_with_context(Context)
                             .map_err(ClientError::InvalidConfig)?,
                     );
                     self.reused_producers

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -71,5 +71,5 @@ impl ProducerContext for Context {
 }
 
 /// The wrapper type around the kafka [`rdkafka::producer::ThreadedProducer`] with our own
-/// [`CaptureErrorContext`] context.
+/// [`Context`].
 pub type ThreadedProducer = rdkafka::producer::ThreadedProducer<Context>;

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -4,13 +4,46 @@ use rdkafka::producer::{DeliveryResult, ProducerContext};
 use rdkafka::{ClientContext, Message};
 use relay_statsd::metric;
 
-use crate::statsd::KafkaCounters;
+use crate::statsd::{KafkaCounters, KafkaGauges};
 
 /// Kafka producer context that logs producer errors.
 #[derive(Debug)]
 pub struct CaptureErrorContext;
 
-impl ClientContext for CaptureErrorContext {}
+impl ClientContext for CaptureErrorContext {
+    /// Report client statistics as statsd metrics.
+    ///
+    /// This method is only called if `statistics.interval.ms` is configured.
+    fn stats(&self, statistics: rdkafka::Statistics) {
+        relay_statsd::metric!(gauge(KafkaGauges::MessageCount) = statistics.msg_cnt);
+        relay_statsd::metric!(gauge(KafkaGauges::MessageCountMax) = statistics.msg_max);
+        relay_statsd::metric!(gauge(KafkaGauges::MessageSize) = statistics.msg_size);
+        relay_statsd::metric!(gauge(KafkaGauges::MessageSizeMax) = statistics.msg_size_max);
+
+        for broker in statistics.brokers.values() {
+            relay_statsd::metric!(
+                gauge(KafkaGauges::OutboundBufferRequests) = broker.outbuf_cnt as u64,
+                broker_name = &broker.name
+            );
+            relay_statsd::metric!(
+                gauge(KafkaGauges::OutboundBufferMessages) = broker.outbuf_msg_cnt as u64,
+                broker_name = &broker.name
+            );
+            if let Some(connects) = broker.connects {
+                relay_statsd::metric!(
+                    gauge(KafkaGauges::Connects) = connects as u64,
+                    broker_name = &broker.name
+                );
+            }
+            if let Some(disconnects) = broker.disconnects {
+                relay_statsd::metric!(
+                    gauge(KafkaGauges::Disconnects) = disconnects as u64,
+                    broker_name = &broker.name
+                );
+            }
+        }
+    }
+}
 
 impl ProducerContext for CaptureErrorContext {
     type DeliveryOpaque = ();

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -33,7 +33,9 @@ impl HistogramMetric for KafkaHistograms {
         }
     }
 }
-
+/// Gauge metrics for the Kafka producer.
+///
+/// Most of these metrics are taken from the [`rdkafka::statistics`] module.
 pub enum KafkaGauges {
     /// The number of messages waiting to be sent to, or acknowledged by, the broker.
     ///
@@ -42,12 +44,56 @@ pub enum KafkaGauges {
     /// This metric is tagged with:
     /// - `topic`
     InFlightCount,
+
+    /// The current number of messages in producer queues.
+    MessageCount,
+
+    /// The maximum number of messages allowed in the producer queues.
+    MessageCountMax,
+
+    /// The current total size of messages in producer queues.
+    MessageSize,
+
+    /// The maximum total size of messages allowed in the producer queues.
+    MessageSizeMax,
+
+    /// The number of requests awaiting transmission to the broker.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    OutboundBufferRequests,
+
+    /// The number of messages awaiting transmission to the broker.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    OutboundBufferMessages,
+
+    /// The number of connection attempts, including successful and failed attempts, and name resolution failures.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    Connects,
+
+    /// The number of disconnections, whether triggered by the broker, the network, the load balancer, or something else.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    Disconnects,
 }
 
 impl GaugeMetric for KafkaGauges {
     fn name(&self) -> &'static str {
         match self {
             KafkaGauges::InFlightCount => "kafka.in_flight_count",
+            KafkaGauges::MessageCount => "kafka.message_count",
+            KafkaGauges::MessageCountMax => "kafka.message_count_max",
+            KafkaGauges::MessageSize => "kafka.message_size",
+            KafkaGauges::MessageSizeMax => "kafka.message_size_max",
+            KafkaGauges::OutboundBufferRequests => "kafka.broker.outbuf.requests",
+            KafkaGauges::OutboundBufferMessages => "kafka.broker.outbuf.messages",
+            KafkaGauges::Connects => "kafka.broker.connects",
+            KafkaGauges::Disconnects => "kafka.broker.disconnects",
         }
     }
 }


### PR DESCRIPTION
Emit statistics collected by rdkafka as statsd metric. 

These metrics are disabled by default and need to be enabled by setting `statistics.interval.ms` in the Kafka config.

ref: https://github.com/getsentry/team-ingest/issues/310

#skip-changelog