### PR TITLE
ref(relay): Move cabi glob matching into cabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,6 +3620,7 @@ version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "globset",
  "json-forensics",
  "lru",
  "once_cell",
@@ -3670,9 +3671,7 @@ version = "24.7.1"
 dependencies = [
  "chrono",
  "globset",
- "lru",
  "once_cell",
- "parking_lot",
  "regex",
  "sentry-types",
  "serde",

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 chrono = { workspace = true }
+globset = { workspace = true }
 json-forensics = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }

--- a/relay-cabi/src/lib.rs
+++ b/relay-cabi/src/lib.rs
@@ -102,6 +102,7 @@ mod codeowners;
 mod constants;
 mod core;
 mod ffi;
+mod glob;
 mod processing;
 
 pub use crate::auth::*;
@@ -109,4 +110,5 @@ pub use crate::codeowners::*;
 pub use crate::constants::*;
 pub use crate::core::*;
 pub use crate::ffi::*;
+pub use crate::glob::*;
 pub use crate::processing::*;

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -11,7 +11,6 @@ use std::sync::OnceLock;
 
 use chrono::{DateTime, Utc};
 use relay_cardinality::CardinalityLimit;
-use relay_common::glob::{glob_match_bytes, GlobOptions};
 use relay_dynamic_config::{normalize_json, GlobalConfig, ProjectConfig};
 use relay_event_normalization::{
     normalize_event, validate_event, BreakdownsConfig, ClientHints, EventValidationConfig,
@@ -28,7 +27,7 @@ use relay_sampling::SamplingConfig;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::core::{RelayBuf, RelayStr};
+use crate::core::RelayStr;
 
 /// Configuration for the store step -- validation and normalization.
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -367,46 +366,6 @@ pub unsafe extern "C" fn relay_pii_selector_suggestions_from_event(
 #[allow(clippy::diverging_sub_expression)]
 pub unsafe extern "C" fn relay_test_panic() -> () {
     panic!("this is a test panic")
-}
-
-/// Controls the globbing behaviors.
-#[repr(u32)]
-pub enum GlobFlags {
-    /// When enabled `**` matches over path separators and `*` does not.
-    DoubleStar = 1,
-    /// Enables case insensitive path matching.
-    CaseInsensitive = 2,
-    /// Enables path normalization.
-    PathNormalize = 4,
-    /// Allows newlines.
-    AllowNewline = 8,
-}
-
-/// Performs a glob operation on bytes.
-///
-/// Returns `true` if the glob matches, `false` otherwise.
-#[no_mangle]
-#[relay_ffi::catch_unwind]
-pub unsafe extern "C" fn relay_is_glob_match(
-    value: *const RelayBuf,
-    pat: *const RelayStr,
-    flags: GlobFlags,
-) -> bool {
-    let mut options = GlobOptions::default();
-    let flags = flags as u32;
-    if (flags & GlobFlags::DoubleStar as u32) != 0 {
-        options.double_star = true;
-    }
-    if (flags & GlobFlags::CaseInsensitive as u32) != 0 {
-        options.case_insensitive = true;
-    }
-    if (flags & GlobFlags::PathNormalize as u32) != 0 {
-        options.path_normalize = true;
-    }
-    if (flags & GlobFlags::AllowNewline as u32) != 0 {
-        options.allow_newline = true;
-    }
-    glob_match_bytes((*value).as_bytes(), (*pat).as_str(), options)
 }
 
 /// Parse a sentry release structure from a string.

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -15,9 +15,7 @@ workspace = true
 [dependencies]
 chrono = { workspace = true }
 globset = { workspace = true }
-lru = { workspace = true }
 once_cell = { workspace = true }
-parking_lot = { workspace = true }
 regex = { workspace = true }
 sentry-types = { workspace = true }
 serde = { workspace = true }

--- a/relay-common/src/lib.rs
+++ b/relay-common/src/lib.rs
@@ -8,7 +8,6 @@
 
 mod macros;
 
-pub mod glob;
 pub mod glob2;
 pub mod glob3;
 pub mod time;


### PR DESCRIPTION
Relay doesn't use this glob matching at all, it only exists for the CABI and should eventually be moved to [ophio](https://github.com/getsentry/ophio/).

This is also a first step for unifying Relays glob implementations. As a nice side effect this does also cut down some dependencies for certain crates.

#skip-changelog