### PR TITLE
ci(ci): Skip unused build steps in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - release-library/**
 
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - release-library/**
 
   pull_request:
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,16 +186,23 @@ jobs:
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"
 
     env:
-      RUN_ALL: "${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-Build') }}"
+      FULL_CI: "${{
+        github.ref == 'refs/heads/master'
+        || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
+      }}"
 
     steps:
       - id: set-outputs
         run: |
-          echo $RUN_ALL
-
-          echo 'image_names=["relay", "relay-pop"]' >> $GITHUB_OUTPUT
-          echo "targets=[x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]" >> $GITHUB_OUTPUT
-
+          if [[ "$FULL_CI" == "true" ]]; then
+            echo "Running full CI"
+            echo 'image_names=["relay", "relay-pop"]' >> $GITHUB_OUTPUT
+            echo 'targets=["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]' >> $GITHUB_OUTPUT
+          else
+            echo "Skipping some CI steps"
+            echo 'image_names=["relay"]' >> $GITHUB_OUTPUT
+            echo 'targets=["x86_64-unknown-linux-gnu"]' >> $GITHUB_OUTPUT
+          fi
     outputs:
       image_names: "${{ steps.set-outputs.outputs.image_names }}"
       targets: "${{ steps.set-outputs.outputs.targets }}"
@@ -277,14 +284,14 @@ jobs:
 
   build-docker:
     timeout-minutes: 5
-    needs: build
+    needs: [build-setup, build]
 
     name: Build Docker Image
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        image_name: [relay, relay-pop]
+        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
 
     env:
       PLATFORMS: "linux/amd64,linux/arm64"
@@ -315,7 +322,7 @@ jobs:
             --push .
 
   publish-to-dockerhub:
-    needs: build-docker
+    needs: [build-setup, build-docker]
 
     runs-on: ubuntu-20.04
     name: Publish Relay to DockerHub
@@ -356,14 +363,14 @@ jobs:
 
   publish-to-gcr:
     timeout-minutes: 5
-    needs: build-docker
+    needs: [build-setup, build-docker]
 
     name: Publish Relay to GCR
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        image_name: [relay, relay-pop]
+        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
 
     # required for google auth
     permissions:
@@ -413,14 +420,14 @@ jobs:
 
   gocd-artifacts:
     timeout-minutes: 5
-    needs: build-docker
+    needs: [build-setup, build-docker]
 
     name: Upload build artifacts to gocd
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        image_name: [relay, relay-pop]
+        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
 
     # required for google auth
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,36 @@ jobs:
       - name: Run Python Tests
         run: pytest -v py
 
+  build-setup:
+    name: Setup build metadata
+    runs-on: ubuntu-latest
+
+    if: "!startsWith(github.ref, 'refs/heads/release-library/')"
+
+    env:
+      RUN_ALL: "${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-Build') }}"
+
+    steps:
+      - id: set-outputs
+        run: |
+          echo $RUN_ALL
+
+          echo 'image_names=["relay", "relay-pop"]' >> $GITHUB_OUTPUT
+          echo "targets=[x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]" >> $GITHUB_OUTPUT
+
+    outputs:
+      image_names: "${{ steps.set-outputs.outputs.image_names }}"
+      targets: "${{ steps.set-outputs.outputs.targets }}"
+
+
   build:
+    needs: build-setup
     timeout-minutes: 30
+
     strategy:
       matrix:
-        image_name: [relay, relay-pop]
-        target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
+        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
+        target: ${{ fromJson(needs.build-setup.outputs.targets ) }}
 
     name: Build Relay Binary
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,19 +194,24 @@ jobs:
     steps:
       - id: set-outputs
         run: |
+          echo "full_ci=$FULL_CI" >> $GITHUB_OUTPUT
+
           if [[ "$FULL_CI" == "true" ]]; then
             echo "Running full CI"
             echo 'image_names=["relay", "relay-pop"]' >> $GITHUB_OUTPUT
             echo 'targets=["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]' >> $GITHUB_OUTPUT
+            echo 'platforms=["linux/amd64","linux/arm64"]' >> $GITHUB_OUTPUT
           else
             echo "Skipping some CI steps"
             echo 'image_names=["relay"]' >> $GITHUB_OUTPUT
             echo 'targets=["x86_64-unknown-linux-gnu"]' >> $GITHUB_OUTPUT
+            echo 'platforms=["linux/amd64"]' >> $GITHUB_OUTPUT
           fi
     outputs:
       image_names: "${{ steps.set-outputs.outputs.image_names }}"
       targets: "${{ steps.set-outputs.outputs.targets }}"
-
+      platforms: "${{ steps.set-outputs.outputs.platforms }}"
+      full_ci: "${{ steps.set-outputs.outputs.full_ci }}"
 
   build:
     needs: build-setup
@@ -215,7 +220,7 @@ jobs:
     strategy:
       matrix:
         image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
-        target: ${{ fromJson(needs.build-setup.outputs.targets ) }}
+        target: ${{ fromJson(needs.build-setup.outputs.targets) }}
 
     name: Build Relay Binary
     runs-on: ubuntu-latest
@@ -294,7 +299,7 @@ jobs:
         image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
 
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
+      PLATFORMS: "${{ join(fromJSON(needs.build-setup.outputs.platforms), ',') }}"
       DOCKER_IMAGE: "ghcr.io/getsentry/${{ matrix.image_name }}"
       REVISION: "${{ github.event.pull_request.head.sha || github.sha }}"
 
@@ -384,7 +389,7 @@ jobs:
 
     # Skip redundant checks for library releases
     # Skip for dependabot and if run on a fork
-    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && "
 
     steps:
       - name: Install cosign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
       - release-library/**
 
   pull_request:
-    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
 
     # Skip redundant checks for library releases
     # Skip for dependabot and if run on a fork
-    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && "
+    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     steps:
       - name: Install cosign
@@ -443,7 +443,7 @@ jobs:
       GHCR_DOCKER_IMAGE: "ghcr.io/getsentry/${{ matrix.image_name }}"
       REVISION: "${{ github.event.pull_request.head.sha || github.sha }}"
 
-    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     steps:
       - name: Google Auth


### PR DESCRIPTION
PRs by default do no longer publish artifacts to gocd and gcr and only build the relay docker image for the `linux/amd64` platform (required for Sentry integration tests).

All steps still run on master, a PR can opt in to run the full CI by setting the `Trigger: Full-CI` label, it will re-run CI will all steps.

#skip-changelog