### PR TITLE
ref(cogs): Emit cogs as statsd metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,8 +4652,7 @@ dependencies = [
 [[package]]
 name = "sentry_usage_accountant"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f0a631e328036db251337a0076dc5858a155f6831110c6417fe2537502ceae"
+source = "git+https://github.com/getsentry/rust-usage-accountant.git?rev=48df2ef#48df2ef1cdc560b00db0a4fa0493f528307c5141"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ sentry-core = "0.32.2"
 sentry-kafka-schemas = { version = "0.1.86", default-features = false }
 sentry-release-parser = { version = "1.3.2", default-features = false }
 sentry-types = "0.32.2"
-sentry_usage_accountant = { version = "0.1.0", default-features = false }
+sentry_usage_accountant = { git = "https://github.com/getsentry/rust-usage-accountant.git", rev = "48df2ef", default-features = false }
 semver = "1.0.23"
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde-transcode = "1.1.1"

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -672,6 +672,18 @@ pub enum RelayCounters {
     MissingDynamicSamplingContext,
     /// The number of attachments processed in the same envelope as a user_report_v2 event.
     FeedbackAttachments,
+    /// All COGS tracked values before aggregation.
+    ///
+    /// This metric is tagged with:
+    /// - `resource_id`: The COGS resource id.
+    /// - `app_feature`: The COGS app feature.
+    CogsRaw,
+    /// All COGS tracked values.
+    ///
+    /// This metric is tagged with:
+    /// - `resource_id`: The COGS resource id.
+    /// - `app_feature`: The COGS app feature.
+    CogsUsage,
 }
 
 impl CounterMetric for RelayCounters {
@@ -714,6 +726,8 @@ impl CounterMetric for RelayCounters {
             RelayCounters::TransactionsFromSpans => "transactions_from_spans",
             RelayCounters::MissingDynamicSamplingContext => "missing_dynamic_sampling_context",
             RelayCounters::FeedbackAttachments => "processing.feedback_attachments",
+            RelayCounters::CogsRaw => "cogs.raw",
+            RelayCounters::CogsUsage => "cogs.usage",
         }
     }
 }


### PR DESCRIPTION
Update usage accountant to use a PR/commit which makes the `Producer` emit a `Message` instead of `Vec<u8>`: https://github.com/getsentry/rust-usage-accountant/pull/11

Emits all the COGS data also as statsd, this allows us to track COGS in PoP Relays but also help us track down why COGS data is slightly off for some categories.

#skip-changelog