### PR TITLE
fix(spans): Normalize segment span ID

### DIFF
--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -65,11 +65,12 @@ fn otel_value_to_string(value: OtelValue) -> Option<String> {
 }
 
 fn otel_value_to_span_id(value: OtelValue) -> Option<String> {
-    match value {
-        OtelValue::StringValue(s) => Some(s),
-        OtelValue::BytesValue(b) => Some(hex::encode(b)),
-        _ => None,
-    }
+    let decoded = match value {
+        OtelValue::StringValue(s) => hex::decode(s).ok()?,
+        OtelValue::BytesValue(b) => b,
+        _ => None?,
+    };
+    Some(hex::encode(decoded))
 }
 
 fn otel_value_to_metric_summary(value: AnyValue) -> Option<MetricSummary> {
@@ -191,7 +192,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
                     segment_id = otel_value_to_span_id(value);
                 }
                 "sentry.profile.id" => {
-                    profile_id = otel_value_to_span_id(value);
+                    profile_id = otel_value_to_string(value);
                 }
                 other => {
                     if let Some(metric_name) = other.strip_prefix("sentry.metrics_summary.") {
@@ -521,7 +522,7 @@ mod tests {
                 {
                     "key" : "sentry.segment.id",
                     "value": {
-                        "stringValue": "fa90fdead5f74052"
+                        "stringValue": "FA90FDEAD5F74052"
                     }
                 },
                 {
@@ -690,5 +691,14 @@ mod tests {
             other: {},
         }
         "###);
+    }
+
+    #[test]
+    fn uppercase_span_id() {
+        let input = OtelValue::StringValue("FA90FDEAD5F74052".to_owned());
+        assert_eq!(
+            otel_value_to_span_id(input).as_deref(),
+            Some("fa90fdead5f74052")
+        );
     }
 }


### PR DESCRIPTION
`SpanId` is represented as a string internally, so if we construct it without going through `Annotated::from_value`, lowercase span IDs and uppercase span IDs will be treated as different. This is problematic in `set_segment_attributes`, which compares the span's ID to its segment ID.

We should probably represent `SpanId` as `[u8; 8]`, or at least go through `Annotated::from_value` for all Otel types, but this PR should do as a quick fix.

#skip-changelog