### PR TITLE
Revert "ref(cardinality): Switch histogram to gauge"

### DIFF
--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -10,7 +10,7 @@ use crate::{
         script::{CardinalityScript, Status},
         state::{LimitState, RedisEntry},
     },
-    statsd::{CardinalityLimiterGauges, CardinalityLimiterTimers},
+    statsd::{CardinalityLimiterHistograms, CardinalityLimiterTimers},
     CardinalityLimit, Result,
 };
 use relay_common::time::UnixTimestamp;
@@ -63,7 +63,7 @@ impl RedisSetLimiter {
         let entries = state.take_entries();
 
         metric!(
-            gauge(CardinalityLimiterGauges::RedisCheckHashes) = entries.len() as u64,
+            histogram(CardinalityLimiterHistograms::RedisCheckHashes) = entries.len() as u64,
             id = state.id(),
         );
 
@@ -79,7 +79,7 @@ impl RedisSetLimiter {
             .invoke(con, limit, scope.redis_key_ttl(), hashes, keys)?;
 
         metric!(
-            gauge(CardinalityLimiterGauges::RedisSetCardinality) = result.cardinality,
+            histogram(CardinalityLimiterHistograms::RedisSetCardinality) = result.cardinality,
             id = state.id(),
         );
 

--- a/relay-cardinality/src/statsd.rs
+++ b/relay-cardinality/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{CounterMetric, GaugeMetric, SetMetric, TimerMetric};
+use relay_statsd::{CounterMetric, HistogramMetric, SetMetric, TimerMetric};
 
 /// Counter metrics for the Relay Cardinality Limiter.
 pub enum CardinalityLimiterCounters {
@@ -81,7 +81,7 @@ impl TimerMetric for CardinalityLimiterTimers {
     }
 }
 
-pub enum CardinalityLimiterGauges {
+pub enum CardinalityLimiterHistograms {
     /// Amount of hashes sent to Redis to check the cardinality.
     ///
     /// This metric is tagged with:
@@ -96,7 +96,7 @@ pub enum CardinalityLimiterGauges {
     RedisSetCardinality,
 }
 
-impl GaugeMetric for CardinalityLimiterGauges {
+impl HistogramMetric for CardinalityLimiterHistograms {
     fn name(&self) -> &'static str {
         match *self {
             #[cfg(feature = "redis")]


### PR DESCRIPTION
Reverts getsentry/relay#3331

Turns out datadog gauges suck compared to Sentry gauges.

#skip-changelog