### PR TITLE
ci(gocd): Update pipelines to use new github ci job names

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -41,8 +41,8 @@ pipelines:
                     ${GO_REVISION_RELAY_REPO} \
                     "Integration Tests" \
                     "Test All Features (ubuntu-latest)" \
-                    "Push GCR Docker Image (relay)" \
-                    "Push GCR Docker Image (relay-pop)"
+                    "Publish Relay to GCR (relay)" \
+                    "Publish Relay to GCR (relay-pop)"
 
       - deploy-experimental:
           approval:

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -5,5 +5,5 @@
     "${GO_REVISION_RELAY_REPO}" \
     "Integration Tests" \
     "Test All Features (ubuntu-latest)" \
-    "Push GCR Docker Image (relay)" \
-    "Push GCR Docker Image (relay-pop)"
+    "Publish Relay to GCR (relay)" \
+    "Publish Relay to GCR (relay-pop)"


### PR DESCRIPTION
The gocd pipelines are still referencing the old pipeline names, updated the pipeline names.

#skip-changelog