### PR TITLE
feat(dynamic-sampling): Track metric every time a DSC is built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,6 +4157,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rust-embed",
+ "semver",
  "sentry_usage_accountant",
  "serde",
  "serde_bytes",
@@ -4570,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "sentry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ sentry-kafka-schemas = { version = "0.1.79", default-features = false }
 sentry-release-parser = { version = "1.3.2", default-features = false }
 sentry-types = "0.32.2"
 sentry_usage_accountant = { version = "0.1.0", default-features = false }
+semver = "1.0.23"
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde-transcode = "1.1.1"
 serde_bytes = "0.11"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -134,6 +134,7 @@ url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v5"] }
 zstd = { workspace = true, optional = true }
 axum-extra = { workspace = true, features = ["protobuf"] }
+semver = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ['test-util'] }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -653,6 +653,9 @@ pub enum RelayCounters {
     /// Counts how many transactions were created from segment spans.
     #[cfg(feature = "processing")]
     TransactionsFromSpans,
+    /// Counter for when the DSC is missing from an event that comes from an SDK that should support
+    /// it.
+    MissingDynamicSamplingContext,
 }
 
 impl CounterMetric for RelayCounters {
@@ -693,6 +696,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::DynamicSamplingDecision => "dynamic_sampling_decision",
             #[cfg(feature = "processing")]
             RelayCounters::TransactionsFromSpans => "transactions_from_spans",
+            RelayCounters::MissingDynamicSamplingContext => "missing_dynamic_sampling_context",
         }
     }
 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -12,6 +12,7 @@ use relay_sampling::dsc::{DynamicSamplingContext, TraceUserContext};
 use relay_sampling::evaluation::{SamplingEvaluator, SamplingMatch};
 
 use crate::envelope::{Envelope, ItemType};
+use crate::statsd::RelayCounters;
 use once_cell::sync::Lazy;
 
 static SUPPORTED_SDK_VERSIONS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
@@ -270,9 +271,12 @@ fn track_missing_dsc(event: &Event) {
 
     match compare_versions(sdk_version, min_sdk_version) {
         Ordering::Greater | Ordering::Equal => {
-            // TRACK METRIC
+            relay_statsd::metric!(
+                counter(RelayCounters::MissingDynamicSamplingContext) += 1,
+                sdk_name = sdk_name.as_str()
+            );
         }
-        _ => return,
+        _ => (),
     };
 }
 

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -1,5 +1,4 @@
 //! Functionality for calculating if a trace should be processed or dropped.
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 
@@ -14,117 +13,116 @@ use relay_sampling::evaluation::{SamplingEvaluator, SamplingMatch};
 use crate::envelope::{Envelope, ItemType};
 use crate::statsd::RelayCounters;
 use once_cell::sync::Lazy;
+use semver::{Version, VersionReq};
 
 // List of minimum SDK versions that support Performance at Scale (aka Dynamic Sampling).
 // The list is defined here:
 // https://docs.sentry.io/product/performance/performance-at-scale/getting-started
 static SUPPORTED_SDK_VERSIONS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
