### PR TITLE
ci(binary): Build binary on ubuntu 20.04 for lower glibc requirement

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Build release binaries in ubuntu 20.04 this lowers the glibc requirements of the resulting binaries. This was unintentionally  bumped when adding the ARM builds and broke the binary for older glibc versions in the 24.4.2 release.

We build the docker image binaries in a docker container with an even lower glibc requirement, so with #3497 we should just use the binaries built with cross for the release.

#skip-changelog