### PR TITLE
fix(redis): Fix Redis data corruption on connection timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,9 +1442,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2717,11 +2717,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2760,11 +2759,10 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -3031,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -3455,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "redis"
 version = "0.25.3"
-source = "git+https://github.com/redis-rs/redis-rs.git?rev=7e79e3a380a07eb0c1e559d9afa9152a87d2e50c#7e79e3a380a07eb0c1e559d9afa9152a87d2e50c"
+source = "git+https://github.com/redis-rs/redis-rs.git?rev=939e5df6f9cc976b0a53987f6eb3f76b2c398bd6#939e5df6f9cc976b0a53987f6eb3f76b2c398bd6"
 dependencies = [
  "arc-swap",
  "combine",
@@ -5900,12 +5898,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,8 @@ rand = "0.8.5"
 rand_pcg = "0.3.1"
 rdkafka = "0.29.0"
 rdkafka-sys = "4.3.0"
-# Git revision until https://github.com/redis-rs/redis-rs/pull/1097 is released (already merged).
-redis = { git = "https://github.com/redis-rs/redis-rs.git", rev = "7e79e3a380a07eb0c1e559d9afa9152a87d2e50c", default-features = false }
+# Git revision until https://github.com/redis-rs/redis-rs/pull/1097 (merged) and https://github.com/redis-rs/redis-rs/pull/1253 are released.
+redis = { git = "https://github.com/redis-rs/redis-rs.git", rev = "939e5df6f9cc976b0a53987f6eb3f76b2c398bd6", default-features = false }
 regex = "1.10.2"
 reqwest = "0.11.1"
 rmp-serde = "1.1.1"
@@ -175,7 +175,7 @@ tracing-subscriber = "0.3.17"
 uaparser = "0.6.0"
 unescaper = "0.1.4"
 unicase = "2.6.0"
-url = "2.1.1"
+url = "2.5.2"
 utf16string = "0.2.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 walkdir = "2.3.2"


### PR DESCRIPTION
Updates Redis to PR https://github.com/redis-rs/redis-rs/pull/1253 which addresses https://github.com/redis-rs/redis-rs/issues/1252 which we've been seeing occasionally in production.

#skip-changelog