### PR TITLE
chore(self-hosted): Automatically pick up e2e test action from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,7 +609,7 @@ jobs:
         # Skip for dependabot or if it's a fork as the image cannot be uploaded to ghcr since this test attempts to pull
         # the image from ghcr
         if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
-        uses: getsentry/action-self-hosted-e2e-tests@267fab2add9e173029c1e09ecfd82e04688d7c44
+        uses: getsentry/action-self-hosted-e2e-tests@main
         with:
           project_name: relay
           image_url: ghcr.io/getsentry/relay:${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
I've recently updated the self-hosted e2e test action to properly pick up changes on pre-submit after noticing breakage snuck into master from https://github.com/getsentry/relay/pull/3633. 

It seems reasonable to pin this to main given that our team has alerting for when this CI check fails on master, and we don't update it frequently. Please let me know if there are any concerns here.

#skip-changelog