-    let mut supported_sdk_versions = HashMap::new();
-
-    supported_sdk_versions.insert("sentry-python", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.tornado", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.starlette", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.flask", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.fastapi", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.falcon", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.django", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.bottle", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.aws_lambda", "1.7.2");
-    supported_sdk_versions.insert("sentry.python.aiohttp", "1.7.2");
-    supported_sdk_versions.insert("sentry.python", "1.7.2");
-    supported_sdk_versions.insert("sentry-browser", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.angular", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.astro", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.browser", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.ember", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.gatsby", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.nextjs", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.react", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.remix", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.serverless", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.svelte", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.vue", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.node", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.angular-ivy", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.sveltekit", "7.6.0");
-    supported_sdk_versions.insert("sentry.javascript.bun", "7.70.0");
-    supported_sdk_versions.insert("sentry-cocoa", "7.23.0");
-    supported_sdk_versions.insert("sentry-objc", "7.23.0");
-    supported_sdk_versions.insert("sentry-swift", "7.23.0");
-    supported_sdk_versions.insert("sentry.cocoa", "7.18.0");
-    supported_sdk_versions.insert("sentry.swift", "7.23.0");
-    supported_sdk_versions.insert("SentrySwift", "7.23.0");
-    supported_sdk_versions.insert("sentry-android", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.android.timber", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.android", "6.5.0");
-    supported_sdk_versions.insert("sentry.native.android", "6.5.0");
-    supported_sdk_versions.insert("sentry-react-native", "4.3.0");
-    supported_sdk_versions.insert("sentry.cocoa.react-native", "4.3.0");
-    supported_sdk_versions.insert("sentry.java.android.react-native", "4.3.0");
-    supported_sdk_versions.insert("sentry.javascript.react-native", "4.3.0");
-    supported_sdk_versions.insert("sentry.native.android.react-native", "4.3.0");
-    supported_sdk_versions.insert("sentry.javascript.react-native.expo", "6.0.0");
-    supported_sdk_versions.insert("sentry.javascript.react.expo", "6.0.0");
-    supported_sdk_versions.insert("dart", "6.11.0");
-    supported_sdk_versions.insert("dart-sentry-client", "6.11.0");
-    supported_sdk_versions.insert("sentry.dart", "6.11.0");
-    supported_sdk_versions.insert("sentry.dart.logging", "6.11.0");
-    supported_sdk_versions.insert("sentry.cocoa.flutter", "6.11.0");
-    supported_sdk_versions.insert("sentry.dart.flutter", "6.11.0");
-    supported_sdk_versions.insert("sentry.java.android.flutter", "6.11.0");
-    supported_sdk_versions.insert("sentry.native.android.flutter", "6.11.0");
-    supported_sdk_versions.insert("sentry.dart.browser", "6.11.0");
-    supported_sdk_versions.insert("sentry-php", "3.9.0");
-    supported_sdk_versions.insert("sentry.php", "3.9.0");
-    supported_sdk_versions.insert("sentry-laravel", "3.0.0");
-    supported_sdk_versions.insert("sentry.php.laravel", "3.0.0");
-    supported_sdk_versions.insert("sentry-symfony", "4.4.0");
-    supported_sdk_versions.insert("sentry.php.symfony", "4.4.0");
-    supported_sdk_versions.insert("Symphony.SentryClient", "4.4.0");
-    supported_sdk_versions.insert("sentry-ruby", "5.5.0");
-    supported_sdk_versions.insert("sentry.ruby", "5.5.0");
-    supported_sdk_versions.insert("sentry.ruby.delayed_job", "5.5.0");
-    supported_sdk_versions.insert("sentry.ruby.rails", "5.5.0");
-    supported_sdk_versions.insert("sentry.ruby.resque", "5.5.0");
-    supported_sdk_versions.insert("sentry.ruby.sidekiq", "5.5.0");
-    supported_sdk_versions.insert("sentry-java", "6.5.0");
-    supported_sdk_versions.insert("sentry.java", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.jul", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.log4j2", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.logback", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.spring", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.spring-boot", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.spring-boot.jakarta", "6.5.0");
-    supported_sdk_versions.insert("sentry.java.spring.jakarta", "6.5.0");
-    supported_sdk_versions.insert("sentry.aspnetcore", "3.22.0");
-    supported_sdk_versions.insert("Sentry.AspNetCore", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.android", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.aspnet", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.aspnetcore", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.aspnetcore.grpc", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.atlasproper", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.cocoa", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.ef", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.extensions.logging", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.google-cloud-function", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.log4net", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.maui", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.nlog", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.serilog", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.xamarin", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.xamarin-forms", "3.22.0");
-    supported_sdk_versions.insert("Sentry.Extensions.Logging", "3.22.0");
-    supported_sdk_versions.insert("Sentry.NET", "3.22.0");
-    supported_sdk_versions.insert("Sentry.UWP", "3.22.0");
-    supported_sdk_versions.insert("SentryDotNet", "3.22.0");
-    supported_sdk_versions.insert("SentryDotNet.AspNetCore", "3.22.0");
-    supported_sdk_versions.insert("sentry.dotnet.unity", "0.24.0");
-    supported_sdk_versions.insert("sentry.cocoa.unity", "0.24.0");
-    supported_sdk_versions.insert("sentry.java.android.unity", "0.24.0");
-    supported_sdk_versions.insert("sentry.go", "0.16.0");
-
-    supported_sdk_versions
+    HashMap::from([
+        ("sentry-python", "1.7.2"),
+        ("sentry.python.tornado", "1.7.2"),
+        ("sentry.python.starlette", "1.7.2"),
+        ("sentry.python.flask", "1.7.2"),
+        ("sentry.python.fastapi", "1.7.2"),
+        ("sentry.python.falcon", "1.7.2"),
+        ("sentry.python.django", "1.7.2"),
+        ("sentry.python.bottle", "1.7.2"),
+        ("sentry.python.aws_lambda", "1.7.2"),
+        ("sentry.python.aiohttp", "1.7.2"),
+        ("sentry.python", "1.7.2"),
+        ("sentry-browser", "7.6.0"),
+        ("sentry.javascript.angular", "7.6.0"),
+        ("sentry.javascript.astro", "7.6.0"),
+        ("sentry.javascript.browser", "7.6.0"),
+        ("sentry.javascript.ember", "7.6.0"),
+        ("sentry.javascript.gatsby", "7.6.0"),
+        ("sentry.javascript.nextjs", "7.6.0"),
+        ("sentry.javascript.react", "7.6.0"),
+        ("sentry.javascript.remix", "7.6.0"),
+        ("sentry.javascript.serverless", "7.6.0"),
+        ("sentry.javascript.svelte", "7.6.0"),
+        ("sentry.javascript.vue", "7.6.0"),
+        ("sentry.javascript.node", "7.6.0"),
+        ("sentry.javascript.angular-ivy", "7.6.0"),
+        ("sentry.javascript.sveltekit", "7.6.0"),
+        ("sentry.javascript.bun", "7.70.0"),
+        ("sentry-cocoa", "7.23.0"),
+        ("sentry-objc", "7.23.0"),
+        ("sentry-swift", "7.23.0"),
+        ("sentry.cocoa", "7.18.0"),
+        ("sentry.swift", "7.23.0"),
+        ("SentrySwift", "7.23.0"),
+        ("sentry-android", "6.5.0"),
+        ("sentry.java.android.timber", "6.5.0"),
+        ("sentry.java.android", "6.5.0"),
+        ("sentry.native.android", "6.5.0"),
+        ("sentry-react-native", "4.3.0"),
+        ("sentry.cocoa.react-native", "4.3.0"),
+        ("sentry.java.android.react-native", "4.3.0"),
+        ("sentry.javascript.react-native", "4.3.0"),
+        ("sentry.native.android.react-native", "4.3.0"),
+        ("sentry.javascript.react-native.expo", "6.0.0"),
+        ("sentry.javascript.react.expo", "6.0.0"),
+        ("dart", "6.11.0"),
+        ("dart-sentry-client", "6.11.0"),
+        ("sentry.dart", "6.11.0"),
+        ("sentry.dart.logging", "6.11.0"),
+        ("sentry.cocoa.flutter", "6.11.0"),
+        ("sentry.dart.flutter", "6.11.0"),
+        ("sentry.java.android.flutter", "6.11.0"),
+        ("sentry.native.android.flutter", "6.11.0"),
+        ("sentry.dart.browser", "6.11.0"),
+        ("sentry-php", "3.9.0"),
+        ("sentry.php", "3.9.0"),
+        ("sentry-laravel", "3.0.0"),
+        ("sentry.php.laravel", "3.0.0"),
+        ("sentry-symfony", "4.4.0"),
+        ("sentry.php.symfony", "4.4.0"),
+        ("Symphony.SentryClient", "4.4.0"),
+        ("sentry-ruby", "5.5.0"),
+        ("sentry.ruby", "5.5.0"),
+        ("sentry.ruby.delayed_job", "5.5.0"),
+        ("sentry.ruby.rails", "5.5.0"),
+        ("sentry.ruby.resque", "5.5.0"),
+        ("sentry.ruby.sidekiq", "5.5.0"),
+        ("sentry-java", "6.5.0"),
+        ("sentry.java", "6.5.0"),
+        ("sentry.java.jul", "6.5.0"),
+        ("sentry.java.log4j2", "6.5.0"),
+        ("sentry.java.logback", "6.5.0"),
+        ("sentry.java.spring", "6.5.0"),
+        ("sentry.java.spring-boot", "6.5.0"),
+        ("sentry.java.spring-boot.jakarta", "6.5.0"),
+        ("sentry.java.spring.jakarta", "6.5.0"),
+        ("sentry.aspnetcore", "3.22.0"),
+        ("Sentry.AspNetCore", "3.22.0"),
+        ("sentry.dotnet", "3.22.0"),
+        ("sentry.dotnet.android", "3.22.0"),
+        ("sentry.dotnet.aspnet", "3.22.0"),
+        ("sentry.dotnet.aspnetcore", "3.22.0"),
+        ("sentry.dotnet.aspnetcore.grpc", "3.22.0"),
+        ("sentry.dotnet.atlasproper", "3.22.0"),
+        ("sentry.dotnet.cocoa", "3.22.0"),
+        ("sentry.dotnet.ef", "3.22.0"),
+        ("sentry.dotnet.extensions.logging", "3.22.0"),
+        ("sentry.dotnet.google-cloud-function", "3.22.0"),
+        ("sentry.dotnet.log4net", "3.22.0"),
+        ("sentry.dotnet.maui", "3.22.0"),
+        ("sentry.dotnet.nlog", "3.22.0"),
+        ("sentry.dotnet.serilog", "3.22.0"),
+        ("sentry.dotnet.xamarin", "3.22.0"),
+        ("sentry.dotnet.xamarin-forms", "3.22.0"),
+        ("Sentry.Extensions.Logging", "3.22.0"),
+        ("Sentry.NET", "3.22.0"),
+        ("Sentry.UWP", "3.22.0"),
+        ("SentryDotNet", "3.22.0"),
+        ("SentryDotNet.AspNetCore", "3.22.0"),
+        ("sentry.dotnet.unity", "0.24.0"),
+        ("sentry.cocoa.unity", "0.24.0"),
+        ("sentry.java.android.unity", "0.24.0"),
+        ("sentry.go", "0.16.0"),
+    ])
 });
 
 /// Represents the specification for sampling an incoming event.
