### PR TITLE
ref(gocd): Add combined trigger for relay pipelines

### DIFF
--- a/gocd/pipelines/relay.yaml
+++ b/gocd/pipelines/relay.yaml
@@ -1,0 +1,53 @@
+# More information on gocd-flavor YAML can be found here:
+# - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
+# - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
+format_version: 10
+pipelines:
+  deploy-relay:
+    group: relay
+    lock_behavior: unlockWhenFinished
+
+    materials:
+      relay_repo:
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+        branch: master
+        destination: relay
+
+    stages:
+      - checks:
+          approval:
+            type: manual
+          fetch_materials: true
+
+          jobs:
+            checks-pipeline-status:
+              environment_variables:
+                # Required for checkruns.
+                GOCD_ACCESS_TOKEN: "{{SECRET:[devinfra][gocd_access_token]}}"
+              timeout: 300
+              elastic_profile_id: relay
+              tasks:
+                - script: |
+                    /devinfra/scripts/checks/gocd/pipeline_status.py \
+                    deploy-relay-processing \
+                    deploy-relay-pop
+      - deploy-relay:
+          approval:
+            type: success
+            allow_only_on_success: true
+          fetch_materials: true
+
+          jobs:
+            trigger-deploys:
+              environment_variables:
+                GOCD_ACCESS_TOKEN: "{{SECRET:[devinfra][gocd_access_token]}}"
+              timeout: 300
+              elastic_profile_id: relay
+              tasks:
+                - script: |
+                    /devinfra/scripts/gocd/trigger_pipeline.py \
+                    --pipeline-name=deploy-relay-processing \
+                    --pipeline-name=deploy-relay-pop \
+                    --material-name=relay_repo \
+                    --sha="${GO_REVISION_RELAY_REPO}"


### PR DESCRIPTION
resolves #3264
Adding a new `deploy-relay` pipeline that triggers both the `deploy-relay-processing` and `deploy-relay-pop` pipelines.

Some key features include:
* **Schedulability Checks:** Before triggering the deploys, the `deploy-relay` pipeline first checks that both `deploy-relay-processing` and `deploy-relay-pop` are schedulable. This means they are not paused or currently running.
* **Sequential Triggering:** While the intention is to trigger both pipelines simultaneously, they are technically triggered sequentially. The `deploy-relay-processing` pipeline is triggered first, followed by `deploy-relay-pop`. However, testing has shown no perceptible difference between the scheduling times between the two pipelines.

The main source of deviation is the duration of the pipelines themselves and GoCD's scheduling of agents behind the scenes to cary out the tasks which are both practically unavoidable.

This change aims to streamline relay deploys by enabling one-click deployments of both processing and pops while still enabling the individual triggering of each pipeline separately.
#skip-changelog