### PR TITLE
feat(crons): Add `owner` to `MonitorConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Features**:
 
 - Use same keys for OTel span attributes and Sentry span data. ([#3457](https://github.com/getsentry/relay/pull/3457))
+- Support passing owner when upserting Monitors. ([#3468](https://github.com/getsentry/relay/pull/3468))
 
 **Internal**:
 

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -115,7 +115,10 @@ pub struct MonitorConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     recovery_threshold: Option<u64>,
 
-    /// Who the owner of the monitor should be.
+    /// Who the owner of the monitor should be. Uses the ActorTuple [0] 
+    /// identifier format.
+    ///
+    /// [0]: https://github.com/getsentry/sentry/blob/3644f5c4f2a99073bf925181b5237a6e05c1d6c2/src/sentry/utils/actor.py#L17
     #[serde(default, skip_serializing_if = "Option::is_none")]
     owner: Option<String>,
 }

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -114,6 +114,10 @@ pub struct MonitorConfig {
     /// How many consecutive OK check-ins it takes to resolve an issue.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     recovery_threshold: Option<u64>,
+
+    /// Who the owner of the monitor should be.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    owner: Option<String>,
 }
 
 /// The trace context sent with a check-in.
@@ -325,7 +329,8 @@ mod tests {
     "max_runtime": 10,
     "timezone": "America/Los_Angles",
     "failure_issue_threshold": 3,
-    "recovery_threshold": 1
+    "recovery_threshold": 1,
+    "owner": "user:123"
   }
 }"#;
 

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -115,7 +115,7 @@ pub struct MonitorConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     recovery_threshold: Option<u64>,
 
-    /// Who the owner of the monitor should be. Uses the ActorTuple [0] 
+    /// Who the owner of the monitor should be. Uses the ActorTuple [0]
     /// identifier format.
     ///
     /// [0]: https://github.com/getsentry/sentry/blob/3644f5c4f2a99073bf925181b5237a6e05c1d6c2/src/sentry/utils/actor.py#L17


### PR DESCRIPTION
We recently added the ability to assign an owner to a Monitor. We want to support setting this via upsert.


