### PR TITLE
fix(spans): Restrict usage of otel endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add support for `event.` in the `Span` `Getter` implementation. ([#3577](https://github.com/getsentry/relay/pull/3577))
 - Ensure `chunk_id` and `profiler_id` are UUIDs and sort samples. ([#3588](https://github.com/getsentry/relay/pull/3588))
 - Add a calculated measurement based on the AI model and the tokens used. ([#3554](https://github.com/getsentry/relay/pull/3554))
+- Restrict usage of OTel endpoint. ([#3597](github.com/getsentry/relay/pull/3597))
 
 
 ## 24.4.2

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
 
 /// Features exposed by project config.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Feature {
     /// Enables ingestion of Session Replays (Replay Recordings and Replay Events).
     ///
@@ -56,6 +56,11 @@ pub enum Feature {
     /// Serialized as `organizations:standalone-span-ingestion`.
     #[serde(rename = "organizations:standalone-span-ingestion")]
     StandaloneSpanIngestion,
+    /// Enable standalone span ingestion via the `/spans/` OTel endpoint.
+    ///
+    /// Serialized as `projects:relay-otel-endpoint`.
+    #[serde(rename = "projects:relay-otel-endpoint")]
+    OtelEndpoint,
     /// Enable processing and extracting data from profiles that would normally be dropped by dynamic sampling.
     ///
     /// This is required for [slowest function aggregation](https://github.com/getsentry/snuba/blob/b5311b404a6bd73a9e1997a46d38e7df88e5f391/snuba/snuba_migrations/functions/0001_functions.py#L209-L256). The profile payload will be dropped on the sentry side.

--- a/relay-server/src/endpoints/spans.rs
+++ b/relay-server/src/endpoints/spans.rs
@@ -7,6 +7,7 @@ use axum_extra::protobuf::Protobuf;
 use bytes::Bytes;
 
 use relay_config::Config;
+use relay_dynamic_config::Feature;
 use relay_spans::otel_trace::TracesData;
 
 use crate::endpoints::common;
@@ -36,6 +37,7 @@ where
     };
 
     let mut envelope = Envelope::from_request(None, meta);
+    envelope.require_feature(Feature::OtelEndpoint);
     for resource_span in trace.resource_spans {
         for scope_span in resource_span.scope_spans {
             for span in scope_span.spans {

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -202,7 +202,7 @@ impl Outcome {
     /// Returns the `reason` code field of this outcome.
     pub fn to_reason(&self) -> Option<Cow<'_, str>> {
         match self {
-            Outcome::Invalid(discard_reason) => Some(Cow::Owned(discard_reason.to_string())),
+            Outcome::Invalid(discard_reason) => Some(Cow::Borrowed(discard_reason.name())),
             Outcome::Filtered(filter_key) => Some(filter_key.clone().name()),
             Outcome::FilteredSampling(rule_ids) => Some(Cow::Owned(format!("Sampled:{rule_ids}"))),
             Outcome::RateLimited(code_opt) => {

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -22,6 +22,7 @@ use smallvec::SmallVec;
 use tokio::time::Instant;
 use url::Url;
 
+use crate::envelope::Envelope;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 #[cfg(feature = "processing")]
 use crate::services::processor::RateLimitBuckets;
@@ -329,17 +330,23 @@ impl ProjectState {
         Ok(())
     }
 
-    /// Determines whether the given request should be accepted or discarded.
+    /// Determines whether the given envelope should be accepted or discarded.
     ///
-    /// Returns `Ok(())` if the request should be accepted. Returns `Err(DiscardReason)` if the
-    /// request should be discarded, by indicating the reason. The checks preformed for this are:
+    /// Returns `Ok(())` if the envelope should be accepted. Returns `Err(DiscardReason)` if the
+    /// envelope should be discarded, by indicating the reason. The checks preformed for this are:
     ///
     ///  - Allowed origin headers
     ///  - Disabled or unknown projects
     ///  - Disabled project keys (DSN)
-    pub fn check_request(&self, meta: &RequestMeta, config: &Config) -> Result<(), DiscardReason> {
+    ///  - Feature flags
+    pub fn check_envelope(
+        &self,
+        envelope: &Envelope,
+        config: &Config,
+    ) -> Result<(), DiscardReason> {
         // Verify that the stated project id in the DSN matches the public key used to retrieve this
         // project state.
+        let meta = envelope.meta();
         if !self.is_valid_project_id(meta.project_id(), config) {
             return Err(DiscardReason::ProjectId);
         }
@@ -357,6 +364,15 @@ impl ProjectState {
 
         // Check for invalid or disabled projects.
         self.check_disabled(config)?;
+
+        // Check feature.
+        if let Some(disabled_feature) = envelope
+            .required_features()
+            .iter()
+            .find(|f| !self.has_feature(**f))
+        {
+            return Err(DiscardReason::FeatureDisabled(*disabled_feature));
+        }
 
         Ok(())
     }
@@ -1037,7 +1053,7 @@ impl Project {
             scoping = state.scope_request(envelope.envelope().meta());
             envelope.scope(scoping);
 
-            if let Err(reason) = state.check_request(envelope.envelope().meta(), &self.config) {
+            if let Err(reason) = state.check_envelope(envelope.envelope(), &self.config) {
                 envelope.reject(Outcome::Invalid(reason));
                 return Err(reason);
             }


### PR DESCRIPTION
Span ingestion was limited in general by the `organizations:standalone-span-ingestion` feature, but was GA'd for INP spans. However, we still want to restrict access to the experimental OTel `/spans/` endpoint, which is why this PR introduces a new feature `projects:relay-otel-endpoint`.

#skip-changelog