### PR TITLE
fix(spans): Fixes a broken spans snapshot

### DIFF
--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -487,6 +487,7 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 "release": "1.2.3",
                 "sdk.name": "sentry.javascript.react-native",
                 "sdk.version": "unknown",
+                "trace.status": "unknown",
                 "transaction": "gEt /api/:version/users/",
                 "transaction.method": "GET",
                 "ttid": "ttid",


### PR DESCRIPTION
Fixes a broken snapshot test, from https://github.com/getsentry/relay/pull/3407, due to merging to master without pulling latest snapshot changes.

#skip-changelog