### PR TITLE
ref: size-optimize the relay python library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ debug = false
 # panic and error stack traces to Sentry.
 debug = true
 
+[profile.release-cabi]
+inherits = "release"
+lto = true
+debug = false
+strip = true
+
 [workspace.lints.clippy]
 dbg_macro = "warn"
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove publishing of x86 wheels. [#3596](https://github.com/getsentry/relay/pull/3596)
 - Require minimum macos 14.x for wheels [#3611](https://github.com/getsentry/relay/pull/3611)
+- Significantly reduce size of published wheels [#3610](https://github.com/getsentry/relay/pull/3610)
 
 ## 0.8.64
 

--- a/py/setup.py
+++ b/py/setup.py
@@ -48,8 +48,8 @@ class CustomSDist(sdist):
 def build_native(spec):
     cmd = ["cargo", "build", "-p", "relay-cabi"]
     if not DEBUG_BUILD:
-        cmd.append("--release")
-        target = "release"
+        cmd.extend(("--profile", "release-cabi"))
+        target = "release-cabi"
     else:
         target = "debug"
 

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -25,7 +25,7 @@ docker run \
   -e $TARGET_LINKER \
   -e CARGO_BUILD_TARGET \
   ${BUILDER_NAME} \
-  bash -c 'cargo build -p relay-cabi --release'
+  bash -c 'cargo build -p relay-cabi --profile release-cabi'
 
 # create a wheel for the correct architecture
 docker run \


### PR DESCRIPTION
on linux this reduces the installed library size from 240MB to 14MB (might actually be smaller but I'm impatient -- that number was with `debug = true` still accidentally on)




<!-- Describe your PR here. -->