### PR TITLE
feat(process-value): Add object level trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
 
 - Add `EnvelopeStack` and `SQLiteEnvelopeStack` to manage envelopes on disk. ([#3855](https://github.com/getsentry/relay/pull/3855))
 - Add `client_sample_rate` to spans, pulled from the trace context ([#3872](https://github.com/getsentry/relay/pull/3872)).
-- Add new trimming behavior in the derive macros. ([#3877](https://github.com/getsentry/relay/pull/3877))
-
+- Introduce `trim = "disabled"` type attribute to prevent trimming of spans. ([#3877](https://github.com/getsentry/relay/pull/3877))
 
 ## 24.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add `EnvelopeStack` and `SQLiteEnvelopeStack` to manage envelopes on disk. ([#3855](https://github.com/getsentry/relay/pull/3855))
 - Add `client_sample_rate` to spans, pulled from the trace context ([#3872](https://github.com/getsentry/relay/pull/3872)).
+- Add new trimming behavior in the derive macros. ([#3877](https://github.com/getsentry/relay/pull/3877))
 
 
 ## 24.7.1

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -639,17 +639,6 @@ fn parse_field_attributes(
                                         panic!("Got non string literal for retain");
                                     }
                                 }
-                            } else if ident == "trim" {
-                                match name_value.lit {
-                                    Lit::Str(litstr) => match litstr.value().as_str() {
-                                        "true" => rv.trim = None,
-                                        "false" => rv.trim = Some(false),
-                                        other => panic!("Unknown value {other}"),
-                                    },
-                                    _ => {
-                                        panic!("Got non string literal for trim");
-                                    }
-                                }
                             } else if ident == "legacy_alias" || ident == "skip_serialization" {
                                 // Skip
                             } else {

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -416,7 +416,7 @@ mod tests {
     use relay_event_schema::protocol::{
         Breadcrumb, Context, Contexts, Event, Exception, ExtraValue, Span, TagEntry, Tags, Values,
     };
-    use relay_protocol::{Map, Remark, SerializableAnnotated};
+    use relay_protocol::{get_value, Map, Remark, SerializableAnnotated};
     use similar_asserts::assert_eq;
 
     use crate::MaxChars;
@@ -952,7 +952,7 @@ mod tests {
         processor::process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         // We check that all the spans that were kept have no trimmed fields.
-        let trimmed_spans = event.clone().0.unwrap().spans.0.unwrap();
+        let trimmed_spans = get_value!(event.spans).unwrap();
         assert_eq!(trimmed_spans.len(), 8);
         for trimmed_span in trimmed_spans {
             let platform = trimmed_span.value().unwrap().platform.value().unwrap();
@@ -961,6 +961,14 @@ mod tests {
 
         // We check that the meta on spans is preserved signaling that we originally had 10
         // elements.
-        assert_eq!(event.0.unwrap().spans.meta().original_length().unwrap(), 10);
+        assert_eq!(
+            get_value!(event)
+                .unwrap()
+                .spans
+                .meta()
+                .original_length()
+                .unwrap(),
+            10
+        );
     }
 }

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -56,7 +56,7 @@ impl TrimmingProcessor {
     }
 
     fn should_trim(&self, state: &ProcessingState<'_>) -> bool {
-        !state.attrs().simulate_trim
+        state.attrs().trim
     }
 }
 
@@ -88,6 +88,7 @@ impl Processor for TrimmingProcessor {
                 return Err(ProcessingAction::DeleteValueHard);
             }
         }
+
         Ok(())
     }
 
@@ -413,8 +414,7 @@ mod tests {
     use std::iter::repeat;
 
     use relay_event_schema::protocol::{
-        Breadcrumb, Context, Contexts, Event, Exception, ExtraValue, Span, SpanId, TagEntry, Tags,
-        Timestamp, TraceId, Values,
+        Breadcrumb, Context, Contexts, Event, Exception, ExtraValue, Span, TagEntry, Tags, Values,
     };
     use relay_protocol::{Map, Remark, SerializableAnnotated};
     use similar_asserts::assert_eq;

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -130,6 +130,8 @@ pub struct FieldAttrs {
     pub retain: bool,
     /// Whether the trimming processor is allowed to shorten or drop this field.
     pub trim: bool,
+    /// Whether to run all the trimming logic but not trimming the content.
+    pub fake_trim: bool,
 }
 
 /// A set of characters allowed or denied for a (string) field.
@@ -170,6 +172,7 @@ impl FieldAttrs {
             pii: Pii::False,
             retain: false,
             trim: true,
+            fake_trim: false,
         }
     }
 

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -129,7 +129,7 @@ pub struct FieldAttrs {
     /// Whether additional properties should be retained during normalization.
     pub retain: bool,
     /// Whether to run all the trimming logic but not trimming the content.
-    pub simulate_trim: bool,
+    pub trim: bool,
 }
 
 /// A set of characters allowed or denied for a (string) field.
@@ -169,7 +169,7 @@ impl FieldAttrs {
             max_bytes: None,
             pii: Pii::False,
             retain: false,
-            simulate_trim: false,
+            trim: true,
         }
     }
 

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -128,10 +128,8 @@ pub struct FieldAttrs {
     pub pii: Pii,
     /// Whether additional properties should be retained during normalization.
     pub retain: bool,
-    /// Whether the trimming processor is allowed to shorten or drop this field.
-    pub trim: bool,
     /// Whether to run all the trimming logic but not trimming the content.
-    pub fake_trim: bool,
+    pub simulate_trim: bool,
 }
 
 /// A set of characters allowed or denied for a (string) field.
@@ -171,8 +169,7 @@ impl FieldAttrs {
             max_bytes: None,
             pii: Pii::False,
             retain: false,
-            trim: true,
-            fake_trim: false,
+            simulate_trim: false,
         }
     }
 

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -128,7 +128,7 @@ pub struct FieldAttrs {
     pub pii: Pii,
     /// Whether additional properties should be retained during normalization.
     pub retain: bool,
-    /// Whether to run all the trimming logic but not trimming the content.
+    /// `true` if the field is allowed to be trimmed.
     pub trim: bool,
 }
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -12,11 +12,7 @@ use crate::protocol::{
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-#[metastructure(
-    process_func = "process_span",
-    value_type = "Span",
-    simulate_trim = "true"
-)]
+#[metastructure(process_func = "process_span", value_type = "Span", trim = "disabled")]
 pub struct Span {
     /// Timestamp when the span was ended.
     #[metastructure(required = "true")]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -12,7 +12,7 @@ use crate::protocol::{
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-#[metastructure(process_func = "process_span", value_type = "Span")]
+#[metastructure(process_func = "process_span", value_type = "Span", fake_trim = "true")]
 pub struct Span {
     /// Timestamp when the span was ended.
     #[metastructure(required = "true", trim = "false")]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -12,14 +12,18 @@ use crate::protocol::{
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
-#[metastructure(process_func = "process_span", value_type = "Span", fake_trim = "true")]
+#[metastructure(
+    process_func = "process_span",
+    value_type = "Span",
+    simulate_trim = "true"
+)]
 pub struct Span {
     /// Timestamp when the span was ended.
-    #[metastructure(required = "true", trim = "false")]
+    #[metastructure(required = "true")]
     pub timestamp: Annotated<Timestamp>,
 
     /// Timestamp when the span started.
-    #[metastructure(required = "true", trim = "false")]
+    #[metastructure(required = "true")]
     pub start_timestamp: Annotated<Timestamp>,
 
     /// The amount of time in milliseconds spent in this span,
@@ -27,30 +31,27 @@ pub struct Span {
     pub exclusive_time: Annotated<f64>,
 
     /// Span type (see `OperationType` docs).
-    #[metastructure(max_chars = 128, trim = "false")]
+    #[metastructure(max_chars = 128)]
     pub op: Annotated<OperationType>,
 
     /// The Span id.
-    #[metastructure(required = "true", trim = "false")]
+    #[metastructure(required = "true")]
     pub span_id: Annotated<SpanId>,
 
     /// The ID of the span enclosing this span.
-    #[metastructure(trim = "false")]
     pub parent_span_id: Annotated<SpanId>,
 
     /// The ID of the trace the span belongs to.
-    #[metastructure(required = "true", trim = "false")]
+    #[metastructure(required = "true")]
     pub trace_id: Annotated<TraceId>,
 
     /// A unique identifier for a segment within a trace (8 byte hexadecimal string).
     ///
     /// For spans embedded in transactions, the `segment_id` is the `span_id` of the containing
     /// transaction.
-    #[metastructure(trim = "false")]
     pub segment_id: Annotated<SpanId>,
 
     /// Whether or not the current span is the root of the segment.
-    #[metastructure(trim = "false")]
     pub is_segment: Annotated<bool>,
 
     /// The status of a span.


### PR DESCRIPTION
This PR adds an object-level trimming control, which works slightly differently from before. Instead of avoiding trimming altogether, this implementation performs all the traversal as if it were trimming but doesn't perform the actual trimming. This way, any arbitrary node in the traversal path can treat a child node with `trim = disabled` as if it were trimmed, but its contents in reality are not.

In our example, we want to limit an array of spans to 800 KiB, but we don't want the trimming to happen inside the span. Rather, we want to let the system trim the entire spans in the array. To achieve this, we had to implement this system in which a span signals how many bytes were used but no data is trimmed. Then, the array sees that the remaining size is 0 and will start dropping entire spans.

Closes: https://github.com/getsentry/relay/issues/3880