### PR TITLE
fix(spool): Fix performance regression when enqueueing envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Extract `cache.item_size` and `cache.hit` data into span indexed ([#3367]https://github.com/getsentry/relay/pull/3367)
 - Allow IP addresses in metrics domain tag. ([#3365](https://github.com/getsentry/relay/pull/3365))
 
+**Bug Fixes**:
+
+- Fix performance regression in the spooler. ([#3378](https://github.com/getsentry/relay/pull/3378))
+
 **Internal**:
 
 - Enable `db.redis` span metrics extraction. ([#3283](https://github.com/getsentry/relay/pull/3283))

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -689,9 +689,9 @@ impl OnDisk {
         }
     }
 
-    /// Estimates the db size by multiplying `page_count * page_size`.
+    /// Estimates the db size by summing the size of all stored envelopes.
     async fn estimate_spool_size(&self) -> Result<i64, BufferError> {
-        let size: i64 = sql::current_size()
+        let size: i64 = sql::estimate_size()
             .fetch_one(&self.db)
             .await
             .and_then(|r| r.try_get(0))
@@ -1557,7 +1557,7 @@ mod tests {
             .filter(|name| name.contains("buffer."))
             .collect();
 
-        assert_debug_snapshot!(captures, @r#"
+        assert_debug_snapshot!(captures, @r###"
         [
             "buffer.envelopes_mem:2000|h",
             "buffer.envelopes_mem_count:1|g",
@@ -1569,26 +1569,31 @@ mod tests {
             "buffer.writes:1|c",
             "buffer.envelopes_written:3|c",
             "buffer.envelopes_disk_count:3|g",
-            "buffer.disk_size:1031|h",
+            "buffer.disk_size:777|h",
             "buffer.envelopes_written:1|c",
             "buffer.envelopes_disk_count:4|g",
             "buffer.writes:1|c",
-            "buffer.disk_size:1372|h",
-            "buffer.disk_size:1372|h",
-            "buffer.envelopes_written:1|c",
-            "buffer.envelopes_disk_count:5|g",
+            "buffer.disk_size:1036|h",
+            "buffer.reads:1|c",
+            "buffer.envelopes_read:-4|c",
+            "buffer.envelopes_disk_count:0|g",
+            "buffer.reads:1|c",
+            "buffer.envelopes_mem:10000|h",
+            "buffer.envelopes_mem_count:5|g",
+            "buffer.envelopes_mem:0|h",
             "buffer.writes:1|c",
-            "buffer.disk_size:1713|h",
+            "buffer.envelopes_written:5|c",
+            "buffer.envelopes_disk_count:5|g",
             "buffer.dequeue_attempts:1|h",
             "buffer.reads:1|c",
             "buffer.envelopes_read:-5|c",
             "buffer.envelopes_disk_count:0|g",
             "buffer.dequeue_attempts:1|h",
             "buffer.reads:1|c",
-            "buffer.disk_size:8|h",
+            "buffer.disk_size:0|h",
             "buffer.reads:1|c",
         ]
-        "#);
+        "###);
     }
 
     pub enum TestHealth {

--- a/relay-server/src/services/spooler/sql.rs
+++ b/relay-server/src/services/spooler/sql.rs
@@ -70,11 +70,11 @@ pub fn delete<'a>(key: QueueKey) -> Query<'a, Sqlite, SqliteArguments<'a>> {
         .bind(key.sampling_key.to_string())
 }
 
-/// Creates a query which fetches the `envelopes` table size.
+/// Creates a query which estimates the `envelopes` table size.
 ///
-/// This info used to calculate the current allocated database size.
-pub fn current_size<'a>() -> Query<'a, Sqlite, SqliteArguments<'a>> {
-    sqlx::query(r#"SELECT SUM(pgsize - unused) FROM dbstat WHERE name="envelopes""#)
+/// This info used to estimate the current allocated database size.
+pub fn estimate_size<'a>() -> Query<'a, Sqlite, SqliteArguments<'a>> {
+    sqlx::query(r#"SELECT SUM(length(envelope)) FROM envelopes"#)
 }
 
 /// Creates the query to select only 1 record's `received_at` from the database.


### PR DESCRIPTION
For every `Enqueue` message we execute an insert and then afterwards run the `current_size` query on the database, which becomes slower with every additional byte inserted into the table. After 500mb inserted each query already takes more than 250ms!

The new query may slightly be under estimating the actual size of the database but should be close enough for our needs.

In the future we should re-consider this current mechanism and keep track of the database size in memory or other means, I didn't want to refactor the spooling code and potentially introduce new bugs now, this should fix our immediate problem. We can revisit the architecture of the spool at a later point.

In my very simple tests it showed that inserting in a batch by constructing multiple statements via the query builder vs multiple separate insert statements made no noticeable difference.