### PR TITLE
fix(normalization): Consider feature flag for event deserialization

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1409,7 +1409,11 @@ impl EnvelopeProcessorService {
             unreal::expand(state, &self.inner.config)?;
         });
 
-        event::extract(state, &self.inner.config)?;
+        event::extract(
+            state,
+            &self.inner.config,
+            &self.inner.global_config.current(),
+        )?;
 
         if_processing!(self.inner.config, {
             unreal::process(state)?;
@@ -1444,7 +1448,11 @@ impl EnvelopeProcessorService {
         state: &mut ProcessEnvelopeState<TransactionGroup>,
     ) -> Result<(), ProcessingError> {
         profile::filter(state);
-        event::extract(state, &self.inner.config)?;
+        event::extract(
+            state,
+            &self.inner.config,
+            &self.inner.global_config.current(),
+        )?;
         profile::transfer_id(state);
 
         if_processing!(self.inner.config, {

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -40,6 +40,7 @@ use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
 pub fn extract<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
     config: &Config,
+    global_config: &GlobalConfig,
 ) -> Result<(), ProcessingError> {
     let envelope = &mut state.envelope_mut();
 
@@ -67,6 +68,13 @@ pub fn extract<G: EventProcessing>(
         return Err(ProcessingError::DuplicateItem(duplicate.ty().clone()));
     }
 
+    let is_normalization_enabled =
+        if config.processing_enabled() && global_config.options.processing_disable_normalization {
+            false
+        } else {
+            config.normalization_level().is_enabled()
+        };
+
     let mut sample_rates = None;
     let (event, event_len) = if let Some(mut item) = event_item.or(security_item) {
         relay_log::trace!("processing json event");
@@ -76,7 +84,7 @@ pub fn extract<G: EventProcessing>(
             // Event items can never include transactions, so retain the event type and let
             // inference deal with this during normalization.
             if let Some(event) = annotated_event.value_mut() {
-                if config.normalization_level().is_enabled() {
+                if is_normalization_enabled {
                     event.ty.set_value(None);
                 }
             }

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1530,3 +1530,54 @@ def test_error_with_type_transaction_fixed_by_inference(
     ingested, _ = events_consumer.get_event(timeout=7)
     assert ingested["type"] == "error"
     events_consumer.assert_empty()
+
+
+@pytest.mark.parametrize("processing_disable_normalization", [False, True])
+def test_error_with_type_transaction_fixed_by_inference_even_if_only_feature_flags(
+    mini_sentry,
+    events_consumer,
+    relay_with_processing,
+    relay,
+    relay_credentials,
+    processing_disable_normalization,
+):
+    """
+    Ensure Relay sets the correct type for bogus payloads of errors with
+    `type=transaction` some clients send, even if configured by feature flags
+    and not static config.
+    """
+    project_id = 42
+    mini_sentry.add_basic_project_config(project_id)
+    events_consumer = events_consumer()
+
+    if processing_disable_normalization:
+        mini_sentry.global_config["options"] = {
+            "relay.disable_normalization.processing": True,
+        }
+
+    credentials = relay_credentials()
+    processing = relay_with_processing(
+        static_relays={
+            credentials["id"]: {
+                "public_key": credentials["public_key"],
+                "internal": True,
+            },
+        },
+        # normalization.level == 'default'
+    )
+    relay = relay(
+        processing,
+        credentials=credentials,
+        # normalization.level == 'default'
+    )
+
+    bogus_error = make_error({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    bogus_error["type"] = "transaction"
+    envelope = Envelope()
+    envelope.add_event(bogus_error)
+
+    relay.send_envelope(project_id, envelope)
+
+    ingested, _ = events_consumer.get_event(timeout=7)
+    assert ingested["type"] == "error"
+    events_consumer.assert_empty()


### PR DESCRIPTION
https://github.com/getsentry/relay/commit/b74053c53983aeaa3a5c12dd75e25f85742e39e1 added feature flags to control the normalization of Relay. However, resetting the event.type during deserialization wasn't updated and only depended on the static config, ignoring the feature flag that overrides it. This PR fixes that by prioritizing the feature flag during deserialization.

#skip-changelog