### PR TITLE
ref(metrics): Flatten aggregator config

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2361,10 +2361,10 @@ impl Config {
             mut max_tag_value_length,
             mut max_project_key_bucket_bytes,
             ..
-        } = AggregatorConfig::from(self.default_aggregator_config());
+        } = self.default_aggregator_config().aggregator;
 
         for secondary_config in self.secondary_aggregator_configs() {
-            let agg = &secondary_config.config;
+            let agg = &secondary_config.config.aggregator;
 
             bucket_interval = bucket_interval.min(agg.bucket_interval);
             max_secs_in_past = max_secs_in_past.max(agg.max_secs_in_past);
@@ -2382,7 +2382,7 @@ impl Config {
             .map(|sc| &sc.config)
             .chain(std::iter::once(self.default_aggregator_config()))
         {
-            if agg.bucket_interval % bucket_interval != 0 {
+            if agg.aggregator.bucket_interval % bucket_interval != 0 {
                 relay_log::error!("buckets don't align");
             }
         }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -29,7 +29,6 @@ use relay_event_schema::protocol::{
     ClientReport, Event, EventId, EventType, IpAddr, Metrics, NetworkReportError,
 };
 use relay_filter::FilterStatKey;
-use relay_metrics::aggregator::AggregatorConfig;
 use relay_metrics::{
     Bucket, BucketMetadata, BucketValue, BucketView, BucketsView, FiniteF64, MetricMeta,
     MetricNamespace,
@@ -1426,6 +1425,7 @@ impl EnvelopeProcessorService {
             self.inner
                 .config
                 .aggregator_config_for(MetricNamespace::Spans)
+                .aggregator
                 .max_tag_value_length,
             global.options.span_extraction_sample_rate,
         );
@@ -1555,7 +1555,7 @@ impl EnvelopeProcessorService {
                 max_secs_in_past: Some(self.inner.config.max_secs_in_past()),
                 max_secs_in_future: Some(self.inner.config.max_secs_in_future()),
                 transaction_timestamp_range: Some(
-                    AggregatorConfig::from(transaction_aggregator_config).timestamp_range(),
+                    transaction_aggregator_config.aggregator.timestamp_range(),
                 ),
                 is_validated: false,
             };
@@ -1589,6 +1589,7 @@ impl EnvelopeProcessorService {
                 },
                 max_name_and_unit_len: Some(
                     transaction_aggregator_config
+                        .aggregator
                         .max_name_length
                         .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),
                 ),
@@ -1611,6 +1612,7 @@ impl EnvelopeProcessorService {
                     .inner
                     .config
                     .aggregator_config_for(MetricNamespace::Spans)
+                    .aggregator
                     .max_tag_value_length,
                 is_renormalize: false,
                 remove_other: full_normalization,

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -18,7 +18,7 @@ use relay_event_normalization::{normalize_transaction_name, ModelCosts};
 use relay_event_schema::processor::{process_value, ProcessingState};
 use relay_event_schema::protocol::{BrowserContext, Contexts, Event, Span, SpanData};
 use relay_log::protocol::{Attachment, AttachmentType};
-use relay_metrics::{aggregator::AggregatorConfig, MetricNamespace, UnixTimestamp};
+use relay_metrics::{MetricNamespace, UnixTimestamp};
 use relay_pii::PiiProcessor;
 use relay_protocol::{Annotated, Empty};
 use relay_quotas::DataCategory;
@@ -360,6 +360,7 @@ pub fn extract_from_event(
         event,
         config
             .aggregator_config_for(MetricNamespace::Spans)
+            .aggregator
             .max_tag_value_length,
     ) else {
         return;
@@ -434,21 +435,19 @@ fn get_normalize_span_config<'a>(
     performance_score: Option<&'a PerformanceScoreConfig>,
     ai_model_costs: Option<&'a ModelCosts>,
 ) -> NormalizeSpanConfig<'a> {
-    let aggregator_config =
-        AggregatorConfig::from(config.aggregator_config_for(MetricNamespace::Spans));
+    let aggregator_config = config.aggregator_config_for(MetricNamespace::Spans);
 
     NormalizeSpanConfig {
         received_at,
-        timestamp_range: aggregator_config.timestamp_range(),
-        max_tag_value_size: config
-            .aggregator_config_for(MetricNamespace::Spans)
-            .max_tag_value_length,
+        timestamp_range: aggregator_config.aggregator.timestamp_range(),
+        max_tag_value_size: aggregator_config.aggregator.max_tag_value_length,
         measurements: Some(CombinedMeasurementsConfig::new(
             project_measurements_config,
             global_measurements_config,
         )),
         max_name_and_unit_len: Some(
             aggregator_config
+                .aggregator
                 .max_name_length
                 .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),
         ),


### PR DESCRIPTION
`AggregatorServiceConfig` duplicates all of `AggregatorConfig` fields unnecessarily. Use `#[serde(flatten)]` to deduplicate.

The idea behind having two different types was that `Aggregator` should not get config fields that are a concern of `AggregatorService`. Since this affects only two fields, the alternative would be to remove `AggregatorServiceConfig` and put everything in `AggregatorConfig` again.

#skip-changelog