### PR TITLE
build(py): Revert librealy python requirement back to 3.10

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Build Wheel
         run: |
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Build sdist
         run: python setup.py sdist --format=zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install Dependencies
         run: pip install -U pytest

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Revert the Python version bump back to Python 3.10.
+
 ## 0.8.63
 
 - This release requires Python 3.11 or later. There are no intentionally breaking changes included in this release, but we stopped testing against Python 3.10.

--- a/py/setup.py
+++ b/py/setup.py
@@ -113,7 +113,7 @@ setup(
     package_data={"sentry_relay": ["py.typed", "_lowlevel.pyi"]},
     zip_safe=False,
     platforms="any",
-    python_requires=">=3.11",
+    python_requires=">=3.10",
     install_requires=["milksnake>=0.1.6"],
     setup_requires=["milksnake>=0.1.6"],
     milksnake_tasks=[build_native],


### PR DESCRIPTION
Package publishing infra still requires Python 3.10 support. 

#skip-changelog