### PR TITLE
fix(cogs): Only attribute rate limit buckets to spans and transaction metrics

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2671,7 +2671,13 @@ impl EnvelopeProcessorService {
             EnvelopeProcessor::SubmitClientReports(_) => AppFeature::ClientReports.into(),
             #[cfg(feature = "processing")]
             EnvelopeProcessor::RateLimitBuckets(v) => {
-                relay_metrics::cogs::ByCount(v.bucket_limiter.buckets()).into()
+                relay_metrics::cogs::ByCount(v.bucket_limiter.buckets().filter(|b| {
+                    matches!(
+                        b.name.try_namespace(),
+                        Some(MetricNamespace::Spans | MetricNamespace::Transactions)
+                    )
+                }))
+                .into()
             }
         }
     }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2672,6 +2672,8 @@ impl EnvelopeProcessorService {
             #[cfg(feature = "processing")]
             EnvelopeProcessor::RateLimitBuckets(v) => {
                 relay_metrics::cogs::ByCount(v.bucket_limiter.buckets().filter(|b| {
+                    // Only spans and transactions are actually rate limited at this point.
+                    // Other metrics do not cause costs.
                     matches!(
                         b.name.try_namespace(),
                         Some(MetricNamespace::Spans | MetricNamespace::Transactions)


### PR DESCRIPTION
Only spans and transactions are actually rate limited in that stage.

#skip-changelog