### PR TITLE
fix(spans): Detect db_system redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**:
 
 - Apply globally defined metric tags to legacy transaction metrics. ([#3615](https://github.com/getsentry/relay/pull/3615))
+- Scrub identifiers in spans with `op:db` and `db_system:redis`. ([#3642](https://github.com/getsentry/relay/pull/3642))
 
 **Features**:
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -57,7 +57,9 @@ pub(crate) fn scrub_span_description(
         .map(|op| op.split_once('.').unwrap_or((op, "")))
         .and_then(|(op, sub)| match (op, sub) {
             ("http", _) => scrub_http(description),
-            ("cache", _) | ("db", "redis") => scrub_redis_keys(description),
+            ("cache", _) | ("db", "redis") | ("db", _) if db_system == Some("redis") => {
+                scrub_redis_keys(description)
+            }
             ("db", sub) => {
                 if sub.contains("clickhouse")
                     || sub.contains("mongodb")
@@ -1122,6 +1124,24 @@ mod tests {
 
         // Can be scrubbed with db system.
         assert_eq!(scrubbed.0.as_deref(), Some("SELECT a FROM b"));
+    }
+
+    #[test]
+    fn redis_with_db_system() {
+        let json = r#"{
+            "description": "del myveryrandomkey:123Xalsdkxfhn",
+            "op": "db",
+            "data": {
+                "db.system": "redis"
+            }
+        }"#;
+
+        let mut span = Annotated::<Span>::from_json(json).unwrap();
+
+        let scrubbed = scrub_span_description(span.value_mut().as_mut().unwrap());
+
+        // NOTE: this should return `DEL *`, but we cannot detect lowercase command names yet.
+        assert_eq!(scrubbed.0.as_deref(), Some("*"));
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -57,9 +57,8 @@ pub(crate) fn scrub_span_description(
         .map(|op| op.split_once('.').unwrap_or((op, "")))
         .and_then(|(op, sub)| match (op, sub) {
             ("http", _) => scrub_http(description),
-            ("cache", _) | ("db", "redis") | ("db", _) if db_system == Some("redis") => {
-                scrub_redis_keys(description)
-            }
+            ("cache", _) | ("db", "redis") => scrub_redis_keys(description),
+            ("db", _) if db_system == Some("redis") => scrub_redis_keys(description),
             ("db", sub) => {
                 if sub.contains("clickhouse")
                     || sub.contains("mongodb")


### PR DESCRIPTION
It seems that javascript V8 sends `span.op: db` with `span.data.db_system: redis`. We need to treat this case like `db.redis` to prevent identifiers ending up in metrics storage unscrubbed.