### PR TITLE
ci(ci): Fix CI for forks without permissions to secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,17 +311,37 @@ jobs:
           pattern: "${{ matrix.image_name }}@*"
           merge-multiple: true
 
-      - name: Build and push to ghcr.io
-        if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
-        run: |
-          docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+      # - name: Build and push to ghcr.io
+      #   if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+      #   run: |
+      #     docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+      #
+      #     docker buildx build \
+      #       --platform "${PLATFORMS}" \
+      #       --tag "${DOCKER_IMAGE}:${REVISION}" \
+      #       $( [[ "${GITHUB_REF}" == "refs/heads/master" ]] && printf %s "--tag ${DOCKER_IMAGE}:nightly" ) \
+      #       --file Dockerfile.release \
+      #       --push \
+      #       .
 
+      - name: Build and publish docker artifact
+        # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        run: |
           docker buildx build \
             --platform "${PLATFORMS}" \
             --tag "${DOCKER_IMAGE}:${REVISION}" \
-            $( [[ "${GITHUB_REF}" == "refs/heads/master" ]] && printf %s "--tag ${DOCKER_IMAGE}:nightly" ) \
             --file Dockerfile.release \
-            --push .
+            --output type=docker,dest=${{ matrix.image_name }}-docker-image \
+            .
+
+      - name: Upload docker image
+        # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          name: ${{ matrix.image_name }}-docker-image
+          path: "${{ matrix.image_name }}-docker-image"
+
 
   publish-to-dockerhub:
     needs: [build-setup, build-docker]
@@ -585,6 +605,16 @@ jobs:
           kafka: true
           symbolicator: true
 
+      - name: Download Docker Image
+      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        uses: actions/download-artifact@v4
+        with:
+          name: relay-docker-image
+
+      - name: Import Docker Image
+      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        run: docker load -i relay-docker-image
+
       - name: Run Sentry integration tests
         working-directory: sentry
         env:
@@ -604,6 +634,16 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Download Docker Image
+      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        uses: actions/download-artifact@v4
+        with:
+          name: relay-docker-image
+
+      - name: Import Docker Image
+      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        run: docker load -i relay-docker-image
 
       - name: Run Sentry self-hosted e2e CI
         # Skip for dependabot or if it's a fork as the image cannot be uploaded to ghcr since this test attempts to pull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,21 +311,21 @@ jobs:
           pattern: "${{ matrix.image_name }}@*"
           merge-multiple: true
 
-      # - name: Build and push to ghcr.io
-      #   if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
-      #   run: |
-      #     docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
-      #
-      #     docker buildx build \
-      #       --platform "${PLATFORMS}" \
-      #       --tag "${DOCKER_IMAGE}:${REVISION}" \
-      #       $( [[ "${GITHUB_REF}" == "refs/heads/master" ]] && printf %s "--tag ${DOCKER_IMAGE}:nightly" ) \
-      #       --file Dockerfile.release \
-      #       --push \
-      #       .
+      - name: Build and push to ghcr.io
+        if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+        run: |
+          docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+
+          docker buildx build \
+            --platform "${PLATFORMS}" \
+            --tag "${DOCKER_IMAGE}:${REVISION}" \
+            $( [[ "${GITHUB_REF}" == "refs/heads/master" ]] && printf %s "--tag ${DOCKER_IMAGE}:nightly" ) \
+            --file Dockerfile.release \
+            --push \
+            .
 
       - name: Build and publish docker artifact
-        # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
         run: |
           docker buildx build \
             --platform "${PLATFORMS}" \
@@ -335,13 +335,12 @@ jobs:
             .
 
       - name: Upload docker image
-        # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
         uses: actions/upload-artifact@v4
         with:
           retention-days: 1
           name: ${{ matrix.image_name }}-docker-image
           path: "${{ matrix.image_name }}-docker-image"
-
 
   publish-to-dockerhub:
     needs: [build-setup, build-docker]
@@ -606,13 +605,13 @@ jobs:
           symbolicator: true
 
       - name: Download Docker Image
-      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
         uses: actions/download-artifact@v4
         with:
           name: relay-docker-image
 
       - name: Import Docker Image
-      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
         run: docker load -i relay-docker-image
 
       - name: Run Sentry integration tests
@@ -636,13 +635,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Docker Image
-      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
         uses: actions/download-artifact@v4
         with:
           name: relay-docker-image
 
       - name: Import Docker Image
-      # if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
+        if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
         run: docker load -i relay-docker-image
 
       - name: Run Sentry self-hosted e2e CI


### PR DESCRIPTION
Ext contributors don't have permissions to ghcr, we need to use an artifact. 

#skip-changelog