### PR TITLE
ref(config): Validate some Kafka configuration on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3599,6 +3599,7 @@ dependencies = [
  "hostname",
  "once_cell",
  "relay-config",
+ "relay-kafka",
  "relay-log",
  "relay-server",
  "relay-statsd",

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -11,7 +11,8 @@ use anyhow::Context;
 use relay_auth::{generate_key_pair, generate_relay_id, PublicKey, RelayId, SecretKey};
 use relay_common::Dsn;
 use relay_kafka::{
-    ConfigError as KafkaConfigError, KafkaConfig, KafkaConfigParam, KafkaTopic, TopicAssignments,
+    ConfigError as KafkaConfigError, KafkaConfig, KafkaConfigParam, KafkaTopic, TopicAssignment,
+    TopicAssignments,
 };
 use relay_metrics::aggregator::{AggregatorConfig, ShiftKey};
 use relay_metrics::{
@@ -2240,6 +2241,11 @@ impl Config {
             &self.values.processing.kafka_config,
             &self.values.processing.secondary_kafka_configs,
         )
+    }
+
+    /// All unused but configured topic assignments.
+    pub fn unused_topic_assignments(&self) -> &BTreeMap<String, TopicAssignment> {
+        &self.values.processing.topics.unused
     }
 
     /// Redis servers to connect to, for rate limiting.

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -82,18 +82,20 @@ impl KafkaTopic {
 }
 
 macro_rules! define_topic_assignments {
-    ($struct_name:ident {
-        $($field_name:ident : ($kafka_topic:path, $default_topic: literal, $doc: literal)),* $(,)? }) => {
-
+    ($($field_name:ident : ($kafka_topic:path, $default_topic:literal, $doc:literal)),* $(,)?) => {
         /// Configuration for topics.
         #[derive(Serialize, Deserialize, Debug)]
         #[serde(default)]
         pub struct TopicAssignments {
             $(
                 #[serde(alias = $default_topic)]
-                #[doc=$doc]
+                #[doc = $doc]
                 pub $field_name: TopicAssignment,
             )*
+
+            /// Additional topic assignments configured but currently unused by this Relay instance.
+            #[serde(flatten)]
+            pub unused: BTreeMap<String, TopicAssignment>,
         }
 
         impl TopicAssignments{
@@ -114,7 +116,7 @@ macro_rules! define_topic_assignments {
                     $(
                         $field_name: $default_topic.to_owned().into(),
                     )*
-
+                    unused: BTreeMap::new(),
                 }
             }
         }
@@ -122,23 +124,21 @@ macro_rules! define_topic_assignments {
 }
 
 define_topic_assignments! {
-    TopicAssignments {
-        events: (KafkaTopic::Events, "ingest-events", "Simple events topic name."),
-        attachments: (KafkaTopic::Attachments, "ingest-attachments", "Events with attachments topic name."),
-        transactions: (KafkaTopic::Transactions, "ingest-transactions", "Transaction events topic name."),
-        outcomes: (KafkaTopic::Outcomes, "outcomes", "Outcomes topic name."),
-        outcomes_billing: (KafkaTopic::OutcomesBilling, "outcomes-billing", "Outcomes topic name for billing critical outcomes."),
-        metrics_sessions: (KafkaTopic::MetricsSessions, "ingest-metrics", "Topic name for metrics extracted from sessions, aka release health."),
-        metrics_generic: (KafkaTopic::MetricsGeneric, "ingest-performance-metrics", "Topic name for all other kinds of metrics."),
-        profiles: (KafkaTopic::Profiles, "profiles", "Stacktrace topic name"),
-        replay_events: (KafkaTopic::ReplayEvents, "ingest-replay-events", "Replay Events topic name."),
-        replay_recordings: (KafkaTopic::ReplayRecordings, "ingest-replay-recordings", "Recordings topic name."),
-        monitors: (KafkaTopic::Monitors, "ingest-monitors", "Monitor check-ins."),
-        spans: (KafkaTopic::Spans, "snuba-spans", "Standalone spans without a transaction."),
-        metrics_summaries: (KafkaTopic::MetricsSummaries, "snuba-metrics-summaries", "Summary for metrics collected during a span."),
-        cogs: (KafkaTopic::Cogs, "shared-resources-usage", "COGS measurements."),
-        feedback: (KafkaTopic::Feedback, "ingest-feedback-events", "Feedback events topic."),
-    }
+    events: (KafkaTopic::Events, "ingest-events", "Simple events topic name."),
+    attachments: (KafkaTopic::Attachments, "ingest-attachments", "Events with attachments topic name."),
+    transactions: (KafkaTopic::Transactions, "ingest-transactions", "Transaction events topic name."),
+    outcomes: (KafkaTopic::Outcomes, "outcomes", "Outcomes topic name."),
+    outcomes_billing: (KafkaTopic::OutcomesBilling, "outcomes-billing", "Outcomes topic name for billing critical outcomes."),
+    metrics_sessions: (KafkaTopic::MetricsSessions, "ingest-metrics", "Topic name for metrics extracted from sessions, aka release health."),
+    metrics_generic: (KafkaTopic::MetricsGeneric, "ingest-performance-metrics", "Topic name for all other kinds of metrics."),
+    profiles: (KafkaTopic::Profiles, "profiles", "Stacktrace topic name"),
+    replay_events: (KafkaTopic::ReplayEvents, "ingest-replay-events", "Replay Events topic name."),
+    replay_recordings: (KafkaTopic::ReplayRecordings, "ingest-replay-recordings", "Recordings topic name."),
+    monitors: (KafkaTopic::Monitors, "ingest-monitors", "Monitor check-ins."),
+    spans: (KafkaTopic::Spans, "snuba-spans", "Standalone spans without a transaction."),
+    metrics_summaries: (KafkaTopic::MetricsSummaries, "snuba-metrics-summaries", "Summary for metrics collected during a span."),
+    cogs: (KafkaTopic::Cogs, "shared-resources-usage", "COGS measurements."),
+    feedback: (KafkaTopic::Feedback, "ingest-feedback-events", "Feedback events topic."),
 }
 
 /// Configuration for a "logical" topic/datasink that Relay should forward data into.

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [features]
 dashboard = ["relay-server/dashboard", "relay-log/dashboard"]
 default = []
-processing = ["relay-server/processing"]
+processing = ["relay-server/processing", "dep:relay-kafka"]
 crash-handler = ["relay-log/crash-handler"]
 
 [lints]
@@ -30,6 +30,7 @@ relay-config = { workspace = true }
 relay-log = { workspace = true, features = ["init"] }
 relay-server = { workspace = true }
 relay-statsd = { workspace = true }
+relay-kafka = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -51,7 +51,6 @@ def processing_config(get_topic_name):
                 "transactions": get_topic_name("transactions"),
                 "outcomes": outcomes_topic,
                 "outcomes_billing": outcomes_topic,
-                "sessions": get_topic_name("sessions"),
                 "metrics_sessions": metrics_topic,
                 "metrics_generic": metrics_topic,
                 "replay_events": get_topic_name("replay_events"),

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -41,6 +41,13 @@ class Relay(SentryLike):
         self.options = options
         self.version = version
 
+    def wait_for_exit(self, timeout=5):
+        try:
+            return self.process.wait(timeout)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            raise
+
     def shutdown(self, sig=signal.SIGKILL):
         self.process.send_signal(sig)
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,20 @@
+def test_invalid_kafka_config_should_fail(mini_sentry, relay_with_processing):
+    options = {
+        "processing": {
+            "topics": {
+                "__unknown": "foobar",
+                "profiles": {
+                    "name": "profiles",
+                    "config": "does_not_exist",
+                },
+            }
+        }
+    }
+
+    relay = relay_with_processing(options=options, wait_health_check=False)
+    assert relay.wait_for_exit() != 0
+
+    error = str(mini_sentry.test_failures.pop(0))
+    assert "__unknown" in error
+    error = str(mini_sentry.test_failures.pop(0))
+    assert "profiles" in error.lower()


### PR DESCRIPTION
Checks for unused topic configurations but does not fail, this is useful when preparing to rollout a new topic or rolling back to an older Relay version.

Validates that configuration for every topic can be built.


related to https://github.com/getsentry/relay/issues/3404

#skip-changelog