### PR TITLE
ref(normalization): Merge the two event validation steps

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -14,9 +14,8 @@ use relay_cardinality::CardinalityLimit;
 use relay_common::glob::{glob_match_bytes, GlobOptions};
 use relay_dynamic_config::{normalize_json, GlobalConfig, ProjectConfig};
 use relay_event_normalization::{
-    normalize_event, validate_event_timestamps, validate_transaction, BreakdownsConfig,
-    ClientHints, EventValidationConfig, GeoIpLookup, NormalizationConfig, RawUserAgentInfo,
-    TransactionValidationConfig,
+    normalize_event, validate_event, BreakdownsConfig, ClientHints, EventValidationConfig,
+    GeoIpLookup, NormalizationConfig, RawUserAgentInfo,
 };
 use relay_event_schema::processor::{process_value, split_chunks, ProcessingState};
 use relay_event_schema::protocol::{Event, IpAddr, VALID_PLATFORMS};
@@ -237,15 +236,10 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         received_at: config.received_at,
         max_secs_in_past: config.max_secs_in_past,
         max_secs_in_future: config.max_secs_in_future,
-        is_validated: config.is_renormalize.unwrap_or(false),
-    };
-    validate_event_timestamps(&mut event, &event_validation_config)?;
-
-    let tx_validation_config = TransactionValidationConfig {
         timestamp_range: None, // only supported in relay
         is_validated: config.is_renormalize.unwrap_or(false),
     };
-    validate_transaction(&mut event, &tx_validation_config)?;
+    validate_event(&mut event, &event_validation_config)?;
 
     let is_renormalize = config.is_renormalize.unwrap_or(false);
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         received_at: config.received_at,
         max_secs_in_past: config.max_secs_in_past,
         max_secs_in_future: config.max_secs_in_future,
-        timestamp_range: None, // only supported in relay
+        transaction_timestamp_range: None, // only supported in relay
         is_validated: config.is_renormalize.unwrap_or(false),
     };
     validate_event(&mut event, &event_validation_config)?;

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -24,10 +24,7 @@ mod transactions;
 mod trimming;
 mod validation;
 
