### PR TITLE
ref(metrics): Log metric outcomes via dedicated struct

### DIFF
--- a/relay-cardinality/src/lib.rs
+++ b/relay-cardinality/src/lib.rs
@@ -16,7 +16,9 @@ mod window;
 
 pub use self::config::*;
 pub use self::error::*;
-pub use self::limiter::{CardinalityItem, CardinalityLimits, CardinalityReport, Scoping};
+pub use self::limiter::{
+    CardinalityItem, CardinalityLimits, CardinalityLimitsSplit, CardinalityReport, Scoping,
+};
 #[cfg(feature = "redis")]
 pub use self::redis::{RedisSetLimiter, RedisSetLimiterOptions};
 pub use self::window::SlidingWindow;

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -454,9 +454,32 @@ impl<'a> BucketView<'a> {
 
     /// Returns the metadata for this bucket.
     ///
+    /// The aggregation process of metadata is inheritly lossy, which means
+    /// some metadata, for example the amount of merges, can not be accurately split
+    /// or divided over multiple bucket views.
+    ///
+    /// To compensate for this only a bucket view which contains the start of a bucket
+    /// will yield this metadata, all other views created from the bucket return an
+    /// identity value. Merging all metadata from non-overlapping bucket views must
+    /// yield the same values as stored on the original bucket.
+    ///
+    /// This causes some problems when operations on partial buckets are fallible,
+    /// for example transmitting two bucket views in separate http requests.
+    /// To deal with this Relay needs to prevent the splitting of buckets in the first place,
+    /// by never not creating too large buckets via aggregation in the first place.
+    ///
     /// See also: [`Bucket::metadata`].
-    pub fn metadata(&self) -> &BucketMetadata {
-        &self.inner.metadata
+    pub fn metadata(&self) -> BucketMetadata {
+        let merges = if self.range.start == 0 {
+            self.inner.metadata.merges
+        } else {
+            0
+        };
+
+        BucketMetadata {
+            merges,
+            received_at: self.inner.metadata.received_at,
+        }
     }
 
     /// Number of raw datapoints in this view.
@@ -788,6 +811,12 @@ mod tests {
     }
 
     #[test]
+    fn test_bucket_view_counter_metadata() {
+        let bucket = Bucket::parse(b"b0:1|c", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(bucket.metadata, BucketView::new(&bucket).metadata());
+    }
+
+    #[test]
     fn test_bucket_view_select_distribution() {
         let bucket = Bucket::parse(b"b2:1:2:3:5:5|d", UnixTimestamp::from_secs(5000)).unwrap();
 
@@ -821,6 +850,26 @@ mod tests {
     }
 
     #[test]
+    fn test_bucket_view_distribution_metadata() {
+        let bucket = Bucket::parse(b"b2:1:2:3:5:5|d", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(bucket.metadata, BucketView::new(&bucket).metadata());
+
+        assert_eq!(
+            BucketView::new(&bucket).select(0..3).unwrap().metadata(),
+            bucket.metadata
+        );
+
+        let m = BucketView::new(&bucket).select(1..3).unwrap().metadata();
+        assert_eq!(
+            m,
+            BucketMetadata {
+                merges: 0,
+                ..bucket.metadata
+            }
+        );
+    }
+
+    #[test]
     fn test_bucket_view_select_set() {
         let bucket = Bucket::parse(b"b3:42:75|s", UnixTimestamp::from_secs(5000)).unwrap();
         let s = [42, 75].into();
@@ -843,6 +892,26 @@ mod tests {
         assert!(BucketView::new(&bucket).select(0..3).is_none());
         assert!(BucketView::new(&bucket).select(2..5).is_none());
         assert!(BucketView::new(&bucket).select(77..99).is_none());
+    }
+
+    #[test]
+    fn test_bucket_view_set_metadata() {
+        let bucket = Bucket::parse(b"b2:1:2:3:5:5|s", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(bucket.metadata, BucketView::new(&bucket).metadata());
+
+        assert_eq!(
+            BucketView::new(&bucket).select(0..3).unwrap().metadata(),
+            bucket.metadata
+        );
+
+        let m = BucketView::new(&bucket).select(1..3).unwrap().metadata();
+        assert_eq!(
+            m,
+            BucketMetadata {
+                merges: 0,
+                ..bucket.metadata
+            }
+        );
     }
 
     #[test]
@@ -873,6 +942,13 @@ mod tests {
         assert!(BucketView::new(&bucket).select(0..4).is_none());
         assert!(BucketView::new(&bucket).select(5..5).is_none());
         assert!(BucketView::new(&bucket).select(5..6).is_none());
+    }
+
+    #[test]
+    fn test_bucket_view_gauge_metadata() {
+        let bucket =
+            Bucket::parse(b"b4:25:17:42:220:85|g", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(BucketView::new(&bucket).metadata(), bucket.metadata);
     }
 
     fn buckets<T>(s: &[u8]) -> T

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -259,6 +259,7 @@ mod envelope;
 mod extractors;
 mod http;
 mod metric_stats;
+mod metrics;
 mod metrics_extraction;
 mod middlewares;
 mod service;

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -63,12 +63,7 @@ impl MetricStats {
     }
 
     /// Tracks the metric volume and outcome for the bucket.
-    pub fn track_metric<'a, T>(
-        &self,
-        scoping: Scoping,
-        bucket: impl TrackableBucket,
-        outcome: &Outcome,
-    ) {
+    pub fn track_metric(&self, scoping: Scoping, bucket: impl TrackableBucket, outcome: &Outcome) {
         if !self.is_enabled(scoping) {
             return;
         }

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -6,9 +6,7 @@ use relay_cardinality::{CardinalityLimit, CardinalityReport};
 use relay_config::Config;
 #[cfg(feature = "processing")]
 use relay_metrics::GaugeValue;
-use relay_metrics::{
-    Aggregator, Bucket, BucketValue, BucketView, MergeBuckets, MetricName, UnixTimestamp,
-};
+use relay_metrics::{Aggregator, Bucket, BucketValue, MergeBuckets, MetricName, UnixTimestamp};
 use relay_quotas::Scoping;
 use relay_system::Addr;
 

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -72,7 +72,7 @@ impl MetricStats {
 
         relay_log::trace!(
             "Tracking volume of {} for mri '{}': {}",
-            bucket.metadata().merges.get(),
+            bucket.metadata().merges,
             bucket.name(),
             outcome
         );
@@ -121,7 +121,7 @@ impl MetricStats {
     }
 
     fn to_volume_metric(&self, bucket: impl TrackableBucket, outcome: &Outcome) -> Option<Bucket> {
-        let volume = bucket.metadata().merges.get();
+        let volume = bucket.metadata().merges;
         if volume == 0 {
             return None;
         }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -127,7 +127,7 @@ impl MetricOutcomes {
 
     /// Tracks the cardinality of a metric.
     #[cfg(feature = "processing")]
-    pub fn track_cardinality(
+    pub fn cardinality(
         &self,
         scoping: Scoping,
         limit: &CardinalityLimit,
@@ -168,7 +168,7 @@ pub trait TrackableBucket {
     fn summary(&self, mode: ExtractionMode) -> BucketSummary;
 
     /// Metric bucket metadata.
-    fn metadata(&self) -> BucketMetadata;
+    fn metadata(&self) -> &BucketMetadata;
 }
 
 impl<T: TrackableBucket> TrackableBucket for &T {
@@ -184,7 +184,7 @@ impl<T: TrackableBucket> TrackableBucket for &T {
         (**self).summary(mode)
     }
 
-    fn metadata(&self) -> BucketMetadata {
+    fn metadata(&self) -> &BucketMetadata {
         (**self).metadata()
     }
 }
@@ -202,8 +202,8 @@ impl TrackableBucket for Bucket {
         BucketView::new(self).summary(mode)
     }
 
-    fn metadata(&self) -> BucketMetadata {
-        self.metadata
+    fn metadata(&self) -> &BucketMetadata {
+        &self.metadata
     }
 }
 
@@ -247,8 +247,8 @@ impl TrackableBucket for BucketView<'_> {
         }
     }
 
-    fn metadata(&self) -> BucketMetadata {
-        *self.metadata()
+    fn metadata(&self) -> &BucketMetadata {
+        self.metadata()
     }
 }
 

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -1,0 +1,278 @@
+use chrono::Utc;
+use relay_metrics::{
+    Bucket, BucketMetadata, BucketView, BucketViewValue, MetricName, MetricNamespace,
+    MetricResourceIdentifier, MetricType,
+};
+use relay_quotas::{DataCategory, Scoping};
+use relay_system::Addr;
+
+use crate::envelope::SourceQuantities;
+use crate::metric_stats::MetricStats;
+use crate::services::outcome::{Outcome, TrackOutcome};
+use crate::utils::ExtractionMode;
+#[cfg(feature = "processing")]
+use relay_cardinality::{CardinalityLimit, CardinalityReport};
+
+const PROFILE_TAG: &str = "has_profile";
+
+pub struct Track {
+    scoping: Scoping,
+    buckets: Vec<Bucket>,
+    quantities: Quantities,
+    outcome: Outcome,
+}
+
+impl Track {
+    pub fn new(
+        scoping: Scoping,
+        buckets: Vec<Bucket>,
+        quantities: impl Into<Quantities>,
+        outcome: Outcome,
+    ) -> Self {
+        Self {
+            scoping,
+            buckets,
+            quantities: quantities.into(),
+            outcome,
+        }
+    }
+}
+
+pub enum Quantities {
+    Extract(ExtractionMode),
+    Value(SourceQuantities),
+}
+
+impl From<ExtractionMode> for Quantities {
+    fn from(value: ExtractionMode) -> Self {
+        Self::Extract(value)
+    }
+}
+
+impl From<SourceQuantities> for Quantities {
+    fn from(value: SourceQuantities) -> Self {
+        Self::Value(value)
+    }
+}
+
+/// [`MetricOutcomes`] takes care of creating the right outcomes for metrics at the end of their
+/// lifecycle.
+///
+/// It is aware of surrogate metrics like transaction- and span-duration as well as pure metrics
+/// like custom.
+#[derive(Debug, Clone)]
+pub struct MetricOutcomes {
+    metric_stats: MetricStats,
+    outcomes: Addr<TrackOutcome>,
+}
+
+impl MetricOutcomes {
+    /// Creates a new [`MetricOutcomes`].
+    pub fn new(metric_stats: MetricStats, outcomes: Addr<TrackOutcome>) -> Self {
+        Self {
+            metric_stats,
+            outcomes,
+        }
+    }
+
+    /// Tracks an outcome for a list of buckets and generates the necessary outcomes.
+    pub fn track(
+        &self,
+        scoping: Scoping,
+        buckets: &[impl TrackableBucket],
+        quantities: impl Into<Quantities>,
+        outcome: Outcome,
+    ) {
+        let timestamp = Utc::now();
+
+        // Never emit accepted outcomes for surrogate metrics.
+        // These are handled from within Sentry.
+        if !matches!(outcome, Outcome::Accepted) {
+            let quantities = match quantities.into() {
+                Quantities::Extract(mode) => extract_quantities(buckets, mode),
+                Quantities::Value(source) => source,
+            };
+
+            let categories = [
+                (DataCategory::Transaction, quantities.transactions as u32),
+                (DataCategory::Profile, quantities.profiles as u32),
+                (DataCategory::MetricBucket, quantities.buckets as u32),
+            ];
+
+            for (category, quantity) in categories {
+                if quantity > 0 {
+                    self.outcomes.send(TrackOutcome {
+                        timestamp,
+                        scoping,
+                        outcome: outcome.clone(),
+                        event_id: None,
+                        remote_addr: None,
+                        category,
+                        quantity,
+                    });
+                }
+            }
+        }
+
+        // When rejecting metrics, we need to make sure that the number of merges is correctly handled
+        // for buckets views, since if we have a bucket which has 5 merges, and it's split into 2
+        // bucket views, we will emit the volume of the rejection as 5 + 5 merges since we still read
+        // the underlying metadata for each view, and it points to the same bucket reference.
+        // Possible solutions to this problem include emitting the merges only if the bucket view is
+        // the first of view or distributing uniformly the metadata between split views.
+        for bucket in buckets {
+            self.metric_stats.track_metric(scoping, bucket, &outcome)
+        }
+    }
+
+    /// Tracks the cardinality of a metric.
+    #[cfg(feature = "processing")]
+    pub fn track_cardinality(
+        &self,
+        scoping: Scoping,
+        limit: &CardinalityLimit,
+        report: &CardinalityReport,
+    ) {
+        self.metric_stats.track_cardinality(scoping, limit, report)
+    }
+}
+
+/// The return value of [`TrackableBucket::summary`].
+///
+/// Contains the count of total transactions or spans that went into this bucket.
+#[derive(Debug, Default, Clone)]
+pub enum BucketSummary {
+    Transactions {
+        count: usize,
+        has_profile: bool,
+    },
+    Spans(usize),
+    #[default]
+    None,
+}
+
+/// Minimum information required to track outcomes for a metric bucket.
+pub trait TrackableBucket {
+    /// Full mri of the bucket.
+    fn name(&self) -> &MetricName;
+
+    /// Type of the metric bucket.
+    fn ty(&self) -> MetricType;
+
+    /// Extracts quota information from the metric bucket.
+    ///
+    /// If the metric was extracted from one or more transactions or spans, it returns the amount
+    /// of datapoints contained in the bucket.
+    ///
+    /// Additionally tracks whether the transactions also contained profiling information.
+    fn summary(&self, mode: ExtractionMode) -> BucketSummary;
+
+    /// Metric bucket metadata.
+    fn metadata(&self) -> BucketMetadata;
+}
+
+impl<T: TrackableBucket> TrackableBucket for &T {
+    fn name(&self) -> &MetricName {
+        (**self).name()
+    }
+
+    fn ty(&self) -> MetricType {
+        (**self).ty()
+    }
+
+    fn summary(&self, mode: ExtractionMode) -> BucketSummary {
+        (**self).summary(mode)
+    }
+
+    fn metadata(&self) -> BucketMetadata {
+        (**self).metadata()
+    }
+}
+
+impl TrackableBucket for Bucket {
+    fn name(&self) -> &MetricName {
+        &self.name
+    }
+
+    fn ty(&self) -> MetricType {
+        self.value.ty()
+    }
+
+    fn summary(&self, mode: ExtractionMode) -> BucketSummary {
+        BucketView::new(self).summary(mode)
+    }
+
+    fn metadata(&self) -> BucketMetadata {
+        self.metadata
+    }
+}
+
+impl TrackableBucket for BucketView<'_> {
+    fn name(&self) -> &MetricName {
+        self.name()
+    }
+
+    fn ty(&self) -> MetricType {
+        self.ty()
+    }
+
+    fn summary(&self, mode: ExtractionMode) -> BucketSummary {
+        let mri = match MetricResourceIdentifier::parse(self.name()) {
+            Ok(mri) => mri,
+            Err(_) => return BucketSummary::default(),
+        };
+
+        match mri.namespace {
+            MetricNamespace::Transactions => {
+                let usage = matches!(mode, ExtractionMode::Usage);
+                let count = match self.value() {
+                    BucketViewValue::Counter(c) if usage && mri.name == "usage" => {
+                        c.to_f64() as usize
+                    }
+                    BucketViewValue::Distribution(d) if !usage && mri.name == "duration" => d.len(),
+                    _ => 0,
+                };
+                let has_profile = matches!(mri.name.as_ref(), "usage" | "duration")
+                    && self.tag(PROFILE_TAG) == Some("true");
+                BucketSummary::Transactions { count, has_profile }
+            }
+            MetricNamespace::Spans => BucketSummary::Spans(match self.value() {
+                BucketViewValue::Counter(c) if mri.name == "usage" => c.to_f64() as usize,
+                _ => 0,
+            }),
+            _ => {
+                // Nothing to count
+                BucketSummary::default()
+            }
+        }
+    }
+
+    fn metadata(&self) -> BucketMetadata {
+        *self.metadata()
+    }
+}
+
+pub fn extract_quantities<'a, I, T>(buckets: I, mode: ExtractionMode) -> SourceQuantities
+where
+    I: IntoIterator<Item = T>,
+    T: TrackableBucket,
+{
+    let mut quantities = SourceQuantities::default();
+
+    for bucket in buckets {
+        quantities.buckets += 1;
+        let summary = bucket.summary(mode);
+        match summary {
+            BucketSummary::Transactions { count, has_profile } => {
+                quantities.transactions += count;
+                if has_profile {
+                    quantities.profiles += count;
+                }
+            }
+            BucketSummary::Spans(count) => quantities.spans += count,
+            BucketSummary::None => continue,
+        };
+    }
+
+    quantities
+}

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -107,6 +107,7 @@ impl MetricOutcomes {
         // Possible solutions to this problem include emitting the merges only if the bucket view is
         // the first of view or distributing uniformly the metadata between split views.
         for bucket in buckets {
+            relay_log::trace!("{:<50} -> {outcome}", bucket.name());
             self.metric_stats.track_metric(scoping, bucket, &outcome)
         }
     }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -15,14 +15,17 @@ use relay_cardinality::{CardinalityLimit, CardinalityReport};
 
 pub const PROFILE_TAG: &str = "has_profile";
 
+/// Indicates where quantities should be taken from.
 pub enum Quantities {
-    Extract(ExtractionMode),
+    /// Calculates the quantities from the passed buckets using [`ExtractionMode`].
+    FromBuckets(ExtractionMode),
+    /// Uses the provided [`SourceQuantities`].
     Value(SourceQuantities),
 }
 
 impl From<ExtractionMode> for Quantities {
     fn from(value: ExtractionMode) -> Self {
-        Self::Extract(value)
+        Self::FromBuckets(value)
     }
 }
 
@@ -71,7 +74,7 @@ impl MetricOutcomes {
                 profiles,
                 buckets,
             } = match quantities.into() {
-                Quantities::Extract(mode) => extract_quantities(buckets, mode),
+                Quantities::FromBuckets(mode) => extract_quantities(buckets, mode),
                 Quantities::Value(source) => source,
             };
 

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -155,7 +155,7 @@ pub trait TrackableBucket {
     fn summary(&self, mode: ExtractionMode) -> BucketSummary;
 
     /// Metric bucket metadata.
-    fn metadata(&self) -> &BucketMetadata;
+    fn metadata(&self) -> BucketMetadata;
 }
 
 impl<T: TrackableBucket> TrackableBucket for &T {
@@ -171,7 +171,7 @@ impl<T: TrackableBucket> TrackableBucket for &T {
         (**self).summary(mode)
     }
 
-    fn metadata(&self) -> &BucketMetadata {
+    fn metadata(&self) -> BucketMetadata {
         (**self).metadata()
     }
 }
@@ -189,8 +189,8 @@ impl TrackableBucket for Bucket {
         BucketView::new(self).summary(mode)
     }
 
-    fn metadata(&self) -> &BucketMetadata {
-        &self.metadata
+    fn metadata(&self) -> BucketMetadata {
+        self.metadata
     }
 }
 
@@ -234,7 +234,7 @@ impl TrackableBucket for BucketView<'_> {
         }
     }
 
-    fn metadata(&self) -> &BucketMetadata {
+    fn metadata(&self) -> BucketMetadata {
         self.metadata()
     }
 }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -239,6 +239,7 @@ impl TrackableBucket for BucketView<'_> {
     }
 }
 
+/// Extracts quota information from a list of metric buckets.
 pub fn extract_quantities<I, T>(buckets: I, mode: ExtractionMode) -> SourceQuantities
 where
     I: IntoIterator<Item = T>,

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -13,7 +13,7 @@ use crate::utils::ExtractionMode;
 #[cfg(feature = "processing")]
 use relay_cardinality::{CardinalityLimit, CardinalityReport};
 
-const PROFILE_TAG: &str = "has_profile";
+pub const PROFILE_TAG: &str = "has_profile";
 
 pub struct Track {
     scoping: Scoping,

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -182,7 +182,7 @@ impl ServiceState {
                 #[cfg(feature = "processing")]
                 store_forwarder: store.clone(),
             },
-            metric_stats.clone(),
+            metric_outcomes.clone(),
             #[cfg(feature = "processing")]
             buffer_guard.clone(),
         )
@@ -202,7 +202,7 @@ impl ServiceState {
             config.clone(),
             buffer_guard.clone(),
             project_cache_services,
-            metric_stats,
+            metric_outcomes,
             redis_pool,
         )
         .spawn_handler(project_cache_rx);

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::metric_stats::MetricStats;
+use crate::metrics::MetricOutcomes;
 use anyhow::{Context, Result};
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
@@ -141,6 +142,8 @@ impl ServiceState {
             aggregator.clone(),
         );
 
+        let metric_outcomes = MetricOutcomes::new(metric_stats, outcome_aggregator.clone());
+
         #[cfg(feature = "processing")]
         let store = config
             .processing_enabled()
@@ -149,7 +152,7 @@ impl ServiceState {
                     config.clone(),
                     global_config_handle.clone(),
                     outcome_aggregator.clone(),
-                    metric_stats.clone(),
+                    metric_outcomes.clone(),
                 )
                 .map(|s| s.start())
             })

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -65,7 +65,7 @@ use crate::envelope::{
     self, ContentType, Envelope, EnvelopeError, Item, ItemType, SourceQuantities,
 };
 use crate::extractors::{PartialDsn, RequestMeta};
-use crate::metrics::{extract_quantities, MetricOutcomes};
+use crate::metrics::MetricOutcomes;
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::metrics_extraction::transactions::{ExtractedMetrics, TransactionExtractor};
 use crate::service::ServiceError;
@@ -2429,7 +2429,7 @@ impl EnvelopeProcessorService {
                         Envelope::from_request(None, RequestMeta::outbound(dsn.clone()));
 
                     let mut item = Item::new(ItemType::MetricBuckets);
-                    item.set_source_quantities(metrics::extract_quantities(&batch, mode));
+                    item.set_source_quantities(metrics::extract_quantities(batch, mode));
                     item.set_payload(ContentType::Json, serde_json::to_vec(&buckets).unwrap());
                     envelope.add_item(item);
 

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -894,8 +894,8 @@ impl Project {
                 self.merge_buckets_into_aggregator(
                     aggregator,
                     envelope_processor,
-                    metric_outcomes,
                     outcome_aggregator,
+                    metric_outcomes,
                     &state,
                     buckets,
                 );

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -633,8 +633,8 @@ impl Project {
 
     fn process_and_merge_buckets(
         &self,
-        aggregator: Addr<Aggregator>,
-        #[allow(unused_variables)] envelope_processor: Addr<EnvelopeProcessor>,
+        aggregator: &Addr<Aggregator>,
+        #[allow(unused_variables)] envelope_processor: &Addr<EnvelopeProcessor>,
         outcome_aggregator: &Addr<TrackOutcome>,
         metric_outcomes: &MetricOutcomes,
         state: &ProjectState,
@@ -701,10 +701,10 @@ impl Project {
     /// The buckets will be keyed underneath this project key.
     pub fn merge_buckets(
         &mut self,
-        aggregator: Addr<Aggregator>,
-        metric_outcomes: &MetricOutcomes,
+        aggregator: &Addr<Aggregator>,
         outcome_aggregator: &Addr<TrackOutcome>,
-        envelope_processor: Addr<EnvelopeProcessor>,
+        metric_outcomes: &MetricOutcomes,
+        envelope_processor: &Addr<EnvelopeProcessor>,
         buckets: Vec<Bucket>,
     ) {
         if !self.metrics_allowed() {
@@ -726,8 +726,8 @@ impl Project {
                 self.process_and_merge_buckets(
                     aggregator,
                     envelope_processor,
-                    metric_outcomes,
                     outcome_aggregator,
+                    metric_outcomes,
                     &state,
                     buckets,
                 );
@@ -946,10 +946,10 @@ impl Project {
     fn set_state(
         &mut self,
         state: Arc<ProjectState>,
-        aggregator: Addr<Aggregator>,
-        envelope_processor: Addr<EnvelopeProcessor>,
-        outcome_aggregator: Addr<TrackOutcome>,
-        metric_outcomes: MetricOutcomes,
+        aggregator: &Addr<Aggregator>,
+        envelope_processor: &Addr<EnvelopeProcessor>,
+        outcome_aggregator: &Addr<TrackOutcome>,
+        metric_outcomes: &MetricOutcomes,
     ) {
         let project_enabled = state.check_disabled(self.config.as_ref()).is_ok();
         let buckets = self.state.set_state(state.clone());
@@ -960,8 +960,8 @@ impl Project {
                 self.process_and_merge_buckets(
                     aggregator,
                     envelope_processor,
-                    &metric_outcomes,
-                    &outcome_aggregator,
+                    metric_outcomes,
+                    outcome_aggregator,
                     &state,
                     buckets,
                 );
@@ -995,12 +995,12 @@ impl Project {
     #[allow(clippy::too_many_arguments)]
     pub fn update_state(
         &mut self,
-        project_cache: Addr<ProjectCache>,
-        aggregator: Addr<Aggregator>,
+        project_cache: &Addr<ProjectCache>,
+        aggregator: &Addr<Aggregator>,
         mut state: Arc<ProjectState>,
-        envelope_processor: Addr<EnvelopeProcessor>,
-        outcome_aggregator: Addr<TrackOutcome>,
-        metric_outcomes: MetricOutcomes,
+        envelope_processor: &Addr<EnvelopeProcessor>,
+        outcome_aggregator: &Addr<TrackOutcome>,
+        metric_outcomes: &MetricOutcomes,
         no_cache: bool,
     ) {
         // Initiate the backoff if the incoming state is invalid. Reset it otherwise.
@@ -1030,7 +1030,7 @@ impl Project {
             _ => self.set_state(
                 state.clone(),
                 aggregator,
-                envelope_processor.clone(),
+                envelope_processor,
                 outcome_aggregator,
                 metric_outcomes,
             ),

--- a/relay-server/src/services/project/metrics.rs
+++ b/relay-server/src/services/project/metrics.rs
@@ -5,14 +5,11 @@ use relay_dynamic_config::{ErrorBoundary, Feature, Metrics};
 use relay_filter::FilterStatKey;
 use relay_metrics::{Bucket, MetricNamespace};
 use relay_quotas::Scoping;
-use relay_system::Addr;
 
-use crate::metric_stats::MetricStats;
 use crate::metrics::MetricOutcomes;
-use crate::services::outcome::{Outcome, TrackOutcome};
+use crate::services::outcome::Outcome;
 use crate::services::project::ProjectState;
 use crate::services::project_cache::BucketSource;
-use crate::utils;
 
 pub struct Filtered;
 pub struct WithProjectState;
@@ -158,6 +155,9 @@ mod tests {
     use relay_common::glob3::GlobPatterns;
     use relay_dynamic_config::TagBlock;
     use relay_metrics::{Aggregator, BucketValue, UnixTimestamp};
+    use relay_system::Addr;
+
+    use crate::metric_stats::MetricStats;
 
     use super::*;
 
@@ -224,6 +224,7 @@ mod tests {
     fn test_apply_project_state() {
         let (outcome_aggregator, _) = Addr::custom();
         let (metric_stats, mut metric_stats_rx) = MetricStats::test();
+        let metric_outcomes = MetricOutcomes::new(metric_stats, outcome_aggregator);
 
         let project_state = {
             let mut project_state = ProjectState::allowed();
@@ -240,8 +241,7 @@ mod tests {
         let buckets = Buckets::test(vec![b1.clone(), b2.clone()]);
 
         let buckets = buckets.apply_project_state(
-            &outcome_aggregator,
-            &metric_stats,
+            &metric_outcomes,
             &project_state,
             Scoping {
                 organization_id: 42,
@@ -271,14 +271,14 @@ mod tests {
     fn test_apply_project_state_with_disabled_custom_namespace() {
         let (outcome_aggregator, _) = Addr::custom();
         let (metric_stats, mut metric_stats_rx) = MetricStats::test();
+        let metric_outcomes = MetricOutcomes::new(metric_stats, outcome_aggregator);
 
         let b1 = create_custom_bucket_with_name("cpu_time".into());
         let b2 = create_custom_bucket_with_name("memory_usage".into());
         let buckets = Buckets::test(vec![b1.clone(), b2.clone()]);
 
         let buckets = buckets.apply_project_state(
-            &outcome_aggregator,
-            &metric_stats,
+            &metric_outcomes,
             &ProjectState::allowed(),
             Scoping {
                 organization_id: 42,

--- a/relay-server/src/services/project/metrics.rs
+++ b/relay-server/src/services/project/metrics.rs
@@ -103,19 +103,23 @@ impl Buckets<Filtered> {
 
         let mode = project_state.get_extraction_mode();
 
-        metric_outcomes.track(
-            scoping,
-            &disabled_namespace_buckets,
-            mode,
-            Outcome::Filtered(FilterStatKey::DisabledNamespace),
-        );
+        if !disabled_namespace_buckets.is_empty() {
+            metric_outcomes.track(
+                scoping,
+                &disabled_namespace_buckets,
+                mode,
+                Outcome::Filtered(FilterStatKey::DisabledNamespace),
+            );
+        }
 
-        metric_outcomes.track(
-            scoping,
-            &denied_buckets,
-            mode,
-            Outcome::Filtered(FilterStatKey::DeniedName),
-        );
+        if !denied_buckets.is_empty() {
+            metric_outcomes.track(
+                scoping,
+                &denied_buckets,
+                mode,
+                Outcome::Filtered(FilterStatKey::DeniedName),
+            );
+        }
 
         Buckets::new(self.buckets)
     }

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -632,20 +632,13 @@ impl ProjectCacheBroker {
             state,
             no_cache,
         } = message;
-
-        let project_cache = self.services.project_cache.clone();
-        let aggregator = self.services.aggregator.clone();
-        let envelope_processor = self.services.envelope_processor.clone();
-        let outcome_aggregator = self.services.outcome_aggregator.clone();
-        let metric_outcomes = self.metric_outcomes.clone();
-
         self.get_or_create_project(project_key).update_state(
-            project_cache,
-            aggregator,
-            state.clone(),
-            envelope_processor,
-            outcome_aggregator,
-            metric_outcomes,
+            &self.services.project_cache,
+            &self.services.aggregator,
+            state,
+            &self.services.envelope_processor,
+            &self.services.outcome_aggregator,
+            &self.metric_outcomes,
             no_cache,
         );
 
@@ -823,17 +816,14 @@ impl ProjectCacheBroker {
 
     fn handle_add_metric_buckets(&mut self, message: AddMetricBuckets) {
         let project_cache = self.services.project_cache.clone();
-        let aggregator = self.services.aggregator.clone();
-        let outcome_aggregator = self.services.outcome_aggregator.clone();
-        let envelope_processor = self.services.envelope_processor.clone();
 
         let project = self.get_or_create_project(message.project_key);
         project.prefetch(project_cache, false);
         project.merge_buckets(
-            aggregator,
-            outcome_aggregator,
-            envelope_processor,
+            &self.services.aggregator,
+            &self.services.outcome_aggregator,
             &self.metric_outcomes,
+            &self.services.envelope_processor,
             message.buckets,
         );
     }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -405,7 +405,6 @@ impl StoreService {
         for mut bucket in buckets {
             let namespace = encoder.prepare(&mut bucket);
 
-            let mut has_success = false;
             // Create a local bucket view to avoid splitting buckets unnecessarily. Since we produce
             // each bucket separately, we only need to split buckets that exceed the size, but not
             // batches.

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -27,15 +27,15 @@ use serde_json::value::RawValue;
 use serde_json::Deserializer;
 use uuid::Uuid;
 
-use crate::envelope::{AttachmentType, Envelope, Item, ItemType, SourceQuantities};
-use crate::metric_stats::MetricStats;
+use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
+
 use crate::metrics::MetricOutcomes;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::Processed;
 use crate::statsd::RelayCounters;
 use crate::utils::{
-    self, is_rolled_out, ArrayEncoding, BucketEncoder, ExtractionMode, FormDataIter, TypedEnvelope,
+    is_rolled_out, ArrayEncoding, BucketEncoder, ExtractionMode, FormDataIter, TypedEnvelope,
 };
 
 /// Fallback name used for attachment items without a `filename` header.

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -15,6 +15,7 @@ use relay_test::mock_service;
 use crate::envelope::{Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
 use crate::metric_stats::MetricStats;
+use crate::metrics::MetricOutcomes;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::{self, EnvelopeProcessorService};
@@ -127,6 +128,8 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
         .filter(|_| config.processing_enabled())
         .map(|redis_config| relay_redis::RedisPool::new(redis_config).unwrap());
 
+    let metric_outcomes = MetricOutcomes::new(MetricStats::test().0, outcome_aggregator.clone());
+
     let config = Arc::new(config);
     EnvelopeProcessorService::new(
         Arc::clone(&config),
@@ -145,11 +148,7 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
             #[cfg(feature = "processing")]
             store_forwarder: None,
         },
-        MetricStats::new(
-            config,
-            GlobalConfigHandle::fixed(Default::default()),
-            aggregator,
-        ),
+        metric_outcomes,
         #[cfg(feature = "processing")]
         Arc::new(BufferGuard::new(usize::MAX)),
     )
@@ -165,6 +164,9 @@ pub fn create_test_processor_with_addrs(
         .filter(|_| config.processing_enabled())
         .map(|redis_config| relay_redis::RedisPool::new(redis_config).unwrap());
 
+    let metric_outcomes =
+        MetricOutcomes::new(MetricStats::test().0, addrs.outcome_aggregator.clone());
+
     let config = Arc::new(config);
     EnvelopeProcessorService::new(
         Arc::clone(&config),
@@ -173,11 +175,7 @@ pub fn create_test_processor_with_addrs(
         #[cfg(feature = "processing")]
         redis,
         addrs,
-        MetricStats::new(
-            config,
-            GlobalConfigHandle::fixed(Default::default()),
-            Addr::dummy(),
-        ),
+        metric_outcomes,
         #[cfg(feature = "processing")]
         Arc::new(BufferGuard::new(usize::MAX)),
     )

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -120,6 +120,7 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
     let (project_cache, _) = mock_service("project_cache", (), |&mut (), _| {});
     let (upstream_relay, _) = mock_service("upstream_relay", (), |&mut (), _| {});
     let (test_store, _) = mock_service("test_store", (), |&mut (), _| {});
+    #[cfg(feature = "processing")]
     let (aggregator, _) = mock_service("aggregator", (), |&mut (), _| {});
 
     #[cfg(feature = "processing")]

--- a/relay-server/src/utils/metrics_rate_limits.rs
+++ b/relay-server/src/utils/metrics_rate_limits.rs
@@ -185,7 +185,7 @@ impl<Q: AsRef<Vec<Quota>>> MetricsLimiter<Q> {
         metric_outcomes: &MetricOutcomes,
     ) {
         let buckets = std::mem::take(&mut self.buckets);
-        let (buckets, dropped) = utils::split_off(buckets, |b| match b.summary {
+        let (buckets, dropped) = utils::split_off_map(buckets, |b| match b.summary {
             BucketSummary::Transactions { .. } if category == DataCategory::Transaction => {
                 Either::Right(b.bucket)
             }

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -14,6 +14,7 @@ mod retry;
 mod semaphore;
 mod sizes;
 mod sleep_handle;
+mod split_off;
 mod statsd;
 
 #[cfg(feature = "processing")]
@@ -39,6 +40,7 @@ pub use self::retry::*;
 pub use self::semaphore::*;
 pub use self::sizes::*;
 pub use self::sleep_handle::*;
+pub use self::split_off::*;
 pub use self::statsd::*;
 #[cfg(feature = "processing")]
 pub use self::unreal::*;

--- a/relay-server/src/utils/split_off.rs
+++ b/relay-server/src/utils/split_off.rs
@@ -1,7 +1,18 @@
 use itertools::Either;
 
 /// Splits off items from a vector matching a predicate.
-pub fn split_off<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Either<T, S>) -> (Vec<T>, Vec<S>) {
+pub fn split_off<T>(data: Vec<T>, mut f: impl FnMut(&T) -> bool) -> (Vec<T>, Vec<T>) {
+    split_off_map(data, |item| {
+        if f(&item) {
+            Either::Left(item)
+        } else {
+            Either::Right(item)
+        }
+    })
+}
+
+/// Splits off items from a vector matching a predicate and mapping the removed items.
+pub fn split_off_map<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Either<T, S>) -> (Vec<T>, Vec<S>) {
     let mut split = Vec::new();
 
     let data = data
@@ -26,7 +37,7 @@ mod tests {
     fn test_split_off() {
         let data = vec!["apple", "apple", "orange"];
 
-        let (apples, oranges) = split_off(data, |item| {
+        let (apples, oranges) = split_off_map(data, |item| {
             if item != "orange" {
                 Either::Left(item)
             } else {

--- a/relay-server/src/utils/split_off.rs
+++ b/relay-server/src/utils/split_off.rs
@@ -1,16 +1,6 @@
 use itertools::Either;
 
 /// Splits off items from a vector matching a predicate.
-///
-/// # Examples
-///
-/// ```
-/// let data = vec!["apple", "apple", "orange"];
-///
-/// let (apples, oranges) = split_off(data, |item| (item != "orange").then_some(item));
-/// assert_eq!(apples, vec!["apple", "apple"]);
-/// assert_eq!(oranges, vec!["orange"]);
-/// ```
 pub fn split_off<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Either<T, S>) -> (Vec<T>, Vec<S>) {
     let mut split = Vec::new();
 
@@ -26,4 +16,24 @@ pub fn split_off<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Either<T, S>) -> (V
         .collect();
 
     (data, split)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_off() {
+        let data = vec!["apple", "apple", "orange"];
+
+        let (apples, oranges) = split_off(data, |item| {
+            if item != "orange" {
+                Either::Left(item)
+            } else {
+                Either::Right(item)
+            }
+        });
+        assert_eq!(apples, vec!["apple", "apple"]);
+        assert_eq!(oranges, vec!["orange"]);
+    }
 }

--- a/relay-server/src/utils/split_off.rs
+++ b/relay-server/src/utils/split_off.rs
@@ -1,0 +1,27 @@
+/// Splits off items from a vector matching a predicate.
+///
+/// # Examples
+///
+/// ```
+/// let data = vec!["apple", "apple", "orange"];
+///
+/// let (apples, oranges) = split_off(data, |item| (item != "orange").then_some(item));
+/// assert_eq!(apples, vec!["apple", "apple"]);
+/// assert_eq!(oranges, vec!["orange"]);
+/// ```
+pub fn split_off<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Option<S>) -> (Vec<T>, Vec<S>) {
+    let mut split = Vec::new();
+
+    let data = data
+        .into_iter()
+        .filter_map(|item| match f(item) {
+            Some(p) => {
+                split.push(p);
+                None
+            }
+            None => Some(item),
+        })
+        .collect();
+
+    (data, split)
+}

--- a/relay-server/src/utils/split_off.rs
+++ b/relay-server/src/utils/split_off.rs
@@ -1,3 +1,5 @@
+use itertools::Either;
+
 /// Splits off items from a vector matching a predicate.
 ///
 /// # Examples
@@ -9,17 +11,17 @@
 /// assert_eq!(apples, vec!["apple", "apple"]);
 /// assert_eq!(oranges, vec!["orange"]);
 /// ```
-pub fn split_off<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Option<S>) -> (Vec<T>, Vec<S>) {
+pub fn split_off<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Either<T, S>) -> (Vec<T>, Vec<S>) {
     let mut split = Vec::new();
 
     let data = data
         .into_iter()
         .filter_map(|item| match f(item) {
-            Some(p) => {
+            Either::Left(item) => Some(item),
+            Either::Right(p) => {
                 split.push(p);
                 None
             }
-            None => Some(item),
         })
         .collect();
 

--- a/relay-server/src/utils/split_off.rs
+++ b/relay-server/src/utils/split_off.rs
@@ -4,29 +4,29 @@ use itertools::Either;
 pub fn split_off<T>(data: Vec<T>, mut f: impl FnMut(&T) -> bool) -> (Vec<T>, Vec<T>) {
     split_off_map(data, |item| {
         if f(&item) {
-            Either::Left(item)
-        } else {
             Either::Right(item)
+        } else {
+            Either::Left(item)
         }
     })
 }
 
 /// Splits off items from a vector matching a predicate and mapping the removed items.
 pub fn split_off_map<T, S>(data: Vec<T>, mut f: impl FnMut(T) -> Either<T, S>) -> (Vec<T>, Vec<S>) {
-    let mut split = Vec::new();
+    let mut right = Vec::new();
 
-    let data = data
+    let left = data
         .into_iter()
         .filter_map(|item| match f(item) {
             Either::Left(item) => Some(item),
             Either::Right(p) => {
-                split.push(p);
+                right.push(p);
                 None
             }
         })
         .collect();
 
-    (data, split)
+    (left, right)
 }
 
 #[cfg(test)]
@@ -35,6 +35,15 @@ mod tests {
 
     #[test]
     fn test_split_off() {
+        let data = vec!["apple", "apple", "orange"];
+
+        let (apples, oranges) = split_off(data, |item| *item == "orange");
+        assert_eq!(apples, vec!["apple", "apple"]);
+        assert_eq!(oranges, vec!["orange"]);
+    }
+
+    #[test]
+    fn test_split_off_map() {
         let data = vec!["apple", "apple", "orange"];
 
         let (apples, oranges) = split_off_map(data, |item| {

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -215,6 +215,8 @@ def category_value(category):
         return 9
     if category == "user_report_v2":
         return 14
+    if category == "metric_bucket":
+        return 15
     assert False, "invalid category"
 
 

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1511,7 +1511,7 @@ def test_rate_limit_metrics_consistent(
         counter = Counter()
         for outcome in outcomes_consumer.get_outcomes():
             counter[(outcome["category"], outcome["outcome"])] += outcome["quantity"]
-        return counter
+        return dict(counter)
 
     # First batch passes (we over-accept once)
     relay.send_envelope(project_id, envelope)
@@ -1530,7 +1530,9 @@ def test_rate_limit_metrics_consistent(
     assert len(spans) == 0
     metrics = metrics_consumer.get_metrics()
     assert len(metrics) == 0
-    assert summarize_outcomes() == {
+    outcomes = summarize_outcomes()
+    assert outcomes.pop((15, 2)) > 0  # Metric Bucket, RateLimited
+    assert outcomes == {
         (16, 2): 4,  # SpanIndexed, RateLimited
         (12, 2): 4,  # Span, RateLimited
     }

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -486,8 +486,9 @@ def test_processing_quotas(
             assert event["logentry"]["formatted"] == f"otherkey{i}"
 
 
+@pytest.mark.parametrize("namespace", ["transactions", "custom"])
 def test_sends_metric_bucket_outcome(
-    mini_sentry, relay_with_processing, outcomes_consumer
+    mini_sentry, relay_with_processing, outcomes_consumer, namespace
 ):
     """
     Checks that with a zero-quota without categories specified we send metric bucket outcomes.
@@ -513,6 +514,7 @@ def test_sends_metric_bucket_outcome(
     projectconfig["config"]["quotas"] = [
         {
             "scope": "organization",
+            "namespace": namespace,
             "limit": 0,
         }
     ]
@@ -795,8 +797,8 @@ def test_rate_limit_metrics_buckets(
     outcomes_consumer.assert_rate_limited(
         reason_code,
         key_id=key_id,
-        categories=["transaction"],
-        quantity=3,
+        categories=["transaction", "metric_bucket"],
+        quantity=5,
     )
 
 


### PR DESCRIPTION
Replaces `utils::reject_metrics` with a dedicated struct responsible to log outcomes for metrics. Also updates the rate limiter to use the new struct, which surfaced a bug where we did not have outcomes for spans in `reject_metrics`.

Follow ups:
- Always take ownership of buckets when tracking outcomes, this should be the last step in the lifecycle of a bucket
- Implement proper outcomes in the batch metric buckets callback
- Fix the metadata situation, metadata of views should (for volume) needs to be handled differently

#skip-changelog