### PR TITLE
ref(gocd): Re-enabling sentry checks for deploys

### DIFF
--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -57,8 +57,8 @@ local soak_time(region) =
               elastic_profile_id: 'relay-pop',
               tasks: [
                 gocdtasks.script(importstr '../bash/wait-soak.sh'),
-                // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-                // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+                gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+                gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
                 gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
                 utils.pause_on_failure(),
               ],
@@ -97,8 +97,8 @@ local deploy_pop_canary_job(region) =
     tasks: [
       gocdtasks.script(importstr '../bash/deploy-pop-canary.sh'),
       gocdtasks.script(importstr '../bash/wait-canary.sh'),
-      // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-      // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+      gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+      gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
       gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
       utils.pause_on_failure(),
     ],

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -31,8 +31,8 @@ local soak_time(region) =
               elastic_profile_id: 'relay',
               tasks: [
                 gocdtasks.script(importstr '../bash/wait-soak.sh'),
-                // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-                // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+                gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+                gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
                 gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
                 utils.pause_on_failure(),
               ],
@@ -93,8 +93,8 @@ local deploy_canary(region) =
               tasks: [
                 gocdtasks.script(importstr '../bash/deploy-processing-canary.sh'),
                 gocdtasks.script(importstr '../bash/wait-canary.sh'),
-                // gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
-                // gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
+                gocdtasks.script(importstr '../bash/check-sentry-errors.sh'),
+                gocdtasks.script(importstr '../bash/check-sentry-new-errors.sh'),
                 gocdtasks.script(importstr '../bash/check-datadog-status.sh'),
                 utils.pause_on_failure(),
               ],


### PR DESCRIPTION
After discussing with the Ingest team offline, we decided to re-enable Sentry checks (still being dry-run) for Relay deploys. Previously, we had some issues with flakiness which we will investigate further if they resurface.

#skip-changelog