### PR TITLE
ref(metrics): Move max aggregator size into config and allow passing now timestamp for merge

### DIFF
--- a/relay-config/src/aggregator.rs
+++ b/relay-config/src/aggregator.rs
@@ -12,15 +12,6 @@ pub struct AggregatorServiceConfig {
     #[serde(flatten)]
     pub aggregator: AggregatorConfig,
 
-    /// Maximum amount of bytes used for metrics aggregation.
-    ///
-    /// When aggregating metrics, Relay keeps track of how many bytes a metric takes in memory.
-    /// This is only an approximation and does not take into account things such as pre-allocation
-    /// in hashmaps.
-    ///
-    /// Defaults to `None`, i.e. no limit.
-    pub max_total_bucket_bytes: Option<usize>,
-
     /// The approximate maximum number of bytes submitted within one flush cycle.
     ///
     /// This controls how big flushed batches of buckets get, depending on the number of buckets,
@@ -40,7 +31,6 @@ impl Default for AggregatorServiceConfig {
     fn default() -> Self {
         Self {
             aggregator: AggregatorConfig::default(),
-            max_total_bucket_bytes: None,
             max_flush_bytes: 5_000_000, // 5 MB
             flush_interval_ms: 100,     // 100 milliseconds
         }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2470,6 +2470,7 @@ impl Config {
             mut max_tag_key_length,
             mut max_tag_value_length,
             mut max_project_key_bucket_bytes,
+            mut max_total_bucket_bytes,
             ..
         } = self.default_aggregator_config().aggregator;
 
@@ -2484,6 +2485,7 @@ impl Config {
             max_tag_value_length = max_tag_value_length.max(agg.max_tag_value_length);
             max_project_key_bucket_bytes =
                 max_project_key_bucket_bytes.max(agg.max_project_key_bucket_bytes);
+            max_total_bucket_bytes = max_total_bucket_bytes.max(agg.max_total_bucket_bytes);
         }
 
         for agg in self
@@ -2505,6 +2507,7 @@ impl Config {
             max_tag_key_length,
             max_tag_value_length,
             max_project_key_bucket_bytes,
+            max_total_bucket_bytes,
             initial_delay: 30,
             flush_partitions: None,
             flush_batching: FlushBatching::Project,

--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -196,11 +196,7 @@ fn bench_insert_and_flush(c: &mut Criterion) {
                                 #[allow(clippy::unit_arg)]
                                 black_box(
                                     aggregator
-                                        .merge(
-                                            black_box(project_key),
-                                            black_box(bucket),
-                                            black_box(None),
-                                        )
+                                        .merge(black_box(project_key), black_box(bucket))
                                         .unwrap(),
                                 );
                             }
@@ -221,7 +217,7 @@ fn bench_insert_and_flush(c: &mut Criterion) {
                         let timestamp = UnixTimestamp::now();
                         let mut aggregator: Aggregator = Aggregator::new(config.clone());
                         for (project_key, bucket) in input.get_buckets(timestamp) {
-                            aggregator.merge(project_key, bucket, None).unwrap();
+                            aggregator.merge(project_key, bucket).unwrap();
                         }
                         aggregator
                     },


### PR DESCRIPTION
The `max_total_bucket_bytes` config can be just part of the aggregator, it's always passed as an argument with the same value and the project max size is already part of the aggregator.

Additionally improves performance by not re-creating the `now` timestamp over and over again when merging a large batch of metrics into the aggregator. This takes up a significant amount of time.

#skip-changelog