### PR TITLE
feat(spans): extract country code into spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Collect SDK information in profile chunks. ([#3882](https://github.com/getsentry/relay/pull/3882))
 - Introduce `trim = "disabled"` type attribute to prevent trimming of spans. ([#3877](https://github.com/getsentry/relay/pull/3877))
 - Make the tcp listen backlog configurable and raise the default to 1024. ([#3899](https://github.com/getsentry/relay/pull/3899))
-- Extract `user.geo.country_code` into span indexed ([#3367](https://github.com/getsentry/relay/pull/3911))
+- Extract `user.geo.country_code` into span indexed. ([#3911](https://github.com/getsentry/relay/pull/3911))
 
 ## 24.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Collect SDK information in profile chunks. ([#3882](https://github.com/getsentry/relay/pull/3882))
 - Introduce `trim = "disabled"` type attribute to prevent trimming of spans. ([#3877](https://github.com/getsentry/relay/pull/3877))
 - Make the tcp listen backlog configurable and raise the default to 1024. ([#3899](https://github.com/getsentry/relay/pull/3899))
+- Extract `user.geo.country_code` into span indexed ([#3367](https://github.com/getsentry/relay/pull/3911))
 
 ## 24.7.1
 
@@ -48,6 +49,7 @@
 - Only transfer valid profile ids. ([#3809](https://github.com/getsentry/relay/pull/3809))
 
 **Features**:
+
 - Allow list for excluding certain host/IPs from scrubbing in spans. ([#3813](https://github.com/getsentry/relay/pull/3813))
 
 **Internal**:

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -85,7 +85,7 @@ pub enum SpanTagKey {
     ThreadName,
     ThreadId,
     ProfilerId,
-    CountryCode,
+    UserCountryCode,
 }
 
 impl SpanTagKey {
@@ -99,6 +99,7 @@ impl SpanTagKey {
             SpanTagKey::UserID => "user.id",
             SpanTagKey::UserUsername => "user.username",
             SpanTagKey::UserEmail => "user.email",
+            SpanTagKey::UserCountryCode => "user.geo.country_code",
             SpanTagKey::Environment => "environment",
             SpanTagKey::Transaction => "transaction",
             SpanTagKey::TransactionMethod => "transaction.method",
@@ -140,7 +141,6 @@ impl SpanTagKey {
             SpanTagKey::ThreadName => "thread.name",
             SpanTagKey::ThreadId => "thread.id",
             SpanTagKey::ProfilerId => "profiler_id",
-            SpanTagKey::CountryCode => "user.geo.country_code",
         }
     }
 }
@@ -310,10 +310,8 @@ fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
         if let Some(user_email) = user.email.value() {
             tags.insert(SpanTagKey::UserEmail, user_email.clone());
         }
-        if let Some(geo) = user.geo.value() {
-            if let Some(country_code) = geo.country_code.value() {
-                tags.insert(SpanTagKey::CountryCode, country_code.to_owned());
-            }
+        if let Some(country_code) = user.geo.value().and_then(|geo| geo.country_code.value()) {
+            tags.insert(SpanTagKey::UserCountryCode, country_code.to_owned());
         }
     }
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -48,6 +48,7 @@ pub enum SpanTagKey {
     DeviceClass,
     // Mobile OS the transaction originated from.
     OsName,
+
     // Specific to spans
     Action,
     /// The group of the ancestral span with op ai.pipeline.*


### PR DESCRIPTION
work towards https://github.com/getsentry/sentry/issues/75230

This PR adds country_code as an indexed span tag. Eventually we would like to create regional metrics, but we have to make a product decision on whether we want country based metrics, or larger region metrics (ex. continent). There are also ~200 countries, which could be high cardinality wise, but at least we have a known limit (lmk if you have thoughts on this!)