### PR TITLE
Send `attachment` data inline when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Forward `received_at` timestamp for buckets sent to Kafka. ([#3561](https://github.com/getsentry/relay/pull/3561))
 - Limit metric name to 150 characters. ([#3628](https://github.com/getsentry/relay/pull/3628))
 - Add validation of Kafka topics on startup. ([#3543](https://github.com/getsentry/relay/pull/3543))
+- Send `attachment` data inline when possible. ([#3654](https://github.com/getsentry/relay/pull/3654))
 
 ## 24.5.0
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -198,6 +198,17 @@ pub struct Options {
     )]
     pub feedback_ingest_topic_rollout_rate: f32,
 
+    /// Rollout rate for sending attachment chunks inline.
+    ///
+    /// Rate needs to be between `0.0` and `1.0`.
+    /// If set to `1.0` all eligible attachment chunks will be sent as part of the attachment message.
+    #[serde(
+        rename = "relay.inline-attachments.rollout-rate",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub inline_attachments_rollout_rate: f32,
+
     /// Overall sampling of span extraction.
     ///
     /// This number represents the fraction of transactions for which

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -189,28 +189,27 @@ impl StoreService {
         start_time: Instant,
         scoping: Scoping,
     ) -> Result<(), StoreError> {
+        let global_options = &self.global_config.current().options;
         let retention = envelope.retention();
-        let event_id = envelope.event_id();
 
+        let event_id = envelope.event_id();
         let event_item = envelope.as_mut().take_item_by(|item| {
             matches!(
                 item.ty(),
                 ItemType::Event | ItemType::Transaction | ItemType::Security
             )
         });
-        let client = envelope.meta().client();
+        let event_type = event_item.as_ref().map(|item| item.ty());
 
         let topic = if envelope.get_item_by(is_slow_item).is_some() {
             KafkaTopic::Attachments
         } else if event_item.as_ref().map(|x| x.ty()) == Some(&ItemType::Transaction) {
             KafkaTopic::Transactions
         } else if event_item.as_ref().map(|x| x.ty()) == Some(&ItemType::UserReportV2) {
-            let feedback_ingest_topic_rollout_rate = self
-                .global_config
-                .current()
-                .options
-                .feedback_ingest_topic_rollout_rate;
-            if is_rolled_out(scoping.organization_id, feedback_ingest_topic_rollout_rate) {
+            if is_rolled_out(
+                scoping.organization_id,
+                global_options.feedback_ingest_topic_rollout_rate,
+            ) {
                 KafkaTopic::Feedback
             } else {
                 KafkaTopic::Events
@@ -219,8 +218,9 @@ impl StoreService {
             KafkaTopic::Events
         };
 
-        let mut attachments = Vec::new();
+        let send_individual_attachments = matches!(event_type, None | Some(&ItemType::Transaction));
 
+        let mut attachments = Vec::new();
         let mut replay_event = None;
         let mut replay_recording = None;
 
@@ -228,12 +228,19 @@ impl StoreService {
             match item.ty() {
                 ItemType::Attachment => {
                     debug_assert!(topic == KafkaTopic::Attachments);
-                    let attachment = self.produce_attachment_chunks(
+                    let send_inline = is_rolled_out(
+                        scoping.organization_id,
+                        global_options.inline_attachments_rollout_rate,
+                    );
+                    if let Some(attachment) = self.produce_attachment(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
                         item,
-                    )?;
-                    attachments.push(attachment);
+                        send_individual_attachments,
+                        send_inline,
+                    )? {
+                        attachments.push(attachment);
+                    }
                 }
                 ItemType::UserReport => {
                     debug_assert!(topic == KafkaTopic::Attachments);
@@ -289,6 +296,7 @@ impl StoreService {
                     )?;
                 }
                 ItemType::CheckIn => {
+                    let client = envelope.meta().client();
                     self.produce_check_in(scoping.project_id, start_time, client, retention, item)?
                 }
                 ItemType::Span => {
@@ -358,24 +366,24 @@ impl StoreService {
             )?;
         }
 
-        if event_item.is_none() && attachments.is_empty() {
-            // No event-related content. All done.
-            return Ok(());
-        }
+        if let Some(event_item) = event_item {
+            let event_id = event_id.ok_or(StoreError::NoEventId)?;
+            let project_id = scoping.project_id;
+            let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
 
-        let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
-
-        let kafka_messages = Self::extract_kafka_messages_for_event(
-            event_item.as_ref(),
-            event_id.ok_or(StoreError::NoEventId)?,
-            scoping,
-            start_time,
-            remote_addr,
-            attachments,
-        );
-
-        for message in kafka_messages {
-            self.produce(topic, message)?;
+            self.produce(
+                topic,
+                KafkaMessage::Event(EventKafkaMessage {
+                    payload: event_item.payload(),
+                    start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+                    event_id,
+                    project_id,
+                    remote_addr,
+                    attachments,
+                }),
+            )?;
+        } else {
+            debug_assert!(attachments.is_empty());
         }
 
         Ok(())
@@ -483,53 +491,6 @@ impl StoreService {
         })
     }
 
-    fn extract_kafka_messages_for_event(
-        event_item: Option<&Item>,
-        event_id: EventId,
-        scoping: Scoping,
-        start_time: Instant,
-        remote_addr: Option<String>,
-        attachments: Vec<ChunkedAttachment>,
-    ) -> impl Iterator<Item = KafkaMessage> {
-        // There might be a better way to do this:
-        let (individual_attachments, inline_attachments) = match event_item {
-            Some(event_item) => {
-                if matches!(event_item.ty(), ItemType::Transaction) {
-                    // Sentry discards inline attachments for transactions, so send them as individual ones instead.
-                    (attachments, vec![])
-                } else {
-                    (vec![], attachments)
-                }
-            }
-            None => (attachments, vec![]),
-        };
-
-        let project_id = scoping.project_id;
-
-        let event_iterator = event_item
-            .map(|event_item| {
-                KafkaMessage::Event(EventKafkaMessage {
-                    payload: event_item.payload(),
-                    start_time: UnixTimestamp::from_instant(start_time).as_secs(),
-                    event_id,
-                    project_id,
-                    remote_addr,
-                    attachments: inline_attachments,
-                })
-            })
-            .into_iter();
-
-        let attachment_iterator = individual_attachments.into_iter().map(move |attachment| {
-            KafkaMessage::Attachment(AttachmentKafkaMessage {
-                event_id,
-                project_id,
-                attachment,
-            })
-        });
-
-        attachment_iterator.chain(event_iterator)
-    }
-
     fn produce(
         &self,
         topic: KafkaTopic,
@@ -589,40 +550,64 @@ impl StoreService {
         Ok(())
     }
 
-    fn produce_attachment_chunks(
+    /// Produces Kafka messages for the content and metadata of an attachment item.
+    ///
+    /// The `send_individual_attachments` controls whether the metadata of an attachment
+    /// is produced directly as an individual `attachment` message, or returned from this function
+    /// to be later sent as part of an `event` message.
+    ///
+    /// Attachment contents are chunked and sent as multiple `attachment_chunk` messages.
+    /// If the `send_inline` flag is set alongside `send_individual_attachments`, and the
+    /// content is small enough to fit inside a message, no `attachment_chunk` is produced, but
+    /// the content is sent as part of the `attachment` message instead.
+    fn produce_attachment(
         &self,
         event_id: EventId,
         project_id: ProjectId,
         item: &Item,
-    ) -> Result<ChunkedAttachment, StoreError> {
+        send_individual_attachments: bool,
+        send_inline: bool,
+    ) -> Result<Option<ChunkedAttachment>, StoreError> {
         let id = Uuid::new_v4().to_string();
 
         let mut chunk_index = 0;
-        let mut offset = 0;
         let payload = item.payload();
         let size = item.len();
+        let max_chunk_size = self.config.attachment_chunk_size();
 
-        // This skips chunks for empty attachments. The consumer does not require chunks for
-        // empty attachments. `chunks` will be `0` in this case.
-        while offset < size {
-            let max_chunk_size = self.config.attachment_chunk_size();
-            let chunk_size = std::cmp::min(max_chunk_size, size - offset);
-            let attachment_message = KafkaMessage::AttachmentChunk(AttachmentChunkKafkaMessage {
-                payload: payload.slice(offset..offset + chunk_size),
-                event_id,
-                project_id,
-                id: id.clone(),
-                chunk_index,
-            });
-            self.produce(KafkaTopic::Attachments, attachment_message)?;
-            offset += chunk_size;
-            chunk_index += 1;
-        }
+        // When sending individual attachments, and we have a single chunk, we want to send the
+        // `data` inline in the `attachment` message.
+        // This avoids a needless roundtrip through the attachments cache on the Sentry side.
+        let data = if send_individual_attachments && send_inline && size < max_chunk_size {
+            (size > 0).then_some(payload)
+        } else {
+            let mut offset = 0;
+            // This skips chunks for empty attachments. The consumer does not require chunks for
+            // empty attachments. `chunks` will be `0` in this case.
+            while offset < size {
+                let chunk_size = std::cmp::min(max_chunk_size, size - offset);
+                let chunk_message = AttachmentChunkKafkaMessage {
+                    payload: payload.slice(offset..offset + chunk_size),
+                    event_id,
+                    project_id,
+                    id: id.clone(),
+                    chunk_index,
+                };
+
+                self.produce(
+                    KafkaTopic::Attachments,
+                    KafkaMessage::AttachmentChunk(chunk_message),
+                )?;
+                offset += chunk_size;
+                chunk_index += 1;
+            }
+            None
+        };
 
         // The chunk_index is incremented after every loop iteration. After we exit the loop, it
         // is one larger than the last chunk, so it is equal to the number of chunks.
 
-        Ok(ChunkedAttachment {
+        let attachment = ChunkedAttachment {
             id,
             name: match item.filename() {
                 Some(name) => name.to_owned(),
@@ -633,9 +618,22 @@ impl StoreService {
                 .map(|content_type| content_type.as_str().to_owned()),
             attachment_type: item.attachment_type().cloned().unwrap_or_default(),
             chunks: chunk_index,
+            data,
             size: Some(size),
             rate_limited: Some(item.rate_limited()),
-        })
+        };
+
+        if send_individual_attachments {
+            let message = KafkaMessage::Attachment(AttachmentKafkaMessage {
+                event_id,
+                project_id,
+                attachment,
+            });
+            self.produce(KafkaTopic::Attachments, message)?;
+            Ok(None)
+        } else {
+            Ok(Some(attachment))
+        }
     }
 
     fn produce_user_report(
@@ -1119,8 +1117,14 @@ struct ChunkedAttachment {
     #[serde(serialize_with = "serialize_attachment_type")]
     attachment_type: AttachmentType,
 
-    /// Number of chunks. Must be greater than zero.
+    /// Number of outlined chunks.
+    /// Zero if the attachment has `size: 0`, or there was only a single chunk which has been inlined into `data`.
     chunks: usize,
+
+    /// The content of the attachment,
+    /// if they are smaller than the configured `attachment_chunk_size`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Bytes>,
 
     /// The size of the attachment in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1618,139 +1622,7 @@ fn bool_to_str(value: bool) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use relay_base_schema::project::ProjectKey;
-
     use super::*;
-
-    /// Helper function to get the arguments for the `fn extract_kafka_messages(...)` method.
-    fn arguments_extract_kafka_msgs() -> (Instant, EventId, Scoping, Vec<ChunkedAttachment>) {
-        let start_time = Instant::now();
-        let event_id = EventId::new();
-        let scoping = Scoping {
-            organization_id: 42,
-            project_id: ProjectId::new(21),
-            project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
-            key_id: Some(17),
-        };
-
-        let attachment_vec = {
-            let item = Item::new(ItemType::Attachment);
-
-            vec![ChunkedAttachment {
-                id: Uuid::new_v4().to_string(),
-                name: UNNAMED_ATTACHMENT.to_owned(),
-                content_type: item
-                    .content_type()
-                    .map(|content_type| content_type.as_str().to_owned()),
-                attachment_type: item.attachment_type().cloned().unwrap_or_default(),
-                chunks: 0,
-                size: None,
-                rate_limited: Some(item.rate_limited()),
-            }]
-        };
-
-        (start_time, event_id, scoping, attachment_vec)
-    }
-
-    #[test]
-    fn test_return_attachments_when_missing_event_item() {
-        let (start_time, event_id, scoping, attachment_vec) = arguments_extract_kafka_msgs();
-        let number_of_attachments = attachment_vec.len();
-
-        let kafka_messages = StoreService::extract_kafka_messages_for_event(
-            None,
-            event_id,
-            scoping,
-            start_time,
-            None,
-            attachment_vec,
-        );
-
-        assert!(
-            kafka_messages
-                .filter(|msg| matches!(msg, KafkaMessage::Attachment(_)))
-                .count()
-                == number_of_attachments
-        );
-    }
-
-    /// If there is an event_item, and it is of type transaction, then the attachments should not
-    /// be sent together with the event but rather as standalones.
-    #[test]
-    fn test_send_standalone_attachments_when_transaction() {
-        let (start_time, event_id, scoping, attachment_vec) = arguments_extract_kafka_msgs();
-        let number_of_attachments = attachment_vec.len();
-
-        let item = Item::new(ItemType::Transaction);
-        let event_item = Some(&item);
-
-        let kafka_messages = StoreService::extract_kafka_messages_for_event(
-            event_item,
-            event_id,
-            scoping,
-            start_time,
-            None,
-            attachment_vec,
-        );
-
-        let (event, standalone_attachments): (Vec<_>, Vec<_>) =
-            kafka_messages.partition(|item| match item {
-                KafkaMessage::Event(_) => true,
-                KafkaMessage::Attachment(_) => false,
-                _ => panic!("only expected events or attachment type"),
-            });
-
-        // Tests that the event does not contain any attachments.
-        let event = &event[0];
-        if let KafkaMessage::Event(event) = event {
-            assert!(event.attachments.is_empty());
-        } else {
-            panic!("No event found")
-        }
-
-        // Tests that the attachment we sent to `extract_kafka_messages_for_event` is in the
-        // standalone attachments.
-        assert!(standalone_attachments.len() == number_of_attachments);
-    }
-
-    /// If there is an event_item, and it is not a transaction. The attachments should be kept in
-    /// the event and not be returned as stand-alone attachments.
-    #[test]
-    fn test_store_attachment_in_event_when_not_a_transaction() {
-        let (start_time, event_id, scoping, attachment_vec) = arguments_extract_kafka_msgs();
-        let number_of_attachments = attachment_vec.len();
-
-        let item = Item::new(ItemType::Event);
-        let event_item = Some(&item);
-
-        let kafka_messages = StoreService::extract_kafka_messages_for_event(
-            event_item,
-            event_id,
-            scoping,
-            start_time,
-            None,
-            attachment_vec,
-        );
-
-        let (event, standalone_attachments): (Vec<_>, Vec<_>) =
-            kafka_messages.partition(|item| match item {
-                KafkaMessage::Event(_) => true,
-                KafkaMessage::Attachment(_) => false,
-                _ => panic!("only expected events or attachment type"),
-            });
-
-        // Because it's not a transaction event, the attachment should be part of the event,
-        // and therefore the standalone_attachments vec should be empty.
-        assert!(standalone_attachments.is_empty());
-
-        // Checks that the attachment is part of the event.
-        let event = &event[0];
-        if let KafkaMessage::Event(event) = event {
-            assert!(event.attachments.len() == number_of_attachments);
-        } else {
-            panic!("No event found")
-        }
-    }
 
     #[test]
     fn disallow_outcomes() {

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -1,9 +1,12 @@
 import pytest
 import time
 import uuid
+import json
 
 from requests.exceptions import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
+
+from .test_store import make_transaction
 
 
 def test_attachments_400(mini_sentry, relay_with_processing, attachments_consumer):
@@ -20,28 +23,33 @@ def test_attachments_400(mini_sentry, relay_with_processing, attachments_consume
     assert excinfo.value.response.status_code == 400
 
 
-def test_attachments_with_processing(
+def test_mixed_attachments_with_processing(
     mini_sentry, relay_with_processing, attachments_consumer, outcomes_consumer
 ):
     project_id = 42
     event_id = "515539018c9b4260a6f999572f1661ee"
 
-    relay = relay_with_processing()
+    options = {"processing": {"attachment_chunk_size": "100KB"}}
     mini_sentry.add_full_project_config(project_id)
+    mini_sentry.set_global_config_option("relay.inline-attachments.rollout-rate", 1.0)
+    relay = relay_with_processing(options)
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
 
+    chunked_contents = b"heavens no" * 20_000
     attachments = [
-        ("att_1", "foo.txt", b"heavens no"),
+        ("att_1", "foo.txt", chunked_contents),
         ("att_2", "bar.txt", b"hell yeah"),
+        ("att_3", "foobar.txt", b""),
     ]
     relay.send_attachments(project_id, event_id, attachments)
 
+    # A chunked attachment
     attachment_contents = {}
     attachment_ids = []
     attachment_num_chunks = {}
 
-    while set(attachment_contents.values()) != {b"heavens no", b"hell yeah"}:
+    while set(attachment_contents.values()) != {chunked_contents}:
         chunk, v = attachments_consumer.get_attachment_chunk()
         attachment_contents[v["id"]] = attachment_contents.get(v["id"], b"") + chunk
         if v["id"] not in attachment_ids:
@@ -50,14 +58,11 @@ def test_attachments_with_processing(
         assert v["chunk_index"] == num_chunks - 1
         attachment_num_chunks[v["id"]] = num_chunks
 
-    id1, id2 = attachment_ids
-
-    assert attachment_contents[id1] == b"heavens no"
-    assert attachment_contents[id2] == b"hell yeah"
+    (id1,) = attachment_ids
+    assert attachment_contents[id1] == chunked_contents
+    assert attachment_num_chunks[id1] > 1
 
     attachment = attachments_consumer.get_individual_attachment()
-    attachment2 = attachments_consumer.get_individual_attachment()
-
     assert attachment == {
         "type": "attachment",
         "attachment": {
@@ -65,42 +70,14 @@ def test_attachments_with_processing(
             "chunks": attachment_num_chunks[id1],
             "id": id1,
             "name": "foo.txt",
-            "size": len(attachment_contents[id1]),
-            "rate_limited": False,
-        },
-        "event_id": event_id,
-        "project_id": project_id,
-    }
-    assert attachment2 == {
-        "type": "attachment",
-        "attachment": {
-            "attachment_type": "event.attachment",
-            "chunks": attachment_num_chunks[id2],
-            "id": id2,
-            "name": "bar.txt",
-            "size": len(attachment_contents[id2]),
+            "size": len(chunked_contents),
             "rate_limited": False,
         },
         "event_id": event_id,
         "project_id": project_id,
     }
 
-    outcomes_consumer.assert_empty()
-
-
-def test_empty_attachments_with_processing(
-    mini_sentry, relay_with_processing, attachments_consumer
-):
-    project_id = 42
-    event_id = "515539018c9b4260a6f999572f1661ee"
-
-    relay = relay_with_processing()
-    mini_sentry.add_full_project_config(project_id)
-    attachments_consumer = attachments_consumer()
-
-    attachments = [("att_1", "foo.txt", b"")]
-    relay.send_attachments(project_id, event_id, attachments)
-
+    # An inlined attachment
     attachment = attachments_consumer.get_individual_attachment()
 
     # The ID is random. Just assert that it is there and non-zero.
@@ -111,7 +88,29 @@ def test_empty_attachments_with_processing(
         "attachment": {
             "attachment_type": "event.attachment",
             "chunks": 0,
-            "name": "foo.txt",
+            "data": b"hell yeah",
+            "name": "bar.txt",
+            "size": len(b"hell yeah"),
+            "rate_limited": False,
+        },
+        "event_id": event_id,
+        "project_id": project_id,
+    }
+
+    outcomes_consumer.assert_empty()
+
+    # An empty attachment
+    attachment = attachments_consumer.get_individual_attachment()
+
+    # The ID is random. Just assert that it is there and non-zero.
+    assert attachment["attachment"].pop("id")
+
+    assert attachment == {
+        "type": "attachment",
+        "attachment": {
+            "attachment_type": "event.attachment",
+            "chunks": 0,
+            "name": "foobar.txt",
             "size": 0,
             "rate_limited": False,
         },
@@ -126,12 +125,12 @@ def test_attachments_ratelimit(
 ):
     event_id = "515539018c9b4260a6f999572f1661ee"
 
-    relay = relay_with_processing()
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["quotas"] = [
         {"categories": rate_limits, "limit": 0, "reasonCode": "static_disabled_quota"}
     ]
+    relay = relay_with_processing()
 
     outcomes_consumer = outcomes_consumer()
     attachments = [("att_1", "foo.txt", b"")]
@@ -159,8 +158,8 @@ def test_attachments_quotas(
     event_id = "515539018c9b4260a6f999572f1661ee"
     attachment_body = b"blabla"
 
-    relay = relay_with_processing()
     project_id = 42
+    mini_sentry.set_global_config_option("relay.inline-attachments.rollout-rate", 1.0)
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["quotas"] = [
         {
@@ -171,6 +170,7 @@ def test_attachments_quotas(
             "reasonCode": "attachments_exceeded",
         }
     ]
+    relay = relay_with_processing()
 
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
@@ -180,10 +180,9 @@ def test_attachments_quotas(
         relay.send_attachments(
             project_id, event_id, [("att_1", "%s.txt" % i, attachment_body)]
         )
-        chunk, _ = attachments_consumer.get_attachment_chunk()
-        assert chunk == attachment_body
         attachment = attachments_consumer.get_individual_attachment()
         assert attachment["attachment"]["name"] == "%s.txt" % i
+        assert attachment["attachment"]["data"] == attachment_body
 
     # First attachment returns 200 but is rate limited in processing
     relay.send_attachments(project_id, event_id, attachments)
@@ -205,34 +204,40 @@ def test_view_hierarchy_processing(
     project_id = 42
     event_id = "515539018c9b4260a6f999572f1661ee"
 
-    relay = relay_with_processing()
     mini_sentry.add_full_project_config(project_id)
+    mini_sentry.set_global_config_option("relay.inline-attachments.rollout-rate", 1.0)
+    relay = relay_with_processing()
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
+
+    json_payload = {"rendering_system": "compose", "windows": []}
+    expected_payload = json.dumps(json_payload).encode()
 
     envelope = Envelope(headers=[["event_id", event_id]])
     envelope.add_item(
         Item(
             headers=[["attachment_type", "event.view_hierarchy"]],
             type="attachment",
-            payload=PayloadRef(json={"rendering_system": "compose", "windows": []}),
+            payload=PayloadRef(json=json_payload, bytes=expected_payload),
         )
     )
 
     relay.send_envelope(project_id, envelope)
 
-    (payload, chunk) = attachments_consumer.get_attachment_chunk()
     attachment = attachments_consumer.get_individual_attachment()
+
+    # The ID is random. Just assert that it is there and non-zero.
+    assert attachment["attachment"].pop("id")
 
     assert attachment == {
         "type": "attachment",
         "attachment": {
             "attachment_type": "event.view_hierarchy",
-            "chunks": 1,
+            "chunks": 0,
+            "data": expected_payload,
             "content_type": "application/json",
-            "id": chunk["id"],
             "name": "Unnamed Attachment",
-            "size": len(payload),
+            "size": len(expected_payload),
             "rate_limited": False,
         },
         "event_id": event_id,
@@ -240,3 +245,91 @@ def test_view_hierarchy_processing(
     }
 
     outcomes_consumer.assert_empty()
+
+
+@pytest.mark.parametrize("use_inline_attachments", (False, True))
+def test_event_with_attachment(
+    mini_sentry,
+    relay_with_processing,
+    attachments_consumer,
+    outcomes_consumer,
+    use_inline_attachments,
+):
+    project_id = 42
+    event_id = "515539018c9b4260a6f999572f1661ee"
+
+    mini_sentry.add_full_project_config(project_id)
+    if use_inline_attachments:
+        mini_sentry.set_global_config_option(
+            "relay.inline-attachments.rollout-rate", 1.0
+        )
+    relay = relay_with_processing()
+    attachments_consumer = attachments_consumer()
+    outcomes_consumer = outcomes_consumer()
+
+    # event attachments are always sent as chunks, and added to events
+    envelope = Envelope(headers=[["event_id", event_id]])
+    envelope.add_event({"message": "Hello, World!"})
+    envelope.add_item(
+        Item(
+            type="attachment",
+            payload=PayloadRef(bytes=b"event attachment"),
+        )
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    chunk, _ = attachments_consumer.get_attachment_chunk()
+    assert chunk == b"event attachment"
+
+    _, event_message = attachments_consumer.get_event()
+
+    assert event_message["attachments"][0].pop("id")
+    assert list(event_message["attachments"]) == [
+        {
+            "attachment_type": "event.attachment",
+            "chunks": 1,
+            "content_type": "application/octet-stream",
+            "name": "Unnamed Attachment",
+            "size": len(b"event attachment"),
+            "rate_limited": False,
+        }
+    ]
+
+    # transaction attachments are sent as individual attachments,
+    # either using chunks by default, or contents inlined
+    envelope = Envelope(headers=[["event_id", event_id]])
+    envelope.add_transaction(make_transaction({"event_id": event_id}))
+    envelope.add_item(
+        Item(
+            type="attachment",
+            payload=PayloadRef(bytes=b"transaction attachment"),
+        )
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    if not use_inline_attachments:
+        chunk, _ = attachments_consumer.get_attachment_chunk()
+        assert chunk == b"transaction attachment"
+
+    expected_attachment = {
+        "attachment_type": "event.attachment",
+        "chunks": 1,
+        "content_type": "application/octet-stream",
+        "name": "Unnamed Attachment",
+        "size": len(b"transaction attachment"),
+        "rate_limited": False,
+    }
+    if use_inline_attachments:
+        expected_attachment["chunks"] = 0
+        expected_attachment["data"] = b"transaction attachment"
+
+    attachment = attachments_consumer.get_individual_attachment()
+    assert attachment["attachment"].pop("id")
+    assert attachment == {
+        "type": "attachment",
+        "attachment": expected_attachment,
+        "event_id": event_id,
+        "project_id": project_id,
+    }

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -160,6 +160,7 @@ def test_feedback_with_attachment_in_same_envelope(
     mini_sentry.add_basic_project_config(
         42, extra={"config": {"features": ["organizations:user-feedback-ingest"]}}
     )
+    mini_sentry.set_global_config_option("relay.inline-attachments.rollout-rate", 1.0)
 
     if use_feedback_topic:
         mini_sentry.set_global_config_option("feedback.ingest-topic.rollout-rate", 1.0)
@@ -196,15 +197,6 @@ def test_feedback_with_attachment_in_same_envelope(
     relay = relay_with_processing()
     relay.send_envelope(project_id, envelope)
 
-    # attachment data (relaxed version of test_attachments.py)
-    received_contents = {}  # attachment id -> bytes
-    while set(received_contents.values()) != {attachment_contents}:
-        chunk, v = attachments_consumer.get_attachment_chunk()
-        received_contents[v["id"]] = received_contents.get(v["id"], b"") + chunk
-        assert v["event_id"] == event_id
-        assert v["project_id"] == project_id
-    assert len(received_contents) == 1
-
     # attachment headers
     attachment_event = attachments_consumer.get_individual_attachment()
     assert attachment_event["event_id"] == event_id
@@ -212,6 +204,7 @@ def test_feedback_with_attachment_in_same_envelope(
     attachment = attachment_event["attachment"]
     assert attachment["name"] == attachment_headers["filename"]
     assert attachment["content_type"] == attachment_headers["content_type"]
+    assert attachment["data"] == attachment_contents
     assert attachment["size"] == attachment_headers["length"]
 
     # feedback event sent to correct topic


### PR DESCRIPTION
For `invidual_attachments`, we can now send the `data` inline if it is small enough. This avoids having to store temporary `attachment_chunks` in the processing redis store.

Right now, every "event" attachment is sent with outlined chunks, even for things like logfiles, even though only minidumps and other processing-relevant attachments need to be treated that way.
It might be possible to also inline logfiles with more logic. That way, such attachments could be saved as `EventAttachment` directly without putting load on the attachments store. Doing that however would create problems when such events are discarded within the rest of the pipeline.

Support for consuming the `data` property is being added in https://github.com/getsentry/sentry/pull/71522 to the Sentry codebase.

---

Developing this, I noticed that `extract_kafka_messages_for_event` is a free function returning an `Iterator` purely for testing purposes. These tests pretty much just tested the `send_individual_attachments` logic in a very convoluted way, and are now pretty useless.