### PR TITLE
fix(spans): cache item size not being collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Collect `enviornment` tag as part of exclusive_time_light for cache spans. ([#3510](https://github.com/getsentry/relay/pull/3510))
 
-**Features**:
-
-**Internal**:
-
 ## 24.4.2
 
 **Breaking Changes**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes:**
 
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
+- Collect `enviornment` tag as part of exclusive_time_light for cache spans. ([#3510](https://github.com/getsentry/relay/pull/3510))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### Unreleased
+
+**Breaking Changes**:
+
+**Bug fixes:**
+
+- Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
+
+**Features**:
+
+**Internal**:
+
 ## 24.4.2
 
 **Breaking Changes**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Unreleased
 
-**Breaking Changes**:
-
 **Bug fixes:**
 
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -261,7 +261,11 @@ fn span_metrics(transaction_extraction_enabled: bool) -> impl IntoIterator<Item 
                 Tag::with_key("environment")
                     .from_field("span.sentry_tags.environment")
                     .when(
-                        is_db.clone() | is_resource.clone() | is_mobile.clone() | is_http.clone(),
+                        is_db.clone()
+                            | is_resource.clone()
+                            | is_mobile.clone()
+                            | is_http.clone()
+                            | is_cache.clone(),
                     ),
                 Tag::with_key("transaction.op")
                     .from_field("span.sentry_tags.transaction.op")

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -361,7 +361,7 @@ fn span_metrics(transaction_extraction_enabled: bool) -> impl IntoIterator<Item 
         MetricSpec {
             category: DataCategory::Span,
             mri: "d:spans/cache.item_size@byte".into(),
-            field: Some("span.data.cache\\.item_size".into()),
+            field: Some("span.measurements.cache.item_size.value".into()),
             condition: Some(is_cache.clone()),
             tags: vec![
                 Tag::with_key("environment")

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -278,7 +278,7 @@ pub fn hardcoded_span_metrics() -> Vec<(String, Vec<MetricSpec>)> {
                                 is_db.clone()
                                     | is_resource.clone()
                                     | is_mobile.clone()
-                                    | is_http.clone(),
+                                    | is_http.clone()
                                     | is_cache.clone(),
                             ),
                         Tag::with_key("transaction.op")

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -1957,6 +1957,7 @@ expression: metrics
         ),
         tags: {
             "cache.hit": "false",
+            "environment": "fake_environment",
             "span.category": "cache",
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
@@ -4955,6 +4956,7 @@ expression: metrics
         ),
         tags: {
             "cache.hit": "false",
+            "environment": "fake_environment",
             "span.category": "cache",
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
@@ -5055,6 +5057,7 @@ expression: metrics
         ),
         tags: {
             "cache.hit": "true",
+            "environment": "fake_environment",
             "span.category": "cache",
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -1991,6 +1991,27 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
+            "d:spans/cache.item_size@byte",
+        ),
+        value: Distribution(
+            [
+                8.0,
+            ],
+        ),
+        tags: {
+            "cache.hit": "false",
+            "environment": "fake_environment",
+            "span.op": "cache.get_item",
+            "transaction": "gEt /api/:version/users/",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -4959,6 +4980,27 @@ expression: metrics
             "span.op": "cache.get_item",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "d:spans/cache.item_size@byte",
+        ),
+        value: Distribution(
+            [
+                10.0,
+            ],
+        ),
+        tags: {
+            "cache.hit": "false",
+            "environment": "fake_environment",
+            "span.op": "cache.get_item",
+            "transaction": "gEt /api/:version/users/",
         },
         metadata: BucketMetadata {
             merges: 1,


### PR DESCRIPTION
1. cache.item_size was not being collected at all, looks like this is because it was not being retrieved correctly as it comes from measurements.
2. the enviornment tag was not being added