### PR TITLE
build(lib): Update manylinux container to 2_28

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -2,8 +2,8 @@ name: Library Release Build
 
 on:
   push:
-    # branches:
-    #   - release-library/**
+    branches:
+      - release-library/**
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -2,8 +2,8 @@ name: Library Release Build
 
 on:
   push:
-    branches:
-      - release-library/**
+    # branches:
+    #   - release-library/**
 
 env:
   CARGO_TERM_COLOR: always

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Build wheels with manylinux_2_28 and alma linux 8. [#3787](https://github.com/getsentry/relay/pull/3787)
+
 ## 0.8.67
 
 ### Various fixes & improvements

--- a/py/Dockerfile
+++ b/py/Dockerfile
@@ -9,10 +9,6 @@ RUN yum -y update \
     perl-core openssl openssl-devel pkgconfig libatomic \
     && if [ "$(uname -m)" != ${TARGET} ]; then \
     yum install -y "binutils-${TARGET}-linux-gnu" "gcc-${TARGET}-linux-gnu" "gcc-c++-${TARGET}-linux-gnu" \
-    && if [ ${TARGET} == "aarch64" ]; then \
-    curl -L -s https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7-aarch64 > /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64 \
-    && cat /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64 >> /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 ; \
-    fi \
     && dnf --forcearch "${TARGET}" --releasever=8 install -y gcc glibc glibc-devel --installroot "/usr/${TARGET}-linux-gnu/sys-root/" || true \
     && ln -s "/usr/${TARGET}-linux-gnu/sys-root/usr/lib64/libgcc_s.so.1" "/usr/${TARGET}-linux-gnu/sys-root/usr/lib64/libgcc_s.so"; \
     fi \

--- a/py/Dockerfile
+++ b/py/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/centos:7
+FROM almalinux:8
 
 # This must be lower case - used in the paths and packages names
 ARG TARGET
@@ -13,7 +13,7 @@ RUN yum -y update \
     curl -L -s https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7-aarch64 > /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64 \
     && cat /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64 >> /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 ; \
     fi \
-    && dnf --forcearch "${TARGET}" --release 7 install -y gcc glibc glibc-devel --installroot "/usr/${TARGET}-linux-gnu/sys-root/" || true \
+    && dnf --forcearch "${TARGET}" --releasever=8 install -y gcc glibc glibc-devel --installroot "/usr/${TARGET}-linux-gnu/sys-root/" || true \
     && ln -s "/usr/${TARGET}-linux-gnu/sys-root/usr/lib64/libgcc_s.so.1" "/usr/${TARGET}-linux-gnu/sys-root/usr/lib64/libgcc_s.so"; \
     fi \
     && yum clean all \

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -34,7 +34,7 @@ docker run \
   -v "$(pwd):/work" \
   -e SKIP_RELAY_LIB_BUILD=1 \
   -e CARGO_BUILD_TARGET \
-  quay.io/pypa/manylinux2014_${TARGET} \
+  quay.io/pypa/manylinux_2_28_${TARGET} \
   sh manylinux.sh
 
 # Fix permissions for shared directories


### PR DESCRIPTION
- Updates to manylinux_2_28
- Updates the build container to almalinux 8, same which is used for the manylinux_2_28 container

Fixes: #3785

Job ran successfully [here](https://github.com/getsentry/relay/actions/runs/9790363501/job/27031819448?pr=3787)