### PR TITLE
feat(rule-condition): Add `any` and `all` loop conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
+**Features**:
+
+- Add support for `all` and `any` `RuleCondition`(s). ([#3791](https://github.com/getsentry/relay/pull/3791))
+
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
-**Features**:
-
-- Add support for `all` and `any` `RuleCondition`(s). ([#3791](https://github.com/getsentry/relay/pull/3791))
-
 **Internal**:
 
 - Aggregate metrics before rate limiting. ([#3746](https://github.com/getsentry/relay/pull/3746))
@@ -21,6 +17,7 @@
 - Support extrapolation of metrics extracted from sampled data, as long as the sample rate is set in the DynamicSamplingContext. ([#3753](https://github.com/getsentry/relay/pull/3753))
 - Extract thread ID and name in spans. ([#3771](https://github.com/getsentry/relay/pull/3771))
 - Compute metrics summary on the extracted custom metrics. ([#3769](https://github.com/getsentry/relay/pull/3769))
+- Add support for `all` and `any` `RuleCondition`(s). ([#3791](https://github.com/getsentry/relay/pull/3791))
 
 ## 24.6.0
 

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -810,7 +810,7 @@ impl Getter for Event {
 
     fn get_iter(&self, path: &str) -> Option<GetterIter<'_>> {
         Some(match path.strip_prefix("event.")? {
-            "exceptions.values" => {
+            "exception.values" => {
                 GetterIter::new_annotated(self.exceptions.value()?.values.value()?)
             }
             _ => return None,
@@ -1267,7 +1267,7 @@ mod tests {
             event.get_value("event.transaction.source")
         );
 
-        let mut exceptions = event.get_iter("event.exceptions.values").unwrap();
+        let mut exceptions = event.get_iter("event.exception.values").unwrap();
         let exception = exceptions.next().unwrap();
         assert_eq!(
             Some(Val::String("canvas.contentDocument")),

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -5,7 +5,7 @@ use relay_common::time;
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;
 use relay_protocol::{
-    Annotated, Arr, Array, Empty, FromValue, Getter, GetterIter, IntoValue, Object, Val, Value,
+    Annotated, Array, Empty, FromValue, Getter, GetterIter, IntoValue, Object, Val, Value,
 };
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema};

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -816,16 +816,6 @@ impl Getter for Event {
     }
 }
 
-impl Getter for Exception {
-    fn get_value(&self, path: &str) -> Option<Val<'_>> {
-        Some(match path {
-            "ty" => self.ty.as_str()?.into(),
-            "value" => self.value.as_str()?.into(),
-            _ => return None,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -810,7 +810,9 @@ impl Getter for Event {
 
     fn get_iter(&self, path: &str) -> Option<GetterIter<'_>> {
         Some(match path.strip_prefix("event.")? {
-            "exceptions" => GetterIter::new_annotated(self.exceptions.value()?.values.value()?),
+            "exceptions.values" => {
+                GetterIter::new_annotated(self.exceptions.value()?.values.value()?)
+            }
             _ => return None,
         })
     }
@@ -1264,6 +1266,14 @@ mod tests {
             Some(Val::String("route")),
             event.get_value("event.transaction.source")
         );
+
+        let mut exceptions = event.get_iter("event.exceptions.values").unwrap();
+        let exception = exceptions.next().unwrap();
+        assert_eq!(
+            Some(Val::String("canvas.contentDocument")),
+            exception.get_value("value")
+        );
+        assert!(exceptions.next().is_none());
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -4,7 +4,9 @@ use std::str::FromStr;
 use relay_common::time;
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;
-use relay_protocol::{Annotated, Array, Empty, FromValue, Getter, IntoValue, Object, Val, Value};
+use relay_protocol::{
+    Annotated, Arr, Array, Empty, FromValue, Getter, GetterIter, IntoValue, Object, Val, Value,
+};
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema};
 use sentry_release_parser::Release as ParsedRelease;
@@ -803,6 +805,23 @@ impl Getter for Event {
                     return None;
                 }
             }
+        })
+    }
+
+    fn get_iter(&self, path: &str) -> Option<GetterIter<'_>> {
+        Some(match path.strip_prefix("event.")? {
+            "exceptions" => GetterIter::new_annotated(self.exceptions.value()?.values.value()?),
+            _ => return None,
+        })
+    }
+}
+
+impl Getter for Exception {
+    fn get_value(&self, path: &str) -> Option<Val<'_>> {
+        Some(match path {
+            "ty" => self.ty.as_str()?.into(),
+            "value" => self.value.as_str()?.into(),
+            _ => return None,
         })
     }
 }

--- a/relay-event-schema/src/protocol/exception.rs
+++ b/relay-event-schema/src/protocol/exception.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "jsonschema")]
 use relay_jsonschema_derive::JsonSchema;
-use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
+use relay_protocol::{Annotated, Empty, FromValue, Getter, IntoValue, Object, Val, Value};
 
 use crate::processor::ProcessValue;
 use crate::protocol::{JsonLenientString, Mechanism, RawStacktrace, Stacktrace, ThreadId};
@@ -70,6 +70,16 @@ pub struct Exception {
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,
+}
+
+impl Getter for Exception {
+    fn get_value(&self, path: &str) -> Option<Val<'_>> {
+        Some(match path {
+            "ty" => self.ty.as_str()?.into(),
+            "value" => self.value.as_str()?.into(),
+            _ => return None,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -307,6 +307,87 @@ impl NotCondition {
     }
 }
 
+/// Combines multiple conditions using logical AND.
+///
+/// This condition matches if **all** of the inner conditions match. The default value for this
+/// condition is `true`, that is, this rule matches if there are no inner conditions.
+///
+/// See [`RuleCondition::and`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopCondition {
+    /// Path of the field that should match the value.
+    pub name: String,
+    /// Inner rule to match on each element.
+    pub inner: Box<RuleCondition>,
+}
+
+impl LoopCondition {
+    fn supported(&self) -> bool {
+        self.inner.supported()
+    }
+    fn matches<T>(&self, instance: &T) -> bool
+    where
+        T: Getter + ?Sized,
+    {
+        let Some(Val::Array(arr)) = instance.get_value(self.name.as_str()) else {
+            return false;
+        };
+
+        for i in 0..arr.length {
+            let prefix = format!("{}.{}", self.name.as_str(), i);
+            // TODO: we might want to explore how to keep a single cloned copy and mutate that
+            //  in place each time.
+            let mut inner = self.inner.clone();
+            apply_prefix(prefix.as_str(), inner.as_mut());
+            if inner.matches(instance) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+fn apply_prefix(prefix: &str, condition: &mut RuleCondition) {
+    match condition {
+        RuleCondition::Eq(eq) => {
+            eq.name = format!("{}.{}", prefix, eq.name);
+        }
+        RuleCondition::Gte(gte) => {
+            gte.name = format!("{}.{}", prefix, gte.name);
+        }
+        RuleCondition::Lte(lte) => {
+            lte.name = format!("{}.{}", prefix, lte.name);
+        }
+        RuleCondition::Gt(gt) => {
+            gt.name = format!("{}.{}", prefix, gt.name);
+        }
+        RuleCondition::Lt(lt) => {
+            lt.name = format!("{}.{}", prefix, lt.name);
+        }
+        RuleCondition::Glob(glob) => {
+            glob.name = format!("{}.{}", prefix, glob.name);
+        }
+        RuleCondition::Or(or) => {
+            for element in or.inner.iter_mut() {
+                apply_prefix(prefix, element);
+            }
+        }
+        RuleCondition::And(and) => {
+            for element in and.inner.iter_mut() {
+                apply_prefix(prefix, element);
+            }
+        }
+        RuleCondition::Not(not) => {
+            apply_prefix(prefix, not.inner.as_mut());
+        }
+        RuleCondition::Loop(_loop) => {
+            apply_prefix(prefix, _loop.inner.as_mut());
+        }
+        RuleCondition::Unsupported => {}
+    }
+}
+
 /// A condition that can be evaluated on structured data.
 ///
 /// The basic conditions are [`eq`](Self::eq), [`glob`](Self::glob), and the comparison operators.
@@ -444,6 +525,15 @@ pub enum RuleCondition {
     /// let condition = !RuleCondition::eq("obj.status", "invalid");
     /// ```
     Not(NotCondition),
+
+    /// Loops over an array field and returns true if at least one element matches
+    /// the inner condition.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// ```
+    Loop(LoopCondition),
 
     /// An unsupported condition for future compatibility.
     #[serde(other)]
@@ -655,6 +745,7 @@ impl RuleCondition {
             RuleCondition::And(rules) => rules.supported(),
             RuleCondition::Or(rules) => rules.supported(),
             RuleCondition::Not(rule) => rule.supported(),
+            RuleCondition::Loop(rule) => rule.supported(),
         }
     }
 
@@ -673,6 +764,7 @@ impl RuleCondition {
             RuleCondition::And(conditions) => conditions.matches(value),
             RuleCondition::Or(conditions) => conditions.matches(value),
             RuleCondition::Not(condition) => condition.matches(value),
+            RuleCondition::Loop(condition) => condition.matches(value),
             RuleCondition::Unsupported => false,
         }
     }
@@ -705,21 +797,45 @@ impl std::ops::Not for RuleCondition {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Annotated, Array};
+
+    struct Exception {
+        name: String,
+    }
 
     struct MockDSC {
         transaction: String,
         release: String,
         environment: String,
         user_segment: String,
+        exceptions: Array<Exception>,
     }
 
     impl Getter for MockDSC {
         fn get_value(&self, path: &str) -> Option<Val<'_>> {
-            Some(match path.strip_prefix("trace.")? {
+            let path = path.strip_prefix("trace.")?;
+            let mut components = path.split('.');
+
+            Some(match components.next()? {
                 "transaction" => self.transaction.as_str().into(),
                 "release" => self.release.as_str().into(),
                 "environment" => self.environment.as_str().into(),
-                "user.segment" => self.user_segment.as_str().into(),
+                "user" => match components.next()? {
+                    "segment" => self.user_segment.as_str().into(),
+                    _ => return None,
+                },
+                "exceptions" => {
+                    if let Some(value) = components.next() {
+                        let index: usize = value.parse().ok()?;
+                        let v = self.exceptions.get(index)?.value()?;
+                        match components.next()? {
+                            "name" => v.name.as_str().into(),
+                            _ => return None,
+                        }
+                    } else {
+                        (&self.exceptions).into()
+                    }
+                }
                 _ => {
                     return None;
                 }
@@ -733,6 +849,9 @@ mod tests {
             release: "1.1.1".to_string(),
             environment: "debug".to_string(),
             user_segment: "vip".to_string(),
+            exceptions: vec![Annotated::new(Exception {
+                name: "NullPointerException".to_string(),
+            })],
         }
     }
 
@@ -1092,5 +1211,17 @@ mod tests {
             let failure_name = format!("Failed on test: '{rule_test_name}'!!!");
             assert!(!condition.matches(&dsc), "{failure_name}");
         }
+    }
+
+    #[test]
+    fn test_loop_condition() {
+        let condition = RuleCondition::Loop(LoopCondition {
+            name: "trace.exceptions".to_string(),
+            inner: Box::new(RuleCondition::glob("name", "*Exception")),
+        });
+
+        let dsc = mock_dsc();
+
+        assert_eq!(condition.matches(&dsc), true);
     }
 }

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -737,7 +737,7 @@ impl RuleCondition {
         }
     }
 
-    /// Creates a [`AnyCondition`].
+    /// Creates an [`AnyCondition`].
     ///
     /// # Example
     ///

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -838,7 +838,7 @@ impl std::ops::Not for RuleCondition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Array, GetterIter};
+    use crate::GetterIter;
 
     #[derive(Debug)]
     struct Exception {

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -744,7 +744,7 @@ impl RuleCondition {
     /// ```
     /// use relay_protocol::RuleCondition;
     ///
-    /// let condition = RuleCondition::for_any("event.exceptions",
+    /// let condition = RuleCondition::for_any("event.exception.values",
     ///     RuleCondition::eq("name", "NullPointerException")
     /// );
     /// ```

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -752,7 +752,7 @@ impl RuleCondition {
         Self::Any(AnyCondition::new(field, inner))
     }
 
-    /// Creates a [`AllCondition`].
+    /// Creates an [`AllCondition`].
     ///
     /// # Example
     ///

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -525,7 +525,7 @@ pub enum RuleCondition {
     /// ```
     /// use relay_protocol::RuleCondition;
     ///
-    /// let condition = RuleCondition::for_any("event.exceptions",
+    /// let condition = RuleCondition::for_any("obj.exceptions",
     ///     RuleCondition::eq("name", "NullPointerException")
     /// );
     /// ```
@@ -538,7 +538,7 @@ pub enum RuleCondition {
     /// ```
     /// use relay_protocol::RuleCondition;
     ///
-    /// let condition = RuleCondition::for_all("event.exceptions",
+    /// let condition = RuleCondition::for_all("obj.exceptions",
     ///     RuleCondition::eq("name", "NullPointerException")
     /// );
     /// ```
@@ -744,7 +744,7 @@ impl RuleCondition {
     /// ```
     /// use relay_protocol::RuleCondition;
     ///
-    /// let condition = RuleCondition::for_any("event.exception.values",
+    /// let condition = RuleCondition::for_any("obj.exceptions",
     ///     RuleCondition::eq("name", "NullPointerException")
     /// );
     /// ```
@@ -759,7 +759,7 @@ impl RuleCondition {
     /// ```
     /// use relay_protocol::RuleCondition;
     ///
-    /// let condition = RuleCondition::for_all("event.exceptions",
+    /// let condition = RuleCondition::for_all("obj.exceptions",
     ///     RuleCondition::eq("name", "NullPointerException")
     /// );
     /// ```
@@ -947,7 +947,7 @@ mod tests {
             },
             {
                 "op": "any",
-                "name": "event.exceptions",
+                "name": "obj.exceptions",
                 "inner": {
                     "op": "glob",
                     "name": "value",
@@ -956,7 +956,7 @@ mod tests {
             },
             {
                 "op": "all",
-                "name": "event.exceptions",
+                "name": "obj.exceptions",
                 "inner": {
                     "op": "glob",
                     "name": "value",
@@ -1033,7 +1033,7 @@ mod tests {
           ),
           AnyCondition(
             op: "any",
-            name: "event.exceptions",
+            name: "obj.exceptions",
             inner: GlobCondition(
               op: "glob",
               name: "value",
@@ -1044,7 +1044,7 @@ mod tests {
           ),
           AllCondition(
             op: "all",
-            name: "event.exceptions",
+            name: "obj.exceptions",
             inner: GlobCondition(
               op: "glob",
               name: "value",

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -125,8 +125,9 @@ pub trait IntoValue: Debug + Empty {
     }
 }
 
-/// Hides an iterator of [`Getter`]s that is used to iterate over arbitrary [`Getter`]
-/// implementations.
+/// A type-erased iterator over a collection of [`Getter`]s.
+///
+/// This type is usually returned from [`Getter::get_iter`]. 
 ///
 /// # Example
 ///

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -203,7 +203,7 @@ impl<'a> GetterIter<'a> {
         }
     }
 
-    /// Creates a new [`GetterIter`] given an element that can be converted into an iterator of
+    /// Creates a new [`GetterIter`] given a collection of
     /// [`Annotated`]s whose type implement [`Getter`].
     pub fn new_annotated<I, T>(iterator: I) -> Self
     where

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -294,8 +294,9 @@ pub trait Getter {
     /// Returns the serialized value of a field pointed to by a `path`.
     fn get_value(&self, path: &str) -> Option<Val<'_>>;
 
-    /// Returns a [`GetterIter`] that allows iteration on [`Getter`] implementations
-    /// of fields pointed on by `path`.
+    /// Returns an iterator over the array pointed to by a `path`.
+    ///
+    /// If the path does not exist or is not an array, this returns `None`. Note that `get_value` may not return a value for paths that expose an iterator.
     fn get_iter(&self, _path: &str) -> Option<GetterIter<'_>> {
         None
     }

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -127,35 +127,35 @@ pub trait IntoValue: Debug + Empty {
 
 /// A type-erased iterator over a collection of [`Getter`]s.
 ///
-/// This type is usually returned from [`Getter::get_iter`]. 
+/// This type is usually returned from [`Getter::get_iter`].
 ///
 /// # Example
 ///
 /// ```
 /// use relay_protocol::{Getter, GetterIter, Val};
 ///
-/// struct Exception {
-///     name: String,
+/// struct Nested {
+///     nested_value: String,
 /// }
 ///
-/// impl Getter for Exception {
+/// impl Getter for Nested {
 ///     fn get_value(&self, path: &str) -> Option<Val<'_>> {
 ///         Some(match path {
-///             "name" => self.name.as_str().into(),
+///             "nested_value" => self.nested_value.as_str().into(),
 ///                _ => return None,
 ///         })
 ///     }
 /// }
 ///
-/// struct Error {
-///     platform: String,
-///     exceptions: Vec<Exception>,
+/// struct Root {
+///     value_1: String,
+///     value_2: Vec<Nested>,
 /// }
 ///
-/// impl Getter for Error {
+/// impl Getter for Root {
 ///     fn get_value(&self, path: &str) -> Option<Val<'_>> {
-///         Some(match path.strip_prefix("error.")? {
-///             "platform" => self.platform.as_str().into(),
+///         Some(match path.strip_prefix("root.")? {
+///             "value_1" => self.value_1.as_str().into(),
 ///             _ => {
 ///                 return None;
 ///             }
@@ -165,8 +165,8 @@ pub trait IntoValue: Debug + Empty {
 ///     // `get_iter` should return a `GetterIter` that can be used for iterating on the
 ///     // `Getter`(s).
 ///     fn get_iter(&self, path: &str) -> Option<GetterIter<'_>> {
-///         Some(match path.strip_prefix("error.")? {
-///             "exceptions" => GetterIter::new(self.exceptions.iter()),
+///         Some(match path.strip_prefix("root.")? {
+///             "value_2" => GetterIter::new(self.value_2.iter()),
 ///             _ => return None,
 ///         })
 ///     }
@@ -176,12 +176,12 @@ pub trait IntoValue: Debug + Empty {
 /// fn matches<T>(instance: &T) -> bool
 ///     where T: Getter + ?Sized
 /// {
-///     let Some(mut getter_iter) = instance.get_iter("error.exceptions") else {
+///     let Some(mut getter_iter) = instance.get_iter("root.value_2") else {
 ///         return false;
 ///     };
 ///
 ///     for getter in getter_iter {
-///         let exception_name = getter.get_value("name");
+///         let nested_value = getter.get_value("nested_value");
 ///     }
 ///
 ///     true

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -4,13 +4,11 @@ use serde::de::{Deserialize, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::{fmt, str};
 use uuid::Uuid;
 
 use crate::annotated::Annotated;
 use crate::meta::Meta;
-use crate::Getter;
 
 /// Alias for typed arrays.
 pub type Array<T> = Vec<Annotated<T>>;

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -1,14 +1,16 @@
-use std::collections::BTreeMap;
-use std::{fmt, str};
-
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::de::{Deserialize, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::{fmt, str};
 use uuid::Uuid;
 
 use crate::annotated::Annotated;
 use crate::meta::Meta;
+use crate::Getter;
 
 /// Alias for typed arrays.
 pub type Array<T> = Vec<Annotated<T>>;
@@ -354,7 +356,6 @@ where
 /// Borrowed version of [`Array`].
 #[derive(Debug, Clone, Copy)]
 pub struct Arr<'a> {
-    pub length: usize,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
@@ -494,23 +495,13 @@ impl<'a> From<&'a Value> for Val<'a> {
             Value::U64(value) => Self::U64(*value),
             Value::F64(value) => Self::F64(*value),
             Value::String(value) => Self::String(value),
-            Value::Array(value) => Self::Array(Arr {
-                length: value.len(),
+            Value::Array(_) => Self::Array(Arr {
                 _phantom: Default::default(),
             }),
             Value::Object(_) => Self::Object(Obj {
                 _phantom: Default::default(),
             }),
         }
-    }
-}
-
-impl<'a, T> From<&'a Array<T>> for Val<'a> {
-    fn from(value: &'a Array<T>) -> Self {
-        Self::Array(Arr {
-            length: value.len(),
-            _phantom: Default::default(),
-        })
     }
 }
 

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -1,10 +1,11 @@
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::{fmt, str};
+
 #[cfg(feature = "jsonschema")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::de::{Deserialize, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
-use std::collections::BTreeMap;
-use std::fmt::Debug;
-use std::{fmt, str};
 use uuid::Uuid;
 
 use crate::annotated::Annotated;

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -354,6 +354,7 @@ where
 /// Borrowed version of [`Array`].
 #[derive(Debug, Clone, Copy)]
 pub struct Arr<'a> {
+    pub length: usize,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
@@ -493,13 +494,23 @@ impl<'a> From<&'a Value> for Val<'a> {
             Value::U64(value) => Self::U64(*value),
             Value::F64(value) => Self::F64(*value),
             Value::String(value) => Self::String(value),
-            Value::Array(_) => Self::Array(Arr {
+            Value::Array(value) => Self::Array(Arr {
+                length: value.len(),
                 _phantom: Default::default(),
             }),
             Value::Object(_) => Self::Object(Obj {
                 _phantom: Default::default(),
             }),
         }
+    }
+}
+
+impl<'a, T> From<&'a Array<T>> for Val<'a> {
+    fn from(value: &'a Array<T>) -> Self {
+        Self::Array(Arr {
+            length: value.len(),
+            _phantom: Default::default(),
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds new rules for `any` and `all` behaviors in the `RuleCondition` DSL. The new rules allow to match on special fields that return iterators of their own `Getter` implementations.

This work is the foundation for moving existing inbound filters to the generic inbound filters implementation.