### PR TITLE
feat(spooler): Add envelope size in the benchmark for the envelope stack

### DIFF
--- a/relay-server/benches/benches.rs
+++ b/relay-server/benches/benches.rs
@@ -36,14 +36,23 @@ async fn reset_db(db: Pool<Sqlite>) {
         .unwrap();
 }
 
-fn mock_envelope() -> Box<Envelope> {
-    let bytes = Bytes::from(
+fn mock_envelope(size: &str) -> Box<Envelope> {
+    let payload = match size {
+        "small" => "small_payload".to_string(),
+        "medium" => "medium_payload".repeat(100),
+        "big" => "big_payload".repeat(1000),
+        "huge" => "huge_payload".repeat(10000),
+        _ => "default_payload".to_string(),
+    };
+
+    let bytes = Bytes::from(format!(
         "\
-             {\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n\
-             {\"type\":\"attachment\"}\n\
-             helloworld\n\
-             ",
-    );
+         {{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}}\n\
+         {{\"type\":\"attachment\"}}\n\
+         {}\n\
+         ",
+        payload
+    ));
 
     Envelope::parse_bytes(bytes).unwrap()
 }
@@ -60,108 +69,122 @@ fn benchmark_sqlite_envelope_stack(c: &mut Criterion) {
 
     let disk_batch_size = 1000;
     for size in [1_000, 10_000, 100_000].iter() {
-        group.throughput(Throughput::Elements(*size as u64));
+        for envelope_size in &["small", "medium", "big", "huge"] {
+            group.throughput(Throughput::Elements(*size as u64));
 
-        // Benchmark push operations
-        group.bench_with_input(BenchmarkId::new("push", size), size, |b, &size| {
-            b.iter_with_setup(
-                || {
-                    runtime.block_on(async {
-                        reset_db(db.clone()).await;
-                    });
+            // Benchmark push operations
+            group.bench_with_input(
+                BenchmarkId::new(format!("push_{}", envelope_size), size),
+                size,
+                |b, &size| {
+                    b.iter_with_setup(
+                        || {
+                            runtime.block_on(async {
+                                reset_db(db.clone()).await;
+                            });
 
-                    let stack = SQLiteEnvelopeStack::new(
-                        db.clone(),
-                        disk_batch_size,
-                        2,
-                        ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
-                        ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
-                    );
+                            let stack = SQLiteEnvelopeStack::new(
+                                db.clone(),
+                                disk_batch_size,
+                                2,
+                                ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+                                ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+                            );
 
-                    let mut envelopes = Vec::with_capacity(size);
-                    for _ in 0..size {
-                        envelopes.push(mock_envelope());
-                    }
-
-                    (stack, envelopes)
-                },
-                |(mut stack, envelopes)| {
-                    runtime.block_on(async {
-                        for envelope in envelopes {
-                            stack.push(envelope).await.unwrap();
-                        }
-                    });
-                },
-            );
-        });
-
-        // Benchmark pop operations
-        group.bench_with_input(BenchmarkId::new("pop", size), size, |b, &size| {
-            b.iter_with_setup(
-                || {
-                    runtime.block_on(async {
-                        reset_db(db.clone()).await;
-
-                        let mut stack = SQLiteEnvelopeStack::new(
-                            db.clone(),
-                            disk_batch_size,
-                            2,
-                            ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
-                            ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
-                        );
-
-                        // Pre-fill the stack
-                        for _ in 0..size {
-                            let envelope = mock_envelope();
-                            stack.push(envelope).await.unwrap();
-                        }
-
-                        stack
-                    })
-                },
-                |mut stack| {
-                    runtime.block_on(async {
-                        // Benchmark popping
-                        for _ in 0..size {
-                            stack.pop().await.unwrap();
-                        }
-                    });
-                },
-            );
-        });
-
-        // Benchmark mixed push and pop operations
-        group.bench_with_input(BenchmarkId::new("mixed", size), size, |b, &size| {
-            b.iter_with_setup(
-                || {
-                    runtime.block_on(async {
-                        reset_db(db.clone()).await;
-                    });
-
-                    SQLiteEnvelopeStack::new(
-                        db.clone(),
-                        disk_batch_size,
-                        2,
-                        ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
-                        ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
-                    )
-                },
-                |mut stack| {
-                    runtime.block_on(async {
-                        for _ in 0..size {
-                            if rand::random::<bool>() {
-                                let envelope = mock_envelope();
-                                stack.push(envelope).await.unwrap();
-                            } else if stack.pop().await.is_err() {
-                                // If pop fails (empty stack), push instead
-                                let envelope = mock_envelope();
-                                stack.push(envelope).await.unwrap();
+                            let mut envelopes = Vec::with_capacity(size);
+                            for _ in 0..size {
+                                envelopes.push(mock_envelope(envelope_size));
                             }
-                        }
-                    });
+
+                            (stack, envelopes)
+                        },
+                        |(mut stack, envelopes)| {
+                            runtime.block_on(async {
+                                for envelope in envelopes {
+                                    stack.push(envelope).await.unwrap();
+                                }
+                            });
+                        },
+                    );
                 },
             );
-        });
+
+            // Benchmark pop operations
+            group.bench_with_input(
+                BenchmarkId::new(format!("pop_{}", envelope_size), size),
+                size,
+                |b, &size| {
+                    b.iter_with_setup(
+                        || {
+                            runtime.block_on(async {
+                                reset_db(db.clone()).await;
+
+                                let mut stack = SQLiteEnvelopeStack::new(
+                                    db.clone(),
+                                    disk_batch_size,
+                                    2,
+                                    ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+                                    ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+                                );
+
+                                // Pre-fill the stack
+                                for _ in 0..size {
+                                    let envelope = mock_envelope(envelope_size);
+                                    stack.push(envelope).await.unwrap();
+                                }
+
+                                stack
+                            })
+                        },
+                        |mut stack| {
+                            runtime.block_on(async {
+                                // Benchmark popping
+                                for _ in 0..size {
+                                    stack.pop().await.unwrap();
+                                }
+                            });
+                        },
+                    );
+                },
+            );
+
+            // Benchmark mixed push and pop operations
+            group.bench_with_input(
+                BenchmarkId::new(format!("mixed_{}", envelope_size), size),
+                size,
+                |b, &size| {
+                    b.iter_with_setup(
+                        || {
+                            runtime.block_on(async {
+                                reset_db(db.clone()).await;
+                            });
+
+                            SQLiteEnvelopeStack::new(
+                                db.clone(),
+                                disk_batch_size,
+                                2,
+                                ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+                                ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+                            )
+                        },
+                        |mut stack| {
+                            runtime.block_on(async {
+                                for _ in 0..size {
+                                    if rand::random::<bool>() {
+                                        let envelope = mock_envelope(envelope_size);
+                                        stack.push(envelope).await.unwrap();
+                                    } else if stack.pop().await.is_err() {
+                                        // If pop fails (empty stack), push instead
+                                        let envelope = mock_envelope(envelope_size);
+                                        stack.push(envelope).await.unwrap();
+                                    }
+                                }
+                            });
+                        },
+                    );
+                },
+            );
+        }
     }
 
     group.finish();


### PR DESCRIPTION
This PR extends the benchmark for the `EnvelopeStack` to use different sized `Envelope`(s).

#skip-changelog