### PR TITLE
feat(spans): Correctly rate limit spans after extracting from transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Bug fixes**:
 
 - Trim fields in replays to their defined maximum length. ([#3706](https://github.com/getsentry/relay/pull/3706))
-- Apply rate limit on child spans when the transaction is rate limited. ([#3713](https://github.com/getsentry/relay/pull/3713))
+- Apply rate limit on extracted spans when the transaction is rate limited. ([#3713](https://github.com/getsentry/relay/pull/3713))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**:
 
 - Trim fields in replays to their defined maximum length. ([#3706](https://github.com/getsentry/relay/pull/3706))
+- Apply rate limit on child spans when the transaction is rate limited. ([#3713](https://github.com/getsentry/relay/pull/3713))
 
 **Internal**:
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -682,7 +682,7 @@ where
         }
 
         // We want to process spans rate limits only if they were not already applied because a
-        // rate limited transaction had child spans that were also rate limited.
+        // rate limited transaction has also rate limited its child spans.
         if !enforcement.event.is_active() && summary.span_quantity > 0 {
             // Check for rate limits on the main category but do not consume
             // quota. Quota will be consumed by the metrics rate limiter instead.

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1,3 +1,4 @@
+use serde_json::error::Category::Data;
 use std::fmt::{self, Write};
 
 use relay_dynamic_config::{ErrorBoundary, ProjectConfig};
@@ -563,6 +564,8 @@ where
                 // Otherwise, the outcome is logged at a different place.
                 if !summary.transaction_metrics_extracted {
                     enforcement.event_metrics = CategoryLimit::new(category, 1, longest);
+                    enforcement.span_metrics =
+                        CategoryLimit::new(DataCategory::Span, summary.span_quantity, longest);
                 }
 
                 // If the main category is rate limited, we drop both the event and metrics. If
@@ -573,10 +576,14 @@ where
                 }
 
                 enforcement.event = CategoryLimit::new(index_category, 1, longest);
+                enforcement.spans =
+                    CategoryLimit::new(DataCategory::SpanIndexed, summary.span_quantity, longest);
             } else {
                 event_limits = (self.check)(scoping.item(category), 1)?;
                 longest = event_limits.longest();
                 enforcement.event = CategoryLimit::new(category, 1, longest);
+                enforcement.spans =
+                    CategoryLimit::new(DataCategory::Span, summary.span_quantity, longest);
             }
 
             // Record the same reason for attachments, if there are any.

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -568,10 +568,8 @@ where
                 // Otherwise, the outcome is logged at a different place.
                 if !summary.transaction_metrics_extracted {
                     enforcement.event_metrics = CategoryLimit::new(category, 1, longest);
-                    if summary.span_quantity > 0 {
-                        enforcement.span_metrics =
-                            CategoryLimit::new(DataCategory::Span, summary.span_quantity, longest);
-                    }
+                    enforcement.span_metrics =
+                        CategoryLimit::new(DataCategory::Span, summary.span_quantity, longest);
                 }
 
                 // If the main category is rate limited, we drop both the event and metrics. If
@@ -582,21 +580,14 @@ where
                 }
 
                 enforcement.event = CategoryLimit::new(index_category, 1, longest);
-                if summary.span_quantity > 0 {
-                    enforcement.spans = CategoryLimit::new(
-                        DataCategory::SpanIndexed,
-                        summary.span_quantity,
-                        longest,
-                    );
-                }
+                enforcement.spans =
+                    CategoryLimit::new(DataCategory::SpanIndexed, summary.span_quantity, longest);
             } else {
                 event_limits = (self.check)(scoping.item(category), 1)?;
                 longest = event_limits.longest();
                 enforcement.event = CategoryLimit::new(category, 1, longest);
-                if summary.span_quantity > 0 {
-                    enforcement.spans =
-                        CategoryLimit::new(DataCategory::Span, summary.span_quantity, longest);
-                }
+                enforcement.spans =
+                    CategoryLimit::new(DataCategory::Span, summary.span_quantity, longest);
             }
 
             // Record the same reason for attachments, if there are any.

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -307,11 +307,6 @@ impl CategoryLimit {
     fn is_active(&self) -> bool {
         self.quantity > 0
     }
-
-    /// Returns 'true' if this is a default category.
-    fn is_default(&self) -> bool {
-        self.category == DataCategory::Default
-    }
 }
 
 impl Default for CategoryLimit {
@@ -688,10 +683,7 @@ where
 
         // We want to process spans rate limits only if they were not already applied because a
         // rate limited transaction had child spans that were also rate limited.
-        if summary.span_quantity > 0
-            && enforcement.span_metrics.is_default()
-            && enforcement.spans.is_default()
-        {
+        if !enforcement.event.is_active() && summary.span_quantity > 0 {
             // Check for rate limits on the main category but do not consume
             // quota. Quota will be consumed by the metrics rate limiter instead.
             let mut span_limits = (self.check)(scoping.item(DataCategory::Span), 0)?;

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -21,6 +21,7 @@ class SentryLike:
         self.server_address = server_address
         self.upstream = upstream
         self.public_key = public_key
+        self.fail_on_envelope_error = True
 
     def get_dsn_public_key_configs(self, project_id):
         """
@@ -248,7 +249,8 @@ class SentryLike:
             **(headers or {}),
         }
         response = self.post(url, headers=headers, data=envelope.serialize())
-        response.raise_for_status()
+        if self.fail_on_envelope_error:
+            response.raise_for_status()
         return response
 
     def send_session(self, project_id, payload, item_headers=None):

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -21,7 +21,6 @@ class SentryLike:
         self.server_address = server_address
         self.upstream = upstream
         self.public_key = public_key
-        self.fail_on_envelope_error = True
 
     def get_dsn_public_key_configs(self, project_id):
         """
@@ -249,8 +248,7 @@ class SentryLike:
             **(headers or {}),
         }
         response = self.post(url, headers=headers, data=envelope.serialize())
-        if self.fail_on_envelope_error:
-            response.raise_for_status()
+        response.raise_for_status()
         return response
 
     def send_session(self, project_id, payload, item_headers=None):

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1747,6 +1747,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
 
     This test does not cover consistent enforcement of total spans.
     """
+    # TODO: add outcomes check when https://github.com/getsentry/relay/issues/3705 is done.
     # Ignore 429s
     mini_sentry.fail_on_relay_error = False
 

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1760,7 +1760,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     relay.send_envelope(project_id, envelope)
     assert summarize_outcomes() == {
         (2, 2): 1,  # Transaction, RateLimited
-        (12, 2): 2,  # SpanIndexed, RateLimited
+        (12, 2): 2,  # Span, RateLimited
     }
 
     transactions_consumer.assert_empty()

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1782,10 +1782,10 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     This test does not cover consistent enforcement of total spans.
     """
     # TODO: add outcomes check when https://github.com/getsentry/relay/issues/3705 is done.
-    # Ignore 429s
-    mini_sentry.fail_on_relay_error = False
-
     relay = relay_with_processing(options=TEST_CONFIG)
+    # We want to avoid failing on 429s.
+    relay.fail_on_envelope_error = False
+
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["features"] = [

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1654,7 +1654,7 @@ def test_rate_limit_metrics_consistent(
     ]
     project_config["config"]["quotas"] = [
         {
-            "categories": ["transaction"],
+            "categories": ["span"],
             "limit": 3,
             "window": int(datetime.now(UTC).timestamp()),
             "id": uuid.uuid4(),
@@ -1754,10 +1754,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     # We have one nested span and the transaction itself becomes a span
     spans = spans_consumer.get_spans(n=2, timeout=10)
     assert len(spans) == 2
-    assert summarize_outcomes() == {
-        # (2, 0): 1,  # Transaction, Accepted TODO: why we don't get this outcome?
-        (16, 0): 2  # SpanIndexed, Accepted
-    }
+    assert summarize_outcomes() == {(16, 0): 2}  # SpanIndexed, Accepted
 
     # Second batch is limited
     relay.send_envelope(project_id, envelope)


### PR DESCRIPTION
This PR correctly applies enforcements for rate limiting on child spans whenever the transaction is rate limited.

Closes: https://github.com/getsentry/relay/issues/3578