### PR TITLE
fix(spans): Propagate profiler_id to all spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
 - Make sure outcomes for dropped profiles are consistent between indexed and non-indexed categories. ([#3767](https://github.com/getsentry/relay/pull/3767))
 - Add web vitals support for mobile browsers. ([#3762](https://github.com/getsentry/relay/pull/3762))
-- Accept profiler_id in the profile context. ([#3714](https://github.com/getsentry/relay/pull/3714))
+- Ingest profiler_id in the profile context and in spans. ([#3714](https://github.com/getsentry/relay/pull/3714), [#3784](https://github.com/getsentry/relay/pull/3784))
 - Support extrapolation of metrics extracted from sampled data, as long as the sample rate is set in the DynamicSamplingContext. ([#3753](https://github.com/getsentry/relay/pull/3753))
 
 ## 24.6.0

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -333,7 +333,7 @@ fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
         .context::<ProfileContext>()
         .and_then(|profile_context| profile_context.profiler_id.value())
     {
-        tags.insert(SpanTagKey::ProfilerId, profiler_id.into());
+        tags.insert(SpanTagKey::ProfilerId, profiler_id.to_string());
     }
 
     tags.insert(SpanTagKey::SdkName, event.sdk_name().into());


### PR DESCRIPTION
Now that we ingest `profiler_id` in the context properly, we can propagate it to all spans so it gets ingested as part of the `sentry_tags`.