### PR TITLE
feat(bucket-encoding): Switch base64 to base64 without padding

### DIFF
--- a/relay-server/src/utils/bucket_encoding.rs
+++ b/relay-server/src/utils/bucket_encoding.rs
@@ -4,7 +4,7 @@ use relay_dynamic_config::{BucketEncoding, GlobalConfig};
 use relay_metrics::{Bucket, BucketValue, FiniteF64, MetricNamespace, SetView};
 use serde::Serialize;
 
-static BASE64: data_encoding::Encoding = data_encoding::BASE64;
+static BASE64_NOPAD: data_encoding::Encoding = data_encoding::BASE64_NOPAD;
 
 pub struct BucketEncoder<'a> {
     global_config: &'a GlobalConfig,
@@ -144,7 +144,7 @@ impl<'a, T> DynamicArrayEncoding<'a, T> {
 }
 
 fn base64<T: Encodable>(data: T, buffer: &mut String) -> io::Result<ArrayEncoding<T>> {
-    let mut writer = EncoderWriteAdapter(BASE64.new_encoder(buffer));
+    let mut writer = EncoderWriteAdapter(BASE64_NOPAD.new_encoder(buffer));
     data.write_to(&mut writer)?;
     drop(writer);
 
@@ -155,7 +155,7 @@ fn base64<T: Encodable>(data: T, buffer: &mut String) -> io::Result<ArrayEncodin
 
 fn zstd<T: Encodable>(data: T, buffer: &mut String) -> io::Result<ArrayEncoding<T>> {
     let mut writer = zstd::Encoder::new(
-        EncoderWriteAdapter(BASE64.new_encoder(buffer)),
+        EncoderWriteAdapter(BASE64_NOPAD.new_encoder(buffer)),
         zstd::DEFAULT_COMPRESSION_LEVEL,
     )?;
 

--- a/tests/integration/test_metrics_encoding.py
+++ b/tests/integration/test_metrics_encoding.py
@@ -8,15 +8,19 @@ from .test_metrics import TEST_CONFIG, metrics_by_name
 
 
 def b64_set(*values):
-    return base64.b64encode(
-        b"".join(struct.pack("<I", value) for value in values)
-    ).decode("ascii")
+    return (
+        base64.b64encode(b"".join(struct.pack("<I", value) for value in values))
+        .decode("ascii")
+        .rstrip("=")
+    )
 
 
 def b64_dist(*values):
-    return base64.b64encode(
-        b"".join(struct.pack("<d", value) for value in values)
-    ).decode("ascii")
+    return (
+        base64.b64encode(b"".join(struct.pack("<d", value) for value in values))
+        .decode("ascii")
+        .rstrip("=")
+    )
 
 
 def assert_zstd_set(value, *expected):
@@ -36,7 +40,9 @@ def assert_zstd_dist(value, *expected):
 
 
 def zstd_decompress(data):
-    with zstd.ZstdDecompressor().stream_reader(base64.b64decode(data)) as decompressor:
+    with zstd.ZstdDecompressor().stream_reader(
+        base64.b64decode(data + "==")
+    ) as decompressor:
         return decompressor.read()
 
 


### PR DESCRIPTION
Switches the base64 encoding in the bucket encoding to an encoding without padding to save some bytes on small payloads.

#skip-changelog