### PR TITLE
ref(cardinality): Pipeline Redis script invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2840,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -3492,20 +3498,22 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5d95dd18a4d76650f0c2607ed8ebdbf63baf9cb934e1c233cd220c694db1d7"
+version = "0.25.2"
+source = "git+https://github.com/getsentry/redis-rs.git?rev=6201a8c9f8766c4e580deef6834365ec631ce9f8#6201a8c9f8766c4e580deef6834365ec631ce9f8"
 dependencies = [
+ "arc-swap",
  "combine",
  "crc16",
  "itoa",
  "native-tls",
+ "num-bigint",
  "percent-encoding",
  "r2d2",
  "rand",
  "ryu",
  "sha1_smol",
- "socket2 0.4.9",
+ "socket2 0.5.3",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ mime = "0.3.16"
 mime_guess = "2.0.4"
 minidump = "0.15.2"
 multer = "2.0.4"
-num-traits = "0.2.12"
+num-traits = "0.2.18"
 num_cpus = "1.13.0"
 once_cell = "1.13.1"
 opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14" }
@@ -123,7 +123,8 @@ rand = "0.8.5"
 rand_pcg = "0.3.1"
 rdkafka = "0.29.0"
 rdkafka-sys = "4.3.0"
-redis = "0.23.1"
+# Fork until https://github.com/redis-rs/redis-rs/pull/1097 is merged.
+redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "6201a8c9f8766c4e580deef6834365ec631ce9f8", default-features = false }
 regex = "1.10.2"
 reqwasm = "0.5.0"
 reqwest = "0.11.1"

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -11,7 +11,7 @@ use crate::{
         script::{CardinalityScript, CardinalityScriptResult, Status},
         state::{LimitState, RedisEntry},
     },
-    statsd::{CardinalityLimiterGauges, CardinalityLimiterTimers},
+    statsd::{CardinalityLimiterHistograms, CardinalityLimiterTimers},
     CardinalityLimit, Result,
 };
 use relay_common::time::UnixTimestamp;
@@ -80,7 +80,7 @@ impl RedisSetLimiter {
         }
 
         metric!(
-            gauge(CardinalityLimiterGauges::RedisCheckHashes) = num_hashes,
+            histogram(CardinalityLimiterHistograms::RedisCheckHashes) = num_hashes,
             id = state.id(),
         );
 
