### PR TITLE
ref(server): Performance improvements to metric router service

### DIFF
--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -35,7 +35,7 @@ pub enum Aggregator {
 
 impl Aggregator {
     /// Returns the name of the message variant.
-    fn variant(&self) -> &'static str {
+    pub fn variant(&self) -> &'static str {
         match self {
             Aggregator::AcceptsMetrics(_, _) => "AcceptsMetrics",
             Aggregator::MergeBuckets(_) => "MergeBuckets",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -522,6 +522,11 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     ///  - `message`: The type of message that was processed.
     AggregatorServiceDuration,
+    /// Timing in milliseconds for processing a message in the metric router service.
+    ///
+    /// This metric is tagged with:
+    ///  - `message`: The type of message that was processed.
+    MetricRouterServiceDuration,
 }
 
 impl TimerMetric for RelayTimers {
@@ -560,6 +565,7 @@ impl TimerMetric for RelayTimers {
             #[cfg(feature = "processing")]
             RelayTimers::RateLimitBucketsDuration => "processor.rate_limit_buckets",
             RelayTimers::AggregatorServiceDuration => "metrics.aggregator.message.duration",
+            RelayTimers::MetricRouterServiceDuration => "metrics.router.message.duration",
         }
     }
 }

--- a/relay-server/src/utils/split_off.rs
+++ b/relay-server/src/utils/split_off.rs
@@ -1,6 +1,8 @@
 use itertools::Either;
 
 /// Splits off items from a vector matching a predicate.
+///
+/// Matching elements are returned in the second vector.
 pub fn split_off<T>(data: Vec<T>, mut f: impl FnMut(&T) -> bool) -> (Vec<T>, Vec<T>) {
     split_off_map(data, |item| {
         if f(&item) {


### PR DESCRIPTION
- Instruments the service better
- Optimizes the handle_merge_buckets function by not splitting into a message per namespace, but into a message per aggregator
- Optimizes the `AcceptMetrics` message to race the messages instead of checking sequentially

#skip-changelog