### PR TITLE
feat(metrics): Add metric to track how many times a partition overflows

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2541,7 +2541,7 @@ impl EnvelopeProcessorService {
 
         let batch_size = self.inner.config.metrics_max_batch_size_bytes();
         let mut partition = Partition::new(batch_size);
-        let mut partition_overflowed = false;
+        let mut partition_splits = 0;
 
         for (scoping, message) in &scopes {
             let ProjectMetrics { buckets, .. } = message;
@@ -2556,14 +2556,14 @@ impl EnvelopeProcessorService {
                         // always result in a request, otherwise we would enter an endless loop.
                         self.send_global_partition(partition_key, &mut partition);
                         remaining = Some(next);
-                        partition_overflowed = true;
+                        partition_splits += 1;
                     }
                 }
             }
         }
 
-        if partition_overflowed {
-            metric!(counter(RelayCounters::PartitionOverflow) += 1);
+        if partition_splits > 0 {
+            metric!(histogram(RelayHistograms::PartitionSplits) = partition_splits);
         }
 
         self.send_global_partition(partition_key, &mut partition);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2548,6 +2548,7 @@ impl EnvelopeProcessorService {
 
                 while let Some(bucket) = remaining.take() {
                     if let Some(next) = partition.insert(bucket, *scoping) {
+                        metric!(counter(RelayCounters::PartitionOverflow) += 1);
                         // A part of the bucket could not be inserted. Take the partition and submit
                         // it immediately. Repeat until the final part was inserted. This should
                         // always result in a request, otherwise we would enter an endless loop.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -187,6 +187,9 @@ pub enum RelayHistograms {
     /// Measures how many transactions were created from segment spans in a single envelope.
     #[cfg(feature = "processing")]
     TransactionsFromSpansPerEnvelope,
+
+    /// Measures how many splits were performed when sending out a partition.
+    PartitionSplits,
 }
 
 impl HistogramMetric for RelayHistograms {
@@ -224,6 +227,7 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::TransactionsFromSpansPerEnvelope => {
                 "transactions_from_spans_per_envelope"
             }
+            RelayHistograms::PartitionSplits => "partition_splits",
         }
     }
 }
@@ -668,9 +672,6 @@ pub enum RelayCounters {
     MissingDynamicSamplingContext,
     /// The number of attachments processed in the same envelope as a user_report_v2 event.
     FeedbackAttachments,
-    /// Counter for when a partition containing buckets reached the maximum size and is split into
-    /// multiple separate partitions.
-    PartitionOverflow,
 }
 
 impl CounterMetric for RelayCounters {
@@ -713,7 +714,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::TransactionsFromSpans => "transactions_from_spans",
             RelayCounters::MissingDynamicSamplingContext => "missing_dynamic_sampling_context",
             RelayCounters::FeedbackAttachments => "processing.feedback_attachments",
-            RelayCounters::PartitionOverflow => "partition_overflow",
         }
     }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -666,6 +666,9 @@ pub enum RelayCounters {
     /// Counter for when the DSC is missing from an event that comes from an SDK that should support
     /// it.
     MissingDynamicSamplingContext,
+    /// Counter for when a partition containing buckets reached the maximum size and is split into
+    /// multiple separate partitions.
+    PartitionOverflow,
 }
 
 impl CounterMetric for RelayCounters {
@@ -707,6 +710,7 @@ impl CounterMetric for RelayCounters {
             #[cfg(feature = "processing")]
             RelayCounters::TransactionsFromSpans => "transactions_from_spans",
             RelayCounters::MissingDynamicSamplingContext => "missing_dynamic_sampling_context",
+            RelayCounters::PartitionOverflow => "partition_overflow",
         }
     }
 }


### PR DESCRIPTION
This PR adds a metric to track how many times a partition overflows. It will be helpful to inform a decision on whether we should increase the size of the request.

#skip-changelog