### PR TITLE
ref(redis): Switch to fork in getsentry/redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "redis"
 version = "0.25.3"
-source = "git+https://github.com/redis-rs/redis-rs.git?rev=939e5df6f9cc976b0a53987f6eb3f76b2c398bd6#939e5df6f9cc976b0a53987f6eb3f76b2c398bd6"
+source = "git+https://github.com/getsentry/redis-rs.git?rev=939e5df6f9cc976b0a53987f6eb3f76b2c398bd6#939e5df6f9cc976b0a53987f6eb3f76b2c398bd6"
 dependencies = [
  "arc-swap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ rand_pcg = "0.3.1"
 rdkafka = "0.29.0"
 rdkafka-sys = "4.3.0"
 # Git revision until https://github.com/redis-rs/redis-rs/pull/1097 (merged) and https://github.com/redis-rs/redis-rs/pull/1253 are released.
-redis = { git = "https://github.com/redis-rs/redis-rs.git", rev = "939e5df6f9cc976b0a53987f6eb3f76b2c398bd6", default-features = false }
+redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "939e5df6f9cc976b0a53987f6eb3f76b2c398bd6", default-features = false }
 regex = "1.10.2"
 reqwest = "0.11.1"
 rmp-serde = "1.1.1"


### PR DESCRIPTION
Same commit but from a different upstream

#skip-changelog