### PR TITLE
ref(server): Swap CF and Vercel forwarded priority

### DIFF
--- a/relay-server/src/extractors/forwarded_for.rs
+++ b/relay-server/src/extractors/forwarded_for.rs
@@ -36,15 +36,16 @@ impl ForwardedFor {
     /// reverse proxies.
     ///
     /// First match wins in order:
+    /// - [`Self::CLOUDFLARE_FORWARDED_HEADER`], highest priority since users may use Cloudflare
+    /// infront of Vercel, it is generally the first layer.
     /// - [`Self::VERCEL_FORWARDED_HEADER`]
-    /// - [`Self::CLOUDFLARE_FORWARDED_HEADER`]
     /// - [`Self::SENTRY_FORWARDED_HEADER`]
     /// - [`Self::FORWARDED_HEADER`].
     fn get_forwarded_for_ip(header_map: &HeaderMap) -> Option<&str> {
         // List of headers to check from highest to lowest priority.
         let headers = [
-            Self::VERCEL_FORWARDED_HEADER,
             Self::CLOUDFLARE_FORWARDED_HEADER,
+            Self::VERCEL_FORWARDED_HEADER,
             Self::SENTRY_FORWARDED_HEADER,
             Self::FORWARDED_HEADER,
         ];


### PR DESCRIPTION
Users are more likely to run Cloudflare infront of other services, which makes the cloudflare header the one which is most likely to contain the real user IP. Prioritize the cloudflare header over other headers.

Followup of https://github.com/getsentry/relay/issues/3493#issuecomment-2121841368

#skip-changelog