-pub use validation::{
-    validate_event_timestamps, validate_span, validate_transaction, EventValidationConfig,
-    TransactionValidationConfig,
-};
+pub use validation::{validate_event, validate_span, EventValidationConfig};
 pub mod replay;
 pub use event::{
     normalize_event, normalize_measurements, normalize_performance_score, NormalizationConfig,

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -345,7 +345,8 @@ mod tests {
     use relay_event_schema::protocol::{ClientSdkInfo, Contexts, SpanId, TraceId};
     use relay_protocol::{assert_annotated_snapshot, get_value};
 
-    use crate::{validate_transaction, RedactionRule, TransactionValidationConfig};
+    use crate::validation::validate_event;
+    use crate::{EventValidationConfig, RedactionRule};
 
     use super::*;
 
@@ -546,7 +547,7 @@ mod tests {
         })
         .unwrap();
 
-        validate_transaction(&mut event, &TransactionValidationConfig::default()).unwrap();
+        validate_event(&mut event, &EventValidationConfig::default()).unwrap();
         process_value(
             &mut event,
             &mut TransactionsProcessor::default(),

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -33,7 +33,7 @@ pub struct EventValidationConfig {
     ///
     /// Transactions that finish outside this range are invalid. The check is
     /// skipped if no range is provided.
-    pub timestamp_range: Option<Range<UnixTimestamp>>,
+    pub transaction_timestamp_range: Option<Range<UnixTimestamp>>,
 
     /// Controls whether the event has been validated before, in which case disables validation.
     ///
@@ -144,7 +144,7 @@ fn validate_transaction_timestamps(
         transaction_event.timestamp.value(),
     ) {
         (Some(start), Some(end)) => {
-            validate_timestamps(start, end, config.timestamp_range.as_ref())?;
+            validate_timestamps(start, end, config.transaction_timestamp_range.as_ref())?;
             Ok(())
         }
         (_, None) => Err(ProcessingAction::InvalidTransaction(
@@ -366,7 +366,7 @@ mod tests {
             validate_event(
                 &mut event,
                 &EventValidationConfig {
-                    timestamp_range: Some(UnixTimestamp::now()..UnixTimestamp::now()),
+                    transaction_timestamp_range: Some(UnixTimestamp::now()..UnixTimestamp::now()),
                     is_validated: false,
                     ..Default::default()
                 }
@@ -408,7 +408,7 @@ mod tests {
             validate_event(
                 &mut event,
                 &EventValidationConfig {
-                    timestamp_range: None,
+                    transaction_timestamp_range: None,
                     is_validated: false,
                     ..Default::default()
                 }
@@ -435,7 +435,7 @@ mod tests {
             validate_event(
                 &mut event,
                 &EventValidationConfig {
-                    timestamp_range: None,
+                    transaction_timestamp_range: None,
                     is_validated: false,
                     ..Default::default()
                 }

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -485,10 +485,9 @@ mod tests {
         AcceptTransactionNames, CombinedMetricExtractionConfig, MetricExtractionConfig, TagMapping,
     };
     use relay_event_normalization::{
-        normalize_event, set_default_transaction_source, validate_event_timestamps,
-        validate_transaction, BreakdownsConfig, CombinedMeasurementsConfig, EventValidationConfig,
-        MeasurementsConfig, NormalizationConfig, PerformanceScoreConfig, PerformanceScoreProfile,
-        PerformanceScoreWeightedComponent, TransactionValidationConfig,
+        normalize_event, set_default_transaction_source, validate_event, BreakdownsConfig,
+        CombinedMeasurementsConfig, EventValidationConfig, MeasurementsConfig, NormalizationConfig,
+        PerformanceScoreConfig, PerformanceScoreProfile, PerformanceScoreWeightedComponent,
     };
     use relay_metrics::BucketValue;
     use relay_protocol::{Annotated, RuleCondition};
@@ -566,9 +565,7 @@ mod tests {
         )
         .unwrap();
 
-        // Validate and normalize first, to make sure that all things are correct as in the real pipeline:
-        validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
-        validate_transaction(&mut event, &TransactionValidationConfig::default()).unwrap();
+        validate_event(&mut event, &EventValidationConfig::default()).unwrap();
 
         normalize_event(
             &mut event,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -20,9 +20,9 @@ use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding, NormalizationLevel, RelayMode};
 use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary, Feature};
 use relay_event_normalization::{
-    normalize_event, validate_event_timestamps, validate_transaction, ClockDriftProcessor,
-    CombinedMeasurementsConfig, EventValidationConfig, GeoIpLookup, MeasurementsConfig,
-    NormalizationConfig, RawUserAgentInfo, TransactionNameConfig, TransactionValidationConfig,
+    normalize_event, validate_event, ClockDriftProcessor, CombinedMeasurementsConfig,
+    EventValidationConfig, GeoIpLookup, MeasurementsConfig, NormalizationConfig, RawUserAgentInfo,
+    TransactionNameConfig,
 };
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::{
@@ -1467,16 +1467,13 @@ impl EnvelopeProcessorService {
         let ai_model_costs = global_config.ai_model_costs.clone().ok();
 
         utils::log_transaction_name_metrics(&mut state.event, |event| {
-            let tx_validation_config = TransactionValidationConfig {
-                timestamp_range: Some(
-                    AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
-                ),
-                is_validated: false,
-            };
             let event_validation_config = EventValidationConfig {
                 received_at: Some(state.managed_envelope.received_at()),
                 max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
                 max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
+                timestamp_range: Some(
+                    AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
+                ),
                 is_validated: false,
             };
 
@@ -1552,9 +1549,7 @@ impl EnvelopeProcessorService {
             };
 
             metric!(timer(RelayTimers::EventProcessingNormalization), {
-                validate_event_timestamps(event, &event_validation_config)
-                    .map_err(|_| ProcessingError::InvalidTransaction)?;
-                validate_transaction(event, &tx_validation_config)
+                validate_event(event, &event_validation_config)
                     .map_err(|_| ProcessingError::InvalidTransaction)?;
                 normalize_event(event, &normalization_config);
                 if full_normalization && event::has_unprintable_fields(event) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1471,7 +1471,7 @@ impl EnvelopeProcessorService {
                 received_at: Some(state.managed_envelope.received_at()),
                 max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
                 max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
-                timestamp_range: Some(
+                transaction_timestamp_range: Some(
                     AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
                 ),
                 is_validated: false,

--- a/relay-server/tests/test_fixtures.rs
+++ b/relay-server/tests/test_fixtures.rs
@@ -1,8 +1,7 @@
 use std::fs;
 
 use relay_event_normalization::{
-    normalize_event, validate_event_timestamps, validate_transaction, EventValidationConfig,
-    NormalizationConfig, TransactionValidationConfig,
+    normalize_event, validate_event, EventValidationConfig, NormalizationConfig,
 };
 use relay_event_schema::processor::{process_value, ProcessingState};
 use relay_event_schema::protocol::Event;
@@ -72,8 +71,7 @@ macro_rules! event_snapshot {
             fn test_processing() {
                 let mut event = load_fixture();
 
-                validate_transaction(&mut event, &TransactionValidationConfig::default()).unwrap();
-                validate_event_timestamps(&mut event, &EventValidationConfig::default()).unwrap();
+                validate_event(&mut event, &EventValidationConfig::default()).unwrap();
                 normalize_event(&mut event, &NormalizationConfig {
                     remove_other: true,
                     emit_event_errors: true,

--- a/tools/process-event/src/main.rs
+++ b/tools/process-event/src/main.rs
@@ -10,8 +10,7 @@ use std::path::PathBuf;
 use anyhow::{format_err, Context, Result};
 use clap::Parser;
 use relay_event_normalization::{
-    normalize_event, validate_event_timestamps, validate_transaction, EventValidationConfig,
-    NormalizationConfig, TransactionValidationConfig,
+    normalize_event, validate_event, EventValidationConfig, NormalizationConfig,
 };
 use relay_event_schema::processor::{process_value, ProcessingState};
 use relay_event_schema::protocol::Event;
@@ -84,9 +83,7 @@ impl Cli {
         }
 
         if self.store {
-            validate_event_timestamps(&mut event, &EventValidationConfig::default())
-                .map_err(|e| format_err!("{e}"))?;
-            validate_transaction(&mut event, &TransactionValidationConfig::default())
+            validate_event(&mut event, &EventValidationConfig::default())
                 .map_err(|e| format_err!("{e}"))?;
             normalize_event(&mut event, &NormalizationConfig::default());
         }


### PR DESCRIPTION
This PR merges the two existing validation functions, expected to be run in a specific order, into a single validation function. The requirements that caused the split no longer exist.

For an easier review:
- The first commit, `857d579cce7d8d4c8c02078e4ce2ccd05eb825d2`, contains the functional changes.
- The second commit, `c5f5a52f54227f0eb789bd5400156b5bc0a0fddf`, moves code around without functional changes.

#skip-changelog