### PR TITLE
ref(metric-stats): Make metric stats collection configurable

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -520,6 +520,17 @@ struct SentryMetrics {
     ///
     /// Defaults to 5.
     pub meta_locations_max: usize,
+    /// Whether metric stats are collected and emitted.
+    ///
+    /// Metric stats are always collected and emitted when processing
+    /// is enabled.
+    ///
+    /// This option is required for running multiple trusted Relays in a chain
+    /// and you want the metric stats to be collected and forwarded from
+    /// the first Relay in the chain.
+    ///
+    /// Defaults to `false`.
+    pub metric_stats_enabled: bool,
 }
 
 impl Default for SentryMetrics {
@@ -527,6 +538,7 @@ impl Default for SentryMetrics {
         Self {
             meta_locations_expiry: 15 * 24 * 60 * 60,
             meta_locations_max: 5,
+            metric_stats_enabled: false,
         }
     }
 }
@@ -2104,6 +2116,14 @@ impl Config {
     /// Returns the maximum payload size of metric metadata in bytes.
     pub fn max_metric_meta_size(&self) -> usize {
         self.values.limits.max_metric_meta_size.as_bytes()
+    }
+
+    /// Whether metric stats are collected and emitted.
+    ///
+    /// Metric stats are always collected and emitted when processing
+    /// is enabled.
+    pub fn metric_stats_enabled(&self) -> bool {
+        self.values.sentry_metrics.metric_stats_enabled
     }
 
     /// Returns the maximum payload size for general API requests.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2123,7 +2123,7 @@ impl Config {
     /// Metric stats are always collected and emitted when processing
     /// is enabled.
     pub fn metric_stats_enabled(&self) -> bool {
-        self.values.sentry_metrics.metric_stats_enabled
+        self.values.sentry_metrics.metric_stats_enabled || self.values.processing.enabled
     }
 
     /// Returns the maximum payload size for general API requests.

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -107,7 +107,8 @@ impl MetricStats {
     }
 
     fn is_enabled(&self, scoping: Scoping) -> bool {
-        self.config.processing_enabled() && self.is_rolled_out(scoping.organization_id)
+        (self.config.processing_enabled() || self.config.metric_stats_enabled())
+            && self.is_rolled_out(scoping.organization_id)
     }
 
     fn is_rolled_out(&self, organization_id: u64) -> bool {

--- a/relay-server/src/metric_stats.rs
+++ b/relay-server/src/metric_stats.rs
@@ -107,8 +107,7 @@ impl MetricStats {
     }
 
     fn is_enabled(&self, scoping: Scoping) -> bool {
-        (self.config.processing_enabled() || self.config.metric_stats_enabled())
-            && self.is_rolled_out(scoping.organization_id)
+        self.config.metric_stats_enabled() && self.is_rolled_out(scoping.organization_id)
     }
 
     fn is_rolled_out(&self, organization_id: u64) -> bool {


### PR DESCRIPTION
To make it possible to collect metric stats from our pop layer without enabling it for managed customer Relays. This follows a similar configuration pattern we have for outcomes.

#skip-changelog