### PR TITLE
ref(cardinality): Don't call Redis when its not necessary

### DIFF
--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -156,6 +156,10 @@ impl Limiter for RedisSetLimiter {
         let mut connection = client.connection()?;
 
         for mut state in states {
+            if state.is_empty() {
+                continue;
+            }
+
             let results = metric!(timer(CardinalityLimiterTimers::Redis), id = state.id(), {
                 self.check_limits(&mut connection, &mut state, timestamp)
             })?;

--- a/relay-cardinality/src/redis/state.rs
+++ b/relay-cardinality/src/redis/state.rs
@@ -82,6 +82,15 @@ impl<'a> LimitState<'a> {
         self.scopes.entry(scope).or_default().push(entry)
     }
 
+    /// Returns `true` if this state does not contain any entries.
+    ///
+    /// The state can be empty if:
+    /// - there are no entries matching this limit.
+    /// - all entries matching this limit were already handled by the cache.
+    pub fn is_empty(&mut self) -> bool {
+        self.scopes.is_empty()
+    }
+
     /// Returns the underlying cardinality limit id.
     pub fn id(&self) -> &'a str {
         &self.cardinality_limit.id

--- a/relay-cardinality/src/redis/state.rs
+++ b/relay-cardinality/src/redis/state.rs
@@ -87,7 +87,7 @@ impl<'a> LimitState<'a> {
     /// The state can be empty if:
     /// - there are no entries matching this limit.
     /// - all entries matching this limit were already handled by the cache.
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.scopes.is_empty()
     }
 


### PR DESCRIPTION
There is no need to call Redis without any data. Without the change we would still call into redis-rs even when the cache already handled everything.

Makes sure to skip without adding a `CardinalityLimiterTimers::Redis` timing.

#skip-changelog