### PR TITLE
fix(profiling): Only transfer valid profile ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Incorrect span outcomes when generated from a indexed transaction quota. ([#3793](https://github.com/getsentry/relay/pull/3793))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
-- Only transfer valid profile ids ([#3809](https://github.com/getsentry/relay/pull/3809))
+- Only transfer valid profile ids. ([#3809](https://github.com/getsentry/relay/pull/3809))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixes metrics dropped due to missing project state. ([#3553](https://github.com/getsentry/relay/issues/3553))
 - Incorrect span outcomes when generated from a indexed transaction quota. ([#3793](https://github.com/getsentry/relay/pull/3793))
 - Report outcomes for spans when transactions are rate limited. ([#3749](https://github.com/getsentry/relay/pull/3749))
+- Only transfer valid profile ids ([#3809](https://github.com/getsentry/relay/pull/3809))
 
 **Internal**:
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1642,6 +1642,7 @@ impl EnvelopeProcessorService {
         event::extract(state, &self.inner.config)?;
 
         let profile_id = profile::filter(state);
+        profile::transfer_id(state, profile_id);
 
         if_processing!(self.inner.config, {
             attachment::create_placeholders(state);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1703,9 +1703,6 @@ impl EnvelopeProcessorService {
 
         event::extract(state, &self.inner.config)?;
 
-        let profile_id = profile::filter(state);
-        profile::transfer_id(state, profile_id);
-
         if_processing!(self.inner.config, {
             attachment::create_placeholders(state);
         });
@@ -1733,7 +1730,7 @@ impl EnvelopeProcessorService {
             // Before metric extraction to make sure the profile count is reflected correctly.
             let profile_id = match keep_profiles {
                 true => profile::process(state, &self.inner.config),
-                false => profile_id,
+                false => None,
             };
 
             // Extract metrics here, we're about to drop the event/transaction.
@@ -1761,6 +1758,7 @@ impl EnvelopeProcessorService {
         if_processing!(self.inner.config, {
             // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
             let profile_id = profile::process(state, &self.inner.config);
+            profile::transfer_id(state, profile_id);
 
             // Always extract metrics in processing Relays for sampled items.
             self.extract_transaction_metrics(state, SamplingDecision::Keep, profile_id)?;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1641,6 +1641,8 @@ impl EnvelopeProcessorService {
 
         event::extract(state, &self.inner.config)?;
 
+        let profile_id = profile::filter(state);
+
         if_processing!(self.inner.config, {
             attachment::create_placeholders(state);
         });
@@ -1668,7 +1670,7 @@ impl EnvelopeProcessorService {
             // Before metric extraction to make sure the profile count is reflected correctly.
             let profile_id = match keep_profiles {
                 true => profile::process(state, &self.inner.config),
-                false => None,
+                false => profile_id,
             };
 
             // Extract metrics here, we're about to drop the event/transaction.

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -4,8 +4,11 @@ use relay_dynamic_config::Feature;
 
 use relay_base_schema::events::EventType;
 use relay_config::Config;
-use relay_event_schema::protocol::{Contexts, Event, ProfileContext};
+use relay_event_schema::protocol::Event;
+#[cfg(feature = "processing")]
+use relay_event_schema::protocol::{Contexts, ProfileContext};
 use relay_profiling::{ProfileError, ProfileId};
+#[cfg(feature = "processing")]
 use relay_protocol::Annotated;
 
 use crate::envelope::{ContentType, Item, ItemType};
@@ -63,6 +66,7 @@ pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) -> Option<ProfileId> {
 /// The profile id may be `None` when the envelope does not contain a profile,
 /// in that case the profile context is removed.
 /// Some SDKs send transactions with profile ids but omit the profile in the envelope.
+#[cfg(feature = "processing")]
 pub fn transfer_id(
     state: &mut ProcessEnvelopeState<TransactionGroup>,
     profile_id: Option<ProfileId>,
@@ -146,6 +150,7 @@ fn expand_profile(item: &mut Item, event: &Event, config: &Config) -> Result<Pro
 mod tests {
     use std::sync::Arc;
 
+    #[cfg(feature = "processing")]
     use insta::assert_debug_snapshot;
     #[cfg(not(feature = "processing"))]
     use relay_dynamic_config::Feature;
@@ -162,6 +167,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "processing")]
     #[tokio::test]
     async fn test_profile_id_transfered() {
         // Setup
@@ -291,6 +297,7 @@ mod tests {
         "###);
     }
 
+    #[cfg(feature = "processing")]
     #[tokio::test]
     async fn test_invalid_profile_id_not_transfered() {
         // Setup
@@ -459,6 +466,7 @@ mod tests {
         assert!(envelope_response.envelope.is_none());
     }
 
+    #[cfg(feature = "processing")]
     #[tokio::test]
     async fn test_profile_id_removed_profiler_id_kept() {
         // Setup

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -165,7 +165,14 @@ mod tests {
     #[tokio::test]
     async fn test_profile_id_transfered() {
         // Setup
-        let processor = create_test_processor(Default::default());
+        let config = Config::from_json_value(serde_json::json!({
+            "processing": {
+                "enabled": true,
+                "kafka_config": []
+            }
+        }))
+        .unwrap();
+        let processor = create_test_processor(config);
         let event_id = EventId::new();
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
@@ -287,7 +294,14 @@ mod tests {
     #[tokio::test]
     async fn test_invalid_profile_id_not_transfered() {
         // Setup
-        let processor = create_test_processor(Default::default());
+        let config = Config::from_json_value(serde_json::json!({
+            "processing": {
+                "enabled": true,
+                "kafka_config": []
+            }
+        }))
+        .unwrap();
+        let processor = create_test_processor(config);
         let event_id = EventId::new();
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
@@ -448,7 +462,14 @@ mod tests {
     #[tokio::test]
     async fn test_profile_id_removed_profiler_id_kept() {
         // Setup
-        let processor = create_test_processor(Default::default());
+        let config = Config::from_json_value(serde_json::json!({
+            "processing": {
+                "enabled": true,
+                "kafka_config": []
+            }
+        }))
+        .unwrap();
+        let processor = create_test_processor(config);
         let event_id = EventId::new();
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()


### PR DESCRIPTION
This was transfering the profile id onto the transaction all the time which is not desirable since we need to fully validate the profile first.