### PR TITLE
ref(metrics): Use separate merge bucket message for project

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -32,9 +32,7 @@ use relay_event_schema::protocol::{
 };
 use relay_filter::FilterStatKey;
 use relay_metrics::aggregator::AggregatorConfig;
-use relay_metrics::{
-    Bucket, BucketMetadata, BucketView, BucketsView, MergeBuckets, MetricMeta, MetricNamespace,
-};
+use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricMeta, MetricNamespace};
 use relay_pii::PiiConfigError;
 use relay_profiling::ProfileId;
 use relay_protocol::{Annotated, Value};
@@ -56,7 +54,7 @@ use {
         CardinalityLimit, CardinalityLimiter, RedisSetLimiter, RedisSetLimiterOptions,
     },
     relay_dynamic_config::{CardinalityLimiterMode, GlobalConfig, MetricExtractionGroups},
-    relay_metrics::{Aggregator, RedisMetricMetaStore},
+    relay_metrics::{Aggregator, MergeBuckets, RedisMetricMetaStore},
     relay_quotas::{Quota, RateLimitingError, RedisRateLimiter},
     relay_redis::RedisPool,
     std::iter::Chain,
@@ -76,7 +74,9 @@ use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::event::FiltersStatus;
 use crate::services::project::ProjectState;
