### PR TITLE
ref(spans): Log span when encountering a validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Tag span duration metric by group for all ops supporting description scrubbing. ([#3370](https://github.com/getsentry/relay/pull/3370))
 - Copy transaction tags to segment. ([#3386](https://github.com/getsentry/relay/pull/3386))
 - Route spans according to trace_id. ([#3387](https://github.com/getsentry/relay/pull/3387))
+- Log span when encountering a validation error. ([#3401](https://github.com/getsentry/relay/pull/3401))
 
 ## 24.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,6 @@
 - Stop extracting count_per_segment and count_per_op metrics. ([#3380](https://github.com/getsentry/relay/pull/3380))
 - Extract `cache.item_size` and `cache.hit` metrics. ([#3371]https://github.com/getsentry/relay/pull/3371)
 
-**Bug Fixes**:
-
-- Allow spans with no `exclusive_time`. ([#3385](https://github.com/getsentry/relay/pull/3385), [#3401](https://github.com/getsentry/relay/pull/3401))
-
 **Internal**:
 
 - Enable `db.redis` span metrics extraction. ([#3283](https://github.com/getsentry/relay/pull/3283))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 **Bug Fixes**:
 
-- Allow spans with no `exclusive_time`. ([#3385](https://github.com/getsentry/relay/pull/3385))
+- Allow spans with no `exclusive_time`. ([#3385](https://github.com/getsentry/relay/pull/3385), [#3401](https://github.com/getsentry/relay/pull/3401))
 
 **Internal**:
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -441,6 +441,7 @@ fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, anyhow::Error>
         .as_mut()
         .ok_or(anyhow::anyhow!("empty span"))?;
     let Span {
+        ref exclusive_time,
         ref mut tags,
         ref mut sentry_tags,
         ref mut start_timestamp,
@@ -472,6 +473,11 @@ fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, anyhow::Error>
             return Err(anyhow::anyhow!("start_timestamp hard-required for spans"));
         }
     }
+
+    // `is_segment` is set by `extract_span`.
+    exclusive_time
+        .value()
+        .ok_or(anyhow::anyhow!("missing exclusive_time"))?;
 
     if let Some(sentry_tags) = sentry_tags.value_mut() {
         sentry_tags.retain(|key, value| match value.value() {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -122,7 +122,7 @@ pub fn process(
         .ok();
 
         // Validate for kafka (TODO: this should be moved to kafka producer)
-        let annotated_span = match validate(annotated_span.clone()) {
+        match validate(&mut annotated_span) {
             Ok(res) => res,
             Err(err) => {
                 relay_log::error!(
@@ -176,8 +176,8 @@ pub fn extract_from_event(
         }
     }
 
-    let mut add_span = |span: Annotated<Span>| {
-        let span = match validate(span.clone()) {
+    let mut add_span = |mut span: Annotated<Span>| {
+        match validate(&mut span) {
             Ok(span) => span,
             Err(e) => {
                 relay_log::error!(
@@ -451,7 +451,7 @@ fn scrub(
 }
 
 /// We do not extract or ingest spans with missing fields if those fields are required on the Kafka topic.
-fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, ValidationError> {
+fn validate(span: &mut Annotated<Span>) -> Result<(), ValidationError> {
     let inner = span
         .value_mut()
         .as_mut()
@@ -518,7 +518,7 @@ fn validate(mut span: Annotated<Span>) -> Result<Annotated<Span>, ValidationErro
         tags.retain(|_, value| !value.value().is_empty())
     }
 
-    Ok(span)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1357,7 +1357,7 @@ struct SpanKafkaMessage<'a> {
     /// The ID of the transaction event associated to this span, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event_id: Option<EventId>,
-    #[serde(default, rename(deserialize = "exclusive_time"))]
+    #[serde(rename(deserialize = "exclusive_time"))]
     exclusive_time_ms: f64,
     is_segment: bool,
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1357,7 +1357,7 @@ struct SpanKafkaMessage<'a> {
     /// The ID of the transaction event associated to this span, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event_id: Option<EventId>,
-    #[serde(rename(deserialize = "exclusive_time"))]
+    #[serde(default, rename(deserialize = "exclusive_time"))]
     exclusive_time_ms: f64,
     is_segment: bool,
 


### PR DESCRIPTION
Some spans are failing validation because of missing `exclusive_time`. We thought they were OTLP spans and this was OK but after more investigation, we don't know if they are legitimate spans or not.

The plan is to log the span payload with the error to review them and decide whether we want to accept them or keep rejecting them.