### PR TITLE
feat(event-schema): Look up data attributes in tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improve flush time calculation in metrics aggregator. ([#3726](https://github.com/getsentry/relay/pull/3726))
 - Default `client` of `RequestMeta` to `relay-http` for incoming monitor requests. ([#3739](https://github.com/getsentry/relay/pull/3739))
 - Normalize events once in the ingestion pipeline, relying on item headers. ([#3730](https://github.com/getsentry/relay/pull/3730))
+- Provide access to values in `span.tags.*` via `span.data.*`. This serves as an opaque fallback to consolidate data attributes. ([#3751](https://github.com/getsentry/relay/pull/3751))
 
 ## 24.5.1
 


### PR DESCRIPTION
SDKs send certain attributes in `span.tags` rather than `span.data`. To
consolidate access and make all data accessible via a single key, this PR makes
the getter implementation on spans fall back to `tags` if a key is not present
on `data`.

Fixes #3748
