### PR TITLE
fix(metric-stats): Add namespace from limit if available

### DIFF
--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -184,10 +184,13 @@ impl MetricStats {
             if let Some(t) = name.try_type() {
                 tags.insert("mri.type".to_owned(), t.to_string());
             }
-        }
-
-        if let Some(t) = report.metric_type {
-            tags.insert("mri.type".to_owned(), t.to_string());
+        } else {
+            if let Some(namespace) = limit.namespace {
+                tags.insert("mri.namespace".to_owned(), namespace.to_string());
+            }
+            if let Some(t) = report.metric_type {
+                tags.insert("mri.type".to_owned(), t.to_string());
+            }
         }
 
         Some(Bucket {
@@ -206,7 +209,7 @@ mod tests {
     use relay_base_schema::project::{ProjectId, ProjectKey};
     use relay_cardinality::{CardinalityScope, SlidingWindow};
     use relay_dynamic_config::GlobalConfig;
-    use relay_metrics::MetricType;
+    use relay_metrics::{MetricNamespace, MetricType};
     use relay_quotas::ReasonCode;
     use tokio::sync::mpsc::UnboundedReceiver;
 
@@ -391,7 +394,7 @@ mod tests {
             },
             limit: 99,
             scope: CardinalityScope::Type,
-            namespace: None,
+            namespace: Some(MetricNamespace::Spans),
         };
         let report = CardinalityReport {
             organization_id: Some(scoping.organization_id),
@@ -429,6 +432,7 @@ mod tests {
             bucket.tags,
             tags!(
                 ("mri.type", "d"),
+                ("mri.namespace", "spans"),
                 ("cardinality.limit", "test"),
                 ("cardinality.scope", "type"),
                 ("cardinality.window", "246"),


### PR DESCRIPTION
We can grab the namespace from the limit if there is one.

Also we don't have to re-set the type if we already have it from a metric name.

#skip-changelog