### PR TITLE
fix(metric-stats): Use cardinality timestamp for reports

### DIFF
--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use hashbrown::HashSet;
 use relay_base_schema::metrics::{MetricName, MetricNamespace, MetricType};
 use relay_base_schema::project::ProjectId;
+use relay_common::time::UnixTimestamp;
 use relay_statsd::metric;
 
 use crate::statsd::CardinalityLimiterTimers;
@@ -27,6 +28,9 @@ pub struct Scoping {
 /// If all of the scoping information is `None`, the limit is a global cardinality limit.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CardinalityReport {
+    /// Time for which the cardinality limit was enforced.
+    pub timestamp: UnixTimestamp,
+
     /// Organization id for which the cardinality limit was applied.
     ///
     /// Only available if the the limit was at least scoped to
@@ -671,6 +675,7 @@ mod tests {
                 reporter.report_cardinality(
                     &limits[0],
                     CardinalityReport {
+                        timestamp: UnixTimestamp::from_secs(5000),
                         organization_id: Some(scoping.organization_id),
                         project_id: Some(scoping.project_id),
                         metric_type: None,
@@ -682,6 +687,7 @@ mod tests {
                 reporter.report_cardinality(
                     &limits[0],
                     CardinalityReport {
+                        timestamp: UnixTimestamp::from_secs(5001),
                         organization_id: Some(scoping.organization_id),
                         project_id: Some(scoping.project_id),
                         metric_type: None,
@@ -693,6 +699,7 @@ mod tests {
                 reporter.report_cardinality(
                     &limits[2],
                     CardinalityReport {
+                        timestamp: UnixTimestamp::from_secs(5002),
                         organization_id: Some(scoping.organization_id),
                         project_id: Some(scoping.project_id),
                         metric_type: None,
@@ -753,6 +760,7 @@ mod tests {
             reports.get(&limits[0]).unwrap(),
             &[
                 CardinalityReport {
+                    timestamp: UnixTimestamp::from_secs(5000),
                     organization_id: Some(scoping.organization_id),
                     project_id: Some(scoping.project_id),
                     metric_type: None,
@@ -760,6 +768,7 @@ mod tests {
                     cardinality: 1
                 },
                 CardinalityReport {
+                    timestamp: UnixTimestamp::from_secs(5001),
                     organization_id: Some(scoping.organization_id),
                     project_id: Some(scoping.project_id),
                     metric_type: None,
@@ -771,6 +780,7 @@ mod tests {
         assert_eq!(
             reports.get(&limits[2]).unwrap(),
             &[CardinalityReport {
+                timestamp: UnixTimestamp::from_secs(5002),
                 organization_id: Some(scoping.organization_id),
                 project_id: Some(scoping.project_id),
                 metric_type: None,

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -194,7 +194,7 @@ impl MetricStats {
         }
 
         Some(Bucket {
-            timestamp: UnixTimestamp::now(),
+            timestamp: report.timestamp,
             width: 0,
             name: cardinality_metric_mri(),
             value: BucketValue::Gauge(GaugeValue::single(cardinality.into())),
@@ -342,6 +342,7 @@ mod tests {
             namespace: None,
         };
         let report = CardinalityReport {
+            timestamp: UnixTimestamp::from_secs(3333),
             organization_id: Some(scoping.organization_id),
             project_id: Some(scoping.project_id),
             metric_type: None,
@@ -363,6 +364,7 @@ mod tests {
         let bucket = buckets.pop().unwrap();
 
         assert_eq!(&*bucket.name, "g:metric_stats/cardinality@none");
+        assert_eq!(bucket.timestamp, UnixTimestamp::from_secs(3333));
         assert_eq!(
             bucket.value,
             BucketValue::Gauge(GaugeValue {
@@ -407,6 +409,7 @@ mod tests {
             namespace: Some(MetricNamespace::Spans),
         };
         let report = CardinalityReport {
+            timestamp: UnixTimestamp::from_secs(2222),
             organization_id: Some(scoping.organization_id),
             project_id: Some(scoping.project_id),
             metric_type: Some(MetricType::Distribution),
@@ -428,6 +431,7 @@ mod tests {
         let bucket = buckets.pop().unwrap();
 
         assert_eq!(&*bucket.name, "g:metric_stats/cardinality@none");
+        assert_eq!(bucket.timestamp, UnixTimestamp::from_secs(2222));
         assert_eq!(
             bucket.value,
             BucketValue::Gauge(GaugeValue {


### PR DESCRIPTION
Aligns the timestamps of the cardinality reports with the actual cardinality limiting.

Without aligning the timestamps increased cardinality could spill over to new "metric minutes" which in general isn't a big problem but using the same timestamp is correct.

#skip-changelog