### PR TITLE
feat(replays): Add video entry to DataCategory enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Use a dedicated thread pool for CPU intensive workloads. ([#3833](https://github.com/getsentry/relay/pull/3833))
 - Remove `BufferGuard` in favor of memory checks via `MemoryStat`. ([#3821](https://github.com/getsentry/relay/pull/3821))
-- Add video entry to DataCategory enum. ([#3847](https://github.com/getsentry/relay/pull/3847))
+- Add ReplayVideo entry to DataCategory. ([#3847](https://github.com/getsentry/relay/pull/3847))
 
 ## 24.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Use a dedicated thread pool for CPU intensive workloads. ([#3833](https://github.com/getsentry/relay/pull/3833))
 - Remove `BufferGuard` in favor of memory checks via `MemoryStat`. ([#3821](https://github.com/getsentry/relay/pull/3821))
+- Add video entry to DataCategory enum. ([#3847](https://github.com/getsentry/relay/pull/3847))
 
 ## 24.7.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.0
 
 - Build wheels with manylinux_2_28 and alma linux 8. [#3787](https://github.com/getsentry/relay/pull/3787)
+- Add REPLAY_VIDEO entry to DataCategory. ([#3847](https://github.com/getsentry/relay/pull/3847))
 
 ## 0.8.67
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add REPLAY_VIDEO entry to DataCategory. ([#3847](https://github.com/getsentry/relay/pull/3847))
+
 ## 0.9.0
 
 - Build wheels with manylinux_2_28 and alma linux 8. [#3787](https://github.com/getsentry/relay/pull/3787)
-- Add REPLAY_VIDEO entry to DataCategory. ([#3847](https://github.com/getsentry/relay/pull/3847))
 
 ## 0.8.67
 

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -29,6 +29,7 @@ class DataCategory(IntEnum):
     PROFILE_DURATION = 17
     PROFILE_CHUNK = 18
     METRIC_SECOND = 19
+    REPLAY_VIDEO = 20
     UNKNOWN = -1
     # end generated
 

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -29,7 +29,6 @@ class DataCategory(IntEnum):
     PROFILE_DURATION = 17
     PROFILE_CHUNK = 18
     METRIC_SECOND = 19
-    REPLAY_VIDEO = 20
     UNKNOWN = -1
     # end generated
 

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -123,6 +123,7 @@ impl DataCategory {
             "profile_duration" => Self::ProfileDuration,
             "profile_chunk" => Self::ProfileChunk,
             "metric_second" => Self::MetricSecond,
+            "replay_video" => Self::MetricSecond,
             _ => Self::Unknown,
         }
     }
@@ -151,6 +152,7 @@ impl DataCategory {
             Self::ProfileDuration => "profile_duration",
             Self::ProfileChunk => "profile_chunk",
             Self::MetricSecond => "metric_second",
+            Self::ReplayVideo => "replay_video",
             Self::Unknown => "unknown",
         }
     }

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -84,6 +84,10 @@ pub enum DataCategory {
     /// and metric cardinality. Defined here so as not to clash with future
     /// categories.
     MetricSecond = 19,
+    /// Replay Video
+    ///
+    /// This is the data category for Session Replays produced via a video recording.
+    ReplayVideo = 20,
     //
     // IMPORTANT: After adding a new entry to DataCategory, go to the `relay-cabi` subfolder and run
     // `make header` to regenerate the C-binding. This allows using the data category from Python.

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -129,6 +129,12 @@ enum RelayDataCategory {
    */
   RELAY_DATA_CATEGORY_METRIC_SECOND = 19,
   /**
+   * Replay Video
+   *
+   * This is the data category for Session Replays produced via a video recording.
+   */
+  RELAY_DATA_CATEGORY_REPLAY_VIDEO = 20,
+  /**
    * Any other data category not known by this Relay.
    */
   RELAY_DATA_CATEGORY_UNKNOWN = -1,
@@ -652,15 +658,11 @@ struct RelayStr relay_validate_sampling_configuration(const struct RelayStr *val
 
 /**
  * Normalize a project config.
- *
- * If `strict` is true, checks for unknown fields in the input.
  */
 struct RelayStr relay_normalize_project_config(const struct RelayStr *value);
 
 /**
- * Validate cardinality limit config.
- *
- * If `strict` is true, checks for unknown fields in the input.
+ * Normalize a cardinality limit config.
  */
 struct RelayStr normalize_cardinality_limit_config(const struct RelayStr *value);
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -200,7 +200,7 @@ impl CategoryUnit {
             DataCategory::Session => Some(Self::Batched),
             DataCategory::ProfileDuration => Some(Self::Milliseconds),
 
-            DataCategory::Unknown => None,
+            DataCategory::Unknown | DataCategory::ReplayVideo => None,
         }
     }
 }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -183,6 +183,7 @@ impl CategoryUnit {
             | DataCategory::Error
             | DataCategory::Transaction
             | DataCategory::Replay
+            | DataCategory::ReplayVideo
             | DataCategory::Security
             | DataCategory::Profile
             | DataCategory::ProfileIndexed
@@ -200,7 +201,7 @@ impl CategoryUnit {
             DataCategory::Session => Some(Self::Batched),
             DataCategory::ProfileDuration => Some(Self::Milliseconds),
 
-            DataCategory::Unknown | DataCategory::ReplayVideo => None,
+            DataCategory::Unknown => None,
         }
     }
 }


### PR DESCRIPTION
During the beta period we're not emitting accepted replay outcomes for mobile replays (to prevent customer's from being billed).  Tracking usage through Looker is difficult without this data.  We want to emit a non-billed outcome in our consumer for tracking purposes.  This category is assumed to be temporary.

Related: https://github.com/getsentry/team-replay/issues/452