### PR TITLE
fix(spans): Also sample metrics when sample rate is < 1.0

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1162,6 +1162,11 @@ impl EnvelopeProcessorService {
                         .config
                         .aggregator_config_for(MetricNamespace::Spans)
                         .max_tag_value_length,
+                    self.inner
+                        .global_config
+                        .current()
+                        .options
+                        .span_extraction_sample_rate,
                 );
                 state.event_metrics_extracted |= !metrics.is_empty();
                 state.extracted_metrics.project_metrics.extend(metrics);

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -146,6 +146,53 @@ def test_span_extraction(
     spans_consumer.assert_empty()
 
 
+def test_span_extraction_with_sampling(
+    mini_sentry, relay_with_processing, spans_consumer, metrics_consumer
+):
+    mini_sentry.global_config["options"] = {"relay.span-extraction.sample-rate": 0.0}
+
+    relay = relay_with_processing(options=TEST_CONFIG)
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "projects:span-metrics-extraction",
+    ]
+    project_config["config"]["transactionMetrics"] = {
+        "version": 3,
+    }
+
+    spans_consumer = spans_consumer()
+    metrics_consumer = metrics_consumer()
+
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    end = datetime.now(timezone.utc) - timedelta(seconds=1)
+    duration = timedelta(milliseconds=500)
+    start = end - duration
+    event["spans"] = [
+        {
+            "description": "GET /api/0/organizations/?member=1",
+            "op": "http",
+            "parent_span_id": "aaaaaaaaaaaaaaaa",
+            "span_id": "bbbbbbbbbbbbbbbb",
+            "start_timestamp": start.isoformat(),
+            "timestamp": end.isoformat(),
+            "trace_id": "ff62a8b040f340bda5d830223def1d81",
+        },
+    ]
+
+    relay.send_event(project_id, event)
+
+    spans = list(spans_consumer.get_spans(max_attempts=2))
+    assert len(spans) == 0
+
+    metrics = list(metrics_consumer.get_metrics())
+    span_metrics = [m for (m, _) in metrics if ":spans/" in m["name"]]
+    assert len(span_metrics) == 0
+
+    spans_consumer.assert_empty()
+    metrics_consumer.assert_empty()
+
+
 def test_duplicate_performance_score(mini_sentry, relay):
     relay = relay(mini_sentry, options=TEST_CONFIG)
     project_id = 42


### PR DESCRIPTION
Follow-up to #3394: Span metrics are extracted in a different code path than span payloads, so apply the same sampling rate to metrics extraction.

#skip-changelog