### PR TITLE
feat(protocol): Add Linux distributions to os context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Add Linux distributions to os context. ([#3443](https://github.com/getsentry/relay/pull/3443))
+
 **Internal:**
 
 - Emit negative outcomes in metric stats for metrics. ([#3436](https://github.com/getsentry/relay/pull/3436))

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -957,6 +957,7 @@ OsContext {
     build: ~,
     kernel_version: ~,
     rooted: ~,
+    distribution: ~,
     raw_description: ~,
     other: {},
 }
@@ -1028,6 +1029,7 @@ OsContext {
     build: ~,
     kernel_version: ~,
     rooted: ~,
+    distribution: ~,
     raw_description: ~,
     other: {},
 }

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -2170,6 +2170,41 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         "fatal"
       ]
     },
+    "LinuxDistribution": {
+      "description": " Metadata for the Linux Distribution.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": " An index-able name that is stable for each distribution.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pretty_name": {
+              "description": " A full rendering of name + version + release name (not available in all distributions).",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
+              "description": " The version of the distribution (missing in distributions with solely rolling release).",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "LockReason": {
       "description": " Represents an instance of a held lock (java monitor object) in a thread.",
       "anyOf": [
@@ -2754,6 +2789,18 @@ expression: "relay_event_schema::protocol::event_json_schema()"
               "type": [
                 "string",
                 "null"
+              ]
+            },
+            "distribution": {
+              "description": " Meta-data for the Linux Distribution.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/LinuxDistribution"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "kernel_version": {


### PR DESCRIPTION
Users of the Native SDK would love to know and search for the Linux distributions from which their events are coming: https://github.com/getsentry/sentry-native/issues/943

After a basic implementation on the SDK side to parse `/etc/os-release` (https://github.com/getsentry/sentry-native/pull/963), we also need to ensure the data is indexable. This PR is one step towards that goal.

There is a "develop" docs [PR](https://github.com/getsentry/develop/pull/1227) where we should discuss naming, structure, and content.

Cc: @kahest.