### PR TITLE
fix(spans): Accept a UNIX timestamp for measurements

### DIFF
--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::utils::deserialize_number_from_string;
+use crate::utils::{deserialize_number_from_string, is_zero};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Measurement {
@@ -11,12 +11,20 @@ pub struct Measurement {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MeasurementValue {
     // nanoseconds elapsed since the start of the profile
-    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_number_from_string",
+        skip_serializing_if = "is_zero"
+    )]
     elapsed_since_start_ns: u64,
 
     // Android 6.8.0 sends a string instead of a float64 so we need to accept both
     #[serde(deserialize_with = "deserialize_number_from_string")]
     value: f64,
+
+    // Sample Format V2 accepts a timestamp in seconds as a float
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timestamp: Option<f64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/relay-profiling/src/measurements.rs
+++ b/relay-profiling/src/measurements.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::utils::{deserialize_number_from_string, is_zero};
+use crate::utils::deserialize_number_from_string;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Measurement {
@@ -9,22 +9,24 @@ pub struct Measurement {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct MeasurementValue {
-    // nanoseconds elapsed since the start of the profile
-    #[serde(
-        default,
-        deserialize_with = "deserialize_number_from_string",
-        skip_serializing_if = "is_zero"
-    )]
-    elapsed_since_start_ns: u64,
+#[serde(untagged)]
+pub enum MeasurementValue {
+    Default {
+        // nanoseconds elapsed since the start of the profile
+        #[serde(deserialize_with = "deserialize_number_from_string")]
+        elapsed_since_start_ns: u64,
 
-    // Android 6.8.0 sends a string instead of a float64 so we need to accept both
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    value: f64,
+        // Android 6.8.0 sends a string instead of a float64 so we need to accept both
+        #[serde(deserialize_with = "deserialize_number_from_string")]
+        value: f64,
+    },
+    SampleV2 {
+        // UNIX timestamp in seconds as a float
+        timestamp: f64,
 
-    // Sample Format V2 accepts a timestamp in seconds as a float
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    timestamp: Option<f64>,
+        #[serde(deserialize_with = "deserialize_number_from_string")]
+        value: f64,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -45,11 +47,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_roundtrip() {
+        let raw_value = r#"{"elapsed_since_start_ns":1234567890,"value":1234.56789}"#;
+        let parsed_value = serde_json::from_str::<MeasurementValue>(raw_value);
+        assert!(parsed_value.is_ok());
+        let value = parsed_value.unwrap();
+        let encoded_value = serde_json::to_string(&value).unwrap();
+        assert_eq!(encoded_value, raw_value);
+    }
+
+    #[test]
     fn test_value_as_float() {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":1234.56789}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
-        assert_eq!(measurement.unwrap().value, 1234.56789);
+        match measurement.unwrap() {
+            MeasurementValue::Default { value, .. } => assert_eq!(value, 1234.56789),
+            _ => panic!("measurement wasn't properly decoded"),
+        }
     }
 
     #[test]
@@ -57,7 +72,10 @@ mod tests {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"1234.56789"}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
-        assert_eq!(measurement.unwrap().value, 1234.56789);
+        match measurement.unwrap() {
+            MeasurementValue::Default { value, .. } => assert_eq!(value, 1234.56789),
+            _ => panic!("measurement wasn't properly decoded"),
+        }
     }
 
     #[test]
@@ -65,7 +83,10 @@ mod tests {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"1e3"}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
-        assert_eq!(measurement.unwrap().value, 1e3f64);
+        match measurement.unwrap() {
+            MeasurementValue::Default { value, .. } => assert_eq!(value, 1e3f64),
+            _ => panic!("measurement wasn't properly decoded"),
+        }
     }
 
     #[test]
@@ -73,7 +94,10 @@ mod tests {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":"+Infinity"}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
-        assert_eq!(measurement.unwrap().value, f64::INFINITY);
+        match measurement.unwrap() {
+            MeasurementValue::Default { value, .. } => assert_eq!(value, f64::INFINITY),
+            _ => panic!("measurement wasn't properly decoded"),
+        }
     }
 
     #[test]
@@ -81,7 +105,10 @@ mod tests {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":1e3}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_ok());
-        assert_eq!(measurement.unwrap().value, 1e3f64);
+        match measurement.unwrap() {
+            MeasurementValue::Default { value, .. } => assert_eq!(value, 1e3f64),
+            _ => panic!("measurement wasn't properly decoded"),
+        }
     }
 
     #[test]
@@ -89,5 +116,12 @@ mod tests {
         let measurement_json = r#"{"elapsed_since_start_ns":1234567890,"value":+Infinity}"#;
         let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
         assert!(measurement.is_err());
+    }
+
+    #[test]
+    fn test_with_timestamp_only() {
+        let measurement_json = r#"{"timestamp":1717161756.408,"value":10.3}"#;
+        let measurement = serde_json::from_str::<MeasurementValue>(measurement_json);
+        assert!(measurement.is_ok());
     }
 }


### PR DESCRIPTION
Sample format V2 works with UNIX timestamps as opposed to relative timestamps and since we're sharing the measurements struct, we need to make it compatible.

#skip-changelog