### PR TITLE
ci: add dependency review check

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: 'Dependency Review'
+on:
+  pull_request:
+    branches: ['master']
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Dependency Review
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
+        with:
+          # Possible values: "critical", "high", "moderate", "low"
+          fail-on-severity: high


### PR DESCRIPTION
Resolve audit finding.

Dependency review will run when any new dependencies are added, if one of the new dependencies contains a known high or critical vulnerability, the job will fail.

#skip-changelog