### PR TITLE
ref(store): Multithread the store using a rayon pool

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -100,6 +100,24 @@ fn create_processor_pool(config: &Config) -> Result<ThreadPool> {
     Ok(pool)
 }
 
+#[cfg(feature = "processing")]
+fn create_store_pool(config: &Config) -> Result<ThreadPool> {
+    // Spawn a store worker for every 12 threads in the processor pool.
+    // This ratio was found emperically and may need adjustments in the future.
+    //
+    // Ideally in the future the store will be single threaded again, after we move
+    // all the heavy processing (de- and re-serialization) into the processor.
+    let thread_count = config.cpu_concurrency().div_ceil(12);
+    relay_log::info!("starting {thread_count} store workers");
+
+    let pool = crate::utils::ThreadPoolBuilder::new("store")
+        .num_threads(thread_count)
+        .runtime(tokio::runtime::Handle::current())
+        .build()?;
+
+    Ok(pool)
+}
+
 #[derive(Debug)]
 struct StateInner {
     config: Arc<Config>,
@@ -173,6 +191,7 @@ impl ServiceState {
             .processing_enabled()
             .then(|| {
                 StoreService::create(
+                    create_store_pool(&config)?,
                     config.clone(),
                     global_config_handle.clone(),
                     outcome_aggregator.clone(),

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -36,7 +36,7 @@ use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::Processed;
 use crate::statsd::RelayCounters;
-use crate::utils::{is_rolled_out, FormDataIter, TypedEnvelope};
+use crate::utils::{is_rolled_out, FormDataIter, ThreadPool, TypedEnvelope, WorkerGroup};
 
 /// Fallback name used for attachment items without a `filename` header.
 const UNNAMED_ATTACHMENT: &str = "Unnamed Attachment";
@@ -129,6 +129,7 @@ impl FromMessage<StoreCogs> for Store {
 
 /// Service implementing the [`Store`] interface.
 pub struct StoreService {
+    workers: WorkerGroup,
     config: Arc<Config>,
     global_config: GlobalConfigHandle,
     outcome_aggregator: Addr<TrackOutcome>,
@@ -138,6 +139,7 @@ pub struct StoreService {
 
 impl StoreService {
     pub fn create(
+        pool: ThreadPool,
         config: Arc<Config>,
         global_config: GlobalConfigHandle,
         outcome_aggregator: Addr<TrackOutcome>,
@@ -145,6 +147,7 @@ impl StoreService {
     ) -> anyhow::Result<Self> {
         let producer = Producer::create(&config)?;
         Ok(Self {
+            workers: WorkerGroup::new(pool),
             config,
             global_config,
             outcome_aggregator,
@@ -1069,11 +1072,16 @@ impl Service for StoreService {
     type Interface = Store;
 
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+        let this = Arc::new(self);
+
         tokio::spawn(async move {
             relay_log::info!("store forwarder started");
 
             while let Some(message) = rx.recv().await {
-                self.handle_message(message);
+                let service = Arc::clone(&this);
+                this.workers
+                    .spawn(move || service.handle_message(message))
+                    .await;
             }
 
             relay_log::info!("store forwarder stopped");

--- a/relay-server/src/utils/garbage.rs
+++ b/relay-server/src/utils/garbage.rs
@@ -58,6 +58,12 @@ impl<T: Send + 'static> GarbageDisposal<T> {
     }
 }
 
+impl<T: Send + 'static> Default for GarbageDisposal<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};

--- a/relay-server/src/utils/thread_pool.rs
+++ b/relay-server/src/utils/thread_pool.rs
@@ -65,7 +65,7 @@ impl ThreadPoolBuilder {
     }
 }
 
-/// A [`WorkerGroup`] adds an async brackpressure mechanism to a [`ThreadPool`].
+/// A [`WorkerGroup`] adds an async backpressure mechanism to a [`ThreadPool`].
 pub struct WorkerGroup {
     pool: ThreadPool,
     semaphore: Arc<Semaphore>,

--- a/relay-server/src/utils/thread_pool.rs
+++ b/relay-server/src/utils/thread_pool.rs
@@ -74,7 +74,7 @@ pub struct WorkerGroup {
 impl WorkerGroup {
     /// Creates a new worker group from a thread pool.
     pub fn new(pool: ThreadPool) -> Self {
-        // Use `current_num_threads() * 2` to guarnatuee all threads have immediately a new item to work on.
+        // Use `current_num_threads() * 2` to guarantee all threads immediately have a new item to work on.
         let semaphore = Arc::new(Semaphore::new(pool.current_num_threads() * 2));
         Self { pool, semaphore }
     }

--- a/relay-server/src/utils/thread_pool.rs
+++ b/relay-server/src/utils/thread_pool.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
 use std::thread;
 use tokio::runtime::Handle;
 
 pub use rayon::{ThreadPool, ThreadPoolBuildError};
+use tokio::sync::Semaphore;
 
 /// Used to create a new [`ThreadPool`] thread pool.
 pub struct ThreadPoolBuilder {
@@ -63,18 +65,74 @@ impl ThreadPoolBuilder {
     }
 }
 
+/// A [`WorkerGroup`] adds an async brackpressure mechanism to a [`ThreadPool`].
+pub struct WorkerGroup {
+    pool: ThreadPool,
+    semaphore: Arc<Semaphore>,
+}
+
+impl WorkerGroup {
+    /// Creates a new worker group from a thread pool.
+    pub fn new(pool: ThreadPool) -> Self {
+        // Use `current_num_threads() * 2` to guarnatuee all threads have immediately a new item to work on.
+        let semaphore = Arc::new(Semaphore::new(pool.current_num_threads() * 2));
+        Self { pool, semaphore }
+    }
+
+    /// Spawns an asynchronous task on the thread pool.
+    ///
+    /// If the thread pool is saturated the returned future is pending until
+    /// the thread pool has capacity to work on the task.
+    ///
+    /// # Examples:
+    ///
+    /// ```ignore
+    /// # async fn test(mut messages: tokio::sync::mpsc::Receiver<()>) {
+    /// # use relay_server::utils::{WorkerGroup, ThreadPoolBuilder};
+    /// # use std::thread;
+    /// # use std::time::Duration;
+    /// # let pool = ThreadPoolBuilder::new("test").num_threads(1).build().unwrap();
+    /// let workers = WorkerGroup::new(pool);
+    ///
+    /// while let Some(message) = messages.recv().await {
+    ///     workers.spawn(move || {
+    ///         thread::sleep(Duration::from_secs(1));
+    ///         println!("worked on message {message:?}")
+    ///     }).await;
+    /// }
+    /// # }
+    /// ```
+    pub async fn spawn(&self, op: impl FnOnce() + Send + 'static) {
+        let semaphore = Arc::clone(&self.semaphore);
+        let permit = semaphore
+            .acquire_owned()
+            .await
+            .expect("the semaphore is never closed");
+
+        self.pool.spawn(move || {
+            op();
+            drop(permit);
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Barrier;
+    use std::time::Duration;
+
+    use futures::FutureExt;
+
     use super::*;
 
     #[test]
-    fn test_num_threads() {
+    fn test_thread_pool_num_threads() {
         let pool = ThreadPoolBuilder::new("s").num_threads(3).build().unwrap();
         assert_eq!(pool.current_num_threads(), 3);
     }
 
     #[test]
-    fn test_runtime() {
+    fn test_thread_pool_runtime() {
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let pool = ThreadPoolBuilder::new("s")
@@ -88,10 +146,67 @@ mod tests {
     }
 
     #[test]
-    fn test_no_runtime() {
+    fn test_thread_pool_no_runtime() {
         let pool = ThreadPoolBuilder::new("s").num_threads(1).build().unwrap();
 
         let has_runtime = pool.install(|| tokio::runtime::Handle::try_current().is_ok());
         assert!(!has_runtime);
+    }
+
+    #[test]
+    fn test_thread_pool_panic() {
+        let pool = ThreadPoolBuilder::new("s").num_threads(1).build().unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+
+        pool.spawn({
+            let barrier = Arc::clone(&barrier);
+            move || {
+                barrier.wait();
+                panic!();
+            }
+        });
+        barrier.wait();
+
+        pool.spawn({
+            let barrier = Arc::clone(&barrier);
+            move || {
+                barrier.wait();
+            }
+        });
+        barrier.wait();
+    }
+
+    #[test]
+    fn test_worker_group_backpressure() {
+        let pool = ThreadPoolBuilder::new("s").num_threads(1).build().unwrap();
+        let workers = WorkerGroup::new(pool);
+
+        // Num Threads * 2 is the limit after backpressure kicks in
+        let barrier = Arc::new(Barrier::new(2));
+
+        let spawn = || {
+            let barrier = Arc::clone(&barrier);
+            workers
+                .spawn(move || {
+                    barrier.wait();
+                })
+                .now_or_never()
+                .is_some()
+        };
+
+        for _ in 0..15 {
+            // Pool should accept two immediately.
+            assert!(spawn());
+            assert!(spawn());
+            // Pool should reject because there are already 2 tasks active.
+            assert!(!spawn());
+
+            // Unblock the barrier
+            barrier.wait(); // first spawn
+            barrier.wait(); // second spawn
+
+            // wait a tiny bit to make sure the semaphore handle is dropped
+            thread::sleep(Duration::from_millis(50));
+        }
     }
 }


### PR DESCRIPTION
We've seen the store is not being able to keep up if the processor gets parallelized too much. This switches the CPU heavy processing of the store to its own thread pool.

#skip-changelog