### PR TITLE
feat(metrics): Track the number of partitions flushed

### DIFF
--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -294,10 +294,10 @@ impl AggregatorService {
             return;
         }
 
-        let partitions_number = partitions.len();
-        relay_log::trace!("flushing {} partitions to receiver", partitions_number);
+        let partitions_count = partitions.len() as u64;
+        relay_log::trace!("flushing {} partitions to receiver", partitions_count);
         relay_statsd::metric!(
-            histogram(MetricHistograms::PartitionsFlushed) = partitions_number,
+            histogram(MetricHistograms::PartitionsFlushed) = partitions_count,
             aggregator = self.aggregator.name(),
         );
 

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -294,9 +294,10 @@ impl AggregatorService {
             return;
         }
 
-        relay_log::trace!("flushing {} partitions to receiver", partitions.len());
+        let partitions_number = partitions.len();
+        relay_log::trace!("flushing {} partitions to receiver", partitions_number);
         relay_statsd::metric!(
-            histogram(MetricHistograms::PartitionsFlushed) = partitions.len(),
+            histogram(MetricHistograms::PartitionsFlushed) = partitions_number,
             aggregator = self.aggregator.name(),
         );
 

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -295,6 +295,10 @@ impl AggregatorService {
         }
 
         relay_log::trace!("flushing {} partitions to receiver", partitions.len());
+        relay_statsd::metric!(
+            histogram(MetricHistograms::PartitionsFlushed) = partitions.len(),
+            aggregator = self.aggregator.name(),
+        );
 
         let mut total_bucket_count = 0u64;
         for buckets_by_project in partitions.values() {

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -134,6 +134,12 @@ pub enum MetricHistograms {
     ///
     /// This is a temporary metric to better understand why we see so many invalid timestamp errors.
     InvalidBucketTimestamp,
+
+    /// The number of metric partitions flushed in a cycle.
+    ///
+    /// This metric is tagged with:
+    ///  - `aggregator`: The name of the metrics aggregator (usually `"default"`).
+    PartitionsFlushed,
 }
 
 impl HistogramMetric for MetricHistograms {
@@ -143,6 +149,7 @@ impl HistogramMetric for MetricHistograms {
             Self::BucketsFlushedPerProject => "metrics.buckets.flushed_per_project",
             Self::BucketsDelay => "metrics.buckets.delay",
             Self::InvalidBucketTimestamp => "metrics.buckets.invalid_timestamp",
+            Self::PartitionsFlushed => "metrics.partitions.flushed",
         }
     }
 }


### PR DESCRIPTION
This PR adds a new metric to track the number of partitions in each flush cycle.

#skip-changelog