### PR TITLE
fix(spans): Allow spans with no exclusive_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 **Bug Fixes**:
 
-- Allow spans with no exclusive_time. ([#3385](https://github.com/getsentry/relay/pull/3385))
+- Allow spans with no `exclusive_time`. ([#3385](https://github.com/getsentry/relay/pull/3385))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Support the full unicode character set via UTF-8 encoding for metric tags submitted via the statsd format. Certain restricted characters require escape sequences, see [docs](https://develop.sentry.dev/sdk/metrics/#normalization) for the precise rules. ([#3358](https://github.com/getsentry/relay/pull/3358))
 - Stop extracting count_per_segment and count_per_op metrics. ([#3380](https://github.com/getsentry/relay/pull/3380))
 
+**Bug Fixes**:
+
+- Allow spans with exclusive_time 0. ([#3385](https://github.com/getsentry/relay/pull/3385))
+
 **Internal**:
 
 - Enable `db.redis` span metrics extraction. ([#3283](https://github.com/getsentry/relay/pull/3283))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 **Bug Fixes**:
 
-- Allow spans with exclusive_time 0. ([#3385](https://github.com/getsentry/relay/pull/3385))
+- Allow spans with no exclusive_time. ([#3385](https://github.com/getsentry/relay/pull/3385))
 
 **Internal**:
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -431,7 +431,6 @@ fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, anyhow::Error>
         .as_mut()
         .ok_or(anyhow::anyhow!("empty span"))?;
     let Span {
-        ref exclusive_time,
         ref mut tags,
         ref mut sentry_tags,
         ref mut start_timestamp,

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -464,11 +464,6 @@ fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, anyhow::Error>
         }
     }
 
-    // `is_segment` is set by `extract_span`.
-    exclusive_time
-        .value()
-        .ok_or(anyhow::anyhow!("missing exclusive_time"))?;
-
     if let Some(sentry_tags) = sentry_tags.value_mut() {
         sentry_tags.retain(|key, value| match value.value() {
             Some(s) => {


### PR DESCRIPTION
I added this condition to guard against ingesting standalone spans with no `exclusive_time` but some spans can have an `exclusive_time` not set at all and still be considered legitimate spans (standalone spans).

We need to remove this guard.