@@ -92,7 +92,8 @@ impl RedisSetLimiter {
             .zip(results)
             .inspect(|(_, result)| {
                 metric!(
-                    gauge(CardinalityLimiterGauges::RedisSetCardinality) = result.cardinality,
+                    histogram(CardinalityLimiterHistograms::RedisSetCardinality) =
+                        result.cardinality,
                     id = state.id(),
                 );
             })

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -86,6 +86,7 @@ impl RedisSetLimiter {
 
         let results = pipeline.invoke(connection)?;
 
+        debug_assert_eq!(results.len(), scopes.len());
         scopes
             .into_iter()
             .zip(results)

--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -39,6 +39,21 @@ pub struct CardinalityScriptResult {
     pub statuses: Vec<Status>,
 }
 
+impl CardinalityScriptResult {
+    pub fn validate(&self, num_hashes: usize) -> Result<()> {
+        if num_hashes == self.statuses.len() {
+            return Ok(());
+        }
+
+        Err(relay_redis::RedisError::Redis(redis::RedisError::from((
+            redis::ErrorKind::ResponseError,
+            "Script returned an invalid number of elements",
+            format!("Expected {num_hashes} results, got {}", self.statuses.len()),
+        )))
+        .into())
+    }
+}
+
 impl FromRedisValue for CardinalityScriptResult {
     fn from_redis_value(v: &redis::Value) -> redis::RedisResult<Self> {
         let Some(seq) = v.as_sequence() else {
@@ -77,14 +92,29 @@ impl CardinalityScript {
         Self(Script::new(include_str!("cardinality.lua")))
     }
 
-    pub fn invoke(
+    pub fn pipe(&self) -> CardinalityScriptPipeline<'_> {
+        CardinalityScriptPipeline {
+            script: self,
+            pipe: redis::pipe(),
+        }
+    }
+
+    fn load_redis(&self, con: &mut Connection) -> Result<()> {
+        self.0
+            .prepare_invoke()
+            .load(con)
+            .map_err(relay_redis::RedisError::Redis)?;
+
+        Ok(())
+    }
+
+    fn prepare_invocation(
         &self,
-        con: &mut Connection,
         limit: u64,
         expire: u64,
         hashes: impl Iterator<Item = u32>,
         keys: impl Iterator<Item = String>,
-    ) -> Result<CardinalityScriptResult> {
+    ) -> redis::ScriptInvocation<'_> {
         let mut invocation = self.0.prepare_invoke();
 
         for key in keys {
@@ -94,29 +124,45 @@ impl CardinalityScript {
         invocation.arg(limit);
         invocation.arg(expire);
 
-        let mut num_hashes = 0;
         for hash in hashes {
             invocation.arg(&hash.to_le_bytes());
-            num_hashes += 1;
         }
 
-        let result: CardinalityScriptResult = invocation
-            .invoke(con)
-            .map_err(relay_redis::RedisError::Redis)?;
+        invocation
+    }
+}
 
-        if num_hashes != result.statuses.len() {
-            return Err(relay_redis::RedisError::Redis(redis::RedisError::from((
-                redis::ErrorKind::ResponseError,
-                "Script returned an invalid number of elements",
-                format!(
-                    "Expected {num_hashes} results, got {}",
-                    result.statuses.len()
-                ),
-            )))
-            .into());
+pub struct CardinalityScriptPipeline<'a> {
+    script: &'a CardinalityScript,
+    pipe: redis::Pipeline,
+}
+
+impl<'a> CardinalityScriptPipeline<'a> {
+    pub fn add_invocation(
+        &mut self,
+        limit: u64,
+        expire: u64,
+        hashes: impl Iterator<Item = u32>,
+        keys: impl Iterator<Item = String>,
+    ) -> &mut Self {
+        let invocation = self.script.prepare_invocation(limit, expire, hashes, keys);
+        self.pipe.script(invocation);
+        self
+    }
+
+    pub fn invoke(&self, con: &mut Connection<'_>) -> Result<Vec<CardinalityScriptResult>> {
+        match self.pipe.query(con) {
+            Ok(result) => Ok(result),
+            Err(err) if err.kind() == redis::ErrorKind::NoScriptError => {
+                relay_log::trace!("Redis script no loaded, loading it now");
+                self.script.load_redis(con)?;
+                self.pipe
+                    .query(con)
+                    .map_err(relay_redis::RedisError::Redis)
+                    .map_err(Into::into)
+            }
+            Err(err) => Err(relay_redis::RedisError::Redis(err).into()),
         }
-
-        Ok(result)
     }
 }
 
@@ -126,6 +172,25 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    impl CardinalityScript {
+        fn invoke_one(
+            &self,
+            con: &mut Connection,
+            limit: u64,
+            expire: u64,
+            hashes: impl Iterator<Item = u32>,
+            keys: impl Iterator<Item = String>,
+        ) -> Result<CardinalityScriptResult> {
+            let mut results = self
+                .pipe()
+                .add_invocation(limit, expire, hashes, keys)
+                .invoke(con)?;
+
+            assert_eq!(results.len(), 1);
+            Ok(results.pop().unwrap())
+        }
+    }
 
     fn build_redis() -> RedisPool {
         let url = std::env::var("RELAY_REDIS_URL")
@@ -174,13 +239,48 @@ mod tests {
         let k2 = &["b", "c", "d"];
 
         script
-            .invoke(&mut connection, 50, 3600, 0..30, keys(prefix, k1))
+            .invoke_one(&mut connection, 50, 3600, 0..30, keys(prefix, k1))
             .unwrap();
 
         script
-            .invoke(&mut connection, 50, 3600, 0..30, keys(prefix, k2))
+            .invoke_one(&mut connection, 50, 3600, 0..30, keys(prefix, k2))
             .unwrap();
 
         assert_ttls(&mut connection, prefix);
+    }
+
+    #[test]
+    fn test_load_script() {
+        let redis = build_redis();
+        let mut client = redis.client().unwrap();
+        let mut connection = client.connection().unwrap();
+
+        let script = CardinalityScript::load();
+        let keys = keys(Uuid::new_v4(), &["a", "b", "c"]);
+
+        redis::cmd("SCRIPT").arg("FLUSH").execute(&mut connection);
+        script
+            .invoke_one(&mut connection, 50, 3600, 0..30, keys)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_multiple_calls_in_pipeline() {
+        let redis = build_redis();
+        let mut client = redis.client().unwrap();
+        let mut connection = client.connection().unwrap();
+
+        let script = CardinalityScript::load();
+        let k2 = keys(Uuid::new_v4(), &["a", "b", "c"]);
+        let k1 = keys(Uuid::new_v4(), &["a", "b", "c"]);
+
+        let mut pipeline = script.pipe();
+        let results = pipeline
+            .add_invocation(50, 3600, 0..30, k1)
+            .add_invocation(50, 3600, 0..30, k2)
+            .invoke(&mut connection)
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
     }
 }

--- a/relay-cardinality/src/redis/state.rs
+++ b/relay-cardinality/src/redis/state.rs
@@ -93,8 +93,8 @@ impl<'a> LimitState<'a> {
     }
 
     /// Removes all contained scopes and entries and returns them.
-    pub fn take_scopes(&mut self) -> impl Iterator<Item = (QuotaScoping, Vec<RedisEntry>)> {
-        std::mem::take(&mut self.scopes).into_iter()
+    pub fn take_scopes(&mut self) -> BTreeMap<QuotaScoping, Vec<RedisEntry>> {
+        std::mem::take(&mut self.scopes)
     }
 
     /// Increases the cache hit counter.

--- a/relay-cardinality/src/statsd.rs
+++ b/relay-cardinality/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{CounterMetric, GaugeMetric, SetMetric, TimerMetric};
+use relay_statsd::{CounterMetric, HistogramMetric, SetMetric, TimerMetric};
 
 /// Counter metrics for the Relay Cardinality Limiter.
 pub enum CardinalityLimiterCounters {
@@ -81,7 +81,7 @@ impl TimerMetric for CardinalityLimiterTimers {
     }
 }
 
-pub enum CardinalityLimiterGauges {
+pub enum CardinalityLimiterHistograms {
     /// Amount of hashes sent to Redis to check the cardinality.
     ///
     /// This metric is tagged with:
@@ -96,7 +96,7 @@ pub enum CardinalityLimiterGauges {
     RedisSetCardinality,
 }
 
-impl GaugeMetric for CardinalityLimiterGauges {
+impl HistogramMetric for CardinalityLimiterHistograms {
     fn name(&self) -> &'static str {
         match *self {
             #[cfg(feature = "redis")]

--- a/relay-cardinality/src/statsd.rs
+++ b/relay-cardinality/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{CounterMetric, HistogramMetric, SetMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, SetMetric, TimerMetric};
 
 /// Counter metrics for the Relay Cardinality Limiter.
 pub enum CardinalityLimiterCounters {
@@ -81,7 +81,7 @@ impl TimerMetric for CardinalityLimiterTimers {
     }
 }
 
-pub enum CardinalityLimiterHistograms {
+pub enum CardinalityLimiterGauges {
     /// Amount of hashes sent to Redis to check the cardinality.
     ///
     /// This metric is tagged with:
@@ -96,7 +96,7 @@ pub enum CardinalityLimiterHistograms {
     RedisSetCardinality,
 }
 
-impl HistogramMetric for CardinalityLimiterHistograms {
+impl GaugeMetric for CardinalityLimiterGauges {
     fn name(&self) -> &'static str {
         match *self {
             #[cfg(feature = "redis")]

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -19,7 +19,8 @@ redis = { workspace = true, optional = true, features = [
     "r2d2",
     "tls-native-tls",
     "keep-alive",
-] }
+    "script",
+], default-features = false }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -73,8 +73,8 @@ impl ConnectionLike for Connection<'_> {
 }
 
 enum PooledClientInner {
-    Cluster(PooledConnection<redis::cluster::ClusterClient>),
-    Single(PooledConnection<redis::Client>),
+    Cluster(Box<PooledConnection<redis::cluster::ClusterClient>>),
+    Single(Box<PooledConnection<redis::Client>>),
 }
 
 /// A pooled Redis client.
@@ -196,10 +196,10 @@ impl RedisPool {
     pub fn client(&self) -> Result<PooledClient, RedisError> {
         let inner = match self.inner {
             RedisPoolInner::Cluster(ref pool) => {
-                PooledClientInner::Cluster(pool.get().map_err(RedisError::Pool)?)
+                PooledClientInner::Cluster(Box::new(pool.get().map_err(RedisError::Pool)?))
             }
             RedisPoolInner::Single(ref pool) => {
-                PooledClientInner::Single(pool.get().map_err(RedisError::Pool)?)
+                PooledClientInner::Single(Box::new(pool.get().map_err(RedisError::Pool)?))
             }
         };
 


### PR DESCRIPTION
- Pipelines all script invocations which use the same parent quota
- Updates Redis to a fork which supports pipelining scripts.
- Updates the `PooledClientInner` enum to box the clients because of a clippy lint `large size difference between variants`
- Updates num-traits because of conflicts with the new Redis client version which has a higher min version

```
error: large size difference between variants
  --> relay-redis/src/real.rs:75:1
   |
75 | / enum PooledClientInner {
76 | |     Cluster(PooledConnection<redis::cluster::ClusterClient>),
   | |     -------------------------------------------------------- the largest variant contains at least 408 bytes
77 | |     Single(PooledConnection<redis::Client>),
   | |     --------------------------------------- the second-largest variant contains at least 200 bytes
78 | | }
   | |_^ the entire enum is at least 408 bytes
```

Requires: https://github.com/getsentry/relay/pull/3313

#skip-changelog