### PR TITLE
feat(spans): Macro for transaction <-> span conversion

### DIFF
--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -95,7 +95,7 @@ pub struct Span {
 
     /// Platform identifier.
     ///
-    /// See [`Event::platform`].
+    /// See [`Event::platform`](`crate::protocol::Event::platform`).
     #[metastructure(skip_serialization = "empty")]
     pub platform: Annotated<String>,
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -1,3 +1,5 @@
+mod conversion;
+
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;
 use relay_protocol::{Annotated, Empty, FromValue, Getter, IntoValue, Object, Val, Value};
@@ -107,38 +109,38 @@ pub struct Span {
     pub other: Object<Value>,
 }
 
-impl From<&Event> for Span {
-    fn from(event: &Event) -> Self {
-        let mut span = Self {
-            _metrics_summary: event._metrics_summary.clone(),
-            description: event.transaction.clone(),
-            is_segment: Some(true).into(),
-            received: event.received.clone(),
-            start_timestamp: event.start_timestamp.clone(),
-            timestamp: event.timestamp.clone(),
-            measurements: event.measurements.clone(),
-            platform: event.platform.clone(),
-            was_transaction: true.into(),
-            ..Default::default()
-        };
+// impl From<&Event> for Span {
+//     fn from(event: &Event) -> Self {
+//         let mut span = Self {
+//             _metrics_summary: event._metrics_summary.clone(),
+//             description: event.transaction.clone(),
+//             is_segment: Some(true).into(),
+//             received: event.received.clone(),
+//             start_timestamp: event.start_timestamp.clone(),
+//             timestamp: event.timestamp.clone(),
+//             measurements: event.measurements.clone(),
+//             platform: event.platform.clone(),
+//             was_transaction: true.into(),
+//             ..Default::default()
+//         };
 
-        if let Some(trace_context) = event.context::<TraceContext>().cloned() {
-            span.exclusive_time = trace_context.exclusive_time;
-            span.op = trace_context.op;
-            span.parent_span_id = trace_context.parent_span_id;
-            span.segment_id = trace_context.span_id.clone(); // a transaction is a segment
-            span.span_id = trace_context.span_id;
-            span.status = trace_context.status;
-            span.trace_id = trace_context.trace_id;
-        }
+//         if let Some(trace_context) = event.context::<TraceContext>().cloned() {
+//             span.exclusive_time = trace_context.exclusive_time;
+//             span.op = trace_context.op;
+//             span.parent_span_id = trace_context.parent_span_id;
+//             span.segment_id = trace_context.span_id; // a transaction is a segment
+//             span.span_id = trace_context.span_id;
+//             span.status = trace_context.status;
+//             span.trace_id = trace_context.trace_id;
+//         }
 
-        if let Some(profile_context) = event.context::<ProfileContext>() {
-            span.profile_id = profile_context.profile_id.clone();
-        }
+//         if let Some(profile_context) = event.context::<ProfileContext>() {
+//             span.profile_id = profile_context.profile_id.clone();
+//         }
 
-        span
-    }
-}
+//         span
+//     }
+// }
 
 impl Getter for Span {
     fn get_value(&self, path: &str) -> Option<Val<'_>> {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -109,39 +109,6 @@ pub struct Span {
     pub other: Object<Value>,
 }
 
-// impl From<&Event> for Span {
-//     fn from(event: &Event) -> Self {
-//         let mut span = Self {
-//             _metrics_summary: event._metrics_summary.clone(),
-//             description: event.transaction.clone(),
-//             is_segment: Some(true).into(),
-//             received: event.received.clone(),
-//             start_timestamp: event.start_timestamp.clone(),
-//             timestamp: event.timestamp.clone(),
-//             measurements: event.measurements.clone(),
-//             platform: event.platform.clone(),
-//             was_transaction: true.into(),
-//             ..Default::default()
-//         };
-
-//         if let Some(trace_context) = event.context::<TraceContext>().cloned() {
-//             span.exclusive_time = trace_context.exclusive_time;
-//             span.op = trace_context.op;
-//             span.parent_span_id = trace_context.parent_span_id;
-//             span.segment_id = trace_context.span_id; // a transaction is a segment
-//             span.span_id = trace_context.span_id;
-//             span.status = trace_context.status;
-//             span.trace_id = trace_context.trace_id;
-//         }
-
-//         if let Some(profile_context) = event.context::<ProfileContext>() {
-//             span.profile_id = profile_context.profile_id.clone();
-//         }
-
-//         span
-//     }
-// }
-
 impl Getter for Span {
     fn get_value(&self, path: &str) -> Option<Val<'_>> {
         Some(match path.strip_prefix("span.")? {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -6,8 +6,8 @@ use relay_protocol::{Annotated, Empty, FromValue, Getter, IntoValue, Object, Val
 
 use crate::processor::ProcessValue;
 use crate::protocol::{
-    Event, EventId, JsonLenientString, Measurements, MetricsSummary, OperationType, OriginType,
-    ProfileContext, SpanId, SpanStatus, Timestamp, TraceContext, TraceId,
+    EventId, JsonLenientString, Measurements, MetricsSummary, OperationType, OriginType, SpanId,
+    SpanStatus, Timestamp, TraceId,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
@@ -376,7 +376,6 @@ impl Getter for SpanData {
 mod tests {
     use crate::protocol::Measurement;
     use chrono::{TimeZone, Utc};
-    use insta::assert_debug_snapshot;
     use relay_base_schema::metrics::{InformationUnit, MetricUnit};
     use relay_protocol::RuleCondition;
     use similar_asserts::assert_eq;
@@ -486,87 +485,6 @@ mod tests {
         );
         assert!(RuleCondition::eq("span.was_transaction", true).matches(&span));
         assert!(!RuleCondition::eq("span.was_transaction", false).matches(&span));
-    }
-
-    #[test]
-    fn span_from_event() {
-        let event = Annotated::<Event>::from_json(
-            r#"{
-                "contexts": {
-                    "profile": {"profile_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab"},
-                    "trace": {
-                        "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
-                        "span_id": "FA90FDEAD5F74052",
-                        "type": "trace"
-                    }
-                },
-                "_metrics_summary": {
-                    "some_metric": [
-                        {
-                            "min": 1.0,
-                            "max": 2.0,
-                            "sum": 3.0,
-                            "count": 2,
-                            "tags": {
-                                "environment": "test"
-                            }
-                        }
-                    ]
-                }
-            }"#,
-        )
-        .unwrap()
-        .into_value()
-        .unwrap();
-
-        assert_debug_snapshot!(Span::from(&event), @r###"
-        Span {
-            timestamp: ~,
-            start_timestamp: ~,
-            exclusive_time: ~,
-            description: ~,
-            op: ~,
-            span_id: SpanId(
-                "fa90fdead5f74052",
-            ),
-            parent_span_id: ~,
-            trace_id: TraceId(
-                "4c79f60c11214eb38604f4ae0781bfb2",
-            ),
-            segment_id: SpanId(
-                "fa90fdead5f74052",
-            ),
-            is_segment: true,
-            status: ~,
-            tags: ~,
-            origin: ~,
-            profile_id: EventId(
-                a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab,
-            ),
-            data: ~,
-            sentry_tags: ~,
-            received: ~,
-            measurements: ~,
-            _metrics_summary: MetricsSummary(
-                {
-                    "some_metric": [
-                        MetricSummary {
-                            min: 1.0,
-                            max: 2.0,
-                            sum: 3.0,
-                            count: 2,
-                            tags: {
-                                "environment": "test",
-                            },
-                        },
-                    ],
-                },
-            ),
-            platform: ~,
-            was_transaction: true,
-            other: {},
-        }
-        "###);
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -1,4 +1,4 @@
-mod conversion;
+mod convert;
 
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -39,7 +39,7 @@ macro_rules! map_fields {
         contexts {
         $(
             $ContextType:ident {
-                $(span.$foo:ident $(, $(span.$span_field_from_context:ident),+)? <=> context.$context_field:ident), *
+                $(span.$primary_span_field:ident $(, $(span.$additional_span_field:ident),+)? <=> context.$context_field:ident), *
             }
         )*
         }
@@ -59,11 +59,11 @@ macro_rules! map_fields {
                     )*
                     $(
                         $(
-                            $foo: event.context::<$ContextType>()
+                            $primary_span_field: event.context::<$ContextType>()
                                 .map_or(None, |ctx|ctx.$context_field.value().cloned()).into(),
                             $(
                                 $(
-                                    $span_field_from_context: event.context::<$ContextType>()
+                                    $additional_span_field: event.context::<$ContextType>()
                                     .map_or(None, |ctx|ctx.$context_field.value().cloned()).into(),
                                 )+
                             )?

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -82,15 +82,17 @@ macro_rules! map_fields {
     };
 }
 
+// This macro call implements a bidirectional mapping between transaction event and segment spans,
+// allowing users to call both `Event::from(&span)` and `Span::from(&event)`.
 map_fields!(
     top-level:
         span._metrics_summary <=> event._metrics_summary,
+        span.description <=> event.transaction,
         span.measurements <=> event.measurements,
         span.platform <=> event.platform,
         span.received <=> event.received,
         span.start_timestamp <=> event.start_timestamp,
-        span.timestamp <=> event.timestamp,
-        span.description <=> event.transaction
+        span.timestamp <=> event.timestamp
     ;
     contexts:
         TraceContext:
@@ -107,6 +109,7 @@ map_fields!(
         ;
     ;
     fixed_for_span:
+        // A transaction event corresponds to a segment span.
         span.is_segment <= Some(true),
         span.was_transaction <= true
     ;

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -1,0 +1,72 @@
+//! TODO: docs
+use crate::protocol::{Event, Span};
+
+macro_rules! map_fields {
+    (
+        common:
+            $($field:ident), *
+        ;
+        mapped:
+            $(span.$span_field:ident <=> event.$event_field:ident), *
+        ;
+        fixed_for_span:
+            $(span.$fixed_span_field:ident <= $fixed_span_value:expr), *
+        ;
+        fixed_for_event:
+            $($fixed_event_value:expr => span.$fixed_event_field:ident), *
+    ) => {
+        impl From<&Event> for Span {
+            fn from(event: &Event) -> Self {
+                Self {
+                    $(
+                        $field: event.$field.clone(),
+                    )*
+                    $(
+                        $span_field: event.$event_field.clone(),
+                    )*
+                    $(
+                        $fixed_span_field: $fixed_span_value.into(),
+                    )*
+                    ..Default::default()
+                }
+            }
+        }
+
+        impl From<&Span> for Event {
+            fn from(span: &Span) -> Self {
+                Self {
+                    $(
+                        $field: span.$field.clone(),
+                    )*
+                    $(
+                        $event_field: span.$span_field.clone(),
+                    )*
+                    $(
+                        $fixed_event_field: $fixed_event_value.into(),
+                    )*
+                    ..Default::default()
+                }
+            }
+        }
+    };
+}
+
+map_fields!(
+    common:
+        _metrics_summary,
+        measurements,
+        platform,
+        received,
+        start_timestamp,
+        timestamp
+    ;
+    mapped:
+        span.description <=> event.transaction
+    ;
+    fixed_for_span:
+        span.is_segment <= Some(true),
+        span.was_transaction <= true
+    ;
+    fixed_for_event:
+        // nothing yet
+);

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -93,7 +93,7 @@ macro_rules! map_fields {
                                 $(
                                     (<$ContextType as DefaultContext>::default_key().into(), ContextInner($ContextType {
                                         $(
-                                            $context_field: span.$foo.clone(),
+                                            $context_field: span.$primary_span_field.clone(),
                                         )*
                                         ..Default::default()
                                     }.into_context()).into()),

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 ///
 /// Example:
 ///
-/// ```skip
+/// ```ignore
 /// map_fields!(
 ///     top-level:
 ///         span.received: event.received

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -1,5 +1,10 @@
-//! TODO: docs
-use crate::protocol::{Event, ProfileContext, Span, TraceContext};
+//! This module defines bidirectional field mappings between spans and transactions.
+use crate::protocol::{
+    ContextInner, Contexts, DefaultContext, Event, ProfileContext, Span, TraceContext,
+};
+
+use relay_protocol::Annotated;
+use std::collections::BTreeMap;
 
 macro_rules! map_fields {
     (
@@ -10,8 +15,8 @@ macro_rules! map_fields {
             $(span.$span_field:ident <=> event.$event_field:ident), *
             contexts:
             $(
-                #$context_type:ty:
-                    $(span.$span_field_from_context:ident <=> context.$context_field:ident), *
+                #$ContextType:ident:
+                    $(span.$foo:ident $(, $(span.$span_field_from_context:ident),+)? <=> context.$context_field:ident), *
             )*
 
         ;
@@ -32,8 +37,14 @@ macro_rules! map_fields {
                     )*
                     $(
                         $(
-                            $span_field_from_context: event.context::<$context_type>()
+                            $foo: event.context::<$ContextType>()
                                 .map_or(None, |ctx|ctx.$context_field.value().cloned()).into(),
+                            $(
+                                $(
+                                    $span_field_from_context: event.context::<$ContextType>()
+                                    .map_or(None, |ctx|ctx.$context_field.value().cloned()).into(),
+                                )+
+                            )?
                         )*
                     )*
                     $(
@@ -56,11 +67,20 @@ macro_rules! map_fields {
                     $(
                         $fixed_event_field: $fixed_event_value.into(),
                     )*
-                    // contexts: Annotated::new(
-                    //     Contexts(
-
-                    //     )
-                    // )
+                    contexts: Annotated::new(
+                        Contexts(
+                            BTreeMap::from([
+                                $(
+                                    (<$ContextType as DefaultContext>::default_key().into(), ContextInner($ContextType {
+                                        $(
+                                            $context_field: span.$foo.clone(),
+                                        )*
+                                        ..Default::default()
+                                    }.into_context()).into()),
+                                )*
+                            ]),
+                        )
+                    ),
                     ..Default::default()
                 }
             }
@@ -84,8 +104,7 @@ map_fields!(
                 span.exclusive_time <=> context.exclusive_time,
                 span.op <=> context.op,
                 span.parent_span_id <=> context.parent_span_id,
-                span.segment_id <=> context.span_id,
-                span.span_id <=> context.span_id,
+                span.span_id, span.segment_id <=> context.span_id,
                 span.status <=> context.status,
                 span.trace_id <=> context.trace_id
             #ProfileContext:
@@ -98,3 +117,116 @@ map_fields!(
     fixed_for_event:
         // nothing yet
 );
+
+#[cfg(test)]
+mod tests {
+    use relay_protocol::Annotated;
+
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let event = Annotated::<Event>::from_json(
+            r#"{
+                "contexts": {
+                    "profile": {"profile_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab"},
+                    "trace": {
+                        "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
+                        "span_id": "FA90FDEAD5F74052",
+                        "type": "trace",
+                        "op": "myop",
+                        "status": "ok",
+                        "exclusive_time": 123.4,
+                        "parent_span_id": "FA90FDEAD5F74051"
+                    }
+                },
+                "_metrics_summary": {
+                    "some_metric": [
+                        {
+                            "min": 1.0,
+                            "max": 2.0,
+                            "sum": 3.0,
+                            "count": 2,
+                            "tags": {
+                                "environment": "test"
+                            }
+                        }
+                    ]
+                },
+                "measurements": {
+                    "memory": {
+                        "value": 9001.0,
+                        "unit": "byte"
+                    }
+                }
+            }"#,
+        )
+        .unwrap()
+        .into_value()
+        .unwrap();
+
+        let span_from_event = Span::from(&event);
+        insta::assert_debug_snapshot!(span_from_event, @r###"
+        Span {
+            timestamp: ~,
+            start_timestamp: ~,
+            exclusive_time: 123.4,
+            description: ~,
+            op: "myop",
+            span_id: SpanId(
+                "fa90fdead5f74052",
+            ),
+            parent_span_id: SpanId(
+                "fa90fdead5f74051",
+            ),
+            trace_id: TraceId(
+                "4c79f60c11214eb38604f4ae0781bfb2",
+            ),
+            segment_id: SpanId(
+                "fa90fdead5f74052",
+            ),
+            is_segment: true,
+            status: Ok,
+            tags: ~,
+            origin: ~,
+            profile_id: EventId(
+                a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab,
+            ),
+            data: ~,
+            sentry_tags: ~,
+            received: ~,
+            measurements: Measurements(
+                {
+                    "memory": Measurement {
+                        value: 9001.0,
+                        unit: Information(
+                            Byte,
+                        ),
+                    },
+                },
+            ),
+            _metrics_summary: MetricsSummary(
+                {
+                    "some_metric": [
+                        MetricSummary {
+                            min: 1.0,
+                            max: 2.0,
+                            sum: 3.0,
+                            count: 2,
+                            tags: {
+                                "environment": "test",
+                            },
+                        },
+                    ],
+                },
+            ),
+            platform: ~,
+            was_transaction: true,
+            other: {},
+        }
+        "###);
+
+        let roundtripped = Event::from(&span_from_event);
+        assert_eq!(event, roundtripped);
+    }
+}

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -6,6 +6,29 @@ use crate::protocol::{
 use relay_protocol::Annotated;
 use std::collections::BTreeMap;
 
+/// Implements the conversion between transaction events and segment spans.
+///
+/// Invoking this macro implements both `From<&Event> for Span` and `From<&Span> for Event`.
+///
+/// Example:
+///
+/// ```skip
+/// map_fields!(
+///     top-level:
+///         span.received: event.received
+///     contexts:
+///         TraceContext:
+///             span.trace_id: context.trace_id
+///         ;
+///     ;
+///     fixed_for_span:
+///         // ...
+///     ;
+///     fixed_for_event:
+///         // ...
+///     ;
+/// );
+/// ```
 macro_rules! map_fields {
     (
         top-level:

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -20,7 +20,7 @@ impl ClientContext for Context {
         relay_statsd::metric!(gauge(KafkaGauges::MessageSize) = statistics.msg_size);
         relay_statsd::metric!(gauge(KafkaGauges::MessageSizeMax) = statistics.msg_size_max);
 
-        for (_, broker) in statistics.brokers {
+        for broker in statistics.brokers.values() {
             relay_statsd::metric!(
                 gauge(KafkaGauges::OutboundBufferRequests) = broker.outbuf_cnt as u64,
                 broker_name = &broker.name
@@ -41,7 +41,7 @@ impl ClientContext for Context {
                     broker_name = &broker.name
                 );
             }
-            if let Some(int_latency) = broker.int_latency {
+            if let Some(int_latency) = &broker.int_latency {
                 relay_statsd::metric!(
                     gauge(KafkaGauges::ProducerQueueLatency) = int_latency.max as u64,
                     broker_name = &broker.name

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -20,7 +20,7 @@ impl ClientContext for Context {
         relay_statsd::metric!(gauge(KafkaGauges::MessageSize) = statistics.msg_size);
         relay_statsd::metric!(gauge(KafkaGauges::MessageSizeMax) = statistics.msg_size_max);
 
-        for broker in statistics.brokers.values() {
+        for (_, broker) in statistics.brokers {
             relay_statsd::metric!(
                 gauge(KafkaGauges::OutboundBufferRequests) = broker.outbuf_cnt as u64,
                 broker_name = &broker.name

--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -41,7 +41,7 @@ impl ClientContext for Context {
                     broker_name = &broker.name
                 );
             }
-            if let Some(int_latency) = &broker.int_latency {
+            if let Some(int_latency) = broker.int_latency {
                 relay_statsd::metric!(
                     gauge(KafkaGauges::ProducerQueueLatency) = int_latency.max as u64,
                     broker_name = &broker.name


### PR DESCRIPTION
We currently convert transactions to segment spans, and in the near future will convert segment spans to transactions as well (see https://github.com/getsentry/relay/issues/3278).

The goal of this PR is to have a declarative implementation of the conversion in both directions, such that it is easy to extend and to make sure that the two implementations (`From<&Event> for Span` and `From<&Span> for Event`) do not diverge over time.

Future work (not in this PR): Actually conversion of incoming segment spans to transactions.

#skip-changelog