### PR TITLE
feat(spans): support new cache span.op's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Add support for `event.` in the `Span` `Getter` implementation. ([#3577](https://github.com/getsentry/relay/pull/3577))
 - Ensure `chunk_id` and `profiler_id` are UUIDs and sort samples. ([#3588](https://github.com/getsentry/relay/pull/3588))
 - Add a calculated measurement based on the AI model and the tokens used. ([#3554](https://github.com/getsentry/relay/pull/3554))
-
+- Support new cache span ops in metrics and tag extraction. ([#3598](https://github.com/getsentry/relay/pull/3598))
 
 ## 24.4.2
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -33,6 +33,10 @@ const CACHE_SPAN_OPS: &[&str] = &[
     "cache.save",
     "cache.clear",
     "cache.delete_item",
+    "cache.get",
+    "cache.put",
+    "cache.remove",
+    "cache.flush",
 ];
 
 const QUEUE_SPAN_OPS: &[&str] = &[

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1480,6 +1480,24 @@ LIMIT 1
 
                         },
                         "hash": "e2fae740cccd3781"
+                    },
+                    {
+                        "timestamp": 1694732409.3145,
+                        "start_timestamp": 1694732408.8367,
+                        "exclusive_time": 477.800131,
+                        "description": "get my_key_2",
+                        "op": "cache.get",
+                        "span_id": "97c0ef9770a02f9d",
+                        "parent_span_id": "9756d8d7b2b364ff",
+                        "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+                        "data": {
+                            "cache.hit": false,
+                            "cache.item_size": 8,
+                            "thread.id": "6286962688",
+                            "thread.name": "Thread-4 (process_request_thread)"
+
+                        },
+                        "hash": "e2fae740cccd3781"
                     }
                 ]
             }
@@ -1494,13 +1512,17 @@ LIMIT 1
 
         let span_1 = &event.spans.value().unwrap()[0];
         let span_2 = &event.spans.value().unwrap()[1];
+        let span_3 = &event.spans.value().unwrap()[2];
 
         let tags_1 = get_value!(span_1.sentry_tags).unwrap();
         let tags_2 = get_value!(span_2.sentry_tags).unwrap();
+        let tags_3 = get_value!(span_3.sentry_tags).unwrap();
+
         let measurements_1 = span_1.value().unwrap().measurements.value().unwrap();
 
         assert_eq!(tags_1.get("cache.hit").unwrap().as_str(), Some("true"));
         assert_eq!(tags_2.get("cache.hit").unwrap().as_str(), Some("false"));
+        assert_eq!(tags_3.get("cache.hit").unwrap().as_str(), Some("false"));
         assert_debug_snapshot!(measurements_1, @r###"
         Measurements(
             {

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -462,6 +462,20 @@ mod tests {
                     }
                 },
                 {
+                    "description": "GET cache:user:{123}",
+                    "op": "cache.get",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bb7af8b99e95af5f",
+                    "start_timestamp": 1597976300.0000000,
+                    "timestamp": 1597976302.0000000,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "status": "ok",
+                    "data": {
+                        "cache.hit": false,
+                        "cache.item_size": 8
+                    }
+                },
+                {
                     "description": "GET test:123:def",
                     "op": "db.redis",
                     "parent_span_id": "8f5a2b8768cafb4e",

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -2418,6 +2418,123 @@ expression: metrics
             ],
         ),
         tags: {
+            "cache.hit": "false",
+            "environment": "fake_environment",
+            "span.op": "cache.get",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "d:spans/exclusive_time_light@millisecond",
+        ),
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "cache.hit": "false",
+            "environment": "fake_environment",
+            "span.category": "cache",
+            "span.description": "GET *",
+            "span.group": "37e3d9fab1ae9162",
+            "span.op": "cache.get",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "d:spans/duration@millisecond",
+        ),
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
+            "cache.hit": "false",
+            "environment": "fake_environment",
+            "span.op": "cache.get",
+            "transaction": "gEt /api/:version/users/",
+            "transaction.op": "myop",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "d:spans/cache.item_size@byte",
+        ),
+        value: Distribution(
+            [
+                8.0,
+            ],
+        ),
+        tags: {
+            "cache.hit": "false",
+            "environment": "fake_environment",
+            "span.op": "cache.get",
+            "transaction": "gEt /api/:version/users/",
+        },
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "d:spans/exclusive_time@millisecond",
+        ),
+        value: Distribution(
+            [
+                2000.0,
+            ],
+        ),
+        tags: {
             "environment": "fake_environment",
             "span.action": "GET",
             "span.category": "db",


### PR DESCRIPTION
We're changing the cache span op slightly (https://github.com/getsentry/develop/pull/1223/) so we need to add the new span ops.

