### PR TITLE
ref(browser-extensions): Add new regex for permission denied to inbound filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal:**
 
 - Emit negative outcomes in metric stats for metrics. ([#3436](https://github.com/getsentry/relay/pull/3436))
+- Add new inbound filter: Permission denied to access property "x" ([#3442](https://github.com/getsentry/relay/pull/3442))
 
 ## 24.4.0
 

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -48,7 +48,10 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         # Googletag is also very similar, caused by adblockers
         Cannot\sredefine\sproperty:\s(solana|ethereum|googletag)|
         # Translation service errors in Chrome on iOS
-        undefined\sis\snot\san\sobject\s\(evaluating\s'a.L'\)
+        undefined\sis\snot\san\sobject\s\(evaluating\s'a.L'\)|
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
+        # Usually caused by extensions that do stuff that isn't allowed
+        Permission\sdenied\sto\saccess\sproperty\s
     "#,
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex")
@@ -269,6 +272,8 @@ mod tests {
             "Cannot redefine property: ethereum",
             "Cannot redefine property: googletag",
             "undefined is not an object (evaluating 'a.L')",
+            "Permission denied to access property \"correspondingUseElement\"",
+            "Permission denied to access property \"document\"",
         ];
 
         for exc_value in &exceptions {


### PR DESCRIPTION
There are some errors in Sentry that throw this:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied

Often these errors are caused by extensions that do things that are not allowed.
The samples we found in Sentry are thrown in minified React bundles.

ref: https://github.com/getsentry/sentry-javascript/issues/10882#issuecomment-2059220860
