### PR TITLE
feat(spans): Also write inp metrics to transactions name space

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -553,6 +553,101 @@ pub fn hardcoded_span_metrics() -> Vec<(String, Vec<MetricSpec>)> {
                 },
                 MetricSpec {
                     category: DataCategory::Span,
+                    mri: "d:transactions/webvital.score.total@ratio".into(),
+                    field: Some("span.measurements.score.total.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction.op")
+                            .from_field("span.sentry_tags.transaction.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.browser.name")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/webvital.score.inp@ratio".into(),
+                    field: Some("span.measurements.score.inp.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/webvital.score.weight.inp@ratio".into(),
+                    field: Some("span.measurements.score.weight.inp.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/webvital.inp@millisecond".into(),
+                    field: Some("span.measurements.inp.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
                     mri: "d:spans/webvital.score.total@ratio".into(),
                     field: Some("span.measurements.score.total.value".into()),
                     condition: Some(is_allowed_browser.clone()),

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1598,6 +1598,10 @@ mod tests {
             "d:spans/webvital.score.inp@ratio",
             "d:spans/webvital.score.total@ratio",
             "d:spans/webvital.score.weight.inp@ratio",
+            "d:transactions/webvital.inp@millisecond",
+            "d:transactions/webvital.score.inp@ratio",
+            "d:transactions/webvital.score.total@ratio",
+            "d:transactions/webvital.score.weight.inp@ratio",
         ] {
             assert!(metrics.iter().any(|b| &*b.name == mri));
             assert!(metrics.iter().any(|b| b.tags.contains_key("browser.name")));


### PR DESCRIPTION
Right now INP metrics are span metric distributions with percentiles. We rely on these percentiles in the product UI.

There are plans to disable storing percentiles for distributions under the `spans` namespace, so we must move INP metrics to the `transactions` namespace as a workaround to keep INP percentiles. The plan is to extract these `transaction` namespace INP metrics for 90 days until we have enough data to switch over and deprecate the `spans` namespace INP metrics.