### PR TITLE
feat(metric-stats): Implement per type cardinality limits

### DIFF
--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -5,7 +5,7 @@ use crate::metrics::MetricUnit;
 use serde::{Deserialize, Serialize};
 
 /// The type of a [`MetricResourceIdentifier`], determining its aggregation and evaluation.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum MetricType {
     /// Counts instances of an event.
     ///

--- a/relay-cardinality/src/config.rs
+++ b/relay-cardinality/src/config.rs
@@ -53,6 +53,12 @@ pub enum CardinalityScope {
     /// The limit will be enforced for a specific project.
     Project,
 
+    /// A per metric type cardinality limit.
+    ///
+    /// This limit usually doesn't make sense to enforce,
+    /// but is useful for cardinality reports.
+    Type,
+
     /// A per metric name cardinality limit.
     Name,
 

--- a/relay-cardinality/src/config.rs
+++ b/relay-cardinality/src/config.rs
@@ -51,15 +51,25 @@ pub enum CardinalityScope {
     /// A project level cardinality limit.
     ///
     /// The limit will be enforced for a specific project.
+    ///
+    /// Hierarchy: `Organization > Project`.
     Project,
 
     /// A per metric type cardinality limit.
     ///
-    /// This limit usually doesn't make sense to enforce,
-    /// but is useful for cardinality reports.
+    /// This scope is very similar to [`Self::Name`], it operates on a per metric
+    /// basis which includes organization and project id.
+    ///
+    /// A metric type cardinality limit is mostly useful for cardinality reports.
+    ///
+    /// Hierarchy: `Organization > Project > Type`.
     Type,
 
     /// A per metric name cardinality limit.
+    ///
+    /// The name scope is a sub-scope of project and organization.
+    ///
+    /// Hierarchy: `Organization > Project > Name`.
     Name,
 
     /// Any other scope that is not known by this Relay.

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use hashbrown::HashSet;
-use relay_base_schema::metrics::{MetricName, MetricNamespace};
+use relay_base_schema::metrics::{MetricName, MetricNamespace, MetricType};
 use relay_base_schema::project::ProjectId;
 use relay_statsd::metric;
 
@@ -37,11 +37,16 @@ pub struct CardinalityReport {
     /// Only available if the the limit was at least scoped to
     /// [`CardinalityScope::Project`](crate::CardinalityScope::Project).
     pub project_id: Option<ProjectId>,
-    /// Project id for which the cardinality limit was applied.
+    /// Metric type for which the cardinality limit was applied.
     ///
-    /// Only available if the the limit was at least scoped to
+    /// Only available if the the limit was scoped to
+    /// [`CardinalityScope::Type`](crate::CardinalityScope::Type).
+    pub metric_type: Option<MetricType>,
+    /// Metric name for which the cardinality limit was applied.
+    ///
+    /// Only available if the the limit was scoped to
     /// [`CardinalityScope::Name`](crate::CardinalityScope::Name).
-    pub name: Option<MetricName>,
+    pub metric_name: Option<MetricName>,
 
     /// The current cardinality.
     pub cardinality: u32,
@@ -629,7 +634,8 @@ mod tests {
                     CardinalityReport {
                         organization_id: Some(scoping.organization_id),
                         project_id: Some(scoping.project_id),
-                        name: Some(MetricName::from("foo")),
+                        metric_type: None,
+                        metric_name: Some(MetricName::from("foo")),
                         cardinality: 1,
                     },
                 );
@@ -639,7 +645,8 @@ mod tests {
                     CardinalityReport {
                         organization_id: Some(scoping.organization_id),
                         project_id: Some(scoping.project_id),
-                        name: Some(MetricName::from("bar")),
+                        metric_type: None,
+                        metric_name: Some(MetricName::from("bar")),
                         cardinality: 2,
                     },
                 );
@@ -649,7 +656,8 @@ mod tests {
                     CardinalityReport {
                         organization_id: Some(scoping.organization_id),
                         project_id: Some(scoping.project_id),
-                        name: None,
+                        metric_type: None,
+                        metric_name: None,
                         cardinality: 3,
                     },
                 );
@@ -708,13 +716,15 @@ mod tests {
                 CardinalityReport {
                     organization_id: Some(scoping.organization_id),
                     project_id: Some(scoping.project_id),
-                    name: Some(MetricName::from("foo")),
+                    metric_type: None,
+                    metric_name: Some(MetricName::from("foo")),
                     cardinality: 1
                 },
                 CardinalityReport {
                     organization_id: Some(scoping.organization_id),
                     project_id: Some(scoping.project_id),
-                    name: Some(MetricName::from("bar")),
+                    metric_type: None,
+                    metric_name: Some(MetricName::from("bar")),
                     cardinality: 2
                 }
             ]
@@ -724,7 +734,8 @@ mod tests {
             &[CardinalityReport {
                 organization_id: Some(scoping.organization_id),
                 project_id: Some(scoping.project_id),
-                name: None,
+                metric_type: None,
+                metric_name: None,
                 cardinality: 3
             }]
         );

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -95,7 +95,7 @@ impl MetricStats {
         relay_log::trace!(
             "Tracking cardinality '{}' for mri '{}': {}",
             limit.id,
-            report.name.as_deref().unwrap_or("-"),
+            report.metric_name.as_deref().unwrap_or("-"),
             report.cardinality,
         );
         self.aggregator
@@ -160,7 +160,7 @@ impl MetricStats {
             return None;
         }
 
-        let name = report.name.as_ref()?;
+        let name = report.metric_name.as_ref()?;
         let namespace = name.namespace();
 
         if !namespace.has_metric_stats() {


### PR DESCRIPTION
Implements by metric type cardinality limits, these limits don't necessarily make sense to be enforced, but can be used for cardinality reports if you want to weigh cardinality for each type differently.

#skip-changelog