### PR TITLE
test(deps): Bump requests from 2.31.0 to 2.32.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ pytest-xdist==3.5.0
 pytest==7.4.3
 PyYAML==6.0.1
 redis==4.5.4
-requests==2.31.0
+requests==2.32.2
 sentry_sdk==2.1.1
 setuptools==69.0.3
 werkzeug==3.0.1


### PR DESCRIPTION
Resolves https://github.com/getsentry/relay/pull/3750.

#skip-changelog