### PR TITLE
fix(spans): Use `user_agent.original` for browser name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-**Features**
+**Features**:
 
 - "Cardinality limit" outcomes now report which limit was exceeded. ([#3825](https://github.com/getsentry/relay/pull/3825))
+- Derive span browser name from user agent. ([#3834](https://github.com/getsentry/relay/pull/3834))
 
 ## 24.7.0
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -950,8 +950,8 @@ pub fn normalize_performance_score(
                         .into(),
                     );
                 }
-                break; // Stop after the first matching profile.
             }
+            break; // Stop after the first matching profile.
         }
     }
     version

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -3333,35 +3333,40 @@ mod tests {
         }))
         .unwrap();
 
-        normalize_performance_score(&mut event, Some(&performance_score));
+        normalize(
+            &mut event,
+            &mut Meta::default(),
+            &NormalizationConfig {
+                performance_score: Some(&performance_score),
+                ..Default::default()
+            },
+        );
 
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&event.contexts), {}, @r###"
         {
-          "type": "transaction",
-          "timestamp": 1619420405.0,
-          "start_timestamp": 1619420400.0,
-          "contexts": {
-            "performance_score": {
-              "score_profile_version": "beta",
-              "type": "performancescore",
-            },
+          "performance_score": {
+            "score_profile_version": "beta",
+            "type": "performancescore",
           },
-          "measurements": {
-            "inp": {
-              "value": 120.0,
-            },
-            "score.inp": {
-              "value": 0.0,
-              "unit": "ratio",
-            },
-            "score.total": {
-              "value": 0.0,
-              "unit": "ratio",
-            },
-            "score.weight.inp": {
-              "value": 1.0,
-              "unit": "ratio",
-            },
+        }
+        "###);
+        insta::assert_ron_snapshot!(SerializableAnnotated(&event.measurements), {}, @r###"
+        {
+          "inp": {
+            "value": 120.0,
+            "unit": "millisecond",
+          },
+          "score.inp": {
+            "value": 0.0,
+            "unit": "ratio",
+          },
+          "score.total": {
+            "value": 0.0,
+            "unit": "ratio",
+          },
+          "score.weight.inp": {
+            "value": 1.0,
+            "unit": "ratio",
           },
         }
         "###);

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -287,11 +287,14 @@ impl ClientHints<String> {
 }
 
 /// Computes a [`Context`] from either a user agent string and client hints.
-trait FromUserAgentInfo: Sized {
+pub trait FromUserAgentInfo: Sized {
+    /// Tries to populate the context from client hints.
     fn parse_client_hints(client_hints: &ClientHints<&str>) -> Option<Self>;
 
+    /// Tries to populate the context from a user agent header string.
     fn parse_user_agent(user_agent: &str) -> Option<Self>;
 
+    /// Tries to populate the context from client hints or a user agent header string.
     fn from_hints_or_ua(raw_info: &RawUserAgentInfo<&str>) -> Option<Self> {
         Self::parse_client_hints(&raw_info.client_hints)
             .or_else(|| raw_info.user_agent.and_then(Self::parse_user_agent))
@@ -362,7 +365,7 @@ impl FromUserAgentInfo for BrowserContext {
 /// to be a browser and gets returned as such.
 ///
 /// Returns None if no browser field detected.
-fn browser_from_client_hints(s: &str) -> Option<(String, String)> {
+pub fn browser_from_client_hints(s: &str) -> Option<(String, String)> {
     for item in s.split(',') {
         // if it contains one of these then we can know it isn't a browser field. atm chromium
         // browsers are the only ones supporting client hints.

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -175,6 +175,7 @@ impl Getter for Span {
             "release" => self.data.value()?.release.as_str()?.into(),
             "environment" => self.data.value()?.environment.as_str()?.into(),
             "transaction" => self.data.value()?.segment_name.as_str()?.into(),
+            "contexts.browser.name" => self.data.value()?.browser_name.as_str()?.into(),
             // TODO: we might want to add additional fields once they are added to the span.
             _ => return None,
         })

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -16,7 +16,9 @@ use relay_event_normalization::{
 };
 use relay_event_normalization::{normalize_transaction_name, ModelCosts, TransactionNameRule};
 use relay_event_schema::processor::{process_value, ProcessingState};
-use relay_event_schema::protocol::{BrowserContext, Contexts, Event, Span, SpanData};
+use relay_event_schema::protocol::{
+    BrowserContext, Contexts, DeviceContext, Event, Span, SpanData,
+};
 use relay_log::protocol::{Attachment, AttachmentType};
 use relay_metrics::{MetricNamespace, UnixTimestamp};
 use relay_pii::PiiProcessor;
@@ -508,17 +510,10 @@ fn normalize(
             .collect(),
     );
 
-    let mut event = Event {
-        contexts: Annotated::new(default_contexts.clone()),
-        measurements: span.measurements.clone(),
-        spans: Annotated::from(vec![Annotated::new(span.clone())]),
-        ..Default::default()
-    };
-    normalize_performance_score(&mut event, performance_score);
+    normalize_performance_score(span, performance_score);
     if let Some(model_costs_config) = ai_model_costs {
         extract_ai_measurements(span, model_costs_config);
     }
-    span.measurements = event.measurements;
 
     tag_extraction::extract_measurements(span, is_mobile);
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -461,6 +461,7 @@ fn normalize(
     };
 
     populate_ua_fields(span, user_agent.as_deref(), client_hints.as_deref());
+    dbg!(&span.data.value().unwrap().browser_name);
 
     if let Annotated(Some(ref mut measurement_values), ref mut meta) = span.measurements {
         normalize_measurements(

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -461,7 +461,6 @@ fn normalize(
     };
 
     populate_ua_fields(span, user_agent.as_deref(), client_hints.as_deref());
-    dbg!(&span.data.value().unwrap().browser_name);
 
     if let Annotated(Some(ref mut measurement_values), ref mut meta) = span.measurements {
         normalize_measurements(

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -556,7 +556,12 @@ def test_span_ingestion(
 
     assert spans == [
         {
-            "data": {"browser.name": "Chrome"},
+            "data": {
+                "browser.name": "Chrome",
+                "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/111.0.0.0 Safari/537.36",
+            },
             "description": "my 1st OTel span",
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -578,7 +583,12 @@ def test_span_ingestion(
             "trace_id": "89143b0763095bd9c9955e8175d1fb23",
         },
         {
-            "data": {"browser.name": "Chrome"},
+            "data": {
+                "browser.name": "Chrome",
+                "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/111.0.0.0 Safari/537.36",
+            },
             "description": "https://example.com/p/blah.js",
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -604,7 +614,12 @@ def test_span_ingestion(
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
         {
-            "data": {"browser.name": "Chrome"},
+            "data": {
+                "browser.name": "Chrome",
+                "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/111.0.0.0 Safari/537.36",
+            },
             "description": r"test \" with \" escaped \" chars",
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -621,7 +636,10 @@ def test_span_ingestion(
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
         {
-            "data": {"browser.name": "Python Requests"},
+            "data": {
+                "browser.name": "Python Requests",
+                "user_agent.original": "python-requests/2.32.2",
+            },
             "description": "my 2nd OTel span",
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -642,7 +660,12 @@ def test_span_ingestion(
             "trace_id": "89143b0763095bd9c9955e8175d1fb24",
         },
         {
-            "data": {"browser.name": "Chrome"},
+            "data": {
+                "browser.name": "Chrome",
+                "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/111.0.0.0 Safari/537.36",
+            },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
             "is_segment": False,
@@ -661,7 +684,10 @@ def test_span_ingestion(
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
         {
-            "data": {"browser.name": "Python Requests"},
+            "data": {
+                "browser.name": "Python Requests",
+                "user_agent.original": "python-requests/2.32.2",
+            },
             "description": "my 3rd protobuf OTel span",
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -1374,7 +1400,10 @@ def test_span_ingestion_with_performance_scores(
 
     assert spans == [
         {
-            "data": {"browser.name": "Python Requests"},
+            "data": {
+                "browser.name": "Python Requests",
+                "user_agent.original": "python-requests/2.32.2",
+            },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
             "is_segment": False,
@@ -1415,6 +1444,7 @@ def test_span_ingestion_with_performance_scores(
                 "sentry.replay.id": "8477286c8e5148b386b71ade38374d58",
                 "sentry.segment.name": "/page/with/click/interaction/*/*",
                 "user": "admin@sentry.io",
+                "user_agent.original": "python-requests/2.32.2",
             },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1668,6 +1668,11 @@ def test_rate_limit_spans_in_envelope(
 
     assert summarize_outcomes() == {(12, 2): 4, (16, 2): 4}
 
+    # We emit transaction metrics from spans for legacy reasons. These are not rate limited.
+    # (could be a bug)
+    ((metric, _),) = metrics_consumer.get_metrics(n=1)
+    assert ":spans/" not in metric["name"]
+
     spans_consumer.assert_empty()
     metrics_consumer.assert_empty()
 


### PR DESCRIPTION
Use `user_agent.original` to derive the browser name, and only use request headers if that field has not been set.

This PR also refactors span normalization, such that there is no more fake event necessary to derive user agent information or performance scores.

Fixes https://github.com/getsentry/relay/issues/3815.