### PR TITLE
fix(spans): Fixes span outcomes and inherited rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixes raw OS description parsing for iOS and iPadOS originating from the Unity SDK. ([#3780](https://github.com/getsentry/relay/pull/3780))
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
+- Incorrect span outcomes when generated from a indexed transaction quota. ([#3793](https://github.com/getsentry/relay/pull/3793))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
 
 **Internal**:

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -50,7 +50,7 @@ use tokio::sync::Semaphore;
 use {
     crate::metrics::MetricsLimiter,
     crate::services::store::{Store, StoreEnvelope},
-    crate::utils::{sample, EnvelopeLimiter, ItemAction},
+    crate::utils::{sample, Enforcement, EnvelopeLimiter, ItemAction},
     itertools::Itertools,
     relay_cardinality::{
         CardinalityLimit, CardinalityLimiter, CardinalityLimitsSplit, RedisSetLimiter,
@@ -660,12 +660,12 @@ impl ProcessingExtractedMetrics {
     /// This is used to apply rate limits which have been enforced on sampled items of an envelope
     /// to also consistently apply to the metrics extracted from these items.
     #[cfg(feature = "processing")]
-    fn enforce_limits(&mut self, scoping: Scoping, limits: &RateLimits) {
-        for (category, namespace) in [
-            (DataCategory::Transaction, MetricNamespace::Transactions),
-            (DataCategory::Span, MetricNamespace::Spans),
+    fn apply_enforcement(&mut self, enforcement: &Enforcement) {
+        for (namespace, limit) in [
+            (MetricNamespace::Transactions, &enforcement.event),
+            (MetricNamespace::Spans, &enforcement.spans),
         ] {
-            if !limits.check(scoping.item(category)).is_empty() {
+            if limit.is_active() {
                 relay_log::trace!(
                     "dropping {namespace} metrics, due to enforced limit on envelope"
                 );
@@ -1325,10 +1325,8 @@ impl EnvelopeProcessorService {
         let (enforcement, limits) = metric!(timer(RelayTimers::EventProcessingRateLimiting), {
             envelope_limiter.compute(state.managed_envelope.envelope_mut(), &scoping)?
         });
-        let event_active = enforcement.event_active();
-        enforcement.apply_with_outcomes(&mut state.managed_envelope);
 
-        if event_active {
+        if enforcement.is_event_active() {
             state.remove_event();
             debug_assert!(state.envelope().is_empty());
         }
@@ -1336,7 +1334,8 @@ impl EnvelopeProcessorService {
         // Use the same rate limits as used for the envelope on the metrics.
         // Those rate limits should not be checked for expiry or similar to ensure a consistent
         // limiting of envelope items and metrics.
-        state.extracted_metrics.enforce_limits(scoping, &limits);
+        state.extracted_metrics.apply_enforcement(&enforcement);
+        enforcement.apply_with_outcomes(&mut state.managed_envelope);
 
         if !limits.is_empty() {
             self.inner

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -1051,7 +1051,7 @@ impl Project {
 /// as top-level spans, thus if we limited a transaction, we want to count and emit negative
 /// outcomes for each of the spans nested inside that transaction.
 fn sync_spans_to_enforcement(envelope: &ManagedEnvelope, enforcement: &mut Enforcement) {
-    if !enforcement.event_active() {
+    if !enforcement.is_event_active() {
         return;
     }
 


### PR DESCRIPTION
Span outcomes are currently off when created from rate limited transactions in the `transaction_indexed` category. All of the dropped outcomes are also added to the accepted, because the metrics are not dropped.

Additionally outcomes for the span category were emitted when there was a limit for `transaction_indexed` instead of just emitting them from `span_indexed`.

Implementation notes:
Need to drop the metrics based on the enforcement instead of the rate limits, because it is correct that there are no rate limits added for the inherited category. We wouldn't want to start dropping standalone spans because of a transaction quota.