### PR TITLE
feat(spans): Prevent some spans from being turned into segments or transactions

### DIFF
--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -423,6 +423,18 @@ fn get_normalize_span_config<'a>(
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
     let Some(span) = span.value_mut() else { return };
+    let Some(span_op) = span.op.value() else {
+        return;
+    };
+
+    // Identify INP spans and make sure they are not wrapped in a segment.
+    if span_op.starts_with("ui.interaction.") {
+        span.is_segment = false.into();
+        span.parent_span_id = None.into();
+        span.segment_id = None.into();
+        return;
+    }
+
     let Some(span_id) = span.span_id.value() else {
         return;
     };
@@ -836,6 +848,37 @@ mod tests {
     fn segment_only_parent() {
         let mut span: Annotated<Span> = Annotated::from_json(
             r#"{
+         "parent_span_id": "fa90fdead5f74051"
+     }"#,
+        )
+        .unwrap();
+        set_segment_attributes(&mut span);
+        assert_eq!(get_value!(span.is_segment), None);
+        assert_eq!(get_value!(span.segment_id), None);
+    }
+
+    #[test]
+    fn not_segment_but_inp_span() {
+        let mut span: Annotated<Span> = Annotated::from_json(
+            r#"{
+         "op": "ui.interaction.click",
+         "is_segment": false,
+         "parent_span_id": "fa90fdead5f74051"
+     }"#,
+        )
+        .unwrap();
+        set_segment_attributes(&mut span);
+        assert_eq!(get_value!(span.is_segment), None);
+        assert_eq!(get_value!(span.segment_id), None);
+    }
+
+    #[test]
+    fn segment_but_inp_span() {
+        let mut span: Annotated<Span> = Annotated::from_json(
+            r#"{
+         "op": "ui.interaction.click",
+         "segment_id": "fa90fdead5f74051",
+         "is_segment": true,
          "parent_span_id": "fa90fdead5f74051"
      }"#,
         )

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -423,16 +423,15 @@ fn get_normalize_span_config<'a>(
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
     let Some(span) = span.value_mut() else { return };
-    let Some(span_op) = span.op.value() else {
-        return;
-    };
 
     // Identify INP spans and make sure they are not wrapped in a segment.
-    if span_op.starts_with("ui.interaction.") {
-        span.is_segment = false.into();
-        span.parent_span_id = None.into();
-        span.segment_id = None.into();
-        return;
+    if let Some(span_op) = span.op.value() {
+        if span_op.starts_with("ui.interaction.") {
+            span.is_segment = None.into();
+            span.parent_span_id = None.into();
+            span.segment_id = None.into();
+            return;
+        }
     }
 
     let Some(span_id) = span.span_id.value() else {
@@ -654,11 +653,12 @@ fn validate(span: &mut Annotated<Span>) -> Result<(), ValidationError> {
 
 fn convert_to_transaction(annotated_span: &Annotated<Span>) -> Option<Event> {
     let span = annotated_span.value()?;
-    let span_op = span.op.value()?;
 
     // HACK: This is an exception from the JS SDK v8 and we do not want to turn it into a transaction.
-    if span_op == "http.client" && span.parent_span_id.is_empty() {
-        return None;
+    if let Some(span_op) = span.op.value() {
+        if span_op == "http.client" && span.parent_span_id.is_empty() {
+            return None;
+        }
     }
 
     relay_log::trace!("Extracting transaction for span {:?}", &span.span_id);

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -654,6 +654,13 @@ fn validate(span: &mut Annotated<Span>) -> Result<(), ValidationError> {
 
 fn convert_to_transaction(annotated_span: &Annotated<Span>) -> Option<Event> {
     let span = annotated_span.value()?;
+    let span_op = span.op.value()?;
+
+    // HACK: This is an exception from the JS SDK v8 and we do not want to turn it into a transaction.
+    if span_op == "http.client" && span.parent_span_id.is_empty() {
+        return None;
+    }
+
     relay_log::trace!("Extracting transaction for span {:?}", &span.span_id);
     Event::try_from(span).ok()
 }

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1258,11 +1258,10 @@ def test_span_ingestion_with_performance_scores(
         {
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
-            "is_segment": True,
+            "is_segment": False,
             "organization_id": 1,
             "project_id": 42,
             "retention_days": 90,
-            "segment_id": "bd429c44b67a3eb1",
             "sentry_tags": {
                 "browser.name": "Python Requests",
                 "op": "ui.interaction.click",
@@ -1292,12 +1291,11 @@ def test_span_ingestion_with_performance_scores(
         {
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
-            "is_segment": True,
+            "is_segment": False,
             "profile_id": "3d9428087fda4ba0936788b70a7587d0",
             "organization_id": 1,
             "project_id": 42,
             "retention_days": 90,
-            "segment_id": "cd429c44b67a3eb1",
             "sentry_tags": {
                 "browser.name": "Python Requests",
                 "op": "ui.interaction.click",


### PR DESCRIPTION
The JS SDK v8 will send us 2 standalone spans, the INP and http.client spans. There are reasons behind that outside of the scope of this PR.

Due to some complexity around how we ingest standalone spans, we choose promote to a segment every root span not in one already and to double write segments as transactions.

In these 2 specific cases, this is not wanted and this PR is meant to exclude those 2 types of spans from being either:
- promoted as a segment
- double written as a transaction

#skip-changelog