### PR TITLE
fix(runtime): Bump service runtimes with tokio::spawn from 1 to 2 threads

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -322,10 +322,10 @@ impl Runtimes {
     #[allow(unused_variables)]
     pub fn new(config: &Config) -> Self {
         Self {
-            upstream: create_runtime("upstream-rt", 1),
+            upstream: create_runtime("upstream-rt", 2),
             project: create_runtime("project-rt", 2),
-            aggregator: create_runtime("aggregator-rt", 1),
-            outcome: create_runtime("outcome-rt", 1),
+            aggregator: create_runtime("aggregator-rt", 2),
+            outcome: create_runtime("outcome-rt", 2),
             #[cfg(feature = "processing")]
             store: config
                 .processing_enabled()


### PR DESCRIPTION
Stats are showing a backlog in the router service and some health checks timing out. The router service makes use of `tokio::spawn` it is possible that the backlog is made worse by the runtime being single threaded.

The backlog leads to health checks timing out.

This change did have very positive effects on the project cache. If it doesn't seem to improve the situation we can revert it again.

#skip-changelog