### PR TITLE
fix(spans): Always count span usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**:
 
 - Trim fields in replays to their defined maximum length. ([#3706](https://github.com/getsentry/relay/pull/3706))
+- Emit span usage metric for every extracted or standalone span, even if common span metrics are disabled. ([#3719](https://github.com/getsentry/relay/pull/3719))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -70,6 +70,20 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
 
     let features = &project_config.features;
 
+    // If there are any spans in the system, extract the usage metric for them:
+    let any_spans = features.has(Feature::ExtractSpansFromEvent)
+        || features.has(Feature::StandaloneSpanIngestion)
+        || features.has(Feature::ExtractCommonSpanMetricsFromEvent);
+    if any_spans {
+        config.metrics.push(MetricSpec {
+            category: DataCategory::Span,
+            mri: "c:spans/usage@none".into(),
+            field: None,
+            condition: None,
+            tags: vec![],
+        });
+    }
+
     // Common span metrics is a requirement for everything else:
     if !features.has(Feature::ExtractCommonSpanMetricsFromEvent) {
         return;
@@ -182,13 +196,6 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
         (
             GroupKey::SpanMetricsCommon,
             vec![
-                MetricSpec {
-                    category: DataCategory::Span,
-                    mri: "c:spans/usage@none".into(),
-                    field: None,
-                    condition: Some(!is_addon.clone()),
-                    tags: vec![],
-                },
                 MetricSpec {
                     category: DataCategory::Span,
                     mri: "d:spans/exclusive_time@millisecond".into(),
@@ -720,13 +727,6 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
             GroupKey::SpanMetricsAddons,
             vec![
                 // all addon modules
-                MetricSpec {
-                    category: DataCategory::Span,
-                    mri: "c:spans/usage@none".into(),
-                    field: None,
-                    condition: Some(is_addon.clone()),
-                    tags: vec![],
-                },
                 MetricSpec {
                     category: DataCategory::Span,
                     mri: "d:spans/exclusive_time@millisecond".into(),

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -425,6 +425,7 @@ impl<'a> Val<'a> {
     pub fn as_str(&self) -> Option<&'a str> {
         match self {
             Self::String(value) => Some(value),
+
             _ => None,
         }
     }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__only_common.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__only_common.snap
@@ -2293,6 +2293,40 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
             "d:spans/exclusive_time@millisecond",
         ),
         value: Distribution(
@@ -5566,6 +5600,40 @@ expression: metrics
             "transaction.method": "POST",
             "transaction.op": "myop",
         },
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1597976302),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -6333,6 +6401,108 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.op": "myop",
         },
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
+        metadata: BucketMetadata {
+            merges: 1,
+            received_at: Some(
+                UnixTimestamp(0),
+            ),
+        },
+    },
+    Bucket {
+        timestamp: UnixTimestamp(1702474613),
+        width: 0,
+        name: MetricName(
+            "c:spans/usage@none",
+        ),
+        value: Counter(
+            1.0,
+        ),
+        tags: {},
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/3633 introduced separate feature flags for span extraction and span metrics, but this meant that there was no usage metric for spans that were extracted without common span metrics. We need the usage metric for accounting purposes.