### PR TITLE
ref(project): Use latest state when flushing buckets

### DIFF
--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1105,7 +1105,7 @@ impl Project {
         metric_outcomes: &MetricOutcomes,
         mut buckets: Vec<Bucket>,
     ) -> Option<(Scoping, ProjectMetrics)> {
-        let Some(project_state) = self.valid_state() else {
+        let Some(project_state) = self.state_value() else {
             relay_log::error!(
                 tags.project_key = self.project_key.as_str(),
                 "there is no project state: dropping {} buckets",


### PR DESCRIPTION
Fixes: #3553

There is no need to re-validate the project state when flushing buckets from the aggregator, the buckets have already been rate limited with the available state. Longterm we should improve the project cache to not have multiple layers of validity (Cached/Pending and Expiry) and pre-aggregate when the project state is expired.

#skip-changelog