### PR TITLE
feat(server): Use a single tokio runtime, adjust processor task count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Add metrics extraction config to global config. ([#3490](https://github.com/getsentry/relay/pull/3490), [#3504](https://github.com/getsentry/relay/pull/3504))
+- Adjust worker thread distribution of internal services. ([#3516](https://github.com/getsentry/relay/pull/3516))
 
 ## 24.4.2
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -586,7 +586,7 @@ struct Limits {
     max_replay_message_size: ByteSize,
     /// The maximum number of threads to spawn for CPU and web work, each.
     ///
-    /// The total number of threads spawned will roughly be `2 * max_thread_count + 1`. Defaults to
+    /// The total number of threads spawned will roughly be `2 * max_thread_count`. Defaults to
     /// the number of logical CPU cores on the host.
     max_thread_count: usize,
     /// The maximum number of seconds a query is allowed to take across retries. Individual requests

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -276,7 +276,7 @@ use std::sync::Arc;
 use relay_config::Config;
 use relay_system::{Controller, Service};
 
-use crate::service::{Runtimes, ServiceState};
+use crate::service::ServiceState;
 use crate::services::server::HttpServer;
 
 /// Runs a relay web server and spawns all internal worker threads.
@@ -291,23 +291,17 @@ pub fn run(config: Config) -> anyhow::Result<()> {
     // Creates the main runtime.
     let main_runtime = crate::service::create_runtime("main-rt", config.cpu_concurrency());
 
-    // Create secondary service runtimes.
-    //
-    // Runtimes must not be dropped within other runtimes, so keep them alive here.
-    let runtimes = Runtimes::new(&config);
-
     // Run the system and block until a shutdown signal is sent to this process. Inside, start a
     // web server and run all relevant services. See the `actors` module documentation for more
     // information on all services.
     main_runtime.block_on(async {
         Controller::start(config.shutdown_timeout());
-        let service = ServiceState::start(config.clone(), &runtimes)?;
+        let service = ServiceState::start(config.clone())?;
         HttpServer::new(config, service.clone())?.start();
         Controller::shutdown_handle().finished().await;
         anyhow::Ok(())
     })?;
 
-    drop(runtimes);
     drop(main_runtime);
 
     relay_log::info!("relay shutdown complete");

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2630,9 +2630,8 @@ impl Service for EnvelopeProcessorService {
         // Adjust thread count for small cpu counts to not have too many idle cores
         // and distribute workload better.
         let thread_count = match self.inner.config.cpu_concurrency() {
-            0 | 1 => 1,
-            2 | 3 => 2,
-            4 => 3,
+            conc @ 0..=2 => conc.max(1),
+            conc @ 3..=4 => conc - 1,
             conc => conc - 2,
         };
         relay_log::info!("starting {thread_count} envelope processing workers");


### PR DESCRIPTION
As described in #3513.

- Removes all additional secondary runtimes for individual services.
- Adjusts the thread count for the processor to not use all resources given.

Will be followed by an ops PR to adjust configuration settings. 