### PR TITLE
feat(spans): Extract additional user fields for spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add support for `event.` in the `Span` `Getter` implementation. ([#3577](https://github.com/getsentry/relay/pull/3577))
 - Ensure `chunk_id` and `profiler_id` are UUIDs and sort samples. ([#3588](https://github.com/getsentry/relay/pull/3588))
 - Add a calculated measurement based on the AI model and the tokens used. ([#3554](https://github.com/getsentry/relay/pull/3554))
+- Extract additional user fields for spans. ([#3599](https://github.com/getsentry/relay/pull/3599))
 
 
 ## 24.4.2

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1976,12 +1976,12 @@ LIMIT 1
         normalize_event(
             &mut event,
             &NormalizationConfig {
+                enrich_spans: true,
                 ..Default::default()
             },
         );
 
-        let mut event = event.into_value().unwrap();
-        extract_span_tags_from_event(&mut event, 200);
+        let event = event.into_value().unwrap();
 
         let span = &event.spans.value().unwrap()[0];
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1989,8 +1989,6 @@ LIMIT 1
 
         assert_eq!(tags.get("user"), Some(&Annotated::new("id:1".to_string())));
 
-        assert_eq!(tags.get("user"), Some(&Annotated::new("id:1".to_string())));
-
         assert_eq!(tags.get("user.id"), Some(&Annotated::new("1".to_string())));
 
         assert_eq!(

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1982,23 +1982,14 @@ LIMIT 1
         );
 
         let event = event.into_value().unwrap();
-
         let span = &event.spans.value().unwrap()[0];
 
-        let tags = span.value().unwrap().sentry_tags.value().unwrap();
-
-        assert_eq!(tags.get("user"), Some(&Annotated::new("id:1".to_string())));
-
-        assert_eq!(tags.get("user.id"), Some(&Annotated::new("1".to_string())));
-
+        assert_eq!(get_value!(span.sentry_tags["user"]!), "id:1");
+        assert_eq!(get_value!(span.sentry_tags["user.id"]!), "1");
+        assert_eq!(get_value!(span.sentry_tags["user.username"]!), "admin");
         assert_eq!(
-            tags.get("user.username"),
-            Some(&Annotated::new("admin".to_string()))
-        );
-
-        assert_eq!(
-            tags.get("user.email"),
-            Some(&Annotated::new("admin@sentry.io".to_string()))
+            get_value!(span.sentry_tags["user.email"]!),
+            "admin@sentry.io"
         );
     }
 }


### PR DESCRIPTION
Trying to bring the user fields on spans closer to transactions. User alone is not ergonomic and we'd like to be able to search by user email, username etc. Transactions also has the user's ip address but the spans table currently does not have the ipv4 and ipv6 columns for it so going to hold off on it as the other fields are more useful.