### PR TITLE
ref(spans): Limit spans on transactions to 800kib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**:
 
 - Apply globally defined metric tags to legacy transaction metrics. ([#3615](https://github.com/getsentry/relay/pull/3615))
+- Limit the maximum size of spans in an transaction to 800 kib. ([3645](https://github.com/getsentry/relay/pull/3645))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Bug fixes**:
 
 - Apply globally defined metric tags to legacy transaction metrics. ([#3615](https://github.com/getsentry/relay/pull/3615))
-- Limit the maximum size of spans in an transaction to 800 kib. ([3645](https://github.com/getsentry/relay/pull/3645))
+- Limit the maximum size of spans in an transaction to 800 kib. ([#3645](https://github.com/getsentry/relay/pull/3645))
 - Scrub identifiers in spans with `op:db` and `db_system:redis`. ([#3642](https://github.com/getsentry/relay/pull/3642))
 
 **Features**:

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -912,10 +912,8 @@ mod tests {
 
     #[test]
     fn test_too_many_spans_trimmed() {
-        let s_100kb = std::iter::repeat('a').take(1024 * 100).collect();
-
         let span = Span {
-            platform: Annotated::new(s_100kb),
+            platform: Annotated::new("a".repeat(1024 * 100)),
             ..Default::default()
         };
         let spans = std::iter::repeat_with(|| Annotated::new(span.clone()))

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -474,6 +474,7 @@ pub struct Event {
     pub expectstaple: Annotated<ExpectStaple>,
 
     /// Spans for tracing.
+    #[metastructure(max_bytes = 819200)]
     #[metastructure(omit_from_schema)] // we only document error events for now
     pub spans: Annotated<Array<Span>>,
 


### PR DESCRIPTION
Limits the maximum size of spans to 800kib to stay within the 1mb limit for transactions.

Due to normalization Relay may add more information to spans which can push the event over the 1mib limit causing upstream Relays to reject event, which was initially accepted. Limits the spans to 800kib as a best effort approach to not go past the limit.

Technically it is still possible to go over the limit, but reducing the maximum size for spans even further may compromise existing experiences.

Relates to: https://github.com/getsentry/sentry/issues/68331