### PR TITLE
feat(filter): Filter subdomains of localhost as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Features**:
 
 - Apple trace-based sampling rules to standalone spans. ([#3476](https://github.com/getsentry/relay/pull/3476))
+- Localhost inbound filter filters sudomains of localhost. ([#3608](https://github.com/getsentry/relay/pull/3608))
 
 **Internal**:
 


### PR DESCRIPTION
The localhost inbound filter should also filter subdomains of localhost such as `foo.localhost`.

Closes: [#70841](https://github.com/getsentry/sentry/issues/70841)

