### PR TITLE
perf: move json calls to parameters

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add ability to change the json parser. ([#3480](https://github.com/getsentry/relay/pull/3480))
+
 ## 0.8.57
 
 - Add a data category for metirc hours.  [#3384](https://github.com/getsentry/relay/pull/3384)


### PR DESCRIPTION
Moves `json.loads` and `json.dumps` calls to parameters for experimentation on replacing them with `orjson`.

Ref: https://github.com/getsentry/sentry/issues/68903