### PR TITLE
feat(spans): Send microsecond precision timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Add a calculated measurement based on the AI model and the tokens used. ([#3554](https://github.com/getsentry/relay/pull/3554))
 - Restrict usage of OTel endpoint. ([#3597](github.com/getsentry/relay/pull/3597))
 - Support new cache span ops in metrics and tag extraction. ([#3598](https://github.com/getsentry/relay/pull/3598))
+- Send microsecond precision timestamps. ([#3613](https://github.com/getsentry/relay/pull/3613))
 
 ## 24.4.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.79"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d651a09ba1a06c066c54cacaf91abb51814a2143996b8b5877b81eecd598db"
+checksum = "791e0bce4590c9154c58f1d848f3786c4b44646e9c882e9b6b48c8f33a9ef30b"
 dependencies = [
  "jsonschema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ rust-embed = "8.0.0"
 schemars = { version = "=0.8.10", features = ["uuid1", "chrono"] }
 sentry = "0.32.2"
 sentry-core = "0.32.2"
-sentry-kafka-schemas = { version = "0.1.79", default-features = false }
+sentry-kafka-schemas = { version = "0.1.86", default-features = false }
 sentry-release-parser = { version = "1.3.2", default-features = false }
 sentry-types = "0.32.2"
 sentry_usage_accountant = { version = "0.1.0", default-features = false }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1347,10 +1347,6 @@ struct SpanMeasurement {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct SpanKafkaMessage<'a> {
-    #[serde(skip_serializing)]
-    start_timestamp: f64,
-    #[serde(rename(deserialize = "timestamp"), skip_serializing)]
-    end_timestamp: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<&'a RawValue>,
     #[serde(default)]
@@ -1386,11 +1382,16 @@ struct SpanKafkaMessage<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     sentry_tags: Option<BTreeMap<&'a str, String>>,
     span_id: &'a str,
-    #[serde(default)]
-    start_timestamp_ms: u64,
     #[serde(default, skip_serializing_if = "none_or_empty_object")]
     tags: Option<&'a RawValue>,
     trace_id: EventId,
+
+    #[serde(default)]
+    start_timestamp_ms: u64,
+    #[serde(rename(deserialize = "start_timestamp"))]
+    start_timestamp_micro: f64,
+    #[serde(rename(deserialize = "timestamp"))]
+    end_timestamp_micro: f64,
 
     #[serde(borrow, default, skip_serializing)]
     platform: Cow<'a, str>, // We only use this for logging for now

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -930,12 +930,12 @@ impl StoreService {
             }
         };
 
-        span.duration_ms = ((span.end_timestamp - span.start_timestamp) * 1e3) as u32;
+        span.duration_ms = ((span.end_timestamp_micro - span.start_timestamp_micro) * 1e3) as u32;
         span.event_id = event_id;
         span.organization_id = scoping.organization_id;
         span.project_id = scoping.project_id.value();
         span.retention_days = retention_days;
-        span.start_timestamp_ms = (span.start_timestamp * 1e3) as u64;
+        span.start_timestamp_ms = (span.start_timestamp_micro * 1e3) as u64;
 
         if let Some(measurements) = &mut span.measurements {
             measurements.retain(|_, v| {
@@ -990,7 +990,7 @@ impl StoreService {
         };
         let &SpanKafkaMessage {
             duration_ms,
-            end_timestamp,
+            end_timestamp_micro,
             is_segment,
             project_id,
             received,
@@ -1046,7 +1046,7 @@ impl StoreService {
                     KafkaMessage::MetricsSummary(MetricsSummaryKafkaMessage {
                         count,
                         duration_ms,
-                        end_timestamp,
+                        end_timestamp: end_timestamp_micro,
                         group,
                         is_segment,
                         max,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -930,12 +930,13 @@ impl StoreService {
             }
         };
 
-        span.duration_ms = ((span.end_timestamp_micro - span.start_timestamp_micro) * 1e3) as u32;
+        span.duration_ms =
+            ((span.end_timestamp_precise - span.start_timestamp_precise) * 1e3) as u32;
         span.event_id = event_id;
         span.organization_id = scoping.organization_id;
         span.project_id = scoping.project_id.value();
         span.retention_days = retention_days;
-        span.start_timestamp_ms = (span.start_timestamp_micro * 1e3) as u64;
+        span.start_timestamp_ms = (span.start_timestamp_precise * 1e3) as u64;
 
         if let Some(measurements) = &mut span.measurements {
             measurements.retain(|_, v| {
@@ -990,7 +991,7 @@ impl StoreService {
         };
         let &SpanKafkaMessage {
             duration_ms,
-            end_timestamp_micro,
+            end_timestamp_precise,
             is_segment,
             project_id,
             received,
@@ -1046,7 +1047,7 @@ impl StoreService {
                     KafkaMessage::MetricsSummary(MetricsSummaryKafkaMessage {
                         count,
                         duration_ms,
-                        end_timestamp: end_timestamp_micro,
+                        end_timestamp: end_timestamp_precise,
                         group,
                         is_segment,
                         max,
@@ -1389,9 +1390,9 @@ struct SpanKafkaMessage<'a> {
     #[serde(default)]
     start_timestamp_ms: u64,
     #[serde(rename(deserialize = "start_timestamp"))]
-    start_timestamp_micro: f64,
+    start_timestamp_precise: f64,
     #[serde(rename(deserialize = "timestamp"))]
-    end_timestamp_micro: f64,
+    end_timestamp_precise: f64,
 
     #[serde(borrow, default, skip_serializing)]
     platform: Cow<'a, str>, // We only use this for logging for now

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1379,7 +1379,7 @@ def test_span_ingestion_with_performance_scores(
             "span_id": "bd429c44b67a3eb1",
             "start_timestamp_ms": int(start.timestamp() * 1e3),
             "start_timestamp_precise": start.timestamp(),
-            "end_timestamp_precise": end.timestamp(),
+            "end_timestamp_precise": end.timestamp() + 1,
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
             "measurements": {
                 "score.fcp": {"value": 0.14999972769539766},
@@ -1424,7 +1424,7 @@ def test_span_ingestion_with_performance_scores(
             "span_id": "cd429c44b67a3eb1",
             "start_timestamp_ms": int(start.timestamp() * 1e3),
             "start_timestamp_precise": start.timestamp(),
-            "end_timestamp_precise": end.timestamp(),
+            "end_timestamp_precise": end.timestamp() + 1,
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
             "measurements": {
                 "inp": {"value": 100.0},


### PR DESCRIPTION
As we're receiving standalone spans, we need to be able to order sibling spans and we currently store spans only with millisecond precision and that's not enough. This will add timestamps with up to a microsecond precision.

We'll still display and use millisecond in the product.