### PR TITLE
fix(replays): Run TrimmingProcessor on replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug fixes**:
 
-- Trim some fields in replays to the maximum expected length. ([#3706](https://github.com/getsentry/relay/pull/3706))
+- Trim fields in replays to the maximum expected length. ([#3706](https://github.com/getsentry/relay/pull/3706))
 
 ## 24.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug fixes**:
+
+- Trim some fields in replays to the maximum expected length. ([#3706](https://github.com/getsentry/relay/pull/3706))
+
 ## 24.5.1
 
 **Bug fixes**:

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -2,10 +2,12 @@
 
 use std::net::IpAddr as StdIpAddr;
 
+use relay_event_schema::processor::{self, ProcessingState, Processor};
 use relay_event_schema::protocol::{Contexts, IpAddr, Replay};
 use relay_protocol::Annotated;
 
 use crate::normalize::user_agent;
+use crate::trimming;
 use crate::user_agent::RawUserAgentInfo;
 
 /// Replay validation or normalization error.
@@ -84,15 +86,23 @@ pub fn validate(replay: &Replay) -> Result<(), ReplayError> {
 
 /// Adds default fields and normalizes all values in to their standard representation.
 pub fn normalize(
-    replay: &mut Replay,
+    replay: &mut Annotated<Replay>,
     client_ip: Option<StdIpAddr>,
     user_agent: &RawUserAgentInfo<&str>,
 ) {
-    normalize_platform(replay);
-    normalize_ip_address(replay, client_ip);
-    normalize_user_agent(replay, user_agent);
-    normalize_type(replay);
-    normalize_array_fields(replay);
+    let _ = processor::apply(replay, |replay_value, meta| {
+        normalize_platform(replay_value);
+        normalize_ip_address(replay_value, client_ip);
+        normalize_user_agent(replay_value, user_agent);
+        normalize_type(replay_value);
+        normalize_array_fields(replay_value);
+        let _ = trimming::TrimmingProcessor::new().process_replay(
+            replay_value,
+            meta,
+            ProcessingState::root(),
+        );
+        Ok(())
+    });
 }
 
 fn normalize_array_fields(replay: &mut Replay) {
@@ -161,6 +171,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use chrono::{TimeZone, Utc};
+    use relay_protocol::{assert_annotated_snapshot, get_value};
     use uuid::Uuid;
 
     use relay_event_schema::protocol::{
@@ -248,10 +259,9 @@ mod tests {
         let payload = include_str!("../../tests/fixtures/replay.json");
 
         let mut replay: Annotated<Replay> = Annotated::from_json(payload).unwrap();
-        let replay_value = replay.value_mut().as_mut().unwrap();
-        normalize(replay_value, None, &RawUserAgentInfo::default());
+        normalize(&mut replay, None, &RawUserAgentInfo::default());
 
-        let contexts = replay_value.contexts.value().unwrap();
+        let contexts = get_value!(replay.contexts!);
         assert_eq!(
             contexts.get::<BrowserContext>(),
             Some(&BrowserContext {
@@ -283,18 +293,17 @@ mod tests {
     fn test_missing_user() {
         let payload = include_str!("../../tests/fixtures/replay_missing_user.json");
 
-        let mut annotated_replay: Annotated<Replay> = Annotated::from_json(payload).unwrap();
-        let replay = annotated_replay.value_mut().as_mut().unwrap();
+        let mut replay: Annotated<Replay> = Annotated::from_json(payload).unwrap();
 
         // No user object and no ip-address was provided.
-        normalize(replay, None, &RawUserAgentInfo::default());
-        assert_eq!(replay.user.value(), None);
+        normalize(&mut replay, None, &RawUserAgentInfo::default());
+        assert_eq!(get_value!(replay.user), None);
 
         // No user object but an ip-address was provided.
         let ip_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        normalize(replay, Some(ip_address), &RawUserAgentInfo::default());
+        normalize(&mut replay, Some(ip_address), &RawUserAgentInfo::default());
 
-        let ipaddr = replay.user.value().unwrap().ip_address.as_str();
+        let ipaddr = get_value!(replay.user!).ip_address.as_str();
         assert_eq!(Some("127.0.0.1"), ipaddr);
     }
 
@@ -306,10 +315,9 @@ mod tests {
         let payload = include_str!("../../tests/fixtures/replay_missing_user_ip_address.json");
 
         let mut replay: Annotated<Replay> = Annotated::from_json(payload).unwrap();
-        let replay_value = replay.value_mut().as_mut().unwrap();
-        normalize(replay_value, Some(ip_address), &RawUserAgentInfo::default());
+        normalize(&mut replay, Some(ip_address), &RawUserAgentInfo::default());
 
-        let ipaddr = replay_value.user.value().unwrap().ip_address.as_str();
+        let ipaddr = get_value!(replay.user!).ip_address.as_str();
         assert_eq!(Some("127.0.0.1"), ipaddr);
     }
 
@@ -318,10 +326,9 @@ mod tests {
         let payload = include_str!("../../tests/fixtures/replay_failure_22_08_31.json");
 
         let mut replay: Annotated<Replay> = Annotated::from_json(payload).unwrap();
-        let replay_value = replay.value_mut().as_mut().unwrap();
-        normalize(replay_value, None, &RawUserAgentInfo::default());
+        normalize(&mut replay, None, &RawUserAgentInfo::default());
 
-        let user = replay_value.user.value().unwrap();
+        let user = get_value!(replay.user!);
         assert_eq!(user.ip_address.as_str(), Some("127.1.1.1"));
         assert_eq!(user.username.value(), None);
         assert_eq!(user.email.as_str(), Some("email@sentry.io"));
@@ -461,5 +468,33 @@ mod tests {
         let mut replay = Annotated::<Replay>::from_json(json).unwrap();
         let validation_result = validate(replay.value_mut().as_mut().unwrap());
         assert!(validation_result.is_err());
+    }
+
+    #[test]
+    fn test_maxchars_trimming() {
+        let json = format!(r#"{{"dist": "{}"}}"#, "0".repeat(100));
+        let mut replay = Annotated::<Replay>::from_json(json.as_str()).unwrap();
+
+        normalize(&mut replay, None, &RawUserAgentInfo::default());
+        assert_annotated_snapshot!(replay, @r#"{
+  "platform": "other",
+  "dist": "0000000000000000000000000000000000000000000000000000000000000...",
+  "type": "replay_event",
+  "_meta": {
+    "dist": {
+      "": {
+        "rem": [
+          [
+            "!limit",
+            "s",
+            61,
+            64
+          ]
+        ],
+        "len": 100
+      }
+    }
+  }
+}"#);
     }
 }

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -4,7 +4,7 @@ use relay_event_schema::processor::{
     self, Chunk, ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor,
     ValueType,
 };
-use relay_event_schema::protocol::{Frame, RawStacktrace};
+use relay_event_schema::protocol::{Frame, RawStacktrace, Replay};
 use relay_protocol::{Annotated, Array, Empty, Meta, Object, RemarkType, Value};
 
 #[derive(Clone, Debug)]
@@ -261,6 +261,15 @@ impl Processor for TrimmingProcessor {
 
         value.process_child_values(self, state)?;
         Ok(())
+    }
+
+    fn process_replay(
+        &mut self,
+        replay: &mut Replay,
+        _: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        replay.process_child_values(self, state)
     }
 
     fn process_raw_stacktrace(

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -175,13 +175,11 @@ fn process_replay_event(
     let mut replay =
         Annotated::<Replay>::from_json_bytes(payload).map_err(ReplayError::CouldNotParse)?;
 
-    if replay.value().is_none() {
+    let Some(replay_value) = replay.value_mut() else {
         return Err(ReplayError::NoContent);
-    }
+    };
 
-    if let Some(replay_value) = replay.value_mut() {
-        replay::validate(replay_value)?;
-    }
+    replay::validate(replay_value)?;
     replay::normalize(&mut replay, client_ip, user_agent);
 
     if let Some(ref config) = config.pii_config {

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -175,12 +175,14 @@ fn process_replay_event(
     let mut replay =
         Annotated::<Replay>::from_json_bytes(payload).map_err(ReplayError::CouldNotParse)?;
 
-    if let Some(replay_value) = replay.value_mut() {
-        replay::validate(replay_value)?;
-        replay::normalize(replay_value, client_ip, user_agent);
-    } else {
+    if replay.value().is_none() {
         return Err(ReplayError::NoContent);
     }
+
+    if let Some(replay_value) = replay.value_mut() {
+        replay::validate(replay_value)?;
+    }
+    replay::normalize(&mut replay, client_ip, user_agent);
 
     if let Some(ref config) = config.pii_config {
         let mut processor = PiiProcessor::new(config.compiled());


### PR DESCRIPTION
Although some fields in replays have `max_chars` defined, the trimming processor isn't run and thus the limit is not enforced. This PR runs the processor and enforces that limit.