### PR TITLE
feat(metrics): Emit negative outcomes when namespaces are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Collect `enviornment` tag as part of exclusive_time_light for cache spans. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Emit negative outcomes for denied metrics. ([#3508](https://github.com/getsentry/relay/pull/3508))
+- Emit negative outcomes when metrics are rejected because of a disabled namespace. ([#3544](https://github.com/getsentry/relay/pull/3544))
 
 ## 24.4.2
 

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -39,6 +39,9 @@ pub enum FilterStatKey {
     /// Filtered due to name being denied.
     DeniedName,
 
+    /// Filtered due to the namespace being disabled.
+    DisabledNamespace,
+
     /// Filtered due to a generic filter.
     GenericFilter(String),
 }
@@ -69,6 +72,7 @@ impl FilterStatKey {
             FilterStatKey::InvalidCsp => "invalid-csp",
             FilterStatKey::FilteredTransactions => "filtered-transaction",
             FilterStatKey::DeniedName => "denied-name",
+            FilterStatKey::DisabledNamespace => "disabled-namespace",
             FilterStatKey::GenericFilter(filter_identifier) => {
                 return Cow::Owned(filter_identifier);
             }


### PR DESCRIPTION
This PR implements negative outcomes for metrics that are rejected due to disabled namespace.

Closes: https://github.com/getsentry/relay/issues/3532