### PR TITLE
fix(replay): Update replay video data category target

### DIFF
--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -123,7 +123,7 @@ impl DataCategory {
             "profile_duration" => Self::ProfileDuration,
             "profile_chunk" => Self::ProfileChunk,
             "metric_second" => Self::MetricSecond,
-            "replay_video" => Self::MetricSecond,
+            "replay_video" => Self::ReplayVideo,
             _ => Self::Unknown,
         }
     }


### PR DESCRIPTION
Right now the outcomes are going to the metric second category instead of replay-video.

#skip-changelog

Related: https://github.com/getsentry/relay/pull/3847