### PR TITLE
instr(kafka): Tag existing metrics with variant

### DIFF
--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -391,6 +391,7 @@ impl Producer {
             self.last_report.replace(Instant::now());
             metric!(
                 gauge(KafkaGauges::InFlightCount) = producer.in_flight_count() as u64,
+                variant = variant,
                 topic = topic_name
             );
         }
@@ -407,6 +408,7 @@ impl Producer {
                 );
                 metric!(
                     counter(KafkaCounters::ProducerEnqueueError) += 1,
+                    variant = variant,
                     topic = topic_name
                 );
                 ClientError::SendFailed(error)

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -18,7 +18,8 @@ pub enum KafkaCounters {
     /// message a topic that does not exist.
     ///
     /// This metric is tagged with:
-    ///  - `topic`: The Kafka topic being produced to.
+    /// - `topic`: The Kafka topic being produced to.
+    /// - `variant`: The Kafka message variant.
     ProducerEnqueueError,
 }
 
@@ -52,7 +53,8 @@ pub enum KafkaGauges {
     /// See <https://docs.confluent.io/platform/7.5/clients/librdkafka/html/rdkafka_8h.html#ad4b3b7659cf9a79d3353810d6b625bb7>.
     ///
     /// This metric is tagged with:
-    /// - `topic`
+    /// - `topic`: The Kafka topic being produced to.
+    /// - `variant`: The Kafka message variant.
     InFlightCount,
 
     /// The current number of messages in producer queues.


### PR DESCRIPTION
Makes it easier to compare values, some things are only tagged or just queried by variant, if we have the same tags everywhere we can compare graphs.

#skip-changelog