### PR TITLE
ref(glob): Switch glob implementations to regex-lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Make the tcp listen backlog configurable and raise the default to 1024. ([#3899](https://github.com/getsentry/relay/pull/3899))
 - Extract `user.geo.country_code` into span indexed. ([#3911](https://github.com/getsentry/relay/pull/3911))
 - Add `span.system` tag to span metrics ([#3913](https://github.com/getsentry/relay/pull/3913))
+- Switch glob implementations from `regex` to `regex-lite`. ([#3926](https://github.com/getsentry/relay/pull/3926))
 - Extract client sdk from transaction into profiles. ([#3915](https://github.com/getsentry/relay/pull/3915))
 - Extract `user.geo.subregion` into span metrics/indexed. ([#3914](https://github.com/getsentry/relay/pull/3914))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,7 +3678,7 @@ dependencies = [
  "chrono",
  "globset",
  "once_cell",
- "regex",
+ "regex-lite",
  "sentry-types",
  "serde",
  "serde_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ rdkafka-sys = "4.3.0"
 # Git revision until https://github.com/redis-rs/redis-rs/pull/1097 (merged) and https://github.com/redis-rs/redis-rs/pull/1253 are released.
 redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "939e5df6f9cc976b0a53987f6eb3f76b2c398bd6", default-features = false }
 regex = "1.10.2"
+regex-lite = "0.1.6"
 reqwest = "0.11.1"
 rmp-serde = "1.1.1"
 rust-embed = "8.0.0"

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 chrono = { workspace = true }
 globset = { workspace = true }
 once_cell = { workspace = true }
-regex = { workspace = true }
+regex-lite = { workspace = true }
 sentry-types = { workspace = true }
 serde = { workspace = true }
 

--- a/relay-common/src/glob2.rs
+++ b/relay-common/src/glob2.rs
@@ -3,7 +3,7 @@
 use std::sync::OnceLock;
 use std::{fmt, str};
 
-use regex::Regex;
+use regex_lite::Regex;
 
 /// Glob options represent the underlying regex emulating the globs.
 #[derive(Debug)]
@@ -70,7 +70,7 @@ impl<'g> GlobBuilder<'g> {
         let regex = GLOB_RE.get_or_init(|| Regex::new(r"\\\?|\\\*\\\*|\\\*|\?|\*\*|\*").unwrap());
 
         for m in regex.find_iter(self.value) {
-            pattern.push_str(&regex::escape(&self.value[last..m.start()]));
+            pattern.push_str(&regex_lite::escape(&self.value[last..m.start()]));
             match m.as_str() {
                 "?" => pattern.push_str(self.groups.question_mark),
                 "**" => pattern.push_str(self.groups.double_star),
@@ -79,7 +79,7 @@ impl<'g> GlobBuilder<'g> {
             }
             last = m.end();
         }
-        pattern.push_str(&regex::escape(&self.value[last..]));
+        pattern.push_str(&regex_lite::escape(&self.value[last..]));
         pattern.push('$');
 
         Glob {

--- a/relay-common/src/glob3.rs
+++ b/relay-common/src/glob3.rs
@@ -4,12 +4,12 @@ use std::fmt;
 use std::sync::OnceLock;
 
 use globset::GlobBuilder;
-use regex::bytes::{Regex, RegexBuilder};
+use regex_lite::{Regex, RegexBuilder};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Returns `true` if any of the patterns match the given message.
-fn is_match(globs: &[Regex], message: &[u8]) -> bool {
-    globs.iter().any(|regex| regex.is_match(message.as_ref()))
+fn is_match(globs: &[Regex], message: &str) -> bool {
+    globs.iter().any(|regex| regex.is_match(message))
 }
 
 /// A list of patterns for glob matching.
@@ -38,7 +38,7 @@ impl GlobPatterns {
     /// Returns `true` if any of the patterns match the given message.
     pub fn is_match<S>(&self, message: S) -> bool
     where
-        S: AsRef<[u8]>,
+        S: AsRef<str>,
     {
         let message = message.as_ref();
         if message.is_empty() {


### PR DESCRIPTION
Switches the regex implementation for globs from `regex` to regex-lite`, this should bring down memory consumption for all globs.

This is just a temporary stop-gap to unblock the project cache improvements started in #3892, eventually the glob implementations should be unified and ideally be as much as possible regex free.