### PR TITLE
build(workspace): Move unescaper to the workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ tower-http = { version = "0.4.0", default-features = false }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 uaparser = "0.6.0"
+unescaper = "0.1.4"
 unicase = "2.6.0"
 url = "2.1.1"
 utf16string = "0.2.0"

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
-unescaper = "0.1.4"
+unescaper = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Fell through the cracks, moves `unescaper` dependency to the workspace root with all the other dependencies.

#skip-changelog