### PR TITLE
feat(spans): Extracts Queue tags and measurements from transaction trace context 

### DIFF
--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -219,20 +219,16 @@ pub fn extract_span_tags(event: &Event, spans: &mut [Annotated<Span>], max_tag_v
                     .get_or_insert_with(Default::default)
                     .extend(
                         segment_measurements
-                            .clone()
-                            .into_iter()
-                            .map(|(k, v)| (k.to_owned(), Annotated::new(v))),
+                            .iter()
+                            .map(|(k, v)| (k.clone(), Annotated::new(v.clone()))),
                     );
             }
             if !segment_tags.is_empty() {
                 span.sentry_tags
                     .get_or_insert_with(Default::default)
-                    .extend(
-                        segment_tags
-                            .clone()
-                            .into_iter()
-                            .map(|(k, v)| (k.sentry_tag_key().to_owned(), Annotated::new(v))),
-                    );
+                    .extend(segment_tags.iter().map(|(k, v)| {
+                        (k.clone().sentry_tag_key().into(), Annotated::new(v.clone()))
+                    }));
             }
         }
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -212,14 +212,16 @@ pub fn extract_span_tags(event: &Event, spans: &mut [Annotated<Span>], max_tag_v
                 .collect(),
         );
 
-        span.measurements
-            .get_or_insert_with(Default::default)
-            .extend(
-                shared_measurements
-                    .clone()
-                    .into_iter()
-                    .map(|(k, v)| (k.to_owned(), Annotated::new(v))),
-            );
+        if !shared_measurements.is_empty() {
+            span.measurements
+                .get_or_insert_with(Default::default)
+                .extend(
+                    shared_measurements
+                        .clone()
+                        .into_iter()
+                        .map(|(k, v)| (k.to_owned(), Annotated::new(v))),
+                );
+        }
 
         extract_measurements(span, is_mobile);
     }

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -161,18 +161,33 @@ pub struct Data {
     #[metastructure(field = "previousRoute", pii = "maybe", skip_serialization = "empty")]
     pub previous_route: Annotated<Route>,
 
+    /// The destination name (ie queue/topic) that a producer/consumer acts on.
+    ///
+    /// Set by backend SDKs with messaging integration.
     #[metastructure(field = "messaging.destination.name")]
     pub messaging_destination_name: Annotated<String>,
 
+    /// The id of the message in the messaging event.
+    ///
+    /// Set by backend SDKs with messaging integration.
     #[metastructure(field = "messaging.message.id")]
     pub messaging_message_id: Annotated<String>,
 
+    /// The time duration that a message waited in queue before being received.
+    ///
+    /// Set by backend SDKs with messaging integration.
     #[metastructure(field = "messaging.message.receive.latency")]
     pub messaging_message_receive_latency: Annotated<Value>,
 
+    /// The number of times a message was redelivered.
+    ///
+    /// Set by backend SDKs with messaging integration.
     #[metastructure(field = "messaging.message.retry.count")]
     pub messaging_message_retry_count: Annotated<Value>,
 
+    /// The size of the message body in bytes.
+    ///
+    /// Set by backend SDKs with messaging integration.
     #[metastructure(field = "messaging.message.body.size")]
     pub messaging_message_body_size: Annotated<Value>,
 

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -161,6 +161,21 @@ pub struct Data {
     #[metastructure(field = "previousRoute", pii = "maybe", skip_serialization = "empty")]
     pub previous_route: Annotated<Route>,
 
+    #[metastructure(field = "messaging.destination.name")]
+    pub messaging_destination_name: Annotated<String>,
+
+    #[metastructure(field = "messaging.message.id")]
+    pub messaging_message_id: Annotated<String>,
+
+    #[metastructure(field = "messaging.message.receive.latency")]
+    pub messaging_message_receive_latency: Annotated<Value>,
+
+    #[metastructure(field = "messaging.message.retry.count")]
+    pub messaging_message_retry_count: Annotated<Value>,
+
+    #[metastructure(field = "messaging.message.body.size")]
+    pub messaging_message_body_size: Annotated<Value>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(
         additional_properties,

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -34,6 +34,7 @@ pub fn extract_transaction_span(event: &Event, max_tag_value_size: usize) -> Opt
     let mut spans = [Span::from(event).into()];
 
     tag_extraction::extract_span_tags(event, &mut spans, max_tag_value_size);
+    tag_extraction::extract_segment_span_tags(event, &mut spans);
 
     spans.into_iter().next().and_then(Annotated::into_value)
 }

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -1029,6 +1029,7 @@ expression: "relay_event_schema::protocol::event_json_schema()"
           "type": "object",
           "properties": {
             "messaging.destination.name": {
+              "description": " The destination name (ie queue/topic) that a producer/consumer acts on.\n\n Set by backend SDKs with messaging integration.",
               "default": null,
               "type": [
                 "string",
@@ -1036,9 +1037,11 @@ expression: "relay_event_schema::protocol::event_json_schema()"
               ]
             },
             "messaging.message.body.size": {
+              "description": " The size of the message body in bytes.\n\n Set by backend SDKs with messaging integration.",
               "default": null
             },
             "messaging.message.id": {
+              "description": " The id of the message in the messaging event.\n\n Set by backend SDKs with messaging integration.",
               "default": null,
               "type": [
                 "string",
@@ -1046,9 +1049,11 @@ expression: "relay_event_schema::protocol::event_json_schema()"
               ]
             },
             "messaging.message.receive.latency": {
+              "description": " The time duration that a message waited in queue before being received.\n\n Set by backend SDKs with messaging integration.",
               "default": null
             },
             "messaging.message.retry.count": {
+              "description": " The number of times a message was redelivered.\n\n Set by backend SDKs with messaging integration.",
               "default": null
             },
             "previousRoute": {

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -1028,6 +1028,29 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         {
           "type": "object",
           "properties": {
+            "messaging.destination.name": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messaging.message.body.size": {
+              "default": null
+            },
+            "messaging.message.id": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messaging.message.receive.latency": {
+              "default": null
+            },
+            "messaging.message.retry.count": {
+              "default": null
+            },
             "previousRoute": {
               "description": " The previous route in the application\n\n Set by React Native SDK.",
               "default": null,


### PR DESCRIPTION
Updates the "create span from transaction" code path to extract:
- `messaging.destination.name` and `messaging.message.id` as tags from `contexts.trace.data`
- `messaging.message.receive.latency`, `messaging.message.body.size`, and `messaging.message.retry.count` from `contexts.trace.data`

only for Queue transactions.

#skip-changelog