### PR TITLE
revert(spans): Revert back to random partitioning

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1519,7 +1519,6 @@ impl Message for KafkaMessage<'_> {
             Self::AttachmentChunk(message) => message.event_id.0,
             Self::UserReport(message) => message.event_id.0,
             Self::ReplayEvent(message) => message.replay_id.0,
-            Self::Span { message, .. } => message.trace_id.0,
 
             // Monitor check-ins use the hinted UUID passed through from the Envelope.
             //
@@ -1529,6 +1528,7 @@ impl Message for KafkaMessage<'_> {
 
             // Random partitioning
             Self::Profile(_)
+            | Self::Span(_)
             | Self::ReplayRecordingNotChunked(_)
             | Self::MetricsSummary(_)
             | Self::Cogs(_)

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1528,7 +1528,7 @@ impl Message for KafkaMessage<'_> {
 
             // Random partitioning
             Self::Profile(_)
-            | Self::Span(_)
+            | Self::Span { .. }
             | Self::ReplayRecordingNotChunked(_)
             | Self::MetricsSummary(_)
             | Self::Cogs(_)


### PR DESCRIPTION
We wanted to partition by `trace_id` for an experiment that has since been shut down.

Random partitioning is better to distribute the load more equally on each partition so we're reverting back to that.

#skip-changelog