### PR TITLE
ref(metrics): Remove debounce_delay aggregator option

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2380,7 +2380,6 @@ impl Config {
             max_tag_value_length,
             max_project_key_bucket_bytes,
             initial_delay: 30,
-            debounce_delay: 10,
             flush_partitions: None,
             flush_batching: FlushBatching::Project,
         }

--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -57,7 +57,6 @@ fn bench_insert_and_flush(c: &mut Criterion) {
     let config = AggregatorConfig {
         bucket_interval: 1000,
         initial_delay: 0,
-        debounce_delay: 0,
         ..Default::default()
     };
 

--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -162,21 +162,10 @@ pub struct AggregatorConfig {
     /// The initial delay in seconds to wait before flushing a bucket.
     ///
     /// Defaults to `30` seconds. Before sending an aggregated bucket, this is the time Relay waits
-    /// for buckets that are being reported in real time. This should be higher than the
-    /// `debounce_delay`.
+    /// for buckets that are being reported in real time.
     ///
     /// Relay applies up to a full `bucket_interval` of additional jitter after the initial delay to spread out flushing real time buckets.
     pub initial_delay: u64,
-
-    /// The delay in seconds to wait before flushing a backdated buckets.
-    ///
-    /// Defaults to `10` seconds. Metrics can be sent with a past timestamp. Relay wait this time
-    /// before sending such a backdated bucket to the upsteam. This should be lower than
-    /// `initial_delay`.
-    ///
-    /// Unlike `initial_delay`, the debounce delay starts with the exact moment the first metric
-    /// is added to a backdated bucket.
-    pub debounce_delay: u64,
 
     /// The age in seconds of the oldest allowed bucket timestamp.
     ///
@@ -232,11 +221,6 @@ pub struct AggregatorConfig {
 }
 
 impl AggregatorConfig {
-    /// The delay to debounce backdated flushes.
-    fn debounce_delay(&self) -> Duration {
-        Duration::from_secs(self.debounce_delay)
-    }
-
     /// Returns the time width buckets.
     fn bucket_interval(&self) -> Duration {
         Duration::from_secs(self.bucket_interval)
@@ -301,7 +285,6 @@ impl Default for AggregatorConfig {
         Self {
             bucket_interval: 10,
             initial_delay: 30,
-            debounce_delay: 10,
             max_secs_in_past: 5 * 24 * 60 * 60, // 5 days, as for sessions
             max_secs_in_future: 60,             // 1 minute
             max_name_length: 200,
@@ -477,8 +460,7 @@ impl fmt::Debug for CostTracker {
 
 /// Returns the instant at which a bucket should be flushed.
 ///
-/// Recent buckets are flushed after a grace period of `initial_delay`. Backdated buckets, that
-/// is, buckets that lie in the past, are flushed after the shorter `debounce_delay`.
+/// All buckets are flushed after a grace period of `initial_delay`.
 fn get_flush_time(
     config: &AggregatorConfig,
     reference_time: Instant,
@@ -506,7 +488,7 @@ fn get_flush_time(
         let floored_timestamp = (now.as_secs() / config.bucket_interval) * config.bucket_interval;
         UnixTimestamp::from_secs(floored_timestamp)
             + config.bucket_interval()
-            + config.debounce_delay()
+            + config.initial_delay()
     } else {
         // If the initial flush is still pending, use that.
         initial_flush
@@ -961,7 +943,6 @@ mod tests {
         AggregatorConfig {
             bucket_interval: 1,
             initial_delay: 0,
-            debounce_delay: 0,
             max_secs_in_past: 50 * 365 * 24 * 60 * 60,
             max_secs_in_future: 50 * 365 * 24 * 60 * 60,
             max_name_length: 200,
@@ -1310,7 +1291,6 @@ mod tests {
         let config = AggregatorConfig {
             bucket_interval: 10,
             initial_delay: 0,
-            debounce_delay: 0,
             ..Default::default()
         };
 
@@ -1330,7 +1310,6 @@ mod tests {
         let config = AggregatorConfig {
             bucket_interval: 10,
             initial_delay: 0,
-            debounce_delay: 0,
             ..Default::default()
         };
 
@@ -1347,7 +1326,6 @@ mod tests {
         let config = AggregatorConfig {
             bucket_interval: 10,
             initial_delay: 0,
-            debounce_delay: 0,
             ..Default::default()
         };
 
@@ -1366,7 +1344,6 @@ mod tests {
         let config = AggregatorConfig {
             bucket_interval: 10,
             initial_delay: 0,
-            debounce_delay: 0,
             ..Default::default()
         };
 
@@ -1607,7 +1584,6 @@ mod tests {
         let mut config = test_config();
         config.bucket_interval = 3600;
         config.initial_delay = 1300;
-        config.debounce_delay = 1300;
         config.flush_partitions = Some(10);
         config.flush_batching = FlushBatching::Partition;
 

--- a/relay-metrics/src/aggregatorservice.rs
+++ b/relay-metrics/src/aggregatorservice.rs
@@ -33,22 +33,8 @@ pub struct AggregatorServiceConfig {
 
     /// The initial delay in seconds to wait before flushing a bucket.
     ///
-    /// Defaults to `30` seconds. Before sending an aggregated bucket, this is the time Relay waits
-    /// for buckets that are being reported in real time. This should be higher than the
-    /// `debounce_delay`.
-    ///
     /// Relay applies up to a full `bucket_interval` of additional jitter after the initial delay to spread out flushing real time buckets.
     pub initial_delay: u64,
-
-    /// The delay in seconds to wait before flushing a backdated buckets.
-    ///
-    /// Defaults to `10` seconds. Metrics can be sent with a past timestamp. Relay wait this time
-    /// before sending such a backdated bucket to the upsteam. This should be lower than
-    /// `initial_delay`.
-    ///
-    /// Unlike `initial_delay`, the debounce delay starts with the exact moment the first metric
-    /// is added to a backdated bucket.
-    pub debounce_delay: u64,
 
     /// The age in seconds of the oldest allowed bucket timestamp.
     ///
@@ -122,7 +108,6 @@ impl Default for AggregatorServiceConfig {
             max_total_bucket_bytes: None,
             bucket_interval: 10,
             initial_delay: 30,
-            debounce_delay: 10,
             max_secs_in_past: 5 * 24 * 60 * 60, // 5 days, as for sessions
             max_secs_in_future: 60,             // 1 minute
             max_name_length: 200,
@@ -142,7 +127,6 @@ impl From<&AggregatorServiceConfig> for AggregatorConfig {
         Self {
             bucket_interval: value.bucket_interval,
             initial_delay: value.initial_delay,
-            debounce_delay: value.debounce_delay,
             max_secs_in_past: value.max_secs_in_past,
             max_secs_in_future: value.max_secs_in_future,
             max_name_length: value.max_name_length,
@@ -522,7 +506,6 @@ mod tests {
         let config = AggregatorServiceConfig {
             bucket_interval: 1,
             initial_delay: 0,
-            debounce_delay: 0,
             ..Default::default()
         };
         let aggregator = AggregatorService::new(config, Some(recipient)).start();

--- a/tests/integration/test_cardinality_limiter.py
+++ b/tests/integration/test_cardinality_limiter.py
@@ -6,7 +6,6 @@ TEST_CONFIG = {
     "aggregator": {
         "bucket_interval": 1,
         "initial_delay": 0,
-        "debounce_delay": 0,
         "shift_key": "none",
     }
 }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -25,7 +25,6 @@ TEST_CONFIG = {
     "aggregator": {
         "bucket_interval": 1,
         "initial_delay": 0,
-        "debounce_delay": 0,
         "shift_key": "none",
     }
 }
@@ -92,7 +91,6 @@ def test_metrics_proxy_mode_buckets(mini_sentry, relay):
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "shift_key": "none",
             },
         },
@@ -125,7 +123,6 @@ def test_metrics_proxy_mode_statsd(mini_sentry, relay):
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "shift_key": "none",
             },
         },
@@ -151,7 +148,6 @@ def test_metrics_proxy_mode_metrics_meta(mini_sentry, relay):
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "shift_key": "none",
             },
         },
@@ -278,7 +274,6 @@ def test_metrics_partition_key(mini_sentry, relay, metrics_partitions, expected_
         "aggregator": {
             "bucket_interval": 1,
             "initial_delay": 0,
-            "debounce_delay": 0,
             "max_secs_in_past": forever,
             "max_secs_in_future": forever,
             "shift_key": "partition",
@@ -321,7 +316,6 @@ def test_metrics_max_batch_size(mini_sentry, relay, max_batch_size, expected_eve
         "aggregator": {
             "bucket_interval": 1,
             "initial_delay": 0,
-            "debounce_delay": 0,
             "max_secs_in_past": forever,
             "max_secs_in_future": forever,
             "max_flush_bytes": max_batch_size,
@@ -458,7 +452,6 @@ def test_global_metrics_batching(mini_sentry, relay):
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "max_flush_bytes": MAX_FLUSH_SIZE,
             },
         },
@@ -604,7 +597,6 @@ def test_metrics_full(mini_sentry, relay, relay_with_processing, metrics_consume
             "bucket_interval": 1,
             # Give upstream some time to process downstream entries:
             "initial_delay": 2,
-            "debounce_delay": 0,
         }
     }
     upstream = relay_with_processing(options=upstream_config)
@@ -1283,7 +1275,6 @@ def test_graceful_shutdown(mini_sentry, relay):
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 100,
-                "debounce_delay": 0,
                 "shift_key": "none",
             },
         },
@@ -1606,7 +1597,6 @@ def test_span_metrics_secondary_aggregator(
                 # No metrics will arrive through the default aggregator:
                 "bucket_interval": 100,
                 "initial_delay": 100,
-                "debounce_delay": 100,
             },
             "secondary_aggregators": [
                 {
@@ -1616,7 +1606,6 @@ def test_span_metrics_secondary_aggregator(
                         # The spans-specific aggregator has config that will deliver metrics:
                         "bucket_interval": 1,
                         "initial_delay": 0,
-                        "debounce_delay": 0,
                         "max_tag_value_length": 10,
                     },
                 }
@@ -1735,7 +1724,6 @@ def test_relay_forwards_events_without_extracting_metrics_on_broken_global_filte
                 "aggregator": {
                     "bucket_interval": 1,
                     "initial_delay": 0,
-                    "debounce_delay": 0,
                     "shift_key": "none",
                 }
             }
@@ -1747,7 +1735,6 @@ def test_relay_forwards_events_without_extracting_metrics_on_broken_global_filte
                 "aggregator": {
                     "bucket_interval": 1,
                     "initial_delay": 0,
-                    "debounce_delay": 0,
                     "shift_key": "none",
                 }
             },
@@ -1798,7 +1785,6 @@ def test_relay_forwards_events_without_extracting_metrics_on_unsupported_project
                 "aggregator": {
                     "bucket_interval": 1,
                     "initial_delay": 0,
-                    "debounce_delay": 0,
                     "shift_key": "none",
                 }
             }
@@ -1810,7 +1796,6 @@ def test_relay_forwards_events_without_extracting_metrics_on_unsupported_project
                 "aggregator": {
                     "bucket_interval": 1,
                     "initial_delay": 0,
-                    "debounce_delay": 0,
                     "shift_key": "none",
                 }
             },
@@ -1853,7 +1838,6 @@ def test_missing_global_filters_enables_metric_extraction(
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "shift_key": "none",
             }
         }

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1199,7 +1199,10 @@ def test_profile_outcomes(
             },
             "source": "processing-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     # The innermost Relay needs to be in processing mode
@@ -1330,7 +1333,10 @@ def test_profile_outcomes_invalid(
             },
             "source": "pop-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)
@@ -1407,7 +1413,10 @@ def test_profile_outcomes_too_many(
             },
             "source": "pop-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)
@@ -1491,7 +1500,10 @@ def test_profile_outcomes_data_invalid(
             },
             "source": "processing-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)
@@ -1577,7 +1589,10 @@ def test_profile_outcomes_rate_limited(
                 "flush_interval": 0,
             },
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)
@@ -1639,7 +1654,6 @@ def test_global_rate_limit(
             "aggregator": {
                 "bucket_interval": bucket_interval,
                 "initial_delay": 0,
-                "debounce_delay": 0,
             },
         }
     )
@@ -1762,7 +1776,10 @@ def test_span_outcomes(
             },
             "source": "processing-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     # The innermost Relay needs to be in processing mode
@@ -1869,7 +1886,10 @@ def test_span_outcomes_invalid(
             },
             "source": "pop-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
     upstream = relay_with_processing(config)
 
@@ -1937,7 +1957,6 @@ def test_global_rate_limit_by_namespace(
             "aggregator": {
                 "bucket_interval": bucket_interval,
                 "initial_delay": 0,
-                "debounce_delay": 0,
             },
         }
     )
@@ -2075,7 +2094,10 @@ def test_replay_outcomes_item_failed(
             },
             "source": "pop-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -46,7 +46,10 @@ def test_profile_chunk_outcomes(
             },
             "source": "processing-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     # The innermost Relay needs to be in processing mode
@@ -110,7 +113,10 @@ def test_profile_chunk_outcomes_invalid(
             },
             "source": "pop-relay",
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)
@@ -172,7 +178,10 @@ def test_profile_chunk_outcomes_rate_limited(
                 "flush_interval": 0,
             },
         },
-        "aggregator": {"bucket_interval": 1, "initial_delay": 0, "debounce_delay": 0},
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
     }
 
     upstream = relay_with_processing(config)

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -485,7 +485,6 @@ def test_span_ingestion(
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "max_secs_in_past": 2**64 - 1,
             }
         }
@@ -1972,7 +1971,6 @@ def test_dynamic_sampling(
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "max_secs_in_past": 2**64 - 1,
             }
         }

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -505,7 +505,6 @@ def test_sends_metric_bucket_outcome(
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
                 "flush_interval": 0,
             },
         }
@@ -550,7 +549,6 @@ def test_rate_limit_metric_bucket(
             "aggregator": {
                 "bucket_interval": bucket_interval,
                 "initial_delay": 0,
-                "debounce_delay": 0,
             },
         }
     )
@@ -628,7 +626,6 @@ def test_rate_limit_metrics_buckets(
             "aggregator": {
                 "bucket_interval": bucket_interval,
                 "initial_delay": 0,
-                "debounce_delay": 0,
             },
         }
     )
@@ -830,7 +827,6 @@ def test_processing_quota_transaction_indexing(
             "aggregator": {
                 "bucket_interval": 1,
                 "initial_delay": 0,
-                "debounce_delay": 0,
             },
         }
     )


### PR DESCRIPTION
This PR removes the `debounce_delay` aggregator option since this was not used anymore because of https://github.com/getsentry/relay/pull/3661 and https://github.com/getsentry/relay/pull/3726.

#skip-changelog