### PR TITLE
feat(spans): Updates exclusive_time metric to extract known module tags when span is a queue span

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -37,7 +37,7 @@ const CACHE_SPAN_OPS: &[&str] = &[
     "cache.delete_item",
 ];
 
-const QUEUE_SPAN_OPS: &[&str] = &["queue.task.celery", "queue.submit.celery"];
+const QUEUE_SPAN_OPS: &[&str] = &["queue.task.*", "queue.submit.*"];
 
 /// Adds configuration for extracting metrics from spans.
 ///
@@ -159,9 +159,12 @@ fn span_metrics(
         | is_cache.clone())
         & duration_condition.clone();
 
-    let know_modules_condition =
-        (is_db.clone() | is_resource.clone() | is_mobile.clone() | is_http.clone())
-            & duration_condition.clone();
+    let know_modules_condition = (is_db.clone()
+        | is_resource.clone()
+        | is_mobile.clone()
+        | is_http.clone()
+        | is_queue_op.clone())
+        & duration_condition.clone();
     let self_time_tags = vec![
         // All modules:
         Tag::with_key("environment")

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -37,7 +37,14 @@ const CACHE_SPAN_OPS: &[&str] = &[
     "cache.delete_item",
 ];
 
-const QUEUE_SPAN_OPS: &[&str] = &["queue.task.*", "queue.submit.*"];
+const QUEUE_SPAN_OPS: &[&str] = &[
+    "queue.task.*",
+    "queue.submit.*",
+    "queue.task",
+    "queue.submit",
+    "queue.publish",
+    "queue.process",
+];
 
 /// Adds configuration for extracting metrics from spans.
 ///

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1043,6 +1043,26 @@ mod tests {
                 {
                     "timestamp": 1702474613.0495,
                     "start_timestamp": 1702474613.0175,
+                    "description": "sentry.tasks.post_process.post_process_group",
+                    "op": "queue.publish",
+                    "span_id": "9b01bd820a083e63",
+                    "parent_span_id": "a1e13f3f06239d69",
+                    "trace_id": "922dda2462ea4ac2b6a4b339bee90863",
+                    "data": {}
+                },
+                {
+                    "timestamp": 1702474613.0495,
+                    "start_timestamp": 1702474613.0175,
+                    "description": "sentry.tasks.post_process.post_process_group",
+                    "op": "queue.process",
+                    "span_id": "9b01bd820a083e63",
+                    "parent_span_id": "a1e13f3f06239d69",
+                    "trace_id": "922dda2462ea4ac2b6a4b339bee90863",
+                    "data": {}
+                },
+                {
+                    "timestamp": 1702474613.0495,
+                    "start_timestamp": 1702474613.0175,
                     "description": "ConcurrentStream",
                     "op": "ai.run.langchain",
                     "origin": "auto.langchain",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -11256,7 +11256,6 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.category": "queue",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
@@ -11331,7 +11330,6 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.category": "queue",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
@@ -11367,6 +11365,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
             "span.op": "queue.submit.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
@@ -11432,6 +11431,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
             "span.op": "queue.submit.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -11515,6 +11515,306 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
+            "span.op": "queue.publish",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
+        value: Distribution(
+            [
+                32.000065,
+            ],
+        ),
+        tags: {
+            "span.category": "queue",
+            "span.op": "queue.publish",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "d:spans/duration@millisecond",
+        ),
+        value: Distribution(
+            [
+                32.000065,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.op": "queue.publish",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "g:spans/self_time@millisecond",
+        ),
+        value: Gauge(
+            GaugeValue {
+                last: 32.000065,
+                min: 32.000065,
+                max: 32.000065,
+                sum: 32.000065,
+                count: 1,
+            },
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.category": "queue",
+            "span.op": "queue.publish",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "g:spans/self_time_light@millisecond",
+        ),
+        value: Gauge(
+            GaugeValue {
+                last: 32.000065,
+                min: 32.000065,
+                max: 32.000065,
+                sum: 32.000065,
+                count: 1,
+            },
+        ),
+        tags: {
+            "span.category": "queue",
+            "span.op": "queue.publish",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "g:spans/total_time@millisecond",
+        ),
+        value: Gauge(
+            GaugeValue {
+                last: 32.000065,
+                min: 32.000065,
+                max: 32.000065,
+                sum: 32.000065,
+                count: 1,
+            },
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.op": "queue.publish",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
+        value: Distribution(
+            [
+                32.000065,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.category": "queue",
+            "span.op": "queue.process",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
+        value: Distribution(
+            [
+                32.000065,
+            ],
+        ),
+        tags: {
+            "span.category": "queue",
+            "span.op": "queue.process",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "d:spans/duration@millisecond",
+        ),
+        value: Distribution(
+            [
+                32.000065,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.op": "queue.process",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "g:spans/self_time@millisecond",
+        ),
+        value: Gauge(
+            GaugeValue {
+                last: 32.000065,
+                min: 32.000065,
+                max: 32.000065,
+                sum: 32.000065,
+                count: 1,
+            },
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.category": "queue",
+            "span.op": "queue.process",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "g:spans/self_time_light@millisecond",
+        ),
+        value: Gauge(
+            GaugeValue {
+                last: 32.000065,
+                min: 32.000065,
+                max: 32.000065,
+                sum: 32.000065,
+                count: 1,
+            },
+        ),
+        tags: {
+            "span.category": "queue",
+            "span.op": "queue.process",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "g:spans/total_time@millisecond",
+        ),
+        value: Gauge(
+            GaugeValue {
+                last: 32.000065,
+                min: 32.000065,
+                max: 32.000065,
+                sum: 32.000065,
+                count: 1,
+            },
+        ),
+        tags: {
+            "environment": "fake_environment",
+            "span.op": "queue.process",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
+        value: Distribution(
+            [
+                32.000065,
+            ],
+        ),
+        tags: {
+            "environment": "fake_environment",
             "span.op": "ai.run.langchain",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -11215,6 +11215,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
@@ -11255,6 +11256,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
@@ -11280,6 +11282,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
@@ -11328,6 +11331,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "span.category": "queue",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",


### PR DESCRIPTION
Updates exclusive_time metric to extract known module tags when span is a queue span.
Also expands queue span detection to pick up all `"queue.task.*","queue.submit.*","queue.task", "queue.submit", "queue.publish", "queue.process",` ops, instead of just celery ops.

#skip-changelog