### PR TITLE
ref(ddm): Remove metric-meta feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Emit gauges for total and self times for spans. ([#3448](https://github.com/getsentry/relay/pull/3448))
 - Collect exclusive_time_light metrics for `cache.*` spans. ([#3466](https://github.com/getsentry/relay/pull/3466))
 - Build and publish ARM docker images for Relay. ([#3272](https://github.com/getsentry/relay/pull/3272)).
+- Remove `MetricMeta` feature flag and use `CustomMetrics` instead. ([#3503](https://github.com/getsentry/relay/pull/3503))
 
 ## 24.4.1
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -56,11 +56,6 @@ pub enum Feature {
     /// Serialized as `organizations:standalone-span-ingestion`.
     #[serde(rename = "organizations:standalone-span-ingestion")]
     StandaloneSpanIngestion,
-    /// Enable metric metadata.
-    ///
-    /// Serialized as `organizations:metric-meta`.
-    #[serde(rename = "organizations:metric-meta")]
-    MetricMeta,
     /// Enable processing and extracting data from profiles that would normally be dropped by dynamic sampling.
     ///
     /// This is required for [slowest function aggregation](https://github.com/getsentry/snuba/blob/b5311b404a6bd73a9e1997a46d38e7df88e5f391/snuba/snuba_migrations/functions/0001_functions.py#L209-L256). The profile payload will be dropped on the sentry side.

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -737,8 +737,9 @@ impl Project {
     ) {
         let state = self.state_value();
 
-        // Only track metadata if the feature is enabled or we don't know yet whether it is enabled.
-        if !state.map_or(true, |state| state.has_feature(Feature::MetricMeta)) {
+        // Only track metadata if custom metrics are enabled, or we don't know yet whether they are
+        // enabled.
+        if !state.map_or(true, |state| state.has_feature(Feature::CustomMetrics)) {
             relay_log::trace!(
                 "metric meta feature flag not enabled for project {}",
                 self.project_key
@@ -777,7 +778,7 @@ impl Project {
         // All relevant info has been gathered, consider us flushed.
         self.has_pending_metric_meta = false;
 
-        if !state.has_feature(Feature::MetricMeta) {
+        if !state.has_feature(Feature::CustomMetrics) {
             relay_log::debug!(
                 "clearing metric meta aggregator, because project {} does not have feature flag enabled",
                 self.project_key,

--- a/tests/integration/test_metric_meta.py
+++ b/tests/integration/test_metric_meta.py
@@ -23,7 +23,7 @@ def test_metric_meta(mini_sentry, redis_client, relay_with_processing):
     relay = relay_with_processing()
 
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
-    project_config.setdefault("features", []).append("organizations:metric-meta")
+    project_config.setdefault("features", []).append("organizations:custom-metrics")
 
     location1 = {
         "type": "location",


### PR DESCRIPTION
This PR removes the `metric-meta` feature flag since it's now merged into `custom-metrics`.

Closes: https://github.com/getsentry/relay/issues/3024