### PR TITLE
feat(metrics): Limit metric name to 150 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Extract additional user fields for spans. ([#3599](https://github.com/getsentry/relay/pull/3599))
 - Disable `db.redis` span metrics extraction. ([#3600](https://github.com/getsentry/relay/pull/3600))
 - Extract status for spans. ([#3606](https://github.com/getsentry/relay/pull/3606))
+- Limit metric name to 150 characters. ([#3628](https://github.com/getsentry/relay/pull/3628))
 
 ## 24.4.2
 

--- a/relay-base-schema/src/metrics/mod.rs
+++ b/relay-base-schema/src/metrics/mod.rs
@@ -39,8 +39,13 @@ pub fn try_normalize_metric_name(name: &str) -> Option<Cow<'_, str>> {
         return Some(normalized_name);
     }
 
-    // We limit the string to a fixed size. Here we are taking slices assuming that we have a single
-    // character per index since we are normalizing the name above.
+    // We limit the string to a fixed size.
+    //
+    // Here we are taking slices, assuming that we have a single character per index since we are
+    // normalizing the name above.
+    //
+    // If we allow characters that take more than 1 byte per character, we will need to change this
+    // function. Otherwise, it will panic because the index might cut a character in half.
     Some(match normalized_name {
         Cow::Borrowed(value) => Cow::Borrowed(&value[..CUSTOM_METRIC_NAME_MAX_SIZE]),
         Cow::Owned(mut value) => {

--- a/relay-base-schema/src/metrics/mod.rs
+++ b/relay-base-schema/src/metrics/mod.rs
@@ -31,11 +31,11 @@ pub fn try_normalize_metric_name(name: &str) -> Option<Cow<'_, str>> {
 
     // Note: `-` intentionally missing from this list.
     let normalize_re = NORMALIZE_RE.get_or_init(|| Regex::new("[^a-zA-Z0-9_.]+").unwrap());
-    let normalized = normalize_re.replace_all(name, "_");
+    let normalized_name = normalize_re.replace_all(name, "_");
 
     // We limit the string to a fixed size. Here we are taking slices assuming that we have a single
     // character per index since we are normalizing the name above.
-    Some(match normalized {
+    Some(match normalized_name {
         Cow::Borrowed(value) => {
             Cow::Borrowed(&value[..min(value.len(), CUSTOM_METRIC_NAME_MAX_SIZE)])
         }

--- a/relay-base-schema/src/metrics/mod.rs
+++ b/relay-base-schema/src/metrics/mod.rs
@@ -11,9 +11,9 @@ pub use self::units::*;
 use regex::Regex;
 use std::{borrow::Cow, sync::OnceLock};
 
-// The limit is determined by the unit size (15) and the maximum MRI length (200).
-// By choosing a metric name length of 150, we ensure that 35 characters remain available 
-// for the MRI divider characters, metric type, and namespace, which is a reasonable allocation.
+/// The limit is determined by the unit size (15) and the maximum MRI length (200).
+/// By choosing a metric name length of 150, we ensure that 35 characters remain available
+/// for the MRI divider characters, metric type, and namespace, which is a reasonable allocation.
 const CUSTOM_METRIC_NAME_MAX_SIZE: usize = 150;
 
 /// Validates a metric name and normalizes it. This is the statsd name, i.e. without type or unit.

--- a/relay-base-schema/src/metrics/mod.rs
+++ b/relay-base-schema/src/metrics/mod.rs
@@ -9,10 +9,11 @@ pub use self::name::*;
 pub use self::units::*;
 
 use regex::Regex;
-use std::cmp::min;
-use std::thread::current;
 use std::{borrow::Cow, sync::OnceLock};
 
+// The limit is determined by the unit size (15) and the maximum MRI length (200).
+// By choosing a metric name length of 150, we ensure that 35 characters remain available 
+// for the MRI divider characters, metric type, and namespace, which is a reasonable allocation.
 const CUSTOM_METRIC_NAME_MAX_SIZE: usize = 150;
 
 /// Validates a metric name and normalizes it. This is the statsd name, i.e. without type or unit.

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -462,12 +462,6 @@ mod tests {
                 .name,
             "f_o"
         );
-        assert_eq!(
-            MetricResourceIdentifier::parse("c:custom/föo")
-                .unwrap()
-                .name,
-            "f_o"
-        );
     }
 
     #[test]

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -474,6 +474,14 @@ mod tests {
             "ThisIsACharacterLongStringForTestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationW"
         );
 
+        let long_mri_with_replacement = "c:custom/ThisIsÄCharacterLongStringForŤestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationWithoutErrors";
+        assert_eq!(
+            MetricResourceIdentifier::parse(long_mri_with_replacement)
+                .unwrap()
+                .name,
+            "ThisIs_CharacterLongStringFor_estingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationW"
+        );
+
         let short_mri = "c:custom/ThisIsAShortName";
         assert_eq!(
             MetricResourceIdentifier::parse(short_mri).unwrap().name,

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -474,7 +474,7 @@ mod tests {
             "ThisIsACharacterLongStringForTestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationW"
         );
 
-        let long_mri_with_replacement = "c:custom/ThisIsÄCharacterLongStringForŤestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationWithoutErrors";
+        let long_mri_with_replacement = "c:custom/ThisIsÄÂÏCharacterLongStringForŤestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationWithoutErrors";
         assert_eq!(
             MetricResourceIdentifier::parse(long_mri_with_replacement)
                 .unwrap()

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -462,6 +462,29 @@ mod tests {
                 .name,
             "f_o"
         );
+        assert_eq!(
+            MetricResourceIdentifier::parse("c:custom/föo")
+                .unwrap()
+                .name,
+            "f_o"
+        );
+    }
+
+    #[test]
+    fn test_normalize_name_length() {
+        let long_mri = "c:custom/ThisIsACharacterLongStringForTestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationWithoutErrors";
+        assert_eq!(
+            MetricResourceIdentifier::parse(long_mri)
+                .unwrap()
+                .name,
+            "ThisIsACharacterLongStringForTestingPurposesToEnsureThatWeHaveEnoughCharactersToWorkWithAndToCheckIfOurFunctionProperlyHandlesSlicingAndNormalizationW"
+        );
+
+        let short_mri = "c:custom/ThisIsAShortName";
+        assert_eq!(
+            MetricResourceIdentifier::parse(short_mri).unwrap().name,
+            "ThisIsAShortName"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR limits the metric name to 150 characters, which is added to the limit of 15 characters in the metric unit. Since we have a total of 200 characters supported by the indexer, we now have 35 chars for separators, type and namespace of the MRI.

Closes: https://github.com/getsentry/relay/issues/3614