### PR TITLE
fix(server): Increase size limits for batch endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Forward `span.data` on the Kafka message. ([#3523](https://github.com/getsentry/relay/pull/3523))
 - Tag span duration metric like exclusive time. ([#3524](https://github.com/getsentry/relay/pull/3524))
 - Emit negative outcomes for denied metrics. ([#3508](https://github.com/getsentry/relay/pull/3508))
+- Increase size limits for internal batch endpoints. ([#3562](https://github.com/getsentry/relay/pull/3562))
 
 ## 24.4.2
 

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -36,6 +36,9 @@ use relay_config::Config;
 use crate::middlewares;
 use crate::service::ServiceState;
 
+/// Size limit for internal batch endpoints.
+const BATCH_JSON_BODY_LIMIT: usize = 50_000_000; // 50 MB
+
 #[rustfmt::skip]
 pub fn routes<B>(config: &Config) -> Router<ServiceState, B>
 where
@@ -69,7 +72,7 @@ where
     let batch_routes = Router::new()
         .route("/api/0/relays/outcomes/", post(batch_outcomes::handle))
         .route("/api/0/relays/metrics/", post(batch_metrics::handle))
-        .route_layer(DefaultBodyLimit::disable());
+        .route_layer(DefaultBodyLimit::max(BATCH_JSON_BODY_LIMIT));
 
     // Ingestion routes pointing to /api/:project_id/
     let store_routes = Router::new()


### PR DESCRIPTION
These endpoints receive large batches of JSON data from trusted sources. We started seeing some 4xx responses in S4S after switching to 60s bucketing for custom metrics.