### PR TITLE
 feat(ddm): Add negative outcomes to metric stats in pops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Emit negative outcomes in metric stats for metrics. ([#3436](https://github.com/getsentry/relay/pull/3436))
 - Add new inbound filter: Permission denied to access property "x" ([#3442](https://github.com/getsentry/relay/pull/3442))
+- Emit negative outcomes in metrics stats in pop relays. ([#3452](https://github.com/getsentry/relay/pull/3452))
 
 ## 24.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Emit negative outcomes in metric stats for metrics. ([#3436](https://github.com/getsentry/relay/pull/3436))
 - Add new inbound filter: Permission denied to access property "x" ([#3442](https://github.com/getsentry/relay/pull/3442))
-- Emit negative outcomes in metrics stats in pop relays. ([#3452](https://github.com/getsentry/relay/pull/3452))
+- Emit negative outcomes for metrics via metric stats in pop relays. ([#3452](https://github.com/getsentry/relay/pull/3452))
 
 ## 24.4.0
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -227,6 +227,8 @@ pub struct CardinalityLimitsSplit<T> {
 }
 
 impl<T> CardinalityLimitsSplit<T> {
+    /// Creates a new cardinality limits split with a given capacity for `accepted` and `rejected`
+    /// elements.
     fn with_capacity(
         accepted_capacity: usize,
         rejected_capacity: usize,

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -6,6 +6,7 @@ use crate::{
     aggregator, BucketMetadata, CounterType, DistributionType, GaugeValue, MetricName, SetType,
     SetValue,
 };
+use relay_base_schema::metrics::MetricType;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Range;
@@ -385,6 +386,11 @@ impl<'a> BucketView<'a> {
             BucketValue::Set(s) => BucketViewValue::Set(SetView::new(s, self.range.clone())),
             BucketValue::Gauge(g) => BucketViewValue::Gauge(*g),
         }
+    }
+
+    /// Type of the value of the bucket view.
+    pub fn value_ty(&self) -> MetricType {
+        self.inner.value.ty()
     }
 
     /// Name of the bucket.

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -389,8 +389,13 @@ impl<'a> BucketView<'a> {
     }
 
     /// Type of the value of the bucket view.
-    pub fn value_ty(&self) -> MetricType {
-        self.inner.value.ty()
+    pub fn ty(&self) -> MetricType {
+        match &self.inner.value {
+            BucketValue::Counter(_) => MetricType::Counter,
+            BucketValue::Distribution(_) => MetricType::Distribution,
+            BucketValue::Set(_) => MetricType::Set,
+            BucketValue::Gauge(_) => MetricType::Gauge,
+        }
     }
 
     /// Name of the bucket.

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -62,6 +62,7 @@ impl MetricStats {
 
     /// Tracks the metric volume and outcome for the bucket.
     pub fn track_metric(&self, scoping: Scoping, bucket: Bucket, outcome: Outcome) {
+        // TODO: we want to use a reference of bucket view.
         if !self.is_enabled(scoping) {
             return;
         }

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -62,9 +62,9 @@ impl MetricStats {
     }
 
     /// Tracks the metric volume and outcome for the bucket.
-    pub fn track_metric<'a, V>(&self, scoping: Scoping, bucket: V, outcome: Outcome)
+    pub fn track_metric<'a, T>(&self, scoping: Scoping, bucket: T, outcome: Outcome)
     where
-        V: Into<BucketView<'a>>,
+        T: Into<BucketView<'a>>,
     {
         if !self.is_enabled(scoping) {
             return;
@@ -125,20 +125,20 @@ impl MetricStats {
         is_rolled_out(organization_id, rate)
     }
 
-    fn to_volume_metric(&self, bucket_view: &BucketView, outcome: &Outcome) -> Option<Bucket> {
-        let volume = bucket_view.metadata().merges.get();
+    fn to_volume_metric(&self, bucket: &BucketView<'_>, outcome: &Outcome) -> Option<Bucket> {
+        let volume = bucket.metadata().merges.get();
         if volume == 0 {
             return None;
         }
 
-        let namespace = bucket_view.name().namespace();
+        let namespace = bucket.name().namespace();
         if !namespace.has_metric_stats() {
             return None;
         }
 
         let mut tags = BTreeMap::from([
-            ("mri".to_owned(), bucket_view.name().to_string()),
-            ("mri.type".to_owned(), bucket_view.value_ty().to_string()),
+            ("mri".to_owned(), bucket.name().to_string()),
+            ("mri.type".to_owned(), bucket.ty().to_string()),
             ("mri.namespace".to_owned(), namespace.to_string()),
             (
                 "outcome.id".to_owned(),

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -70,15 +70,15 @@ impl MetricStats {
             return;
         }
 
-        let bucket_view = bucket.into();
-        let Some(volume) = self.to_volume_metric(&bucket_view, &outcome) else {
+        let bucket = bucket.into();
+        let Some(volume) = self.to_volume_metric(&bucket, &outcome) else {
             return;
         };
 
         relay_log::trace!(
             "Tracking volume of {} for mri '{}': {}",
-            bucket_view.metadata().merges.get(),
-            bucket_view.name(),
+            bucket.metadata().merges.get(),
+            bucket.name(),
             outcome
         );
         self.aggregator

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, OnceLock};
 
+#[cfg(feature = "processing")]
 use relay_cardinality::{CardinalityLimit, CardinalityReport};
 use relay_config::Config;
+#[cfg(feature = "processing")]
 use relay_metrics::GaugeValue;
 use relay_metrics::{
     Aggregator, Bucket, BucketValue, BucketView, MergeBuckets, MetricName, UnixTimestamp,
@@ -22,6 +24,7 @@ fn volume_metric_mri() -> MetricName {
         .clone()
 }
 
+#[cfg(feature = "processing")]
 fn cardinality_metric_mri() -> MetricName {
     static CARDINALITY_METRIC_MRI: OnceLock<MetricName> = OnceLock::new();
 
@@ -83,6 +86,7 @@ impl MetricStats {
     }
 
     /// Tracks the cardinality of a metric.
+    #[cfg(feature = "processing")]
     pub fn track_cardinality(
         &self,
         scoping: Scoping,
@@ -156,6 +160,7 @@ impl MetricStats {
         })
     }
 
+    #[cfg(feature = "processing")]
     fn to_cardinality_metric(
         &self,
         limit: &CardinalityLimit,
@@ -204,8 +209,10 @@ impl MetricStats {
 #[cfg(test)]
 mod tests {
     use relay_base_schema::project::{ProjectId, ProjectKey};
+    #[cfg(feature = "processing")]
     use relay_cardinality::{CardinalityScope, SlidingWindow};
     use relay_dynamic_config::GlobalConfig;
+    #[cfg(feature = "processing")]
     use relay_metrics::MetricType;
     use relay_quotas::ReasonCode;
     use tokio::sync::mpsc::UnboundedReceiver;
@@ -313,6 +320,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "processing")]
     fn test_metric_stats_cardinality_name() {
         let (ms, mut receiver) = create_metric_stats(1.0);
 
@@ -377,6 +385,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "processing")]
     fn test_metric_stats_cardinality_type() {
         let (ms, mut receiver) = create_metric_stats(1.0);
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -197,13 +197,13 @@ impl ServiceState {
             test_store.clone(),
             upstream_relay.clone(),
             global_config.clone(),
-            metric_stats,
         );
         let guard = runtimes.project.enter();
         ProjectCacheService::new(
             config.clone(),
             buffer_guard.clone(),
             project_cache_services,
+            metric_stats,
             redis_pool,
         )
         .spawn_handler(project_cache_rx);

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -181,7 +181,6 @@ impl ServiceState {
                 #[cfg(feature = "processing")]
                 store_forwarder: store.clone(),
             },
-            #[cfg(feature = "processing")]
             metric_stats.clone(),
             #[cfg(feature = "processing")]
             buffer_guard.clone(),

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -181,6 +181,7 @@ impl ServiceState {
                 #[cfg(feature = "processing")]
                 store_forwarder: store.clone(),
             },
+            #[cfg(feature = "processing")]
             metric_stats.clone(),
             #[cfg(feature = "processing")]
             buffer_guard.clone(),

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -2,6 +2,7 @@ use std::convert::Infallible;
 use std::fmt;
 use std::sync::Arc;
 
+use crate::metric_stats::MetricStats;
 use anyhow::{Context, Result};
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
@@ -136,8 +137,7 @@ impl ServiceState {
         )
         .start_in(&runtimes.aggregator);
 
-        #[cfg(feature = "processing")]
-        let metric_stats = crate::metric_stats::MetricStats::new(
+        let metric_stats = MetricStats::new(
             config.clone(),
             global_config_handle.clone(),
             aggregator.clone(),
@@ -181,8 +181,7 @@ impl ServiceState {
                 #[cfg(feature = "processing")]
                 store_forwarder: store.clone(),
             },
-            #[cfg(feature = "processing")]
-            metric_stats,
+            metric_stats.clone(),
             #[cfg(feature = "processing")]
             buffer_guard.clone(),
         )
@@ -197,6 +196,7 @@ impl ServiceState {
             test_store.clone(),
             upstream_relay.clone(),
             global_config.clone(),
+            metric_stats,
         );
         let guard = runtimes.project.enter();
         ProjectCacheService::new(

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2164,7 +2164,7 @@ impl EnvelopeProcessorService {
                     *item_scoping.scoping,
                     Outcome::RateLimited(reason_code),
                     Some(&self.inner.metric_stats),
-                    Some(buckets),
+                    Some(&buckets),
                 );
 
                 self.inner.addrs.project_cache.send(UpdateRateLimits::new(
@@ -2257,7 +2257,7 @@ impl EnvelopeProcessorService {
             scoping,
             Outcome::CardinalityLimited,
             Some(&self.inner.metric_stats),
-            Some(split.rejected),
+            Some(&split.rejected),
         );
 
         split.accepted
@@ -2886,7 +2886,7 @@ impl UpstreamRequest for SendMetricsRequest {
                 // Request did not arrive, we are responsible for outcomes.
                 Err(error) if !error.is_received() => {
                     for (scoping, quantities) in self.quantities {
-                        utils::reject_metrics::<Vec<Bucket>>(
+                        utils::reject_metrics::<Vec<&Bucket>, &Bucket>(
                             &self.outcome_aggregator,
                             quantities,
                             scoping,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::metric_stats::MetricStats;
 use anyhow::Context;
 use brotli::CompressorWriter as BrotliEncoder;
 use bytes::Bytes;
@@ -48,7 +49,6 @@ use tokio::sync::Semaphore;
 
 #[cfg(feature = "processing")]
 use {
-    crate::metric_stats::MetricStats,
     crate::services::store::{Store, StoreEnvelope},
     crate::utils::{EnvelopeLimiter, ItemAction, MetricsLimiter},
     itertools::Itertools,
@@ -947,7 +947,6 @@ struct InnerProcessor {
     metric_meta_store: Option<RedisMetricMetaStore>,
     #[cfg(feature = "processing")]
     cardinality_limiter: Option<CardinalityLimiter>,
-    #[cfg(feature = "processing")]
     metric_stats: MetricStats,
     #[cfg(feature = "processing")]
     buffer_guard: Arc<BufferGuard>,
@@ -961,7 +960,7 @@ impl EnvelopeProcessorService {
         cogs: Cogs,
         #[cfg(feature = "processing")] redis: Option<RedisPool>,
         addrs: Addrs,
-        #[cfg(feature = "processing")] metric_stats: MetricStats,
+        metric_stats: MetricStats,
         #[cfg(feature = "processing")] buffer_guard: Arc<BufferGuard>,
     ) -> Self {
         let geoip_lookup = config.geoip_path().and_then(|p| {
@@ -1002,7 +1001,6 @@ impl EnvelopeProcessorService {
                     )
                 })
                 .map(CardinalityLimiter::new),
-            #[cfg(feature = "processing")]
             metric_stats,
             config,
             #[cfg(feature = "processing")]

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2424,7 +2424,7 @@ impl EnvelopeProcessorService {
     ///  - partitioning
     ///  - batching by configured size limit
     ///  - serialize to JSON
-    ///  - submit the directly to the upstream
+    ///  - submit directly to the upstream
     ///
     /// Cardinality limiting and rate limiting run only in processing Relays as they both require
     /// access to the central Redis instance. Cached rate limits are applied in the project cache

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1321,11 +1321,10 @@ mod tests {
         project_state.disabled = true;
         project.state = State::Cached(project_state.into());
 
-        let (addr, _) = Addr::custom();
         let metric_stats = MetricStats::new(
             Arc::new(Config::default()),
             GlobalConfigHandle::fixed(GlobalConfig::default()),
-            addr,
+            Addr::custom().0,
         );
 
         let result = project.check_buckets_inner(Addr::custom().0, metric_stats, vec![]);

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1200,11 +1200,11 @@ impl Project {
             let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
             utils::reject_metrics(
                 &outcome_aggregator,
+                &metric_stats,
                 utils::extract_metric_quantities(&buckets, mode),
                 scoping,
                 Outcome::RateLimited(reason_code),
-                Some(&metric_stats),
-                Some(&buckets),
+                &buckets,
             );
 
             return CheckedBuckets::RateLimited(len);

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -1183,6 +1183,8 @@ impl FetchOptionalProjectState {
 
 #[cfg(test)]
 mod tests {
+    use crate::services::global_config::GlobalConfigHandle;
+    use relay_dynamic_config::GlobalConfig;
     use relay_test::mock_service;
     use tokio::select;
     use uuid::Uuid;
@@ -1201,6 +1203,13 @@ mod tests {
         let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
         let (global_config, _) = mock_service("global_config", (), |&mut (), _| {});
 
+        let (addr, _) = Addr::custom();
+        let metric_stats = MetricStats::new(
+            Arc::new(Config::default()),
+            GlobalConfigHandle::fixed(GlobalConfig::default()),
+            addr,
+        );
+
         Services {
             aggregator,
             envelope_processor,
@@ -1209,6 +1218,7 @@ mod tests {
             test_store,
             upstream_relay,
             global_config,
+            metric_stats,
         }
     }
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -443,12 +443,12 @@ impl StoreService {
                 "failed to produce metric buckets: {error}"
             );
 
-            utils::reject_metrics::<Vec<&Bucket>, &Bucket>(
+            utils::reject_metrics::<&Bucket>(
                 &self.outcome_aggregator,
+                &self.metric_stats,
                 dropped_quantities,
                 scoping,
                 Outcome::Invalid(DiscardReason::Internal),
-                None,
                 None,
             );
         }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -428,7 +428,7 @@ impl StoreService {
             // back into the processor service.
             self.metric_stats.track_metric(
                 scoping,
-                bucket,
+                &bucket,
                 if has_success {
                     Outcome::Accepted
                 } else {
@@ -443,7 +443,7 @@ impl StoreService {
                 "failed to produce metric buckets: {error}"
             );
 
-            utils::reject_metrics::<Vec<Bucket>>(
+            utils::reject_metrics::<Vec<&Bucket>, &Bucket>(
                 &self.outcome_aggregator,
                 dropped_quantities,
                 scoping,

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -14,7 +14,6 @@ use relay_test::mock_service;
 
 use crate::envelope::{Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
-#[cfg(feature = "processing")]
 use crate::metric_stats::MetricStats;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::TrackOutcome;
@@ -120,7 +119,6 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
     let (project_cache, _) = mock_service("project_cache", (), |&mut (), _| {});
     let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
     let (test_store, _) = mock_service("test_store", (), |&mut (), _| {});
-    #[cfg(feature = "processing")]
     let (aggregator, _) = mock_service("aggregator", (), |&mut (), _| {});
 
     #[cfg(feature = "processing")]
@@ -147,7 +145,6 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
             #[cfg(feature = "processing")]
             store_forwarder: None,
         },
-        #[cfg(feature = "processing")]
         MetricStats::new(
             config,
             GlobalConfigHandle::fixed(Default::default()),

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -14,6 +14,8 @@ use relay_test::mock_service;
 
 use crate::envelope::{Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
+#[cfg(feature = "processing")]
+use crate::metric_stats::MetricStats;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::{self, EnvelopeProcessorService};
@@ -146,7 +148,7 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
             store_forwarder: None,
         },
         #[cfg(feature = "processing")]
-        crate::metric_stats::MetricStats::new(
+        MetricStats::new(
             config,
             GlobalConfigHandle::fixed(Default::default()),
             aggregator,

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -141,6 +141,12 @@ pub fn reject_metrics<'a, I, V>(
         }
     }
 
+    // When rejecting metrics, we need to make sure that the number of merges is correctly handled
+    // for buckets views, since if we have a bucket which has 5 merges, and it's split into 2
+    // bucket views, we will emit the volume of the rejection as 5 + 5 merges since we still read
+    // the underlying metadata for each view, and it points to the same bucket reference.
+    // Possible solutions to this problem include emitting the merges only if the bucket view is
+    // the first of view or distributing uniformly the metadata between split views.
     if let (Some(metric_stats), Some(buckets)) = (metric_stats, buckets) {
         report_rejected_metrics(metric_stats, scoping, buckets, outcome)
     }

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -94,25 +94,31 @@ where
     quantities
 }
 
-fn report_rejected_metrics<I: IntoIterator<Item = Bucket>>(
+fn report_rejected_metrics<'a, I, V>(
     metric_stats: &MetricStats,
     scoping: Scoping,
     buckets: I,
     outcome: Outcome,
-) {
+) where
+    I: IntoIterator<Item = V>,
+    V: Into<BucketView<'a>>,
+{
     for bucket in buckets {
         metric_stats.track_metric(scoping, bucket, outcome.clone())
     }
 }
 
-pub fn reject_metrics<I: IntoIterator<Item = Bucket>>(
+pub fn reject_metrics<'a, I, V>(
     addr: &Addr<TrackOutcome>,
     quantities: SourceQuantities,
     scoping: Scoping,
     outcome: Outcome,
     metric_stats: Option<&MetricStats>,
     buckets: Option<I>,
-) {
+) where
+    I: IntoIterator<Item = V>,
+    V: Into<BucketView<'a>>,
+{
     let timestamp = Utc::now();
 
     let categories = [

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -17,14 +17,17 @@ def metric_stats_by_mri(metrics_consumer, count, timeout=None):
     cardinality = dict()
     other = list()
 
-    for _ in range(count):
-        metric, _ = metrics_consumer.get_metric(timeout)
-        if metric["name"] == "c:metric_stats/volume@none":
-            volume[metric["tags"]["mri"]] = metric
-        elif metric["name"] == "g:metric_stats/cardinality@none":
-            cardinality[metric["tags"]["mri"]] = metric
-        else:
-            other.append(metric)
+    for i in range(count):
+        try:
+            metric, _ = metrics_consumer.get_metric(timeout)
+            if metric["name"] == "c:metric_stats/volume@none":
+                volume[metric["tags"]["mri"]] = metric
+            elif metric["name"] == "g:metric_stats/cardinality@none":
+                cardinality[metric["tags"]["mri"]] = metric
+            else:
+                other.append(metric)
+        except AssertionError:
+            pytest.fail(f"Message {i + 1} not found.")
 
     metrics_consumer.assert_empty()
     return MetricStatsByMri(volume=volume, cardinality=cardinality, other=other)

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -12,7 +12,7 @@ class MetricStatsByMri:
     other: list[Any]
 
 
-def metric_stats_by_mri(metrics_consumer, count, timeout=None):
+def metric_stats_by_mri(metrics_consumer, count, timeout=5):
     volume = dict()
     cardinality = dict()
     other = list()

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -180,16 +180,24 @@ def test_metric_stats_with_limit_surpassed(
     }
 
     relay.send_metrics(
-        project_id, "custom/foo:1337|d\ncustom/foo:12|d|#tag:value\ncustom/bar:42|s"
+        project_id, "custom/foo:1337|d\ncustom/baz:12|d|#tag:value\ncustom/bar:42|s"
     )
 
-    metrics = metric_stats_by_mri(metrics_consumer, 2)
-    print(metrics)
+    metrics = metric_stats_by_mri(metrics_consumer, 3)
     assert metrics.volume["d:custom/foo@none"]["org_id"] == 0
     assert metrics.volume["d:custom/foo@none"]["project_id"] == project_id
-    assert metrics.volume["d:custom/foo@none"]["value"] == 2.0
+    assert metrics.volume["d:custom/foo@none"]["value"] == 1.0
     assert metrics.volume["d:custom/foo@none"]["tags"] == {
         "mri": "d:custom/foo@none",
+        "mri.type": "d",
+        "mri.namespace": "custom",
+        "outcome.id": "6",
+    }
+    assert metrics.volume["d:custom/baz@none"]["org_id"] == 0
+    assert metrics.volume["d:custom/baz@none"]["project_id"] == project_id
+    assert metrics.volume["d:custom/baz@none"]["value"] == 1.0
+    assert metrics.volume["d:custom/baz@none"]["tags"] == {
+        "mri": "d:custom/baz@none",
         "mri.type": "d",
         "mri.namespace": "custom",
         "outcome.id": "6",
@@ -203,7 +211,7 @@ def test_metric_stats_with_limit_surpassed(
         "mri.namespace": "custom",
         "outcome.id": "6",
     }
-    assert len(metrics.volume) == 2
+    assert len(metrics.volume) == 3
     assert len(metrics.cardinality) == 0
     assert len(metrics.other) == 0
 

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -136,7 +136,7 @@ def test_metric_stats_simple(
     assert len(metrics.other) == 3
 
 
-@pytest.mark.parametrize("mode", ["default", "chain"])
+@pytest.mark.parametrize("mode", ["default"])
 def test_metric_stats_with_limit_surpassed(
     mini_sentry, relay, relay_with_processing, relay_credentials, metrics_consumer, mode
 ):
@@ -184,7 +184,7 @@ def test_metric_stats_with_limit_surpassed(
     )
 
     metrics = metric_stats_by_mri(metrics_consumer, 7)
-
+    print(metrics)
     assert metrics.volume["d:custom/foo@none"]["org_id"] == 0
     assert metrics.volume["d:custom/foo@none"]["project_id"] == project_id
     assert metrics.volume["d:custom/foo@none"]["value"] == 2.0

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -136,7 +136,7 @@ def test_metric_stats_simple(
     assert len(metrics.other) == 3
 
 
-@pytest.mark.parametrize("mode", ["default"])
+@pytest.mark.parametrize("mode", ["default", "chain"])
 def test_metric_stats_with_limit_surpassed(
     mini_sentry, relay, relay_with_processing, relay_credentials, metrics_consumer, mode
 ):

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -183,7 +183,7 @@ def test_metric_stats_with_limit_surpassed(
         project_id, "custom/foo:1337|d\ncustom/foo:12|d|#tag:value\ncustom/bar:42|s"
     )
 
-    metrics = metric_stats_by_mri(metrics_consumer, 7)
+    metrics = metric_stats_by_mri(metrics_consumer, 2)
     print(metrics)
     assert metrics.volume["d:custom/foo@none"]["org_id"] == 0
     assert metrics.volume["d:custom/foo@none"]["project_id"] == project_id
@@ -203,43 +203,9 @@ def test_metric_stats_with_limit_surpassed(
         "mri.namespace": "custom",
         "outcome.id": "6",
     }
-    # assert len(metrics.volume) == 2
-    # assert metrics.cardinality["d:custom/foo@none"]["org_id"] == 0
-    # assert metrics.cardinality["d:custom/foo@none"]["project_id"] == project_id
-    # assert metrics.cardinality["d:custom/foo@none"]["value"] == {
-    #     "count": 1,
-    #     "last": 2.0,
-    #     "max": 2.0,
-    #     "min": 2.0,
-    #     "sum": 2.0,
-    # }
-    # assert metrics.cardinality["d:custom/foo@none"]["tags"] == {
-    #     "mri": "d:custom/foo@none",
-    #     "mri.type": "d",
-    #     "mri.namespace": "custom",
-    #     "cardinality.limit": "custom-limit",
-    #     "cardinality.scope": "name",
-    #     "cardinality.window": "3600",
-    # }
-    # assert metrics.cardinality["s:custom/bar@none"]["org_id"] == 0
-    # assert metrics.cardinality["s:custom/bar@none"]["project_id"] == project_id
-    # assert metrics.cardinality["s:custom/bar@none"]["value"] == {
-    #     "count": 1,
-    #     "last": 1.0,
-    #     "max": 1.0,
-    #     "min": 1.0,
-    #     "sum": 1.0,
-    # }
-    # assert metrics.cardinality["s:custom/bar@none"]["tags"] == {
-    #     "mri": "s:custom/bar@none",
-    #     "mri.type": "s",
-    #     "mri.namespace": "custom",
-    #     "cardinality.limit": "custom-limit",
-    #     "cardinality.scope": "name",
-    #     "cardinality.window": "3600",
-    # }
-    # assert len(metrics.cardinality) == 2
-    # assert len(metrics.other) == 3
+    assert len(metrics.volume) == 2
+    assert len(metrics.cardinality) == 0
+    assert len(metrics.other) == 0
 
 
 def test_metric_stats_max_flush_bytes(

--- a/tests/integration/test_metric_stats.py
+++ b/tests/integration/test_metric_stats.py
@@ -136,6 +136,112 @@ def test_metric_stats_simple(
     assert len(metrics.other) == 3
 
 
+@pytest.mark.parametrize("mode", ["default", "chain"])
+def test_metric_stats_with_limit_surpassed(
+    mini_sentry, relay, relay_with_processing, relay_credentials, metrics_consumer, mode
+):
+    mini_sentry.global_config["options"]["relay.metric-stats.rollout-rate"] = 1.0
+
+    metrics_consumer = metrics_consumer()
+
+    if mode == "default":
+        relay = relay_with_processing(options=TEST_CONFIG)
+    elif mode == "chain":
+        credentials = relay_credentials()
+        static_relays = {
+            credentials["id"]: {
+                "public_key": credentials["public_key"],
+                "internal": True,
+            },
+        }
+        relay = relay(
+            relay_with_processing(options=TEST_CONFIG, static_relays=static_relays),
+            options=TEST_CONFIG,
+            credentials=credentials,
+        )
+
+    project_id = 42
+    project_config = mini_sentry.add_basic_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:custom-metrics",
+        "organizations:metric-stats",
+    ]
+    project_config["config"]["metrics"] = {
+        "cardinalityLimits": [
+            {
+                "id": "custom-limit",
+                "window": {"windowSeconds": 1, "granularitySeconds": 1},
+                "report": True,
+                "limit": 0,
+                "scope": "name",
+                "namespace": "custom",
+            }
+        ]
+    }
+
+    relay.send_metrics(
+        project_id, "custom/foo:1337|d\ncustom/foo:12|d|#tag:value\ncustom/bar:42|s"
+    )
+
+    metrics = metric_stats_by_mri(metrics_consumer, 7)
+
+    assert metrics.volume["d:custom/foo@none"]["org_id"] == 0
+    assert metrics.volume["d:custom/foo@none"]["project_id"] == project_id
+    assert metrics.volume["d:custom/foo@none"]["value"] == 2.0
+    assert metrics.volume["d:custom/foo@none"]["tags"] == {
+        "mri": "d:custom/foo@none",
+        "mri.type": "d",
+        "mri.namespace": "custom",
+        "outcome.id": "6",
+    }
+    assert metrics.volume["s:custom/bar@none"]["org_id"] == 0
+    assert metrics.volume["s:custom/bar@none"]["project_id"] == project_id
+    assert metrics.volume["s:custom/bar@none"]["value"] == 1.0
+    assert metrics.volume["s:custom/bar@none"]["tags"] == {
+        "mri": "s:custom/bar@none",
+        "mri.type": "s",
+        "mri.namespace": "custom",
+        "outcome.id": "6",
+    }
+    # assert len(metrics.volume) == 2
+    # assert metrics.cardinality["d:custom/foo@none"]["org_id"] == 0
+    # assert metrics.cardinality["d:custom/foo@none"]["project_id"] == project_id
+    # assert metrics.cardinality["d:custom/foo@none"]["value"] == {
+    #     "count": 1,
+    #     "last": 2.0,
+    #     "max": 2.0,
+    #     "min": 2.0,
+    #     "sum": 2.0,
+    # }
+    # assert metrics.cardinality["d:custom/foo@none"]["tags"] == {
+    #     "mri": "d:custom/foo@none",
+    #     "mri.type": "d",
+    #     "mri.namespace": "custom",
+    #     "cardinality.limit": "custom-limit",
+    #     "cardinality.scope": "name",
+    #     "cardinality.window": "3600",
+    # }
+    # assert metrics.cardinality["s:custom/bar@none"]["org_id"] == 0
+    # assert metrics.cardinality["s:custom/bar@none"]["project_id"] == project_id
+    # assert metrics.cardinality["s:custom/bar@none"]["value"] == {
+    #     "count": 1,
+    #     "last": 1.0,
+    #     "max": 1.0,
+    #     "min": 1.0,
+    #     "sum": 1.0,
+    # }
+    # assert metrics.cardinality["s:custom/bar@none"]["tags"] == {
+    #     "mri": "s:custom/bar@none",
+    #     "mri.type": "s",
+    #     "mri.namespace": "custom",
+    #     "cardinality.limit": "custom-limit",
+    #     "cardinality.scope": "name",
+    #     "cardinality.window": "3600",
+    # }
+    # assert len(metrics.cardinality) == 2
+    # assert len(metrics.other) == 3
+
+
 def test_metric_stats_max_flush_bytes(
     mini_sentry, relay_with_processing, metrics_consumer
 ):


### PR DESCRIPTION
This PR includes the following changes:
* Adds negative outcomes to the project service.
* Removes a series of `#[cfg(feature = "processing")]` since now we are also using metric stats in pops.
* Metric stats now accepts types that can be converted into `BucketView` for more flexibility.
* Adds integration test for making sure cardinality limited outcomes are emitted.
