### PR TITLE
feat(clock-drift): Apply clock drift normalization only if `sent_at` is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+**Bug fixes:**
+
+- Fix performance regression in disk spooling by using page counts to estimate the spool size. ([#3379](https://github.com/getsentry/relay/pull/3379))
+- Perform clock drift normalization only when `sent_at` is set in the `Envelope` headers. ([#3405](https://github.com/getsentry/relay/pull/3405))
+
 **Features**:
+
 - **Breaking change:** Kafka topic configuration keys now support the default topic name. The previous aliases `metrics` and `metrics_transactions` are no longer supported if configuring topics manually. Use `ingest-metrics` or `metrics_sessions` instead of `metrics`, and `ingest-performance-metrics` or `metrics_generic` instead of `metrics_transactions`. ([#3361](https://github.com/getsentry/relay/pull/3361))
 - Add support for continuous profiling. ([#3270](https://github.com/getsentry/relay/pull/3270))
 - Add support for Reporting API for CSP reports ([#3277](https://github.com/getsentry/relay/pull/3277))
@@ -16,12 +22,6 @@
 - Support the full unicode character set via UTF-8 encoding for metric tags submitted via the statsd format. Certain restricted characters require escape sequences, see [docs](https://develop.sentry.dev/sdk/metrics/#normalization) for the precise rules. ([#3358](https://github.com/getsentry/relay/pull/3358))
 - Stop extracting count_per_segment and count_per_op metrics. ([#3380](https://github.com/getsentry/relay/pull/3380))
 - Extract `cache.item_size` and `cache.hit` metrics. ([#3371]https://github.com/getsentry/relay/pull/3371)
-
-**Bug Fixes**:
-
-- Fix performance regression in disk spooling by using page counts to estimate the spool size. ([#3379](https://github.com/getsentry/relay/pull/3379))
-- Allow spans with no `exclusive_time`. ([#3385](https://github.com/getsentry/relay/pull/3385))
-- Perform clock drift normalization only when `sent_at` is set in the `Envelope` headers. ([#3405](https://github.com/getsentry/relay/pull/3405))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-**Bug fixes:**
-
-- Fix performance regression in disk spooling by using page counts to estimate the spool size. ([#3379](https://github.com/getsentry/relay/pull/3379))
-
 **Features**:
 
 - Add support for continuous profiling. ([#3270](https://github.com/getsentry/relay/pull/3270))
@@ -23,7 +19,9 @@
 
 **Bug Fixes**:
 
+- Fix performance regression in disk spooling by using page counts to estimate the spool size. ([#3379](https://github.com/getsentry/relay/pull/3379))
 - Allow spans with no `exclusive_time`. ([#3385](https://github.com/getsentry/relay/pull/3385))
+- Perform clock drift normalization only when `sent_at` is set in the `Envelope` headers. ([#3405](https://github.com/getsentry/relay/pull/3405))
 
 **Internal**:
 

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -12,7 +12,7 @@ use relay_event_normalization::{nel, ClockDriftProcessor};
 use relay_event_schema::processor::{self, ProcessingState};
 use relay_event_schema::protocol::{
     Breadcrumb, Csp, Event, ExpectCt, ExpectStaple, Hpkp, LenientString, NetworkReportError,
-    OtelContext, RelayInfo, SecurityReportType, Timestamp, Values,
+    OtelContext, RelayInfo, SecurityReportType, Values,
 };
 use relay_pii::PiiProcessor;
 use relay_protocol::{Annotated, Array, Empty, FromValue, Object, Value};
@@ -139,7 +139,6 @@ pub fn finalize<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
     config: &Config,
 ) -> Result<(), ProcessingError> {
-    let is_transaction = state.event_type() == Some(EventType::Transaction);
     let envelope = state.managed_envelope.envelope_mut();
 
     let event = match state.event.value_mut() {

--- a/tests/integration/test_clock_drift.py
+++ b/tests/integration/test_clock_drift.py
@@ -1,0 +1,85 @@
+from datetime import timedelta, datetime
+
+from sentry_sdk.envelope import Envelope
+
+
+def mock_transaction(timestamp):
+    return {
+        "type": "transaction",
+        "timestamp": timestamp.isoformat(),
+        "start_timestamp": (timestamp - timedelta(seconds=2)).isoformat(),
+        "spans": [],
+        "contexts": {
+            "trace": {
+                "op": "http",
+                "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                "span_id": "968cff94913ebb07",
+            }
+        },
+        "transaction": "/hello",
+    }
+
+
+def test_clock_drift_applied_when_timestamp_is_too_old(mini_sentry, relay):
+    relay = relay(mini_sentry)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    now = datetime.utcnow()
+    one_month_ago = now - timedelta(days=30)
+
+    envelope = Envelope(
+        headers={"sent_at": one_month_ago.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}
+    )
+    envelope.add_transaction(mock_transaction(one_month_ago))
+
+    relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
+
+    transaction_event = mini_sentry.captured_events.get(
+        timeout=1
+    ).get_transaction_event()
+    error_name, error_metadata = transaction_event["_meta"]["timestamp"][""]["err"][0]
+    assert error_name == "clock_drift"
+
+
+def test_clock_drift_not_applied_when_timestamp_is_recent(mini_sentry, relay):
+    relay = relay(mini_sentry)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    now = datetime.utcnow()
+    five_minutes_ago = now - timedelta(minutes=5)
+
+    envelope = Envelope(
+        headers={"sent_at": five_minutes_ago.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}
+    )
+    envelope.add_transaction(mock_transaction(five_minutes_ago))
+
+    relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
+
+    transaction_event = mini_sentry.captured_events.get(
+        timeout=1
+    ).get_transaction_event()
+    assert "_meta" not in transaction_event
+
+
+def test_clock_drift_not_applied_when_sent_at_is_not_supplied(mini_sentry, relay):
+    relay = relay(mini_sentry)
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+
+    now = datetime.utcnow()
+    one_month_ago = now - timedelta(days=30)
+
+    envelope = Envelope()
+    envelope.add_transaction(mock_transaction(one_month_ago))
+
+    relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
+
+    transaction_event = mini_sentry.captured_events.get(
+        timeout=1
+    ).get_transaction_event()
+    error_name, error_metadata = transaction_event["_meta"]["timestamp"][""]["err"][0]
+    # In case clock drift is not run, we expect timestamps normalization to go into effect to mark timestamps as
+    # past or future if they surpass a certain threshold.
+    assert error_name == "past_timestamp"

--- a/tests/integration/test_clock_drift.py
+++ b/tests/integration/test_clock_drift.py
@@ -40,9 +40,14 @@ def test_clock_drift_applied_when_timestamp_is_too_old(mini_sentry, relay):
     transaction_event = mini_sentry.captured_events.get(
         timeout=1
     ).get_transaction_event()
+
     error_name, error_metadata = transaction_event["_meta"]["timestamp"][""]["err"][0]
     assert error_name == "clock_drift"
-    assert transaction_event["timestamp"] > one_month_ago.timestamp()
+    assert (
+        one_month_ago.timestamp()
+        < transaction_event["timestamp"]
+        < datetime.now(tz=timezone.utc).timestamp()
+    )
 
 
 def test_clock_drift_not_applied_when_timestamp_is_recent(mini_sentry, relay):
@@ -85,4 +90,8 @@ def test_clock_drift_not_applied_when_sent_at_is_not_supplied(mini_sentry, relay
     # In case clock drift is not run, we expect timestamps normalization to go into effect to mark timestamps as
     # past or future if they surpass a certain threshold.
     assert error_name == "past_timestamp"
-    assert transaction_event["timestamp"] > one_month_ago.timestamp()
+    assert (
+        one_month_ago.timestamp()
+        < transaction_event["timestamp"]
+        < datetime.now(tz=timezone.utc).timestamp()
+    )


### PR DESCRIPTION
This PR applies clock drift normalization only when `sent_at` is defined in the envelope headers.

The previous implementation was falling back to `event.timestamp` if the incoming event was a transaction. That was expected behavior for old SDKs which didn't send `sent_at` however we do not have anymore SDKs using the `/store` endpoint, which means that we can assume that `sent_at` is sent for each envelope. If not sent, we won't perform clock drift normalization instead of using `event.timestamp` like before.

Closes: https://github.com/getsentry/relay/issues/1625