### PR TITLE
Revert "ci(ci): Disable skipping publish for releases"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
 
     # Skip redundant checks for library releases
     # Skip for dependabot and if run on a fork
-    if: "startsWith(github.ref, 'refs/heads/release/') || (!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'")
+    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     steps:
       - name: Install cosign


### PR DESCRIPTION
Reverts getsentry/relay#3601 due to [syntax error in YAML](https://github.com/getsentry/relay/actions/runs/9102324321)

#skip-changelog