### PR TITLE
feat(normalization): Remove feature flags for controlling normalization

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -214,29 +214,6 @@ pub struct Options {
     )]
     pub span_extraction_sample_rate: Option<f32>,
 
-    /// If true, runs full normalization in non-processing Relays.
-    ///
-    /// Doesn't apply to processing Relays. Outdated relays with a stale
-    /// protocol/normalization receiving this flag will not forward unknown
-    /// fields. Disabling the flag solves this behavior.
-    #[serde(
-        default,
-        rename = "relay.force_full_normalization",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub force_full_normalization: bool,
-
-    /// If true, disables normalization in processing Relays for events
-    /// normalized in a previous internal relay.
-    #[serde(
-        default,
-        rename = "relay.disable_normalization.processing",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub processing_disable_normalization: bool,
-
     /// The maximum duplication factor used to extrapolate distribution metrics from sampled data.
     ///
     /// This applies as long as Relay duplicates distribution values to extrapolate. The default is

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1495,15 +1495,10 @@ impl EnvelopeProcessorService {
             return Ok(());
         }
 
-        let options = &self.inner.global_config.current().options;
-
         let full_normalization = match self.inner.config.normalization_level() {
             NormalizationLevel::Full => true,
             NormalizationLevel::Default => {
-                if self.inner.config.processing_enabled()
-                    && options.processing_disable_normalization
-                    && state.event_fully_normalized
-                {
+                if self.inner.config.processing_enabled() && state.event_fully_normalized {
                     metric!(
                         counter(RelayCounters::NormalizationDecision) += 1,
                         event_type = event_type,
@@ -1517,7 +1512,7 @@ impl EnvelopeProcessorService {
                     );
                     return Ok(());
                 } else {
-                    self.inner.config.processing_enabled() || options.force_full_normalization
+                    self.inner.config.processing_enabled()
                 }
             }
         };
@@ -1659,11 +1654,7 @@ impl EnvelopeProcessorService {
             unreal::expand(state, &self.inner.config)?;
         });
 
-        event::extract(
-            state,
-            &self.inner.config,
-            &self.inner.global_config.current(),
-        )?;
+        event::extract(state, &self.inner.config)?;
 
         if_processing!(self.inner.config, {
             unreal::process(state)?;
@@ -1708,11 +1699,7 @@ impl EnvelopeProcessorService {
     ) -> Result<(), ProcessingError> {
         let global_config = self.inner.global_config.current();
 
-        event::extract(
-            state,
-            &self.inner.config,
-            &self.inner.global_config.current(),
-        )?;
+        event::extract(state, &self.inner.config)?;
 
         let profile_id = profile::filter(state);
         profile::transfer_id(state, profile_id);

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -40,7 +40,6 @@ use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
 pub fn extract<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
     config: &Config,
-    global_config: &GlobalConfig,
 ) -> Result<(), ProcessingError> {
     let event_fully_normalized = state.event_fully_normalized;
     let envelope = &mut state.envelope_mut();
@@ -69,9 +68,7 @@ pub fn extract<G: EventProcessing>(
         return Err(ProcessingError::DuplicateItem(duplicate.ty().clone()));
     }
 
-    let skip_normalization = config.processing_enabled()
-        && global_config.options.processing_disable_normalization
-        && event_fully_normalized;
+    let skip_normalization = config.processing_enabled() && event_fully_normalized;
 
     let mut sample_rates = None;
     let (event, event_len) = if let Some(mut item) = event_item.or(security_item) {

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -31,16 +31,11 @@ def drop_props(payload):
 
 
 @pytest.mark.parametrize("config_full_normalization", (False, True))
-@pytest.mark.parametrize("feat_flag_force_normalization", (False, True))
-def test_relay_with_full_normalization(
-    mini_sentry, relay, config_full_normalization, feat_flag_force_normalization
-):
+def test_relay_with_full_normalization(mini_sentry, relay, config_full_normalization):
     input, expected = get_test_data("extended-event")
 
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
-    if feat_flag_force_normalization:
-        mini_sentry.global_config["options"] = {"relay.force_full_normalization": True}
 
     relay = relay(
         upstream=mini_sentry,
@@ -52,16 +47,11 @@ def test_relay_with_full_normalization(
     relay.send_event(project_id, input)
     envelope = mini_sentry.captured_events.get(timeout=10)
 
-    if config_full_normalization or feat_flag_force_normalization:
-        assert "fully_normalized" in envelope.items[0].headers
-        assert drop_props(expected) == drop_props(envelope.get_event())
-    else:
-        assert "fully_normalized" not in envelope.items[0].headers
-        assert drop_props(expected) != drop_props(envelope.get_event())
+    assert "fully_normalized" in envelope.items[0].headers
+    assert drop_props(expected) == drop_props(envelope.get_event())
 
 
 @pytest.mark.parametrize("config_full_normalization", (False, True))
-@pytest.mark.parametrize("feat_flag_skip_normalization", (False, True))
 @pytest.mark.parametrize("request_from_internal", (False, True))
 @pytest.mark.parametrize("fully_normalized", (False, True))
 def test_processing_with_full_normalization(
@@ -70,7 +60,6 @@ def test_processing_with_full_normalization(
     relay_with_processing,
     relay_credentials,
     config_full_normalization,
-    feat_flag_skip_normalization,
     request_from_internal,
     fully_normalized,
 ):
@@ -79,10 +68,6 @@ def test_processing_with_full_normalization(
     events_consumer = events_consumer()
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
-    if feat_flag_skip_normalization:
-        mini_sentry.global_config["options"][
-            "relay.disable_normalization.processing"
-        ] = True
 
     credentials = relay_credentials()
     relay_config = {}
@@ -119,26 +104,17 @@ def test_processing_with_full_normalization(
     )
 
     ingested, _ = events_consumer.get_event(timeout=10)
-    if (
-        not config_full_normalization
-        and feat_flag_skip_normalization
-        and request_from_internal
-        and fully_normalized
-    ):
+    if not config_full_normalization and request_from_internal and fully_normalized:
         assert drop_props(expected) != drop_props(ingested)
     else:
         assert drop_props(expected) == drop_props(ingested)
 
 
 @pytest.mark.parametrize(
-    "relay_static_config_normalization, relay_force_normalization, processing_skip_normalization",
+    "relay_static_config_normalization",
     [
-        (False, False, False),  # 0. nothing enabled
-        (False, True, False),  # 1. enable flag in relay
-        (False, True, True),  # 2. enable flag in processing
-        (True, True, True),  # 3. enable config in relay
-        (True, False, True),  # x. disable config in relay still works
-        (True, False, False),  # x. disable config in processing still works
+        False,
+        True,
     ],
 )
 def test_relay_chain_normalizes_events(
@@ -148,8 +124,6 @@ def test_relay_chain_normalizes_events(
     relay,
     relay_credentials,
     relay_static_config_normalization,
-    relay_force_normalization,
-    processing_skip_normalization,
 ):
     input, expected = get_test_data("extended-event")
 
@@ -157,12 +131,6 @@ def test_relay_chain_normalizes_events(
     project_id = 42
 
     mini_sentry.add_basic_project_config(project_id)
-    if relay_force_normalization:
-        mini_sentry.global_config["options"]["relay.force_full_normalization"] = True
-    if processing_skip_normalization:
-        mini_sentry.global_config["options"][
-            "relay.disable_normalization.processing"
-        ] = True
 
     credentials = relay_credentials()
     processing = relay_with_processing(
@@ -189,9 +157,7 @@ def test_relay_chain_normalizes_events(
 
     # Running full normalization twice on the same envelope adds the errors
     # twice, one per run. The rest is the same.
-    if (
-        relay_static_config_normalization or relay_force_normalization
-    ) and not processing_skip_normalization:
+    if relay_static_config_normalization:
         assert ingested["errors"] == [
             {"name": "location", "type": "invalid_attribute"},
             {"name": "location", "type": "invalid_attribute"},
@@ -202,14 +168,12 @@ def test_relay_chain_normalizes_events(
 
 
 @pytest.mark.parametrize("config_full_normalization", (False, True))
-@pytest.mark.parametrize("feat_flag_force_normalization", (False, True))
 @pytest.mark.parametrize("dump_file_name", ("unreal_crash", "unreal_crash_apple"))
 def test_relay_doesnt_normalize_unextracted_unreal_event(
     mini_sentry,
     relay,
     dump_file_name,
     config_full_normalization,
-    feat_flag_force_normalization,
 ):
     """
     Independently of the configuration, relays forward minidumps, apple crash
@@ -217,8 +181,6 @@ def test_relay_doesnt_normalize_unextracted_unreal_event(
     """
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
-    if feat_flag_force_normalization:
-        mini_sentry.global_config["options"] = {"relay.force_full_normalization": True}
 
     relay = relay(
         mini_sentry,
@@ -243,29 +205,21 @@ def test_relay_doesnt_normalize_unextracted_unreal_event(
     assert "fully_normalized" not in envelope.items[0].headers
 
 
-@pytest.mark.parametrize("processing_skip_normalization", (False, True))
 @pytest.mark.parametrize("request_from_internal", (False, True))
 @pytest.mark.parametrize("fully_normalized", (False, True))
 @pytest.mark.parametrize("dump_file_name", ("unreal_crash", "unreal_crash_apple"))
 def test_processing_normalizes_unreal_event(
     mini_sentry,
-    events_consumer,
     attachments_consumer,
     relay_credentials,
     relay_with_processing,
-    processing_skip_normalization,
     request_from_internal,
     fully_normalized,
     dump_file_name,
 ):
-    events_consumer = events_consumer()
     attachments_consumer = attachments_consumer()
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
-    if processing_skip_normalization:
-        mini_sentry.global_config["options"][
-            "relay.disable_normalization.processing"
-        ] = True
 
     credentials = relay_credentials()
     relay_config = {"processing": {"attachment_chunk_size": "1.23 GB"}}
@@ -304,7 +258,6 @@ def test_processing_normalizes_unreal_event(
     assert event["type"] == "error"
 
 
-@pytest.mark.parametrize("processing_skip_normalization", (False, True))
 @pytest.mark.parametrize("request_from_internal", (False, True))
 @pytest.mark.parametrize("fully_normalized", (False, True))
 def test_processing_normalizes_minidump_events(
@@ -312,17 +265,12 @@ def test_processing_normalizes_minidump_events(
     attachments_consumer,
     relay_with_processing,
     relay_credentials,
-    processing_skip_normalization,
     request_from_internal,
     fully_normalized,
 ):
     attachments_consumer = attachments_consumer()
     project_id = 42
     mini_sentry.add_full_project_config(project_id)
-    if processing_skip_normalization:
-        mini_sentry.global_config["options"][
-            "relay.disable_normalization.processing"
-        ] = True
 
     credentials = relay_credentials()
     if request_from_internal:
@@ -365,12 +313,10 @@ def test_processing_normalizes_minidump_events(
 
 
 @pytest.mark.parametrize(
-    "relay_static_config_normalization, relay_force_normalization, processing_skip_normalization",
+    "relay_static_config_normalization",
     [
-        (False, False, False),
-        (False, True, False),
-        (False, True, True),
-        (True, True, True),
+        False,
+        True,
     ],
 )
 def test_relay_chain_normalizes_minidump_events(
@@ -380,7 +326,6 @@ def test_relay_chain_normalizes_minidump_events(
     relay,
     relay_credentials,
     relay_static_config_normalization,
-    relay_force_normalization,
     processing_skip_normalization,
 ):
 
@@ -388,12 +333,6 @@ def test_relay_chain_normalizes_minidump_events(
     project_id = 42
 
     mini_sentry.add_basic_project_config(project_id)
-    if relay_force_normalization:
-        mini_sentry.global_config["options"]["relay.force_full_normalization"] = True
-    if processing_skip_normalization:
-        mini_sentry.global_config["options"][
-            "relay.disable_normalization.processing"
-        ] = True
 
     credentials = relay_credentials()
     processing = relay_with_processing(

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1375,14 +1375,12 @@ def test_error_with_type_transaction_fixed_by_inference(
     events_consumer.assert_empty()
 
 
-@pytest.mark.parametrize("processing_disable_normalization", [False, True])
 def test_error_with_type_transaction_fixed_by_inference_even_if_only_feature_flags(
     mini_sentry,
     events_consumer,
     relay_with_processing,
     relay,
     relay_credentials,
-    processing_disable_normalization,
 ):
     """
     Ensure Relay sets the correct type for bogus payloads of errors with
@@ -1392,11 +1390,6 @@ def test_error_with_type_transaction_fixed_by_inference_even_if_only_feature_fla
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
     events_consumer = events_consumer()
-
-    if processing_disable_normalization:
-        mini_sentry.global_config["options"] = {
-            "relay.disable_normalization.processing": True,
-        }
 
     credentials = relay_credentials()
     processing = relay_with_processing(


### PR DESCRIPTION
This PR removes all the feature flags that were controlling full normalization on PoP and processing Relays.

Merge this PR first: https://github.com/getsentry/ops/pull/11253
Closes: https://github.com/getsentry/team-ingest/issues/363

#skip-changelog