### PR TITLE
ref(spans): Rename exclusive time attribute name

### DIFF
--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -169,7 +169,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
                 "http.route" | "url.path" => {
                     http_route = otel_value_to_string(value);
                 }
-                key if key.contains("exclusive_time_ns") => {
+                key if key.contains("exclusive_time_nano") => {
                     let value = match value {
                         OtelValue::IntValue(v) => v as f64,
                         OtelValue::DoubleValue(v) => v,
@@ -323,7 +323,7 @@ mod tests {
                     }
                 },
                 {
-                    "key": "sentry.exclusive_time_ns",
+                    "key": "sentry.exclusive_time_nano",
                     "value": {
                         "intValue": 1000000000
                     }
@@ -350,7 +350,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_span_with_exclusive_time_ns_attribute() {
+    fn parse_span_with_exclusive_time_nano_attribute() {
         let json = r#"{
             "traceId": "89143b0763095bd9c9955e8175d1fb23",
             "spanId": "e342abb1214ca181",
@@ -361,7 +361,7 @@ mod tests {
             "endTimeUnixNano": 1697620454980078800,
             "attributes": [
                 {
-                    "key": "sentry.exclusive_time_ns",
+                    "key": "sentry.exclusive_time_nano",
                     "value": {
                         "intValue": 3200000000
                     }
@@ -374,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_span_no_exclusive_time_ns_attribute() {
+    fn parse_span_no_exclusive_time_nano_attribute() {
         let json = r#"{
             "traceId": "89143b0763095bd9c9955e8175d1fb23",
             "spanId": "e342abb1214ca181",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -289,7 +289,7 @@ def envelope_with_spans(
                                 },
                             },
                             {
-                                "key": "sentry.exclusive_time_ns",
+                                "key": "sentry.exclusive_time_nano",
                                 "value": {
                                     "intValue": int(
                                         (end - start).total_seconds() * 1e9
@@ -384,7 +384,7 @@ def make_otel_span(start, end):
                                 "endTimeUnixNano": int(end.timestamp() * 1e9),
                                 "attributes": [
                                     {
-                                        "key": "sentry.exclusive_time_ns",
+                                        "key": "sentry.exclusive_time_nano",
                                         "value": {
                                             "intValue": int(
                                                 (end - start).total_seconds() * 1e9
@@ -465,7 +465,7 @@ def test_span_ingestion(
         end_time_unix_nano=int(end.timestamp() * 1e9),
         attributes=[
             KeyValue(
-                key="sentry.exclusive_time_ns",
+                key="sentry.exclusive_time_nano",
                 value=AnyValue(int_value=int(duration.total_seconds() * 1e9)),
             ),
         ],


### PR DESCRIPTION
This aligns more with how OTel named their timestamp fields, with the unit spelled out more.

This field is not in use yet but will be with https://github.com/getsentry/sentry-javascript/pull/11876.

#skip-changelog