### PR TITLE
ref(health): Add timeout to health checks

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1343,6 +1343,13 @@ pub struct Health {
     ///
     /// Defaults to `0.95` (95%).
     pub max_memory_percent: f32,
+    /// Health check probe timeout in milliseconds.
+    ///
+    /// Any probe exceeding the timeout will be considered failed.
+    /// This limits the max execution time of Relay health checks.
+    ///
+    /// Defaults to 900 milliseconds.
+    pub probe_timeout_ms: u64,
 }
 
 impl Default for Health {
@@ -1351,6 +1358,7 @@ impl Default for Health {
             sys_info_refresh_interval_secs: 3,
             max_memory_bytes: None,
             max_memory_percent: 0.95,
+            probe_timeout_ms: 900,
         }
     }
 }
@@ -2282,6 +2290,11 @@ impl Config {
     /// Maximum memory watermark as a percentage of maximum system memory.
     pub fn health_max_memory_watermark_percent(&self) -> f32 {
         self.values.health.max_memory_percent
+    }
+
+    /// Health check probe timeout.
+    pub fn health_probe_timeout(&self) -> Duration {
+        Duration::from_millis(self.values.health.probe_timeout_ms)
     }
 
     /// Whether COGS measurements are enabled.

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -96,8 +96,10 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
 
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         time.sleep(0.3)  # Wait for error
-        error = str(mini_sentry.test_failures.pop())
+        error = str(mini_sentry.test_failures.pop(0))
         assert "Not enough memory" in error and ">= 42" in error
+        error = str(mini_sentry.test_failures.pop(0))
+        assert "Health check probe 'system memory'" in error
         assert response.status_code == 503
     finally:
         # Authentication failures would fail the test
@@ -113,8 +115,10 @@ def test_readiness_not_enough_memory_percent(mini_sentry, relay):
         )
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         time.sleep(0.3)  # Wait for error
-        error = str(mini_sentry.test_failures.pop())
+        error = str(mini_sentry.test_failures.pop(0))
         assert "Not enough memory" in error and ">= 1.00%" in error
+        error = str(mini_sentry.test_failures.pop(0))
+        assert "Health check probe 'system memory'" in error
         assert response.status_code == 503
     finally:
         # Authentication failures would fail the test
@@ -132,7 +136,7 @@ def test_readiness_depends_on_aggregator_being_full(mini_sentry, relay):
         response = wait_get(relay, "/api/relay/healthcheck/ready/")
         time.sleep(0.3)  # Wait for error
         error = str(mini_sentry.test_failures.pop())
-        assert "Health check probe 'aggregator accept metrics'" in error
+        assert "Health check probe 'aggregator'" in error
         assert response.status_code == 503
     finally:
         # Authentication failures would fail the test


### PR DESCRIPTION
Configures 900ms, that should be plenty of time to return the status within 100ms to the caller, so we stay within 1 second for health check responses.

Tried to add an integration test, but it is fast enough that even a timeout of 0ms never fails in tests.

#skip-changelog