### PR TITLE
feat(replays): Add denylist feature handling for replay video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Add support for `all` and `any` `RuleCondition`(s). ([#3791](https://github.com/getsentry/relay/pull/3791))
 - Copy root span data from `contexts.trace.data` when converting transaction events into raw spans. ([#3790](https://github.com/getsentry/relay/pull/3790))
 - Remove experimental double-write from spans to transactions. ([#3801](https://github.com/getsentry/relay/pull/3801))
-- Add denylist for replay-video events. ([#3803](https://github.com/getsentry/relay/pull/3803))
+- Add feature flag to disable replay-video events. ([#3803](https://github.com/getsentry/relay/pull/3803))
 
 ## 24.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add support for `all` and `any` `RuleCondition`(s). ([#3791](https://github.com/getsentry/relay/pull/3791))
 - Copy root span data from `contexts.trace.data` when converting transaction events into raw spans. ([#3790](https://github.com/getsentry/relay/pull/3790))
 - Remove experimental double-write from spans to transactions. ([#3801](https://github.com/getsentry/relay/pull/3801))
+- Add denylist for replay-video events. ([#3803](https://github.com/getsentry/relay/pull/3803))
 
 ## 24.6.0
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -23,7 +23,7 @@ pub enum Feature {
     SessionReplayCombinedEnvelopeItems,
     /// Disables select organizations from processing mobile replay events.
     ///
-    /// Serialized as `organizations:session-replay-video-denylist`.
+    /// Serialized as `organizations:session-replay-video-disabled`.
     #[serde(rename = "organizations:session-replay-video-disabled")]
     SessionReplayVideoDenylist,
     /// Enables new User Feedback ingest.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -24,7 +24,7 @@ pub enum Feature {
     /// Disables select organizations from processing mobile replay events.
     ///
     /// Serialized as `organizations:session-replay-video-denylist`.
-    #[serde(rename = "organizations:session-replay-video-denylist")]
+    #[serde(rename = "organizations:session-replay-video-disabled")]
     SessionReplayVideoDenylist,
     /// Enables new User Feedback ingest.
     ///

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -25,7 +25,7 @@ pub enum Feature {
     ///
     /// Serialized as `organizations:session-replay-video-disabled`.
     #[serde(rename = "organizations:session-replay-video-disabled")]
-    SessionReplayVideoDenylist,
+    SessionReplayVideoDisabled,
     /// Enables new User Feedback ingest.
     ///
     /// TODO(jferg): rename to UserFeedbackIngest once old UserReport logic is deprecated.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -21,6 +21,11 @@ pub enum Feature {
     /// Serialized as `organizations:session-replay-combined-envelope-items`.
     #[serde(rename = "organizations:session-replay-combined-envelope-items")]
     SessionReplayCombinedEnvelopeItems,
+    /// Disables select organizations from processing mobile replay events.
+    ///
+    /// Serialized as `organizations:session-replay-video-denylist`.
+    #[serde(rename = "organizations:session-replay-video-denylist")]
+    SessionReplayVideoDenylist,
     /// Enables new User Feedback ingest.
     ///
     /// TODO(jferg): rename to UserFeedbackIngest once old UserReport logic is deprecated.

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -316,5 +316,6 @@ fn count_replay_video_events(state: &ProcessEnvelopeState<ReplayGroup>) -> u8 {
         .managed_envelope
         .envelope()
         .items()
-        .fold(0, |_: u8, item| (item.ty() == &ItemType::ReplayVideo) as u8)
+        .filter(|item| item.ty() == &ItemType::ReplayVideo)
+        .count()
 }

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -311,10 +311,10 @@ fn handle_replay_video_item(
 
 // Pre-processors
 
-fn count_replay_video_events(state: &mut ProcessEnvelopeState<ReplayGroup>) -> i32 {
+fn count_replay_video_events(state: &mut ProcessEnvelopeState<ReplayGroup>) -> u8 {
     state
         .managed_envelope
         .envelope()
         .items()
-        .fold(0, |acc, item| (item.ty() == ItemType::ReplayVideo) as i32)
+        .fold(0, |acc, item| (item.ty() == ItemType::ReplayVideo) as u8)
 }

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -29,7 +29,7 @@ pub fn process(
     let project_state = &state.project_state;
     let replays_enabled = project_state.has_feature(Feature::SessionReplay);
     let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
-    let replay_video_enabled = project_state.has_feature(Feature::SessionReplayVideoDenylist);
+    let replay_video_disabled = project_state.has_feature(Feature::SessionReplayVideoDenylist);
 
     let meta = state.envelope().meta().clone();
     let client_addr = meta.client_addr();
@@ -63,7 +63,7 @@ pub fn process(
 
     // If the replay video feature is not enabled check the envelope items for a
     // replay video event.
-    if !replay_video_enabled && count_replay_video_events(state) > 0 {
+    if replay_video_disabled && count_replay_video_events(state) > 0 {
         state.managed_envelope.drop_items_silently();
         return Ok(());
     }

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -311,7 +311,7 @@ fn handle_replay_video_item(
 
 // Pre-processors
 
-fn count_replay_video_events(state: &ProcessEnvelopeState<ReplayGroup>) -> u8 {
+fn count_replay_video_events(state: &ProcessEnvelopeState<ReplayGroup>) -> usize {
     state
         .managed_envelope
         .envelope()

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -29,7 +29,7 @@ pub fn process(
     let project_state = &state.project_state;
     let replays_enabled = project_state.has_feature(Feature::SessionReplay);
     let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
-    let replay_video_disabled = project_state.has_feature(Feature::SessionReplayVideoDenylist);
+    let replay_video_disabled = project_state.has_feature(Feature::SessionReplayVideoDisabled);
 
     let meta = state.envelope().meta().clone();
     let client_addr = meta.client_addr();

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -311,10 +311,10 @@ fn handle_replay_video_item(
 
 // Pre-processors
 
-fn count_replay_video_events(state: &mut ProcessEnvelopeState<ReplayGroup>) -> u8 {
+fn count_replay_video_events(state: &ProcessEnvelopeState<ReplayGroup>) -> u8 {
     state
         .managed_envelope
         .envelope()
         .items()
-        .fold(0, |acc, item| (item.ty() == ItemType::ReplayVideo) as u8)
+        .fold(0, |_: u8, item| (item.ty() == &ItemType::ReplayVideo) as u8)
 }

--- a/tests/integration/test_replay_videos.py
+++ b/tests/integration/test_replay_videos.py
@@ -19,14 +19,7 @@ def test_replay_recording_with_video(
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(
         project_id,
-        extra={
-            "config": {
-                "features": [
-                    "organizations:session-replay",
-                    "organizations:session-replay-video-denylist",
-                ]
-            }
-        },
+        extra={"config": {"features": ["organizations:session-replay"]}},
     )
     replay = generate_replay_sdk_event(replay_id)
     replay_events_consumer = replay_events_consumer(timeout=10)
@@ -79,6 +72,60 @@ def test_replay_recording_with_video(
 
     replay_event, _ = replay_events_consumer.get_replay_event()
     assert_replay_payload_matches(replay, replay_event)
+
+    # Assert all conumers are empty.
+    replay_recordings_consumer.assert_empty()
+    outcomes_consumer.assert_empty()
+    replay_events_consumer.assert_empty()
+
+
+def test_replay_recording_with_video_denied(
+    mini_sentry,
+    relay_with_processing,
+    replay_recordings_consumer,
+    outcomes_consumer,
+    replay_events_consumer,
+):
+    project_id = 42
+    replay_id = "515539018c9b4260a6f999572f1661ee"
+    relay = relay_with_processing()
+    mini_sentry.add_basic_project_config(
+        project_id,
+        extra={
+            "config": {
+                "features": [
+                    "organizations:session-replay",
+                    "organizations:session-replay-video-denylist",
+                ]
+            }
+        },
+    )
+    replay = generate_replay_sdk_event(replay_id)
+    replay_events_consumer = replay_events_consumer(timeout=10)
+    replay_recordings_consumer = replay_recordings_consumer()
+    outcomes_consumer = outcomes_consumer()
+
+    _recording_payload = recording_payload(b"[]")
+    payload = msgpack.packb(
+        {
+            "replay_event": json.dumps(replay).encode(),
+            "replay_recording": _recording_payload,
+            "replay_video": b"hello, world!",
+        }
+    )
+
+    envelope = Envelope(
+        headers=[
+            [
+                "event_id",
+                replay_id,
+            ],
+            ["attachment_type", "replay_video"],
+        ]
+    )
+    envelope.add_item(Item(payload=PayloadRef(bytes=payload), type="replay_video"))
+
+    relay.send_envelope(project_id, envelope)
 
     # Assert all conumers are empty.
     replay_recordings_consumer.assert_empty()

--- a/tests/integration/test_replay_videos.py
+++ b/tests/integration/test_replay_videos.py
@@ -95,7 +95,7 @@ def test_replay_recording_with_video_denied(
             "config": {
                 "features": [
                     "organizations:session-replay",
-                    "organizations:session-replay-video-denylist",
+                    "organizations:session-replay-video-disabled",
                 ]
             }
         },

--- a/tests/integration/test_replay_videos.py
+++ b/tests/integration/test_replay_videos.py
@@ -18,7 +18,15 @@ def test_replay_recording_with_video(
     replay_id = "515539018c9b4260a6f999572f1661ee"
     relay = relay_with_processing()
     mini_sentry.add_basic_project_config(
-        project_id, extra={"config": {"features": ["organizations:session-replay"]}}
+        project_id,
+        extra={
+            "config": {
+                "features": [
+                    "organizations:session-replay",
+                    "organizations:session-replay-video-denylist",
+                ]
+            }
+        },
     )
     replay = generate_replay_sdk_event(replay_id)
     replay_events_consumer = replay_events_consumer(timeout=10)


### PR DESCRIPTION
Adds a pre-processing step to `ReplayGroup` processing.  The envelope items are iterated over and if a replay-video event is found processing exits early before the items are processed.

This feature should always default to enabled.  It should only return the disabled state if the feature was successfully evaluated and the organization was found to be explicitly denied access.

I'm not familiar with all the implications these code paths have.  If someone with more knowledge and experience could double-check my work I would appreciate it.

Related: https://github.com/getsentry/getsentry/pull/14569
Related: https://github.com/getsentry/sentry/pull/73981