### PR TITLE
feat(web-vitals): add support for mobile browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
+- Add web vitals support for mobile browsers. ([#3762](https://github.com/getsentry/relay/pull/3762))
 
 ## 24.6.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -152,6 +152,12 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
             "Safari",
             "Edge",
             "Opera",
+            // Mobile Browsers
+            "Chrome Mobile",
+            "Firefox Mobile",
+            "Mobile Safari",
+            "Edge Mobile",
+            "Opera Mobile",
         ],
     );
 


### PR DESCRIPTION
Adds support for mobile browsers to start ingesting web vitals. 

Continuation of https://github.com/getsentry/sentry/pull/73298/ which adds the scoring percentile configuration for mobile browsers.