### PR TITLE
ref(server): Put processor `Addr`s in separate struct

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -182,6 +182,7 @@ impl ServiceState {
                 #[cfg(feature = "processing")]
                 store_forwarder: store.clone(),
             },
+            #[cfg(feature = "processing")]
             metric_stats,
         )
         .spawn_handler(processor_rx);

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -20,7 +20,7 @@ use crate::services::global_config::{GlobalConfigManager, GlobalConfigService};
 use crate::services::health_check::{HealthCheck, HealthCheckService};
 use crate::services::outcome::{OutcomeProducer, OutcomeProducerService, TrackOutcome};
 use crate::services::outcome_aggregator::OutcomeAggregator;
-use crate::services::processor::{EnvelopeProcessor, EnvelopeProcessorService};
+use crate::services::processor::{self, EnvelopeProcessor, EnvelopeProcessorService};
 use crate::services::project_cache::{ProjectCache, ProjectCacheService, Services};
 use crate::services::relays::{RelayCache, RelayCacheService};
 #[cfg(feature = "processing")]
@@ -172,15 +172,16 @@ impl ServiceState {
             cogs,
             #[cfg(feature = "processing")]
             redis_pool.clone(),
-            outcome_aggregator.clone(),
-            project_cache.clone(),
-            upstream_relay.clone(),
-            test_store.clone(),
-            #[cfg(feature = "processing")]
-            aggregator.clone(),
-            #[cfg(feature = "processing")]
-            store.clone(),
-            #[cfg(feature = "processing")]
+            processor::Addrs {
+                project_cache: project_cache.clone(),
+                outcome_aggregator: outcome_aggregator.clone(),
+                upstream_relay: upstream_relay.clone(),
+                test_store: test_store.clone(),
+                #[cfg(feature = "processing")]
+                aggregator: aggregator.clone(),
+                #[cfg(feature = "processing")]
+                store_forwarder: store.clone(),
+            },
             metric_stats,
         )
         .spawn_handler(processor_rx);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -909,18 +909,25 @@ pub struct EnvelopeProcessorService {
     inner: Arc<InnerProcessor>,
 }
 
