### PR TITLE
fix(spans): Allow spans namespace for usage metric

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -71,10 +71,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
     let features = &project_config.features;
 
     // If there are any spans in the system, extract the usage metric for them:
-    let any_spans = features.has(Feature::ExtractSpansFromEvent)
-        || features.has(Feature::StandaloneSpanIngestion)
-        || features.has(Feature::ExtractCommonSpanMetricsFromEvent);
-    if any_spans {
+    if features.produces_spans() {
         config.metrics.push(MetricSpec {
             category: DataCategory::Span,
             mri: "c:spans/usage@none".into(),

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -143,6 +143,13 @@ impl FeatureSet {
     pub fn has(&self, feature: Feature) -> bool {
         self.0.contains(&feature)
     }
+
+    /// Returns `true` if any spans are produced for this project.
+    pub fn produces_spans(&self) -> bool {
+        self.has(Feature::ExtractSpansFromEvent)
+            || self.has(Feature::StandaloneSpanIngestion)
+            || self.has(Feature::ExtractCommonSpanMetricsFromEvent)
+    }
 }
 
 impl FromIterator<Feature> for FeatureSet {

--- a/relay-server/src/services/project/metrics.rs
+++ b/relay-server/src/services/project/metrics.rs
@@ -125,10 +125,7 @@ fn is_metric_namespace_valid(state: &ProjectState, namespace: MetricNamespace) -
     match namespace {
         MetricNamespace::Sessions => true,
         MetricNamespace::Transactions => true,
-        MetricNamespace::Spans => {
-            state.has_feature(Feature::ExtractCommonSpanMetricsFromEvent)
-                || state.has_feature(Feature::StandaloneSpanIngestion)
-        }
+        MetricNamespace::Spans => state.config.features.produces_spans(),
         MetricNamespace::Profiles => true,
         MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
         MetricNamespace::Stats => true,


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/3719 enabled `c:spans/usage@none` for plans that do not extract other span metrics. We also need to allow the namespace otherwise they will be dropped with outcome `filtered:disabled-namespace`.

#skip-changelog