### PR TITLE
feat(spans): Forward span.data on the Kafka message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add metrics extraction config to global config. ([#3490](https://github.com/getsentry/relay/pull/3490), [#3504](https://github.com/getsentry/relay/pull/3504))
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Collect `enviornment` tag as part of exclusive_time_light for cache spans. ([#3510](https://github.com/getsentry/relay/pull/3510))
+- Forward `span.data` on the Kafka message. ([#3523](https://github.com/getsentry/relay/pull/3523))
 
 ## 24.4.2
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1390,6 +1390,8 @@ struct SpanKafkaMessage<'a> {
     #[serde(default)]
     is_segment: bool,
 
+    #[serde(default, skip_serializing_if = "none_or_empty_object")]
+    data: Option<&'a RawValue>,
     #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
     measurements: Option<BTreeMap<Cow<'a, str>, Option<SpanMeasurement>>>,
     #[serde(default)]

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -122,6 +122,7 @@ def test_span_extraction(
     assert transaction_span == {
         "data": {
             "sentry.sdk.name": "raven-node",
+            "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
         },
         "description": "hi",
@@ -872,6 +873,7 @@ def test_span_extraction_with_metrics_summary(
     assert transaction_span == {
         "data": {
             "sentry.sdk.name": "raven-node",
+            "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
         },
         "description": "hi",
@@ -1049,6 +1051,7 @@ def test_span_extraction_with_ddm_missing_values(
     assert transaction_span == {
         "data": {
             "sentry.sdk.name": "raven-node",
+            "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
         },
         "description": "hi",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -496,6 +496,7 @@ def test_span_ingestion(
 
     assert spans == [
         {
+            "data": {"browser.name": "Chrome"},
             "description": "my 1st OTel span",
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -514,6 +515,7 @@ def test_span_ingestion(
             "trace_id": "89143b0763095bd9c9955e8175d1fb23",
         },
         {
+            "data": {"browser.name": "Chrome"},
             "description": "https://example.com/p/blah.js",
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -537,6 +539,7 @@ def test_span_ingestion(
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
         {
+            "data": {"browser.name": "Chrome"},
             "description": r"test \" with \" escaped \" chars",
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -551,6 +554,7 @@ def test_span_ingestion(
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
         {
+            "data": {"browser.name": "Python Requests"},
             "description": "my 2nd OTel span",
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -568,6 +572,7 @@ def test_span_ingestion(
             "trace_id": "89143b0763095bd9c9955e8175d1fb24",
         },
         {
+            "data": {"browser.name": "Chrome"},
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
             "is_segment": False,
@@ -584,6 +589,7 @@ def test_span_ingestion(
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
         {
+            "data": {"browser.name": "Python Requests"},
             "description": "my 3rd protobuf OTel span",
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -1268,6 +1274,7 @@ def test_span_ingestion_with_performance_scores(
 
     assert spans == [
         {
+            "data": {"browser.name": "Python Requests"},
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
             "is_segment": True,
@@ -1302,6 +1309,12 @@ def test_span_ingestion_with_performance_scores(
             },
         },
         {
+            "data": {
+                "browser.name": "Python Requests",
+                "sentry.replay.id": "8477286c8e5148b386b71ade38374d58",
+                "sentry.segment.name": "/page/with/click/interaction/*/*",
+                "user": "admin@sentry.io",
+            },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
             "is_segment": True,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -120,6 +120,10 @@ def test_span_extraction(
     transaction_span = spans_consumer.get_span()
     del transaction_span["received"]
     assert transaction_span == {
+        "data": {
+            "sentry.sdk.name": "raven-node",
+            "sentry.segment.name": "hi",
+        },
         "description": "hi",
         "duration_ms": duration_ms,
         "event_id": "cbf6960622e14a45abc1f03b2055b186",
@@ -853,6 +857,10 @@ def test_span_extraction_with_metrics_summary(
     transaction_span = spans_consumer.get_span()
     del transaction_span["received"]
     assert transaction_span == {
+        "data": {
+            "sentry.sdk.name": "raven-node",
+            "sentry.segment.name": "hi",
+        },
         "description": "hi",
         "duration_ms": duration_ms,
         "event_id": "cbf6960622e14a45abc1f03b2055b186",
@@ -1026,6 +1034,10 @@ def test_span_extraction_with_ddm_missing_values(
     transaction_span = spans_consumer.get_span()
     del transaction_span["received"]
     assert transaction_span == {
+        "data": {
+            "sentry.sdk.name": "raven-node",
+            "sentry.segment.name": "hi",
+        },
         "description": "hi",
         "duration_ms": duration_ms,
         "event_id": "cbf6960622e14a45abc1f03b2055b186",


### PR DESCRIPTION
We'd like to use more data from the span and eventually store it. First step is to add it to the span Kafka message so downstream can use it.

We understand there might be some duplication between `sentry_tags` and `data` and we accept it for now to not have to parse the object.