### PR TITLE
ref(relay): Update axum-extra and otel-proto libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e433be9382c737320af3924f7d5fc6f89c155cf2bf88949d8f5126fab283f"
+checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
 dependencies = [
  "axum",
  "axum-core",
@@ -2907,23 +2929,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14#dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "once_cell",
- "ordered-float",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.4.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14#dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "hex",
  "opentelemetry",
@@ -2935,14 +2957,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.21.2"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14#dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
  "ordered-float",
@@ -3287,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3297,15 +3320,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -5552,16 +5575,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.0",
  "bytes",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ android_trace_log = { version = "0.3.0", features = ["serde"] }
 ansi-to-html = "0.1.3"
 anyhow = "1.0.66"
 axum = "0.6.20"
-axum-extra = "0.7.7"
+axum-extra = "0.8.0"
 axum-server = "0.4.7"
 backoff = "0.4.0"
 bindgen = "0.64.0"
@@ -114,7 +114,7 @@ multer = "2.0.4"
 num-traits = "0.2.18"
 num_cpus = "1.13.0"
 once_cell = "1.13.1"
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14" }
+opentelemetry-proto = { version = "0.6.0", default-features = false }
 parking_lot = "0.12.1"
 path-slash = "0.2.1"
 pest = "2.1.3"

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -284,8 +284,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "middleware - fastify -> @fastify/multipart",
             "kind": 1,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key": "sentry.environment",
@@ -314,7 +314,7 @@ mod tests {
                 {
                     "key": "sentry.sample_rate",
                     "value": {
-                        "intValue": 1
+                        "intValue": "1"
                     }
                 },
                 {
@@ -326,7 +326,7 @@ mod tests {
                 {
                     "key": "sentry.exclusive_time_nano",
                     "value": {
-                        "intValue": 1000000000
+                        "intValue": "1000000000"
                     }
                 }
             ],
@@ -358,13 +358,13 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "middleware - fastify -> @fastify/multipart",
             "kind": 1,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key": "sentry.exclusive_time_nano",
                     "value": {
-                        "intValue": 3200000000
+                        "intValue": "3200000000"
                     }
                 }
             ]
@@ -382,8 +382,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "middleware - fastify -> @fastify/multipart",
             "kind": 1,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800"
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span);
@@ -398,8 +398,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "database query",
             "kind": 3,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key" : "db.name",
@@ -440,8 +440,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "http client request",
             "kind": 3,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key" : "http.request.method",
@@ -473,8 +473,8 @@ mod tests {
             "traceId": "4c79f60c11214eb38604f4ae0781bfb2",
             "spanId": "fa90fdead5f74052",
             "parentSpanId": "fa90fdead5f74051",
-            "startTimeUnixNano": 123000000000,
-            "endTimeUnixNano": 123500000000,
+            "startTimeUnixNano": "123000000000",
+            "endTimeUnixNano": "123500000000",
             "status": {"code": 0, "message": "foo"},
             "attributes": [
                 {
@@ -561,7 +561,7 @@ mod tests {
                                                 {
                                                     "key": "count",
                                                     "value": {
-                                                        "intValue": 2
+                                                        "intValue": "2"
                                                     }
                                                 },
                                                 {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -321,9 +321,9 @@ def envelope_with_spans(
                             {
                                 "key": "sentry.exclusive_time_nano",
                                 "value": {
-                                    "intValue": str(int(
-                                        (end - start).total_seconds() * 1e9
-                                    )),
+                                    "intValue": str(
+                                        int((end - start).total_seconds() * 1e9)
+                                    ),
                                 },
                             },
                         ],
@@ -455,9 +455,9 @@ def make_otel_span(start, end):
                                     {
                                         "key": "sentry.exclusive_time_nano",
                                         "value": {
-                                            "intValue": str(int(
-                                                (end - start).total_seconds() * 1e9
-                                            )),
+                                            "intValue": str(
+                                                int((end - start).total_seconds() * 1e9)
+                                            ),
                                         },
                                     },
                                 ],

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -309,8 +309,8 @@ def envelope_with_spans(
                         "traceId": "89143b0763095bd9c9955e8175d1fb23",
                         "spanId": "a342abb1214ca181",
                         "name": "my 1st OTel span",
-                        "startTimeUnixNano": int(start.timestamp() * 1e9),
-                        "endTimeUnixNano": int(end.timestamp() * 1e9),
+                        "startTimeUnixNano": str(int(start.timestamp() * 1e9)),
+                        "endTimeUnixNano": str(int(end.timestamp() * 1e9)),
                         "attributes": [
                             {
                                 "key": "sentry.op",
@@ -321,9 +321,9 @@ def envelope_with_spans(
                             {
                                 "key": "sentry.exclusive_time_nano",
                                 "value": {
-                                    "intValue": int(
+                                    "intValue": str(int(
                                         (end - start).total_seconds() * 1e9
-                                    ),
+                                    )),
                                 },
                             },
                         ],
@@ -449,15 +449,15 @@ def make_otel_span(start, end):
                                 "traceId": "89143b0763095bd9c9955e8175d1fb24",
                                 "spanId": "d342abb1214ca182",
                                 "name": "my 2nd OTel span",
-                                "startTimeUnixNano": int(start.timestamp() * 1e9),
-                                "endTimeUnixNano": int(end.timestamp() * 1e9),
+                                "startTimeUnixNano": str(int(start.timestamp() * 1e9)),
+                                "endTimeUnixNano": str(int(end.timestamp() * 1e9)),
                                 "attributes": [
                                     {
                                         "key": "sentry.exclusive_time_nano",
                                         "value": {
-                                            "intValue": int(
+                                            "intValue": str(int(
                                                 (end - start).total_seconds() * 1e9
-                                            ),
+                                            )),
                                         },
                                     },
                                 ],


### PR DESCRIPTION
With the changes from here (https://github.com/open-telemetry/opentelemetry-rust/pull/1753), integers are strings now ...

axum-extra update is required for prost 0.12 which is required for the otel dependency.

#skip-changelog