### PR TITLE
fix(metrics): Improve flush time calculation in metrics aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal**:
 
 - Treat arrays of pairs as key-value mappings during PII scrubbing. ([#3639](https://github.com/getsentry/relay/pull/3639))
+- Improve flush time calculation in metrics aggregator. ([#3726](https://github.com/getsentry/relay/pull/3726))
 
 ## 24.5.1
 

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -1594,13 +1594,14 @@ mod tests {
         let mut config = test_config();
         config.bucket_interval = 3600;
         config.initial_delay = 1300;
+        config.debounce_delay = 1300;
         config.flush_partitions = Some(10);
         config.flush_batching = FlushBatching::Partition;
 
+        let base_instant = Instant::now();
+
         let now_s =
             (UnixTimestamp::now().as_secs() / config.bucket_interval) * config.bucket_interval;
-
-        let aggregator = Aggregator::new(config);
 
         // First bucket has a timestamp two hours ago.
         let timestamp = UnixTimestamp::from_secs(now_s - 7200);
@@ -1620,8 +1621,8 @@ mod tests {
             tags: BTreeMap::new(),
         };
 
-        let flush_time_1 = aggregator.get_flush_time(&bucket_key_1);
-        let flush_time_2 = aggregator.get_flush_time(&bucket_key_2);
+        let flush_time_1 = get_flush_time(&config, base_instant, &bucket_key_1);
+        let flush_time_2 = get_flush_time(&config, base_instant, &bucket_key_2);
 
         assert_eq!(flush_time_1, flush_time_2);
     }

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -478,7 +478,11 @@ impl fmt::Debug for CostTracker {
 ///
 /// Recent buckets are flushed after a grace period of `initial_delay`. Backdated buckets, that
 /// is, buckets that lie in the past, are flushed after the shorter `debounce_delay`.
-fn get_flush_time(config: &AggregatorConfig, base_instant: Instant, bucket_key: &BucketKey) -> Instant {
+fn get_flush_time(
+    config: &AggregatorConfig,
+    base_instant: Instant,
+    bucket_key: &BucketKey,
+) -> Instant {
     let initial_flush = bucket_key.timestamp + config.bucket_interval() + config.initial_delay();
 
     let now = UnixTimestamp::now();
@@ -486,9 +490,9 @@ fn get_flush_time(config: &AggregatorConfig, base_instant: Instant, bucket_key: 
 
     let delay = now.as_secs() as i64 - bucket_key.timestamp.as_secs() as i64;
     relay_statsd::metric!(
-            histogram(MetricHistograms::BucketsDelay) = delay as f64,
-            backdated = if backdated { "true" } else { "false" },
-        );
+        histogram(MetricHistograms::BucketsDelay) = delay as f64,
+        backdated = if backdated { "true" } else { "false" },
+    );
 
     let flush_timestamp = if backdated {
         // If the initial flush time has passed or can't be represented, we want to treat the
@@ -512,7 +516,7 @@ fn get_flush_time(config: &AggregatorConfig, base_instant: Instant, bucket_key: 
     } else {
         Instant::now().checked_sub(now - flush_timestamp)
     }
-        .unwrap_or_else(Instant::now);
+    .unwrap_or_else(Instant::now);
 
     // Since `Instant` doesn't allow to get directly how many seconds elapsed, we leverage the
     // diffing to get a duration and round it to the smallest second.

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -273,11 +273,6 @@ impl AggregatorConfig {
         instant.unwrap_or_else(Instant::now) + self.flush_time_shift(bucket_key)
     }
 
-    /// The delay to debounce backdated flushes.
-    fn debounce_delay(&self) -> Duration {
-        Duration::from_secs(self.debounce_delay)
-    }
-
     /// Returns the time width buckets.
     fn bucket_interval(&self) -> Duration {
         Duration::from_secs(self.bucket_interval)

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -1604,6 +1604,6 @@ mod tests {
         let flush_time_1 = config.get_flush_time(&bucket_key_1);
         let flush_time_2 = config.get_flush_time(&bucket_key_2);
 
-        assert_eq!(flush_time_1.elapsed(), flush_time_2.elapsed());
+        assert_eq!(flush_time_1 - flush_time_2, Duration::from_secs(0));
     }
 }

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -519,7 +519,7 @@ fn get_flush_time(
     .unwrap_or_else(Instant::now);
 
     // Since `Instant` doesn't allow to get directly how many seconds elapsed, we leverage the
-    // diffing to get a duration and round it to the smallest second.
+    // diffing to get a duration and round it to the smallest second to get consistent times.
     let instant = base_instant + Duration::from_secs((instant - base_instant).as_secs());
     instant + config.flush_time_shift(bucket_key)
 }

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -7,6 +7,7 @@ use relay_system::{
     Shutdown,
 };
 use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
 
 use crate::aggregator::{self, AggregatorConfig, FlushBatching};
 use crate::bucket::Bucket;

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -7,7 +7,6 @@ use relay_system::{
     Shutdown,
 };
 use serde::{Deserialize, Serialize};
-use tokio::time::Instant;
 
 use crate::aggregator::{self, AggregatorConfig, FlushBatching};
 use crate::bucket::Bucket;


### PR DESCRIPTION
This PR tries to improve the metrics aggregator flush time calculation by trying to align the previously misaligned intervals due to a different precision in how time differences were calculated.