### PR TITLE
fix(normalization): Added parsing of raw OS description for iOS and iPadOS coming from Unity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**:
 
+- Fixes raw OS description parsing for iOS and iPadOS originating from the Unity SDK ([#3780]https://github.com/getsentry/relay/pull/3780)
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**:
 
-- Fixes raw OS description parsing for iOS and iPadOS originating from the Unity SDK ([#3780]https://github.com/getsentry/relay/pull/3780)
+- Fixes raw OS description parsing for iOS and iPadOS originating from the Unity SDK. ([#3780]https://github.com/getsentry/relay/pull/3780)
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**:
 
-- Fixes raw OS description parsing for iOS and iPadOS originating from the Unity SDK. ([#3780]https://github.com/getsentry/relay/pull/3780)
+- Fixes raw OS description parsing for iOS and iPadOS originating from the Unity SDK. ([#3780](https://github.com/getsentry/relay/pull/3780))
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 


### PR DESCRIPTION
The Unity SDK reports the OS via raw description in the following format:
```
Mac OS X 14.4.1
iPadOS 17.5.1
iOS 17.5.1
Android OS 14 / API-34 (AP2A.240605.024/11860263)
```

The context normalization deals just fine with macOS and Android but skips iOS and iPadOS and sets the version into the `kernel_version` instead. This seems to lead to missing `os`  tags as reported by a user:
![image](https://github.com/getsentry/relay/assets/25725783/77b6cc6c-143d-461a-8616-85d7e27526dc)

Looking at the automatically created tags I get
```
"tags": [
    [
      "device",
      "Mac15,8"
    ],
    [
      "os",
      "macOS 14.4.1"
    ],
    [
      "os.name",
      "macOS"
    ],
  ],
```
and
```
"tags": [
    [
      "device",
      "Google Pixel 6"
    ],
    [
      "os",
      "Android 14"
    ],
    [
      "os.name",
      "Android"
    ],
  ],
```
for macOS and Android but end up with only `os.name` on the mobile devices:
```
  "tags": [
    [
      "device",
      "iPad11,1"
    ],
    [
      "os.name",
      "iPadOS"
    ],
  ],
```

The deleted test also indicates, that this behaviour is not necessarily intentional in the first place.