### PR TITLE
ref(deps): Update redis-rs fork to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,8 +3498,8 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.2"
-source = "git+https://github.com/getsentry/redis-rs.git?rev=6201a8c9f8766c4e580deef6834365ec631ce9f8#6201a8c9f8766c4e580deef6834365ec631ce9f8"
+version = "0.25.3"
+source = "git+https://github.com/getsentry/redis-rs.git?rev=9517cb7d0f247cf7f3c0813eea5e86794d6d8507#9517cb7d0f247cf7f3c0813eea5e86794d6d8507"
 dependencies = [
  "arc-swap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ rand_pcg = "0.3.1"
 rdkafka = "0.29.0"
 rdkafka-sys = "4.3.0"
 # Fork until https://github.com/redis-rs/redis-rs/pull/1097 is merged.
-redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "6201a8c9f8766c4e580deef6834365ec631ce9f8", default-features = false }
+redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "9517cb7d0f247cf7f3c0813eea5e86794d6d8507", default-features = false }
 regex = "1.10.2"
 reqwasm = "0.5.0"
 reqwest = "0.11.1"

--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -162,7 +162,7 @@ impl<'a> CardinalityScriptPipeline<'a> {
         keys: impl Iterator<Item = String>,
     ) -> &mut Self {
         let invocation = self.script.prepare_invocation(limit, expire, hashes, keys);
-        self.pipe.script(invocation);
+        self.pipe.invoke_script(&invocation);
         self
     }
 


### PR DESCRIPTION
The fork changed a bit, update to the latest commit in the fork to make transition to post fork easier. It's also a good way to test it.

#skip-changelog