### PR TITLE
ref(filter): Add Cloudflare Health Checks to the list of web crawlers

### DIFF
--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -31,7 +31,8 @@ static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
                                     # and https://github.com/getsentry/sentry-python/issues/641
         HubSpot\sCrawler|           # HubSpot web crawler (web-crawlers@hubspot.com)
         Bytespider|                 # Bytedance
-        Better\sUptime              # Better Uptime
+        Better\sUptime|             # Better Uptime
+        Cloudflare-Healthchecks     # Cloudflare Health Checks
     "
     )
     .expect("Invalid web crawlers filter Regex")
@@ -117,7 +118,8 @@ mod tests {
             "AdsBot-Google (+http://www.google.com/adsbot.html)",
             "Mozilla/5.0 (compatible; HubSpot Crawler; web-crawlers@hubspot.com)",
             "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)",
-            "Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+            "Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+            "Mozilla/5.0 (compatible;Cloudflare-Healthchecks/1.0;+https://www.cloudflare.com/; healthcheck-id: 0d1ca23e292c8c14)"
         ];
 
         for banned_user_agent in &user_agents {


### PR DESCRIPTION
Adding a crawler signature for [Cloudflare Health Checks](https://developers.cloudflare.com/health-checks/).

> A Health Check is a service that runs on Cloudflare’s edge network to monitor whether an origin server is online. This allows you to view the health of your origin servers even if there is only one origin or you do not yet need to balance traffic across your infrastructure.

It's essentially an uptime monitoring service, difference is that you usually check from multiple locations via this service so this generates a lot of transactions every monitoring interval.

#skip-changelog