### PR TITLE
ref(cardinality): Include more information in script error

### DIFF
--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -65,6 +65,7 @@ impl FromRedisValue for CardinalityScriptResult {
             return Err(redis::RedisError::from((
                 redis::ErrorKind::TypeError,
                 "Expected a sequence from the cardinality script",
+                format!("{v:?}"),
             )));
         };
 


### PR DESCRIPTION
We had a few errors from this code path, I assume due to Redis failures but it would be nice to get more information in the future.

#skip-changelog