### PR TITLE
feat(spans): Adds more queue span tags to metrics

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -254,6 +254,9 @@ fn span_metrics(transaction_extraction_enabled: bool) -> impl IntoIterator<Item 
                 Tag::with_key("messaging.destination.name")
                     .from_field("span.sentry_tags.messaging.destination.name")
                     .when(is_queue_op.clone()),
+                Tag::with_key("trace.status")
+                    .from_field("span.sentry_tags.trace.status")
+                    .when(is_queue_op.clone()),
             ],
         },
         MetricSpec {
@@ -316,6 +319,9 @@ fn span_metrics(transaction_extraction_enabled: bool) -> impl IntoIterator<Item 
                 // Queue module
                 Tag::with_key("messaging.destination.name")
                     .from_field("span.sentry_tags.messaging.destination.name")
+                    .when(is_queue_op.clone()),
+                Tag::with_key("trace.status")
+                    .from_field("span.sentry_tags.trace.status")
                     .when(is_queue_op.clone()),
             ],
         },
@@ -788,6 +794,9 @@ fn span_metrics(transaction_extraction_enabled: bool) -> impl IntoIterator<Item 
                     .always(),
                 Tag::with_key("transaction")
                     .from_field("span.sentry_tags.transaction")
+                    .always(),
+                Tag::with_key("messaging.destination.name")
+                    .from_field("span.sentry_tags.messaging.destination.name")
                     .always(),
             ],
         },

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -5817,6 +5817,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.task.celery",
+            "trace.status": "ok",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
         },
@@ -5839,6 +5840,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.task.celery",
+            "trace.status": "ok",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5882,6 +5884,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "messaging.destination.name": "default",
             "span.op": "queue.task.celery",
             "transaction": "gEt /api/:version/users/",
         },
@@ -5919,6 +5922,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.submit.celery",
+            "trace.status": "ok",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
         },
@@ -5941,6 +5945,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.submit.celery",
+            "trace.status": "ok",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5984,6 +5989,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "messaging.destination.name": "default",
             "span.op": "queue.submit.celery",
             "transaction": "gEt /api/:version/users/",
         },
@@ -6021,6 +6027,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.publish",
+            "trace.status": "ok",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
         },
@@ -6043,6 +6050,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.publish",
+            "trace.status": "ok",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6086,6 +6094,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "messaging.destination.name": "default",
             "span.op": "queue.publish",
             "transaction": "gEt /api/:version/users/",
         },
@@ -6123,6 +6132,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.process",
+            "trace.status": "ok",
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
         },
@@ -6145,6 +6155,7 @@ expression: metrics
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.process",
+            "trace.status": "ok",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6188,6 +6199,7 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
+            "messaging.destination.name": "default",
             "span.op": "queue.process",
             "transaction": "gEt /api/:version/users/",
         },


### PR DESCRIPTION
Adds `trace.status` as a tag to `exclusive_time` metrics, just for queue spans. `trace.status` is low cardinality, see: https://develop.sentry.dev/sdk/event-payloads/contexts/#trace-context

Adds `messaging.destination.name` as a tag to `messaging.message.receive.latency` metric. `messaging.destination.name` should also be low cardinality since it the queue/topic name that a consumer/producer span operates on.

#skip-changelog