### PR TITLE
chore(self-hosted): Mark e2e test check as required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,8 +592,6 @@ jobs:
   self-hosted-end-to-end:
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    # temporary, remove once we are confident the action is working
-    continue-on-error: true
     needs: build-docker
 
     # Skip redundant checks for library releases


### PR DESCRIPTION
It's been in CI for a week and it looks like it's working as intended with no flakes.
#skip-changelog