### PR TITLE
ref(cardinality): Switch histogram to gauge

### DIFF
--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -10,7 +10,7 @@ use crate::{
         script::{CardinalityScript, Status},
         state::{LimitState, RedisEntry},
     },
-    statsd::{CardinalityLimiterHistograms, CardinalityLimiterTimers},
+    statsd::{CardinalityLimiterGauges, CardinalityLimiterTimers},
     CardinalityLimit, Result,
 };
 use relay_common::time::UnixTimestamp;
@@ -63,7 +63,7 @@ impl RedisSetLimiter {
         let entries = state.take_entries();
 
         metric!(
-            histogram(CardinalityLimiterHistograms::RedisCheckHashes) = entries.len() as u64,
+            gauge(CardinalityLimiterGauges::RedisCheckHashes) = entries.len() as u64,
             id = state.id(),
         );
 
@@ -79,7 +79,7 @@ impl RedisSetLimiter {
             .invoke(con, limit, scope.redis_key_ttl(), hashes, keys)?;
 
         metric!(
-            histogram(CardinalityLimiterHistograms::RedisSetCardinality) = result.cardinality,
+            gauge(CardinalityLimiterGauges::RedisSetCardinality) = result.cardinality,
             id = state.id(),
         );
 

--- a/relay-cardinality/src/statsd.rs
+++ b/relay-cardinality/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{CounterMetric, HistogramMetric, SetMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric, SetMetric, TimerMetric};
 
 /// Counter metrics for the Relay Cardinality Limiter.
 pub enum CardinalityLimiterCounters {
@@ -81,7 +81,7 @@ impl TimerMetric for CardinalityLimiterTimers {
     }
 }
 
-pub enum CardinalityLimiterHistograms {
+pub enum CardinalityLimiterGauges {
     /// Amount of hashes sent to Redis to check the cardinality.
     ///
     /// This metric is tagged with:
@@ -96,7 +96,7 @@ pub enum CardinalityLimiterHistograms {
     RedisSetCardinality,
 }
 
-impl HistogramMetric for CardinalityLimiterHistograms {
+impl GaugeMetric for CardinalityLimiterGauges {
     fn name(&self) -> &'static str {
         match *self {
             #[cfg(feature = "redis")]


### PR DESCRIPTION
We're only interested in the max, all other information we'd get from a histogram is not really valuable here.

Extracted from: #3321 

#skip-changelog