### PR TITLE
ref(integration-tests): Remove generators from consumer integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Collect `enviornment` tag as part of exclusive_time_light for cache spans. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Emit negative outcomes for denied metrics. ([#3508](https://github.com/getsentry/relay/pull/3508))
+- Remove generators from consumers in integration tests ([#3545](https://github.com/getsentry/relay/pull/3545))
 
 ## 24.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Extract `cache.item_size` from measurements instead of data. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Collect `enviornment` tag as part of exclusive_time_light for cache spans. ([#3510](https://github.com/getsentry/relay/pull/3510))
 - Emit negative outcomes for denied metrics. ([#3508](https://github.com/getsentry/relay/pull/3508))
-- Remove generators from consumers in integration tests ([#3545](https://github.com/getsentry/relay/pull/3545))
 
 ## 24.4.2
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -355,14 +355,18 @@ class MetricsConsumer(ConsumerBase):
         return json.loads(message.value()), message.headers()
 
     def get_metrics(self, timeout=None, max_attempts=100):
+        metrics = []
+
         for _ in range(max_attempts):
             message = self.poll(timeout=timeout)
 
             if message is None:
-                return
+                break
             else:
                 assert message.error() is None
-                yield json.loads(message.value()), message.headers()
+                metrics.append((json.loads(message.value()), message.headers()))
+
+        return metrics
 
 
 class SessionsConsumer(ConsumerBase):
@@ -493,14 +497,18 @@ class SpansConsumer(ConsumerBase):
         return json.loads(message.value())
 
     def get_spans(self, timeout=None, max_attempts=100):
+        spans = []
+
         for _ in range(max_attempts):
             message = self.poll(timeout=timeout)
 
             if message is None:
-                return
+                break
             else:
                 assert message.error() is None
-                yield json.loads(message.value())
+                spans.append(json.loads(message.value()))
+
+        return spans
 
 
 class ProfileConsumer(ConsumerBase):
@@ -521,14 +529,18 @@ class MetricsSummariesConsumer(ConsumerBase):
         return json.loads(message.value())
 
     def get_metrics_summaries(self, timeout=None, max_attempts=100):
+        metrics_summaries = []
+
         for _ in range(max_attempts):
             message = self.poll(timeout=timeout)
 
             if message is None:
-                return
+                break
             else:
                 assert message.error() is None
-                yield json.loads(message.value())
+                metrics_summaries.append(json.loads(message.value()))
+
+        return metrics_summaries
 
 
 class CogsConsumer(ConsumerBase):

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1550,7 +1550,7 @@ def test_span_metrics_secondary_aggregator(
     )
     processing.send_transaction(project_id, transaction)
 
-    metrics = list(metrics_consumer.get_metrics())
+    metrics = metrics_consumer.get_metrics()
 
     # Transaction metrics are still aggregated:
     assert all([m[0]["name"].startswith("spans", 2) for m in metrics])

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -200,10 +200,10 @@ def test_span_extraction_with_sampling(
 
     relay.send_event(project_id, event)
 
-    spans = list(spans_consumer.get_spans(max_attempts=2))
+    spans = spans_consumer.get_spans(max_attempts=2)
     assert len(spans) == expected_spans
 
-    metrics = list(metrics_consumer.get_metrics())
+    metrics = metrics_consumer.get_metrics()
     span_metrics = [m for (m, _) in metrics if ":spans/" in m["name"]]
     assert len(span_metrics) == expected_metrics
 
@@ -482,7 +482,7 @@ def test_span_ingestion(
         headers={"Content-Type": "application/x-protobuf"},
     )
 
-    spans = list(spans_consumer.get_spans(timeout=10.0, max_attempts=6))
+    spans = spans_consumer.get_spans(timeout=10.0, max_attempts=6)
 
     for span in spans:
         span.pop("received", None)
@@ -1120,7 +1120,7 @@ def test_span_reject_invalid_timestamps(
     )
     relay.send_envelope(project_id, envelope)
 
-    spans = list(spans_consumer.get_spans(timeout=10.0, max_attempts=1))
+    spans = spans_consumer.get_spans(timeout=10.0, max_attempts=1)
 
     assert len(spans) == 1
     assert spans[0]["description"] == "span with valid timestamps"
@@ -1246,7 +1246,7 @@ def test_span_ingestion_with_performance_scores(
     )
     relay.send_envelope(project_id, envelope)
 
-    spans = list(spans_consumer.get_spans(timeout=10.0, max_attempts=2))
+    spans = spans_consumer.get_spans(timeout=10.0, max_attempts=2)
 
     for span in spans:
         span.pop("received", None)
@@ -1358,7 +1358,7 @@ def test_rate_limit_indexed_consistent(
 
     # First batch passes
     relay.send_envelope(project_id, envelope)
-    spans = list(spans_consumer.get_spans(max_attempts=4, timeout=10))
+    spans = spans_consumer.get_spans(max_attempts=4, timeout=10)
     assert len(spans) == 4
     assert summarize_outcomes() == {(16, 0): 4}  # SpanIndexed, Accepted
 
@@ -1420,14 +1420,14 @@ def test_rate_limit_indexed_consistent_extracted(
 
     # First send should be accepted.
     relay.send_event(project_id, event)
-    spans = list(spans_consumer.get_spans(max_attempts=2, timeout=10))
+    spans = spans_consumer.get_spans(max_attempts=2, timeout=10)
     # one for the transaction, one for the contained span
     assert len(spans) == 2
     assert summarize_outcomes() == {(16, 0): 2}  # SpanIndexed, Accepted
 
     # Second send should be rejected immediately.
     relay.send_event(project_id, event)
-    spans = list(spans_consumer.get_spans(max_attempts=1, timeout=2))
+    spans = spans_consumer.get_spans(max_attempts=1, timeout=2)
     assert len(spans) == 0  # all rejected
     assert summarize_outcomes() == {(16, 2): 2}  # SpanIndexed, RateLimited
 
@@ -1477,9 +1477,9 @@ def test_rate_limit_metrics_consistent(
 
     # First batch passes (we over-accept once)
     relay.send_envelope(project_id, envelope)
-    spans = list(spans_consumer.get_spans(max_attempts=4, timeout=10))
+    spans = spans_consumer.get_spans(max_attempts=4, timeout=10)
     assert len(spans) == 4
-    metrics = list(metrics_consumer.get_metrics())
+    metrics = metrics_consumer.get_metrics()
     assert len(metrics) > 0
     assert all(headers == [("namespace", b"spans")] for _, headers in metrics), metrics
 
@@ -1488,9 +1488,9 @@ def test_rate_limit_metrics_consistent(
 
     # Second batch is limited
     relay.send_envelope(project_id, envelope)
-    spans = list(spans_consumer.get_spans(max_attempts=1, timeout=2))
+    spans = spans_consumer.get_spans(max_attempts=1, timeout=2)
     assert len(spans) == 0
-    metrics = list(metrics_consumer.get_metrics())
+    metrics = metrics_consumer.get_metrics()
     assert len(metrics) == 0
     assert summarize_outcomes() == {
         (16, 2): 4,  # SpanIndexed, RateLimited


### PR DESCRIPTION
This PR removes the use of generators in integration tests utilities, since it's very easy to fall in the mistake of asserting the result of a generator which would lead to a true value since a function that has `yield` is guaranteed to always return a generator instance.

Closes: https://github.com/getsentry/relay/issues/3546

#skip-changelog