### PR TITLE
ref(metrics): Remove option for controlling metrics summaries calculation

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -214,14 +214,6 @@ pub struct Options {
     )]
     pub span_extraction_sample_rate: Option<f32>,
 
-    /// Overall sampling of metrics summaries computation.
-    #[serde(
-        rename = "relay.compute-metrics-summaries.sample-rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub compute_metrics_summaries_sample_rate: Option<f32>,
-
     /// The maximum duplication factor used to extrapolate distribution metrics from sampled data.
     ///
     /// This applies as long as Relay duplicates distribution values to extrapolate. The default is

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1195,7 +1195,6 @@ mod tests {
             combined_config(features, None).combined(),
             200,
             None,
-            None,
         )
     }
 
@@ -1398,7 +1397,6 @@ mod tests {
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
-            None,
         );
         insta::assert_debug_snapshot!((&event.value().unwrap().spans, metrics));
     }
@@ -1456,7 +1454,6 @@ mod tests {
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
-            None,
         );
 
         // When transaction.op:ui.load and mobile:true, HTTP spans still get both
@@ -1488,7 +1485,6 @@ mod tests {
             false,
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
-            None,
             None,
         );
 
@@ -1713,7 +1709,6 @@ mod tests {
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
-            None,
         );
 
         assert_eq!(metrics.len(), 4);
@@ -1855,7 +1850,6 @@ mod tests {
             false,
             config,
             200,
-            None,
             None,
         );
 

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -52,20 +52,11 @@ pub fn extract_metrics(
     config: CombinedMetricExtractionConfig<'_>,
     max_tag_value_size: usize,
     span_extraction_sample_rate: Option<f32>,
-    compute_metrics_summaries_sample_rate: Option<f32>,
 ) -> Vec<Bucket> {
     let mut metrics = generic::extract_metrics(event, config);
     // If spans were already extracted for an event, we rely on span processing to extract metrics.
     if !spans_extracted && sample(span_extraction_sample_rate.unwrap_or(1.0)) {
-        let compute_metrics_summaries_sample_rate =
-            compute_metrics_summaries_sample_rate.unwrap_or(1.0);
-        extract_span_metrics_for_event(
-            event,
-            config,
-            max_tag_value_size,
-            &mut metrics,
-            compute_metrics_summaries_sample_rate,
-        );
+        extract_span_metrics_for_event(event, config, max_tag_value_size, &mut metrics);
     }
 
     metrics
@@ -76,17 +67,12 @@ fn extract_span_metrics_for_event(
     config: CombinedMetricExtractionConfig<'_>,
     max_tag_value_size: usize,
     output: &mut Vec<Bucket>,
-    compute_metrics_summaries_sample_rate: f32,
 ) {
-    let compute_metrics_summaries = sample(compute_metrics_summaries_sample_rate);
-
     relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {
         if let Some(transaction_span) = extract_transaction_span(event, max_tag_value_size) {
             let (metrics, metrics_summary) =
                 metrics_summary::extract_and_summarize_metrics(&transaction_span, config);
-            if compute_metrics_summaries {
-                metrics_summary.apply_on(&mut event._metrics_summary);
-            }
+            metrics_summary.apply_on(&mut event._metrics_summary);
             output.extend(metrics);
         }
 
@@ -95,9 +81,7 @@ fn extract_span_metrics_for_event(
                 if let Some(span) = annotated_span.value_mut() {
                     let (metrics, metrics_summary) =
                         metrics_summary::extract_and_summarize_metrics(span, config);
-                    if compute_metrics_summaries {
-                        metrics_summary.apply_on(&mut span._metrics_summary);
-                    }
+                    metrics_summary.apply_on(&mut span._metrics_summary);
                     output.extend(metrics);
                 }
             }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1428,7 +1428,6 @@ impl EnvelopeProcessorService {
                 .aggregator
                 .max_tag_value_length,
             global.options.span_extraction_sample_rate,
-            global.options.compute_metrics_summaries_sample_rate,
         );
 
         state

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -158,14 +158,7 @@ pub fn process(
                 span,
                 CombinedMetricExtractionConfig::new(global_metrics_config, config),
             );
-            if sample(
-                global_config
-                    .options
-                    .compute_metrics_summaries_sample_rate
-                    .unwrap_or(1.0),
-            ) {
-                metrics_summary.apply_on(&mut span._metrics_summary)
-            }
+            metrics_summary.apply_on(&mut span._metrics_summary);
 
             state
                 .extracted_metrics

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -2062,10 +2062,6 @@ def test_metrics_summary_with_extracted_spans(
     relay_with_processing,
     metrics_summaries_consumer,
 ):
-    mini_sentry.global_config["options"] = {
-        "relay.compute-metrics-summaries.sample-rate": 1.0
-    }
-
     metrics_summaries_consumer = metrics_summaries_consumer()
 
     relay = relay_with_processing()
@@ -2139,10 +2135,6 @@ def test_metrics_summary_with_standalone_spans(
     relay_with_processing,
     metrics_summaries_consumer,
 ):
-    mini_sentry.global_config["options"] = {
-        "relay.compute-metrics-summaries.sample-rate": 1.0
-    }
-
     metrics_summaries_consumer = metrics_summaries_consumer()
 
     relay = relay_with_processing()


### PR DESCRIPTION
This PR removes an option for controlling metrics summaries calculation, since it's not needed anymore.

#skip-changelog