### PR TITLE
fix(metric-stats): Only emit volume metadata for the first bucket view

### DIFF
--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -811,6 +811,12 @@ mod tests {
     }
 
     #[test]
+    fn test_bucket_view_counter_metadata() {
+        let bucket = Bucket::parse(b"b0:1|c", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(bucket.metadata, BucketView::new(&bucket).metadata());
+    }
+
+    #[test]
     fn test_bucket_view_select_distribution() {
         let bucket = Bucket::parse(b"b2:1:2:3:5:5|d", UnixTimestamp::from_secs(5000)).unwrap();
 
@@ -844,6 +850,26 @@ mod tests {
     }
 
     #[test]
+    fn test_bucket_view_distribution_metadata() {
+        let bucket = Bucket::parse(b"b2:1:2:3:5:5|d", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(bucket.metadata, BucketView::new(&bucket).metadata());
+
+        assert_eq!(
+            BucketView::new(&bucket).select(0..3).unwrap().metadata(),
+            bucket.metadata
+        );
+
+        let m = BucketView::new(&bucket).select(1..3).unwrap().metadata();
+        assert_eq!(
+            m,
+            BucketMetadata {
+                merges: 0,
+                ..bucket.metadata
+            }
+        );
+    }
+
+    #[test]
     fn test_bucket_view_select_set() {
         let bucket = Bucket::parse(b"b3:42:75|s", UnixTimestamp::from_secs(5000)).unwrap();
         let s = [42, 75].into();
@@ -866,6 +892,26 @@ mod tests {
         assert!(BucketView::new(&bucket).select(0..3).is_none());
         assert!(BucketView::new(&bucket).select(2..5).is_none());
         assert!(BucketView::new(&bucket).select(77..99).is_none());
+    }
+
+    #[test]
+    fn test_bucket_view_set_metadata() {
+        let bucket = Bucket::parse(b"b2:1:2:3:5:5|s", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(bucket.metadata, BucketView::new(&bucket).metadata());
+
+        assert_eq!(
+            BucketView::new(&bucket).select(0..3).unwrap().metadata(),
+            bucket.metadata
+        );
+
+        let m = BucketView::new(&bucket).select(1..3).unwrap().metadata();
+        assert_eq!(
+            m,
+            BucketMetadata {
+                merges: 0,
+                ..bucket.metadata
+            }
+        );
     }
 
     #[test]
@@ -896,6 +942,13 @@ mod tests {
         assert!(BucketView::new(&bucket).select(0..4).is_none());
         assert!(BucketView::new(&bucket).select(5..5).is_none());
         assert!(BucketView::new(&bucket).select(5..6).is_none());
+    }
+
+    #[test]
+    fn test_bucket_view_gauge_metadata() {
+        let bucket =
+            Bucket::parse(b"b4:25:17:42:220:85|g", UnixTimestamp::from_secs(5000)).unwrap();
+        assert_eq!(BucketView::new(&bucket).metadata(), bucket.metadata);
     }
 
     fn buckets<T>(s: &[u8]) -> T

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -72,7 +72,7 @@ impl MetricStats {
 
         relay_log::trace!(
             "Tracking volume of {} for mri '{}': {}",
-            bucket.metadata().merges.get(),
+            bucket.metadata().merges,
             bucket.name(),
             outcome
         );
@@ -121,7 +121,7 @@ impl MetricStats {
     }
 
     fn to_volume_metric(&self, bucket: impl TrackableBucket, outcome: &Outcome) -> Option<Bucket> {
-        let volume = bucket.metadata().merges.get();
+        let volume = bucket.metadata().merges;
         if volume == 0 {
             return None;
         }

--- a/relay-server/src/metrics.rs
+++ b/relay-server/src/metrics.rs
@@ -155,7 +155,7 @@ pub trait TrackableBucket {
     fn summary(&self, mode: ExtractionMode) -> BucketSummary;
 
     /// Metric bucket metadata.
-    fn metadata(&self) -> &BucketMetadata;
+    fn metadata(&self) -> BucketMetadata;
 }
 
 impl<T: TrackableBucket> TrackableBucket for &T {
@@ -171,7 +171,7 @@ impl<T: TrackableBucket> TrackableBucket for &T {
         (**self).summary(mode)
     }
 
-    fn metadata(&self) -> &BucketMetadata {
+    fn metadata(&self) -> BucketMetadata {
         (**self).metadata()
     }
 }
@@ -189,8 +189,8 @@ impl TrackableBucket for Bucket {
         BucketView::new(self).summary(mode)
     }
 
-    fn metadata(&self) -> &BucketMetadata {
-        &self.metadata
+    fn metadata(&self) -> BucketMetadata {
+        self.metadata
     }
 }
 
@@ -234,7 +234,7 @@ impl TrackableBucket for BucketView<'_> {
         }
     }
 
-    fn metadata(&self) -> &BucketMetadata {
+    fn metadata(&self) -> BucketMetadata {
         self.metadata()
     }
 }


### PR DESCRIPTION
Splitting a bucket into multiple via a `BucketView` brings the problem that some of the metadata can't be attributed correctly anymore (aggregation is a lossy process for metadata). To solve this problem for the volume metadata, it will only be attached to the bucket view containing the start of the bucket.

#skip-changelog