### PR TITLE
fix(ci): Skip flaky error checks

### DIFF
--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -53,8 +53,8 @@ local soak_time(region) =
               elastic_profile_id: 'relay-pop',
               tasks: [
                 gocdtasks.script(importstr '../bash/wait-soak.sh'),
-                gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-                gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+                // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+                // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
                 gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
                 utils.pause_on_failure(),
               ],
@@ -93,8 +93,8 @@ local deploy_pop_canary_job(region) =
     tasks: [
       gocdtasks.script(importstr '../bash/deploy-pop-canary.sh'),
       gocdtasks.script(importstr '../bash/wait-canary.sh'),
-      gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-      gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+      // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+      // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
       gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
       utils.pause_on_failure(),
     ],

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -31,8 +31,8 @@ local soak_time(region) =
               elastic_profile_id: 'relay',
               tasks: [
                 gocdtasks.script(importstr '../bash/wait-soak.sh'),
-                gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-                gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+                // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+                // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
                 gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
                 utils.pause_on_failure(),
               ],
@@ -93,8 +93,8 @@ local deploy_canary(region) =
               tasks: [
                 gocdtasks.script(importstr '../bash/deploy-processing-canary.sh'),
                 gocdtasks.script(importstr '../bash/wait-canary.sh'),
-                gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-                gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+                // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+                // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
                 gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
                 utils.pause_on_failure(),
               ],


### PR DESCRIPTION
These checks fail repeatedly with the following exception, preventing full Relay deploys.

```bash
urllib.error.URLError: <urlopen error [Errno 110] Connection timed out>
```

#skip-changelog