### PR TITLE
ref(store/feedback): remove unreachable condition in store_envelope

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -205,15 +205,6 @@ impl StoreService {
             KafkaTopic::Attachments
         } else if event_item.as_ref().map(|x| x.ty()) == Some(&ItemType::Transaction) {
             KafkaTopic::Transactions
-        } else if event_item.as_ref().map(|x| x.ty()) == Some(&ItemType::UserReportV2) {
-            if is_rolled_out(
-                scoping.organization_id,
-                global_options.feedback_ingest_topic_rollout_rate,
-            ) {
-                KafkaTopic::Feedback
-            } else {
-                KafkaTopic::Events
-            }
         } else {
             KafkaTopic::Events
         };


### PR DESCRIPTION
I missed this in https://github.com/getsentry/relay/pull/3617. This condition never happens since we handle user report v2's in the for-match loop

#skip-changelog