### PR TITLE
feat(spans): Route spans according to trace_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Pass `retention_days` in the Kafka profile messages. ([#3362](https://github.com/getsentry/relay/pull/3362))
 - Support and expose namespaces for metric rate limit propagation via the `x-sentry-rate-limits` header. ([#3347](https://github.com/getsentry/relay/pull/3347))
 - Tag span duration metric by group for all ops supporting description scrubbing. ([#3370](https://github.com/getsentry/relay/pull/3370))
+- Route spans according to trace_id. ([#3387](https://github.com/getsentry/relay/pull/3387))
 
 ## 24.3.0
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1031,7 +1031,7 @@ impl StoreService {
                         project_id,
                         received,
                         retention_days,
-                        segment_id,
+                        segment_id: segment_id.unwrap_or_default(),
                         span_id,
                         sum,
                         tags,
@@ -1378,7 +1378,8 @@ struct SpanKafkaMessage<'a> {
     /// Number of days until these data should be deleted.
     #[serde(default)]
     retention_days: u16,
-    segment_id: &'a str,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    segment_id: Option<&'a str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     sentry_tags: Option<BTreeMap<&'a str, String>>,
     span_id: &'a str,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -49,7 +49,7 @@ def test_span_extraction(
         project_config["config"]["features"].append("projects:discard-transaction")
 
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
-    end = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=1)
+    end = datetime.now(timezone.utc) - timedelta(seconds=1)
     duration = timedelta(milliseconds=500)
     start = end - duration
     event["spans"] = [
@@ -325,7 +325,7 @@ def test_span_ingestion(
     ]
 
     duration = timedelta(milliseconds=500)
-    end = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=1)
+    end = datetime.now(timezone.utc) - timedelta(seconds=1)
     start = end - duration
 
     # 1 - Send OTel span and sentry span via envelope
@@ -869,10 +869,10 @@ def test_span_reject_invalid_timestamps(
     duration = timedelta(milliseconds=500)
     yesterday_delta = timedelta(days=1)
 
-    end_yesterday = datetime.utcnow().replace(tzinfo=timezone.utc) - yesterday_delta
+    end_yesterday = datetime.now(timezone.utc) - yesterday_delta
     start_yesterday = end_yesterday - duration
 
-    end_today = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=1)
+    end_today = datetime.now(timezone.utc) - timedelta(seconds=1)
     start_today = end_today - duration
 
     envelope = Envelope()
@@ -978,7 +978,7 @@ def test_span_ingestion_with_performance_scores(
     ]
 
     duration = timedelta(milliseconds=500)
-    end = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=1)
+    end = datetime.now(timezone.utc) - timedelta(seconds=1)
     start = end - duration
 
     envelope = Envelope()
@@ -1134,7 +1134,7 @@ def test_rate_limit_indexed_consistent(
     spans_consumer = spans_consumer()
     outcomes_consumer = outcomes_consumer()
 
-    start = datetime.utcnow()
+    start = datetime.now(timezone.utc)
     end = start + timedelta(seconds=1)
 
     envelope = envelope_with_spans(start, end)
@@ -1182,11 +1182,11 @@ def test_rate_limit_indexed_consistent_extracted(
     spans_consumer = spans_consumer()
     outcomes_consumer = outcomes_consumer()
 
-    start = datetime.utcnow()
+    start = datetime.now(timezone.utc)
     end = start + timedelta(seconds=1)
 
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
-    end = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=1)
+    end = datetime.now(timezone.utc) - timedelta(seconds=1)
     duration = timedelta(milliseconds=500)
     start = end - duration
     event["spans"] = [
@@ -1252,7 +1252,7 @@ def test_rate_limit_metrics_consistent(
     metrics_consumer = metrics_consumer()
     outcomes_consumer = outcomes_consumer()
 
-    start = datetime.utcnow()
+    start = datetime.now(timezone.utc)
     end = start + timedelta(seconds=1)
 
     envelope = envelope_with_spans(start, end)


### PR DESCRIPTION
We're in need of buffering spans later in the pipeline and it helps to have them on the same partition. We only need them routed per `segment_id` but since it's not a `Uuid`, using `trace_id` is simpler. An alternative would be to properly transform the `segment_id` into a `u64` and then call `Uuid::from_u64_pair(segment_id, 0)` but that seems unnecessary.