### PR TITLE
fix(profiles): Fix unsampled profiles being dropped in processing Relays

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1510,12 +1510,17 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<TransactionGroup>,
     ) -> Result<(), ProcessingError> {
-        profile::filter(state);
+        let global_config = self.inner.global_config.current();
+
+        dynamic_sampling::ensure_dsc(state);
+
         event::extract(
             state,
             &self.inner.config,
             &self.inner.global_config.current(),
         )?;
+
+        profile::filter(state);
         profile::transfer_id(state);
 
         if_processing!(self.inner.config, {
@@ -1524,57 +1529,70 @@ impl EnvelopeProcessorService {
 
         event::finalize(state, &self.inner.config)?;
         self.normalize_event(state)?;
-        dynamic_sampling::ensure_dsc(state);
+
         let filter_run = event::filter(state, &self.inner.global_config.current())?;
 
-        if self.inner.config.processing_enabled() || matches!(filter_run, FiltersStatus::Ok) {
-            let sampling_result = dynamic_sampling::run(state, &self.inner.config);
-            // Remember sampling decision, before it is reset in `dynamic_sampling::sample_envelope_items`.
-            let sampling_should_drop = sampling_result.should_drop();
+        // Always run dynamic sampling on processing Relays,
+        // but delay decision until inbound filters have been fully processed.
+        let sampling_result =
+            if self.inner.config.processing_enabled() || matches!(filter_run, FiltersStatus::Ok) {
+                dynamic_sampling::run(state, &self.inner.config)
+            } else {
+                SamplingResult::NoMatch
+            };
 
-            // We avoid extracting metrics if we are not sampling the event while in non-processing
-            // relays, in order to synchronize rate limits on indexed and processed transactions.
-            if self.inner.config.processing_enabled() || sampling_should_drop {
-                self.extract_transaction_metrics(state, &sampling_result)?;
+        // We avoid extracting metrics if we are not sampling the event while in non-processing
+        // Relays, in order to synchronize rate limits on indexed and processed transactions.
+        if self.inner.config.processing_enabled() || sampling_result.should_drop() {
+            self.extract_transaction_metrics(state, &sampling_result)?;
+        }
+
+        if let Some(outcome) = sampling_result.into_dropped_outcome() {
+            let keep_profiles = dynamic_sampling::forward_unsampled_profiles(state, &global_config);
+
+            // Process profiles before dropping the transaction, if necessary.
+            if keep_profiles {
+                profile::process(state, &self.inner.config);
             }
 
-            dynamic_sampling::sample_envelope_items(
-                state,
-                sampling_result,
-                &self.inner.config,
-                &self.inner.global_config.current(),
-            );
+            dynamic_sampling::drop_unsampled_items(state, outcome, keep_profiles);
+
+            // At this point we have:
+            //  - An empty envelope.
+            //  - An envelope containing only processed profiles.
+            // We need to make sure there are enough quotas for these profiles.
+            if_processing!(self.inner.config, {
+                self.enforce_quotas(state)?;
+            });
+
+            return Ok(());
         }
+
+        // Need to scrub the transaction before extracting spans.
+        //
+        // Unconditionally scrub to make sure PII is removed as early as possible.
+        event::scrub(state)?;
+        attachment::scrub(state);
 
         if_processing!(self.inner.config, {
             profile::process(state, &self.inner.config);
-        });
 
-        if state.has_event() {
-            event::scrub(state)?;
+            if state
+                .project_state
+                .has_feature(Feature::ExtractSpansFromEvent)
+            {
+                span::extract_from_event(
+                    state,
+                    &self.inner.config,
+                    &self.inner.global_config.current(),
+                );
+            }
 
-            if_processing!(self.inner.config, {
-                if state
-                    .project_state
-                    .has_feature(Feature::ExtractSpansFromEvent)
-                {
-                    span::extract_from_event(
-                        state,
-                        &self.inner.config,
-                        &self.inner.global_config.current(),
-                    );
-                }
-            });
-        }
-
-        if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
             span::maybe_discard_transaction(state);
         });
-        if state.has_event() {
-            event::serialize(state)?;
-        }
-        attachment::scrub(state);
+
+        event::serialize(state)?;
 
         Ok(())
     }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1581,11 +1581,7 @@ impl EnvelopeProcessorService {
                 .project_state
                 .has_feature(Feature::ExtractSpansFromEvent)
             {
-                span::extract_from_event(
-                    state,
-                    &self.inner.config,
-                    &self.inner.global_config.current(),
-                );
+                span::extract_from_event(state, &self.inner.config, &global_config);
             }
 
             self.enforce_quotas(state)?;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1592,7 +1592,10 @@ impl EnvelopeProcessorService {
             span::maybe_discard_transaction(state);
         });
 
-        event::serialize(state)?;
+        // Event may have been dropped because of a quota and the envelope can be empty.
+        if state.has_event() {
+            event::serialize(state)?;
+        }
 
         Ok(())
     }

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -17,7 +17,7 @@ use crate::utils::ItemAction;
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
     let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
     let has_transaction = state.event_type() == Some(EventType::Transaction);
-    let unsampled_profiles = state
+    let keep_unsampled_profiles = state
         .project_state
         .has_feature(Feature::IngestUnsampledProfiles);
 
@@ -31,7 +31,7 @@ pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
 
             // Drop profile without a transaction in the same envelope,
             // except if unsampled profiles are allowed for this project.
-            let profile_allowed = has_transaction || (!item.sampled() && unsampled_profiles);
+            let profile_allowed = has_transaction || (keep_unsampled_profiles && !item.sampled());
             if !profile_allowed {
                 return ItemAction::DropSilently;
             }
@@ -83,7 +83,7 @@ pub fn process(state: &mut ProcessEnvelopeState<TransactionGroup>, config: &Conf
             }
 
             // There should always be an event/transaction available at this stage.
-            // It is required to expand the profle. If it's missing, drop the item.
+            // It is required to expand the profile. If it's missing, drop the item.
             let Some(event) = state.event.value() else {
                 return ItemAction::DropSilently;
             };

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -1,6 +1,5 @@
 //! Profiles related processor code.
 
-#[cfg(feature = "processing")]
 use relay_dynamic_config::Feature;
 
 use relay_base_schema::events::EventType;
@@ -16,18 +15,23 @@ use crate::utils::ItemAction;
 
 /// Removes profiles from the envelope if they can not be parsed.
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
-    let transaction_count: usize = state
-        .managed_envelope
-        .envelope()
-        .items()
-        .filter(|item| item.ty() == &ItemType::Transaction)
-        .count();
+    let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
+    let has_transaction = state.event_type() == Some(EventType::Transaction);
+    let unsampled_profiles = state
+        .project_state
+        .has_feature(Feature::IngestUnsampledProfiles);
+
     let mut profile_id = None;
     state.managed_envelope.retain_items(|item| match item.ty() {
         // First profile found in the envelope, we'll keep it if metadata are valid.
         ItemType::Profile if profile_id.is_none() => {
-            // Drop profile without a transaction in the same envelope.
-            let profile_allowed = transaction_count > 0 || !item.sampled();
+            if !profiling_enabled {
+                return ItemAction::DropSilently;
+            }
+
+            // Drop profile without a transaction in the same envelope,
+            // except if unsampled profiles are allowed for this project.
+            let profile_allowed = has_transaction || (!item.sampled() && unsampled_profiles);
             if !profile_allowed {
                 return ItemAction::DropSilently;
             }
@@ -69,7 +73,6 @@ pub fn transfer_id(state: &mut ProcessEnvelopeState<TransactionGroup>) {
 }
 
 /// Processes profiles and set the profile ID in the profile context on the transaction if successful.
-#[cfg(feature = "processing")]
 pub fn process(state: &mut ProcessEnvelopeState<TransactionGroup>, config: &Config) {
     let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
     let mut found_profile_id = None;
@@ -78,7 +81,9 @@ pub fn process(state: &mut ProcessEnvelopeState<TransactionGroup>, config: &Conf
             if !profiling_enabled {
                 return ItemAction::DropSilently;
             }
-            // If we don't have an event at this stage, we need to drop the profile.
+
+            // There should always be an event/transaction available at this stage.
+            // It is required to expand the profle. If it's missing, drop the item.
             let Some(event) = state.event.value() else {
                 return ItemAction::DropSilently;
             };
@@ -101,7 +106,7 @@ pub fn process(state: &mut ProcessEnvelopeState<TransactionGroup>, config: &Conf
 }
 
 /// Transfers transaction metadata to profile and check its size.
-pub fn expand_profile(
+fn expand_profile(
     item: &mut Item,
     event: &Event,
     config: &Config,

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -169,11 +169,10 @@ impl SamplingResult {
     /// Consumes the sampling results and returns and outcome if the sampling decision is drop.
     pub fn into_dropped_outcome(self) -> Option<Outcome> {
         match self {
-            SamplingResult::Match(sampling_match) => {
-                let matched_rules = sampling_match.into_matched_rules();
-                Some(Outcome::FilteredSampling(matched_rules.into()))
-            }
-            // If no rules matched on an event, we want to keep it.
+            SamplingResult::Match(sampling_match) if sampling_match.should_drop() => Some(
+                Outcome::FilteredSampling(sampling_match.into_matched_rules().into()),
+            ),
+            SamplingResult::Match(_) => None,
             SamplingResult::NoMatch => None,
             SamplingResult::Pending => None,
         }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -11,6 +11,7 @@ use relay_sampling::dsc::{DynamicSamplingContext, TraceUserContext};
 use relay_sampling::evaluation::{SamplingEvaluator, SamplingMatch};
 
 use crate::envelope::{Envelope, ItemType};
+use crate::services::outcome::Outcome;
 use crate::statsd::RelayCounters;
 use once_cell::sync::Lazy;
 use semver::{Version, VersionReq};
@@ -162,6 +163,19 @@ impl SamplingResult {
             // If no rules matched on an event, we want to keep it.
             SamplingResult::NoMatch => true,
             SamplingResult::Pending => true,
+        }
+    }
+
+    /// Consumes the sampling results and returns and outcome if the sampling decision is drop.
+    pub fn into_dropped_outcome(self) -> Option<Outcome> {
+        match self {
+            SamplingResult::Match(sampling_match) => {
+                let matched_rules = sampling_match.into_matched_rules();
+                Some(Outcome::FilteredSampling(matched_rules.into()))
+            }
+            // If no rules matched on an event, we want to keep it.
+            SamplingResult::NoMatch => None,
+            SamplingResult::Pending => None,
         }
     }
 }

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -661,8 +661,9 @@ def test_relay_chain(
     envelope.get_transaction_event()
 
 
+@pytest.mark.parametrize("mode", ["default", "chain"])
 def test_relay_chain_keep_unsampled_profile(
-    mini_sentry, relay, relay_with_processing, profiles_consumer
+    mini_sentry, relay, relay_with_processing, profiles_consumer, mode
 ):
     mini_sentry.global_config["options"] = {
         "profiling.profile_metrics.unsampled_profiles.platforms": ["python"],
@@ -695,12 +696,18 @@ def test_relay_chain_keep_unsampled_profile(
         return envelope
 
     project_id = 42
-    relay = relay(relay_with_processing())
+    if mode == "chain":
+        relay = relay(relay_with_processing())
+    else:
+        relay = relay_with_processing()
     config = mini_sentry.add_basic_project_config(project_id)
     config["config"]["transactionMetrics"] = {
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
     }
-    config["config"]["features"] = ["projects:profiling-ingest-unsampled-profiles"]
+    config["config"]["features"] = [
+        "organizations:profiling",
+        "projects:profiling-ingest-unsampled-profiles",
+    ]
 
     public_key = config["publicKeys"][0]["publicKey"]
     _add_sampling_config(config, sample_rate=0.0, rule_type="transaction")


### PR DESCRIPTION
Currently if transactions with profiles are unsampled in a processing Relay they are immediately dropped right after (integration test in `default` mode fails without these changes).

The changes hopefully also simplify the profile logic a bit and pull more logical decisions directly into processing function instead of it being hidden away in a bunch of implicit state.

Also:
- adds a few more feature flag checks, standalone profiles were never checked for whether the feature flags are active. 
- with the unsampled profiles flag, the feature flag for profiles was never actually checked.

#skip-changelog