### PR TITLE
release: 0.5.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "relay-cabi"
-version = "0.8.56"
+version = "0.5.87"
 dependencies = [
  "anyhow",
  "chrono",

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.87
 
 - Add a data category for metirc hours.  [#3384](https://github.com/getsentry/relay/pull/3384)
 

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-cabi"
-version = "0.8.56"
+version = "0.5.87"
 authors = ["Sentry <oss@sentry.io>"]
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"


### PR DESCRIPTION
Releasing MetricHour Data Category via library bump to 0.5.87