### PR TITLE
ref(metrics): Create extracted metrics summary for sets with min/max/sum of 0

### DIFF
--- a/relay-server/src/metrics_extraction/metrics_summary.rs
+++ b/relay-server/src/metrics_extraction/metrics_summary.rs
@@ -100,9 +100,9 @@ impl<'a> From<&'a SetValue> for MetricsSummaryBucketValue {
     fn from(set: &'a SetValue) -> Self {
         // For sets, we limit to counting the number of occurrences.
         MetricsSummaryBucketValue {
-            min: None,
-            max: None,
-            sum: None,
+            min: Some(0.into()),
+            max: Some(0.into()),
+            sum: Some(0.into()),
             count: set.len() as u64,
         }
     }
@@ -342,18 +342,18 @@ mod tests {
             {
                 "s:custom/my_set@none": [
                     MetricSummary {
-                        min: ~,
-                        max: ~,
-                        sum: ~,
+                        min: 0.0,
+                        max: 0.0,
+                        sum: 0.0,
                         count: 2,
                         tags: {
                             "platform": "android",
                         },
                     },
                     MetricSummary {
-                        min: ~,
-                        max: ~,
-                        sum: ~,
+                        min: 0.0,
+                        max: 0.0,
+                        sum: 0.0,
                         count: 2,
                         tags: {
                             "platform": "ios",
@@ -458,9 +458,9 @@ mod tests {
                 ],
                 "s:custom/my_set@none": [
                     MetricSummary {
-                        min: ~,
-                        max: ~,
-                        sum: ~,
+                        min: 0.0,
+                        max: 0.0,
+                        sum: 0.0,
                         count: 4,
                         tags: {
                             "platform": "ios",


### PR DESCRIPTION
> It seems to me that snuba consumer expects those fields and fails when those fields are not present, and the metric summary is than never persisted in the database (metric summary table doesn't allow this fields to be NULL, so I think setting those fields to 0 is the best solution)


Created by Relay:
![image](https://github.com/user-attachments/assets/e1307072-ae54-44b5-804a-a954503058ba)

Sent from the SDK:
![image](https://github.com/user-attachments/assets/566672da-1ae0-43b4-82ed-f18676c1ff37)


PR creates the set summary using the same `0` defaults.

#skip-changelog
