### PR TITLE
feat(spans): Group function spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Send `attachment` data inline when possible. ([#3654](https://github.com/getsentry/relay/pull/3654))
 - Drops support for transaction metrics extraction versions < 3. ([#3672](https://github.com/getsentry/relay/pull/3672))
 - Move partitioning into the `Aggregator` and add a new `Partition` bucket shift mode. ([#3661](https://github.com/getsentry/relay/pull/3661))
+- Calculate group hash for function spans. ([#3697](https://github.com/getsentry/relay/pull/3697))
 
 ## 24.5.0
 

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 use url::{Host, Url};
 
 use crate::regexes::{
-    DB_SQL_TRANSACTION_CORE_DATA_REGEX, DB_SUPABASE_REGEX, REDIS_COMMAND_REGEX,
-    RESOURCE_NORMALIZER_REGEX,
+    DB_SQL_TRANSACTION_CORE_DATA_REGEX, DB_SUPABASE_REGEX, FUNCTION_NORMALIZER_REGEX,
+    REDIS_COMMAND_REGEX, RESOURCE_NORMALIZER_REGEX,
 };
 use crate::span::description::resource::COMMON_PATH_SEGMENTS;
 use crate::span::tag_extraction::HTTP_METHOD_EXTRACTOR_REGEX;
@@ -135,6 +135,7 @@ pub(crate) fn scrub_span_description(
                 Some(description.to_owned())
             }
             ("file", _) => scrub_file(description),
+            ("function", _) => scrub_function(description),
             _ => None,
         });
     (scrubbed_description, parsed_sql)
@@ -519,6 +520,10 @@ fn scrub_resource_file_extension(mut extension: &str) -> &str {
     }
 
     extension
+}
+
+fn scrub_function(string: &str) -> Option<String> {
+    Some(FUNCTION_NORMALIZER_REGEX.replace_all(string, "*").into())
 }
 
 #[cfg(test)]
@@ -1071,6 +1076,20 @@ mod tests {
     );
 
     span_description_test!(db_prisma, "User find", "db.sql.prisma", "User find");
+
+    span_description_test!(
+        function_python,
+        "sentry.event_manager.assign_event_to_group",
+        "function",
+        "sentry.event_manager.assign_event_to_group"
+    );
+
+    span_description_test!(
+        function_rust,
+        "symbolicator_native::symbolication::symbolicate::symbolicate",
+        "function",
+        "symbolicator_native::symbolication::symbolicate::symbolicate"
+    );
 
     #[test]
     fn informed_sql_parser() {

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -1091,6 +1091,20 @@ mod tests {
         "symbolicator_native::symbolication::symbolicate::symbolicate"
     );
 
+    span_description_test!(
+        function_with_hex,
+        "symbolicator_native::symbolication::symbolicate::deadbeef",
+        "function",
+        "symbolicator_native::symbolication::symbolicate::*"
+    );
+
+    span_description_test!(
+        function_with_uuid,
+        "symbolicator_native::symbolication::fb37f08422034ee985e9fc553ef27e6e::symbolicate",
+        "function",
+        "symbolicator_native::symbolication::*::symbolicate"
+    );
+
     #[test]
     fn informed_sql_parser() {
         let json = r#"

--- a/relay-event-normalization/src/regexes.rs
+++ b/relay-event-normalization/src/regexes.rs
@@ -95,3 +95,15 @@ pub static DB_SUPABASE_REGEX: Lazy<Regex> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static FUNCTION_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?xi)
+        # UUIDs.
+        (?P<uuid>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}) |
+        # Hexadecimal strings with more than 5 digits.
+        (?P<hex>[a-f0-9]{5}[a-f0-9]+)
+        ",
+    )
+    .unwrap()
+});


### PR DESCRIPTION
We don't calculate a group hash for function spans and this means the span summary shows one group only for this op. We'd like to show each function individually.

This will reduce cardinality in function names by removing UUIDs or hexadecimal strings equal or longer than 5 characters and calculate the group hash, enabling us to store span metrics for each function separately.