### PR TITLE
feat(spans): Restrict extraction of span time metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
-
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
 - Add web vitals support for mobile browsers. ([#3762](https://github.com/getsentry/relay/pull/3762))
 - Accept profiler_id in the profile context. ([#3714](https://github.com/getsentry/relay/pull/3714))
+- Only extract span duration metrics for known modules. ([#3768](https://github.com/getsentry/relay/pull/3768))
 
 ## 24.6.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -211,7 +211,7 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
                     category: DataCategory::Span,
                     mri: "d:spans/exclusive_time@millisecond".into(),
                     field: Some("span.exclusive_time".into()),
-                    condition: Some(!is_addon.clone() /* & is_common.clone() */),
+                    condition: Some(!is_addon.clone() & is_common.clone()),
                     tags: vec![],
                 },
                 MetricSpec {
@@ -286,7 +286,7 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
                     category: DataCategory::Span,
                     mri: "d:spans/duration@millisecond".into(),
                     field: Some("span.duration".into()),
-                    condition: Some(!is_addon.clone() /* & is_common.clone() */),
+                    condition: Some(!is_addon.clone() & is_common.clone()),
                     tags: vec![],
                 },
                 MetricSpec {

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -211,7 +211,7 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
                     category: DataCategory::Span,
                     mri: "d:spans/exclusive_time@millisecond".into(),
                     field: Some("span.exclusive_time".into()),
-                    condition: Some(!is_addon.clone() & is_common.clone()),
+                    condition: Some(!is_addon.clone() /* & is_common.clone() */),
                     tags: vec![],
                 },
                 MetricSpec {
@@ -286,7 +286,7 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
                     category: DataCategory::Span,
                     mri: "d:spans/duration@millisecond".into(),
                     field: Some("span.duration".into()),
-                    condition: Some(!is_addon.clone() & is_common.clone()),
+                    condition: Some(!is_addon.clone() /* & is_common.clone() */),
                     tags: vec![],
                 },
                 MetricSpec {

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -2430,4 +2430,20 @@ LIMIT 1
             "admin@sentry.io"
         );
     }
+
+    #[test]
+    fn long_descriptions_are_truncated() {
+        let json = r#"{
+            "description": "SELECT column FROM table1 WHERE another_col = %s AND yet_another_col = something_very_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+            "op": "db"
+        }"#;
+
+        let span = Annotated::<Span>::from_json(json)
+            .unwrap()
+            .into_value()
+            .unwrap();
+
+        let tags = extract_tags(&span, 200, None, None, false, None);
+        assert_eq!(tags[&SpanTagKey::Description], "SELECT column FROM table1 WHERE another_col = %s AND yet_another_col = something_very_longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*");
+    }
 }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__both_feature_flags_enabled.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__both_feature_flags_enabled.snap
@@ -22,56 +22,6 @@ expression: metrics
         },
     },
     Bucket {
-        timestamp: UnixTimestamp(1619420400),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                59000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "myop",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1619420400),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                59000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "myop",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
@@ -81,56 +31,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -2628,56 +2528,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -2696,112 +2546,12 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -2938,56 +2688,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.sql.query",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.sql.query",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -3096,56 +2796,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.mongodb.find",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.mongodb.find",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -3275,56 +2925,6 @@ expression: metrics
         },
     },
     Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis.command",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis.command",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
         timestamp: UnixTimestamp(1695255152),
         width: 0,
         name: MetricName(
@@ -3334,56 +2934,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1695255152),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                15833.532095,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.load",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1695255152),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                15833.532095,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.load",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -3864,56 +3414,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -6281,56 +5781,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -6349,112 +5799,12 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -1400,54 +1400,6 @@ expression: "(&event.value().unwrap().spans, metrics)"
             timestamp: UnixTimestamp(1597976303),
             width: 0,
             name: MetricName(
-                "d:spans/exclusive_time@millisecond",
-            ),
-            value: Distribution(
-                [
-                    3000.0,
-                ],
-            ),
-            tags: {
-                "span.op": "custom.op",
-                "transaction": "gEt /api/:version/users/",
-                "transaction.op": "ui.load",
-            },
-            metadata: BucketMetadata {
-                merges: 1,
-                received_at: Some(
-                    UnixTimestamp(0),
-                ),
-                extracted_from_indexed: false,
-            },
-        },
-        Bucket {
-            timestamp: UnixTimestamp(1597976303),
-            width: 0,
-            name: MetricName(
-                "d:spans/duration@millisecond",
-            ),
-            value: Distribution(
-                [
-                    3000.0,
-                ],
-            ),
-            tags: {
-                "span.op": "custom.op",
-                "transaction": "gEt /api/:version/users/",
-                "transaction.op": "ui.load",
-            },
-            metadata: BucketMetadata {
-                merges: 1,
-                received_at: Some(
-                    UnixTimestamp(0),
-                ),
-                extracted_from_indexed: false,
-            },
-        },
-        Bucket {
-            timestamp: UnixTimestamp(1597976303),
-            width: 0,
-            name: MetricName(
                 "c:spans/usage@none",
             ),
             value: Counter(

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__only_common.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__only_common.snap
@@ -22,56 +22,6 @@ expression: metrics
         },
     },
     Bucket {
-        timestamp: UnixTimestamp(1619420400),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                59000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "myop",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1619420400),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                59000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "myop",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
@@ -81,56 +31,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -2420,56 +2320,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -2488,112 +2338,12 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -2730,56 +2480,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.sql.query",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.sql.query",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -2888,56 +2588,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.mongodb.find",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.mongodb.find",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -3067,56 +2717,6 @@ expression: metrics
         },
     },
     Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis.command",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis.command",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
         timestamp: UnixTimestamp(1695255152),
         width: 0,
         name: MetricName(
@@ -3126,56 +2726,6 @@ expression: metrics
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1695255152),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                15833.532095,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.load",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1695255152),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                15833.532095,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.load",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(
@@ -3668,56 +3218,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "ui.react.render",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -5890,56 +5390,6 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
@@ -5958,112 +5408,12 @@ expression: metrics
         timestamp: UnixTimestamp(1597976302),
         width: 0,
         name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
             "c:spans/usage@none",
         ),
         value: Counter(
             1.0,
         ),
         tags: {},
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/exclusive_time@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
-        metadata: BucketMetadata {
-            merges: 1,
-            received_at: Some(
-                UnixTimestamp(0),
-            ),
-            extracted_from_indexed: false,
-        },
-    },
-    Bucket {
-        timestamp: UnixTimestamp(1597976302),
-        width: 0,
-        name: MetricName(
-            "d:spans/duration@millisecond",
-        ),
-        value: Distribution(
-            [
-                2000.0,
-            ],
-        ),
-        tags: {
-            "environment": "fake_environment",
-            "span.op": "db.redis",
-            "transaction": "gEt /api/:version/users/",
-            "transaction.op": "myop",
-        },
         metadata: BucketMetadata {
             merges: 1,
             received_at: Some(

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -782,30 +782,6 @@ def test_span_ingestion(
             "received_at": time_after(now_timestamp),
         },
         {
-            "name": "d:spans/duration@millisecond",
-            "org_id": 1,
-            "project_id": 42,
-            "retention_days": 90,
-            "tags": {
-                "span.op": "default",
-            },
-            "timestamp": expected_timestamp,
-            "type": "d",
-            "value": [500.0, 500.0],
-            "received_at": time_after(now_timestamp),
-        },
-        {
-            "name": "d:spans/duration@millisecond",
-            "org_id": 1,
-            "project_id": 42,
-            "retention_days": 90,
-            "tags": {"span.op": "default"},
-            "timestamp": expected_timestamp + 1,
-            "type": "d",
-            "value": [1500.0, 1500.0],
-            "received_at": time_after(now_timestamp),
-        },
-        {
             "org_id": 1,
             "project_id": 42,
             "name": "d:spans/exclusive_time@millisecond",
@@ -832,28 +808,6 @@ def test_span_ingestion(
             "timestamp": expected_timestamp,
             "type": "d",
             "value": [500.0],
-            "received_at": time_after(now_timestamp),
-        },
-        {
-            "name": "d:spans/exclusive_time@millisecond",
-            "org_id": 1,
-            "project_id": 42,
-            "retention_days": 90,
-            "tags": {"span.op": "default"},
-            "timestamp": expected_timestamp,
-            "type": "d",
-            "value": [500.0, 500.0],
-            "received_at": time_after(now_timestamp),
-        },
-        {
-            "name": "d:spans/exclusive_time@millisecond",
-            "org_id": 1,
-            "project_id": 42,
-            "retention_days": 90,
-            "tags": {"span.op": "default"},
-            "timestamp": expected_timestamp + 1,
-            "type": "d",
-            "value": [345.0, 345.0],
             "received_at": time_after(now_timestamp),
         },
         {
@@ -1640,7 +1594,7 @@ def test_rate_limit_consistent_extracted(
     assert len(spans) == 2
     assert summarize_outcomes() == {(16, 0): 2}  # SpanIndexed, Accepted
     # A limit only for span_indexed does not affect extracted metrics
-    metrics = metrics_consumer.get_metrics(n=10)
+    metrics = metrics_consumer.get_metrics(n=6)
     span_count = sum(
         [m[0]["value"] for m in metrics if m[0]["name"] == "c:spans/usage@none"]
     )

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -175,9 +175,9 @@ def test_span_extraction(
 @pytest.mark.parametrize(
     "sample_rate,expected_spans,expected_metrics",
     [
-        (None, 2, 6),
-        (1.0, 2, 6),
-        (0.0, 0, 0),
+        (None, 2, True),
+        (1.0, 2, True),
+        (0.0, 0, False),
     ],
 )
 def test_span_extraction_with_sampling(
@@ -231,7 +231,7 @@ def test_span_extraction_with_sampling(
 
     metrics = metrics_consumer.get_metrics()
     span_metrics = [m for (m, _) in metrics if ":spans/" in m["name"]]
-    assert len(span_metrics) == expected_metrics
+    assert bool(span_metrics) == expected_metrics
 
     spans_consumer.assert_empty()
     metrics_consumer.assert_empty()


### PR DESCRIPTION
Only extract `span.duration`, `span.exclusive_time` and `span.exclusive_time_light` if it is needed for a common or an addon insights module.

We wanted to show the span.duration in the ddm UI for all spans, but this need disappeared, so we can restrict it again.