### PR TITLE
ref(metrics): Switch to hashbrown in metrics aggregator

### DIFF
--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::time::Duration;
 
 use relay_base_schema::project::ProjectKey;


### PR DESCRIPTION
Hashbrown should gives about 10% performance simply by switching to ahash, additionally we can switch the `retain` with `extract_if`.

Drive by fix: Calculates now for `elapsed()` only once instead of N times.

#skip-changelog