### PR TITLE
fix(spans): Optional exclusive time

### DIFF
--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -664,10 +664,6 @@ fn validate(span: &mut Annotated<Span>) -> Result<(), ValidationError> {
         }
     }
 
-    exclusive_time
-        .value()
-        .ok_or(anyhow::anyhow!("missing exclusive_time"))?;
-
     if let Some(sentry_tags) = sentry_tags.value_mut() {
         sentry_tags.retain(|key, value| match value.value() {
             Some(s) => {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -627,7 +627,6 @@ fn validate(span: &mut Annotated<Span>) -> Result<(), ValidationError> {
         .as_mut()
         .ok_or(anyhow::anyhow!("empty span"))?;
     let Span {
-        ref exclusive_time,
         ref mut tags,
         ref mut sentry_tags,
         ref mut start_timestamp,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1608,6 +1608,7 @@ fn bool_to_str(value: bool) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
@@ -1622,5 +1623,33 @@ mod tests {
 
             assert!(matches!(res, Err(ClientError::InvalidTopicName)));
         }
+    }
+
+    #[test]
+    fn missing_exclusive_time() {
+        let serialized = r#"{
+    "received": 0,
+    "span_id": "foo",
+    "trace_id": "fc6d8c0c43fc4630ad850ee518f1b9d0",
+    "start_timestamp": 1,
+    "timestamp": 2
+}"#;
+        let span: SpanKafkaMessage<'_> = serde_json::from_str(serialized).unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&span).unwrap(),
+            r#"{
+  "duration_ms": 0,
+  "is_segment": false,
+  "organization_id": 0,
+  "project_id": 0,
+  "received": 0.0,
+  "retention_days": 0,
+  "span_id": "foo",
+  "trace_id": "fc6d8c0c43fc4630ad850ee518f1b9d0",
+  "start_timestamp_ms": 0,
+  "start_timestamp_precise": 1.0,
+  "end_timestamp_precise": 2.0
+}"#
+        );
     }
 }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1336,8 +1336,11 @@ struct SpanKafkaMessage<'a> {
     /// The ID of the transaction event associated to this span, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event_id: Option<EventId>,
-    #[serde(rename(deserialize = "exclusive_time"))]
-    exclusive_time_ms: f64,
+    #[serde(
+        rename(deserialize = "exclusive_time"),
+        skip_serializing_if = "Option::is_none"
+    )]
+    exclusive_time_ms: Option<f64>,
     #[serde(default)]
     is_segment: bool,
 


### PR DESCRIPTION
`exclusive_time` will not be required in the future.

Do not merge before the consumer can handle this.

Fixes [RELAY-2NYA](https://sentry.my.sentry.io/organizations/sentry/issues/1223607/).