### PR TITLE
build: Enable missing tokio features in relay-system

### DIFF
--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -17,7 +17,7 @@ futures = { workspace = true }
 once_cell = { workspace = true }
 relay-log = { workspace = true }
 relay-statsd = { workspace = true }
-tokio = { workspace = true, features = ["rt", "signal", "macros"] }
+tokio = { workspace = true, features = ["rt", "signal", "macros", "sync", "time"] }
 
 [dev-dependencies]
 relay-statsd = { workspace = true, features = ["test"] }


### PR DESCRIPTION
Running `cargo check` in `relay-system` fails without those 2 flags, both `tokio::time` and `tokio::sync` are used.

#skip-changelog