### PR TITLE
fix(spans): Scrub extensions in description and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Route spans according to trace_id. ([#3387](https://github.com/getsentry/relay/pull/3387))
 - Log span when encountering a validation error. ([#3401](https://github.com/getsentry/relay/pull/3401))
 - Optionally skip normalization. ([#3377](https://github.com/getsentry/relay/pull/3377))
+- Scrub file extensions in file spans and tags. ([#3413](https://github.com/getsentry/relay/pull/3413))
 
 ## 24.3.0
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -398,7 +398,7 @@ fn scrub_resource_segment(segment: &str) -> Cow<str> {
     segment
 }
 
-pub(crate) fn scrub_resource_file_extension(mut extension: &str) -> &str {
+fn scrub_resource_file_extension(mut extension: &str) -> &str {
     // Only accept short, clean file extensions.
     let mut digits = 0;
     for (i, byte) in extension.bytes().enumerate() {

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -186,7 +186,7 @@ fn scrub_file(description: &str) -> Option<String> {
     };
     match Path::new(filename).extension() {
         Some(extension) => {
-            let ext = extension.to_str()?;
+            let ext = scrub_resource_file_extension(extension.to_str()?);
             Some(format!("*.{ext}"))
         }
         _ => Some("*".to_owned()),
@@ -398,7 +398,7 @@ fn scrub_resource_segment(segment: &str) -> Cow<str> {
     segment
 }
 
-fn scrub_resource_file_extension(mut extension: &str) -> &str {
+pub(crate) fn scrub_resource_file_extension(mut extension: &str) -> &str {
     // Only accept short, clean file extensions.
     let mut digits = 0;
     for (i, byte) in extension.bytes().enumerate() {

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -187,7 +187,11 @@ fn scrub_file(description: &str) -> Option<String> {
     match Path::new(filename).extension() {
         Some(extension) => {
             let ext = scrub_resource_file_extension(extension.to_str()?);
-            Some(format!("*.{ext}"))
+            if ext != "*" {
+                Some(format!("*.{ext}"))
+            } else {
+                Some("*".to_string())
+            }
         }
         _ => Some("*".to_owned()),
     }
@@ -776,6 +780,13 @@ mod tests {
     span_description_test!(
         span_description_file_with_no_extension,
         "somefilenamewithnoextension",
+        "file.read",
+        "*"
+    );
+
+    span_description_test!(
+        span_description_file_extension_with_numbers_only,
+        "backup.2024041101",
         "file.read",
         "*"
     );

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -15,7 +15,9 @@ use sqlparser::ast::Visit;
 use sqlparser::ast::{ObjectName, Visitor};
 use url::Url;
 
-use crate::span::description::{normalize_domain, scrub_span_description};
+use crate::span::description::{
+    normalize_domain, scrub_resource_file_extension, scrub_span_description,
+};
 use crate::utils::{
     extract_transaction_op, http_status_code_from_span, MAIN_THREAD_NAME, MOBILE_SDKS,
 };
@@ -435,7 +437,10 @@ pub fn extract_tags(
                     .and_then(|last_segment| last_segment.rsplit_once('.'))
                     .map(|(_, extension)| extension)
                 {
-                    span_tags.insert(SpanTagKey::FileExtension, ext.to_lowercase());
+                    span_tags.insert(
+                        SpanTagKey::FileExtension,
+                        scrub_resource_file_extension(ext.to_lowercase().as_str()).to_string(),
+                    );
                 }
             }
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -15,9 +15,7 @@ use sqlparser::ast::Visit;
 use sqlparser::ast::{ObjectName, Visitor};
 use url::Url;
 
-use crate::span::description::{
-    normalize_domain, scrub_resource_file_extension, scrub_span_description,
-};
+use crate::span::description::{normalize_domain, scrub_span_description};
 use crate::utils::{
     extract_transaction_op, http_status_code_from_span, MAIN_THREAD_NAME, MOBILE_SDKS,
 };
@@ -437,10 +435,7 @@ pub fn extract_tags(
                     .and_then(|last_segment| last_segment.rsplit_once('.'))
                     .map(|(_, extension)| extension)
                 {
-                    span_tags.insert(
-                        SpanTagKey::FileExtension,
-                        scrub_resource_file_extension(ext.to_lowercase().as_str()).to_string(),
-                    );
+                    span_tags.insert(SpanTagKey::FileExtension, ext.to_lowercase());
                 }
             }
 

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1293,7 +1293,7 @@ mod tests {
             .filter(|b| &*b.name == "c:spans/usage@none")
             .collect::<Vec<_>>();
 
-        let expected_usage = 9; // We count all spans received by Relay, plus one for the transaction
+        let expected_usage = 10; // We count all spans received by Relay, plus one for the transaction
         assert_eq!(usage_metrics.len(), expected_usage);
         for m in usage_metrics {
             assert!(m.tags.is_empty());

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1020,7 +1020,6 @@ mod tests {
                         "ui.component_name": "my-component-name"
                     }
                 }
-
             ]
         }
         "#;
@@ -1153,6 +1152,14 @@ mod tests {
                     "data": {
                         "app_start_type": "cold"
                     }
+                },
+                {
+                    "op": "file.read",
+                    "description": "somebackup.212321",
+                    "span_id": "bd429c44b67a3eb2",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976303.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81"
                 }
             ]
         }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -442,6 +442,54 @@ expression: "(&event.value().unwrap().spans, metrics)"
             was_transaction: ~,
             other: {},
         },
+        Span {
+            timestamp: Timestamp(
+                2020-08-21T02:18:23Z,
+            ),
+            start_timestamp: Timestamp(
+                2020-08-21T02:18:20Z,
+            ),
+            exclusive_time: 3000.0,
+            description: "somebackup.212321",
+            op: "file.read",
+            span_id: SpanId(
+                "bd429c44b67a3eb2",
+            ),
+            parent_span_id: ~,
+            trace_id: TraceId(
+                "ff62a8b040f340bda5d830223def1d81",
+            ),
+            segment_id: ~,
+            is_segment: ~,
+            status: ~,
+            tags: ~,
+            origin: ~,
+            profile_id: ~,
+            data: ~,
+            sentry_tags: {
+                "app_start_type": "warm",
+                "category": "file",
+                "description": "*",
+                "device.class": "1",
+                "group": "3389dae361af79b0",
+                "mobile": "true",
+                "op": "file.read",
+                "os.name": "iOS",
+                "platform": "cocoa",
+                "release": "1.2.3",
+                "sdk.name": "sentry.javascript.react-native",
+                "sdk.version": "unknown",
+                "transaction": "gEt /api/:version/users/",
+                "transaction.method": "GET",
+                "ttid": "ttid",
+            },
+            received: ~,
+            measurements: ~,
+            _metrics_summary: ~,
+            platform: ~,
+            was_transaction: ~,
+            other: {},
+        },
     ],
     [
         Bucket {
@@ -1124,6 +1172,58 @@ expression: "(&event.value().unwrap().spans, metrics)"
             ),
             tags: {
                 "span.op": "process.load",
+                "transaction": "gEt /api/:version/users/",
+            },
+            metadata: BucketMetadata {
+                merges: 1,
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: MetricName(
+                "c:spans/usage@none",
+            ),
+            value: Counter(
+                1.0,
+            ),
+            tags: {},
+            metadata: BucketMetadata {
+                merges: 1,
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: MetricName(
+                "d:spans/exclusive_time@millisecond",
+            ),
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "span.op": "file.read",
+                "transaction": "gEt /api/:version/users/",
+            },
+            metadata: BucketMetadata {
+                merges: 1,
+            },
+        },
+        Bucket {
+            timestamp: UnixTimestamp(1597976303),
+            width: 0,
+            name: MetricName(
+                "d:spans/duration@millisecond",
+            ),
+            value: Distribution(
+                [
+                    3000.0,
+                ],
+            ),
+            tags: {
+                "span.op": "file.read",
                 "transaction": "gEt /api/:version/users/",
             },
             metadata: BucketMetadata {


### PR DESCRIPTION
The cardinality report was flagging some projects with file spans with high cardinality which turned out to be file extensions being numbers.

This will apply the same scrubbing we do on file extensions for resource spans to all extensions.