### PR TITLE
feat(outcomes): Aggregate all outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add support for Reporting API for CSP reports ([#3277](https://github.com/getsentry/relay/pull/3277))
 - Extract op and description while converting opentelemetry spans to sentry spans. ([#3287](https://github.com/getsentry/relay/pull/3287))
+- Drop `event_id` and `remote_addr` from all outcomes. ([#3319](https://github.com/getsentry/relay/pull/3319))
 
 **Internal**:
 

--- a/relay-server/src/services/outcome_aggregator.rs
+++ b/relay-server/src/services/outcome_aggregator.rs
@@ -34,7 +34,7 @@ struct BucketKey {
 pub struct OutcomeAggregator {
     /// Whether or not to produce outcomes.
     ///
-    /// If `true`, all outcomes will be dropped/
+    /// If `true`, all outcomes will be dropped.
     disabled: bool,
     /// The width of each aggregated bucket in seconds
     bucket_interval: u64,

--- a/relay-server/src/services/outcome_aggregator.rs
+++ b/relay-server/src/services/outcome_aggregator.rs
@@ -2,7 +2,6 @@
 //! and flushed them periodically.
 
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -12,7 +11,7 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_statsd::metric;
 use relay_system::{Addr, Controller, Service, Shutdown};
 
-use crate::services::outcome::{DiscardReason, Outcome, OutcomeProducer, TrackOutcome};
+use crate::services::outcome::{Outcome, OutcomeProducer, TrackOutcome};
 use crate::statsd::RelayTimers;
 use crate::utils::SleepHandle;
 
@@ -25,27 +24,18 @@ struct BucketKey {
     pub scoping: Scoping,
     /// The outcome.
     pub outcome: Outcome,
-    /// The client ip address.
-    pub remote_addr: Option<IpAddr>,
     /// The event's data category.
     pub category: DataCategory,
-}
-
-#[derive(PartialEq)]
-enum AggregationMode {
-    /// Aggregator drops all outcomes
-    DropEverything,
-    /// Aggregator keeps all outcome fields intact
-    Lossless,
-    /// Aggregator removes fields to improve aggregation
-    Lossy,
 }
 
 /// Aggregates [`Outcome`]s into buckets and flushes them periodically.
 ///
 /// This service handles a single message [`TrackOutcome`].
 pub struct OutcomeAggregator {
-    mode: AggregationMode,
+    /// Whether or not to produce outcomes.
+    ///
+    /// If `false`, all outcomes will be dropped/
+    enabled: bool,
     /// The width of each aggregated bucket in seconds
     bucket_interval: u64,
     /// The number of seconds between flushes of all buckets
@@ -60,14 +50,10 @@ pub struct OutcomeAggregator {
 
 impl OutcomeAggregator {
     pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducer>) -> Self {
-        let mode = match config.emit_outcomes() {
-            EmitOutcomes::AsOutcomes => AggregationMode::Lossless,
-            EmitOutcomes::AsClientReports => AggregationMode::Lossy,
-            EmitOutcomes::None => AggregationMode::DropEverything,
-        };
+        let enabled = !matches!(config.emit_outcomes(), EmitOutcomes::None);
 
         Self {
-            mode,
+            enabled,
             bucket_interval: config.outcome_aggregator().bucket_interval,
             flush_interval: config.outcome_aggregator().flush_interval,
             buckets: HashMap::new(),
@@ -88,24 +74,12 @@ impl OutcomeAggregator {
             return;
         }
 
-        let (event_id, remote_addr) = if self.erase_high_cardinality_fields(&msg) {
-            (None, None)
-        } else {
-            (msg.event_id, msg.remote_addr)
-        };
-
-        if event_id.is_some() {
-            self.outcome_producer.send(msg);
-            return;
-        }
-
         let offset = msg.timestamp.timestamp() as u64 / self.bucket_interval;
 
         let bucket_key = BucketKey {
             offset,
             scoping: msg.scoping,
             outcome: msg.outcome,
-            remote_addr,
             category: msg.category,
         };
 
@@ -132,7 +106,6 @@ impl OutcomeAggregator {
                 offset,
                 scoping,
                 outcome,
-                remote_addr,
                 category,
             } = bucket_key;
 
@@ -146,27 +119,13 @@ impl OutcomeAggregator {
                 scoping,
                 outcome,
                 event_id: None,
-                remote_addr,
+                remote_addr: None,
                 category,
                 quantity,
             };
 
             outcome_producer.send(outcome);
         }
-    }
-
-    /// Return true if event_id and remote_addr should be erased
-    fn erase_high_cardinality_fields(&self, msg: &TrackOutcome) -> bool {
-        // In lossy mode, always erase
-        matches!(self.mode, AggregationMode::Lossy)
-            || matches!(
-                // Always erase high-cardinality fields for specific outcomes:
-                msg.outcome,
-                Outcome::RateLimited(_)
-                    | Outcome::Invalid(DiscardReason::ProjectId)
-                    | Outcome::FilteredSampling(_)
-                    | Outcome::Accepted
-            )
     }
 
     fn flush(&mut self) {

--- a/relay-server/src/services/outcome_aggregator.rs
+++ b/relay-server/src/services/outcome_aggregator.rs
@@ -34,8 +34,8 @@ struct BucketKey {
 pub struct OutcomeAggregator {
     /// Whether or not to produce outcomes.
     ///
-    /// If `false`, all outcomes will be dropped/
-    enabled: bool,
+    /// If `true`, all outcomes will be dropped/
+    disabled: bool,
     /// The width of each aggregated bucket in seconds
     bucket_interval: u64,
     /// The number of seconds between flushes of all buckets
@@ -50,10 +50,10 @@ pub struct OutcomeAggregator {
 
 impl OutcomeAggregator {
     pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducer>) -> Self {
-        let enabled = !matches!(config.emit_outcomes(), EmitOutcomes::None);
+        let disabled = matches!(config.emit_outcomes(), EmitOutcomes::None);
 
         Self {
-            enabled,
+            disabled,
             bucket_interval: config.outcome_aggregator().bucket_interval,
             flush_interval: config.outcome_aggregator().flush_interval,
             buckets: HashMap::new(),
@@ -70,7 +70,7 @@ impl OutcomeAggregator {
     }
 
     fn handle_track_outcome(&mut self, msg: TrackOutcome) {
-        if self.mode == AggregationMode::DropEverything {
+        if self.disabled {
             return;
         }
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -977,10 +977,10 @@ def test_outcomes_aggregate_dynamic_sampling(relay, mini_sentry):
     assert outcome == expected_outcome
 
 
-def test_outcomes_do_not_aggregate(
+def test_outcomes_aggregate_inbound_filters(
     relay, relay_with_processing, mini_sentry, outcomes_consumer
 ):
-    """Make sure that certain types are not aggregated"""
+    """Make sure that inbound filters outcomes are aggregated"""
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["filterSettings"]["releases"] = {"releases": ["foo@1.2.3"]}
@@ -1010,18 +1010,18 @@ def test_outcomes_do_not_aggregate(
     for outcome in outcomes:
         del outcome["timestamp"]
 
-    # Results in two outcomes, nothing aggregated:
-    expected_outcome = {
-        "org_id": 1,
-        "project_id": 42,
-        "key_id": 123,
-        "outcome": 1,
-        "reason": "release-version",
-        "category": 1,
-        "quantity": 2,
-    }
-    # Convert to dict to ignore sort order:
-    assert outcomes == [expected_outcome]
+    # Results in a single aggregated outcome:
+    assert outcomes == [
+        {
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 1,
+            "reason": "release-version",
+            "category": 1,
+            "quantity": 2,
+        }
+    ]
 
 
 def test_graceful_shutdown(relay, mini_sentry):

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1001,42 +1001,27 @@ def test_outcomes_do_not_aggregate(
     outcomes_consumer = outcomes_consumer(timeout=1.2)
 
     # Send empty body twice
-    event_id1 = _send_event(relay)
-    event_id2 = _send_event(relay)
+    _send_event(relay)
+    _send_event(relay)
 
-    outcomes = outcomes_consumer.get_outcomes()
-    assert len(outcomes) == 2, outcomes
+    outcomes = outcomes_consumer.get_outcomes(timeout=5)
+    assert len(outcomes) == 1, outcomes
 
     for outcome in outcomes:
         del outcome["timestamp"]
 
     # Results in two outcomes, nothing aggregated:
-    expected_outcomes = {
-        event_id1: {
-            "org_id": 1,
-            "project_id": 42,
-            "key_id": 123,
-            "outcome": 1,
-            "event_id": event_id1,
-            "remote_addr": "127.0.0.1",
-            "reason": "release-version",
-            "category": 1,
-            "quantity": 1,
-        },
-        event_id2: {
-            "org_id": 1,
-            "project_id": 42,
-            "key_id": 123,
-            "outcome": 1,
-            "event_id": event_id2,
-            "remote_addr": "127.0.0.1",
-            "reason": "release-version",
-            "category": 1,
-            "quantity": 1,
-        },
+    expected_outcome = {
+        "org_id": 1,
+        "project_id": 42,
+        "key_id": 123,
+        "outcome": 1,
+        "reason": "release-version",
+        "category": 1,
+        "quantity": 2,
     }
     # Convert to dict to ignore sort order:
-    assert {x["event_id"]: x for x in outcomes} == expected_outcomes
+    assert outcomes == [expected_outcome]
 
 
 def test_graceful_shutdown(relay, mini_sentry):
@@ -1330,13 +1315,11 @@ def test_profile_outcomes_invalid(
             "project_id": 42,
             "quantity": 1,
             "reason": "profiling_invalid_json",
-            "remote_addr": "127.0.0.1",
             "source": "pop-relay",
         },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")
-        outcome.pop("event_id", None)
 
     assert outcomes == expected_outcomes, outcomes
 
@@ -1421,13 +1404,11 @@ def test_profile_outcomes_too_many(
             "project_id": 42,
             "quantity": 1,
             "reason": "profiling_too_many_profiles",
-            "remote_addr": "127.0.0.1",
             "source": "pop-relay",
         },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")
-        outcome.pop("event_id", None)
 
     assert outcomes == expected_outcomes, outcomes
 
@@ -1508,13 +1489,11 @@ def test_profile_outcomes_data_invalid(
             "project_id": 42,
             "quantity": 1,
             "reason": "profiling_invalid_json",
-            "remote_addr": "127.0.0.1",
             "source": "processing-relay",
         },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")
-        outcome.pop("event_id", None)
 
     assert outcomes == expected_outcomes, outcomes
 
@@ -1619,7 +1598,6 @@ def test_profile_outcomes_rate_limited(
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")
-        outcome.pop("event_id", None)
 
     assert outcomes == expected_outcomes, outcomes
 
@@ -1908,7 +1886,6 @@ def test_span_outcomes_invalid(
             "project_id": 42,
             "quantity": 1,
             "reason": "invalid_transaction",
-            "remote_addr": "127.0.0.1",
             "source": "pop-relay",
         },
         {
@@ -1919,13 +1896,11 @@ def test_span_outcomes_invalid(
             "project_id": 42,
             "quantity": 1,
             "reason": "internal",
-            "remote_addr": "127.0.0.1",
             "source": "pop-relay",
         },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")
-        outcome.pop("event_id")
 
     assert outcomes == expected_outcomes, outcomes
 
@@ -2096,13 +2071,11 @@ def test_replay_outcomes_item_failed(
 
     expected = {
         "category": 7,
-        "event_id": "515539018c9b4260a6f999572f1661ee",
         "key_id": 123,
         "outcome": 3,
         "project_id": 42,
         "quantity": 2,
         "reason": "invalid_replay",
-        "remote_addr": "127.0.0.1",
         "source": "pop-relay",
     }
     expected["timestamp"] = outcomes[0]["timestamp"]


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/1134 introduced aggregation for most outcomes, but it did not include inbound filters.

Outcomes are no longer used for investigating individual events, so we might as well save resources by aggregating all outcomes unconditionally.