### PR TITLE
ref(protocol): Update examples with canonical name for logentry

### DIFF
--- a/relay-event-schema/src/protocol/logentry.rs
+++ b/relay-event-schema/src/protocol/logentry.rs
@@ -12,7 +12,7 @@ use crate::protocol::JsonLenientString;
 ///
 /// ```json
 /// {
-///   "message": {
+///   "logentry": {
 ///     "message": "My raw message with interpreted strings like %s",
 ///     "params": ["this"]
 ///   }
@@ -21,7 +21,7 @@ use crate::protocol::JsonLenientString;
 ///
 /// ```json
 /// {
-///   "message": {
+///   "logentry": {
 ///     "message": "My raw message with interpreted strings like {foo}",
 ///     "params": {"foo": "this"}
 ///   }

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -2291,7 +2291,7 @@ expression: "relay_event_schema::protocol::event_json_schema()"
       ]
     },
     "LogEntry": {
-      "description": " A log entry message.\n\n A log message is similar to the `message` attribute on the event itself but\n can additionally hold optional parameters.\n\n ```json\n {\n   \"message\": {\n     \"message\": \"My raw message with interpreted strings like %s\",\n     \"params\": [\"this\"]\n   }\n }\n ```\n\n ```json\n {\n   \"message\": {\n     \"message\": \"My raw message with interpreted strings like {foo}\",\n     \"params\": {\"foo\": \"this\"}\n   }\n }\n ```",
+      "description": " A log entry message.\n\n A log message is similar to the `message` attribute on the event itself but\n can additionally hold optional parameters.\n\n ```json\n {\n   \"logentry\": {\n     \"message\": \"My raw message with interpreted strings like %s\",\n     \"params\": [\"this\"]\n   }\n }\n ```\n\n ```json\n {\n   \"logentry\": {\n     \"message\": \"My raw message with interpreted strings like {foo}\",\n     \"params\": {\"foo\": \"this\"}\n   }\n }\n ```",
       "anyOf": [
         {
           "type": "object",


### PR DESCRIPTION
The normalized name of the "message" interface is `logentry`. This PR
updates all doc examples used for the JSON schema to use the canonical
name.

#skip-changelog