### PR TITLE
ref(system): Instrument spawned tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,7 +3869,9 @@ name = "relay-system"
 version = "24.10.0"
 dependencies = [
  "futures",
+ "insta",
  "once_cell",
+ "pin-project-lite",
  "relay-log",
  "relay-statsd",
  "tokio",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "tokio::spawn", reason = "use `relay_system::spawn!` instead" },
+]

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -240,7 +240,7 @@ impl DiskUsage {
         let last_known_usage_weak = Arc::downgrade(&self.last_known_usage);
         let refresh_frequency = self.refresh_frequency;
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 // When our `Weak` reference can't be upgraded to an `Arc`, it means that the value
                 // is not referenced anymore by self, meaning that `DiskUsage` was dropped.

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -387,7 +387,7 @@ impl Service for EnvelopeBufferService {
         let dequeue = Arc::<AtomicBool>::new(true.into());
         let dequeue1 = dequeue.clone();
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let buffer = PolymorphicEnvelopeBuffer::from_config(&config, memory_checker).await;
 
             let mut buffer = match buffer {
@@ -464,7 +464,7 @@ impl Service for EnvelopeBufferService {
         });
 
         #[cfg(unix)]
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             use tokio::signal::unix::{signal, SignalKind};
             let Ok(mut signal) = signal(SignalKind::user_defined1()) else {
                 return;

--- a/relay-server/src/services/cogs.rs
+++ b/relay-server/src/services/cogs.rs
@@ -55,7 +55,7 @@ impl Service for CogsService {
     type Interface = CogsReport;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             while let Some(message) = rx.recv().await {
                 self.handle_report(message);
             }

--- a/relay-server/src/services/global_config.rs
+++ b/relay-server/src/services/global_config.rs
@@ -263,7 +263,7 @@ impl GlobalConfigService {
         let upstream_relay = self.upstream.clone();
         let internal_tx = self.internal_tx.clone();
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             metric!(timer(RelayTimers::GlobalConfigRequestDuration), {
                 let query = GetGlobalConfig::new();
                 let res = upstream_relay.send(SendQuery(query)).await;
@@ -339,7 +339,7 @@ impl Service for GlobalConfigService {
     type Interface = GlobalConfigManager;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let mut shutdown_handle = Controller::shutdown_handle();
 
             relay_log::info!("global config service starting");

--- a/relay-server/src/services/health_check.rs
+++ b/relay-server/src/services/health_check.rs
@@ -199,7 +199,7 @@ impl Service for HealthCheckService {
         // Add 10% buffer to the internal timeouts to avoid race conditions.
         let status_timeout = (check_interval + self.config.health_probe_timeout()).mul_f64(1.1);
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let shutdown = Controller::shutdown_handle();
 
             while shutdown.get().is_none() {
@@ -216,7 +216,7 @@ impl Service for HealthCheckService {
             update_tx.send(StatusUpdate::new(Status::Unhealthy)).ok();
         });
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             while let Some(HealthCheck(message, sender)) = rx.recv().await {
                 let update = update_rx.borrow();
 

--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -247,7 +247,7 @@ impl Service for AggregatorService {
     type Interface = Aggregator;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let mut ticker = tokio::time::interval(Duration::from_millis(self.flush_interval_ms));
             let mut shutdown = Controller::shutdown_handle();
 
@@ -362,7 +362,7 @@ mod tests {
         type Interface = TestInterface;
 
         fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
-            tokio::spawn(async move {
+            relay_system::spawn!(async move {
                 while let Some(message) = rx.recv().await {
                     let buckets = message.0.buckets;
                     relay_log::debug!(?buckets, "received buckets");

--- a/relay-server/src/services/metrics/router.rs
+++ b/relay-server/src/services/metrics/router.rs
@@ -54,7 +54,7 @@ impl Service for RouterService {
     type Interface = Aggregator;
 
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let mut router = StartedRouter::start(self);
             relay_log::info!("metrics router started");
 

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -658,7 +658,7 @@ impl HttpOutcomeProducer {
 
         let upstream_relay = self.upstream_relay.clone();
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             match upstream_relay.send(SendQuery(request)).await {
                 Ok(_) => relay_log::trace!("outcome batch sent"),
                 Err(error) => {
@@ -684,7 +684,7 @@ impl Service for HttpOutcomeProducer {
     type Interface = TrackRawOutcome;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 tokio::select! {
                     // Prioritize flush over receiving messages to prevent starving.
@@ -777,7 +777,7 @@ impl Service for ClientReportOutcomeProducer {
     type Interface = TrackOutcome;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 tokio::select! {
                     // Prioritize flush over receiving messages to prevent starving.
@@ -1038,7 +1038,7 @@ impl Service for OutcomeProducerService {
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
         let Self { config, inner } = self;
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let broker = inner.start();
 
             relay_log::info!("OutcomeProducer started.");

--- a/relay-server/src/services/outcome_aggregator.rs
+++ b/relay-server/src/services/outcome_aggregator.rs
@@ -139,7 +139,7 @@ impl Service for OutcomeAggregator {
     type Interface = TrackOutcome;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let mut shutdown = Controller::shutdown_handle();
             relay_log::info!("outcome aggregator started");
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2830,7 +2830,7 @@ impl Service for EnvelopeProcessorService {
     type Interface = EnvelopeProcessor;
 
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             while let Some(message) = rx.recv().await {
                 let service = self.clone();
                 self.inner

--- a/relay-server/src/services/projects/cache/legacy.rs
+++ b/relay-server/src/services/projects/cache/legacy.rs
@@ -694,7 +694,7 @@ impl Service for ProjectCacheService {
         let outcome_aggregator = services.outcome_aggregator.clone();
         let test_store = services.test_store.clone();
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             relay_log::info!("project cache started");
 
             let global_config = match global_config_rx.borrow().clone() {
@@ -930,7 +930,7 @@ mod tests {
         }
 
         // Emulate the project cache service loop.
-        tokio::task::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 select! {
                     Ok(project_event) = project_events.recv() => {

--- a/relay-server/src/services/projects/cache/service.rs
+++ b/relay-server/src/services/projects/cache/service.rs
@@ -205,7 +205,7 @@ impl relay_system::Service for ProjectCacheService {
             }};
         }
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 tokio::select! {
                     biased;

--- a/relay-server/src/services/projects/source/local.rs
+++ b/relay-server/src/services/projects/source/local.rs
@@ -156,7 +156,7 @@ async fn spawn_poll_local_states(
     poll_local_states(&project_path, &tx).await;
 
     // Start a background loop that polls periodically:
-    tokio::spawn(async move {
+    relay_system::spawn!(async move {
         // To avoid running two load tasks simultaneously at startup, we delay the interval by one period:
         let start_at = Instant::now() + period;
         let mut ticker = tokio::time::interval_at(start_at, period);
@@ -176,7 +176,7 @@ impl Service for LocalProjectSourceService {
         // collect the result, the producer will block, which is acceptable.
         let (state_tx, mut state_rx) = mpsc::channel(1);
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             relay_log::info!("project local cache started");
 
             // Start the background task that periodically reloads projects from disk:

--- a/relay-server/src/services/projects/source/upstream.rs
+++ b/relay-server/src/services/projects/source/upstream.rs
@@ -579,7 +579,7 @@ impl UpstreamProjectSourceService {
         let channels = self.prepare_batches();
         let upstream_relay = self.upstream_relay.clone();
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let responses = Self::fetch_states(config, upstream_relay, channels).await;
             // Send back all resolved responses and also unused channels.
             // These responses will be handled by `handle_responses` function.
@@ -636,7 +636,7 @@ impl Service for UpstreamProjectSourceService {
     type Interface = UpstreamProjectSource;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             relay_log::info!("project upstream cache started");
             loop {
                 tokio::select! {

--- a/relay-server/src/services/relays.rs
+++ b/relay-server/src/services/relays.rs
@@ -238,7 +238,7 @@ impl RelayCacheService {
 
         let fetch_tx = self.fetch_tx();
         let upstream_relay = self.upstream_relay.clone();
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let request = GetRelays {
                 relay_ids: channels.keys().cloned().collect(),
             };
@@ -335,7 +335,7 @@ impl Service for RelayCacheService {
     type Interface = RelayCache;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             relay_log::info!("key cache started");
 
             loop {

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -139,14 +139,14 @@ fn serve(listener: TcpListener, app: App, config: Arc<Config>) {
         .keep_alive_timeout(config.keepalive_timeout());
 
     let service = ServiceExt::<Request>::into_make_service_with_connect_info::<SocketAddr>(app);
-    tokio::spawn(server.serve(service));
+    relay_system::spawn!(server.serve(service));
 
-    tokio::spawn(emit_active_connections_metric(
+    relay_system::spawn!(emit_active_connections_metric(
         config.metrics_periodic_interval(),
         handle.clone(),
     ));
 
-    tokio::spawn(async move {
+    relay_system::spawn!(async move {
         let Shutdown { timeout } = Controller::shutdown_handle().notified().await;
         relay_log::info!("Shutting down HTTP server");
 

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -1194,7 +1194,7 @@ impl BufferService {
             BufferState::Disk(ref disk) => {
                 let db = disk.db.clone();
                 let project_cache = self.services.project_cache.clone();
-                tokio::spawn(async move {
+                relay_system::spawn!(async move {
                     match OnDisk::get_spooled_index(&db).await {
                         Ok(index) => {
                             relay_log::trace!(
@@ -1265,7 +1265,7 @@ impl Service for BufferService {
     type Interface = Buffer;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let mut shutdown = Controller::shutdown_handle();
 
             loop {

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -139,7 +139,7 @@ impl Service for RelayStats {
             return;
         };
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 let _ = tokio::join!(
                     self.upstream_status(),

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1051,7 +1051,7 @@ impl Service for StoreService {
     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
         let this = Arc::new(self);
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             relay_log::info!("store forwarder started");
 
             while let Some(message) = rx.recv().await {

--- a/relay-server/src/services/test_store.rs
+++ b/relay-server/src/services/test_store.rs
@@ -135,7 +135,7 @@ impl relay_system::Service for TestStoreService {
     type Interface = TestStore;
 
     fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             while let Some(message) = rx.recv().await {
                 self.handle_message(message);
             }

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -1347,7 +1347,7 @@ impl ConnectionMonitor {
         // Only take action if we exceeded the grace period.
         if first_error + self.client.config.http_outage_grace_period() <= now {
             let return_tx = return_tx.clone();
-            let task = tokio::spawn(Self::connect(self.client.clone(), return_tx));
+            let task = relay_system::spawn!(Self::connect(self.client.clone(), return_tx));
             self.state = ConnectionState::Reconnecting(task);
         }
     }
@@ -1432,7 +1432,7 @@ impl UpstreamBroker {
         let client = self.client.clone();
         let action_tx = self.action_tx.clone();
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             let send_start = Instant::now();
             let result = client.send(entry.request.as_mut()).await;
             emit_response_metrics(send_start, &entry, &result);
@@ -1515,7 +1515,7 @@ impl Service for UpstreamRelayService {
             state: AuthState::Unknown,
             tx: action_tx.clone(),
         };
-        tokio::spawn(auth.run());
+        relay_system::spawn!(auth.run());
 
         // Main broker that serializes public and internal messages, as well as maintains connection
         // and authentication state.
@@ -1528,7 +1528,7 @@ impl Service for UpstreamRelayService {
             action_tx,
         };
 
-        tokio::spawn(async move {
+        relay_system::spawn!(async move {
             loop {
                 tokio::select! {
                     biased;

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -18,7 +18,10 @@ once_cell = { workspace = true }
 relay-log = { workspace = true }
 relay-statsd = { workspace = true }
 tokio = { workspace = true, features = ["rt", "signal", "macros", "sync", "time"] }
+pin-project-lite = { workspace = true }
+
 
 [dev-dependencies]
+insta = { workspace = true }
 relay-statsd = { workspace = true, features = ["test"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -130,7 +130,7 @@ impl ShutdownHandle {
 ///     type Interface = ();
 ///
 ///     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
-///         tokio::spawn(async move {
+///         relay_system::spawn!(async move {
 ///             let mut shutdown = Controller::shutdown_handle();
 ///
 ///             loop {
@@ -166,8 +166,9 @@ pub struct Controller;
 
 impl Controller {
     /// Starts a controller that monitors shutdown signals.
+    #[track_caller]
     pub fn start(shutdown_timeout: Duration) {
-        tokio::spawn(monitor_shutdown(shutdown_timeout));
+        crate::spawn!(monitor_shutdown(shutdown_timeout));
     }
 
     /// Manually initiates the shutdown process of the system.

--- a/relay-system/src/lib.rs
+++ b/relay-system/src/lib.rs
@@ -23,8 +23,10 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 mod controller;
+mod runtime;
 mod service;
 mod statsd;
 
 pub use self::controller::*;
+pub use self::runtime::*;
 pub use self::service::*;

--- a/relay-system/src/runtime.rs
+++ b/relay-system/src/runtime.rs
@@ -1,0 +1,122 @@
+use futures::Future;
+use tokio::task::JoinHandle;
+
+use crate::statsd::SystemCounters;
+
+/// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.
+///
+/// This is in instrumented spawn variant of Tokio's [`tokio::spawn`].
+#[macro_export]
+macro_rules! spawn {
+    ($future:expr) => {{
+        static _TASK_ID: ::std::sync::OnceLock<$crate::TaskId> = ::std::sync::OnceLock::new();
+        let task_id = _TASK_ID.get_or_init(|| (*::std::panic::Location::caller()).into());
+        $crate::_spawn_inner(task_id, $future)
+    }};
+}
+
+#[doc(hidden)]
+#[allow(clippy::disallowed_methods)]
+pub fn _spawn_inner<F>(task_id: &'static TaskId, future: F) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::spawn(Task::new(task_id, future))
+}
+
+/// An internal id for a spawned task.
+#[doc(hidden)]
+pub struct TaskId {
+    id: String,
+    file: String,
+    line: String,
+}
+
+impl From<std::panic::Location<'_>> for TaskId {
+    fn from(value: std::panic::Location<'_>) -> Self {
+        Self {
+            id: format!("{}:{}", value.file(), value.line()),
+            file: value.file().to_owned(),
+            line: value.line().to_string(),
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// Wraps a future and emits related task metrics.
+    struct Task<T> {
+        id: &'static TaskId,
+        #[pin]
+        inner: T,
+    }
+
+    impl<T> PinnedDrop for Task<T> {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+            relay_statsd::metric!(
+                counter(SystemCounters::RuntimeTaskTerminated) += 1,
+                id = this.id.id.as_str(),
+                file = this.id.file.as_str(),
+                line = this.id.line.as_str(),
+            );
+        }
+    }
+}
+
+impl<T> Task<T> {
+    fn new(id: &'static TaskId, inner: T) -> Self {
+        relay_statsd::metric!(
+            counter(SystemCounters::RuntimeTaskCreated) += 1,
+            id = id.id.as_str(),
+            file = id.file.as_str(),
+            line = id.line.as_str(),
+        );
+        Self { id, inner }
+    }
+}
+
+impl<T: Future> Future for Task<T> {
+    type Output = T::Output;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        this.inner.poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn test_spawn_spawns_a_future() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let captures = relay_statsd::with_capturing_test_client(|| {
+            rt.block_on(async {
+                let _ = crate::spawn!(async {}).await;
+            })
+        });
+
+        #[cfg(not(windows))]
+        assert_debug_snapshot!(captures, @r###"
+        [
+            "runtime.task.spawn.created:1|c|#id:relay-system/src/runtime.rs:103,file:relay-system/src/runtime.rs,line:103",
+            "runtime.task.spawn.terminated:1|c|#id:relay-system/src/runtime.rs:103,file:relay-system/src/runtime.rs,line:103",
+        ]
+        "###);
+        #[cfg(windows)]
+        assert_debug_snapshot!(captures, @r###"
+        [
+            "runtime.task.spawn.created:1|c|#id:relay-system\\src\\runtime.rs:103,file:relay-system\\src\\runtime.rs,line:103",
+            "runtime.task.spawn.terminated:1|c|#id:relay-system\\src\\runtime.rs:103,file:relay-system\\src\\runtime.rs,line:103",
+        ]
+        "###);
+    }
+}

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -1,5 +1,34 @@
 use relay_statsd::{CounterMetric, GaugeMetric};
 
+/// Counter metrics for Relay system components.
+pub enum SystemCounters {
+    /// Number of runtime tasks created/spawned.
+    ///
+    /// Every call to [`spawn`](`crate::spawn`) increases this counter by one.
+    ///
+    /// This metric is tagged with:
+    ///  - `id`: A unique identifier for the task, derived from its location in code.
+    ///  - `file`: The source filename where the task is created.
+    ///  - `line`: The source line where the task is created within the file.
+    RuntimeTaskCreated,
+    /// Number of runtime tasks terminated.
+    ///
+    /// This metric is tagged with:
+    ///  - `id`: A unique identifier for the task, derived from its location in code.
+    ///  - `file`: The source filename where the task is created.
+    ///  - `line`: The source line where the task is created within the file.
+    RuntimeTaskTerminated,
+}
+
+impl CounterMetric for SystemCounters {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::RuntimeTaskCreated => "runtime.task.spawn.created",
+            Self::RuntimeTaskTerminated => "runtime.task.spawn.terminated",
+        }
+    }
+}
+
 /// Gauge metrics for Relay system components.
 pub enum SystemGauges {
     /// A number of messages queued in a services inbound message channel.
@@ -16,29 +45,7 @@ pub enum SystemGauges {
 impl GaugeMetric for SystemGauges {
     fn name(&self) -> &'static str {
         match *self {
-            SystemGauges::ServiceBackPressure => "service.back_pressure",
-        }
-    }
-}
-
-/// Counter metrics for Relay system components.
-pub enum SystemCounters {
-    /// The amount of time a service spends waiting for new messages.
-    ///
-    /// This is an indicator of how much more load a service can take on.
-    ///
-    /// Caveat: Some services circumvent the service framework by using custom incoming queues.
-    /// For these, we cannot fully rely on this metric.
-    ///
-    /// This metric is tagged with:
-    ///  - `service`: The fully qualified type name of the service implementation.
-    ServiceIdleTime,
-}
-
-impl CounterMetric for SystemCounters {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::ServiceIdleTime => "service.idle_time_nanos",
+            Self::ServiceBackPressure => "service.back_pressure",
         }
     }
 }

--- a/relay-test/src/lib.rs
+++ b/relay-test/src/lib.rs
@@ -44,7 +44,7 @@ where
 {
     let (addr, mut rx) = channel(name);
 
-    let handle = tokio::spawn(async move {
+    let handle = relay_system::spawn!(async move {
         while let Some(msg) = rx.recv().await {
             f(&mut state, msg);
         }


### PR DESCRIPTION
Instruments all `tokio::spawn` calls with a new spawn function `relay_system::spawn`.

#skip-changelog