@@ -215,44 +213,6 @@ pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
     envelope.dsc().map(|dsc| dsc.public_key)
 }
 
-/// Compares two semantic versions.
-///
-/// This function is just temporary since it's used to compare SDK versions when an [`Event`] is
-/// received.
-fn compare_versions(version1: &str, version2: &str) -> std::cmp::Ordering {
-    // Split the version strings into individual numbers
-    let nums1: Vec<&str> = version1.split('.').collect();
-    let nums2: Vec<&str> = version2.split('.').collect();
-
-    // Pad the shorter version with zeros to ensure equal length
-    let length = usize::max(nums1.len(), nums2.len());
-    let nums1 = {
-        let mut padded = vec!["0"; length - nums1.len()];
-        padded.extend(nums1);
-        padded
-    };
-    let nums2 = {
-        let mut padded = vec!["0"; length - nums2.len()];
-        padded.extend(nums2);
-        padded
-    };
-
-    // Compare the numbers from left to right
-    for (num1, num2) in nums1.iter().zip(nums2.iter()) {
-        let num1 = num1.parse::<i32>().unwrap_or(0);
-        let num2 = num2.parse::<i32>().unwrap_or(0);
-
-        match num1.cmp(&num2) {
-            Ordering::Greater => return Ordering::Greater,
-            Ordering::Less => return Ordering::Less,
-            Ordering::Equal => continue,
-        }
-    }
-
-    // All numbers are equal
-    Ordering::Equal
-}
-
 /// Emits a metric when an [`Event`] is inside an [`Envelope`] without [`DynamicSamplingContext`].
 ///
 /// This function is a temporary function which has been added mainly for debugging purposes. Our
