### PR TITLE
feat(spans): Sample extraction

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -166,10 +166,9 @@ pub struct Options {
     #[serde(
         rename = "relay.span-extraction.sample-rate",
         deserialize_with = "default_on_error",
-        default = "one",
-        skip_serializing_if = "is_one"
+        skip_serializing_if = "is_default"
     )]
-    pub span_extraction_sample_rate: f32,
+    pub span_extraction_sample_rate: Option<f32>,
 
     /// All other unknown options.
     #[serde(flatten)]
@@ -300,14 +299,6 @@ pub enum BucketEncoding {
 /// Returns `true` if this value is equal to `Default::default()`.
 fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     *t == T::default()
-}
-
-fn one() -> f32 {
-    1.0
-}
-
-fn is_one(value: &f32) -> bool {
-    *value == 1.0
 }
 
 fn default_on_error<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -162,7 +162,7 @@ pub struct Options {
     /// spans are extracted. It applies on top of [`crate::Feature::ExtractSpansAndSpanMetricsFromEvent`],
     /// so both feature flag and sample rate need to be enabled to get any spans extracted.
     ///
-    /// Any value below 1.0 will cause the product to break, so use with caution.
+    /// Note: Any value below 1.0 will cause the product to break, so use with caution.
     #[serde(
         rename = "relay.span-extraction.sample-rate",
         deserialize_with = "default_on_error",

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -156,6 +156,21 @@ pub struct Options {
     )]
     pub metric_stats_rollout_rate: f32,
 
