### PR TITLE
ref(spans): Remove conversion to transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Compute metrics summary on the extracted custom metrics. ([#3769](https://github.com/getsentry/relay/pull/3769))
 - Add support for `all` and `any` `RuleCondition`(s). ([#3791](https://github.com/getsentry/relay/pull/3791))
 - Copy root span data from `contexts.trace.data` when converting transaction events into raw spans. ([#3790](https://github.com/getsentry/relay/pull/3790))
+- Remove experimental double-write from spans to transactions. ([#3801](https://github.com/getsentry/relay/pull/3801))
 
 ## 24.6.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -101,18 +101,11 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
             .is_enabled = true;
     }
 
-    // Enable transaction metrics for span (score.total), but only if double-write to transactions
-    // is disabled.
-    if !project_config
-        .features
-        .has(Feature::ExtractTransactionFromSegmentSpan)
-    {
-        let span_metrics_tx = config
-            .global_groups
-            .entry(GroupKey::SpanMetricsTx)
-            .or_default();
-        span_metrics_tx.is_enabled = true;
-    }
+    let span_metrics_tx = config
+        .global_groups
+        .entry(GroupKey::SpanMetricsTx)
+        .or_default();
+    span_metrics_tx.is_enabled = true;
 
     config._span_metrics_extended = true;
     if config.version == 0 {

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -76,15 +76,6 @@ pub enum Feature {
     #[serde(rename = "organizations:continuous-profiling")]
     ContinuousProfiling,
 
-    /// When enabled, every standalone segment span will be duplicated as a transaction.
-    ///
-    /// This allows support of product features that rely on transactions for SDKs that only
-    /// send spans.
-    ///
-    /// Serialized as `projects:extract-transaction-from-segment-span`.
-    #[serde(rename = "projects:extract-transaction-from-segment-span")]
-    ExtractTransactionFromSegmentSpan,
-
     /// Enables metric extraction from spans for common modules.
     ///
     /// Serialized as `projects:span-metrics-extraction`.

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -1,62 +1,24 @@
 //! This module defines bidirectional field mappings between spans and transactions.
 
-use crate::protocol::{
-    BrowserContext, Contexts, Event, ProfileContext, Span, SpanData, TraceContext,
-};
+use crate::protocol::{BrowserContext, Event, ProfileContext, Span, SpanData, TraceContext};
 
 impl From<&Event> for Span {
     fn from(event: &Event) -> Self {
         let Event {
-            id,
-            level,
-            version,
-            ty,
-            fingerprint,
-            culprit,
             transaction,
-            transaction_info,
-            time_spent,
-            logentry,
-            logger,
-            modules,
+
             platform,
             timestamp,
             start_timestamp,
             received,
-            server_name,
             release,
-            dist,
             environment,
-            site,
-            user,
-            request,
-            contexts,
-            breadcrumbs,
-            exceptions,
-            stacktrace,
-            template,
-            threads,
             tags,
-            extra,
-            debug_meta,
-            client_sdk,
-            ingest_path,
-            errors,
-            key_id,
-            project,
-            grouping_config,
-            checksum,
-            csp,
-            hpkp,
-            expectct,
-            expectstaple,
-            spans,
+
             measurements,
-            breakdowns,
-            scraping_attempts,
             _metrics,
             _metrics_summary,
-            other,
+            ..
         } = event;
 
         let trace = event.context::<TraceContext>();
@@ -68,6 +30,7 @@ impl From<&Event> for Span {
 
         // Overwrite specific fields:
         let span_data = data.get_or_insert_with(Default::default);
+        span_data.segment_name = transaction.clone();
         span_data.release = release.clone();
         span_data.environment = environment.clone();
         if let Some(browser) = event.context::<BrowserContext>() {
@@ -111,9 +74,6 @@ impl From<&Event> for Span {
 #[cfg(test)]
 mod tests {
     use relay_protocol::Annotated;
-    use similar_asserts::assert_eq;
-
-    use crate::protocol::{SpanData, SpanId};
 
     use super::*;
 

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -1,191 +1,112 @@
 //! This module defines bidirectional field mappings between spans and transactions.
 
-use crate::protocol::{BrowserContext, Contexts, Event, ProfileContext, Span, TraceContext};
+use crate::protocol::{
+    BrowserContext, Contexts, Event, ProfileContext, Span, SpanData, TraceContext,
+};
 
-use relay_base_schema::events::EventType;
-use relay_protocol::Annotated;
+impl From<&Event> for Span {
+    fn from(event: &Event) -> Self {
+        let Event {
+            id,
+            level,
+            version,
+            ty,
+            fingerprint,
+            culprit,
+            transaction,
+            transaction_info,
+            time_spent,
+            logentry,
+            logger,
+            modules,
+            platform,
+            timestamp,
+            start_timestamp,
+            received,
+            server_name,
+            release,
+            dist,
+            environment,
+            site,
+            user,
+            request,
+            contexts,
+            breadcrumbs,
+            exceptions,
+            stacktrace,
+            template,
+            threads,
+            tags,
+            extra,
+            debug_meta,
+            client_sdk,
+            ingest_path,
+            errors,
+            key_id,
+            project,
+            grouping_config,
+            checksum,
+            csp,
+            hpkp,
+            expectct,
+            expectstaple,
+            spans,
+            measurements,
+            breakdowns,
+            scraping_attempts,
+            _metrics,
+            _metrics_summary,
+            other,
+        } = event;
 
-macro_rules! write_path(
-    ($root:expr, $path_root:ident $($path_segment:ident)*) => {
-        {
-            let annotated = &mut ($root).$path_root;
-            $(
-                let value = annotated.get_or_insert_with(Default::default);
-                let annotated = &mut value.$path_segment;
-            )*
-            annotated
+        let trace = event.context::<TraceContext>();
+
+        // Fill data from trace context:
+        let mut data = trace
+            .map(|c| c.data.clone().map_value(SpanData::from))
+            .unwrap_or_default();
+
+        // Overwrite specific fields:
+        let span_data = data.get_or_insert_with(Default::default);
+        span_data.release = release.clone();
+        span_data.environment = environment.clone();
+        if let Some(browser) = event.context::<BrowserContext>() {
+            span_data.browser_name = browser.name.clone();
         }
-    };
-);
-
-macro_rules! read_value(
-    ($span:expr, $path_root:ident $($path_segment:ident)*) => {
-        {
-            let value = ($span).$path_root.value();
-            $(
-                let value = value.and_then(|value| value.$path_segment.value());
-            )*
-            value
+        if let Some(client_sdk) = event.client_sdk.value() {
+            span_data.sdk_name = client_sdk.name.clone();
+            span_data.sdk_version = client_sdk.version.clone();
         }
-    };
-);
 
-macro_rules! context_write_path (
-    ($event:expr, $ContextType:ty, $context_field:ident) => {
-        {
-            let contexts = $event.contexts.get_or_insert_with(Contexts::default);
-            let context = contexts.get_or_default::<$ContextType>();
-            write_path!(context, $context_field)
+        Self {
+            timestamp: timestamp.clone(),
+            start_timestamp: start_timestamp.clone(),
+            exclusive_time: trace.map(|c| c.exclusive_time.clone()).unwrap_or_default(),
+            op: trace.map(|c| c.op.clone()).unwrap_or_default(),
+            span_id: trace.map(|c| c.span_id.clone()).unwrap_or_default(),
+            parent_span_id: trace.map(|c| c.parent_span_id.clone()).unwrap_or_default(),
+            trace_id: trace.map(|c| c.trace_id.clone()).unwrap_or_default(),
+            segment_id: trace.map(|c| c.span_id.clone()).unwrap_or_default(),
+            is_segment: true.into(),
+            status: trace.map(|c| c.status.clone()).unwrap_or_default(),
+            description: transaction.clone(),
+            tags: tags.clone().map_value(|t| t.into()),
+            origin: trace.map(|c| c.origin.clone()).unwrap_or_default(),
+            profile_id: event
+                .context::<ProfileContext>()
+                .map(|c| c.profile_id.clone())
+                .unwrap_or_default(),
+            data,
+            sentry_tags: Default::default(),
+            received: received.clone(),
+            measurements: measurements.clone(),
+            _metrics_summary: _metrics_summary.clone(),
+            platform: platform.clone(),
+            was_transaction: true.into(),
+            other: Default::default(),
         }
-    };
-);
-
-macro_rules! event_write_path(
-    ($event:expr, contexts browser $context_field:ident) => {
-        context_write_path!($event, BrowserContext, $context_field)
-    };
-    ($event:expr, contexts trace $context_field:ident) => {
-        context_write_path!($event, TraceContext, $context_field)
-    };
-    ($event:expr, contexts profile $context_field:ident) => {
-        context_write_path!($event, ProfileContext, $context_field)
-    };
-    ($event:expr, $path_root:ident $($path_segment:ident)*) => {
-        {
-            write_path!($event, $path_root $($path_segment)*)
-        }
-    };
-);
-
-macro_rules! context_value (
-    ($event:expr, $ContextType:ty, $context_field:ident) => {
-        {
-            let context = &($event).context::<$ContextType>();
-            context.map_or(None, |ctx|ctx.$context_field.value())
-        }
-    };
-);
-
-macro_rules! event_value(
-    ($event:expr, contexts browser $context_field:ident) => {
-        context_value!($event, BrowserContext, $context_field)
-    };
-    ($event:expr, contexts trace $context_field:ident) => {
-        context_value!($event, TraceContext, $context_field)
-    };
-    ($event:expr, contexts profile $context_field:ident) => {
-        context_value!($event, ProfileContext, $context_field)
-    };
-    ($event:expr, $path_root:ident $($path_segment:ident)*) => {
-        {
-            let value = ($event).$path_root.value();
-            $(
-                let value = value.and_then(|value|value.$path_segment.value());
-            )*
-            value
-        }
-    };
-);
-
-#[derive(Debug, thiserror::Error)]
-pub enum TryFromSpanError {
-    #[error("span is not a segment")]
-    NotASegment,
-    #[error("span has no span ID")]
-    MissingSpanId,
-    #[error("failed to parse event ID")]
-    InvalidSpanId(#[from] uuid::Error),
+    }
 }
-
-/// Implements the conversion between transaction events and segment spans.
-///
-/// Invoking this macro implements both `From<&Event> for Span` and `From<&Span> for Event`.
-macro_rules! map_fields {
-    (
-        $(span $(. $span_path:ident)+ <=> event $(. $event_path:ident)+),+
-        ;
-        $(span . $fixed_span_path:tt <= $fixed_span_field:expr),+
-        ;
-        $($fixed_event_field:expr => event . $fixed_event_path:tt),+
-    ) => {
-        impl From<&Event> for Span {
-            fn from(event: &Event) -> Self {
-                let mut span = Span::default();
-                $(
-                    if let Some(value) = event_value!(event, $($event_path)+) {
-                        *write_path!(&mut span, $($span_path)+) = Annotated::new(value.clone()).map_value(Into::into);
-                    }
-                )+
-                $(
-                    *write_path!(&mut span, $fixed_span_path) = Annotated::new($fixed_span_field);
-                )+
-                span
-            }
-        }
-
-        impl<'a> TryFrom<&'a Span> for Event {
-            type Error = TryFromSpanError;
-
-            fn try_from(span: &Span) -> Result<Self, Self::Error> {
-                let mut event = Event::default();
-                let span_id = span.span_id.value().ok_or(TryFromSpanError::MissingSpanId)?;
-                event.id = Annotated::new(span_id.try_into()?);
-
-                if !span.is_segment.value().unwrap_or(&false) {
-                    // Only segment spans can become transactions.
-                    return Err(TryFromSpanError::NotASegment);
-                }
-
-                $(
-                    if let Some(value) = read_value!(span, $($span_path)+) {
-                        *event_write_path!(&mut event, $($event_path)+) = Annotated::new(value.clone()).map_value(Into::into)
-                    }
-                )+
-                $(
-                    *event_write_path!(&mut event, $fixed_event_path) = Annotated::new($fixed_event_field);
-                )+
-
-                Ok(event)
-            }
-        }
-    };
-}
-
-// This macro call implements a bidirectional mapping between transaction event and segment spans,
-// allowing users to call both `Event::from(&span)` and `Span::from(&event)`.
-map_fields!(
-    // Data must go first to ensure it doesn't overwrite more specific fields
-    span.data <=> event.contexts.trace.data,
-    span._metrics_summary <=> event._metrics_summary,
-    span.description <=> event.transaction,
-    span.data.segment_name <=> event.transaction,
-    span.measurements <=> event.measurements,
-    span.platform <=> event.platform,
-    span.received <=> event.received,
-    span.start_timestamp <=> event.start_timestamp,
-    span.tags <=> event.tags,
-    span.timestamp <=> event.timestamp,
-    span.exclusive_time <=> event.contexts.trace.exclusive_time,
-    span.op <=> event.contexts.trace.op,
-    span.parent_span_id <=> event.contexts.trace.parent_span_id,
-    // A transaction corresponds to a segment span, so span_id and segment_id have the same value:
-    span.span_id <=> event.contexts.trace.span_id,
-    span.segment_id <=> event.contexts.trace.span_id,
-    span.status <=> event.contexts.trace.status,
-    span.trace_id <=> event.contexts.trace.trace_id,
-    span.profile_id <=> event.contexts.profile.profile_id,
-    span.data.release <=> event.release,
-    span.data.environment <=> event.environment,
-    span.data.browser_name <=> event.contexts.browser.name,
-    span.data.sdk_name <=> event.client_sdk.name,
-    span.data.sdk_version <=> event.client_sdk.version,
-    span.origin <=> event.contexts.trace.origin
-    ;
-    span.is_segment <= true,
-    span.was_transaction <= true
-    ;
-    EventType::Transaction => event.ty
-);
 
 #[cfg(test)]
 mod tests {
@@ -197,7 +118,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip() {
+    fn convert() {
         let event = Annotated::<Event>::from_json(
             r#"{
                 "type": "transaction",
@@ -366,59 +287,5 @@ mod tests {
             other: {},
         }
         "###);
-
-        let mut event_from_span = Event::try_from(&span_from_event).unwrap();
-
-        let event_id = event_from_span.id.value_mut().take().unwrap();
-        assert_eq!(&event_id.to_string(), "0000000000000000fa90fdead5f74052");
-
-        // Before comparing, remove any additional data that was injected into trace data during
-        // span conversion. Note that the keys are renamed on the `SpanData` struct and mostly start
-        // with `sentry.`.
-        let trace = event_from_span.context_mut::<TraceContext>().unwrap();
-        let trace_data = trace.data.value_mut().as_mut().unwrap();
-
-        trace_data.other.retain(|k, v| {
-            if v.value().is_none() || k.starts_with("sentry.") {
-                return false;
-            }
-
-            // Seems to be a special case
-            k != "browser.name"
-        });
-
-        assert_eq!(event, event_from_span);
-    }
-
-    #[test]
-    fn segment_name_takes_precedence_over_description() {
-        let span = Span {
-            span_id: SpanId("fa90fdead5f74052".to_owned()).into(),
-            is_segment: true.into(),
-            description: "This is the description".to_owned().into(),
-            data: SpanData {
-                segment_name: "This is the segment name".to_owned().into(),
-                ..Default::default()
-            }
-            .into(),
-            ..Default::default()
-        };
-        let event = Event::try_from(&span).unwrap();
-
-        assert_eq!(event.transaction.as_str(), Some("This is the segment name"));
-    }
-
-    #[test]
-    fn no_empty_profile_context() {
-        let span = Span {
-            span_id: SpanId("fa90fdead5f74052".to_owned()).into(),
-            is_segment: true.into(),
-            ..Default::default()
-        };
-        let event = Event::try_from(&span).unwrap();
-
-        // No profile context is set.
-        // profile_id is required on ProfileContext so we should not create an empty one.
-        assert!(event.context::<ProfileContext>().is_none());
     }
 }

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -554,10 +554,6 @@ pub struct ItemHeaders {
     #[serde(default, skip_serializing_if = "is_false")]
     metrics_extracted: bool,
 
-    /// Whether or not a transaction has been extracted from a segment span.
-    #[serde(default, skip_serializing_if = "is_false")]
-    transaction_extracted: bool,
-
     /// Whether or not spans and span metrics have been extracted from a transaction.
     ///
     /// This header is set to `true` after both span extraction and span metrics extraction,
@@ -651,7 +647,6 @@ impl Item {
                 sample_rates: None,
                 other: BTreeMap::new(),
                 metrics_extracted: false,
-                transaction_extracted: false,
                 spans_extracted: false,
                 sampled: true,
                 fully_normalized: false,
@@ -845,16 +840,6 @@ impl Item {
     /// Sets the metrics extracted flag.
     pub fn set_metrics_extracted(&mut self, metrics_extracted: bool) {
         self.headers.metrics_extracted = metrics_extracted;
-    }
-
-    /// Returns the transaction extracted flag.
-    pub fn transaction_extracted(&self) -> bool {
-        self.headers.transaction_extracted
-    }
-
-    /// Sets the transaction extracted flag.
-    pub fn set_transaction_extracted(&mut self, transaction_extracted: bool) {
-        self.headers.transaction_extracted = transaction_extracted;
     }
 
     /// Returns the spans extracted flag.

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -180,8 +180,6 @@ impl ServiceState {
                 store_forwarder: store.clone(),
             },
             metric_outcomes.clone(),
-            #[cfg(feature = "processing")]
-            buffer_guard.clone(),
         )
         .spawn_handler(processor_rx);
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -172,8 +172,6 @@ impl ServiceState {
             #[cfg(feature = "processing")]
             redis_pool.clone(),
             processor::Addrs {
-                #[cfg(feature = "processing")]
-                envelope_processor: processor.clone(),
                 project_cache: project_cache.clone(),
                 outcome_aggregator: outcome_aggregator.clone(),
                 upstream_relay: upstream_relay.clone(),

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -83,8 +83,6 @@ use crate::services::upstream::{
     SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
 };
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
-#[cfg(feature = "processing")]
-use crate::utils::BufferGuard;
 use crate::utils::{
     self, InvalidProcessingGroupType, ManagedEnvelope, SamplingResult, TypedEnvelope,
 };
@@ -1129,8 +1127,6 @@ struct InnerProcessor {
     #[cfg(feature = "processing")]
     cardinality_limiter: Option<CardinalityLimiter>,
     metric_outcomes: MetricOutcomes,
-    #[cfg(feature = "processing")]
-    buffer_guard: Arc<BufferGuard>,
 }
 
 impl EnvelopeProcessorService {
@@ -1142,7 +1138,6 @@ impl EnvelopeProcessorService {
         #[cfg(feature = "processing")] redis: Option<RedisPool>,
         addrs: Addrs,
         metric_outcomes: MetricOutcomes,
-        #[cfg(feature = "processing")] buffer_guard: Arc<BufferGuard>,
     ) -> Self {
         let geoip_lookup = config.geoip_path().and_then(|p| {
             match GeoIpLookup::open(p).context(ServiceError::GeoIp) {
@@ -1184,8 +1179,6 @@ impl EnvelopeProcessorService {
                 .map(CardinalityLimiter::new),
             metric_outcomes,
             config,
-            #[cfg(feature = "processing")]
-            buffer_guard,
         };
 
         Self {
@@ -1836,13 +1829,7 @@ impl EnvelopeProcessorService {
         if_processing!(self.inner.config, {
             let global_config = self.inner.global_config.current();
 
-            span::process(
-                state,
-                self.inner.config.clone(),
-                &global_config,
-                &self.inner.addrs,
-                &self.inner.buffer_guard,
-            );
+            span::process(state, self.inner.config.clone(), &global_config);
 
             self.enforce_quotas(state)?;
         });

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1093,8 +1093,6 @@ pub struct EnvelopeProcessorService {
 
 /// Contains the addresses of services that the processor publishes to.
 pub struct Addrs {
-    #[cfg(feature = "processing")]
-    pub envelope_processor: Addr<EnvelopeProcessor>,
     pub project_cache: Addr<ProjectCache>,
     pub outcome_aggregator: Addr<TrackOutcome>,
     pub upstream_relay: Addr<UpstreamRelay>,
@@ -1106,8 +1104,6 @@ pub struct Addrs {
 impl Default for Addrs {
     fn default() -> Self {
         Addrs {
-            #[cfg(feature = "processing")]
-            envelope_processor: Addr::dummy(),
             project_cache: Addr::dummy(),
             outcome_aggregator: Addr::dummy(),
             upstream_relay: Addr::dummy(),

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -275,10 +275,6 @@ pub enum RelayHistograms {
     /// If it is not, this metric should expose it.
     PartitionKeys,
 
-    /// Measures how many transactions were created from segment spans in a single envelope.
-    #[cfg(feature = "processing")]
-    TransactionsFromSpansPerEnvelope,
-
     /// Measures how many splits were performed when sending out a partition.
     PartitionSplits,
 }
@@ -314,10 +310,6 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::UpstreamEnvelopeBodySize => "upstream.envelope.body_size",
             RelayHistograms::UpstreamMetricsBodySize => "upstream.metrics.body_size",
             RelayHistograms::PartitionKeys => "metrics.buckets.partition_keys",
-            #[cfg(feature = "processing")]
-            RelayHistograms::TransactionsFromSpansPerEnvelope => {
-                "transactions_from_spans_per_envelope"
-            }
             RelayHistograms::PartitionSplits => "partition_splits",
         }
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -747,9 +747,6 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     ///  - `success`: whether deserializing the global config succeeded.
     GlobalConfigFetched,
-    /// Counts how many transactions were created from segment spans.
-    #[cfg(feature = "processing")]
-    TransactionsFromSpans,
     /// The number of attachments processed in the same envelope as a user_report_v2 event.
     FeedbackAttachments,
     /// All COGS tracked values.
@@ -799,8 +796,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricsTransactionNameExtracted => "metrics.transaction_name",
             RelayCounters::OpenTelemetryEvent => "event.opentelemetry",
             RelayCounters::GlobalConfigFetched => "global_config.fetch",
-            #[cfg(feature = "processing")]
-            RelayCounters::TransactionsFromSpans => "transactions_from_spans",
             RelayCounters::FeedbackAttachments => "processing.feedback_attachments",
             RelayCounters::CogsUsage => "cogs.usage",
             RelayCounters::ProjectStateFlushMetricsNoProject => "project_state.metrics.no_project",

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -136,8 +136,6 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
         #[cfg(feature = "processing")]
         redis,
         processor::Addrs {
-            #[cfg(feature = "processing")]
-            envelope_processor: Addr::dummy(),
             outcome_aggregator,
             project_cache,
             upstream_relay,

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -20,8 +20,6 @@ use crate::services::outcome::TrackOutcome;
 use crate::services::processor::{self, EnvelopeProcessorService};
 use crate::services::project::ProjectState;
 use crate::services::test_store::TestStore;
-#[cfg(feature = "processing")]
-use crate::utils::BufferGuard;
 
 pub fn state_with_rule_and_condition(
     sample_rate: Option<f64>,
@@ -144,8 +142,6 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
             store_forwarder: None,
         },
         metric_outcomes,
-        #[cfg(feature = "processing")]
-        Arc::new(BufferGuard::new(usize::MAX)),
     )
 }
 
@@ -171,8 +167,6 @@ pub fn create_test_processor_with_addrs(
         redis,
         addrs,
         metric_outcomes,
-        #[cfg(feature = "processing")]
-        Arc::new(BufferGuard::new(usize::MAX)),
     )
 }
 

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -868,24 +868,6 @@ def test_span_ingestion(
     ]
     assert [m for m in metrics if ":spans/" in m["name"]] == expected_span_metrics
 
-    transaction_duration_metrics = [
-        m for m in metrics if m["name"] == "d:transactions/duration@millisecond"
-    ]
-
-    if extract_transaction:
-        assert {
-            (m["name"], m["tags"]["transaction"]) for m in transaction_duration_metrics
-        } == {
-            ("d:transactions/duration@millisecond", "https://example.com/p/blah.js"),
-            ("d:transactions/duration@millisecond", "my 1st OTel span"),
-            ("d:transactions/duration@millisecond", "my 2nd OTel span"),
-        }
-        # Make sure we're not double-reporting:
-        for m in transaction_duration_metrics:
-            assert len(m["value"]) == 1
-    else:
-        assert len(transaction_duration_metrics) == 0
-
     # Regardless of whether transactions are extracted, score.total is only converted to a transaction metric once:
     score_total_metrics = [
         m


### PR DESCRIPTION
Double-writing segment spans as transactions was meant as a temporary measure to transition to the spans dataset in the product. The feature was never used by more than a handful of projects and can now be removed. 