### PR TITLE
ref(metrics): Normalize metrics in the processor instead of aggregator

### DIFF
--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -17,6 +17,9 @@ use crate::{FiniteF64, MetricNamespace, ParseMetricError};
 
 const VALUE_SEPARATOR: char = ':';
 
+/// Type of [`Bucket::tags`].
+pub type MetricTags = BTreeMap<String, String>;
+
 /// A snapshot of values within a [`Bucket`].
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GaugeValue {
@@ -401,8 +404,8 @@ fn parse_gauge(string: &str) -> Option<GaugeValue> {
 /// Parses tags in the format `tag1,tag2:value`.
 ///
 /// Tag values are optional. For tags with missing values, an empty `""` value is assumed.
-fn parse_tags(string: &str) -> Option<BTreeMap<String, String>> {
-    let mut map = BTreeMap::new();
+fn parse_tags(string: &str) -> Option<MetricTags> {
+    let mut map = MetricTags::new();
 
     for pair in string.split(',') {
         let mut name_value = pair.splitn(2, ':');
@@ -606,8 +609,8 @@ pub struct Bucket {
     /// ```text
     /// endpoint.hits:1|c|#route:user_index,environment:production,release:1.4.0
     /// ```
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub tags: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "MetricTags::is_empty")]
+    pub tags: MetricTags,
 
     /// Relay internal metadata for a metric bucket.
     ///

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -78,7 +78,7 @@ fn normalize_metric_name(name: &mut MetricName) -> Result<(), NormalizationError
 
 /// Removes tags with invalid characters in the key, and validates tag values.
 ///
-/// Tag values are validated with [`validate_tag_value`].
+/// Tag values are validated with [`normalize_tag_value`].
 fn normalize_metric_tags(tags: &mut MetricTags) {
     tags.retain(|tag_key, tag_value| {
         if !is_valid_tag_key(tag_key) {
@@ -140,7 +140,7 @@ pub(crate) fn escape_tag_value(raw: &str) -> String {
 /// resolved.
 ///
 /// Control characters are stripped from the resulting string. This is equivalent to
-/// [`validate_tag_value`].
+/// [`normalize_tag_value`].
 pub(crate) fn unescape_tag_value(escaped: &str) -> Result<String, UnescapeError> {
     let mut unescaped = unescaper::unescape(escaped)?;
     normalize_tag_value(&mut unescaped);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2181,14 +2181,24 @@ impl EnvelopeProcessorService {
         let clock_drift_processor =
             ClockDriftProcessor::new(sent_at, received).at_least(MINIMUM_CLOCK_DRIFT);
 
-        for bucket in &mut buckets {
+        buckets.retain_mut(|bucket| {
+            if let Err(error) = relay_metrics::normalize_bucket(bucket) {
+                relay_log::debug!(error = &error as &dyn Error, "dropping bucket {bucket:?}");
+                return false;
+            }
+
+            if !self::metrics::is_valid_namespace(bucket, source) {
+                return false;
+            }
+
             clock_drift_processor.process_timestamp(&mut bucket.timestamp);
+
             if !matches!(source, BucketSource::Internal) {
                 bucket.metadata = BucketMetadata::new(received_timestamp);
             }
-        }
 
-        let buckets = self::metrics::filter_namespaces(buckets, source);
+            true
+        });
 
         // Best effort check to filter and rate limit buckets, if there is no project state
         // available at the current time, we will check again after flushing.

--- a/relay-server/src/services/processor/metrics.rs
+++ b/relay-server/src/services/processor/metrics.rs
@@ -8,13 +8,13 @@ use crate::services::outcome::Outcome;
 use crate::services::project::ProjectInfo;
 use crate::services::project_cache::BucketSource;
 
-/// Filters buckets based on their namespace.
+/// Checks if the namespace of the passed bucket is valid.
 ///
-/// This is a noop for most namespaces except:
+/// This is returns `true` for most namespaces except:
 ///  - [`MetricNamespace::Unsupported`]: Equal to invalid/unknown namespaces.
 ///  - [`MetricNamespace::Stats`]: Metric stats are only allowed if the `source` is [`BucketSource::Internal`].
-pub fn filter_namespaces(mut buckets: Vec<Bucket>, source: BucketSource) -> Vec<Bucket> {
-    buckets.retain(|bucket| match bucket.name.namespace() {
+pub fn is_valid_namespace(bucket: &Bucket, source: BucketSource) -> bool {
+    match bucket.name.namespace() {
         MetricNamespace::Sessions => true,
         MetricNamespace::Transactions => true,
         MetricNamespace::Spans => true,
@@ -22,9 +22,7 @@ pub fn filter_namespaces(mut buckets: Vec<Bucket>, source: BucketSource) -> Vec<
         MetricNamespace::Custom => true,
         MetricNamespace::Stats => source == BucketSource::Internal,
         MetricNamespace::Unsupported => false,
-    });
-
-    buckets
+    }
 }
 
 pub fn apply_project_info(


### PR DESCRIPTION
Normalizing metrics is quite costly, especially since we always allocate a new metric name. We should do this in the processor with all the other normalizations and checks. This will take quite a bit of load of the aggregator.

#skip-changelog