### PR TITLE
instr(kafka): Improve produce error handling

### DIFF
--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -20,7 +20,7 @@ use relay_statsd::metric;
 use thiserror::Error;
 
 use crate::config::{KafkaConfig, KafkaParams, KafkaTopic};
-use crate::statsd::{KafkaGauges, KafkaHistograms};
+use crate::statsd::{KafkaGauges, KafkaHistograms, KafkaCounters};
 
 mod utils;
 use utils::{Context, ThreadedProducer};
@@ -402,7 +402,12 @@ impl Producer {
                 relay_log::error!(
                     error = &error as &dyn std::error::Error,
                     tags.variant = variant,
-                    "error sending kafka message"
+                    "error sending kafka message to topic {}",
+                    topic_name
+                );
+                metric!(
+                    counter(KafkaCounters::ProducerEnqueueError) += 1,
+                    topic = topic_name
                 );
                 ClientError::SendFailed(error)
             })

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -20,7 +20,7 @@ use relay_statsd::metric;
 use thiserror::Error;
 
 use crate::config::{KafkaConfig, KafkaParams, KafkaTopic};
-use crate::statsd::{KafkaGauges, KafkaHistograms, KafkaCounters};
+use crate::statsd::{KafkaCounters, KafkaGauges, KafkaHistograms};
 
 mod utils;
 use utils::{Context, ThreadedProducer};

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -402,8 +402,8 @@ impl Producer {
                 relay_log::error!(
                     error = &error as &dyn std::error::Error,
                     tags.variant = variant,
-                    "error sending kafka message to topic {}",
-                    topic_name
+                    tags.topic = topic_name,
+                    "error sending kafka message",
                 );
                 metric!(
                     counter(KafkaCounters::ProducerEnqueueError) += 1,

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -11,12 +11,22 @@ pub enum KafkaCounters {
     /// This metric is tagged with:
     ///  - `topic`: The Kafka topic being produced to.
     ProcessingProduceError,
+
+    /// Number of messages that failed to be enqueued in the Kafka producer's memory buffer.
+    ///
+    /// These errors include, for example, _"UnknownTopic"_ errors when attempting to send a
+    /// message a topic that does not exist.
+    ///
+    /// This metric is tagged with:
+    ///  - `topic`: The Kafka topic being produced to.
+    ProducerEnqueueError,
 }
 
 impl CounterMetric for KafkaCounters {
     fn name(&self) -> &'static str {
         match self {
             Self::ProcessingProduceError => "processing.produce.error",
+            Self::ProducerEnqueueError => "producer.enqueue.error",
         }
     }
 }


### PR DESCRIPTION
- Include the name of the topic in the log message when `producer.send` fails.
- Report a metric for the number of Kafka messages that fail to enqueue.

See INC-696 for the motivation behind these changes.

#skip-changelog