### PR TITLE
test(metrics): Fix flaky graceful shutdown test

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1268,6 +1268,8 @@ def test_graceful_shutdown(mini_sentry, relay):
     relay.send_metrics(project_id, metrics_payload)
     relay.process.send_signal(signal.SIGTERM)
 
+    time.sleep(0.1)
+
     # Try to send another metric (will be rejected)
     metrics_payload = f"transactions/now:666|c|T{timestamp}"
     with pytest.raises(requests.ConnectionError):


### PR DESCRIPTION
Fixes: #3298

It flakes whenever the shutdown isn't propagated fast enough in Relay, give it a tiny bit of extra time. Ideally we'd wait for a certain log message but we can't do that yet.

#skip-changelog