+/// Contains the addresses of services that the processor publishes to.
+pub struct Addrs {
+    pub project_cache: Addr<ProjectCache>,
+    pub outcome_aggregator: Addr<TrackOutcome>,
+    #[cfg(feature = "processing")]
+    pub aggregator: Addr<Aggregator>,
+    pub upstream_relay: Addr<UpstreamRelay>,
+    pub test_store: Addr<TestStore>,
+    #[cfg(feature = "processing")]
+    pub store_forwarder: Option<Addr<Store>>,
+}
+
 struct InnerProcessor {
     config: Arc<Config>,
     global_config: GlobalConfigHandle,
     cogs: Cogs,
     #[cfg(feature = "processing")]
     redis_pool: Option<RedisPool>,
-    project_cache: Addr<ProjectCache>,
-    outcome_aggregator: Addr<TrackOutcome>,
-    #[cfg(feature = "processing")]
-    aggregator: Addr<Aggregator>,
-    upstream_relay: Addr<UpstreamRelay>,
-    test_store: Addr<TestStore>,
+    addrs: Addrs,
     #[cfg(feature = "processing")]
     rate_limiter: Option<RedisRateLimiter>,
     geoip_lookup: Option<GeoIpLookup>,
@@ -929,25 +936,17 @@ struct InnerProcessor {
     #[cfg(feature = "processing")]
     cardinality_limiter: Option<CardinalityLimiter>,
     #[cfg(feature = "processing")]
-    store_forwarder: Option<Addr<Store>>,
-    #[cfg(feature = "processing")]
     metric_stats: MetricStats,
 }
 
 impl EnvelopeProcessorService {
     /// Creates a multi-threaded envelope processor.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
         global_config: GlobalConfigHandle,
         cogs: Cogs,
         #[cfg(feature = "processing")] redis: Option<RedisPool>,
-        outcome_aggregator: Addr<TrackOutcome>,
-        project_cache: Addr<ProjectCache>,
-        upstream_relay: Addr<UpstreamRelay>,
-        test_store: Addr<TestStore>,
-        #[cfg(feature = "processing")] aggregator: Addr<Aggregator>,
-        #[cfg(feature = "processing")] store_forwarder: Option<Addr<Store>>,
+        addrs: Addrs,
         #[cfg(feature = "processing")] metric_stats: MetricStats,
     ) -> Self {
         let geoip_lookup = config.geoip_path().and_then(|p| {
@@ -969,13 +968,8 @@ impl EnvelopeProcessorService {
             rate_limiter: redis
                 .clone()
                 .map(|pool| RedisRateLimiter::new(pool).max_limit(config.max_rate_limit())),
-            project_cache,
-            outcome_aggregator,
-            upstream_relay,
-            test_store,
+            addrs,
             geoip_lookup,
-            #[cfg(feature = "processing")]
-            aggregator,
             #[cfg(feature = "processing")]
             metric_meta_store: redis.clone().map(|pool| {
                 RedisMetricMetaStore::new(pool, config.metrics_meta_locations_expiry())
@@ -993,8 +987,6 @@ impl EnvelopeProcessorService {
                     )
                 })
                 .map(CardinalityLimiter::new),
-            #[cfg(feature = "processing")]
-            store_forwarder,
             #[cfg(feature = "processing")]
             metric_stats,
             config,
@@ -1119,6 +1111,7 @@ impl EnvelopeProcessorService {
 
         if limits.is_limited() {
             self.inner
+                .addrs
                 .project_cache
                 .send(UpdateRateLimits::new(scoping.project_key, limits));
         }
@@ -1131,7 +1124,7 @@ impl EnvelopeProcessorService {
         enforcement.track_outcomes(
             state.envelope(),
             &state.managed_envelope.scoping(),
-            self.inner.outcome_aggregator.clone(),
+            self.inner.addrs.outcome_aggregator.clone(),
         );
 
         Ok(())
@@ -1491,7 +1484,7 @@ impl EnvelopeProcessorService {
         report::process_client_reports(
             state,
             &self.inner.config,
-            self.inner.outcome_aggregator.clone(),
+            self.inner.addrs.outcome_aggregator.clone(),
         );
 
         Ok(())
@@ -1695,7 +1688,7 @@ impl EnvelopeProcessorService {
 
                         state.extracted_metrics.send_metrics(
                             state.managed_envelope.envelope(),
-                            self.inner.project_cache.clone(),
+                            self.inner.addrs.project_cache.clone(),
                         );
 
                         let envelope_response = if state.managed_envelope.envelope().is_empty() {
@@ -1818,6 +1811,7 @@ impl EnvelopeProcessorService {
 
         relay_log::trace!("merging metric buckets into project cache");
         self.inner
+            .addrs
             .project_cache
             .send(MergeBuckets::new(public_key, buckets));
     }
@@ -1868,6 +1862,7 @@ impl EnvelopeProcessorService {
 
             relay_log::trace!("merging metric buckets into project cache");
             self.inner
+                .addrs
                 .project_cache
                 .send(MergeBuckets::new(public_key, buckets));
         }
@@ -1894,6 +1889,7 @@ impl EnvelopeProcessorService {
                 Ok(meta) => {
                     relay_log::trace!("adding metric metadata to project cache");
                     self.inner
+                        .addrs
                         .project_cache
                         .send(AddMetricMeta { project_key, meta });
                 }
@@ -1928,7 +1924,7 @@ impl EnvelopeProcessorService {
 
         #[cfg(feature = "processing")]
         if self.inner.config.processing_enabled() {
-            if let Some(store_forwarder) = self.inner.store_forwarder.clone() {
+            if let Some(store_forwarder) = self.inner.addrs.store_forwarder.clone() {
                 relay_log::trace!("sending envelope to kafka");
                 store_forwarder.send(StoreEnvelope { envelope });
                 return;
@@ -1938,7 +1934,10 @@ impl EnvelopeProcessorService {
         // If we are in capture mode, we stash away the event instead of forwarding it.
         if Capture::should_capture(&self.inner.config) {
             relay_log::trace!("capturing envelope in memory");
-            self.inner.test_store.send(Capture::accepted(envelope));
+            self.inner
+                .addrs
+                .test_store
+                .send(Capture::accepted(envelope));
             return;
         }
 
@@ -1957,12 +1956,15 @@ impl EnvelopeProcessorService {
 
         match result {
             Ok(body) => {
-                self.inner.upstream_relay.send(SendRequest(SendEnvelope {
-                    envelope,
-                    body,
-                    http_encoding,
-                    project_cache: self.inner.project_cache.clone(),
-                }));
+                self.inner
+                    .addrs
+                    .upstream_relay
+                    .send(SendRequest(SendEnvelope {
+                        envelope,
+                        body,
+                        http_encoding,
+                        project_cache: self.inner.addrs.project_cache.clone(),
+                    }));
             }
             Err(error) => {
                 // Errors are only logged for what we consider an internal discard reason. These
@@ -1996,8 +1998,8 @@ impl EnvelopeProcessorService {
 
         let envelope = ManagedEnvelope::standalone(
             envelope,
-            self.inner.outcome_aggregator.clone(),
-            self.inner.test_store.clone(),
+            self.inner.addrs.outcome_aggregator.clone(),
+            self.inner.addrs.test_store.clone(),
             ProcessingGroup::ClientReport,
         );
         self.handle_submit_envelope(SubmitEnvelope {
@@ -2040,11 +2042,12 @@ impl EnvelopeProcessorService {
 
             if rate_limits.is_limited() {
                 let was_enforced = bucket_limiter
-                    .enforce_limits(&rate_limits, self.inner.outcome_aggregator.clone());
+                    .enforce_limits(&rate_limits, self.inner.addrs.outcome_aggregator.clone());
 
                 if was_enforced {
                     // Update the rate limits in the project cache.
                     self.inner
+                        .addrs
                         .project_cache
                         .send(UpdateRateLimits::new(scoping.project_key, rate_limits));
                 }
@@ -2056,6 +2059,7 @@ impl EnvelopeProcessorService {
 
         if !buckets.is_empty() {
             self.inner
+                .addrs
                 .aggregator
                 .send(MergeBuckets::new(project_key, buckets));
         }
@@ -2114,13 +2118,13 @@ impl EnvelopeProcessorService {
 
                 let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
                 utils::reject_metrics(
-                    &self.inner.outcome_aggregator,
+                    &self.inner.addrs.outcome_aggregator,
                     quantities,
                     *item_scoping.scoping,
                     Outcome::RateLimited(reason_code),
                 );
 
-                self.inner.project_cache.send(UpdateRateLimits::new(
+                self.inner.addrs.project_cache.send(UpdateRateLimits::new(
                     item_scoping.scoping.project_key,
                     limits,
                 ));
@@ -2202,7 +2206,7 @@ impl EnvelopeProcessorService {
 
         // Log outcomes for rejected buckets.
         utils::reject_metrics(
-            &self.inner.outcome_aggregator,
+            &self.inner.addrs.outcome_aggregator,
             utils::extract_metric_quantities(limits.rejected(), mode),
             scoping,
             Outcome::CardinalityLimited,
@@ -2311,8 +2315,8 @@ impl EnvelopeProcessorService {
 
                     let mut envelope = ManagedEnvelope::standalone(
                         envelope,
-                        self.inner.outcome_aggregator.clone(),
-                        self.inner.test_store.clone(),
+                        self.inner.addrs.outcome_aggregator.clone(),
+                        self.inner.addrs.test_store.clone(),
                         ProcessingGroup::Metrics,
                     );
                     envelope.set_partition_key(partition_key).scope(scoping);
@@ -2357,10 +2361,10 @@ impl EnvelopeProcessorService {
             encoded,
             http_encoding,
             quantities,
-            outcome_aggregator: self.inner.outcome_aggregator.clone(),
+            outcome_aggregator: self.inner.addrs.outcome_aggregator.clone(),
         };
 
-        self.inner.upstream_relay.send(SendRequest(request));
+        self.inner.addrs.upstream_relay.send(SendRequest(request));
     }
 
     /// Serializes metric buckets to JSON and sends them to the upstream via the global endpoint.
@@ -2419,7 +2423,7 @@ impl EnvelopeProcessorService {
     fn handle_encode_metrics(&self, message: EncodeMetrics) {
         #[cfg(feature = "processing")]
         if self.inner.config.processing_enabled() {
-            if let Some(ref store_forwarder) = self.inner.store_forwarder {
+            if let Some(ref store_forwarder) = self.inner.addrs.store_forwarder {
                 return self.encode_metrics_processing(message, store_forwarder);
             }
         }
@@ -2453,8 +2457,8 @@ impl EnvelopeProcessorService {
 
         let envelope = ManagedEnvelope::standalone(
             envelope,
-            self.inner.outcome_aggregator.clone(),
-            self.inner.test_store.clone(),
+            self.inner.addrs.outcome_aggregator.clone(),
+            self.inner.addrs.test_store.clone(),
             ProcessingGroup::Metrics,
         );
         self.handle_submit_envelope(SubmitEnvelope {

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -18,7 +18,7 @@ use crate::extractors::RequestMeta;
 use crate::metric_stats::MetricStats;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::TrackOutcome;
-use crate::services::processor::EnvelopeProcessorService;
+use crate::services::processor::{self, EnvelopeProcessorService};
 use crate::services::project::ProjectState;
 use crate::services::test_store::TestStore;
 
@@ -119,7 +119,7 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
     let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
     let (test_store, _) = mock_service("test_store", (), |&mut (), _| {});
     #[cfg(feature = "processing")]
-    let (_aggregator, _) = mock_service("aggregator", (), |&mut (), _| {});
+    let (aggregator, _) = mock_service("aggregator", (), |&mut (), _| {});
 
     #[cfg(feature = "processing")]
     let redis = config
@@ -134,19 +134,21 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
         Cogs::noop(),
         #[cfg(feature = "processing")]
         redis,
-        outcome_aggregator,
-        project_cache,
-        upstream_relay,
-        test_store,
-        #[cfg(feature = "processing")]
-        _aggregator.clone(),
-        #[cfg(feature = "processing")]
-        None,
+        processor::Addrs {
+            outcome_aggregator,
+            project_cache,
+            upstream_relay,
+            test_store,
+            #[cfg(feature = "processing")]
+            aggregator: aggregator.clone(),
+            #[cfg(feature = "processing")]
+            store_forwarder: None,
+        },
         #[cfg(feature = "processing")]
         MetricStats::new(
             config,
             GlobalConfigHandle::fixed(Default::default()),
-            _aggregator,
+            aggregator,
         ),
     )
 }


### PR DESCRIPTION
Non-functional change to get rid of `#[allow(clippy::too_many_arguments)]` on `EnvelopeProcessorService::new`. This PR was originally part of https://github.com/getsentry/relay/pull/3375, which adds yet another `Addr`, but I decided to make a separate PR for reviewability.

#skip-changelog