### PR TITLE
ref(sessions): Discard unprocessed sessions and log error

### DIFF
--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -222,6 +222,13 @@ fn process_session(
     // Drop the session if metrics have been extracted in this or a prior Relay
     if item.metrics_extracted() {
         return false;
+    } else if config.processing_enabled() {
+        relay_log::error!(
+            "Session metrics extraction disabled on a processing Relay, \
+            make sure you're running an up to date Relay matching the Sentry \
+            version."
+        );
+        return false;
     }
 
     if changed {


### PR DESCRIPTION
Discards unprocessed sessions in processing Relays and logs an error.

It's possible that the Relay version is too outdated or Sentry does not send any session metrics extraction info in the project config. Discard the sessions (instead of trying to forward it to Kafka) and log an error.

#skip-changelog