### PR TITLE
instr(metrics): Include namespace in store message variant

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -16,8 +16,8 @@ use relay_event_schema::protocol::{EventId, SessionStatus, VALID_PLATFORMS};
 
 use relay_kafka::{ClientError, KafkaClient, KafkaTopic, Message};
 use relay_metrics::{
-    Bucket, BucketView, BucketViewValue, BucketsView, FiniteF64, GaugeValue, MetricNamespace,
-    SetView,
+    Bucket, BucketView, BucketViewValue, BucketsView, FiniteF64, GaugeValue, MetricName,
+    MetricNamespace, SetView,
 };
 use relay_quotas::Scoping;
 use relay_statsd::metric;
@@ -657,7 +657,7 @@ impl StoreService {
             MetricNamespace::Sessions => KafkaTopic::MetricsSessions,
             MetricNamespace::Unsupported => {
                 relay_log::with_scope(
-                    |scope| scope.set_extra("metric_message.name", message.name.into()),
+                    |scope| scope.set_extra("metric_message.name", message.name.as_ref().into()),
                     || relay_log::error!("store service dropping unknown metric usecase"),
                 );
                 return Ok(());
@@ -1254,7 +1254,7 @@ struct SessionKafkaMessage {
 struct MetricKafkaMessage<'a> {
     org_id: u64,
     project_id: ProjectId,
-    name: &'a str,
+    name: &'a MetricName,
     #[serde(flatten)]
     value: MetricValue<'a>,
     timestamp: UnixTimestamp,
@@ -1490,7 +1490,15 @@ impl Message for KafkaMessage<'_> {
             KafkaMessage::Attachment(_) => "attachment",
             KafkaMessage::AttachmentChunk(_) => "attachment_chunk",
             KafkaMessage::UserReport(_) => "user_report",
-            KafkaMessage::Metric { .. } => "metric",
+            KafkaMessage::Metric { message, .. } => match message.name.namespace() {
+                MetricNamespace::Sessions => "metric_sessions",
+                MetricNamespace::Transactions => "metric_transactions",
+                MetricNamespace::Spans => "metric_spans",
+                MetricNamespace::Profiles => "metric_profiles",
+                MetricNamespace::Custom => "metric_custom",
+                MetricNamespace::Stats => "metric_metric_stats",
+                MetricNamespace::Unsupported => "metric_unsupported",
+            },
             KafkaMessage::Profile(_) => "profile",
             KafkaMessage::ReplayEvent(_) => "replay_event",
             KafkaMessage::ReplayRecordingNotChunked(_) => "replay_recording_not_chunked",


### PR DESCRIPTION
Includes the namespace in the variant name, this is an easy way to have all metrics tagged with the namespace, including the ones emitted from `relay-kafka`.

This will be very interesting to see for the metric bucket encoding change.

#skip-changelog