### PR TITLE
ref(statsd): Rename event normalization metric name

### DIFF
--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1452,7 +1452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_light_normalization_respects_is_renormalize() {
+    fn test_normalization_respects_is_renormalize() {
         let mut event = Annotated::<Event>::from_json(
             r#"
             {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1311,7 +1311,7 @@ impl EnvelopeProcessorService {
                     .and_then(|ctx| ctx.replay_id),
             };
 
-            metric!(timer(RelayTimers::EventProcessingLightNormalization), {
+            metric!(timer(RelayTimers::EventProcessingNormalization), {
                 validate_event_timestamps(event, &event_validation_config)
                     .map_err(|_| ProcessingError::InvalidTransaction)?;
                 validate_transaction(event, &tx_validation_config)

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -220,9 +220,9 @@ pub enum RelayTimers {
     /// Time in milliseconds spent deserializing an event from JSON bytes into the native data
     /// structure on which Relay operates.
     EventProcessingDeserialize,
-    /// Time in milliseconds spent running light normalization on an event. Light normalization
-    /// happens before envelope filtering and metrics extraction.
-    EventProcessingLightNormalization,
+    /// Time in milliseconds spent running normalization on an event. Normalization
+    /// happens before envelope filtering and metric extraction.
+    EventProcessingNormalization,
     /// Time in milliseconds spent running inbound data filters on an event.
     EventProcessingFiltering,
     /// Time in milliseconds spent checking for organization, project, and DSN rate limits.
@@ -388,9 +388,7 @@ impl TimerMetric for RelayTimers {
     fn name(&self) -> &'static str {
         match self {
             RelayTimers::EventProcessingDeserialize => "event_processing.deserialize",
-            RelayTimers::EventProcessingLightNormalization => {
-                "event_processing.light_normalization"
-            }
+            RelayTimers::EventProcessingNormalization => "event_processing.normalization",
             RelayTimers::EventProcessingFiltering => "event_processing.filtering",
             #[cfg(feature = "processing")]
             RelayTimers::EventProcessingRateLimiting => "event_processing.rate_limiting",


### PR DESCRIPTION
Since we no longer have light normalization, the metric shouldn't have that name either.

I didn't find any usage of this metric in the main dashboards we monitor. I'm leaving the metric as I think it's still valuable to have it.

#skip-changelog