### PR TITLE
build(sentry): Vendor the sentry-tower integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,6 +4133,7 @@ dependencies = [
  "minidump",
  "multer",
  "once_cell",
+ "pin-project-lite",
  "rand",
  "regex",
  "relay-auth",
@@ -4582,9 +4583,9 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "sentry"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0097a48cd1999d983909f07cb03b15241c5af29e5e679379efac1c06296abecc"
+checksum = "766448f12e44d68e675d5789a261515c46ac6ccd240abdd451a9c46c84a49523"
 dependencies = [
  "httpdate",
  "native-tls",
@@ -4594,7 +4595,6 @@ dependencies = [
  "sentry-core",
  "sentry-debug-images",
  "sentry-panic",
- "sentry-tower",
  "sentry-tracing",
  "tokio",
  "ureq",
@@ -4602,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a7b80fa1dd6830a348d38a8d3a9761179047757b7dca29aef82db0118b9670"
+checksum = "32701cad8b3c78101e1cd33039303154791b0ff22e7802ed8cc23212ef478b45"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -4614,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7615dc588930f1fd2e721774f25844ae93add2dbe2d3c2f995ce5049af898147"
+checksum = "17ddd2a91a13805bd8dab4ebf47323426f758c35f7bf24eacc1aded9668f3824"
 dependencies = [
  "hostname",
  "libc",
@@ -4628,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f51264e4013ed9b16558cce43917b983fa38170de2ca480349ceb57d71d6053"
+checksum = "b1189f68d7e7e102ef7171adf75f83a59607fafd1a5eecc9dc06c026ff3bdec4"
 dependencies = [
  "once_cell",
  "rand",
@@ -4641,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe6180fa564d40bb942c9f0084ffb5de691c7357ead6a2b7a3154fae9e401dd"
+checksum = "7b4d0a615e5eeca5699030620c119a094e04c14cf6b486ea1030460a544111a7"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -4665,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323160213bba549f9737317b152af116af35c0410f4468772ee9b606d3d6e0fa"
+checksum = "d1c18d0b5fba195a4950f2f4c31023725c76f00aabb5840b7950479ece21b5ca"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4685,25 +4685,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-tower"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffe3ab7bf7f65c9f8ccd20aa136ce5b2140aa6d6a11339e823cd43a7d694a9e"
-dependencies = [
- "axum",
- "http",
- "pin-project",
- "sentry-core",
- "tower-layer",
- "tower-service",
- "url",
-]
-
-[[package]]
 name = "sentry-tracing"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38033822128e73f7b6ca74c1631cef8868890c6cb4008a291cf73530f87b4eac"
+checksum = "3012699a9957d7f97047fd75d116e22d120668327db6e7c59824582e16e791b2"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4713,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.31.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e663b3eb62ddfc023c9cf5432daf5f1a4f6acb1df4d78dd80b740b32dd1a740"
+checksum = "c7173fd594569091f68a7c37a886e202f4d0c1db1e1fa1d18a051ba695b2e2ec"
 dependencies = [
  "debugid",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ parking_lot = "0.12.1"
 path-slash = "0.2.1"
 pest = "2.1.3"
 pest_derive = "2.1.0"
+pin-project-lite = "0.2.12"
 pretty-hex = "0.3.0"
 proc-macro2 = "1.0.8"
 quote = "1.0.2"
@@ -131,11 +132,11 @@ reqwest = "0.11.1"
 rmp-serde = "1.1.1"
 rust-embed = "8.0.0"
 schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }
-sentry = "0.31.7"
-sentry-core = "0.31.7"
+sentry = "0.32.2"
+sentry-core = "0.32.2"
 sentry-kafka-schemas = { version = "0.1.64", default-features = false }
 sentry-release-parser = { version = "1.3.2", default-features = false }
-sentry-types = "0.31.3"
+sentry-types = "0.32.2"
 sentry_usage_accountant = { version = "0.1.0", default-features = false }
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde-transcode = "1.1.1"

--- a/relay-log/Cargo.toml
+++ b/relay-log/Cargo.toml
@@ -21,11 +21,12 @@ relay-common = { workspace = true }
 relay-crash = { workspace = true, optional = true }
 sentry = { workspace = true, features = [
     "debug-images",
-    "tower-axum-matched-path",
     "tracing",
 ], optional = true }
 sentry-core = { workspace = true }
-tokio = { workspace = true, default-features = false, features = ["sync"], optional = true }
+tokio = { workspace = true, default-features = false, features = [
+    "sync",
+], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tracing = { workspace = true }

--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -126,12 +126,10 @@ mod test;
 pub use test::*;
 
 mod utils;
-#[cfg(feature = "sentry")]
-pub use sentry::integrations::tower;
 // Expose the minimal log facade.
 #[doc(inline)]
 pub use tracing::{debug, error, info, trace, warn, Level};
 // Expose the minimal error reporting API.
 #[doc(inline)]
-pub use sentry_core::{capture_error, configure_scope, protocol, with_scope, Hub};
+pub use sentry_core::{self as sentry, capture_error, configure_scope, protocol, with_scope, Hub};
 pub use utils::*;

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -64,6 +64,7 @@ mime_guess = { workspace = true, optional = true }
 minidump = { workspace = true, optional = true }
 multer = { workspace = true }
 once_cell = { workspace = true }
+pin-project-lite = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 relay-auth = { workspace = true }
@@ -138,9 +139,7 @@ axum-extra = { workspace = true, features = ["protobuf"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ['test-util'] }
 insta = { workspace = true }
-relay-event-schema = { workspace = true, features = [
-    "jsonschema",
-] }
+relay-event-schema = { workspace = true, features = ["jsonschema"] }
 relay-protocol = { workspace = true, features = ["test"] }
 relay-test = { workspace = true }
 similar-asserts = { workspace = true }

--- a/relay-server/src/middlewares/mod.rs
+++ b/relay-server/src/middlewares/mod.rs
@@ -12,6 +12,7 @@ mod decompression;
 mod handle_panic;
 mod metrics;
 mod normalize_path;
+mod sentry_tower;
 mod trace;
 
 pub use self::cors::*;
@@ -19,4 +20,5 @@ pub use self::decompression::*;
 pub use self::handle_panic::*;
 pub use self::metrics::*;
 pub use self::normalize_path::*;
+pub use self::sentry_tower::*;
 pub use self::trace::*;

--- a/relay-server/src/middlewares/sentry_tower.rs
+++ b/relay-server/src/middlewares/sentry_tower.rs
@@ -1,3 +1,9 @@
+//! Support for automatic hub binding for each request received by the Tower server.
+//!
+//! Vendored version `0.31.8` from
+//! [`sentry-tower`](https://github.com/getsentry/sentry-rust/blob/0.31.8/sentry-tower/src/lib.rs)
+//! with updated imports.
+
 use std::convert::TryInto;
 use std::future::Future;
 use std::marker::PhantomData;

--- a/relay-server/src/middlewares/sentry_tower.rs
+++ b/relay-server/src/middlewares/sentry_tower.rs
@@ -1,0 +1,343 @@
+use std::convert::TryInto;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::http::{header, uri, Request, Response, StatusCode};
+use relay_log::sentry::{self, protocol, Hub, SentryFutureExt};
+use tower::{Layer, Service};
+
+/// Tower Layer that logs Http Request Headers.
+///
+/// The Service created by this Layer can also optionally start a new
+/// performance monitoring transaction for each incoming request,
+/// continuing the trace based on incoming distributed tracing headers.
+///
+/// The created transaction will automatically use the request URI as its name.
+/// This is sometimes not desirable in case the request URI contains unique IDs
+/// or similar. In this case, users should manually override the transaction name
+/// in the request handler using the [`Scope::set_transaction`](sentry::Scope::set_transaction)
+/// method.
+#[derive(Clone, Default)]
+pub struct SentryHttpLayer {
+    start_transaction: bool,
+}
+
+impl SentryHttpLayer {
+    /// Creates a new Layer which starts a new performance monitoring transaction
+    /// for each incoming request.
+    pub fn with_transaction() -> Self {
+        Self {
+            start_transaction: true,
+        }
+    }
+}
+
+/// Tower Service that logs Http Request Headers.
+///
+/// The Service can also optionally start a new performance monitoring transaction
+/// for each incoming request, continuing the trace based on incoming
+/// distributed tracing headers.
+#[derive(Clone)]
+pub struct SentryHttpService<S> {
+    service: S,
+    start_transaction: bool,
+}
+
+impl<S> Layer<S> for SentryHttpLayer {
+    type Service = SentryHttpService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Self::Service {
+            service,
+            start_transaction: self.start_transaction,
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// The Future returned from [`SentryHttpService`].
+    pub struct SentryHttpFuture<F> {
+        on_first_poll: Option<(protocol::Request, Option<sentry::TransactionContext>)>,
+        transaction: Option<(
+            sentry::TransactionOrSpan,
+            Option<sentry::TransactionOrSpan>,
+        )>,
+        #[pin]
+        future: F,
+    }
+}
+
+impl<F, ResBody, Error> Future for SentryHttpFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, Error>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let slf = self.project();
+        if let Some((sentry_req, trx_ctx)) = slf.on_first_poll.take() {
+            relay_log::configure_scope(|scope| {
+                if let Some(trx_ctx) = trx_ctx {
+                    let transaction: sentry::TransactionOrSpan =
+                        sentry::start_transaction(trx_ctx).into();
+                    transaction.set_request(sentry_req.clone());
+                    let parent_span = scope.get_span();
+                    scope.set_span(Some(transaction.clone()));
+                    *slf.transaction = Some((transaction, parent_span));
+                }
+
+                scope.add_event_processor(move |mut event| {
+                    if event.request.is_none() {
+                        event.request = Some(sentry_req.clone());
+                    }
+                    Some(event)
+                });
+            });
+        }
+        match slf.future.poll(cx) {
+            Poll::Ready(res) => {
+                if let Some((transaction, parent_span)) = slf.transaction.take() {
+                    if transaction.get_status().is_none() {
+                        let status = match &res {
+                            Ok(res) => map_status(res.status()),
+                            Err(_) => protocol::SpanStatus::UnknownError,
+                        };
+                        transaction.set_status(status);
+                    }
+                    transaction.finish();
+                    relay_log::configure_scope(|scope| scope.set_span(parent_span));
+                }
+                Poll::Ready(res)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for SentryHttpService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = SentryHttpFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let sentry_req = protocol::Request {
+            method: Some(request.method().to_string()),
+            url: get_url_from_request(&request),
+            headers: request
+                .headers()
+                .into_iter()
+                .map(|(header, value)| {
+                    (
+                        header.to_string(),
+                        value.to_str().unwrap_or_default().into(),
+                    )
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let trx_ctx = if self.start_transaction {
+            let headers = request.headers().into_iter().flat_map(|(header, value)| {
+                value.to_str().ok().map(|value| (header.as_str(), value))
+            });
+            let tx_name = format!("{} {}", request.method(), path_from_request(&request));
+            Some(sentry::TransactionContext::continue_from_headers(
+                &tx_name,
+                "http.server",
+                headers,
+            ))
+        } else {
+            None
+        };
+
+        SentryHttpFuture {
+            on_first_poll: Some((sentry_req, trx_ctx)),
+            transaction: None,
+            future: self.service.call(request),
+        }
+    }
+}
+
+fn path_from_request<B>(request: &Request<B>) -> &str {
+    if let Some(matched_path) = request.extensions().get::<axum::extract::MatchedPath>() {
+        return matched_path.as_str();
+    }
+
+    request.uri().path()
+}
+
+fn map_status(status: StatusCode) -> protocol::SpanStatus {
+    match status {
+        StatusCode::UNAUTHORIZED => protocol::SpanStatus::Unauthenticated,
+        StatusCode::FORBIDDEN => protocol::SpanStatus::PermissionDenied,
+        StatusCode::NOT_FOUND => protocol::SpanStatus::NotFound,
+        StatusCode::TOO_MANY_REQUESTS => protocol::SpanStatus::ResourceExhausted,
+        status if status.is_client_error() => protocol::SpanStatus::InvalidArgument,
+        StatusCode::NOT_IMPLEMENTED => protocol::SpanStatus::Unimplemented,
+        StatusCode::SERVICE_UNAVAILABLE => protocol::SpanStatus::Unavailable,
+        status if status.is_server_error() => protocol::SpanStatus::InternalError,
+        StatusCode::CONFLICT => protocol::SpanStatus::AlreadyExists,
+        status if status.is_success() => protocol::SpanStatus::Ok,
+        _ => protocol::SpanStatus::UnknownError,
+    }
+}
+
+fn get_url_from_request<B>(request: &Request<B>) -> Option<url::Url> {
+    let uri = request.uri().clone();
+    let mut uri_parts = uri.into_parts();
+    uri_parts.scheme.get_or_insert(uri::Scheme::HTTP);
+    if uri_parts.authority.is_none() {
+        let host = request.headers().get(header::HOST)?.as_bytes();
+        uri_parts.authority = Some(host.try_into().ok()?);
+    }
+    let uri = uri::Uri::from_parts(uri_parts).ok()?;
+    uri.to_string().parse().ok()
+}
+
+/// Provides a hub for each request
+pub trait HubProvider<H, Request>
+where
+    H: Into<Arc<Hub>>,
+{
+    /// Returns a hub to be bound to the request
+    fn hub(&self, request: &Request) -> H;
+}
+
+impl<H, F, Request> HubProvider<H, Request> for F
+where
+    F: Fn(&Request) -> H,
+    H: Into<Arc<Hub>>,
+{
+    fn hub(&self, request: &Request) -> H {
+        (self)(request)
+    }
+}
+
+impl<Request> HubProvider<Arc<Hub>, Request> for Arc<Hub> {
+    fn hub(&self, _request: &Request) -> Arc<Hub> {
+        self.clone()
+    }
+}
+
+/// Provides a new hub made from the currently active hub for each request
+#[derive(Clone, Copy)]
+pub struct NewFromTopProvider;
+
+impl<Request> HubProvider<Arc<Hub>, Request> for NewFromTopProvider {
+    fn hub(&self, _request: &Request) -> Arc<Hub> {
+        // The Clippy lint here is a false positive, the suggestion to write
+        // `Hub::with(Hub::new_from_top)` does not compiles:
+        //     143 |         Hub::with(Hub::new_from_top).into()
+        //         |         ^^^^^^^^^ implementation of `std::ops::FnOnce` is not general enough
+        #[allow(clippy::redundant_closure)]
+        Hub::with(|hub| Hub::new_from_top(hub)).into()
+    }
+}
+
+/// Tower layer that binds a specific Sentry hub for each request made.
+pub struct SentryLayer<P, H, Request>
+where
+    P: HubProvider<H, Request>,
+    H: Into<Arc<Hub>>,
+{
+    provider: P,
+    _hub: PhantomData<(H, Request)>,
+}
+
+impl<S, P, H, Request> Layer<S> for SentryLayer<P, H, Request>
+where
+    P: HubProvider<H, Request> + Clone,
+    H: Into<Arc<Hub>>,
+{
+    type Service = SentryService<S, P, H, Request>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        SentryService {
+            service,
+            provider: self.provider.clone(),
+            _hub: PhantomData,
+        }
+    }
+}
+
+impl<P, H, Request> Clone for SentryLayer<P, H, Request>
+where
+    P: HubProvider<H, Request> + Clone,
+    H: Into<Arc<Hub>>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            provider: self.provider.clone(),
+            _hub: PhantomData,
+        }
+    }
+}
+
+/// Tower service that binds a specific Sentry hub for each request made.
+pub struct SentryService<S, P, H, Request>
+where
+    P: HubProvider<H, Request>,
+    H: Into<Arc<Hub>>,
+{
+    service: S,
+    provider: P,
+    _hub: PhantomData<(H, Request)>,
+}
+
+impl<S, Request, P, H> Service<Request> for SentryService<S, P, H, Request>
+where
+    S: Service<Request>,
+    P: HubProvider<H, Request>,
+    H: Into<Arc<Hub>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = sentry::SentryFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let hub = self.provider.hub(&request).into();
+        let fut = Hub::run(hub.clone(), || self.service.call(request));
+        fut.bind_hub(hub)
+    }
+}
+
+impl<S, P, H, Request> Clone for SentryService<S, P, H, Request>
+where
+    S: Clone,
+    P: HubProvider<H, Request> + Clone,
+    H: Into<Arc<Hub>>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            service: self.service.clone(),
+            provider: self.provider.clone(),
+            _hub: PhantomData,
+        }
+    }
+}
+
+/// Tower layer that binds a new Sentry hub for each request made
+pub type NewSentryLayer<Request> = SentryLayer<NewFromTopProvider, Arc<Hub>, Request>;
+
+impl<Request> NewSentryLayer<Request> {
+    /// Create a new Sentry layer that binds a new Sentry hub for each request made
+    pub fn new_from_top() -> Self {
+        Self {
+            provider: NewFromTopProvider,
+            _hub: PhantomData,
+        }
+    }
+}

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -6,7 +6,6 @@ use axum::http::{header, HeaderName, HeaderValue};
 use axum::ServiceExt;
 use axum_server::{AddrIncomingConfig, Handle, HttpConfig};
 use relay_config::Config;
-use relay_log::tower::{NewSentryLayer, SentryHttpLayer};
 use relay_system::{Controller, Service, Shutdown};
 use tower::ServiceBuilder;
 use tower_http::compression::predicate::SizeAbove;
@@ -15,7 +14,8 @@ use tower_http::set_header::SetResponseHeaderLayer;
 
 use crate::constants;
 use crate::middlewares::{
-    self, CatchPanicLayer, HandleErrorLayer, NormalizePathLayer, RequestDecompressionLayer,
+    self, CatchPanicLayer, HandleErrorLayer, NewSentryLayer, NormalizePathLayer,
+    RequestDecompressionLayer, SentryHttpLayer,
 };
 use crate::service::ServiceState;
 use crate::statsd::RelayCounters;


### PR DESCRIPTION
Vendors the `sentry-tower` integration and upgrades the Sentry SDK to `0.32.x` without upgrading axum. Going forward, this allows us to keep the Sentry SDK up-to-date independently of the web framework.

The integration's code was copied from version `0.31.8`, which is the last release matching our version of `axum`. Minor adjustments to the imports were made.

This will be removed once `axum` is upgraded to latest.

#skip-changelog