### PR TITLE
Revert "ref(project-cache): Check revision before loading from Redis"

### DIFF
--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -310,11 +310,7 @@ impl Project {
                 "project {} state requested {attempts} times",
                 self.project_key
             );
-            project_cache.send(RequestUpdate {
-                project_key: self.project_key,
-                no_cache,
-                cached_state: self.state.clone(),
-            });
+            project_cache.send(RequestUpdate::new(self.project_key, no_cache));
         }
 
         channel
@@ -477,11 +473,7 @@ impl Project {
                 self.project_key
             );
 
-            project_cache.send(RequestUpdate {
-                project_key: self.project_key,
-                no_cache,
-                cached_state: self.state.clone(),
-            });
+            project_cache.send(RequestUpdate::new(self.project_key, no_cache));
             return old_state;
         }
 

--- a/relay-server/src/services/project/state.rs
+++ b/relay-server/src/services/project/state.rs
@@ -53,17 +53,6 @@ impl ProjectState {
         }
     }
 
-    /// Returns the revision of the contained project info.
-    ///
-    /// `None` if the revision is missing or not available.
-    pub fn revision(&self) -> Option<&str> {
-        match &self {
-            ProjectState::Enabled(info) => info.rev.as_deref(),
-            ProjectState::Disabled => None,
-            ProjectState::Pending => None,
-        }
-    }
-
     /// Creates `Scoping` for this project if the state is loaded.
     ///
     /// Returns `Some` if the project state has been fetched and contains a project identifier,

--- a/relay-server/src/services/project/state/fetch_state.rs
+++ b/relay-server/src/services/project/state/fetch_state.rs
@@ -25,14 +25,6 @@ impl ProjectFetchState {
         }
     }
 
-    /// Refreshes the expiry of the fetch state.
-    pub fn refresh(old: ProjectFetchState) -> Self {
-        Self {
-            last_fetch: Some(Instant::now()),
-            state: old.state,
-        }
-    }
-
     /// Project state for an unknown but allowed project.
     ///
     /// This state is used for forwarding in Proxy mode.
@@ -40,7 +32,6 @@ impl ProjectFetchState {
         Self::enabled(ProjectInfo {
             project_id: None,
             last_change: None,
-            rev: None,
             public_keys: Default::default(),
             slug: None,
             config: ProjectConfig::default(),
@@ -127,13 +118,6 @@ impl ProjectFetchState {
         } else {
             Expiry::Updated
         }
-    }
-
-    /// Returns the revision of the contained project state.
-    ///
-    /// See: [`ProjectState::revision`].
-    pub fn revision(&self) -> Option<&str> {
-        self.state.revision()
     }
 }
 

--- a/relay-server/src/services/project/state/info.rs
+++ b/relay-server/src/services/project/state/info.rs
@@ -30,9 +30,8 @@ pub struct ProjectInfo {
     ///
     /// This might be `None` in some rare cases like where states
     /// are faked locally.
+    #[serde(default)]
     pub last_change: Option<DateTime<Utc>>,
-    /// The revision id of the project config.
-    pub rev: Option<String>,
     /// Indicates that the project is disabled.
     /// A container of known public keys in the project.
     ///
@@ -57,7 +56,6 @@ pub struct ProjectInfo {
 pub struct LimitedProjectInfo {
     pub project_id: Option<ProjectId>,
     pub last_change: Option<DateTime<Utc>>,
-    pub rev: Option<String>,
     pub public_keys: SmallVec<[PublicKeyConfig; 1]>,
     pub slug: Option<String>,
     #[serde(with = "LimitedProjectConfig")]

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -647,13 +647,8 @@ pub enum RelayCounters {
     ProjectStateNoCache,
     /// Number of times a project state is requested from the central Redis cache.
     ///
-    /// This metric is tagged with:
-    ///  - `hit`: One of:
-    ///     - `revision`: the cached version was validated to be up to date using its revision.
-    ///     - `project_config`: the request was handled by the cache.
-    ///     - `project_config_revision`: the request was handled by the cache and the revision did
-    ///        not change.
-    ///     - `false`: the request will be sent to the sentry endpoint.
+    /// This has a tag `hit` with values `true` or `false`.  If false the request will be
+    /// sent to the sentry endpoint.
     #[cfg(feature = "processing")]
     ProjectStateRedis,
     /// Number of times a project is looked up from the cache.


### PR DESCRIPTION
Reverts getsentry/relay#3892

Noticing some problems with this commit using too much memory, almost looks like a memory leak.

#skip-changelog