### PR TITLE
ref(schema): Split BagSize into max_depth and max_bytes

### DIFF
--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -321,8 +321,8 @@ struct FieldAttrs {
     characters: Option<TokenStream>,
     max_chars: Option<TokenStream>,
     max_chars_allowance: Option<TokenStream>,
-    max_struct_depth: Option<TokenStream>,
-    max_struct_bytes: Option<TokenStream>,
+    max_depth: Option<TokenStream>,
+    max_bytes: Option<TokenStream>,
 }
 
 impl FieldAttrs {
@@ -384,18 +384,18 @@ impl FieldAttrs {
             quote!(0)
         };
 
-        let max_struct_depth = if let Some(ref max_struct_depth) = self.max_struct_depth {
-            quote!(Some(#max_struct_depth))
+        let max_depth = if let Some(ref max_depth) = self.max_depth {
+            quote!(Some(#max_depth))
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
-            quote!(#parent_attrs.max_struct_depth)
+            quote!(#parent_attrs.max_depth)
         } else {
             quote!(None)
         };
 
-        let max_struct_bytes = if let Some(ref max_struct_bytes) = self.max_struct_bytes {
-            quote!(Some(#max_struct_bytes))
+        let max_bytes = if let Some(ref max_bytes) = self.max_bytes {
+            quote!(Some(#max_bytes))
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
-            quote!(#parent_attrs.max_struct_bytes)
+            quote!(#parent_attrs.max_bytes)
         } else {
             quote!(None)
         };
@@ -417,8 +417,8 @@ impl FieldAttrs {
                 max_chars: #max_chars,
                 max_chars_allowance: #max_chars_allowance,
                 characters: #characters,
-                max_struct_depth: #max_struct_depth,
-                max_struct_bytes: #max_struct_bytes,
+                max_depth: #max_depth,
+                max_bytes: #max_bytes,
                 pii: #pii,
                 retain: #retain,
             }
@@ -554,22 +554,22 @@ fn parse_field_attributes(
                                         panic!("Got non integer literal for max_chars_allowance");
                                     }
                                 }
-                            } else if ident == "max_struct_depth" {
+                            } else if ident == "max_depth" {
                                 match name_value.lit {
                                     Lit::Int(litint) => {
-                                        rv.max_struct_depth = Some(quote!(#litint));
+                                        rv.max_depth = Some(quote!(#litint));
                                     }
                                     _ => {
-                                        panic!("Got non integer literal for max_struct_depth");
+                                        panic!("Got non integer literal for max_depth");
                                     }
                                 }
-                            } else if ident == "max_struct_bytes" {
+                            } else if ident == "max_bytes" {
                                 match name_value.lit {
                                     Lit::Int(litint) => {
-                                        rv.max_struct_bytes = Some(quote!(#litint));
+                                        rv.max_bytes = Some(quote!(#litint));
                                     }
                                     _ => {
-                                        panic!("Got non integer literal for max_struct_bytes");
+                                        panic!("Got non integer literal for max_bytes");
                                     }
                                 }
                             } else if ident == "pii" {

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -214,17 +214,6 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
     })
 }
 
-fn parse_bag_size(name: &str) -> TokenStream {
-    match name {
-        "small" => quote!(crate::processor::BagSize::Small),
-        "medium" => quote!(crate::processor::BagSize::Medium),
-        "large" => quote!(crate::processor::BagSize::Large),
-        "larger" => quote!(crate::processor::BagSize::Larger),
-        "massive" => quote!(crate::processor::BagSize::Massive),
-        _ => panic!("invalid bag_size variant '{name}'"),
-    }
-}
-
 #[derive(Default)]
 struct TypeAttrs {
     process_func: Option<String>,
@@ -332,7 +321,8 @@ struct FieldAttrs {
     characters: Option<TokenStream>,
     max_chars: Option<TokenStream>,
     max_chars_allowance: Option<TokenStream>,
-    bag_size: Option<TokenStream>,
+    max_struct_depth: Option<TokenStream>,
+    max_struct_bytes: Option<TokenStream>,
 }
 
 impl FieldAttrs {
@@ -394,10 +384,18 @@ impl FieldAttrs {
             quote!(0)
         };
 
-        let bag_size = if let Some(ref bag_size) = self.bag_size {
-            quote!(Some(#bag_size))
+        let max_struct_depth = if let Some(ref max_struct_depth) = self.max_struct_depth {
+            quote!(Some(#max_struct_depth))
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
-            quote!(#parent_attrs.bag_size)
+            quote!(#parent_attrs.max_struct_depth)
+        } else {
+            quote!(None)
+        };
+
+        let max_struct_bytes = if let Some(ref max_struct_bytes) = self.max_struct_bytes {
+            quote!(Some(#max_struct_bytes))
+        } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
+            quote!(#parent_attrs.max_struct_bytes)
         } else {
             quote!(None)
         };
@@ -419,7 +417,8 @@ impl FieldAttrs {
                 max_chars: #max_chars,
                 max_chars_allowance: #max_chars_allowance,
                 characters: #characters,
-                bag_size: #bag_size,
+                max_struct_depth: #max_struct_depth,
+                max_struct_bytes: #max_struct_bytes,
                 pii: #pii,
                 retain: #retain,
             }
@@ -555,14 +554,22 @@ fn parse_field_attributes(
                                         panic!("Got non integer literal for max_chars_allowance");
                                     }
                                 }
-                            } else if ident == "bag_size" {
+                            } else if ident == "max_struct_depth" {
                                 match name_value.lit {
-                                    Lit::Str(litstr) => {
-                                        let attr = parse_bag_size(litstr.value().as_str());
-                                        rv.bag_size = Some(quote!(#attr));
+                                    Lit::Int(litint) => {
+                                        rv.max_struct_depth = Some(quote!(#litint));
                                     }
                                     _ => {
-                                        panic!("Got non string literal for bag_size");
+                                        panic!("Got non integer literal for max_struct_depth");
+                                    }
+                                }
+                            } else if ident == "max_struct_bytes" {
+                                match name_value.lit {
+                                    Lit::Int(litint) => {
+                                        rv.max_struct_bytes = Some(quote!(#litint));
+                                    }
+                                    _ => {
+                                        panic!("Got non integer literal for max_struct_bytes");
                                     }
                                 }
                             } else if ident == "pii" {

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -38,7 +38,7 @@ impl TrimmingProcessor {
             .iter()
             .filter_map(|size_state| {
                 // The current depth in the entire event payload minus the depth at which we found the
-                // max_struct_depth attribute is the depth where we are at in the property.
+                // max_depth attribute is the depth where we are at in the property.
                 let current_depth = state.depth() - size_state.encountered_at_depth;
                 size_state
                     .max_depth
@@ -63,14 +63,14 @@ impl Processor for TrimmingProcessor {
         _: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        // If we encounter a max_struct_bytes or max_struct_depth attribute it
+        // If we encounter a max_bytes or max_depth attribute it
         // resets the size and depth that is permitted below it.
         // XXX(iker): test setting only one of the two attributes.
-        if state.attrs().max_struct_bytes.is_some() || state.attrs().max_struct_depth.is_some() {
+        if state.attrs().max_bytes.is_some() || state.attrs().max_depth.is_some() {
             self.size_state.push(SizeState {
-                size_remaining: state.attrs().max_struct_bytes,
+                size_remaining: state.attrs().max_bytes,
                 encountered_at_depth: state.depth(),
-                max_depth: state.attrs().max_struct_depth,
+                max_depth: state.attrs().max_depth,
             });
         }
 

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -121,9 +121,9 @@ pub struct FieldAttrs {
     /// The extra char length allowance on top of max_chars.
     pub max_chars_allowance: usize,
     /// The maximum depth of this field.
-    pub max_struct_depth: Option<usize>,
+    pub max_depth: Option<usize>,
     /// The maximum number of bytes of this field.
-    pub max_struct_bytes: Option<usize>,
+    pub max_bytes: Option<usize>,
     /// The type of PII on the field.
     pub pii: Pii,
     /// Whether additional properties should be retained during normalization.
@@ -163,8 +163,8 @@ impl FieldAttrs {
             characters: None,
             max_chars: None,
             max_chars_allowance: 0,
-            max_struct_depth: None,
-            max_struct_bytes: None,
+            max_depth: None,
+            max_bytes: None,
             pii: Pii::False,
             retain: false,
         }

--- a/relay-event-schema/src/protocol/breadcrumb.rs
+++ b/relay-event-schema/src/protocol/breadcrumb.rs
@@ -108,7 +108,7 @@ pub struct Breadcrumb {
     ///
     /// Contains a dictionary whose contents depend on the breadcrumb `type`. Additional parameters
     /// that are unsupported by the type are rendered as a key/value table.
-    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(pii = "true", max_depth = 5, max_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub data: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/breadcrumb.rs
+++ b/relay-event-schema/src/protocol/breadcrumb.rs
@@ -108,7 +108,7 @@ pub struct Breadcrumb {
     ///
     /// Contains a dictionary whose contents depend on the breadcrumb `type`. Additional parameters
     /// that are unsupported by the type are rendered as a key/value table.
-    #[metastructure(pii = "true", bag_size = "medium")]
+    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub data: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -97,7 +97,9 @@ pub enum Context {
 
 #[derive(Clone, Debug, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-pub struct ContextInner(#[metastructure(bag_size = "large")] pub Context);
+pub struct ContextInner(
+    #[metastructure(max_struct_depth = 7, max_struct_bytes = 8192)] pub Context,
+);
 
 impl From<Context> for ContextInner {
     fn from(c: Context) -> ContextInner {

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -97,9 +97,7 @@ pub enum Context {
 
 #[derive(Clone, Debug, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-pub struct ContextInner(
-    #[metastructure(max_struct_depth = 7, max_struct_bytes = 8192)] pub Context,
-);
+pub struct ContextInner(#[metastructure(max_depth = 7, max_bytes = 8192)] pub Context);
 
 impl From<Context> for ContextInner {
     fn from(c: Context) -> ContextInner {

--- a/relay-event-schema/src/protocol/contexts/otel.rs
+++ b/relay-event-schema/src/protocol/contexts/otel.rs
@@ -13,13 +13,13 @@ pub struct OtelContext {
     /// Attributes of the OpenTelemetry span that maps to a Sentry event.
     ///
     /// <https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186>
-    #[metastructure(pii = "maybe", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "maybe", max_depth = 7, max_bytes = 8192)]
     attributes: Annotated<Object<Value>>,
 
     /// Information about an OpenTelemetry resource.
     ///
     /// <https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/resource/v1/resource.proto>
-    #[metastructure(pii = "maybe", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "maybe", max_depth = 7, max_bytes = 8192)]
     resource: Annotated<Object<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/contexts/otel.rs
+++ b/relay-event-schema/src/protocol/contexts/otel.rs
@@ -13,13 +13,13 @@ pub struct OtelContext {
     /// Attributes of the OpenTelemetry span that maps to a Sentry event.
     ///
     /// <https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186>
-    #[metastructure(pii = "maybe", bag_size = "large")]
+    #[metastructure(pii = "maybe", max_struct_depth = 7, max_struct_bytes = 8192)]
     attributes: Annotated<Object<Value>>,
 
     /// Information about an OpenTelemetry resource.
     ///
     /// <https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/resource/v1/resource.proto>
-    #[metastructure(pii = "maybe", bag_size = "large")]
+    #[metastructure(pii = "maybe", max_struct_depth = 7, max_struct_bytes = 8192)]
     resource: Annotated<Object<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/contexts/response.rs
+++ b/relay-event-schema/src/protocol/contexts/response.rs
@@ -15,7 +15,7 @@ pub struct ResponseContext {
     /// The cookie values.
     ///
     /// Can be given unparsed as string, as dictionary, or as a list of tuples.
-    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(pii = "true", max_depth = 5, max_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub cookies: Annotated<Cookies>,
 
@@ -23,7 +23,7 @@ pub struct ResponseContext {
     ///
     /// If a header appears multiple times it, needs to be merged according to the HTTP standard
     /// for header merging. Header names are treated case-insensitively by Sentry.
-    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "true", max_depth = 7, max_bytes = 8192)]
     #[metastructure(skip_serialization = "empty")]
     pub headers: Annotated<Headers>,
 
@@ -37,7 +37,7 @@ pub struct ResponseContext {
     ///
     /// SDKs should discard large and binary bodies by default. Can be given as a string or
     /// structural data of any format.
-    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "true", max_depth = 7, max_bytes = 8192)]
     pub data: Annotated<Value>,
 
     /// The inferred content type of the response payload.

--- a/relay-event-schema/src/protocol/contexts/response.rs
+++ b/relay-event-schema/src/protocol/contexts/response.rs
@@ -15,7 +15,7 @@ pub struct ResponseContext {
     /// The cookie values.
     ///
     /// Can be given unparsed as string, as dictionary, or as a list of tuples.
-    #[metastructure(pii = "true", bag_size = "medium")]
+    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub cookies: Annotated<Cookies>,
 
@@ -23,7 +23,7 @@ pub struct ResponseContext {
     ///
     /// If a header appears multiple times it, needs to be merged according to the HTTP standard
     /// for header merging. Header names are treated case-insensitively by Sentry.
-    #[metastructure(pii = "true", bag_size = "large")]
+    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
     #[metastructure(skip_serialization = "empty")]
     pub headers: Annotated<Headers>,
 
@@ -37,7 +37,7 @@ pub struct ResponseContext {
     ///
     /// SDKs should discard large and binary bodies by default. Can be given as a string or
     /// structural data of any format.
-    #[metastructure(pii = "true", bag_size = "large")]
+    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
     pub data: Annotated<Value>,
 
     /// The inferred content type of the response payload.

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -182,8 +182,8 @@ pub struct Route {
     #[metastructure(
         pii = "true",
         skip_serialization = "empty",
-        max_struct_depth = 5,
-        max_struct_bytes = 2048
+        max_depth = 5,
+        max_bytes = 2048
     )]
     params: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -179,7 +179,12 @@ pub struct Route {
     #[metastructure(pii = "maybe", skip_serialization = "empty")]
     name: Annotated<String>,
     /// Parameters assigned to this route.
-    #[metastructure(pii = "true", skip_serialization = "empty", bag_size = "medium")]
+    #[metastructure(
+        pii = "true",
+        skip_serialization = "empty",
+        max_struct_depth = 5,
+        max_struct_bytes = 2048
+    )]
     params: Annotated<Object<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -66,7 +66,7 @@ impl FromStr for EventId {
 relay_common::impl_str_serde!(EventId, "an event identifier");
 
 #[derive(Debug, FromValue, IntoValue, ProcessValue, Empty, Clone, PartialEq)]
-pub struct ExtraValue(#[metastructure(bag_size = "larger")] pub Value);
+pub struct ExtraValue(#[metastructure(max_struct_depth = 7, max_struct_bytes = 16_384)] pub Value);
 
 #[cfg(feature = "jsonschema")]
 impl schemars::JsonSchema for ExtraValue {
@@ -243,7 +243,11 @@ pub struct Event {
     /// This is primarily used for suggesting to enable certain SDK integrations from within the UI
     /// and for making informed decisions on which frameworks to support in future development
     /// efforts.
-    #[metastructure(skip_serialization = "empty_deep", bag_size = "large")]
+    #[metastructure(
+        skip_serialization = "empty_deep",
+        max_struct_depth = 7,
+        max_struct_bytes = 8192
+    )]
     pub modules: Annotated<Object<String>>,
 
     /// Platform identifier of this event (defaults to "other").
@@ -403,7 +407,7 @@ pub struct Event {
     ///         "some_other_value": "foo bar"
     ///     }
     /// }```
-    #[metastructure(bag_size = "massive")]
+    #[metastructure(max_struct_depth = 7, max_struct_bytes = 262_144)]
     #[metastructure(pii = "true", skip_serialization = "empty")]
     pub extra: Annotated<Object<ExtraValue>>,
 
@@ -417,7 +421,7 @@ pub struct Event {
     pub client_sdk: Annotated<ClientSdkInfo>,
 
     /// Information about the Relays that processed this event during ingest.
-    #[metastructure(bag_size = "medium")]
+    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048)]
     #[metastructure(skip_serialization = "empty", omit_from_schema)]
     pub ingest_path: Annotated<Array<RelayInfo>>,
 

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -66,7 +66,7 @@ impl FromStr for EventId {
 relay_common::impl_str_serde!(EventId, "an event identifier");
 
 #[derive(Debug, FromValue, IntoValue, ProcessValue, Empty, Clone, PartialEq)]
-pub struct ExtraValue(#[metastructure(max_struct_depth = 7, max_struct_bytes = 16_384)] pub Value);
+pub struct ExtraValue(#[metastructure(max_depth = 7, max_bytes = 16_384)] pub Value);
 
 #[cfg(feature = "jsonschema")]
 impl schemars::JsonSchema for ExtraValue {
@@ -243,11 +243,7 @@ pub struct Event {
     /// This is primarily used for suggesting to enable certain SDK integrations from within the UI
     /// and for making informed decisions on which frameworks to support in future development
     /// efforts.
-    #[metastructure(
-        skip_serialization = "empty_deep",
-        max_struct_depth = 7,
-        max_struct_bytes = 8192
-    )]
+    #[metastructure(skip_serialization = "empty_deep", max_depth = 7, max_bytes = 8192)]
     pub modules: Annotated<Object<String>>,
 
     /// Platform identifier of this event (defaults to "other").
@@ -407,7 +403,7 @@ pub struct Event {
     ///         "some_other_value": "foo bar"
     ///     }
     /// }```
-    #[metastructure(max_struct_depth = 7, max_struct_bytes = 262_144)]
+    #[metastructure(max_depth = 7, max_bytes = 262_144)]
     #[metastructure(pii = "true", skip_serialization = "empty")]
     pub extra: Annotated<Object<ExtraValue>>,
 
@@ -421,7 +417,7 @@ pub struct Event {
     pub client_sdk: Annotated<ClientSdkInfo>,
 
     /// Information about the Relays that processed this event during ingest.
-    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(max_depth = 5, max_bytes = 2048)]
     #[metastructure(skip_serialization = "empty", omit_from_schema)]
     pub ingest_path: Annotated<Array<RelayInfo>>,
 

--- a/relay-event-schema/src/protocol/logentry.rs
+++ b/relay-event-schema/src/protocol/logentry.rs
@@ -50,7 +50,7 @@ pub struct LogEntry {
 
     /// Parameters to be interpolated into the log message. This can be an array of positional
     /// parameters as well as a mapping of named arguments to their values.
-    #[metastructure(bag_size = "medium", pii = "true")]
+    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048, pii = "true")]
     pub params: Annotated<Value>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/logentry.rs
+++ b/relay-event-schema/src/protocol/logentry.rs
@@ -50,7 +50,7 @@ pub struct LogEntry {
 
     /// Parameters to be interpolated into the log message. This can be an array of positional
     /// parameters as well as a mapping of named arguments to their values.
-    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048, pii = "true")]
+    #[metastructure(max_depth = 5, max_bytes = 2048, pii = "true")]
     pub params: Annotated<Value>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/mechanism.rs
+++ b/relay-event-schema/src/protocol/mechanism.rs
@@ -191,7 +191,7 @@ pub struct Mechanism {
     pub parent_id: Annotated<u64>,
 
     /// Arbitrary extra data that might help the user understand the error thrown by this mechanism.
-    #[metastructure(pii = "true", bag_size = "medium")]
+    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub data: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/mechanism.rs
+++ b/relay-event-schema/src/protocol/mechanism.rs
@@ -191,7 +191,7 @@ pub struct Mechanism {
     pub parent_id: Annotated<u64>,
 
     /// Arbitrary extra data that might help the user understand the error thrown by this mechanism.
-    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(pii = "true", max_depth = 5, max_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub data: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -132,15 +132,15 @@ pub struct Replay {
     pub replay_start_timestamp: Annotated<Timestamp>,
 
     /// A list of URLs visted during the lifetime of the segment.
-    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "true", max_depth = 7, max_bytes = 8192)]
     pub urls: Annotated<Array<String>>,
 
     /// A list of error-ids discovered during the lifetime of the segment.
-    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(max_depth = 5, max_bytes = 2048)]
     pub error_ids: Annotated<Array<Uuid>>,
 
     /// A list of trace-ids discovered during the lifetime of the segment.
-    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(max_depth = 5, max_bytes = 2048)]
     pub trace_ids: Annotated<Array<Uuid>>,
 
     /// Contexts describing the environment (e.g. device, os or browser).

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -132,15 +132,15 @@ pub struct Replay {
     pub replay_start_timestamp: Annotated<Timestamp>,
 
     /// A list of URLs visted during the lifetime of the segment.
-    #[metastructure(pii = "true", bag_size = "large")]
+    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
     pub urls: Annotated<Array<String>>,
 
     /// A list of error-ids discovered during the lifetime of the segment.
-    #[metastructure(bag_size = "medium")]
+    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048)]
     pub error_ids: Annotated<Array<Uuid>>,
 
     /// A list of trace-ids discovered during the lifetime of the segment.
-    #[metastructure(bag_size = "medium")]
+    #[metastructure(max_struct_depth = 5, max_struct_bytes = 2048)]
     pub trace_ids: Annotated<Array<Uuid>>,
 
     /// Contexts describing the environment (e.g. device, os or browser).

--- a/relay-event-schema/src/protocol/request.rs
+++ b/relay-event-schema/src/protocol/request.rs
@@ -449,7 +449,7 @@ pub struct Request {
     ///
     /// SDKs should discard large and binary bodies by default. Can be given as a string or
     /// structural data of any format.
-    #[metastructure(pii = "true", bag_size = "large")]
+    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
     pub data: Annotated<Value>,
 
     /// The query string component of the URL.
@@ -458,7 +458,7 @@ pub struct Request {
     ///
     /// If the query string is not declared and part of the `url`, Sentry moves it to the
     /// query string.
-    #[metastructure(pii = "true", bag_size = "small")]
+    #[metastructure(pii = "true", max_struct_depth = 3, max_struct_bytes = 1024)]
     #[metastructure(skip_serialization = "empty")]
     pub query_string: Annotated<Query>,
 
@@ -470,7 +470,7 @@ pub struct Request {
     /// The cookie values.
     ///
     /// Can be given unparsed as string, as dictionary, or as a list of tuples.
-    #[metastructure(pii = "true", bag_size = "medium")]
+    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub cookies: Annotated<Cookies>,
 
@@ -478,7 +478,7 @@ pub struct Request {
     ///
     /// If a header appears multiple times it, needs to be merged according to the HTTP standard
     /// for header merging. Header names are treated case-insensitively by Sentry.
-    #[metastructure(pii = "true", bag_size = "large")]
+    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
     #[metastructure(skip_serialization = "empty")]
     pub headers: Annotated<Headers>,
 
@@ -491,7 +491,7 @@ pub struct Request {
     /// information such as CGI/WSGI/Rack keys go that are not HTTP headers.
     ///
     /// Sentry will explicitly look for `REMOTE_ADDR` to extract an IP address.
-    #[metastructure(pii = "true", bag_size = "large")]
+    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
     #[metastructure(skip_serialization = "empty")]
     pub env: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/request.rs
+++ b/relay-event-schema/src/protocol/request.rs
@@ -449,7 +449,7 @@ pub struct Request {
     ///
     /// SDKs should discard large and binary bodies by default. Can be given as a string or
     /// structural data of any format.
-    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "true", max_depth = 7, max_bytes = 8192)]
     pub data: Annotated<Value>,
 
     /// The query string component of the URL.
@@ -458,7 +458,7 @@ pub struct Request {
     ///
     /// If the query string is not declared and part of the `url`, Sentry moves it to the
     /// query string.
-    #[metastructure(pii = "true", max_struct_depth = 3, max_struct_bytes = 1024)]
+    #[metastructure(pii = "true", max_depth = 3, max_bytes = 1024)]
     #[metastructure(skip_serialization = "empty")]
     pub query_string: Annotated<Query>,
 
@@ -470,7 +470,7 @@ pub struct Request {
     /// The cookie values.
     ///
     /// Can be given unparsed as string, as dictionary, or as a list of tuples.
-    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(pii = "true", max_depth = 5, max_bytes = 2048)]
     #[metastructure(skip_serialization = "empty")]
     pub cookies: Annotated<Cookies>,
 
@@ -478,7 +478,7 @@ pub struct Request {
     ///
     /// If a header appears multiple times it, needs to be merged according to the HTTP standard
     /// for header merging. Header names are treated case-insensitively by Sentry.
-    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "true", max_depth = 7, max_bytes = 8192)]
     #[metastructure(skip_serialization = "empty")]
     pub headers: Annotated<Headers>,
 
@@ -491,7 +491,7 @@ pub struct Request {
     /// information such as CGI/WSGI/Rack keys go that are not HTTP headers.
     ///
     /// Sentry will explicitly look for `REMOTE_ADDR` to extract an IP address.
-    #[metastructure(pii = "true", max_struct_depth = 7, max_struct_bytes = 8192)]
+    #[metastructure(pii = "true", max_depth = 7, max_bytes = 8192)]
     #[metastructure(skip_serialization = "empty")]
     pub env: Annotated<Object<Value>>,
 

--- a/relay-event-schema/src/protocol/stacktrace.rs
+++ b/relay-event-schema/src/protocol/stacktrace.rs
@@ -121,7 +121,7 @@ pub struct Frame {
 
     /// Mapping of local variables and expression names that were available in this frame.
     // XXX: Probably want to trim per-var => new bag size?
-    #[metastructure(pii = "true", bag_size = "medium")]
+    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
     pub vars: Annotated<FrameVars>,
 
     /// Auxiliary information about the frame that is platform specific.

--- a/relay-event-schema/src/protocol/stacktrace.rs
+++ b/relay-event-schema/src/protocol/stacktrace.rs
@@ -121,7 +121,7 @@ pub struct Frame {
 
     /// Mapping of local variables and expression names that were available in this frame.
     // XXX: Probably want to trim per-var => new bag size?
-    #[metastructure(pii = "true", max_struct_depth = 5, max_struct_bytes = 2048)]
+    #[metastructure(pii = "true", max_depth = 5, max_bytes = 2048)]
     pub vars: Annotated<FrameVars>,
 
     /// Auxiliary information about the frame that is platform specific.


### PR DESCRIPTION
This PR splits the `BagSize` into the separate `max_depth` and `max_bytes` attributes.

Following up https://github.com/getsentry/relay/pull/2887, string values are confusing and may lead to investigating where the mappings are happening and applied. Further, updating `BagSize` values impact multiple fields and may have unintended effects.

### Tests

Using the attributes independently is not tested, and we'll do them once we have that use case.

Since the two attributes are now split, setting them up individually is possible. Although this should work, it's not tested since a dummy struct deriving `ProcessValue` [needs to be defined](https://github.com/getsentry/relay/blob/5e319709dbbc51433b3ec9d908b149d3ad405ce6/relay-event-derive/src/lib.rs#L3-L4) in `relay-event-schema` and the test with the `TrimmingProcessor` in `relay-event-normalization`, requiring exposing the dummy struct which is not great. So, I've added a comment to test this in the future. Current use cases are supported as expected.

#skip-changelog