### PR TITLE
log(feedback): Add logging to verify produce to ingest-feedback-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Internal:**
 
 - Emit negative outcomes in metric stats for metrics. ([#3436](https://github.com/getsentry/relay/pull/3436))
+- Temporarily log when messages are produced to ingest-feedback-events (low volume, s4s only). ([#3450](https://github.com/getsentry/relay/pull/3450))
 
 ## 24.4.0
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -599,6 +599,15 @@ impl StoreService {
                     event_type = message.variant(),
                     topic = topic_name,
                 );
+                if topic_name == "ingest-feedback-events" {
+                    if let KafkaMessage::Event(event_msg) = message {
+                        relay_log::info!("Producing to ingest-feedback-events.\n start_time={}\n event_id={}\n project_id={}",
+                            event_msg.start_time,
+                            event_msg.event_id,
+                            event_msg.project_id
+                        );
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/issues/66100
Temporary debugging for s4s. Right now the consumer is deployed and rollout rate is set only in s4s. We're having trouble finding metrics in datadog and want to log as a sanity check. 
