### PR TITLE
ref(redis): Set minimum redis pool size

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2283,7 +2283,7 @@ impl Config {
                 .options
                 .max_connections
                 .unwrap_or(cpu_concurrency as u32 * 2)
-                .min(24),
+                .min(crate::redis::DEFAULT_MIN_MAX_CONNECTIONS),
             connection_timeout: redis.options.connection_timeout,
             max_lifetime: redis.options.max_lifetime,
             idle_timeout: redis.options.idle_timeout,

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2282,7 +2282,8 @@ impl Config {
             max_connections: redis
                 .options
                 .max_connections
-                .unwrap_or(cpu_concurrency as u32 * 2),
+                .unwrap_or(cpu_concurrency as u32 * 2)
+                .min(24),
             connection_timeout: redis.options.connection_timeout,
             max_lifetime: redis.options.max_lifetime,
             idle_timeout: redis.options.idle_timeout,

--- a/relay-config/src/redis.rs
+++ b/relay-config/src/redis.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct PartialRedisConfigOptions {
     /// Maximum number of connections managed by the pool.
     ///
-    /// Defaults to 2x `limits.max_thread_count`.
+    /// Defaults to 2x `limits.max_thread_count` or a minimum of 24.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<u32>,
     /// Sets the connection timeout used by the pool, in seconds.

--- a/relay-config/src/redis.rs
+++ b/relay-config/src/redis.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+/// For small setups, `2 x limits.max_thread_count` does not leave enough headroom.
+/// In this case, we fall back to the old default.
+pub(crate) const DEFAULT_MIN_MAX_CONNECTIONS: u32 = 24;
+
 /// Additional configuration options for a redis client.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(default)]


### PR DESCRIPTION
We should have a minimum for small setups with almost no cores, I choose our previous default as the new minimum.

#skip-changelog