### PR TITLE
docs(readme): fix relay product docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SDKs as well as the Sentry server into a proxy process.
 
 ## Documentation
 
-- Product documentation can be found at: [https://docs.sentry.io/meta/relay/](https://docs.sentry.io/meta/relay).
+- Product documentation can be found at: [https://docs.sentry.io/product/relay/](https://docs.sentry.io/product/relay).
 - Code and development documentation can be found at:
   [https://getsentry.github.io/relay/](https://getsentry.github.io/relay/).
 


### PR DESCRIPTION
fixes getsentry/sentry-docs#10226

#skip-changelog