### PR TITLE
feat(crons): Default to relay-http in case no client is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Treat arrays of pairs as key-value mappings during PII scrubbing. ([#3639](https://github.com/getsentry/relay/pull/3639))
 - Improve flush time calculation in metrics aggregator. ([#3726](https://github.com/getsentry/relay/pull/3726))
+- Default `client` of `RequestMeta` to `relay-http` for incoming monitor requests. ([#3739](https://github.com/getsentry/relay/pull/3739))
 
 ## 24.5.1
 

--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -28,3 +28,6 @@ pub const DEFAULT_EVENT_RETENTION: u16 = 90;
 
 /// Maximum size of JSON request bodies.
 pub const MAX_JSON_SIZE: usize = 262_144;
+
+/// The default client used for check ins whenever the incoming request has no client set.
+pub const DEFAULT_CHECK_IN_CLIENT: &str = "relay-http";

--- a/relay-server/src/endpoints/monitor.rs
+++ b/relay-server/src/endpoints/monitor.rs
@@ -63,7 +63,7 @@ where
     // In case the `client` was not specified in the `RequestMeta` we mark the client as the Relay
     // HTTP endpoint since we don't know from which client the request came from.
     if meta.client().is_none() {
-        meta.set_client(DEFAULT_CHECK_IN_CLIENT.to_string());
+        meta.set_client(DEFAULT_CHECK_IN_CLIENT.to_owned());
     }
 
     let mut envelope = Envelope::from_request(Some(EventId::new()), meta);

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -321,6 +321,11 @@ impl<D> RequestMeta<D> {
     pub fn set_from_internal_relay(&mut self, value: bool) {
         self.from_internal_relay = value;
     }
+
+    /// Sets the client for this [`RequestMeta`] on the current envelope.
+    pub fn set_client(&mut self, client: String) {
+        self.client = Some(client);
+    }
 }
 
 impl RequestMeta {

--- a/tests/integration/test_monitors.py
+++ b/tests/integration/test_monitors.py
@@ -136,6 +136,7 @@ def test_monitor_endpoint_embedded_auth_with_processing(
     assert message["message_type"] == "check_in"
     assert message["start_time"] is not None
     assert message["project_id"] == project_id
+    assert message["sdk"] == "relay-http"
     assert check_in == {
         "check_in_id": "00000000000000000000000000000000",
         "monitor_slug": "my-monitor",


### PR DESCRIPTION
This PR sets a default of `relay-http` as the `client` of `RequestMeta` for any incoming monitor request that doesn't specify it.

Closes: https://github.com/getsentry/relay/issues/2332