### PR TITLE
ci(ci): bump pytest concurrency for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,7 @@ jobs:
 
       - run: make test-integration
         env:
+          PYTEST_N: 6
           RELAY_VERSION_CHAIN: "20.6.0,latest"
 
   sentry-relay-integration-tests:

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,9 @@ test-python: setup-git setup-venv ## run tests for Python code
 	.venv/bin/pytest -v py
 .PHONY: test-python
 
+PYTEST_N ?= auto
 test-integration: build setup-venv ## run integration tests
-	.venv/bin/pytest tests -n auto -v
+	.venv/bin/pytest tests -n $(PYTEST_N) -v
 .PHONY: test-integration
 
 # Documentation


### PR DESCRIPTION
It's about 5 minutes faster.

#skip-changelog