@@ -273,15 +233,20 @@ fn track_missing_dsc(event: &Event) {
         return;
     };
 
-    match compare_versions(sdk_version, min_sdk_version) {
-        Ordering::Greater | Ordering::Equal => {
-            relay_statsd::metric!(
-                counter(RelayCounters::MissingDynamicSamplingContext) += 1,
-                sdk_name = sdk_name.as_str()
-            );
-        }
-        _ => (),
+    let Ok(req) = VersionReq::parse(format!(">={}", min_sdk_version).as_str()) else {
+        return;
     };
+
+    let Ok(version) = Version::parse(sdk_version) else {
+        return;
+    };
+
+    if req.matches(&version) {
+        relay_statsd::metric!(
+            counter(RelayCounters::MissingDynamicSamplingContext) += 1,
+            sdk_name = sdk_name.as_str()
+        );
+    }
 }
 
 /// Computes a dynamic sampling context from a transaction event.
@@ -514,27 +479,5 @@ mod tests {
 
         let result = is_trace_fully_sampled(&config, &dsc);
         assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_sdk_versions_comparison() {
-        let minimum_sdk_version = SUPPORTED_SDK_VERSIONS.get("sentry.python.flask").unwrap();
-        let received_sdk_versions = ["1.0.0", "0.1", "1.7.3", "1.10.20", "1.0", "1.7.2"];
-        let expected_comparisons = [
-            Ordering::Less,
-            Ordering::Less,
-            Ordering::Greater,
-            Ordering::Greater,
-            Ordering::Less,
-            Ordering::Equal,
-        ];
-
-        for (received_sdk_version, expected_comparison) in received_sdk_versions
-            .iter()
-            .zip(expected_comparisons.iter())
-        {
-            let comparison = compare_versions(received_sdk_version, minimum_sdk_version);
-            assert_eq!(comparison, *expected_comparison);
-        }
     }
 }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -119,6 +119,7 @@ static SUPPORTED_SDK_VERSIONS: Lazy<HashMap<&'static str, &'static str>> = Lazy:
     supported_sdk_versions.insert("sentry.dotnet.unity", "0.24.0");
     supported_sdk_versions.insert("sentry.cocoa.unity", "0.24.0");
     supported_sdk_versions.insert("sentry.java.android.unity", "0.24.0");
