### PR TITLE
test(quotas): Increase quota window to remove flakiness

### DIFF
--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1984,7 +1984,7 @@ def test_global_rate_limit_by_namespace(
             "scope": "global",
             "categories": ["metric_bucket"],
             "limit": metric_bucket_limit,
-            "window": 1000,
+            "window": int(datetime.now(UTC).timestamp()),
             "reasonCode": global_reason_code,
         },
         {
@@ -1993,7 +1993,7 @@ def test_global_rate_limit_by_namespace(
             "categories": ["metric_bucket"],
             "limit": transaction_limit,
             "namespace": "transactions",
-            "window": 1000,
+            "window": int(datetime.now(UTC).timestamp()),
             "reasonCode": transaction_reason_code,
         },
     ]

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 
 import pytest
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
@@ -1491,7 +1491,7 @@ def test_rate_limit_indexed_consistent(
         {
             "categories": ["span_indexed"],
             "limit": 4,
-            "window": 1000,
+            "window": int(datetime.now(UTC).timestamp()),
             "id": uuid.uuid4(),
             "reasonCode": "indexed_exceeded",
         },
@@ -1543,7 +1543,7 @@ def test_rate_limit_indexed_consistent_extracted(
         {
             "categories": ["span_indexed"],
             "limit": 3,
-            "window": 1000,
+            "window": int(datetime.now(UTC).timestamp()),
             "id": uuid.uuid4(),
             "reasonCode": "indexed_exceeded",
         },
@@ -1613,7 +1613,7 @@ def test_rate_limit_metrics_consistent(
         {
             "categories": ["span"],
             "limit": 3,
-            "window": 1000,
+            "window": int(datetime.now(UTC).timestamp()),
             "id": uuid.uuid4(),
             "reasonCode": "total_exceeded",
         },
@@ -1623,7 +1623,7 @@ def test_rate_limit_metrics_consistent(
     metrics_consumer = metrics_consumer()
     outcomes_consumer = outcomes_consumer()
 
-    start = datetime.now(timezone.utc)
+    start = datetime.now(UTC)
     end = start + timedelta(seconds=1)
 
     envelope = envelope_with_spans(start, end)


### PR DESCRIPTION
Test failed again [here](https://github.com/getsentry/relay/actions/runs/9313968434/job/25637293117), I assume because the quota was reset during the execution of the test.

#skip-changelog