### PR TITLE
ref: Fix Rust 1.79 clippy lints

### DIFF
--- a/relay-cogs/src/cogs.rs
+++ b/relay-cogs/src/cogs.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Instant;
-use std::usize;
 
 use crate::{AppFeature, ResourceId};
 use crate::{CogsMeasurement, CogsRecorder, Value};

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -437,11 +437,7 @@ impl CspRaw {
 
         // Now we need to stitch on a scheme to the value, but let's not stitch on the boring
         // values.
-        let original_uri = match self.document_uri {
-            Some(ref u) => u,
-            None => "",
-        };
-
+        let original_uri = self.document_uri.as_deref().unwrap_or_default();
         match original_uri.split_once(':').map(|x| x.0) {
             None | Some("http" | "https") => Cow::Borrowed(value),
             Some(scheme) => Cow::Owned(unsplit_uri(scheme, value)),

--- a/relay-pii/src/minidumps.rs
+++ b/relay-pii/src/minidumps.rs
@@ -352,7 +352,8 @@ mod tests {
             // both our dumps different types which is awkward to work with.  So we store
             // the Vec separately to keep the slice alive and pretend we give Minidump a
             // &'static [u8].
-            let slice = unsafe { std::mem::transmute(scrubbed_data.as_slice()) };
+            let slice =
+                unsafe { std::mem::transmute::<&[u8], &'static [u8]>(scrubbed_data.as_slice()) };
             let scrubbed_dump = Minidump::read(slice).expect("scrubbed minidump failed to parse");
             Self {
                 orig_dump,

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -171,6 +171,7 @@ impl ServiceState {
             #[cfg(feature = "processing")]
             redis_pool.clone(),
             processor::Addrs {
+                #[cfg(feature = "processing")]
                 envelope_processor: processor.clone(),
                 project_cache: project_cache.clone(),
                 outcome_aggregator: outcome_aggregator.clone(),

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -963,6 +963,7 @@ pub struct EnvelopeProcessorService {
 
 /// Contains the addresses of services that the processor publishes to.
 pub struct Addrs {
+    #[cfg(feature = "processing")]
     pub envelope_processor: Addr<EnvelopeProcessor>,
     pub project_cache: Addr<ProjectCache>,
     pub outcome_aggregator: Addr<TrackOutcome>,
@@ -977,6 +978,7 @@ pub struct Addrs {
 impl Default for Addrs {
     fn default() -> Self {
         Addrs {
+            #[cfg(feature = "processing")]
             envelope_processor: Addr::dummy(),
             project_cache: Addr::dummy(),
             outcome_aggregator: Addr::dummy(),

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -138,6 +138,7 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
         #[cfg(feature = "processing")]
         redis,
         processor::Addrs {
+            #[cfg(feature = "processing")]
             envelope_processor: Addr::dummy(),
             outcome_aggregator,
             project_cache,


### PR DESCRIPTION
New rust, new clippy, new lints.

#skip-changelog