### PR TITLE
Remove rollout option for inline attachments

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -198,17 +198,6 @@ pub struct Options {
     )]
     pub feedback_ingest_topic_rollout_rate: f32,
 
-    /// Rollout rate for sending attachment chunks inline.
-    ///
-    /// Rate needs to be between `0.0` and `1.0`.
-    /// If set to `1.0` all eligible attachment chunks will be sent as part of the attachment message.
-    #[serde(
-        rename = "relay.inline-attachments.rollout-rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub inline_attachments_rollout_rate: f32,
-
     /// Overall sampling of span extraction.
     ///
     /// This number represents the fraction of transactions for which

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -160,7 +160,6 @@ def test_feedback_with_attachment_in_same_envelope(
     mini_sentry.add_basic_project_config(
         42, extra={"config": {"features": ["organizations:user-feedback-ingest"]}}
     )
-    mini_sentry.set_global_config_option("relay.inline-attachments.rollout-rate", 1.0)
 
     if use_feedback_topic:
         mini_sentry.set_global_config_option("feedback.ingest-topic.rollout-rate", 1.0)


### PR DESCRIPTION
We haven’t seen any problems since rolling this out, so make it the default.

#skip-changelog
☝🏻 unless someone has a different opinion?