### PR TITLE
chore(gocd): Updating de to be a prod region

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.8"
+      "version": "v2.9.1"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "172de74e6347127957707d990f20f3e99c6c1c46",
-      "sum": "pBB9Jio0EnAgB7811tnly/S1B5fz6BeYoi4hQ7KgsHM="
+      "version": "4a103d77466c9c2d24df3fdfc8fc876bdceea135",
+      "sum": "JOy7bA1E50Ycp2gQloaJ9yEeHGArW1GGj8Cq/BM9nx0="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumping the [gocd-jsonnet](https://github.com/getsentry/gocd-jsonnet) version to [2.9.1](https://github.com/getsentry/gocd-jsonnet/compare/v2.8...v2.9.1) in order to move DE from a test-region to a prod-region. This will result in the DE region to deploying after S4S and before the US region.
#skip-changelog