### PR TITLE
instr(server): Remove cogs related statsd metrics

### DIFF
--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -11,14 +11,12 @@ use relay_protocol::{Annotated, Empty};
 use relay_sampling::config::RuleType;
 use relay_sampling::evaluation::{ReservoirEvaluator, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
-use relay_statsd::metric;
 
 use crate::envelope::ItemType;
 use crate::services::outcome::Outcome;
 use crate::services::processor::{
     profile, EventProcessing, ProcessEnvelopeState, Sampling, TransactionGroup,
 };
-use crate::statsd::RelayCounters;
 use crate::utils::{self, sample, ItemAction, SamplingResult};
 
 /// Ensures there is a valid dynamic sampling context and corresponding project state.
@@ -107,10 +105,6 @@ pub fn sample_envelope_items(
         };
         let should_drop =
             event.ty.value() == Some(&EventType::Transaction) && sampling_match.should_drop();
-        metric!(
-            counter(RelayCounters::DynamicSamplingDecision) += 1,
-            decision = if should_drop { "drop" } else { "keep" }
-        );
         if should_drop {
             let unsampled_profiles_enabled = forward_unsampled_profiles(state, global_config);
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -252,10 +252,6 @@ pub enum RelayTimers {
     EventProcessingSerialization,
     /// Time used to extract span metrics from an event.
     EventProcessingSpanMetricsExtraction,
-    /// Time spent on transaction processing after dynamic sampling.
-    ///
-    /// This includes PII scrubbing and for processing relays also consistent rate limiting.
-    TransactionProcessingAfterDynamicSampling,
     /// Time spent between the start of request handling and processing of the envelope.
     ///
     /// This includes streaming the request body, scheduling overheads, project config fetching,
@@ -419,9 +415,6 @@ impl TimerMetric for RelayTimers {
                 "event_processing.span_metrics_extraction"
             }
             RelayTimers::EventProcessingSerialization => "event_processing.serialization",
-            RelayTimers::TransactionProcessingAfterDynamicSampling => {
-                "transaction.processing.post_ds"
-            }
             RelayTimers::EnvelopeWaitTime => "event.wait_time",
             RelayTimers::EnvelopeProcessingTime => "event.processing_time",
             RelayTimers::EnvelopeTotalTime => "event.total_time",
@@ -667,11 +660,6 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     ///  - `success`: whether deserializing the global config succeeded.
     GlobalConfigFetched,
-    /// Counter for dynamic sampling decision.
-    ///
-    /// This metric is tagged with:
-    /// - `decision`: "drop" if dynamic sampling drops the envelope, else "keep".
-    DynamicSamplingDecision,
     /// Counts how many transactions were created from segment spans.
     #[cfg(feature = "processing")]
     TransactionsFromSpans,
@@ -716,7 +704,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
             RelayCounters::GlobalConfigFetched => "global_config.fetch",
-            RelayCounters::DynamicSamplingDecision => "dynamic_sampling_decision",
             #[cfg(feature = "processing")]
             RelayCounters::TransactionsFromSpans => "transactions_from_spans",
             RelayCounters::MissingDynamicSamplingContext => "missing_dynamic_sampling_context",


### PR DESCRIPTION
These were introduced for an ad-hoc COGS estimate. We're attempting to reduce the amount of metrics (see https://github.com/getsentry/team-ingest/issues/353).

#skip-changelog