### PR TITLE
instr(kafka): More broker stats

### DIFF
--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -20,7 +20,7 @@ impl ClientContext for Context {
         relay_statsd::metric!(gauge(KafkaGauges::MessageSize) = statistics.msg_size);
         relay_statsd::metric!(gauge(KafkaGauges::MessageSizeMax) = statistics.msg_size_max);
 
-        for broker in statistics.brokers.values() {
+        for (_, broker) in statistics.brokers {
             relay_statsd::metric!(
                 gauge(KafkaGauges::OutboundBufferRequests) = broker.outbuf_cnt as u64,
                 broker_name = &broker.name
@@ -43,13 +43,13 @@ impl ClientContext for Context {
             }
             if let Some(int_latency) = broker.int_latency {
                 relay_statsd::metric!(
-                    gauge(KafkaGauges::InternalLatency) = int_latency.max as u64,
+                    gauge(KafkaGauges::ProducerQueueLatency) = int_latency.max as u64,
                     broker_name = &broker.name
                 );
             }
             if let Some(outbuf_latency) = broker.outbuf_latency {
                 relay_statsd::metric!(
-                    gauge(KafkaGauges::OutboundBufferLatency) = outbuf_latency.max as u64,
+                    gauge(KafkaGauges::RequestQueueLatency) = outbuf_latency.max as u64,
                     broker_name = &broker.name
                 );
             }

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -41,6 +41,18 @@ impl ClientContext for Context {
                     broker_name = &broker.name
                 );
             }
+            if let Some(int_latency) = broker.int_latency {
+                relay_statsd::metric!(
+                    gauge(KafkaGauges::InternalLatency) = int_latency.max as u64,
+                    broker_name = &broker.name
+                );
+            }
+            if let Some(outbuf_latency) = broker.outbuf_latency {
+                relay_statsd::metric!(
+                    gauge(KafkaGauges::OutboundBufferLatency) = outbuf_latency.max as u64,
+                    broker_name = &broker.name
+                );
+            }
         }
     }
 }

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -80,6 +80,18 @@ pub enum KafkaGauges {
     /// This metric is tagged with:
     /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
     Disconnects,
+
+    /// Maximum internal producer queue latency, in microseconds.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    ProducerQueueLatency,
+
+    /// Maximum internal request queue latency, in microseconds.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    RequestQueueLatency,
 }
 
 impl GaugeMetric for KafkaGauges {
@@ -94,6 +106,8 @@ impl GaugeMetric for KafkaGauges {
             KafkaGauges::OutboundBufferMessages => "kafka.stats.broker.outbuf.messages",
             KafkaGauges::Connects => "kafka.stats.broker.connects",
             KafkaGauges::Disconnects => "kafka.stats.broker.disconnects",
+            KafkaGauges::ProducerQueueLatency => "kafka.stats.broker.int_latency",
+            KafkaGauges::RequestQueueLatency => "kafka.stats.broker.outbuf_latency",
         }
     }
 }


### PR DESCRIPTION
Follow-up to #3315: Also emit `int_latency` and `outbuf_latency` metrics. 

#skip-changelog