### PR TITLE
fix(metrics): Properly split large buckets repeatedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow metrics summaries with only `count` (for sets). ([#3864](https://github.com/getsentry/relay/pull/3864))
 - Do not trim any span field. Remove entire span instead. ([#3890](https://github.com/getsentry/relay/pull/3890))
 - Do not drop replays, profiles and standalone spans in proxy Relays. ([#3888](https://github.com/getsentry/relay/pull/3888))
+- Prevent an endless loop that causes high request volume and backlogs when certain large metric buckets are ingested or extrected. ([#3893](https://github.com/getsentry/relay/pull/3893))
 
 **Internal**:
 

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -730,7 +730,7 @@ impl<'a> Serialize for SetView<'a> {
     }
 }
 
-/// Result of [`split_at`].
+/// Result of [`split`].
 enum SplitDecision {
     /// Bucket fits within the current budget.
     ///


### PR DESCRIPTION
A bug in `BucketView::split` causes an endless loop when splitting a bucket more
than once. Split did not honor the index of the last split and repeatedly
returned the same view on subsequent calls.

This function is used when sending global metric partitions, which causes high
request volume and backlogs when large buckets are ingested.

