### PR TITLE
feat(spans): Correctly emit negative outcomes for rate limited transactions that have nested spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
-- Correctly emit negative outcomes for nested spans. ([#3749](https://github.com/getsentry/relay/pull/3749))
+- Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
 ## 24.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 **Bug Fixes**:
 
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
+- Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
 
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
-- Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
 ## 24.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
+- Correctly emit negative outcomes for nested spans. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
 ## 24.6.0
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1240,13 +1240,13 @@ impl EnvelopeProcessorService {
         let (enforcement, limits) = metric!(timer(RelayTimers::EventProcessingRateLimiting), {
             envelope_limiter.compute(state.managed_envelope.envelope_mut(), &scoping)?
         });
+        let event_active = enforcement.event_active();
+        enforcement.apply_with_outcomes(&mut state.managed_envelope);
 
-        if enforcement.event_active() {
+        if event_active {
             state.remove_event();
             debug_assert!(state.envelope().is_empty());
         }
-
-        enforcement.apply_with_outcomes(&mut state.managed_envelope);
 
         // Use the same rate limits as used for the envelope on the metrics.
         // Those rate limits should not be checked for expiry or similar to ensure a consistent

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1071,7 +1071,9 @@ impl Project {
                 .items()
                 .find(|i| *i.ty() == ItemType::Transaction && !i.spans_extracted())
                 .and_then(|i| serde_json::from_slice::<PartialEvent>(&i.payload()).ok())
-                .map_or(0, |p| p.spans.0)
+                // We do + 1, since we count the transaction itself because it will be extracted
+                // as a span and counted during the slow path of rate limiting.
+                .map_or(0, |p| p.spans.0 + 1)
         } else {
             0
         };

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1032,7 +1032,7 @@ impl Project {
     ///   should be accepted or discarded
     ///
     /// IMPORTANT: If the [`ProjectState`] is invalid, the `check_request` will be skipped and only
-    /// rate limites will be validated. This function **must not** be called in the main processing
+    /// rate limits will be validated. This function **must not** be called in the main processing
     /// pipeline.
     pub fn check_envelope(
         &mut self,

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -960,7 +960,7 @@ impl Project {
         let (enforcement, mut rate_limits) =
             envelope_limiter.enforce(envelope.envelope_mut(), &scoping)?;
 
-        if check_nested_spans {
+        if spans > 0 {
             track_nested_spans_outcomes(&envelope, &enforcement, spans);
         }
 

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1054,7 +1054,7 @@ fn sync_spans_to_enforcement(envelope: &ManagedEnvelope, enforcement: &mut Enfor
     if !enforcement.event_active() {
         return;
     }
-    
+
     let spans_count = count_nested_spans(envelope);
     if spans_count == 0 {
         return;
@@ -1077,7 +1077,7 @@ fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
     struct PartialEvent {
         spans: SeqCount,
     }
-    
+
     envelope
         .envelope()
         .items()

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1461,10 +1461,10 @@ mod tests {
         drop(outcome_aggregator);
 
         let expected = [
-            (DataCategory::Span, 3),
-            (DataCategory::SpanIndexed, 3),
             (DataCategory::Transaction, 1),
             (DataCategory::TransactionIndexed, 1),
+            (DataCategory::Span, 3),
+            (DataCategory::SpanIndexed, 3),
         ];
 
         for (expected_category, expected_quantity) in expected {

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1471,8 +1471,8 @@ mod tests {
         drop(outcome_aggregator);
 
         let expected = [
-            (DataCategory::Span, 2),
-            (DataCategory::SpanIndexed, 2),
+            (DataCategory::Span, 3),
+            (DataCategory::SpanIndexed, 3),
             (DataCategory::Transaction, 1),
             (DataCategory::TransactionIndexed, 1),
         ];

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1048,8 +1048,8 @@ impl Project {
     }
 }
 
-/// Counts the nested spans inside an [`Envelope`] for each [`Item`] of type
-/// [`ItemType::Transaction`] that didn't have spans extracted before.
+/// Counts the nested spans inside an [`Envelope`] for each item of type
+/// transaction that didn't have spans extracted before.
 fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
     #[derive(Debug, Deserialize)]
     struct PartialEvent {

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1121,6 +1121,7 @@ pub enum CheckedBuckets {
 
 #[cfg(test)]
 mod tests {
+    use crate::envelope::{ContentType, Item};
     use crate::metrics::MetricStats;
     use crate::services::processor::ProcessingGroup;
     use relay_common::time::UnixTimestamp;

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1081,11 +1081,11 @@ fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
     envelope
         .envelope()
         .items()
-        .find(|i| *i.ty() == ItemType::Transaction && !i.spans_extracted())
-        .and_then(|i| serde_json::from_slice::<PartialEvent>(&i.payload()).ok())
+        .find(|item| *item.ty() == ItemType::Transaction && !item.spans_extracted())
+        .and_then(|item| serde_json::from_slice::<PartialEvent>(&item.payload()).ok())
         // We do + 1, since we count the transaction itself because it will be extracted
         // as a span and counted during the slow path of rate limiting.
-        .map_or(0, |p| p.spans.0 + 1)
+        .map_or(0, |event| event.spans.0 + 1)
 }
 
 /// Return value of [`Project::check_buckets`].

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -753,14 +753,13 @@ impl ProjectCacheBroker {
     ) -> Result<CheckedEnvelope, DiscardReason> {
         let CheckEnvelope { envelope: context } = message;
         let project_cache = self.services.project_cache.clone();
-        let outcome_aggregator = self.services.outcome_aggregator.clone();
         let project = self.get_or_create_project(context.envelope().meta().public_key());
 
         // Preload the project cache so that it arrives a little earlier in processing. However,
         // do not pass `no_cache`. In case the project is rate limited, we do not want to force
         // a full reload. Fetching must not block the store request.
         project.prefetch(project_cache, false);
-        project.check_envelope(context, outcome_aggregator)
+        project.check_envelope(context)
     }
 
     /// Handles the processing of the provided envelope.
@@ -793,7 +792,7 @@ impl ProjectCacheBroker {
         if let Ok(CheckedEnvelope {
             envelope: Some(managed_envelope),
             ..
-        }) = project.check_envelope(managed_envelope, self.services.outcome_aggregator.clone())
+        }) = project.check_envelope(managed_envelope)
         {
             let reservoir_counters = project.reservoir_counters();
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -354,10 +354,6 @@ impl ManagedEnvelope {
         });
     }
 
-    pub fn track_outcome_object(&self, outcome: TrackOutcome) {
-        self.outcome_aggregator.send(outcome);
-    }
-
     /// Accepts the envelope and drops the context.
     ///
     /// This should be called if the envelope has been accepted by the upstream, which means that

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -354,6 +354,10 @@ impl ManagedEnvelope {
         });
     }
 
+    pub fn track_outcome_object(&self, outcome: TrackOutcome) {
+        self.outcome_aggregator.send(outcome);
+    }
+
     /// Accepts the envelope and drops the context.
     ///
     /// This should be called if the envelope has been accepted by the upstream, which means that

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -16,6 +16,7 @@ mod statsd;
 
 #[cfg(feature = "processing")]
 mod native;
+mod serde;
 #[cfg(feature = "processing")]
 mod unreal;
 
@@ -32,6 +33,7 @@ pub use self::pick::*;
 pub use self::rate_limits::*;
 pub use self::retry::*;
 pub use self::semaphore::*;
+pub use self::serde::*;
 pub use self::sizes::*;
 pub use self::sleep_handle::*;
 pub use self::split_off::*;

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1485,18 +1485,4 @@ mod tests {
         assert_eq!(summary.profile_quantity, 2);
         assert_eq!(summary.secondary_transaction_quantity, 7);
     }
-
-    #[test]
-    fn test_nested_spans_outcomes_tracked_when_no_spans_extracted() {
-        let rate_limit = RateLimit {
-            categories: SmallVec::new(),
-            scope: RateLimitScope::Global,
-            reason_code: Some(ReasonCode::new("my_rate_limit".to_owned())),
-            retry_after: RetryAfter::from_secs(10),
-            namespaces: Default::default(),
-        };
-        let mut enforcement = Enforcement::default();
-        enforcement.event = CategoryLimit::new(DataCategory::Transaction, 1, Some(&rate_limit));
-        let scoping = scoping();
-    }
 }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -467,7 +467,7 @@ impl Enforcement {
     /// Invokes [`TrackOutcome`] on all enforcements reported by the [`EnvelopeLimiter`].
     ///
     /// Relay generally does not emit outcomes for sessions, so those are skipped.
-    fn track_outcomes(
+    pub fn track_outcomes(
         self,
         envelope: &Envelope,
         scoping: &Scoping,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -258,15 +258,15 @@ impl EnvelopeSummary {
 #[derive(Debug)]
 pub struct CategoryLimit {
     /// The limited data category.
-    pub category: DataCategory,
+    category: DataCategory,
     /// The total rate limited quantity across all items.
     ///
     /// This will be `0` if nothing was rate limited.
-    pub quantity: usize,
+    quantity: usize,
     /// The reason code of the applied rate limit.
     ///
     /// Defaults to `None` if the quota does not declare a reason code.
-    pub reason_code: Option<ReasonCode>,
+    reason_code: Option<ReasonCode>,
 }
 
 impl CategoryLimit {

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1,6 +1,4 @@
-use serde::de::{MapAccess, Visitor};
 use serde::{de, Deserialize, Deserializer};
-use serde_json::Error;
 use std::fmt::{self, Write};
 
 use relay_quotas::{
@@ -327,7 +325,7 @@ impl<'de> Deserialize<'de> for PartialEvent {
     {
         struct PartialEventVisitor;
 
-        impl<'de> Visitor<'de> for PartialEventVisitor {
+        impl<'de> de::Visitor<'de> for PartialEventVisitor {
             type Value = PartialEvent;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -336,7 +334,7 @@ impl<'de> Deserialize<'de> for PartialEvent {
 
             fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
             where
-                V: MapAccess<'de>,
+                V: de::MapAccess<'de>,
             {
                 let mut spans_length = None;
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer};
+use serde::de;
 use std::fmt::{self, Write};
 
 use relay_quotas::{
@@ -318,10 +318,10 @@ pub struct PartialEvent {
     pub spans_length: usize,
 }
 
-impl<'de> Deserialize<'de> for PartialEvent {
+impl<'de> de::Deserialize<'de> for PartialEvent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         struct PartialEventVisitor;
 
@@ -435,7 +435,7 @@ impl Enforcement {
         let nested_spans = event.clone_for(DataCategory::Span, spans_length);
         let nested_spans_indexed = event_indexed.clone_for(DataCategory::SpanIndexed, spans_length);
 
-        let mut limits = [
+        let limits = [
             event,
             event_indexed,
             attachments,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -258,15 +258,15 @@ impl EnvelopeSummary {
 #[derive(Debug)]
 pub struct CategoryLimit {
     /// The limited data category.
-    category: DataCategory,
+    pub category: DataCategory,
     /// The total rate limited quantity across all items.
     ///
     /// This will be `0` if nothing was rate limited.
-    quantity: usize,
+    pub quantity: usize,
     /// The reason code of the applied rate limit.
     ///
     /// Defaults to `None` if the quota does not declare a reason code.
-    reason_code: Option<ReasonCode>,
+    pub reason_code: Option<ReasonCode>,
 }
 
 impl CategoryLimit {
@@ -300,11 +300,6 @@ impl CategoryLimit {
     pub fn is_active(&self) -> bool {
         self.quantity > 0
     }
-
-    /// Returns a reference to the `reason_code` of the [`CategoryLimit`].
-    pub fn reason_code(&self) -> &Option<ReasonCode> {
-        &self.reason_code
-    }
 }
 
 impl Default for CategoryLimit {
@@ -321,45 +316,35 @@ impl Default for CategoryLimit {
 #[derive(Default, Debug)]
 pub struct Enforcement {
     /// The event item rate limit.
-    event: CategoryLimit,
+    pub event: CategoryLimit,
     /// The rate limit for the indexed category of the event.
-    event_indexed: CategoryLimit,
+    pub event_indexed: CategoryLimit,
     /// The combined attachment item rate limit.
-    attachments: CategoryLimit,
+    pub attachments: CategoryLimit,
     /// The combined session item rate limit.
-    sessions: CategoryLimit,
+    pub sessions: CategoryLimit,
     /// The combined profile item rate limit.
-    profiles: CategoryLimit,
+    pub profiles: CategoryLimit,
     /// The rate limit for the indexed profiles category.
-    profiles_indexed: CategoryLimit,
+    pub profiles_indexed: CategoryLimit,
     /// The combined replay item rate limit.
-    replays: CategoryLimit,
+    pub replays: CategoryLimit,
     /// The combined check-in item rate limit.
-    check_ins: CategoryLimit,
+    pub check_ins: CategoryLimit,
     /// The combined spans rate limit.
-    spans: CategoryLimit,
+    pub spans: CategoryLimit,
     /// The rate limit for the indexed span category.
-    spans_indexed: CategoryLimit,
+    pub spans_indexed: CategoryLimit,
     /// The combined rate limit for user-reports.
-    user_reports_v2: CategoryLimit,
+    pub user_reports_v2: CategoryLimit,
     /// The combined profile chunk item rate limit.
-    profile_chunks: CategoryLimit,
+    pub profile_chunks: CategoryLimit,
 }
 
 impl Enforcement {
     /// Returns `true` if the event should be rate limited.
     pub fn event_active(&self) -> bool {
         self.event.is_active() || self.event_indexed.is_active()
-    }
-
-    /// Returns a reference to the `event` of [`CategoryLimit`].
-    pub fn event_limit(&self) -> &CategoryLimit {
-        &self.event
-    }
-
-    /// Returns a reference to the `event_indexed` of [`CategoryLimit`].
-    pub fn event_indexed_limit(&self) -> &CategoryLimit {
-        &self.event_indexed
     }
 
     /// Helper for `track_outcomes`.
@@ -751,17 +736,15 @@ impl<F> fmt::Debug for EnvelopeLimiter<F> {
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
-    use relay_base_schema::project::{ProjectId, ProjectKey};
-    use relay_metrics::MetricNamespace;
-    use relay_quotas::RetryAfter;
-    use smallvec::{smallvec, SmallVec};
-    use tokio::time::Instant;
-
     use super::*;
     use crate::{
         envelope::{AttachmentType, ContentType, SourceQuantities},
         extractors::RequestMeta,
     };
+    use relay_base_schema::project::{ProjectId, ProjectKey};
+    use relay_metrics::MetricNamespace;
+    use relay_quotas::RetryAfter;
+    use smallvec::smallvec;
 
     #[test]
     fn test_format_rate_limits() {

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -736,15 +736,16 @@ impl<F> fmt::Debug for EnvelopeLimiter<F> {
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
+    use relay_base_schema::project::{ProjectId, ProjectKey};
+    use relay_metrics::MetricNamespace;
+    use relay_quotas::RetryAfter;
+    use smallvec::smallvec;
+
     use super::*;
     use crate::{
         envelope::{AttachmentType, ContentType, SourceQuantities},
         extractors::RequestMeta,
     };
-    use relay_base_schema::project::{ProjectId, ProjectKey};
-    use relay_metrics::MetricNamespace;
-    use relay_quotas::RetryAfter;
-    use smallvec::smallvec;
 
     #[test]
     fn test_format_rate_limits() {

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1068,6 +1068,8 @@ mod tests {
             .enforce(envelope, &scoping)
             .unwrap();
 
+        // We implemented `clone` only for tests because we don't want to make `apply_with_outcomes`
+        // &self because we want move semantics to prevent double tracking.
         enforcement
             .clone()
             .apply_with_outcomes(envelope, &scoping, outcome_aggregator);

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -352,10 +352,12 @@ impl Enforcement {
         self.event.is_active() || self.event_indexed.is_active()
     }
 
+    /// Returns a reference to the `event` of [`CategoryLimit`].
     pub fn event_limit(&self) -> &CategoryLimit {
         &self.event
     }
 
+    /// Returns a reference to the `event_indexed` of [`CategoryLimit`].
     pub fn event_indexed_limit(&self) -> &CategoryLimit {
         &self.event_indexed
     }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -450,7 +450,7 @@ impl Enforcement {
         }
     }
 
-    /// Invokes [`TrackOutcome`] on all enforcements reported by the [`EnvelopeLimiter`].
+    /// Invokes track outcome on all enforcements reported by the [`EnvelopeLimiter`].
     ///
     /// Relay generally does not emit outcomes for sessions, so those are skipped.
     fn track_outcomes(self, envelope: &mut ManagedEnvelope) {

--- a/relay-server/src/utils/serde.rs
+++ b/relay-server/src/utils/serde.rs
@@ -1,0 +1,37 @@
+use serde::de::IgnoredAny;
+use serde::{de, Deserialize, Deserializer};
+
+/// Deserializes only the count of a sequence ignoring all individual items.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SeqCount(pub usize);
+
+impl<'de> Deserialize<'de> for SeqCount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'a> de::Visitor<'a> for Visitor {
+            type Value = SeqCount;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'a>,
+            {
+                let mut count = 0;
+                while seq.next_element::<IgnoredAny>()?.is_some() {
+                    count += 1;
+                }
+
+                Ok(SeqCount(count))
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor)
+    }
+}

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1811,21 +1811,18 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     with maybe_raises:
         relay.send_envelope(project_id, envelope)
 
-    # On the fast path, we don't count the transaction itself as a span, whereas in the slow path
-    # the transaction is extracted into a span itself, thus the count is 2.
-    spans_length = 1 if hits_fast_path else 2
     if category == "transaction":
         assert summarize_outcomes() == {
             (2, 2): 1,  # Transaction, Rate Limited
             (9, 2): 1,  # TransactionIndexed, Rate Limited
-            (12, 2): spans_length,  # Span, Rate Limited
-            (16, 2): spans_length,  # SpanIndexed, Rate Limited
+            (12, 2): 2,  # Span, Rate Limited
+            (16, 2): 2,  # SpanIndexed, Rate Limited
         }
     elif category == "transaction_indexed":
         assert summarize_outcomes() == {
             (9, 2): 1,  # TransactionIndexed, Rate Limited
-            (12, 2): spans_length,  # Span, Rate Limited
-            (16, 2): spans_length,  # SpanIndexed, Rate Limited
+            (12, 2): 2,  # Span, Rate Limited
+            (16, 2): 2,  # SpanIndexed, Rate Limited
         }
 
     transactions_consumer.assert_empty()

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1718,7 +1718,7 @@ def test_rate_limit_spans_in_envelope(
 
 
 @pytest.mark.parametrize(
-    "category,hits_fast_path",
+    "category,raises_rate_limited",
     [
         ("transaction", True),
         ("transaction_indexed", False),
@@ -1731,7 +1731,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     spans_consumer,
     outcomes_consumer,
     category,
-    hits_fast_path,
+    raises_rate_limited,
 ):
     """
     Rate limits are consistent between transactions and nested spans.
@@ -1804,7 +1804,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     # Third batch might raise 429 since it hits the fast path
     maybe_raises = (
         pytest.raises(HTTPError, match="429 Client Error")
-        if hits_fast_path
+        if raises_rate_limited
         else contextlib.nullcontext()
     )
     with maybe_raises:

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1734,9 +1734,8 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     category,
     hits_fast_path,
 ):
-    """Rate limits for indexed are enforced consistently after metrics extraction.
-
-    This test does not cover consistent enforcement of total spans.
+    """
+    Rate limits are consistent between transactions and nested spans.
     """
     relay = relay_with_processing(options=TEST_CONFIG)
     project_id = 42

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1719,9 +1719,8 @@ def test_rate_limit_spans_in_envelope(
 
 
 @pytest.mark.parametrize(
-    "category,raises_rate_limited",
+    "category,hits_fast_path",
     [
-        ("transaction", True),
         ("transaction", True),
         ("transaction_indexed", False),
     ],
@@ -1731,14 +1730,14 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     relay_with_processing,
     transactions_consumer,
     spans_consumer,
+    outcomes_consumer,
     category,
-    raises_rate_limited,
+    hits_fast_path,
 ):
     """Rate limits for indexed are enforced consistently after metrics extraction.
 
     This test does not cover consistent enforcement of total spans.
     """
-    # TODO: add outcomes check when https://github.com/getsentry/relay/issues/3705 is done.
     relay = relay_with_processing(options=TEST_CONFIG)
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -1762,31 +1761,73 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
 
     transactions_consumer = transactions_consumer()
     spans_consumer = spans_consumer()
+    outcomes_consumer = outcomes_consumer()
 
     start = datetime.now(timezone.utc)
     end = start + timedelta(seconds=1)
 
     envelope = envelope_with_transaction_and_spans(start, end)
 
+    def summarize_outcomes():
+        counter = Counter()
+        for outcome in outcomes_consumer.get_outcomes(timeout=10):
+            counter[(outcome["category"], outcome["outcome"])] += outcome["quantity"]
+        return dict(counter)
+
     # First batch passes
     relay.send_envelope(project_id, envelope)
+
     event, _ = transactions_consumer.get_event(timeout=10)
     assert event["transaction"] == "my_transaction"
     # We have one nested span and the transaction itself becomes a span
     spans = spans_consumer.get_spans(n=2, timeout=10)
     assert len(spans) == 2
+    assert summarize_outcomes() == {(16, 0): 2}  # SpanIndexed, Accepted
 
+    # Second batch nothing passes
     relay.send_envelope(project_id, envelope)
+
     transactions_consumer.assert_empty()
     spans_consumer.assert_empty()
+    if category == "transaction":
+        assert summarize_outcomes() == {
+            (2, 2): 1,  # Transaction, Rate Limited
+            (9, 2): 1,  # TransactionIndexed, Rate Limited
+            (12, 2): 2,  # Span, Rate Limited
+            (16, 2): 2,  # SpanIndexed, Rate Limited
+        }
+    elif category == "transaction_indexed":
+        assert summarize_outcomes() == {
+            (9, 2): 1,  # TransactionIndexed, Rate Limited
+            (12, 2): 2,  # Span, Rate Limited
+            (16, 2): 2,  # SpanIndexed, Rate Limited
+        }
 
+    # Third batch might raise 429 since it hits the fast path
     maybe_raises = (
         pytest.raises(HTTPError, match="429 Client Error")
-        if raises_rate_limited
+        if hits_fast_path
         else contextlib.nullcontext()
     )
     with maybe_raises:
         relay.send_envelope(project_id, envelope)
+
+    # On the fast path, we don't count the transaction itself as a span, whereas in the slow path
+    # the transaction is extracted into a span itself, thus the count is 2.
+    spans_length = 1 if hits_fast_path else 2
+    if category == "transaction":
+        assert summarize_outcomes() == {
+            (2, 2): 1,  # Transaction, Rate Limited
+            (9, 2): 1,  # TransactionIndexed, Rate Limited
+            (12, 2): spans_length,  # Span, Rate Limited
+            (16, 2): spans_length,  # SpanIndexed, Rate Limited
+        }
+    elif category == "transaction_indexed":
+        assert summarize_outcomes() == {
+            (9, 2): 1,  # TransactionIndexed, Rate Limited
+            (12, 2): spans_length,  # Span, Rate Limited
+            (16, 2): spans_length,  # SpanIndexed, Rate Limited
+        }
 
     transactions_consumer.assert_empty()
     spans_consumer.assert_empty()


### PR DESCRIPTION
This PR correctly emits negative outcomes for rate-limited transactions with nested spans by also emitting negative outcomes for the nested spans themselves.

Closes: https://github.com/getsentry/relay/issues/3705