### PR TITLE
feat(spans): Use zero-padded span ID as event ID

### DIFF
--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -15,8 +15,8 @@ use crate::protocol::{
     AppContext, Breadcrumb, Breakdowns, BrowserContext, ClientSdkInfo, Contexts, Csp, DebugMeta,
     DefaultContext, DeviceContext, EventType, Exception, ExpectCt, ExpectStaple, Fingerprint, Hpkp,
     LenientString, Level, LogEntry, Measurements, Metrics, MetricsSummary, OsContext,
-    ProfileContext, RelayInfo, Request, ResponseContext, Span, Stacktrace, Tags, TemplateInfo,
-    Thread, Timestamp, TraceContext, TransactionInfo, User, Values,
+    ProfileContext, RelayInfo, Request, ResponseContext, Span, SpanId, Stacktrace, Tags,
+    TemplateInfo, Thread, Timestamp, TraceContext, TransactionInfo, User, Values,
 };
 
 /// Wrapper around a UUID with slightly different formatting.
@@ -64,6 +64,16 @@ impl FromStr for EventId {
 }
 
 relay_common::impl_str_serde!(EventId, "an event identifier");
+
+impl TryFrom<&SpanId> for EventId {
+    type Error = ();
+
+    fn try_from(value: &SpanId) -> Result<Self, Self::Error> {
+        // TODO: Represent SpanId as bytes / u64 so we can call `Uuid::from_u64_pair`.
+        let s = format!("0000000000000000{value}");
+        s.parse().map_err(|_| ())
+    }
+}
 
 #[derive(Debug, FromValue, IntoValue, ProcessValue, Empty, Clone, PartialEq)]
 pub struct ExtraValue(#[metastructure(max_depth = 7, max_bytes = 16_384)] pub Value);

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -66,12 +66,12 @@ impl FromStr for EventId {
 relay_common::impl_str_serde!(EventId, "an event identifier");
 
 impl TryFrom<&SpanId> for EventId {
-    type Error = ();
+    type Error = <EventId as FromStr>::Err;
 
     fn try_from(value: &SpanId) -> Result<Self, Self::Error> {
         // TODO: Represent SpanId as bytes / u64 so we can call `Uuid::from_u64_pair`.
         let s = format!("0000000000000000{value}");
-        s.parse().map_err(|_| ())
+        s.parse()
     }
 }
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -16,7 +16,7 @@ use relay_event_normalization::{
     PerformanceScoreConfig, RawUserAgentInfo, TransactionsProcessor,
 };
 use relay_event_schema::processor::{process_value, ProcessingState};
-use relay_event_schema::protocol::{BrowserContext, Contexts, Event, EventId, Span, SpanData};
+use relay_event_schema::protocol::{BrowserContext, Contexts, Event, Span, SpanData};
 use relay_log::protocol::{Attachment, AttachmentType};
 use relay_metrics::{aggregator::AggregatorConfig, MetricNamespace, UnixTimestamp};
 use relay_pii::PiiProcessor;
@@ -194,7 +194,7 @@ pub fn process(
     });
 
     let mut transaction_count = 0;
-    for mut transaction in extracted_transactions {
+    for transaction in extracted_transactions {
         // Enqueue a full processing request for every extracted transaction item.
         match Envelope::try_from_event(state.envelope().headers().clone(), transaction) {
             Ok(mut envelope) => {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -195,9 +195,6 @@ pub fn process(
 
     let mut transaction_count = 0;
     for mut transaction in extracted_transactions {
-        // Give each transaction event a new random ID:
-        transaction.id = EventId::new().into();
-
         // Enqueue a full processing request for every extracted transaction item.
         match Envelope::try_from_event(state.envelope().headers().clone(), transaction) {
             Ok(mut envelope) => {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -606,6 +606,11 @@ def test_span_ingestion(
         ]
 
         assert len(transactions) == expected_transactions
+        assert sorted([transaction["event_id"] for transaction in transactions]) == [
+            "0000000000000000a342abb1214ca181",
+            "0000000000000000b0429c44b67a3eb1",
+            "0000000000000000d342abb1214ca182",
+        ]
         for transaction in transactions:
             # Not checking all individual fields here, most should be tested in convert.rs
 


### PR DESCRIPTION
For events created from segment spans, deterministically map the span ID to an event ID.

Options:

- [chosen] Pad span ID with zeros. This still leaves `2^64 == 18,446,744,073,709,551,616` combinations so should be good enough to prevent collisions within a project.
- XOR span ID with the trace ID. This might be a better alternative if collisions are an issue, but makes it harder to spot a span-ID-turned-event-ID with the naked eye.
- [rejected] Create a UUID v5 from a namespace (as we do [here](https://github.com/getsentry/relay/blob/c81f37f4d55e45c94cc344d145b151cced609e5f/relay-monitors/src/lib.rs#L212-L215)). Discarded because it is not reversible.

#skip-changelog