### PR TITLE
feat(perf): Extract `span.domain` tag from the `server.address` span attribute

### DIFF
--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -358,6 +358,7 @@ pub fn extract_tags(
                 } else {
                     scrubbed
                 };
+
                 if let Some(domain) = Url::parse(url).ok().and_then(|url| {
                     url.host_str().map(|h| {
                         let mut domain = h.to_lowercase();

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -377,7 +377,7 @@ pub fn extract_tags(
                 {
                     let lowercase_address = server_address.to_lowercase();
 
-                    // According to OTel semantic conventions the server port should be in a separate property, called `server.port`, but incoming data sometimes disagrees
+                    // According to OTel semantic conventions the server port should be in a separate property called `server.port`, but incoming data sometimes disagrees. We expect that the port will be appended to the host a lot of the time, especially in the JavaScript SDK
                     let (domain, port) = match lowercase_address.split_once(':') {
                         Some((domain, port)) => (domain, port.parse::<u16>().ok()),
                         None => (server_address, None),

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -359,17 +359,7 @@ pub fn extract_tags(
                     scrubbed
                 };
 
-                if let Some(domain) = Url::parse(url).ok().and_then(|url| {
-                    url.host_str().map(|h| {
-                        let mut domain = h.to_lowercase();
-                        if let Some(port) = url.port() {
-                            domain = format!("{domain}:{port}");
-                        }
-                        domain
-                    })
-                }) {
-                    Some(domain)
-                } else if let Some(server_address) = span
+                if let Some(server_address) = span
                     .data
                     .value()
                     .and_then(|data| data.server_address.value())
@@ -403,6 +393,16 @@ pub fn extract_tags(
                     }
 
                     Some(concatenate_host_and_port(Some(domain.as_ref()), port).into_owned())
+                } else if let Some(domain) = Url::parse(url).ok().and_then(|url| {
+                    url.host_str().map(|h| {
+                        let mut domain = h.to_lowercase();
+                        if let Some(port) = url.port() {
+                            domain = format!("{domain}:{port}");
+                        }
+                        domain
+                    })
+                }) {
+                    Some(domain)
                 } else {
                     None
                 }

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1454,6 +1454,26 @@ LIMIT 1
                         },
                         "hash": "8e7b6caca435801d",
                         "same_process_as_parent": true
+                    },
+                    {
+                        "timestamp": 1711007391.034472,
+                        "start_timestamp": 1711007391.442037,
+                        "exclusive_time": 0.407565,
+                        "description": "GET /data.json",
+                        "op": "http.client",
+                        "span_id": "3b2f834c74872798",
+                        "parent_span_id": "a1bdf3c7d2afe10e",
+                        "trace_id": "2920522dedff493ebe5d84da7be4319f",
+                        "data": {
+                            "http.request_method": "GET",
+                            "http.response.status_code": 200,
+                            "http.fragment": "",
+                            "http.query": "",
+                            "reason": "OK",
+                            "server.address": "dataprovider.my.app:7999"
+                        },
+                        "hash": "8e7b6caca435801d",
+                        "same_process_as_parent": true
                     }
                 ]
             }
@@ -1468,9 +1488,11 @@ LIMIT 1
 
         let span_1 = &event.spans.value().unwrap()[0];
         let span_2 = &event.spans.value().unwrap()[1];
+        let span_3 = &event.spans.value().unwrap()[2];
 
         let tags_1 = get_value!(span_1.sentry_tags).unwrap();
         let tags_2 = get_value!(span_2.sentry_tags).unwrap();
+        let tags_3 = get_value!(span_3.sentry_tags).unwrap();
 
         // Allow loopback IPs
         assert_eq!(
@@ -1488,6 +1510,13 @@ LIMIT 1
             Some("GET http://*.*.*.*")
         );
         assert_eq!(tags_2.get("domain").unwrap().as_str(), Some("*.*.*.*"));
+
+        // Obey the server address
+        assert_eq!(tags_3.get("description").unwrap().as_str(), Some("GET *"));
+        assert_eq!(
+            tags_3.get("domain").unwrap().as_str(),
+            Some("*.my.app:7999")
+        );
     }
 
     #[test]


### PR DESCRIPTION
If the `server.address` span attribute is present, prefer using it for the `span.domain` tag, instead of parsing the URL.

1. `server.address`, if present, should be the authoritative answer to what address the `http.client` span request went to. If it's present, we should obey it
2. Relative URLs cannot be parsed! Instead of attempting to parse a URL we know might fail, let's try the `server.address` property instead