+    supported_sdk_versions.insert("sentry.go", "0.16.0");
 
     supported_sdk_versions
 });

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -216,7 +216,8 @@ pub fn get_sampling_key(envelope: &Envelope) -> Option<ProjectKey> {
 /// Emits a metric when an [`Event`] is inside an [`Envelope`] without [`DynamicSamplingContext`].
 ///
 /// This function is a temporary function which has been added mainly for debugging purposes. Our
-/// goal with this function is to validate how many times the DSC is not
+/// goal with this function is to validate how many times the DSC is not on an [`Event`] which
+/// should have it.
 fn track_missing_dsc(event: &Event) -> bool {
     let Some(client_sdk_info) = event.client_sdk.value() else {
         return false;

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -263,7 +263,7 @@ pub fn dsc_from_event(public_key: ProjectKey, event: &Event) -> Option<DynamicSa
                 should_have_dsc = "true"
             );
         }
-        _ => {
+        None => {
             relay_statsd::metric!(
                 counter(RelayCounters::MissingDynamicSamplingContext) += 1,
                 should_have_dsc = "false"
@@ -491,9 +491,7 @@ mod tests {
             ..Default::default()
         });
 
-        let Some(sdk_name) = should_have_dsc(&event) else {
-            panic!();
-        };
+        let sdk_name = should_have_dsc(&event).unwrap();
         assert_eq!(sdk_name, "sentry.python.flask".to_string());
     }
 

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -253,7 +253,7 @@ pub fn dsc_from_event(public_key: ProjectKey, event: &Event) -> Option<DynamicSa
 
     // When we arrive at this point, we know that a DSC can be built from the event, implying that
     // the event doesn't have one. We want to track a metric when the event should have the DSC
-    // or not based on the SDk version.
+    // or not based on the SDK version.
     let sdk_name = should_have_dsc(event);
     match sdk_name {
         Some(sdk_name) => {

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -15,6 +15,9 @@ use crate::envelope::{Envelope, ItemType};
 use crate::statsd::RelayCounters;
 use once_cell::sync::Lazy;
 
+// List of minimum SDK versions that support Performance at Scale (aka Dynamic Sampling).
+// The list is defined here:
+// https://docs.sentry.io/product/performance/performance-at-scale/getting-started
 static SUPPORTED_SDK_VERSIONS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     let mut supported_sdk_versions = HashMap::new();
 


### PR DESCRIPTION
This PR adds a new metric that collects the number of times the DSC is built by Relay when it was not found on a transaction that should contain the DSC.

The logic in this PR performs a semantic versioning comparison between the minimum version of an SDK that should support a DSC and the current SDK version of the SDK that sent the event.

Closes: https://github.com/getsentry/relay/issues/3570

#skip-changelog