### PR TITLE
fix(config): Use default values for processing config

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -963,6 +963,7 @@ fn default_max_rate_limit() -> Option<u32> {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Processing {
     /// True if the Relay should do processing. Defaults to `false`.
+    #[serde(default)]
     pub enabled: bool,
     /// GeoIp DB file source.
     #[serde(default)]
@@ -977,6 +978,7 @@ pub struct Processing {
     #[serde(default = "default_max_session_secs_in_past")]
     pub max_session_secs_in_past: u32,
     /// Kafka producer configurations.
+    #[serde(default)]
     pub kafka_config: Vec<KafkaConfigParam>,
     /// Additional kafka producer configurations.
     ///


### PR DESCRIPTION
Initializing Relay with the `processing` config fails if `enabled` and `kafka_config` aren't provided. This PR defaults these values to the default implementation.

I don't understand why this doesn't fail in existing integration tests, but I see the failure when spinning up relay locally.

This change also implies that setting a `processing` key without `enabled` and `kafka_config` is now acceptable, which was not before.

#skip-changelog