### PR TITLE
feat(metrics): Add configurable flush interval for metrics aggregator

### DIFF
--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -12,9 +12,6 @@ use crate::aggregator::{self, AggregatorConfig, FlushBatching};
 use crate::bucket::Bucket;
 use crate::statsd::{MetricCounters, MetricHistograms, MetricTimers};
 
-/// Interval for the flush cycle of the [`AggregatorService`].
-const FLUSH_INTERVAL: Duration = Duration::from_millis(100);
-
 /// Parameters used by the [`AggregatorService`].
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
@@ -111,6 +108,10 @@ pub struct AggregatorServiceConfig {
     /// partition, effectively allowing all the elements of that partition to be flushed together.
     #[serde(alias = "shift_key")]
     pub flush_batching: FlushBatching,
+
+    /// The flushing interval in milliseconds that determines how often the aggregator is polled for
+    /// flushing new buckets.
+    pub flush_interval: u64,
 }
 
 impl Default for AggregatorServiceConfig {
@@ -129,6 +130,7 @@ impl Default for AggregatorServiceConfig {
             max_flush_bytes: 5_000_000, // 5 MB
             flush_partitions: None,
             flush_batching: FlushBatching::Project,
+            flush_interval: 100, // 100 milliseconds
         }
     }
 }
@@ -245,6 +247,7 @@ pub struct AggregatorService {
     state: AggregatorState,
     receiver: Option<Recipient<FlushBuckets, NoResponse>>,
     max_total_bucket_bytes: Option<usize>,
+    flush_interval: u64,
 }
 
 impl AggregatorService {
@@ -270,6 +273,7 @@ impl AggregatorService {
             state: AggregatorState::Running,
             max_total_bucket_bytes: config.max_total_bucket_bytes,
             aggregator: aggregator::Aggregator::named(name, AggregatorConfig::from(&config)),
+            flush_interval: config.flush_interval,
         }
     }
 
@@ -363,7 +367,7 @@ impl Service for AggregatorService {
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
         tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(FLUSH_INTERVAL);
+            let mut ticker = tokio::time::interval(Duration::from_millis(self.flush_interval));
             let mut shutdown = Controller::shutdown_handle();
 
             // Note that currently this loop never exits and will run till the tokio runtime shuts


### PR DESCRIPTION
This PR adds configurable flush interval for the metrics aggregator.

#skip-changelog