### PR TITLE
ref(relay): Document the project cache

### DIFF
--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -556,7 +556,7 @@ struct ProjectCacheBroker {
     metric_outcomes: MetricOutcomes,
     // Need hashbrown because extract_if is not stable in std yet.
     projects: hashbrown::HashMap<ProjectKey, Project>,
-    /// Utility for disposing of garbage project data safely.
+    /// Utility for disposing of expired project data efficiently.
     garbage_disposal: GarbageDisposal<Project>,
     /// Source for fetching project states via multiple layers.
     source: ProjectSource,

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -562,7 +562,7 @@ struct ProjectCacheBroker {
     source: ProjectSource,
     /// Tx channel used to send the updated project state whenever requested.
     state_tx: mpsc::UnboundedSender<UpdateProjectState>,
-    /// Tx channel used by the [`BufferService`] to send back the requested dequed elements.
+    /// Tx channel used by the [`BufferService`] to send back the requested dequeued elements.
     buffer_tx: mpsc::UnboundedSender<UnspooledEnvelope>,
     /// Shared semaphore used to control how many envelopes are currently running through Relay.
     buffer_guard: Arc<BufferGuard>,

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -566,7 +566,7 @@ struct ProjectCacheBroker {
     buffer_tx: mpsc::UnboundedSender<UnspooledEnvelope>,
     /// Shared semaphore used to control how many envelopes are currently running through Relay.
     buffer_guard: Arc<BufferGuard>,
-    /// Index containing all the [`QueueKey`](s) that have been enqueued in the [`BufferService`].
+    /// Index containing all the [`QueueKey`] that have been enqueued in the [`BufferService`].
     index: HashSet<QueueKey>,
     /// Handle to schedule periodic unspooling of buffered envelopes.
     buffer_unspool_handle: SleepHandle,

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -556,7 +556,7 @@ struct ProjectCacheBroker {
     metric_outcomes: MetricOutcomes,
     // Need hashbrown because extract_if is not stable in std yet.
     projects: hashbrown::HashMap<ProjectKey, Project>,
-    /// Utility for disposing of expired project data efficiently.
+    /// Utility for disposing of expired project data in a background thread.
     garbage_disposal: GarbageDisposal<Project>,
     /// Source for fetching project states via multiple layers.
     source: ProjectSource,

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -558,7 +558,7 @@ struct ProjectCacheBroker {
     projects: hashbrown::HashMap<ProjectKey, Project>,
     /// Utility for disposing of expired project data in a background thread.
     garbage_disposal: GarbageDisposal<Project>,
-    /// Source for fetching project states via multiple layers.
+    /// Source for fetching project states from the upstream or from disk.
     source: ProjectSource,
     /// Tx channel used to send the updated project state whenever requested.
     state_tx: mpsc::UnboundedSender<UpdateProjectState>,

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -556,16 +556,26 @@ struct ProjectCacheBroker {
     metric_outcomes: MetricOutcomes,
     // Need hashbrown because extract_if is not stable in std yet.
     projects: hashbrown::HashMap<ProjectKey, Project>,
+    /// Utility for disposing of garbage project data safely.
     garbage_disposal: GarbageDisposal<Project>,
+    /// Source for fetching project states via multiple layers.
     source: ProjectSource,
+    /// Tx channel used to send the updated project state whenever requested.
     state_tx: mpsc::UnboundedSender<UpdateProjectState>,
+    /// Tx channel used by the [`BufferService`] to send back the requested dequed elements.
     buffer_tx: mpsc::UnboundedSender<UnspooledEnvelope>,
+    /// Shared semaphore used to control how many envelopes are currently running through Relay.
     buffer_guard: Arc<BufferGuard>,
-    /// Index of the buffered project keys.
+    /// Index containing all the [`QueueKey`](s) that have been enqueued in the [`BufferService`].
     index: HashSet<QueueKey>,
+    /// Handle to schedule periodic unspooling of buffered envelopes.
     buffer_unspool_handle: SleepHandle,
+    /// Backoff strategy for retrying unspool attempts.
     buffer_unspool_backoff: RetryBackoff,
+    /// Address of the [`BufferService`] used for enqueuing and dequeuing envelopes that can't be
+    /// immediately processed.
     buffer: Addr<Buffer>,
+    /// Status of the global configuration, used to determine readiness for processing.
     global_config: GlobalConfigStatus,
 }
 


### PR DESCRIPTION
This PR adds some simple comments to the project cache broker since it's a complex service that has a lot of interaction in the information flow.

#skip-changelog