-use crate::services::project_cache::{AddMetricMeta, ProjectCache, UpdateRateLimits};
+use crate::services::project_cache::{
+    AddMetricBuckets, AddMetricMeta, ProjectCache, UpdateRateLimits,
+};
 use crate::services::test_store::{Capture, TestStore};
 use crate::services::upstream::{
     SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
@@ -556,7 +556,10 @@ impl ExtractedMetrics {
         let project_key = envelope.meta().public_key();
 
         if !self.project_metrics.is_empty() {
-            project_cache.send(MergeBuckets::new(project_key, self.project_metrics));
+            project_cache.send(AddMetricBuckets {
+                project_key,
+                buckets: self.project_metrics,
+            });
         }
 
         if !self.sampling_metrics.is_empty() {
@@ -567,10 +570,10 @@ impl ExtractedMetrics {
             // dependent_project_with_tracing  -> metrics goes to root
             // root_project_with_tracing       -> metrics goes to root == self
             let sampling_project_key = utils::get_sampling_key(envelope).unwrap_or(project_key);
-            project_cache.send(MergeBuckets::new(
-                sampling_project_key,
-                self.sampling_metrics,
-            ));
+            project_cache.send(AddMetricBuckets {
+                project_key: sampling_project_key,
+                buckets: self.sampling_metrics,
+            });
         }
     }
 }
@@ -1831,7 +1834,7 @@ impl EnvelopeProcessorService {
     fn handle_process_metrics(&self, cogs: &mut Token, message: ProcessMetrics) {
         let ProcessMetrics {
             items,
-            project_key: public_key,
+            project_key,
             start_time,
             sent_at,
             keep_metadata,
@@ -1896,10 +1899,10 @@ impl EnvelopeProcessorService {
         cogs.update(relay_metrics::cogs::BySize(&buckets));
 
         relay_log::trace!("merging metric buckets into project cache");
-        self.inner
-            .addrs
-            .project_cache
-            .send(MergeBuckets::new(public_key, buckets));
+        self.inner.addrs.project_cache.send(AddMetricBuckets {
+            project_key,
+            buckets,
+        });
     }
 
     fn handle_process_batched_metrics(&self, cogs: &mut Token, message: ProcessBatchedMetrics) {
@@ -1932,7 +1935,7 @@ impl EnvelopeProcessorService {
         };
 
         let mut feature_weights = FeatureWeights::none();
-        for (public_key, mut buckets) in buckets {
+        for (project_key, mut buckets) in buckets {
             if buckets.is_empty() {
                 continue;
             }
@@ -1947,10 +1950,10 @@ impl EnvelopeProcessorService {
             feature_weights = feature_weights.merge(relay_metrics::cogs::BySize(&buckets).into());
 
             relay_log::trace!("merging metric buckets into project cache");
-            self.inner
-                .addrs
-                .project_cache
-                .send(MergeBuckets::new(public_key, buckets));
+            self.inner.addrs.project_cache.send(AddMetricBuckets {
+                project_key,
+                buckets,
+            });
         }
 
         if !feature_weights.is_empty() {

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -7,7 +7,7 @@ use crate::metric_stats::MetricStats;
 use hashbrown::HashSet;
 use relay_base_schema::project::ProjectKey;
 use relay_config::{Config, RelayMode};
-use relay_metrics::{Aggregator, FlushBuckets, MergeBuckets, MetricMeta};
+use relay_metrics::{Aggregator, Bucket, FlushBuckets, MetricMeta};
 use relay_quotas::RateLimits;
 use relay_redis::RedisPool;
 use relay_statsd::metric;
@@ -171,6 +171,18 @@ impl UpdateRateLimits {
     }
 }
 
+/// Add metric buckets to the project.
+///
+/// Metric buckets added via the project are filtered and rate limited
+/// according to the project state.
+///
+/// Adding buckets directly to the aggregator bypasses all of these checks.
+#[derive(Debug)]
+pub struct AddMetricBuckets {
+    pub project_key: ProjectKey,
+    pub buckets: Vec<Bucket>,
+}
+
 /// Add metric metadata to the aggregator.
 #[derive(Debug)]
 pub struct AddMetricMeta {
@@ -215,7 +227,7 @@ pub struct RefreshIndexCache(pub HashSet<QueueKey>);
 /// information.
 ///
 /// There are also higher-level operations, such as [`CheckEnvelope`] and [`ValidateEnvelope`] that
-/// inspect contents of envelopes for ingestion, as well as [`MergeBuckets`] to aggregate metrics
+/// inspect contents of envelopes for ingestion, as well as [`AddMetricBuckets`] to aggregate metrics
 /// associated with a project.
 ///
 /// See the enumerated variants for a full list of available messages for this service.
@@ -229,7 +241,7 @@ pub enum ProjectCache {
     ),
     ValidateEnvelope(ValidateEnvelope),
     UpdateRateLimits(UpdateRateLimits),
-    MergeBuckets(MergeBuckets),
+    AddMetricBuckets(AddMetricBuckets),
     AddMetricMeta(AddMetricMeta),
     FlushBuckets(FlushBuckets),
     UpdateSpoolIndex(UpdateSpoolIndex),
@@ -246,7 +258,7 @@ impl ProjectCache {
             Self::CheckEnvelope(_, _) => "CheckEnvelope",
             Self::ValidateEnvelope(_) => "ValidateEnvelope",
             Self::UpdateRateLimits(_) => "UpdateRateLimits",
-            Self::MergeBuckets(_) => "MergeBuckets",
+            Self::AddMetricBuckets(_) => "AddMetricBuckets",
             Self::AddMetricMeta(_) => "AddMetricMeta",
             Self::FlushBuckets(_) => "FlushBuckets",
             Self::UpdateSpoolIndex(_) => "UpdateSpoolIndex",
@@ -328,11 +340,11 @@ impl FromMessage<UpdateRateLimits> for ProjectCache {
     }
 }
 
-impl FromMessage<MergeBuckets> for ProjectCache {
+impl FromMessage<AddMetricBuckets> for ProjectCache {
     type Response = relay_system::NoResponse;
 
-    fn from_message(message: MergeBuckets, _: ()) -> Self {
-        Self::MergeBuckets(message)
+    fn from_message(message: AddMetricBuckets, _: ()) -> Self {
+        Self::AddMetricBuckets(message)
     }
 }
 
@@ -809,21 +821,21 @@ impl ProjectCacheBroker {
             .merge_rate_limits(message.rate_limits);
     }
 
-    fn handle_merge_buckets(&mut self, message: MergeBuckets) {
+    fn handle_add_metric_buckets(&mut self, message: AddMetricBuckets) {
         let project_cache = self.services.project_cache.clone();
         let aggregator = self.services.aggregator.clone();
         let outcome_aggregator = self.services.outcome_aggregator.clone();
         let envelope_processor = self.services.envelope_processor.clone();
         let metric_stats = self.metric_stats.clone();
 
-        let project = self.get_or_create_project(message.project_key());
+        let project = self.get_or_create_project(message.project_key);
         project.prefetch(project_cache, false);
         project.merge_buckets(
             aggregator,
             outcome_aggregator,
             envelope_processor,
             metric_stats,
-            message.buckets(),
+            message.buckets,
         );
     }
 
@@ -985,7 +997,9 @@ impl ProjectCacheBroker {
                         self.handle_validate_envelope(message)
                     }
                     ProjectCache::UpdateRateLimits(message) => self.handle_rate_limits(message),
-                    ProjectCache::MergeBuckets(message) => self.handle_merge_buckets(message),
+                    ProjectCache::AddMetricBuckets(message) => {
+                        self.handle_add_metric_buckets(message)
+                    }
                     ProjectCache::AddMetricMeta(message) => self.handle_add_metric_meta(message),
                     ProjectCache::FlushBuckets(message) => self.handle_flush_buckets(message),
                     ProjectCache::UpdateSpoolIndex(message) => self.handle_buffer_index(message),


### PR DESCRIPTION
Separates the aggregator from the project message to reduce confusion. One validates and filters all inserts, the other bypasses all checks.

In a followup I'll add additional conditional validation which is *not* required when sending messages to the aggregator.

#skip-changelog