### PR TITLE
test(kafka): Bump the default poll timeout from 1 to 2s

### DIFF
--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -156,7 +156,7 @@ class ConsumerBase:
         self.consumer = consumer
         self.test_producer = kafka_producer(options)
         self.topic_name = topic_name
-        self.timeout = timeout or 1
+        self.timeout = timeout or 2
 
         # Connect to the topic and poll a first test message.
         # First poll takes forever, the next ones are fast.


### PR DESCRIPTION
Should hopefully fix: #3169 - it fails when trying to get outcomes, it does not specify a timeout and sometimes an outcome hasn't arrived yet.

This does slightly increase the time it takes for a failing test, but shouldn't affect the duration of succeeding tests.

#skip-changelog