+    /// Overall sampling of span extraction.
+    ///
+    /// This number represents the fraction of transactions for which
+    /// spans are extracted. It applies on top of [`crate::Feature::ExtractSpansAndSpanMetricsFromEvent`],
+    /// so both feature flag and sample rate need to be enabled to get any spans extracted.
+    ///
+    /// Any value below 1.0 will cause the product to break, so use with caution.
+    #[serde(
+        rename = "relay.span-extraction.sample-rate",
+        deserialize_with = "default_on_error",
+        default = "one",
+        skip_serializing_if = "is_one"
+    )]
+    pub span_extraction_sample_rate: f32,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,
@@ -285,6 +300,14 @@ pub enum BucketEncoding {
 /// Returns `true` if this value is equal to `Default::default()`.
 fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     *t == T::default()
+}
+
+fn one() -> f32 {
+    1.0
+}
+
+fn is_one(value: &f32) -> bool {
+    *value == 1.0
 }
 
 fn default_on_error<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -162,6 +162,8 @@ pub struct Options {
     /// spans are extracted. It applies on top of [`crate::Feature::ExtractSpansAndSpanMetricsFromEvent`],
     /// so both feature flag and sample rate need to be enabled to get any spans extracted.
     ///
+    /// `None` is the default and interpreted as a value of 1.0 (extract everything).
+    ///
     /// Note: Any value below 1.0 will cause the product to break, so use with caution.
     #[serde(
         rename = "relay.span-extraction.sample-rate",

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1418,7 +1418,11 @@ impl EnvelopeProcessorService {
                 if state.has_event() {
                     event::scrub(state)?;
                     if_processing!(self.inner.config, {
-                        span::extract_from_event(state, &self.inner.config);
+                        span::extract_from_event(
+                            state,
+                            &self.inner.config,
+                            &self.inner.global_config.current(),
+                        );
                     });
                 }
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -149,23 +149,25 @@ pub fn extract_from_event(
     global_config: &GlobalConfig,
 ) {
     // Only extract spans from transactions (not errors).
-    if state.event_type() != Some(EventType::Transaction) {
+    if dbg!(state.event_type()) != Some(EventType::Transaction) {
         return;
     };
 
-    if !state
+    if !dbg!(state
         .project_state
-        .has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent)
+        .has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent))
     {
         return;
     }
 
-    if !sample(global_config.options.span_extraction_sample_rate) {
-        return;
+    if let Some(sample_rate) = global_config.options.span_extraction_sample_rate {
+        if !sample(sample_rate) {
+            return;
+        }
     }
 
     let mut add_span = |span: Annotated<Span>| {
-        let span = match validate(span) {
+        let span = match dbg!(validate(span)) {
             Ok(span) => span,
             Err(e) => {
                 relay_log::error!("Invalid span: {e}");
@@ -202,12 +204,12 @@ pub fn extract_from_event(
         return;
     };
 
-    let Some(transaction_span) = extract_transaction_span(
+    let Some(transaction_span) = dbg!(extract_transaction_span(
         event,
         config
             .aggregator_config_for(MetricNamespace::Spans)
             .max_tag_value_length,
-    ) else {
+    )) else {
         return;
     };
     // Add child spans as envelope items.
@@ -498,4 +500,131 @@ fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, anyhow::Error>
     }
 
     Ok(span)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use bytes::Bytes;
+    use relay_base_schema::project::ProjectId;
+    use relay_event_schema::protocol::{
+        Context, ContextInner, SpanId, Timestamp, TraceContext, TraceId,
+    };
+    use relay_sampling::evaluation::{ReservoirCounters, ReservoirEvaluator};
+    use relay_system::Addr;
+
+    use crate::envelope::Envelope;
+    use crate::services::processor::ProcessingGroup;
+    use crate::services::project::ProjectState;
+    use crate::utils::ManagedEnvelope;
+
+    use super::*;
+
+    fn state() -> ProcessEnvelopeState<'static, TransactionGroup> {
+        let bytes = Bytes::from(
+            "\
+             {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n\
+             {\"type\":\"transaction\"}\n{}\n",
+        );
+
+        let dummy_envelope = Envelope::parse_bytes(bytes).unwrap();
+        let mut project_state = ProjectState::allowed();
+        project_state
+            .config
+            .features
+            .0
+            .insert(Feature::ExtractSpansAndSpanMetricsFromEvent);
+
+        let event = Event {
+            ty: EventType::Transaction.into(),
+            start_timestamp: Timestamp(DateTime::from_timestamp(0, 0).unwrap()).into(),
+            timestamp: Timestamp(DateTime::from_timestamp(1, 0).unwrap()).into(),
+
+            contexts: Contexts(BTreeMap::from([(
+                "trace".into(),
+                ContextInner(Context::Trace(Box::new(TraceContext {
+                    trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
+                    span_id: Annotated::new(SpanId("fa90fdead5f74053".into())),
+                    exclusive_time: 1000.0.into(),
+                    ..Default::default()
+                })))
+                .into(),
+            )]))
+            .into(),
+            ..Default::default()
+        };
+
+        let managed_envelope = ManagedEnvelope::standalone(
+            dummy_envelope,
+            Addr::dummy(),
+            Addr::dummy(),
+            ProcessingGroup::Transaction,
+        );
+
+        ProcessEnvelopeState {
+            event: Annotated::from(event),
+            metrics: Default::default(),
+            sample_rates: None,
+            extracted_metrics: Default::default(),
+            project_state: Arc::new(project_state),
+            sampling_project_state: None,
+            project_id: ProjectId::new(42),
+            managed_envelope: managed_envelope.try_into().unwrap(),
+            profile_id: None,
+            event_metrics_extracted: false,
+            reservoir: ReservoirEvaluator::new(ReservoirCounters::default()),
+        }
+    }
+
+    #[test]
+    fn extract_sampled_default() {
+        let config = Config::default();
+        let global_config = GlobalConfig::default();
+        assert!(global_config.options.span_extraction_sample_rate.is_none());
+        let mut state = state();
+        extract_from_event(&mut state, &config, &global_config);
+        assert!(
+            state
+                .envelope()
+                .items()
+                .any(|item| item.ty() == &ItemType::Span),
+            "{:?}",
+            state.envelope()
+        );
+    }
+
+    #[test]
+    fn extract_sampled_explicit() {
+        let config = Config::default();
+        let mut global_config = GlobalConfig::default();
+        global_config.options.span_extraction_sample_rate = Some(1.0);
+        let mut state = state();
+        extract_from_event(&mut state, &config, &global_config);
+        assert!(
+            state
+                .envelope()
+                .items()
+                .any(|item| item.ty() == &ItemType::Span),
+            "{:?}",
+            state.envelope()
+        );
+    }
+
+    #[test]
+    fn extract_sampled_dropped() {
+        let config = Config::default();
+        let mut global_config = GlobalConfig::default();
+        global_config.options.span_extraction_sample_rate = Some(0.0);
+        let mut state = state();
+        extract_from_event(&mut state, &config, &global_config);
+        assert!(
+            !state
+                .envelope()
+                .items()
+                .any(|item| item.ty() == &ItemType::Span),
+            "{:?}",
+            state.envelope()
+        );
+    }
 }

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -149,13 +149,13 @@ pub fn extract_from_event(
     global_config: &GlobalConfig,
 ) {
     // Only extract spans from transactions (not errors).
-    if dbg!(state.event_type()) != Some(EventType::Transaction) {
+    if state.event_type() != Some(EventType::Transaction) {
         return;
     };
 
-    if !dbg!(state
+    if !state
         .project_state
-        .has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent))
+        .has_feature(Feature::ExtractSpansAndSpanMetricsFromEvent)
     {
         return;
     }
@@ -167,7 +167,7 @@ pub fn extract_from_event(
     }
 
     let mut add_span = |span: Annotated<Span>| {
-        let span = match dbg!(validate(span)) {
+        let span = match validate(span) {
             Ok(span) => span,
             Err(e) => {
                 relay_log::error!("Invalid span: {e}");
@@ -204,12 +204,12 @@ pub fn extract_from_event(
         return;
     };
 
-    let Some(transaction_span) = dbg!(extract_transaction_span(
+    let Some(transaction_span) = extract_transaction_span(
         event,
         config
             .aggregator_config_for(MetricNamespace::Spans)
             .max_tag_value_length,
-    )) else {
+    ) else {
         return;
     };
     // Add child spans as envelope items.


### PR DESCRIPTION
Add a global option to sample span extraction, such that the feature can be ramped up slowly even in deployments with only a few dominant projects (e.g. S4S).

#skip-changelog