### PR TITLE
ref(metrics): Drops support for tx metric extranction versions < 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Limit metric name to 150 characters. ([#3628](https://github.com/getsentry/relay/pull/3628))
 - Add validation of Kafka topics on startup. ([#3543](https://github.com/getsentry/relay/pull/3543))
 - Send `attachment` data inline when possible. ([#3654](https://github.com/getsentry/relay/pull/3654))
+- Drops support for transaction metrics extraction versions < 3. ([#3672](https://github.com/getsentry/relay/pull/3672))
 
 ## 24.5.0
 

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -122,6 +122,9 @@ pub struct CustomMeasurementConfig {
 ///  - 6: Bugfix to make transaction metrics extraction apply globally defined tag mappings.
 const TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION: u16 = 6;
 
+/// Minimum supported version of metrics extraction from transaction.
+const TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION: u16 = 3;
+
 /// Deprecated. Defines whether URL transactions should be considered low cardinality.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -167,12 +170,8 @@ impl TransactionMetricsConfig {
 
     /// Returns `true` if metrics extraction is enabled and compatible with this Relay.
     pub fn is_enabled(&self) -> bool {
-        self.version > 0 && self.version <= TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION
-    }
-
-    /// Returns `true` if usage should be tracked through a dedicated metric.
-    pub fn usage_metric(&self) -> bool {
-        self.version >= 3
+        self.version >= TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+            && self.version <= TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION
     }
 }
 

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -163,7 +163,7 @@ impl TransactionMetricsConfig {
     /// Creates an enabled configuration with empty defaults.
     pub fn new() -> Self {
         Self {
-            version: 1,
+            version: TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
             ..Self::default()
         }
     }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -394,18 +394,12 @@ impl TransactionExtractor<'_> {
         // Duration
         let duration = relay_common::time::chrono_to_positive_millis(end - start);
         if let Some(duration) = FiniteF64::new(duration) {
-            let has_profile = if self.config.version >= 3 {
-                false
-            } else {
-                self.has_profile
-            };
-
             metrics.project_metrics.push(
                 TransactionMetric::Duration {
                     unit: DurationUnit::MilliSecond,
                     value: duration,
                     tags: TransactionDurationTags {
-                        has_profile,
+                        has_profile: false,
                         universal_tags: tags.clone(),
                     },
                 }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -13,7 +13,7 @@ use relay_metrics::{Bucket, DurationUnit, FiniteF64};
 use crate::metrics_extraction::generic;
 use crate::metrics_extraction::transactions::types::{
     CommonTag, CommonTags, ExtractMetricsError, LightTransactionTags, TransactionCPRTags,
-    TransactionDurationTags, TransactionMeasurementTags, TransactionMetric, UsageTags,
+    TransactionMeasurementTags, TransactionMetric, UsageTags,
 };
 use crate::metrics_extraction::IntoMetric;
 use crate::statsd::RelayCounters;
@@ -398,10 +398,7 @@ impl TransactionExtractor<'_> {
                 TransactionMetric::Duration {
                     unit: DurationUnit::MilliSecond,
                     value: duration,
-                    tags: TransactionDurationTags {
-                        has_profile: false,
-                        universal_tags: tags.clone(),
-                    },
+                    tags: tags.clone(),
                 }
                 .into_metric(timestamp),
             );

--- a/relay-server/src/metrics_extraction/transactions/types.rs
+++ b/relay-server/src/metrics_extraction/transactions/types.rs
@@ -21,7 +21,7 @@ pub enum TransactionMetric {
     Duration {
         unit: DurationUnit,
         value: DistributionType,
-        tags: TransactionDurationTags,
+        tags: CommonTags,
     },
     /// A distribution metric for the transaction duration with limited tags.
     DurationLight {
@@ -130,22 +130,6 @@ impl IntoMetric for TransactionMetric {
             tags,
             metadata: BucketMetadata::new(received_at),
         }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
-pub struct TransactionDurationTags {
-    pub has_profile: bool,
-    pub universal_tags: CommonTags,
-}
-
-impl From<TransactionDurationTags> for BTreeMap<String, String> {
-    fn from(tags: TransactionDurationTags) -> Self {
-        let mut map: BTreeMap<String, String> = tags.universal_tags.into();
-        if tags.has_profile {
-            map.insert("has_profile".to_string(), "true".to_string());
-        }
-        map
     }
 }
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -482,13 +482,13 @@ mod tests {
         let sampling_result = run(&mut state, &config);
         assert!(sampling_result.should_keep());
 
-        // Current version is 1, so it won't run DS if it's outdated
-        let mut state = get_state(Some(0));
+        // Current version is 3, so it won't run DS if it's outdated
+        let mut state = get_state(Some(2));
         let sampling_result = run(&mut state, &config);
         assert!(sampling_result.should_keep());
 
         // Dynamic sampling is run, as the transactionmetrics version is up to date.
-        let mut state = get_state(Some(1));
+        let mut state = get_state(Some(3));
         let sampling_result = run(&mut state, &config);
         assert!(sampling_result.should_drop());
     }

--- a/relay-server/src/services/project/metrics.rs
+++ b/relay-server/src/services/project/metrics.rs
@@ -101,13 +101,10 @@ impl Buckets<Filtered> {
             })
             .collect();
 
-        let mode = project_state.get_extraction_mode();
-
         if !disabled_namespace_buckets.is_empty() {
             metric_outcomes.track(
                 scoping,
                 &disabled_namespace_buckets,
-                mode,
                 Outcome::Filtered(FilterStatKey::DisabledNamespace),
             );
         }
@@ -116,7 +113,6 @@ impl Buckets<Filtered> {
             metric_outcomes.track(
                 scoping,
                 &denied_buckets,
-                mode,
                 Outcome::Filtered(FilterStatKey::DeniedName),
             );
         }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 
-use crate::metrics::{ArrayEncoding, BucketEncoder, ExtractionMode, MetricOutcomes};
+use crate::metrics::{ArrayEncoding, BucketEncoder, MetricOutcomes};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
@@ -88,7 +88,6 @@ pub struct StoreMetrics {
     pub buckets: Vec<Bucket>,
     pub scoping: Scoping,
     pub retention: u16,
-    pub mode: ExtractionMode,
 }
 
 #[derive(Debug)]
@@ -394,7 +393,6 @@ impl StoreService {
             buckets,
             scoping,
             retention,
-            mode,
         } = message;
 
         let batch_size = self.config.metrics_max_batch_size_bytes();
@@ -433,7 +431,7 @@ impl StoreService {
                     }
                 };
 
-                self.metric_outcomes.track(scoping, &[view], mode, outcome);
+                self.metric_outcomes.track(scoping, &[view], outcome);
             }
         }
 

--- a/tests/integration/consts.py
+++ b/tests/integration/consts.py
@@ -1,0 +1,4 @@
+# Minimum supported version for metric transaction by Relay.
+TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION = 3
+# Maximum supported version for metric transaction by Relay.
+TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION = 6

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -1,6 +1,10 @@
 from datetime import datetime
 import uuid
 import json
+from .consts import (
+    TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
+    TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
+)
 
 import pytest
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
@@ -233,7 +237,9 @@ def test_it_removes_events(mini_sentry, relay):
 
     # create a basic project config
     config = mini_sentry.add_basic_project_config(project_id)
-    config["config"]["transactionMetrics"] = {"version": 1}
+    config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
 
     public_key = config["publicKeys"][0]["publicKey"]
 
@@ -345,7 +351,9 @@ def test_sample_on_parametrized_root_transaction(mini_sentry, relay):
     parametrized_transaction = "/auth/login/*/"
 
     config = mini_sentry.add_basic_project_config(project_id)
-    config["config"]["transactionMetrics"] = {"version": 1}
+    config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION
+    }
 
     sampling_config = mini_sentry.add_basic_project_config(43)
     sampling_public_key = sampling_config["publicKeys"][0]["publicKey"]
@@ -455,14 +463,18 @@ def test_uses_trace_public_key(mini_sentry, relay):
     # create basic project configs
     project_id1 = 42
     config1 = mini_sentry.add_basic_project_config(project_id1)
-    config1["config"]["transactionMetrics"] = {"version": 1}
+    config1["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
 
     public_key1 = config1["publicKeys"][0]["publicKey"]
     _add_sampling_config(config1, sample_rate=0, rule_type="trace")
 
     project_id2 = 43
     config2 = mini_sentry.add_basic_project_config(project_id2)
-    config2["config"]["transactionMetrics"] = {"version": 1}
+    config2["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     public_key2 = config2["publicKeys"][0]["publicKey"]
     _add_sampling_config(config2, sample_rate=1, rule_type="trace")
 
@@ -525,7 +537,9 @@ def test_multi_item_envelope(mini_sentry, relay, rule_type, event_factory):
 
     # create a basic project config
     config = mini_sentry.add_basic_project_config(project_id)
-    config["config"]["transactionMetrics"] = {"version": 1}
+    config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     # add a sampling rule to project config that removes all transactions (sample_rate=0)
     public_key = config["publicKeys"][0]["publicKey"]
     # add a sampling rule to project config that drops all events (sample_rate=0), it should be ignored
@@ -575,7 +589,9 @@ def test_client_sample_rate_adjusted(mini_sentry, relay, rule_type, event_factor
     project_id = 42
     relay = relay(mini_sentry)
     config = mini_sentry.add_basic_project_config(project_id)
-    config["config"]["transactionMetrics"] = {"version": 1}
+    config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     public_key = config["publicKeys"][0]["publicKey"]
 
     # the closer to 0, the less flaky the test is
@@ -681,7 +697,9 @@ def test_relay_chain_keep_unsampled_profile(
     project_id = 42
     relay = relay(relay_with_processing())
     config = mini_sentry.add_basic_project_config(project_id)
-    config["config"]["transactionMetrics"] = {"version": 1}
+    config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     config["config"]["features"] = ["projects:profiling-ingest-unsampled-profiles"]
 
     public_key = config["publicKeys"][0]["publicKey"]
@@ -824,7 +842,9 @@ def test_invalid_global_generic_filters_skip_dynamic_sampling(mini_sentry, relay
 
     project_id = 42
     config = mini_sentry.add_basic_project_config(project_id)
-    config["config"]["transactionMetrics"] = {"version": 1}
+    config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     public_key = config["publicKeys"][0]["publicKey"]
 
     # Reject all transactions with dynamic sampling

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -803,7 +803,7 @@ def test_transaction_metrics(
         )
 
     if extract_metrics == "corrupted":
-        config["transactionMetrics"] = (TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION + 1,)
+        config["transactionMetrics"] = TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION + 1
 
     elif extract_metrics:
         config["transactionMetrics"] = {
@@ -1170,6 +1170,10 @@ def test_transaction_metrics_not_extracted_on_unsupported_version(
     tx, _ = tx_consumer.get_event()
     assert tx["transaction"] == "/organizations/:orgId/performance/:eventSlug/"
     tx_consumer.assert_empty()
+
+    if unsupported_version < TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION:
+        error = str(mini_sentry.test_failures.pop(0))
+        assert "Processing Relay outdated" in error
 
     metrics_consumer.assert_empty()
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -7,6 +7,10 @@ import json
 import signal
 import time
 import queue
+from .consts import (
+    TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
+    TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
+)
 
 import pytest
 import requests
@@ -799,11 +803,11 @@ def test_transaction_metrics(
         )
 
     if extract_metrics == "corrupted":
-        config["transactionMetrics"] = 42
+        config["transactionMetrics"] = (TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION + 1,)
 
     elif extract_metrics:
         config["transactionMetrics"] = {
-            "version": 1,
+            "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
         }
         config.setdefault("features", []).append("projects:span-metrics-extraction")
 
@@ -940,7 +944,7 @@ def test_transaction_metrics_count_per_root_project(
             "span_ops": {"type": "spanOperations", "matches": ["react.mount"]}
         }
         config["transactionMetrics"] = {
-            "version": 1,
+            "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
         }
 
     transaction = generate_transaction_item()
@@ -1013,7 +1017,9 @@ def test_transaction_metrics_extraction_external_relays(
     project_id = 42
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
-    config["transactionMetrics"] = {"version": 3}
+    config["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     config["sampling"] = {
         "version": 2,
         "rules": [
@@ -1093,7 +1099,7 @@ def test_transaction_metrics_extraction_processing_relays(
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     tx = generate_transaction_item()
@@ -1173,7 +1179,7 @@ def test_no_transaction_metrics_when_filtered(mini_sentry, relay):
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     config["filterSettings"]["releases"] = {"releases": ["foo@1.2.4"]}
 
@@ -1204,7 +1210,7 @@ def test_transaction_name_too_long(
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     transaction = {
@@ -1320,7 +1326,7 @@ def test_limit_custom_measurements(
         "maxCustomMeasurements": 1,
     }
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     transaction = generate_transaction_item()
@@ -1379,7 +1385,7 @@ def test_span_metrics(
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     config.setdefault("features", []).append("projects:span-metrics-extraction")
 
@@ -1464,7 +1470,9 @@ def test_generic_metric_extraction(mini_sentry, relay):
             }
         ],
     }
-    config["transactionMetrics"] = {"version": 3}
+    config["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     config["sampling"] = {
         "version": 2,
         "rules": [
@@ -1517,7 +1525,7 @@ def test_span_metrics_secondary_aggregator(
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     config.setdefault("features", []).append("projects:span-metrics-extraction")
 
@@ -1687,7 +1695,7 @@ def test_relay_forwards_events_without_extracting_metrics_on_broken_global_filte
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     if is_processing_relay:
@@ -1750,7 +1758,7 @@ def test_relay_forwards_events_without_extracting_metrics_on_unsupported_project
         }
     }
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     if is_processing_relay:
@@ -1806,7 +1814,7 @@ def test_missing_global_filters_enables_metric_extraction(
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
     config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     relay = relay_with_processing(
@@ -1946,7 +1954,7 @@ def test_histogram_outliers(mini_sentry, relay):
         mini_sentry.global_config["metricExtraction"] = yaml.full_load(f)
     project_config = mini_sentry.add_full_project_config(project_id=42)["config"]
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     project_config["metricExtraction"] = {
         "version": 3,

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from queue import Empty
+from .consts import TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
 
 import pytest
 import requests
@@ -793,7 +794,9 @@ def test_outcome_to_client_report(relay, mini_sentry):
     # Create project config
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["transactionMetrics"] = {"version": 1}
+    project_config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     project_config["config"]["sampling"] = {
         "version": 2,
         "rules": [
@@ -972,7 +975,9 @@ def test_outcomes_aggregate_dynamic_sampling(relay, mini_sentry):
         ],
     }
 
-    project_config["config"]["transactionMetrics"] = {"version": 1}
+    project_config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
 
     upstream = relay(
         mini_sentry,
@@ -1064,7 +1069,9 @@ def test_graceful_shutdown(relay, mini_sentry):
     # Create project config
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["transactionMetrics"] = {"version": 1}
+    project_config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     project_config["config"]["sampling"] = {
         "version": 2,
         "rules": [
@@ -1151,7 +1158,7 @@ def test_profile_outcomes(
 
     project_config.setdefault("features", []).append("organizations:profiling")
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     project_config["sampling"] = {
         "version": 2,
@@ -1299,7 +1306,7 @@ def test_profile_outcomes_invalid(
 
     project_config.setdefault("features", []).append("organizations:profiling")
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     config = {
@@ -1385,7 +1392,7 @@ def test_profile_outcomes_too_many(
 
     project_config.setdefault("features", []).append("organizations:profiling")
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     config = {
@@ -1473,7 +1480,7 @@ def test_profile_outcomes_data_invalid(
 
     project_config.setdefault("features", []).append("organizations:profiling")
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     config = {
@@ -1745,7 +1752,7 @@ def test_span_outcomes(
         ]
     )
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     project_config["sampling"] = {
         "version": 2,
@@ -1869,7 +1876,7 @@ def test_span_outcomes_invalid(
         ]
     )
     project_config["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     config = {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from collections import Counter
 from datetime import datetime, timedelta, timezone, UTC
+from .consts import TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
 
 import pytest
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
@@ -43,7 +44,7 @@ def test_span_extraction(
         "organizations:indexed-spans-extraction",
     ]
     project_config["config"]["transactionMetrics"] = {
-        "version": 3,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     if discard_transaction:
@@ -199,7 +200,7 @@ def test_span_extraction_with_sampling(
         "organizations:indexed-spans-extraction",
     ]
     project_config["config"]["transactionMetrics"] = {
-        "version": 3,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
     spans_consumer = spans_consumer()
@@ -243,7 +244,7 @@ def test_duplicate_performance_score(mini_sentry, relay):
         "organizations:indexed-spans-extraction",
     ]
     project_config["config"]["transactionMetrics"] = {
-        "version": 1,
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
     project_config["config"]["performanceScore"] = {
         "profiles": [
@@ -455,7 +456,9 @@ def test_span_ingestion(
         "projects:span-metrics-extraction",
         "projects:relay-otel-endpoint",
     ]
-    project_config["config"]["transactionMetrics"] = {"version": 1}
+    project_config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     if extract_transaction:
         project_config["config"]["features"].append(
             "projects:extract-transaction-from-segment-span"
@@ -1534,7 +1537,9 @@ def test_rate_limit_indexed_consistent_extracted(
     project_config = mini_sentry.add_full_project_config(project_id)
     # Span metrics won't be extracted without a supported transactionMetrics config.
     # Without extraction, the span is treated as `Span`, not `SpanIndexed`.
-    project_config["config"]["transactionMetrics"] = {"version": 3}
+    project_config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
     project_config["config"]["features"] = [
         "projects:span-metrics-extraction",
         "organizations:indexed-spans-extraction",
@@ -1803,7 +1808,9 @@ def test_dynamic_sampling(
     project_config["config"]["features"] = [
         "organizations:standalone-span-ingestion",
     ]
-    project_config["config"]["transactionMetrics"] = {"version": 1}
+    project_config["config"]["transactionMetrics"] = {
+        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
+    }
 
     sampling_config = mini_sentry.add_basic_project_config(43)
     sampling_public_key = sampling_config["publicKeys"][0]["publicKey"]

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -7,6 +7,11 @@ import uuid
 from datetime import UTC, datetime, timedelta, timezone
 from time import sleep
 
+from .consts import (
+    TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
+    TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
+)
+
 import pytest
 from flask import Response, abort
 from requests.exceptions import HTTPError
@@ -803,7 +808,13 @@ def test_rate_limit_metrics_buckets(
     )
 
 
-@pytest.mark.parametrize("extraction_version", [1, 3])
+@pytest.mark.parametrize(
+    "extraction_version",
+    [
+        TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
+        TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
+    ],
+)
 def test_processing_quota_transaction_indexing(
     mini_sentry,
     relay_with_processing,

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import json
+from .consts import TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION
 
 
 def _load_dump_file(base_file_name: str):
@@ -23,7 +24,7 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, extract_metrics):
     if extract_metrics:
         # regression: we dropped unreal events in customer relays while metrics extraction was on
         config["transactionMetrics"] = {
-            "version": 3,
+            "version": TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
         }
 
     unreal_content = _load_dump_file(dump_file_name)

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -23,7 +23,7 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, extract_metrics):
     if extract_metrics:
         # regression: we dropped unreal events in customer relays while metrics extraction was on
         config["transactionMetrics"] = {
-            "version": 1,
+            "version": 3,
         }
 
     unreal_content = _load_dump_file(dump_file_name)


### PR DESCRIPTION
Removes all conditional `extraction mode` handling, essentially drops support for metrics extraction `< 3`