### PR TITLE
ref(filter): Add GTmetrix to the list of web crawlers

### DIFF
--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -32,7 +32,8 @@ static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
         HubSpot\sCrawler|           # HubSpot web crawler (web-crawlers@hubspot.com)
         Bytespider|                 # Bytedance
         Better\sUptime|             # Better Uptime
-        Cloudflare-Healthchecks     # Cloudflare Health Checks
+        Cloudflare-Healthchecks|    # Cloudflare Health Checks
+        GTmetrix                    # GTmetrix
     "
     )
     .expect("Invalid web crawlers filter Regex")
@@ -119,7 +120,8 @@ mod tests {
             "Mozilla/5.0 (compatible; HubSpot Crawler; web-crawlers@hubspot.com)",
             "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)",
             "Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
-            "Mozilla/5.0 (compatible;Cloudflare-Healthchecks/1.0;+https://www.cloudflare.com/; healthcheck-id: 0d1ca23e292c8c14)"
+            "Mozilla/5.0 (compatible;Cloudflare-Healthchecks/1.0;+https://www.cloudflare.com/; healthcheck-id: 0d1ca23e292c8c14)",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36 GTmetrix",
         ];
 
         for banned_user_agent in &user_agents {


### PR DESCRIPTION
Adding a crawler signature for [GTmetrix](https://gtmetrix.com/).

> GTmetrix was developed as a tool for customers to easily test the performance of their webpages.

It's a performance testing tool that allows one-off and continuous monitoring. 

#skip-changelog