### PR TITLE
chore(gocd): Update gocd-jsonnet to remove customer-6

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.10.2"
+      "version": "v2.12.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "4ea5baaceaec881adc338e08b235bef4fb325b3e",
-      "sum": "GdmT/ufKbfQw3VnnwSBnDLWkIRhTn4TgT7Y2pzOiwSE="
+      "version": "153fcc02aa4d0da06a0b303efc33df96d8877f65",
+      "sum": "kag0gTgr8OUwtb/bfRYyWFpDNaWpW24XWknqpROt0Xw="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Updating gocd-jsonnet library version to remove customer-6 which is no longer used. https://github.com/getsentry/gocd-jsonnet/releases/tag/v2.12.0

#skip-changelog