### PR TITLE
ref(normalization): Remove duplicated normalization

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1515,7 +1515,7 @@ mod tests {
 
         assert_eq!(event.level.value().unwrap().to_string(), "info");
         assert_eq!(event.ty.value().unwrap().to_string(), "transaction");
-        assert_eq!(event.platform.value().unwrap().to_owned(), "other");
+        assert_eq!(event.platform.as_str().unwrap(), "other");
     }
 
     #[test]


### PR DESCRIPTION
When light normalization was introduced, the normalization of `platform` and `level` was duplicated from the store normalization. Now that there's a single normalization step, this PR removes that duplication.

#skip-changelog