### PR TITLE
ref(metrics): Switches set hashing algo to crc32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Limit metric name to 150 characters. ([#3628](https://github.com/getsentry/relay/pull/3628))
 - Add validation of Kafka topics on startup. ([#3543](https://github.com/getsentry/relay/pull/3543))
 - Send `attachment` data inline when possible. ([#3654](https://github.com/getsentry/relay/pull/3654))
+- Change metrics set hashing to CRC32. ([#3669](https://github.com/getsentry/relay/pull/3669))
 
 ## 24.5.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,6 +4072,7 @@ dependencies = [
  "flate2",
  "fnv",
  "futures",
+ "hash32",
  "hashbrown 0.14.3",
  "insta",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,9 +811,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -3880,6 +3880,7 @@ version = "24.5.0"
 dependencies = [
  "bytecount",
  "chrono",
+ "crc32fast",
  "criterion",
  "fnv",
  "hash32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ chrono = { version = "0.4.31", default-features = false, features = [
 clap = { version = "4.4.6" }
 clap_complete = "4.1.1"
 cmake = "0.1.46"
+crc32fast = "1.4.2"
 console = "0.15.5"
 cookie = "0.17.0"
 criterion = "0.5"

--- a/relay-metrics/Cargo.toml
+++ b/relay-metrics/Cargo.toml
@@ -18,6 +18,7 @@ redis = ["relay-redis/impl"]
 [dependencies]
 bytecount = { workspace = true }
 chrono = { workspace = true }
+crc32fast = { workspace = true }
 fnv = { workspace = true }
 hash32 = { workspace = true }
 hashbrown = { workspace = true }

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
 use std::iter::FusedIterator;
-use std::{fmt, mem};
+use std::mem;
 
 use hash32::{FnvHasher, Hasher as _};
 use relay_cardinality::CardinalityItem;
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::protocol::{
-    self, hash_set_value, CounterType, DistributionType, GaugeType, MetricName,
-    MetricResourceIdentifier, MetricType, SetType,
+    self, CounterType, DistributionType, GaugeType, MetricName, MetricResourceIdentifier,
+    MetricType, SetType,
 };
 use crate::{FiniteF64, MetricNamespace, ParseMetricError};
 
@@ -271,16 +271,6 @@ impl BucketValue {
     /// Returns a bucket value representing a set with a single given hash value.
     pub fn set(value: SetType) -> Self {
         Self::Set(std::iter::once(value).collect())
-    }
-
-    /// Returns a bucket value representing a set with a single given string value.
-    pub fn set_from_str(string: &str) -> Self {
-        Self::set(hash_set_value(string))
-    }
-
-    /// Returns a bucket value representing a set with a single given value.
-    pub fn set_from_display(display: impl fmt::Display) -> Self {
-        Self::set(hash_set_value(&display.to_string()))
     }
 
     /// Returns a bucket value representing a gauge with a single given value.

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -1023,7 +1023,7 @@ mod tests {
         let s = "transactions/foo:e2546e4c-ecd0-43ad-ae27-87960e57a658|s";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Bucket::parse(s.as_bytes(), timestamp).unwrap();
-        assert_eq!(metric.value, BucketValue::Set([4267882815].into()));
+        assert_eq!(metric.value, BucketValue::Set([1017918600].into()));
     }
 
     #[test]
@@ -1033,7 +1033,7 @@ mod tests {
         let metric = Bucket::parse(s.as_bytes(), timestamp).unwrap();
         assert_eq!(
             metric.value,
-            BucketValue::Set([181348692, 4267882815].into())
+            BucketValue::Set([1017918600, 2871483987].into())
         );
     }
 

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -1,7 +1,3 @@
-use std::hash::Hasher as _;
-
-use hash32::{FnvHasher, Hasher as _};
-
 #[doc(inline)]
 pub use relay_base_schema::metrics::{
     CustomUnit, DurationUnit, FractionUnit, InformationUnit, MetricName, MetricNamespace,
@@ -93,10 +89,11 @@ pub(crate) fn validate_tag_value(tag_value: &mut String) {
 ///
 /// Sets only guarantee 32-bit accuracy, but arbitrary strings are allowed on the protocol. Upon
 /// parsing, they are hashed and only used as hashes subsequently.
+///
+/// Relay and the SDKs use CRC32 for hashing to make sets from different sources
+/// merge correctly.
 pub(crate) fn hash_set_value(string: &str) -> u32 {
-    let mut hasher = FnvHasher::default();
-    hasher.write(string.as_bytes());
-    hasher.finish32()
+    crc32fast::hash(string.as_bytes())
 }
 
 #[cfg(test)]

--- a/relay-metrics/tests/fixtures/set.json
+++ b/relay-metrics/tests/fixtures/set.json
@@ -2,6 +2,6 @@
   "name": "s:custom/endpoint.users@none",
   "width": 0,
   "timestamp": 1615889449,
-  "value": [4267882815],
+  "value": [1017918600],
   "type": "s"
 }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -54,6 +54,7 @@ data-encoding = { workspace = true }
 flate2 = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
+hash32 = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
 json-forensics = { workspace = true }

--- a/relay-server/src/metrics_extraction/generic.rs
+++ b/relay-server/src/metrics_extraction/generic.rs
@@ -9,6 +9,8 @@ use relay_metrics::{
 use relay_protocol::{Getter, Val};
 use relay_quotas::DataCategory;
 
+use crate::metrics_extraction::hash_fnv_32;
+
 /// Item from which metrics can be extracted.
 pub trait Extractable: Getter {
     /// Data category for the metric spec to match on.
@@ -165,7 +167,7 @@ fn read_metric_value(
         MetricType::Distribution => {
             BucketValue::distribution(finite(instance.get_value(field?)?.as_f64()?)?)
         }
-        MetricType::Set => BucketValue::set_from_str(instance.get_value(field?)?.as_str()?),
+        MetricType::Set => BucketValue::set(hash_fnv_32(instance.get_value(field?)?.as_str()?)),
         MetricType::Gauge => BucketValue::gauge(finite(instance.get_value(field?)?.as_f64()?)?),
     })
 }

--- a/relay-server/src/metrics_extraction/mod.rs
+++ b/relay-server/src/metrics_extraction/mod.rs
@@ -5,6 +5,9 @@ pub mod event;
 pub mod generic;
 pub mod sessions;
 pub mod transactions;
+mod utils;
+
+use self::utils::*;
 
 pub trait IntoMetric {
     fn into_metric(self, timestamp: UnixTimestamp) -> Bucket;

--- a/relay-server/src/metrics_extraction/sessions/types.rs
+++ b/relay-server/src/metrics_extraction/sessions/types.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
 use std::fmt::{self, Display};
+use std::hash::Hasher as _;
+
+use hash32::{FnvHasher, Hasher as _};
 
 use relay_common::time::UnixTimestamp;
 use relay_event_schema::protocol::SessionStatus;
@@ -103,9 +106,9 @@ impl IntoMetric for SessionMetric {
             SessionMetric::Error {
                 session_id: id,
                 tags,
-            } => (BucketValue::set_from_display(id), tags.into()),
+            } => (BucketValue::set(hash_id(&id.to_string())), tags.into()),
             SessionMetric::User { distinct_id, tags } => {
-                (BucketValue::set_from_display(distinct_id), tags.into())
+                (BucketValue::set(hash_id(&distinct_id)), tags.into())
             }
             SessionMetric::Session { counter, tags } => {
                 (BucketValue::Counter(counter), tags.into())
@@ -146,4 +149,10 @@ impl Display for SessionMetric {
             Self::Error { .. } => write!(f, "error"),
         }
     }
+}
+
+pub(crate) fn hash_id(string: &str) -> u32 {
+    let mut hasher = FnvHasher::default();
+    hasher.write(string.as_bytes());
+    hasher.finish32()
 }

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -8,7 +8,7 @@ use relay_metrics::{
     MetricResourceIdentifier, MetricUnit,
 };
 
-use crate::metrics_extraction::IntoMetric;
+use crate::metrics_extraction::{hash_fnv_32, IntoMetric};
 
 /// Enumerates the metrics extracted from transaction payloads.
 #[derive(Clone, Debug, PartialEq)]
@@ -60,7 +60,7 @@ impl IntoMetric for TransactionMetric {
         let (name, value, unit, tags) = match self {
             Self::User { value, tags } => (
                 Cow::Borrowed("user"),
-                BucketValue::set_from_str(&value),
+                BucketValue::set(hash_fnv_32(&value)),
                 MetricUnit::None,
                 tags.into(),
             ),

--- a/relay-server/src/metrics_extraction/utils.rs
+++ b/relay-server/src/metrics_extraction/utils.rs
@@ -1,0 +1,15 @@
+use std::hash::Hasher as _;
+
+use hash32::{FnvHasher, Hasher as _};
+
+/// Hashes the passed string using FNV32.
+///
+/// The default for metrics has been changed from fnv32 to crc32 to align the implementation with
+/// the SDKs.
+///
+/// To not break already extracted metrics, the metric extraction still uses fnv32.
+pub fn hash_fnv_32(string: &str) -> u32 {
+    let mut hasher = FnvHasher::default();
+    hasher.write(string.as_bytes());
+    hasher.finish32()
+}


### PR DESCRIPTION
The SDKs already use CRC32, to stay compatible with the SDKs we should use crc32 as well. This may break some sets for usecases where the SDK did *not* hash. But overall it delivers a more consistent behaviour.

All existing usecases with metrics extraction keep using fnv32 to not break the product.