### PR TITLE
ref(profiles): Process profiles before metric extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
+- Make sure outcomes for dropped profiles are consistent between indexed and non-indexed categories. ([#3767](https://github.com/getsentry/relay/pull/3767))
 - Add web vitals support for mobile browsers. ([#3762](https://github.com/getsentry/relay/pull/3762))
 - Accept profiler_id in the profile context. ([#3714](https://github.com/getsentry/relay/pull/3714))
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1632,7 +1632,8 @@ impl EnvelopeProcessorService {
             &self.inner.global_config.current(),
         )?;
 
-        profile::filter(state);
+        let profile_id = profile::filter(state);
+        profile::transfer_id(state, profile_id);
 
         if_processing!(self.inner.config, {
             attachment::create_placeholders(state);
@@ -1661,7 +1662,7 @@ impl EnvelopeProcessorService {
             // Before metric extraction to make sure the profile count is reflected correctly.
             let profile_id = match keep_profiles {
                 true => profile::process(state, &self.inner.config),
-                false => None,
+                false => profile_id,
             };
 
             // Extract metrics here, we're about to drop the event/transaction.

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1632,8 +1632,7 @@ impl EnvelopeProcessorService {
             &self.inner.global_config.current(),
         )?;
 
-        let profile_id = profile::filter(state);
-        profile::transfer_id(state, profile_id);
+        profile::filter(state);
 
         if_processing!(self.inner.config, {
             attachment::create_placeholders(state);
@@ -1657,15 +1656,16 @@ impl EnvelopeProcessorService {
         };
 
         if let Some(outcome) = sampling_result.into_dropped_outcome() {
+            let keep_profiles = dynamic_sampling::forward_unsampled_profiles(state, &global_config);
+            // Process profiles before dropping the transaction, if necessary.
+            // Before metric extraction to make sure the profile count is reflected correctly.
+            let profile_id = match keep_profiles {
+                true => profile::process(state, &self.inner.config),
+                false => None,
+            };
+
             // Extract metrics here, we're about to drop the event/transaction.
             self.extract_transaction_metrics(state, SamplingDecision::Drop, profile_id)?;
-
-            let keep_profiles = dynamic_sampling::forward_unsampled_profiles(state, &global_config);
-
-            // Process profiles before dropping the transaction, if necessary.
-            if keep_profiles {
-                profile::process(state, &self.inner.config);
-            }
 
             dynamic_sampling::drop_unsampled_items(state, outcome, keep_profiles);
 
@@ -1687,10 +1687,11 @@ impl EnvelopeProcessorService {
         attachment::scrub(state);
 
         if_processing!(self.inner.config, {
+            // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
+            let profile_id = profile::process(state, &self.inner.config);
+
             // Always extract metrics in processing Relays for sampled items.
             self.extract_transaction_metrics(state, SamplingDecision::Keep, profile_id)?;
-
-            profile::process(state, &self.inner.config);
 
             if state
                 .project_state

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1563,10 +1563,9 @@ def test_profile_outcomes_data_invalid(
         for category in [6, 11]  # Profile, ProfileIndexed
     ]
 
-    # Because invalid data is detected _after_ metrics extraction, there is still a metric:
     metrics = metrics_by_name(metrics_consumer, 4)
     assert "has_profile" not in metrics["d:transactions/duration@millisecond"]["tags"]
-    assert metrics["c:transactions/usage@none"]["tags"]["has_profile"] == "true"
+    assert "has_profile" not in metrics["c:transactions/usage@none"]["tags"]
 
 
 @pytest.mark.parametrize("quota_category", ["transaction", "profile"])

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1302,11 +1302,25 @@ def test_profile_outcomes(
     assert outcomes == expected_outcomes, outcomes
 
 
+@pytest.mark.parametrize(
+    "profile_payload,expected_outcome",
+    [
+        # Completely invalid header
+        (b"foobar", "profiling_invalid_json"),
+        # Invalid platform -> invalid profile, but a valid profile header
+        (
+            b"""{"profile_id":"11111111111111111111111111111111","version":"2","platform":"<this does not exist>"}""",
+            "profiling_platform_not_supported",
+        ),
+    ],
+)
 def test_profile_outcomes_invalid(
     mini_sentry,
     relay_with_processing,
     outcomes_consumer,
     metrics_consumer,
+    profile_payload,
+    expected_outcome,
 ):
     """
     Tests that Relay reports correct outcomes for invalid profiles as `Profile`.
@@ -1351,7 +1365,9 @@ def test_profile_outcomes_invalid(
                 type="transaction",
             )
         )
-        envelope.add_item(Item(payload=PayloadRef(bytes=b""), type="profile"))
+        envelope.add_item(
+            Item(payload=PayloadRef(bytes=profile_payload), type="profile")
+        )
 
         return envelope
 
@@ -1369,7 +1385,7 @@ def test_profile_outcomes_invalid(
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": 1,
-            "reason": "profiling_invalid_json",
+            "reason": expected_outcome,
             "source": "pop-relay",
             "timestamp": time_within_delta(),
         }


### PR DESCRIPTION
Invalid profiles with a valid header which are ultimately discarded as invalid would still tag the transaction usage metric with `has_profile`, even though the profile was dropped.

- Collapses `process::transfer_id` into `process::filter`
- Moves profile expansion/processing before metrics extraction
- Adds an integration test for this case