### PR TITLE
ref: dual-publish docker image to google's artifact registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
     env:
       GHCR_DOCKER_IMAGE: "ghcr.io/getsentry/${{ matrix.image_name }}"
       GCR_DOCKER_IMAGE: "us.gcr.io/sentryio/${{ matrix.image_name }}"
+      AR_DOCKER_IMAGE: "us-central1-docker.pkg.dev/sentryio/relay/${{ matrix.image_name }}"
       REVISION: "${{ github.event.pull_request.head.sha || github.sha }}"
 
     # Skip redundant checks for library releases
@@ -408,7 +409,7 @@ jobs:
 
       - name: Configure docker
         run: |
-          gcloud auth configure-docker us.gcr.io
+          gcloud auth configure-docker us.gcr.io,us-central1-docker.pkg.dev
 
       - name: Install regctl
         uses: regclient/actions/regctl-installer@2dac4eff5925ed07edbfe12d2d11af6304df29a6
@@ -416,9 +417,16 @@ jobs:
       - name: Copy Image from GHCR to GCR
         run: regctl image copy "${GHCR_DOCKER_IMAGE}:${REVISION}" "${GCR_DOCKER_IMAGE}:${REVISION}"
 
+      - name: Copy Image from GHCR to AR
+        run: regctl image copy "${GHCR_DOCKER_IMAGE}:${REVISION}" "${AR_DOCKER_IMAGE}:${REVISION}"
+
       - name: Copy Nightly from GHCR to GCR
         if: github.ref == 'refs/heads/master'
         run: regctl image copy "${GHCR_DOCKER_IMAGE}:nightly" "${GCR_DOCKER_IMAGE}:nightly"
+
+      - name: Copy Nightly from GHCR to AR
+        if: github.ref == 'refs/heads/master'
+        run: regctl image copy "${GHCR_DOCKER_IMAGE}:nightly" "${AR_DOCKER_IMAGE}:nightly"
 
   gocd-artifacts:
     timeout-minutes: 5


### PR DESCRIPTION
gcr is being phased out within the year

#skip-changelog




<!-- Describe your PR here. -->