### PR TITLE
ref: lie about the min macos version on x86_64

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            py-platform: macosx-14_0_x86_64
+            py-platform: macosx-13_0_x86_64
           - target: aarch64-apple-darwin
             py-platform: macosx-14_0_arm64
 

--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -17,7 +17,7 @@ targets:
           cacheControl: "public, max-age=2592000"
 
 requireNames:
-  - /^sentry_relay-.*-py2\.py3-none-macosx_14_0_x86_64.whl$/
+  - /^sentry_relay-.*-py2\.py3-none-macosx_13_0_x86_64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-macosx_14_0_arm64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_x86_64.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux2014_aarch64.*\.whl$/


### PR DESCRIPTION
turns out github CI only has 13.x for intel so we need to make this wheel name compatible and _hope_ that the symbols are good enough


#skip-changelog

<!-- Describe your PR here. -->