### PR TITLE
ref(cogs): Remove unused metric, revert to release usage accountant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4645,7 +4645,8 @@ dependencies = [
 [[package]]
 name = "sentry_usage_accountant"
 version = "0.1.0"
-source = "git+https://github.com/getsentry/rust-usage-accountant.git?rev=48df2ef#48df2ef1cdc560b00db0a4fa0493f528307c5141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f0a631e328036db251337a0076dc5858a155f6831110c6417fe2537502ceae"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ sentry-core = "0.32.2"
 sentry-kafka-schemas = { version = "0.1.86", default-features = false }
 sentry-release-parser = { version = "1.3.2", default-features = false }
 sentry-types = "0.32.2"
-sentry_usage_accountant = { git = "https://github.com/getsentry/rust-usage-accountant.git", rev = "48df2ef", default-features = false }
+sentry_usage_accountant = { version = "0.1.0", default-features = false }
 semver = "1.0.23"
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde-transcode = "1.1.1"

--- a/relay-server/src/services/cogs.rs
+++ b/relay-server/src/services/cogs.rs
@@ -34,16 +34,10 @@ enum RelayProducer {
 impl Producer for RelayProducer {
     type Error = std::convert::Infallible;
 
-    fn send(&mut self, message: &sentry_usage_accountant::Message) -> Result<(), Self::Error> {
-        relay_statsd::metric!(
-            counter(RelayCounters::CogsUsage) += message.amount as i64,
-            resource_id = &message.shared_resource_id,
-            app_feature = &message.app_feature
-        );
-
+    fn send(&mut self, _message: Vec<u8>) -> Result<(), Self::Error> {
         match self {
             #[cfg(feature = "processing")]
-            Self::Store(addr) => addr.send(StoreCogs(message.serialize())),
+            Self::Store(addr) => addr.send(StoreCogs(_message)),
             Self::Noop => {}
         }
 
@@ -91,7 +85,7 @@ impl CogsService {
         };
 
         relay_statsd::metric!(
-            counter(RelayCounters::CogsRaw) += amount as i64,
+            counter(RelayCounters::CogsUsage) += amount as i64,
             resource_id = resource_id,
             app_feature = measurement.feature.as_str()
         );

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -672,12 +672,6 @@ pub enum RelayCounters {
     MissingDynamicSamplingContext,
     /// The number of attachments processed in the same envelope as a user_report_v2 event.
     FeedbackAttachments,
-    /// All COGS tracked values before aggregation.
-    ///
-    /// This metric is tagged with:
-    /// - `resource_id`: The COGS resource id.
-    /// - `app_feature`: The COGS app feature.
-    CogsRaw,
     /// All COGS tracked values.
     ///
     /// This metric is tagged with:
@@ -732,7 +726,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::TransactionsFromSpans => "transactions_from_spans",
             RelayCounters::MissingDynamicSamplingContext => "missing_dynamic_sampling_context",
             RelayCounters::FeedbackAttachments => "processing.feedback_attachments",
-            RelayCounters::CogsRaw => "cogs.raw",
             RelayCounters::CogsUsage => "cogs.usage",
             RelayCounters::NormalizationDecision => "normalization.decision",
         }


### PR DESCRIPTION
Removes the now unused metric, reverts to a released sentry-usuage-accountant in preparation to drop the entire lib after we can only emit the metric.

#skip-changelog