### PR TITLE
ref(redis): Default redis connections to 2x cpu concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,6 +3661,7 @@ version = "24.6.0"
 dependencies = [
  "anyhow",
  "human-size",
+ "insta",
  "num_cpus",
  "relay-auth",
  "relay-common",

--- a/relay-auth/Cargo.toml
+++ b/relay-auth/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 workspace = true
 
 [dependencies]
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 data-encoding = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 hmac = { workspace = true }

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -32,3 +32,6 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/relay-config/src/lib.rs
+++ b/relay-config/src/lib.rs
@@ -9,9 +9,11 @@
 pub mod aggregator;
 mod byte_size;
 mod config;
+mod redis;
 mod upstream;
 
 pub use crate::aggregator::{AggregatorServiceConfig, ScopedAggregatorConfig};
 pub use crate::byte_size::*;
 pub use crate::config::*;
+pub use crate::redis::*;
 pub use crate::upstream::*;

--- a/relay-config/src/redis.rs
+++ b/relay-config/src/redis.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct PartialRedisConfigOptions {
     /// Maximum number of connections managed by the pool.
+    ///
+    /// Defaults to 2x `limits.max_thread_count`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<u32>,
     /// Sets the connection timeout used by the pool, in seconds.

--- a/relay-config/src/redis.rs
+++ b/relay-config/src/redis.rs
@@ -1,0 +1,278 @@
+use serde::{Deserialize, Serialize};
+
+/// Additional configuration options for a redis client.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(default)]
+pub struct PartialRedisConfigOptions {
+    /// Maximum number of connections managed by the pool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_connections: Option<u32>,
+    /// Sets the connection timeout used by the pool, in seconds.
+    ///
+    /// Calls to `Pool::get` will wait this long for a connection to become available before returning an error.
+    pub connection_timeout: u64,
+    /// Sets the maximum lifetime of connections in the pool, in seconds.
+    pub max_lifetime: u64,
+    /// Sets the idle timeout used by the pool, in seconds.
+    pub idle_timeout: u64,
+    /// Sets the read timeout out on the connection, in seconds.
+    pub read_timeout: u64,
+    /// Sets the write timeout on the connection, in seconds.
+    pub write_timeout: u64,
+}
+
+impl Default for PartialRedisConfigOptions {
+    fn default() -> Self {
+        Self {
+            max_connections: None,
+            connection_timeout: 5,
+            max_lifetime: 300,
+            idle_timeout: 60,
+            read_timeout: 3,
+            write_timeout: 3,
+        }
+    }
+}
+
+/// Configuration for connecting a redis client.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+enum RedisConfigFromFile {
+    /// Connect to a Redis cluster.
+    Cluster {
+        /// List of `redis://` urls to use in cluster mode.
+        ///
+        /// This can also be a single node which is configured in cluster mode.
+        cluster_nodes: Vec<String>,
+
+        /// Additional configuration options for the redis client and a connections pool.
+        #[serde(flatten)]
+        options: PartialRedisConfigOptions,
+    },
+
+    /// Connect to a single Redis instance.
+    ///
+    /// Contains the `redis://` url to the node.
+    Single(String),
+
+    /// Connect to a single Redis instance.
+    ///
+    /// Allows to provide more configuration options, e.g. `max_connections`.
+    SingleWithOpts {
+        /// Containes the `redis://` url to the node.
+        server: String,
+
+        /// Additional configuration options for the redis client and a connections pool.
+        #[serde(flatten)]
+        options: PartialRedisConfigOptions,
+    },
+}
+
+/// Redis connection parameters.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum RedisConnection {
+    /// Connect to a Redis Cluster.
+    #[serde(rename = "cluster_nodes")]
+    Cluster(Vec<String>),
+    /// Connect to a single Redis instance.
+    #[serde(rename = "server")]
+    Single(String),
+}
+
+/// Configuration for connecting a redis client.
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
+pub struct RedisConfig {
+    /// Redis connection info.
+    #[serde(flatten)]
+    pub connection: RedisConnection,
+    /// Additional configuration options for the redis client and a connections pool.
+    #[serde(flatten)]
+    pub options: PartialRedisConfigOptions,
+}
+
+impl RedisConfig {
+    /// Creates a new Redis config for a single Redis instance with default settings.
+    pub fn single(server: String) -> Self {
+        Self {
+            connection: RedisConnection::Single(server),
+            options: Default::default(),
+        }
+    }
+}
+
+impl From<RedisConfigFromFile> for RedisConfig {
+    fn from(value: RedisConfigFromFile) -> Self {
+        match value {
+            RedisConfigFromFile::Cluster {
+                cluster_nodes,
+                options,
+            } => Self {
+                connection: RedisConnection::Cluster(cluster_nodes),
+                options,
+            },
+            RedisConfigFromFile::Single(server) => Self {
+                connection: RedisConnection::Single(server),
+                options: Default::default(),
+            },
+            RedisConfigFromFile::SingleWithOpts { server, options } => Self {
+                connection: RedisConnection::Single(server),
+                options,
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RedisConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        RedisConfigFromFile::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_json_snapshot;
+
+    use super::*;
+
+    #[test]
+    fn test_redis_single_opts() {
+        let yaml = r#"
+server: "redis://127.0.0.1:6379"
+max_connections: 42
+connection_timeout: 5
+"#;
+
+        let config: RedisConfig = serde_yaml::from_str(yaml)
+            .expect("Parsed processing redis config: single with options");
+
+        assert_eq!(
+            config,
+            RedisConfig {
+                connection: RedisConnection::Single("redis://127.0.0.1:6379".to_owned()),
+                options: PartialRedisConfigOptions {
+                    max_connections: Some(42),
+                    connection_timeout: 5,
+                    ..Default::default()
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_redis_single_serialize() {
+        let config = RedisConfig {
+            connection: RedisConnection::Single("redis://127.0.0.1:6379".to_owned()),
+            options: PartialRedisConfigOptions {
+                connection_timeout: 5,
+                ..Default::default()
+            },
+        };
+
+        assert_json_snapshot!(config, @r###"
+        {
+          "server": "redis://127.0.0.1:6379",
+          "connection_timeout": 5,
+          "max_lifetime": 300,
+          "idle_timeout": 60,
+          "read_timeout": 3,
+          "write_timeout": 3
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_redis_single_opts_default() {
+        let yaml = r#"
+server: "redis://127.0.0.1:6379"
+"#;
+
+        let config: RedisConfig = serde_yaml::from_str(yaml)
+            .expect("Parsed processing redis config: single with options");
+
+        assert_eq!(
+            config,
+            RedisConfig {
+                connection: RedisConnection::Single("redis://127.0.0.1:6379".to_owned()),
+                options: Default::default()
+            }
+        );
+    }
+
+    // To make sure that we have backwards compatibility and still support the redis configuration
+    // when the single `redis://...` address is provided.
+    #[test]
+    fn test_redis_single() {
+        let yaml = r#"
+"redis://127.0.0.1:6379"
+"#;
+
+        let config: RedisConfig = serde_yaml::from_str(yaml)
+            .expect("Parsed processing redis config: single with options");
+
+        assert_eq!(
+            config,
+            RedisConfig {
+                connection: RedisConnection::Single("redis://127.0.0.1:6379".to_owned()),
+                options: Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_redis_cluster_nodes_opts() {
+        let yaml = r#"
+cluster_nodes:
+    - "redis://127.0.0.1:6379"
+    - "redis://127.0.0.2:6379"
+read_timeout: 10
+"#;
+
+        let config: RedisConfig = serde_yaml::from_str(yaml)
+            .expect("Parsed processing redis config: single with options");
+
+        assert_eq!(
+            config,
+            RedisConfig {
+                connection: RedisConnection::Cluster(vec![
+                    "redis://127.0.0.1:6379".to_owned(),
+                    "redis://127.0.0.2:6379".to_owned()
+                ]),
+                options: PartialRedisConfigOptions {
+                    read_timeout: 10,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_redis_cluster_serialize() {
+        let config = RedisConfig {
+            connection: RedisConnection::Cluster(vec![
+                "redis://127.0.0.1:6379".to_owned(),
+                "redis://127.0.0.2:6379".to_owned(),
+            ]),
+            options: PartialRedisConfigOptions {
+                read_timeout: 33,
+                ..Default::default()
+            },
+        };
+
+        assert_json_snapshot!(config, @r###"
+        {
+          "cluster_nodes": [
+            "redis://127.0.0.1:6379",
+            "redis://127.0.0.2:6379"
+          ],
+          "connection_timeout": 5,
+          "max_lifetime": 300,
+          "idle_timeout": 60,
+          "read_timeout": 33,
+          "write_timeout": 3
+        }
+        "###);
+    }
+}

--- a/relay-redis/src/config.rs
+++ b/relay-redis/src/config.rs
@@ -1,188 +1,33 @@
 use serde::{Deserialize, Serialize};
 
-const fn default_max_connections() -> u32 {
-    24
-}
-
-const fn default_connection_timeout() -> u64 {
-    5
-}
-
-const fn default_max_lifetime() -> u64 {
-    300
-}
-
-const fn default_idle_timeout() -> u64 {
-    60
-}
-
-const fn default_read_timeout() -> u64 {
-    3
-}
-
-const fn default_write_timeout() -> u64 {
-    3
-}
-
 /// Additional configuration options for a redis client.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(default)]
 pub struct RedisConfigOptions {
     /// Maximum number of connections managed by the pool.
-    #[serde(default = "default_max_connections")]
     pub max_connections: u32,
     /// Sets the connection timeout used by the pool, in seconds.
     ///
     /// Calls to `Pool::get` will wait this long for a connection to become available before returning an error.
-    #[serde(default = "default_connection_timeout")]
     pub connection_timeout: u64,
     /// Sets the maximum lifetime of connections in the pool, in seconds.
-    #[serde(default = "default_max_lifetime")]
     pub max_lifetime: u64,
     /// Sets the idle timeout used by the pool, in seconds.
-    #[serde(default = "default_idle_timeout")]
     pub idle_timeout: u64,
     /// Sets the read timeout out on the connection, in seconds.
-    #[serde(default = "default_read_timeout")]
     pub read_timeout: u64,
     /// Sets the write timeout on the connection, in seconds.
-    #[serde(default = "default_write_timeout")]
     pub write_timeout: u64,
 }
 
 impl Default for RedisConfigOptions {
     fn default() -> Self {
         Self {
-            max_connections: default_max_connections(),
-            connection_timeout: default_connection_timeout(),
-            max_lifetime: default_max_lifetime(),
-            idle_timeout: default_idle_timeout(),
-            read_timeout: default_read_timeout(),
-            write_timeout: default_write_timeout(),
-        }
-    }
-}
-
-/// Configuration for connecting a redis client.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(untagged)]
-pub enum RedisConfig {
-    /// Connect to a Redis cluster.
-    Cluster {
-        /// List of `redis://` urls to use in cluster mode.
-        ///
-        /// This can also be a single node which is configured in cluster mode.
-        cluster_nodes: Vec<String>,
-
-        /// Additional configuration options for the redis client and a connections pool.
-        #[serde(flatten)]
-        options: RedisConfigOptions,
-    },
-
-    /// Connect to a single Redis instance.
-    ///
-    /// Contains the `redis://` url to the node.
-    Single(String),
-
-    /// Connect to a single Redis instance.
-    ///
-    /// Allows to provide more configuration options, e.g. `max_connections`.
-    SingleWithOpts {
-        /// Containes the `redis://` url to the node.
-        server: String,
-
-        /// Additional configuration options for the redis client and a connections pool.
-        #[serde(flatten)]
-        options: RedisConfigOptions,
-    },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_redis_single_opts() {
-        let yaml = r#"
-server: "redis://127.0.0.1:6379"
-max_connections: 42
-connection_timeout: 5
-"#;
-
-        let config: RedisConfig = serde_yaml::from_str(yaml)
-            .expect("Parsed processing redis config: single with options");
-
-        match config {
-            RedisConfig::SingleWithOpts { server, options } => {
-                assert_eq!(options.max_connections, 42);
-                assert_eq!(options.connection_timeout, 5);
-                assert_eq!(server, "redis://127.0.0.1:6379");
-            }
-            e => panic!("Expected RedisConfig::SingleWithOpts but got {e:?}"),
-        }
-    }
-
-    #[test]
-    fn test_redis_single_opts_default() {
-        let yaml = r#"
-server: "redis://127.0.0.1:6379"
-"#;
-
-        let config: RedisConfig = serde_yaml::from_str(yaml)
-            .expect("Parsed processing redis config: single with options");
-
-        match config {
-            RedisConfig::SingleWithOpts { options, .. } => {
-                // check if all the defaults are correctly set
-                assert_eq!(options.max_connections, 24);
-            }
-            e => panic!("Expected RedisConfig::SingleWithOpts but got {e:?}"),
-        }
-    }
-
-    // To make sure that we have backwards compatibility and still support the redis configuration
-    // when the single `redis://...` address is provided.
-    #[test]
-    fn test_redis_single() {
-        let yaml = r#"
-"redis://127.0.0.1:6379"
-"#;
-
-        let config: RedisConfig = serde_yaml::from_str(yaml)
-            .expect("Parsed processing redis config: single with options");
-
-        match config {
-            RedisConfig::Single(server) => {
-                assert_eq!(server, "redis://127.0.0.1:6379");
-            }
-            e => panic!("Expected RedisConfig::Single but got {e:?}"),
-        }
-    }
-
-    #[test]
-    fn test_redis_cluster_nodes_opts() {
-        let yaml = r#"
-cluster_nodes:
-    - "redis://127.0.0.1:6379"
-    - "redis://127.0.0.2:6379"
-read_timeout: 10
-"#;
-
-        let config: RedisConfig = serde_yaml::from_str(yaml)
-            .expect("Parsed processing redis config: single with options");
-
-        match config {
-            RedisConfig::Cluster {
-                cluster_nodes,
-                options,
-            } => {
-                assert_eq!(options.max_connections, 24);
-                assert_eq!(options.connection_timeout, 5);
-                assert_eq!(options.read_timeout, 10);
-                assert_eq!(options.write_timeout, 3);
-                assert!(cluster_nodes.contains(&String::from("redis://127.0.0.2:6379")));
-            }
-            e => panic!("Expected RedisConfig::SingleWithOpts but got {e:?}"),
+            max_connections: 24,
+            connection_timeout: 5,
+            max_lifetime: 300,
+            idle_timeout: 60,
+            read_timeout: 3,
+            write_timeout: 3,
         }
     }
 }

--- a/relay-redis/src/noop.rs
+++ b/relay-redis/src/noop.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::config::RedisConfig;
+use crate::config::RedisConfigOptions;
 
 /// This is an unconstructable type to make `Option<RedisPool>` zero-sized.
 #[derive(Clone, Debug)]
@@ -12,10 +12,20 @@ pub struct RedisPool;
 pub struct RedisError;
 
 impl RedisPool {
-    /// Creates a `RedisPool` from the given configuration.
+    /// Creates a `RedisPool` in cluster configuration.
     ///
-    /// Always returns `Ok(None)`.
-    pub fn new(_config: &RedisConfig) -> Result<Self, RedisError> {
+    /// Always returns `Ok(Self)`.
+    pub fn cluster<'a>(
+        _servers: impl IntoIterator<Item = &'a str>,
+        _opts: RedisConfigOptions,
+    ) -> Result<Self, RedisError> {
+        Ok(Self)
+    }
+
+    /// Creates a `RedisPool` in single-node configuration.
+    ///
+    /// Always returns `Ok(Self)`.
+    pub fn single(_server: &str, _opts: RedisConfigOptions) -> Result<Self, RedisError> {
         Ok(Self)
     }
 }

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -6,7 +6,7 @@ pub use redis;
 use redis::ConnectionLike;
 use thiserror::Error;
 
-use crate::config::{RedisConfig, RedisConfigOptions};
+use crate::config::RedisConfigOptions;
 
 /// An error returned from `RedisPool`.
 #[derive(Debug, Error)]
@@ -144,26 +144,11 @@ pub struct RedisPool {
 }
 
 impl RedisPool {
-    /// Creates a `RedisPool` from configuration.
-    pub fn new(config: &RedisConfig) -> Result<Self, RedisError> {
-        match config {
-            RedisConfig::Cluster {
-                ref cluster_nodes,
-                options,
-            } => {
-                let servers = cluster_nodes.iter().map(String::as_str).collect();
-                Self::cluster(servers, options.clone())
-            }
-            RedisConfig::Single(ref server) => Self::single(server, RedisConfigOptions::default()),
-            RedisConfig::SingleWithOpts {
-                ref server,
-                options,
-            } => Self::single(server, options.clone()),
-        }
-    }
-
     /// Creates a `RedisPool` in cluster configuration.
-    pub fn cluster(servers: Vec<&str>, opts: RedisConfigOptions) -> Result<Self, RedisError> {
+    pub fn cluster<'a>(
+        servers: impl IntoIterator<Item = &'a str>,
+        opts: RedisConfigOptions,
+    ) -> Result<Self, RedisError> {
         let pool = Pool::builder()
             .max_size(opts.max_connections)
             .test_on_check_out(false)

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -12,6 +12,9 @@ use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 use relay_system::Addr;
 use relay_test::mock_service;
 
+#[cfg(feature = "processing")]
+use {relay_config::RedisConnection, relay_redis::RedisPool};
+
 use crate::envelope::{Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
 use crate::metrics::{MetricOutcomes, MetricStats};
@@ -122,7 +125,14 @@ pub fn create_test_processor(config: Config) -> EnvelopeProcessorService {
     let redis = config
         .redis()
         .filter(|_| config.processing_enabled())
-        .map(|redis_config| relay_redis::RedisPool::new(redis_config).unwrap());
+        .map(|redis| match redis {
+            (RedisConnection::Single(server), options) => {
+                RedisPool::single(server, options).unwrap()
+            }
+            (RedisConnection::Cluster(servers), options) => {
+                RedisPool::cluster(servers.iter().map(|s| s.as_str()), options).unwrap()
+            }
+        });
 
     let metric_outcomes = MetricOutcomes::new(MetricStats::test().0, outcome_aggregator.clone());
 
@@ -153,7 +163,14 @@ pub fn create_test_processor_with_addrs(
     let redis = config
         .redis()
         .filter(|_| config.processing_enabled())
-        .map(|redis_config| relay_redis::RedisPool::new(redis_config).unwrap());
+        .map(|redis| match redis {
+            (RedisConnection::Single(server), options) => {
+                RedisPool::single(server, options).unwrap()
+            }
+            (RedisConnection::Cluster(servers), options) => {
+                RedisPool::cluster(servers.iter().map(|s| s.as_str()), options).unwrap()
+            }
+        });
 
     let metric_outcomes =
         MetricOutcomes::new(MetricStats::test().0, addrs.outcome_aggregator.clone());


### PR DESCRIPTION
Infers the redis pool size based on the cpu concurrency to 2x the amount of threads which mirrors what we currently are working with in production.

#skip-changelog