### PR TITLE
fix(metrics): remove Redis spans from Queries insights module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Incorrect span outcomes when generated from a indexed transaction quota. ([#3793](https://github.com/getsentry/relay/pull/3793))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
+- Don't produce Queries module metrics for Redis spans. ([#3795](https://github.com/getsentry/relay/pull/3795))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -129,6 +129,7 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
 
     let is_db = RuleCondition::eq("span.sentry_tags.category", "db")
         & !(RuleCondition::eq("span.system", "mongodb")
+            | RuleCondition::eq("span.system", "redis")
             | RuleCondition::glob("span.op", DISABLED_DATABASES)
             | RuleCondition::glob("span.description", MONGODB_QUERIES));
     let is_resource = RuleCondition::glob("span.op", RESOURCE_SPAN_OPS);


### PR DESCRIPTION
Redis spans were intended to be filtered out of the Queries insights module, since it currently only supports SQL. This used to work via a check for `*redis*` in the span op. With the JS SDK's v8 release the span op for redis spans became simply `db` and Redis spans starting showing up in the Queries module.

JS v8 follows the OTel standard of setting the `db.system` attribute to `"redis"`, so we can use that as a secondary check to bring back the expected filtering.