### PR TITLE
ref(event-schema): Merge trace data with span data

### DIFF
--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -610,16 +610,14 @@ pub fn extract_tags(
             if let Some(destination) = span
                 .data
                 .value()
-                .and_then(|data| data.messaging_destination_name.value())
-                .and_then(|value| value.as_str())
+                .and_then(|data| data.messaging_destination_name.as_str())
             {
                 span_tags.insert(SpanTagKey::MessagingDestinationName, destination.into());
             }
             if let Some(message_id) = span
                 .data
                 .value()
-                .and_then(|data| data.messaging_message_id.value())
-                .and_then(|value| value.as_str())
+                .and_then(|data| data.messaging_message_id.as_str())
             {
                 span_tags.insert(SpanTagKey::MessagingMessageId, message_id.into());
             }
@@ -737,12 +735,7 @@ pub fn extract_tags(
     }
 
     if is_mobile {
-        if let Some(thread_name) = span
-            .data
-            .value()
-            .and_then(|data| data.thread_name.value())
-            .and_then(|value| value.as_str())
-        {
+        if let Some(thread_name) = span.data.value().and_then(|data| data.thread_name.as_str()) {
             if thread_name == MAIN_THREAD_NAME {
                 span_tags.insert(SpanTagKey::MainThread, "true".to_owned());
             }
@@ -784,7 +777,7 @@ pub fn extract_tags(
             span_tags.insert(SpanTagKey::ThreadId, thread_id.to_string());
         }
 
-        if let Some(thread_name) = data.thread_name.value().and_then(|name| name.as_str()) {
+        if let Some(thread_name) = data.thread_name.as_str() {
             span_tags.insert(SpanTagKey::ThreadName, thread_name.into());
         }
     }

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -207,12 +207,12 @@ mod tests {
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {
                     "custom_attribute": I64(
                         42,
                     ),
-                    "previousRoute": ~,
-                    "route": ~,
                 },
             },
             sentry_tags: ~,

--- a/relay-filter/src/releases.rs
+++ b/relay-filter/src/releases.rs
@@ -36,10 +36,11 @@ mod tests {
     }
 
     fn get_span_for_release(release: &str) -> Span {
-        let mut data = SpanData::default();
-        data.release = Annotated::from(LenientString::from(release.to_string()));
         Span {
-            data: Annotated::new(data),
+            data: Annotated::new(SpanData {
+                release: Annotated::from(LenientString::from(release.to_string())),
+                ..Default::default()
+            }),
             ..Default::default()
         }
     }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -132,6 +132,8 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {},
             },
             sentry_tags: {
@@ -447,6 +449,8 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {},
             },
             sentry_tags: {
@@ -548,6 +552,8 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {},
             },
             sentry_tags: {
@@ -697,6 +703,8 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {},
             },
             sentry_tags: {
@@ -798,6 +806,8 @@ expression: "(&event.value().unwrap().spans, metrics)"
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {},
             },
             sentry_tags: {

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -1022,89 +1022,6 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         }
       ]
     },
-    "Data": {
-      "description": " The arbitrary data on the trace.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "messaging.destination.name": {
-              "description": " The destination name (ie queue/topic) that a producer/consumer acts on.\n\n Set by backend SDKs with messaging integration.",
-              "default": null,
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "messaging.message.body.size": {
-              "description": " The size of the message body in bytes.\n\n Set by backend SDKs with messaging integration.",
-              "default": null
-            },
-            "messaging.message.id": {
-              "description": " The id of the message in the messaging event.\n\n Set by backend SDKs with messaging integration.",
-              "default": null,
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "messaging.message.receive.latency": {
-              "description": " The time duration that a message waited in queue before being received.\n\n Set by backend SDKs with messaging integration.",
-              "default": null
-            },
-            "messaging.message.retry.count": {
-              "description": " The number of times a message was redelivered.\n\n Set by backend SDKs with messaging integration.",
-              "default": null
-            },
-            "previousRoute": {
-              "description": " The previous route in the application\n\n Set by React Native SDK.",
-              "default": null,
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Route"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "route": {
-              "description": " The current route in the application.\n\n Set by React Native SDK.",
-              "default": null,
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Route"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "thread.id": {
-              "description": " The ID of the thread from which the transaction originated from",
-              "default": null,
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ThreadId"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "thread.name": {
-              "description": " The name of the thread from which the transaction originated from",
-              "default": null,
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "DebugId": {
       "type": "string"
     },
@@ -3502,6 +3419,287 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         }
       ]
     },
+    "SpanData": {
+      "description": " Arbitrary additional data on a span.\n\n Besides arbitrary user data, this type also contains SDK-provided fields used by the\n product (see <https://develop.sentry.dev/sdk/performance/span-data-conventions/>).",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ai.completion_tokens.used": {
+              "description": " The output tokens used by an LLM call (the ones the LLM actually generated)",
+              "default": null
+            },
+            "ai.input_messages": {
+              "description": " The input messages to an AI model call",
+              "default": null
+            },
+            "ai.model_id": {
+              "description": " The Model ID of an AI pipeline, e.g., gpt-4",
+              "default": null
+            },
+            "ai.pipeline.name": {
+              "description": " The 'name' field of the ancestor span with op ai.pipeline.*",
+              "default": null
+            },
+            "ai.prompt_tokens.used": {
+              "description": " The input tokens used by an LLM call (usually cheaper than output tokens)",
+              "default": null
+            },
+            "ai.responses": {
+              "description": " The responses to an AI model call",
+              "default": null
+            },
+            "ai.total_tokens.used": {
+              "description": " The total tokens that were used by an LLM call",
+              "default": null
+            },
+            "app_start_type": {
+              "description": " Mobile app start variant.\n\n Can be either \"cold\" or \"warm\".",
+              "default": null
+            },
+            "browser.name": {
+              "description": " The client's browser name.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cache.hit": {
+              "description": " Whether cache was hit or miss on a read operation.",
+              "default": null
+            },
+            "cache.item_size": {
+              "description": " The size of the cache item.",
+              "default": null
+            },
+            "cache.key": {
+              "description": " The name of the cache key.",
+              "default": null
+            },
+            "client.address": {
+              "description": " The client's IP address.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "code.filepath": {
+              "description": " The source code file name that identifies the code unit as uniquely as possible.",
+              "default": null
+            },
+            "code.function": {
+              "description": " The method or function name, or equivalent.\n\n Usually rightmost part of the code unit's name.",
+              "default": null
+            },
+            "code.lineno": {
+              "description": " The line number in `code.filepath` best representing the operation.",
+              "default": null
+            },
+            "code.namespace": {
+              "description": " The \"namespace\" within which `code.function` is defined.\n\n Usually the qualified class or module name, such that\n `code.namespace + some separator + code.function`\n form a unique identifier for the code unit.",
+              "default": null
+            },
+            "db.operation": {
+              "description": " The name of the operation being executed.\n\n E.g. the MongoDB command name such as findAndModify, or the SQL keyword.\n Based on [OpenTelemetry's call level db attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes).",
+              "default": null
+            },
+            "db.system": {
+              "description": " An identifier for the database management system (DBMS) product being used.\n\n See [OpenTelemetry docs for a list of well-known identifiers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem).",
+              "default": null
+            },
+            "frames.delay": {
+              "default": null
+            },
+            "http.decoded_response_content_length": {
+              "description": " The decoded body size of the response (in bytes).",
+              "default": null
+            },
+            "http.request_method": {
+              "description": " The HTTP method used.",
+              "default": null
+            },
+            "http.response.status_code": {
+              "description": " The status HTTP response.",
+              "default": null
+            },
+            "http.response_content_length": {
+              "description": " The encoded body size of the response (in bytes).",
+              "default": null
+            },
+            "http.response_transfer_size": {
+              "description": " The transfer size of the response (in bytes).",
+              "default": null
+            },
+            "messaging.destination.name": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messaging.message.body.size": {
+              "description": " Message Body Size",
+              "default": null
+            },
+            "messaging.message.id": {
+              "description": " Message ID",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messaging.message.receive.latency": {
+              "description": " Message Receive Latency",
+              "default": null
+            },
+            "messaging.message.retry.count": {
+              "description": " Message Retry Count",
+              "default": null
+            },
+            "previousRoute": {
+              "description": " The previous route in the application\n\n Set by React Native SDK.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Route"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "resource.render_blocking_status": {
+              "description": " The render blocking status of the resource.",
+              "default": null
+            },
+            "route": {
+              "description": " The current route in the application.\n\n Set by React Native SDK.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Route"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sentry.environment": {
+              "description": " The sentry environment.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sentry.frames.frozen": {
+              "description": " Frozen Frames",
+              "default": null
+            },
+            "sentry.frames.slow": {
+              "description": " Slow Frames",
+              "default": null
+            },
+            "sentry.frames.total": {
+              "description": " Total Frames",
+              "default": null
+            },
+            "sentry.release": {
+              "description": " The release version of the project.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sentry.replay.id": {
+              "description": " Replay ID",
+              "default": null
+            },
+            "sentry.sdk.name": {
+              "description": " The sentry SDK (see [`crate::protocol::ClientSdkInfo`]).",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sentry.sdk.version": {
+              "description": " The sentry SDK version (see [`crate::protocol::ClientSdkInfo`]).",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sentry.segment.name": {
+              "description": " Name of the segment that this span belongs to (see `segment_id`).\n\n This corresponds to the transaction name in the transaction-based model.\n\n For INP spans, this is the route name where the interaction occurred.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "server.address": {
+              "description": " Name of the web server host.",
+              "default": null
+            },
+            "thread.id": {
+              "description": " ID of thread from where the span originated.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ThreadId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "thread.name": {
+              "description": " Label identifying a thread from where the span originated.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ui.component_name": {
+              "description": " Name of the UI component (e.g. React).",
+              "default": null
+            },
+            "url.full": {
+              "description": " Absolute URL of a network resource.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "url.scheme": {
+              "description": " The URL scheme, e.g. `\"https\"`.",
+              "default": null
+            },
+            "user": {
+              "description": " User Display",
+              "default": null
+            },
+            "user_agent.original": {
+              "description": " Value of the HTTP User-Agent header sent by the client.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "SpanId": {
       "description": " A 16-character hex string as described in the W3C trace context spec.",
       "anyOf": [
@@ -3784,11 +3982,11 @@ expression: "relay_event_schema::protocol::event_json_schema()"
               "format": "double"
             },
             "data": {
-              "description": " Arbitrary additional data on a trace.",
+              "description": " Data of the trace's root span.",
               "default": null,
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Data"
+                  "$ref": "#/definitions/SpanData"
                 },
                 {
                   "type": "null"

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -674,6 +674,8 @@ mod tests {
                 user_agent_original: ~,
                 url_full: ~,
                 client_address: ~,
+                route: ~,
+                previous_route: ~,
                 other: {},
             },
             sentry_tags: ~,


### PR DESCRIPTION
Merges `contexts.trace.data` with `span.data`, since data on the trace context actually refers to the root span of the transaction event, which doesn't have an explicit entry in the spans list.

Originates in https://github.com/getsentry/relay/pull/3790#issuecomment-2210366034
#skip-changelog