### PR TITLE
ref(gocd): Remove soon-to-be-removed monitors

### DIFF
--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -39,7 +39,7 @@ local soak_time(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
-                DATADOG_MONITOR_IDS: '22592147 27804625 22634395 22635255',
+                DATADOG_MONITOR_IDS: '27804625 22634395 22635255',
                 // Sentry projects to check for errors <project_id>:<project_slug>:<service>
                 SENTRY_PROJECTS: if region == 's4s' then '1513938:sentry-for-sentry:relay' else '9:pop-relay:relay-pop 4:relay:relay',
                 SENTRY_SINGLE_TENANT: if region == 's4s' then 'true' else 'false',
@@ -79,7 +79,7 @@ local deploy_pop_canary_job(region) =
       DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
       DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
       // Datadog monitor IDs for the canary deployment
-      DATADOG_MONITOR_IDS: '22592147 27804625 22634395 22635255',
+      DATADOG_MONITOR_IDS: '27804625 22634395 22635255',
       // Sentry projects to check for errors <project_id>:<project_slug>:<service>
       SENTRY_PROJECTS: '9:pop-relay:relay-pop 4:relay:relay',
       SENTRY_SINGLE_TENANT: 'false',

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -17,7 +17,7 @@ local soak_time(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
-                DATADOG_MONITOR_IDS: '14146876 137619914 14030245',
+                DATADOG_MONITOR_IDS: '14146876 137619914',
                 // Sentry projects to check for errors <project_id>:<project_slug>:<service>
                 SENTRY_PROJECTS: if region == 's4s' then '1513938:sentry-for-sentry:relay' else '4:relay:relay 9:pop-relay:relay-pop',
                 SENTRY_SINGLE_TENANT: if region == 's4s' then 'true' else 'false',
@@ -79,7 +79,7 @@ local deploy_canary(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the canary deployment
-                DATADOG_MONITOR_IDS: '14146876 137619914 14030245',
+                DATADOG_MONITOR_IDS: '14146876 137619914',
                 // Sentry projects to check for errors <project_id>:<project_slug>:<service>
                 SENTRY_PROJECTS: '4:relay:relay 9:pop-relay:relay-pop',
                 SENTRY_SINGLE_TENANT: 'false',


### PR DESCRIPTION
These monitors will be removed in https://github.com/getsentry/datadog-terraform/pull/117. GoCD will pause the deployment when checking for a monitor that doesn't exist.

#skip-changelog