### PR TITLE
ci(gocd): Rename relay.debug.zip back to relay-debug.zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,12 +237,12 @@ jobs:
           llvm-objcopy --add-gnu-debuglink "${RELAY_BIN}"{.debug,}
 
           cross-util run --target "${{ matrix.target }}" -- "sentry-cli difutil bundle-sources ${RELAY_BIN}.debug"
-          zip "${RELAY_BIN}.debug.zip" "${RELAY_BIN}.debug"
+          zip "${RELAY_BIN}-debug.zip" "${RELAY_BIN}.debug"
 
       - name: Prepare Artifacts
         run: |
           mkdir -p "artifacts/${DOCKER_PLATFORM}"
-          cp "${RELAY_BIN}"{,.debug.zip,.src.zip} "artifacts/${DOCKER_PLATFORM}"
+          cp "${RELAY_BIN}"{,-debug.zip,.src.zip} "artifacts/${DOCKER_PLATFORM}"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -430,7 +430,7 @@ jobs:
           VERSION="$(docker run --rm "${GHCR_DOCKER_IMAGE}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
-          docker run --rm --entrypoint cat "${GHCR_DOCKER_IMAGE}:${REVISION}" /opt/relay.debug.zip > relay.debug.zip
+          docker run --rm --entrypoint cat "${GHCR_DOCKER_IMAGE}:${REVISION}" /opt/relay-debug.zip > relay-debug.zip
           docker run --rm --entrypoint cat "${GHCR_DOCKER_IMAGE}:${REVISION}" /opt/relay.src.zip > relay.src.zip
           docker run --rm --entrypoint tar "${GHCR_DOCKER_IMAGE}:${REVISION}" -cf - /lib/x86_64-linux-gnu > libs.tar
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -24,7 +24,7 @@ EXPOSE 3000
 
 COPY $TARGETPLATFORM/relay /bin/relay
 RUN chmod +x /bin/relay
-COPY $TARGETPLATFORM/relay.debug.zip /opt/relay.debug.zip
+COPY $TARGETPLATFORM/relay-debug.zip /opt/relay-debug.zip
 COPY $TARGETPLATFORM/relay.src.zip /opt/relay.src.zip
 
 COPY ./docker-entrypoint.sh /

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-linux-release: setup-git ## build linux release of the relay
 
 collect-source-bundle: setup-git ## copy the built relay binary to current folder and collects debug bundles
 	mv target/${TARGET}/release/relay ./relay-bin
-	zip relay.debug.zip target/${TARGET}/release/relay.debug
+	zip relay-debug.zip target/${TARGET}/release/relay.debug
 	sentry-cli --version
 	sentry-cli difutil bundle-sources target/${TARGET}/release/relay.debug
 	mv target/${TARGET}/release/relay.src.zip ./relay.src.zip

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -31,13 +31,13 @@ fi
 echo 'Downloading debug info, source bundle, system symbols...'
 gsutil cp \
   "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/release-name" \
-  "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/relay.debug.zip" \
+  "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/relay-debug.zip" \
   "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/relay.src.zip" \
   "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/libs.tar" \
   .
 
 echo 'Uploading debug information and source bundle...'
-sentry-cli upload-dif ./relay.debug.zip ./relay.src.zip
+sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
 
 echo 'Uploading system symbols...'
 tar xf libs.tar


### PR DESCRIPTION
Renames it back to the inconsistent `relay.debug.zip` to prevent potential compatibility issues. Also should fix a missed rename in the ci.yml.

See: #3499 

#skip-changelog