### PR TITLE
chore(gocd): Bumping gocd-jsonnet

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.10.0"
+      "version": "v2.10.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "74ae5728e2d7ed39fdd43cf3b2d28dde7e4567a1",
-      "sum": "AKMGYALLyaVVVjTNnZy64PoCDA8QjxTbHBe5dCnE4tE="
+      "version": "4ea5baaceaec881adc338e08b235bef4fb325b3e",
+      "sum": "GdmT/ufKbfQw3VnnwSBnDLWkIRhTn4TgT7Y2pzOiwSE="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumping gocd-jsonnet to make use of new feature to better track who triggered rollbacks.

#skip-changelog