### PR TITLE
feat(spans): Extract environment for exclusive_time_light when span is a queue op

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -294,7 +294,8 @@ pub fn hardcoded_span_metrics() -> Vec<(String, Vec<MetricSpec>)> {
                                     | is_resource.clone()
                                     | is_mobile.clone()
                                     | is_http.clone()
-                                    | is_cache.clone(),
+                                    | is_cache.clone()
+                                    | is_queue_op.clone(),
                             ),
                         Tag::with_key("transaction.op")
                             .from_field("span.sentry_tags.transaction.op")

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics.snap
@@ -6840,6 +6840,7 @@ expression: metrics
             ],
         ),
         tags: {
+            "environment": "fake_environment",
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.task.celery",
@@ -6963,6 +6964,7 @@ expression: metrics
             ],
         ),
         tags: {
+            "environment": "fake_environment",
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.submit.celery",
@@ -7086,6 +7088,7 @@ expression: metrics
             ],
         ),
         tags: {
+            "environment": "fake_environment",
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.publish",
@@ -7209,6 +7212,7 @@ expression: metrics
             ],
         ),
         tags: {
+            "environment": "fake_environment",
             "messaging.destination.name": "default",
             "span.category": "queue",
             "span.op": "queue.process",


### PR DESCRIPTION
Extract environment as a tag for the `exclusive_time_light` metric when span is a queue op

#skip-changelog