### PR TITLE
ref(metrics): Change MetricHour data category to MetricSecond

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Update data category metirc hours to metric seconds. [#3558](https://github.com/getsentry/relay/pull/3558)
+
 ## 0.8.60
 
 - Expose project config normalization. Drop support for `validate_project_config`. ([#3495](https://github.com/getsentry/relay/pull/3495))
@@ -15,7 +19,7 @@
 
 ## 0.8.57
 
-- Add a data category for metirc hours.  [#3384](https://github.com/getsentry/relay/pull/3384)
+- Add a data category for metirc hours. [#3384](https://github.com/getsentry/relay/pull/3384)
 
 ## 0.8.56
 
@@ -67,7 +71,6 @@
 ## 0.8.44
 
 - Add ability to block metrics matching a glob pattern. ([#2954](https://github.com/getsentry/relay/pull/2954))
-
 
 ## 0.8.43
 
@@ -158,10 +161,7 @@ This release requires Python 3.8 or later.
 - Add filter based on transaction names. ([#2118](https://github.com/getsentry/relay/pull/2118))
 - Add `lock` attribute to the frame protocol. ([#2171](https://github.com/getsentry/relay/pull/2171))
 
-
 ## 0.8.25
-
-
 
 ## 0.8.24
 

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -28,7 +28,7 @@ class DataCategory(IntEnum):
     SPAN_INDEXED = 16
     PROFILE_DURATION = 17
     PROFILE_CHUNK = 18
-    METRIC_HOUR = 19
+    METRIC_SECOND = 19
     UNKNOWN = -1
     # end generated
 

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -78,12 +78,12 @@ pub enum DataCategory {
     /// This is a count of profile chunks received. It will not be used for billing but will be
     /// useful for customers to track what's being dropped.
     ProfileChunk = 18,
-    /// MetricHour
+    /// MetricSecond
     ///
     /// Reserved by billing to summarize the bucketed product of metric volume
     /// and metric cardinality. Defined here so as not to clash with future
     /// categories.
-    MetricHour = 19,
+    MetricSecond = 19,
     //
     // IMPORTANT: After adding a new entry to DataCategory, go to the `relay-cabi` subfolder and run
     // `make header` to regenerate the C-binding. This allows using the data category from Python.
@@ -118,7 +118,7 @@ impl DataCategory {
             "span_indexed" => Self::SpanIndexed,
             "profile_duration" => Self::ProfileDuration,
             "profile_chunk" => Self::ProfileChunk,
-            "metric_hour" => Self::MetricHour,
+            "metric_second" => Self::MetricSecond,
             _ => Self::Unknown,
         }
     }
@@ -146,7 +146,7 @@ impl DataCategory {
             Self::SpanIndexed => "span_indexed",
             Self::ProfileDuration => "profile_duration",
             Self::ProfileChunk => "profile_chunk",
-            Self::MetricHour => "metric_hour",
+            Self::MetricSecond => "metric_second",
             Self::Unknown => "unknown",
         }
     }

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -121,13 +121,13 @@ enum RelayDataCategory {
    */
   RELAY_DATA_CATEGORY_PROFILE_CHUNK = 18,
   /**
-   * MetricHour
+   * MetricSecond
    *
    * Reserved by billing to summarize the bucketed product of metric volume
    * and metric cardinality. Defined here so as not to clash with future
    * categories.
    */
-  RELAY_DATA_CATEGORY_METRIC_HOUR = 19,
+  RELAY_DATA_CATEGORY_METRIC_SECOND = 19,
   /**
    * Any other data category not known by this Relay.
    */

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -195,7 +195,7 @@ impl CategoryUnit {
             | DataCategory::MetricBucket
             | DataCategory::UserReportV2
             | DataCategory::ProfileChunk
-            | DataCategory::MetricHour => Some(Self::Count),
+            | DataCategory::MetricSecond => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
             DataCategory::Session => Some(Self::Batched),
             DataCategory::ProfileDuration => Some(Self::Milliseconds),


### PR DESCRIPTION
A new DataCategory for METRIC_HOUR was added in [#3384](https://github.com/getsentry/relay/pull/3384) that revenue will use in future outcomes consumer that summarizes metric usage. It was determined that we will be storing usage based on second buckets instead of hour buckets, so we are updating the data category to reflect that. 

The data category is not being used in sentry/getsentry yet.

Relevant tech specs:

https://www.notion.so/sentry/Metric-Hour-Pricing-2817cfeb664b47418bc82b397638b75c
https://www.notion.so/sentry/Billing-for-Metrics-552b2f6dcf9b4bb48ae7732afd14ddc3