### PR TITLE
fix(metrics): Extract set span metrics from numeric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Do not trim any span field. Remove entire span instead. ([#3890](https://github.com/getsentry/relay/pull/3890))
 - Do not drop replays, profiles and standalone spans in proxy Relays. ([#3888](https://github.com/getsentry/relay/pull/3888))
 - Prevent an endless loop that causes high request volume and backlogs when certain large metric buckets are ingested or extrected. ([#3893](https://github.com/getsentry/relay/pull/3893))
+- Extract set span metrics from numeric values. ([#3897](https://github.com/getsentry/relay/pull/3897))
 
 **Internal**:
 


### PR DESCRIPTION
Numbers in the data couldn't be used as sets. This came up as an issue when configuring metric extraction rules, especially since setting a number as a tag would implicitly convert the value to a string and make the set work. Adds the extraction for numbers as well, but convert them to a string first, this allows for consistent sets across tags and data as well better behaviour for users. 