### PR TITLE
feat(server): Extrapolate sampled metrics numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
-
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
 - Add web vitals support for mobile browsers. ([#3762](https://github.com/getsentry/relay/pull/3762))
 - Accept profiler_id in the profile context. ([#3714](https://github.com/getsentry/relay/pull/3714))
+- Support extrapolation of metrics extracted from sampled data, as long as the sample rate is set in the DynamicSamplingContext. ([#3753](https://github.com/getsentry/relay/pull/3753))
 
 ## 24.6.0
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -237,7 +237,11 @@ pub struct Options {
     )]
     pub processing_disable_normalization: bool,
 
-    /// TODO(ja): Doc
+    /// The maximum duplication factor used to extrapolate distribution metrics from sampled data.
+    ///
+    /// This applies as long as Relay duplicates distribution values to extrapolate. The default is
+    /// `0`, which disables extrapolation of distributions completely. This option does not apply to
+    /// any other metric types.
     #[serde(
         default,
         rename = "sentry-metrics.extrapolation.duplication-limit",

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -244,7 +244,7 @@ pub struct Options {
         deserialize_with = "default_on_error",
         skip_serializing_if = "is_default"
     )]
-    pub extrapolation_duplication_limit: u32,
+    pub extrapolation_duplication_limit: usize,
 
     /// All other unknown options.
     #[serde(flatten)]

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -237,6 +237,15 @@ pub struct Options {
     )]
     pub processing_disable_normalization: bool,
 
+    /// TODO(ja): Doc
+    #[serde(
+        default,
+        rename = "sentry-metrics.extrapolation.duplication-limit",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub extrapolation_duplication_limit: u32,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -302,7 +302,7 @@ pub struct MetricExtractionConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<TagMapping>,
 
-    /// TODO(ja): Doc
+    /// Extrapolation for metrics extracted from sampled data.
     #[serde(default, skip_serializing_if = "ExtrapolationConfig::is_empty")]
     pub extrapolate: ExtrapolationConfig,
 
@@ -643,14 +643,14 @@ pub fn convert_conditional_tagging(project_config: &mut ProjectConfig) {
     }
 }
 
-/// TODO(ja): Doc
+/// Configuration for metric extrapolation from sampled data.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ExtrapolationConfig {
-    /// TODO(ja): Doc
+    /// A list of MRI glob patterns to include in extrapolation.
     #[serde(default)]
     pub include: Vec<LazyGlob>,
 
-    /// TODO(ja): Doc
+    /// A list of MRI glob patterns to exclude from extrapolation, overriding inclusion.
     #[serde(default)]
     pub exclude: Vec<LazyGlob>,
 }

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -303,7 +303,7 @@ pub struct MetricExtractionConfig {
     pub tags: Vec<TagMapping>,
 
     /// TODO(ja): Doc
-    #[serde(default, skip_serializing_if = "ExtrapolateConfig::is_empty")]
+    #[serde(default, skip_serializing_if = "ExtrapolationConfig::is_empty")]
     pub extrapolate: ExtrapolationConfig,
 
     /// This config has been extended with fields from `conditional_tagging`.

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -645,6 +645,7 @@ pub fn convert_conditional_tagging(project_config: &mut ProjectConfig) {
 
 /// Configuration for metric extrapolation from sampled data.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExtrapolationConfig {
     /// A list of MRI glob patterns to include in extrapolation.
     #[serde(default)]

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -304,7 +304,7 @@ pub struct MetricExtractionConfig {
 
     /// TODO(ja): Doc
     #[serde(default, skip_serializing_if = "ExtrapolateConfig::is_empty")]
-    pub extrapolate: ExtrapolateConfig,
+    pub extrapolate: ExtrapolationConfig,
 
     /// This config has been extended with fields from `conditional_tagging`.
     ///
@@ -645,7 +645,7 @@ pub fn convert_conditional_tagging(project_config: &mut ProjectConfig) {
 
 /// TODO(ja): Doc
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct ExtrapolateConfig {
+pub struct ExtrapolationConfig {
     /// TODO(ja): Doc
     #[serde(default)]
     pub include: Vec<LazyGlob>,
@@ -655,7 +655,7 @@ pub struct ExtrapolateConfig {
     pub exclude: Vec<LazyGlob>,
 }
 
-impl ExtrapolateConfig {
+impl ExtrapolationConfig {
     /// Returns `true` if this config is empty.
     pub fn is_empty(&self) -> bool {
         self.include.is_empty()

--- a/relay-metrics/src/finite.rs
+++ b/relay-metrics/src/finite.rs
@@ -82,6 +82,11 @@ impl FiniteF64 {
         Self((self.0 * other.0).clamp(f64::MIN, f64::MAX))
     }
 
+    /// Divides two numbers, saturating at the maximum and minimum representable values.
+    pub fn saturating_div(self, other: Self) -> Self {
+        Self((self.0 / other.0).clamp(f64::MIN, f64::MAX))
+    }
+
     // NB: There is no saturating_div, since 0/0 is NaN, which is not finite.
 }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -692,8 +692,8 @@ impl ProcessingExtractedMetrics {
             _ => return,
         };
 
-        let max_duplication = self.global.options.extrapolation_duplication_limit as usize;
-        let duplication = max_duplication.min(factor.to_f64().round() as usize);
+        let duplication = (factor.to_f64().round() as usize)
+            .min(self.global.options.extrapolation_duplication_limit);
 
         for bucket in buckets {
             if !extrapolate.matches(&bucket.name) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -18,7 +18,7 @@ use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_cogs::{AppFeature, Cogs, FeatureWeights, ResourceId, Token};
 use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding, NormalizationLevel, RelayMode};
-use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary, Feature};
+use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary, Feature, GlobalConfig};
 use relay_event_normalization::{
     normalize_event, validate_event_timestamps, validate_transaction, ClockDriftProcessor,
     CombinedMeasurementsConfig, EventValidationConfig, GeoIpLookup, MeasurementsConfig,
@@ -57,7 +57,7 @@ use {
         CardinalityLimit, CardinalityLimiter, CardinalityLimitsSplit, RedisSetLimiter,
         RedisSetLimiterOptions,
     },
-    relay_dynamic_config::{CardinalityLimiterMode, GlobalConfig, MetricExtractionGroups},
+    relay_dynamic_config::{CardinalityLimiterMode, MetricExtractionGroups},
     relay_metrics::{Aggregator, MergeBuckets, RedisMetricMetaStore},
     relay_quotas::{Quota, RateLimitingError, RateLimits, RedisRateLimiter},
     relay_redis::RedisPool,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -681,7 +681,6 @@ impl ProcessingExtractedMetrics {
         self.metrics.sampling_metrics.retain(&mut f);
     }
 
-    /// TODO(ja): Doc
     fn extrapolate(&self, buckets: &mut [Bucket]) {
         let Some(factor) = self.extrapolation_factor else {
             return;
@@ -693,7 +692,8 @@ impl ProcessingExtractedMetrics {
         };
 
         let duplication = (factor.to_f64().round() as usize)
-            .min(self.global.options.extrapolation_duplication_limit);
+            .min(self.global.options.extrapolation_duplication_limit)
+            .max(1);
 
         for bucket in buckets {
             if !extrapolate.matches(&bucket.name) {

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -276,7 +276,9 @@ mod tests {
 
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
-    use crate::services::processor::{ProcessEnvelope, ProcessingGroup, SpanGroup};
+    use crate::services::processor::{
+        ProcessEnvelope, ProcessingExtractedMetrics, ProcessingGroup, SpanGroup,
+    };
     use crate::services::project::ProjectState;
     use crate::testutils::{
         self, create_test_processor, new_envelope, state_with_rule_and_condition,
@@ -452,16 +454,23 @@ mod tests {
                     .into();
             }
 
+            let project_state = Arc::new(project_state);
+            let envelope = new_envelope(false, "foo");
+
             ProcessEnvelopeState::<TransactionGroup> {
                 event: Annotated::from(event),
                 metrics: Default::default(),
                 sample_rates: None,
-                extracted_metrics: Default::default(),
-                project_state: Arc::new(project_state),
+                extracted_metrics: ProcessingExtractedMetrics::new(
+                    project_state.clone(),
+                    Arc::new(GlobalConfig::default()),
+                    envelope.dsc(),
+                ),
+                project_state,
                 sampling_project_state: None,
                 project_id: ProjectId::new(42),
                 managed_envelope: ManagedEnvelope::new(
-                    new_envelope(false, "foo"),
+                    envelope,
                     TestSemaphore::new(42).try_acquire().unwrap(),
                     outcome_aggregator.clone(),
                     test_store.clone(),
@@ -709,6 +718,15 @@ mod tests {
     where
         G: Sampling + TryFrom<ProcessingGroup>,
     {
+        let project_state = {
+            let mut state = ProjectState::allowed();
+            state.config.transaction_metrics = Some(ErrorBoundary::Ok(TransactionMetricsConfig {
+                version: 1,
+                ..Default::default()
+            }));
+            Arc::new(state)
+        };
+
         let bytes = Bytes::from(
             r#"{"dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","trace":{"trace_id":"89143b0763095bd9c9955e8175d1fb23","public_key":"e12d836b15bb49d7bbf99e64295d995b"}}"#,
         );
@@ -719,16 +737,12 @@ mod tests {
             spans_extracted: false,
             metrics: Default::default(),
             sample_rates: Default::default(),
-            extracted_metrics: Default::default(),
-            project_state: {
-                let mut state = ProjectState::allowed();
-                state.config.transaction_metrics =
-                    Some(ErrorBoundary::Ok(TransactionMetricsConfig {
-                        version: 1,
-                        ..Default::default()
-                    }));
-                Arc::new(state)
-            },
+            extracted_metrics: ProcessingExtractedMetrics::new(
+                project_state.clone(),
+                Arc::new(GlobalConfig::default()),
+                envelope.dsc(),
+            ),
+            project_state,
             sampling_project_state: {
                 let mut state = ProjectState::allowed();
                 state.config.metric_extraction =

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -718,7 +718,7 @@ mod tests {
     use relay_system::Addr;
 
     use crate::envelope::Envelope;
-    use crate::services::processor::ProcessingGroup;
+    use crate::services::processor::{ProcessingExtractedMetrics, ProcessingGroup};
     use crate::services::project::ProjectState;
     use crate::utils::ManagedEnvelope;
 
@@ -738,6 +738,7 @@ mod tests {
             .features
             .0
             .insert(Feature::ExtractCommonSpanMetricsFromEvent);
+        let project_state = Arc::new(project_state);
 
         let event = Event {
             ty: EventType::Transaction.into(),
@@ -769,8 +770,12 @@ mod tests {
             event: Annotated::from(event),
             metrics: Default::default(),
             sample_rates: None,
-            extracted_metrics: Default::default(),
-            project_state: Arc::new(project_state),
+            extracted_metrics: ProcessingExtractedMetrics::new(
+                project_state.clone(),
+                Arc::new(GlobalConfig::default()),
+                managed_envelope.envelope().dsc(),
+            ),
+            project_state,
             sampling_project_state: None,
             project_id: ProjectId::new(42),
             managed_envelope: managed_envelope.try_into().unwrap(),


### PR DESCRIPTION
Extrapolates numbers tracked as metrics after extraction from spans.
This allows to view the original order of magnitude before client
sampling and should remove jumps resulting from changes in sample rates.

Extrapolation is part of metric extraction in Relay and controlled via a
project config field. In addition to that, there is a global threshold
for the maximum duplication factor for expansion of distribution
metrics:

Extrapolation is controlled via `MetricExtractionConfig::extrapolate`.
Metrics from the namespaces listed in this field will be extrapolated
unless explicitly excluded. The default is empty.

```json
"metricExtraction": {
    "version": 1,
    "extrapolate": {
        "include": [
    	    "?:transactions/*",
    	    "?:spans/*",
    	    "?:custom/*"
        ],
        "exclude": [
    	    "c:spans/usage@none",
    	    "c:transactions/usage@none",
    	    "c:transactions/count_per_root_project@none"
        ]
    }
}
```

The option to control the maximum duplication factor is called
`sentry-metrics.extrapolation.duplication-limit`, declared in
`genericmetrics.yaml`, and is exposed to Relay via
`GlobalConfig::options`. It is a numeric value of type `u32` in the
range $[0, 2^{32})$. Relay can assume a non-zero default value when this
option is missing.

```yaml
# The maximum duplication factor used to extrapolate distribution metrics from sampled data.
#
# This applies as long as Relay duplicates distribution values to extrapolate. The default is
# `0`, which disables extrapolation of distributions completely. This option does not apply to
# any other metric types.
sentry-metrics.extrapolation.duplication-limit: 100
```