### PR TITLE
ref(processing/store): remove references to feedback attachments option

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -198,19 +198,6 @@ pub struct Options {
     )]
     pub feedback_ingest_topic_rollout_rate: f32,
 
-    /// Flag for handling feedback and attachments in the same envelope. This is for the SDK team to send less requests
-    /// for the user feedback screenshots feature. Prior to this change, feedback sent w/attachments would be produced
-    /// to the attachments topic, rather than its own topic. The items are now split up accordingly.
-    ///
-    /// This option is used as a temporary FF/kill-switch to toggle back to the old code path in relay's StoreService.
-    /// This is for testing convenience and will be removed after user feedback's GA release.
-    #[serde(
-        rename = "feedback.ingest-inline-attachments",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub feedback_ingest_same_envelope_attachments: bool,
-
     /// Overall sampling of span extraction.
     ///
     /// This number represents the fraction of transactions for which

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -190,19 +190,10 @@ impl StoreService {
         let retention = envelope.retention();
         let event_id = envelope.event_id();
 
-        let feedback_ingest_same_envelope_attachments = self
-            .global_config
-            .current()
-            .options
-            .feedback_ingest_same_envelope_attachments;
-
         let event_item = envelope.as_mut().take_item_by(|item| {
             matches!(
-                (item.ty(), feedback_ingest_same_envelope_attachments),
-                (ItemType::Event, _)
-                    | (ItemType::Transaction, _)
-                    | (ItemType::Security, _)
-                    | (ItemType::UserReportV2, false)
+                item.ty(),
+                ItemType::Event | ItemType::Transaction | ItemType::Security
             )
         });
         let client = envelope.meta().client();
@@ -251,7 +242,7 @@ impl StoreService {
                         item,
                     )?;
                 }
-                ItemType::UserReportV2 if feedback_ingest_same_envelope_attachments => {
+                ItemType::UserReportV2 => {
                     let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
                     self.produce_user_report_v2(
                         event_id.ok_or(StoreError::NoEventId)?,

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -96,13 +96,9 @@ def test_feedback_event_with_processing(
     events_consumer,
     feedback_consumer,
     use_feedback_topic,
-    use_feedback_ingest_v2,
 ):
     mini_sentry.add_basic_project_config(
         42, extra={"config": {"features": ["organizations:user-feedback-ingest"]}}
-    )
-    mini_sentry.set_global_config_option(
-        "feedback.ingest-inline-attachments", use_feedback_ingest_v2
     )
 
     if use_feedback_topic:
@@ -132,15 +128,12 @@ def test_feedback_event_with_processing(
 @pytest.mark.parametrize("use_feedback_ingest_v2", (False, True))
 @pytest.mark.parametrize("use_feedback_topic", (False, True))
 def test_feedback_events_without_processing(
-    mini_sentry, relay_chain, use_feedback_topic, use_feedback_ingest_v2
+    mini_sentry, relay_chain, use_feedback_topic
 ):
     project_id = 42
     mini_sentry.add_basic_project_config(
         project_id,
         extra={"config": {"features": ["organizations:user-feedback-ingest"]}},
-    )
-    mini_sentry.set_global_config_option(
-        "feedback.ingest-inline-attachments", use_feedback_ingest_v2
     )
     mini_sentry.set_global_config_option(
         "feedback.ingest-topic.rollout-rate", 1.0 if use_feedback_topic else 0.0
@@ -169,8 +162,6 @@ def test_feedback_with_attachment_in_same_envelope(
     mini_sentry.add_basic_project_config(
         42, extra={"config": {"features": ["organizations:user-feedback-ingest"]}}
     )
-    # Test will only pass with this option set
-    mini_sentry.set_global_config_option("feedback.ingest-inline-attachments", True)
 
     if use_feedback_topic:
         mini_sentry.set_global_config_option("feedback.ingest-topic.rollout-rate", 1.0)

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -88,7 +88,6 @@ def assert_expected_feedback(parsed_feedback, sent_feedback):
     }
 
 
-@pytest.mark.parametrize("use_feedback_ingest_v2", (False, True))
 @pytest.mark.parametrize("use_feedback_topic", (False, True))
 def test_feedback_event_with_processing(
     mini_sentry,
@@ -125,7 +124,6 @@ def test_feedback_event_with_processing(
     other_consumer.assert_empty()
 
 
-@pytest.mark.parametrize("use_feedback_ingest_v2", (False, True))
 @pytest.mark.parametrize("use_feedback_topic", (False, True))
 def test_feedback_events_without_processing(
     mini_sentry, relay_chain, use_feedback_topic


### PR DESCRIPTION
Follow up after https://github.com/getsentry/team-replay/issues/393. We've set the option to true for all regions and tested that it works, so this is a dead code path we can remove

Relates to https://github.com/getsentry/sentry-javascript/pull/11428

#skip-changelog