### PR TITLE
fix(event): Fix remaining snapshot to fix CI in master

### DIFF
--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -487,6 +487,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "release": "1.2.3",
                 "sdk.name": "sentry.javascript.react-native",
                 "sdk.version": "unknown",
+                "trace.status": "unknown",
                 "transaction": "gEt /api/:version/users/",
                 "transaction.method": "GET",
                 "ttid": "ttid",


### PR DESCRIPTION
CI in `master` is currently red because of a stale snapshot.

#skip-changelog