### PR TITLE
feat(spans): disable redis span metrics extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Add support for `event.` in the `Span` `Getter` implementation. ([#3577](https://github.com/getsentry/relay/pull/3577))
 - Ensure `chunk_id` and `profiler_id` are UUIDs and sort samples. ([#3588](https://github.com/getsentry/relay/pull/3588))
 - Add a calculated measurement based on the AI model and the tokens used. ([#3554](https://github.com/getsentry/relay/pull/3554))
-- Disable `db.redis` span metrics extraction. ([#3283](https://github.com/getsentry/relay/pull/3283))
+- Disable `db.redis` span metrics extraction. ([#3600](https://github.com/getsentry/relay/pull/3600))
 
 ## 24.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Add support for `event.` in the `Span` `Getter` implementation. ([#3577](https://github.com/getsentry/relay/pull/3577))
 - Ensure `chunk_id` and `profiler_id` are UUIDs and sort samples. ([#3588](https://github.com/getsentry/relay/pull/3588))
 - Add a calculated measurement based on the AI model and the tokens used. ([#3554](https://github.com/getsentry/relay/pull/3554))
-
+- Disable `db.redis` span metrics extraction. ([#3283](https://github.com/getsentry/relay/pull/3283))
 
 ## 24.4.2
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -7,7 +7,13 @@ use crate::metrics::MetricSpec;
 use crate::{Feature, MetricExtractionConfig, ProjectConfig, Tag};
 
 /// A list of `span.op` patterns that indicate databases that should be skipped.
-const DISABLED_DATABASES: &[&str] = &["*clickhouse*", "*compile*", "*mongodb*", "db.orm"];
+const DISABLED_DATABASES: &[&str] = &[
+    "*clickhouse*",
+    "*compile*",
+    "*mongodb*",
+    "*redis*",
+    "db.orm",
+];
 
 /// A list of `span.op` patterns we want to enable for mobile.
 const MOBILE_OPS: &[&str] = &[

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -2419,40 +2419,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
-            "span.op": "db.redis",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -2474,13 +2443,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {
@@ -2520,40 +2484,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
-            "span.op": "db.redis",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -2575,13 +2508,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {
@@ -2621,40 +2549,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "SET",
-            "span.category": "db",
-            "span.description": "SET *",
-            "span.group": "46b2cac4b418f556",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SET",
-            "span.category": "db",
-            "span.description": "SET *",
-            "span.group": "46b2cac4b418f556",
-            "span.op": "db.redis",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -2676,13 +2573,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "SET",
-            "span.category": "db",
-            "span.description": "SET *",
-            "span.group": "46b2cac4b418f556",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {
@@ -3150,36 +3042,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
             "span.op": "db.redis.command",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
-            "span.op": "db.redis.command",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -3201,11 +3066,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "SAVEPOINT",
-            "span.category": "db",
             "span.op": "db.redis.command",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {
@@ -6068,40 +5930,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
-            "span.op": "db.redis",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6123,13 +5954,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {
@@ -6169,40 +5995,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
-            "span.op": "db.redis",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6224,13 +6019,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "GET",
-            "span.category": "db",
-            "span.description": "GET *",
-            "span.group": "37e3d9fab1ae9162",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {
@@ -6270,40 +6060,9 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "SET",
-            "span.category": "db",
-            "span.description": "SET *",
-            "span.group": "46b2cac4b418f556",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time_light@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.action": "SET",
-            "span.category": "db",
-            "span.description": "SET *",
-            "span.group": "46b2cac4b418f556",
-            "span.op": "db.redis",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6325,13 +6084,8 @@ expression: metrics
         ),
         tags: {
             "environment": "fake_environment",
-            "span.action": "SET",
-            "span.category": "db",
-            "span.description": "SET *",
-            "span.group": "46b2cac4b418f556",
             "span.op": "db.redis",
             "transaction": "gEt /api/:version/users/",
-            "transaction.method": "POST",
             "transaction.op": "myop",
         },
         metadata: BucketMetadata {


### PR DESCRIPTION
We originally re-enabled db.redis in order to collect metrics for the cache module. However, since then we decided that the cache module will only look at `cache.*` span ops.

Therefore we can stop collecting `db.redis` span metrics.