### PR TITLE
ref(ua): Disables unicode support in user agent parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Extract `user.geo.country_code` into span indexed. ([#3911](https://github.com/getsentry/relay/pull/3911))
 - Add `span.system` tag to span metrics ([#3913](https://github.com/getsentry/relay/pull/3913))
 - Switch glob implementations from `regex` to `regex-lite`. ([#3926](https://github.com/getsentry/relay/pull/3926))
+- Disables unicode support in user agent regexes. ([#3929](https://github.com/getsentry/relay/pull/3929))
 - Extract client sdk from transaction into profiles. ([#3915](https://github.com/getsentry/relay/pull/3915))
 - Extract `user.geo.subregion` into span metrics/indexed. ([#3914](https://github.com/getsentry/relay/pull/3914))
 

--- a/relay-ua/src/lib.rs
+++ b/relay-ua/src/lib.rs
@@ -17,7 +17,9 @@ pub use uaparser::{Device, UserAgent, OS};
 /// For usage, see [`Parser`].
 static UA_PARSER: Lazy<UserAgentParser> = Lazy::new(|| {
     let ua_regexes = include_bytes!("../uap-core/regexes.yaml");
-    UserAgentParser::from_bytes(ua_regexes)
+    UserAgentParser::builder()
+        .with_unicode_support(false)
+        .build_from_bytes(ua_regexes)
         .expect("Could not create UserAgent. You are probably using a bad build of relay.")
 });
 


### PR DESCRIPTION
Disables unicode support for the user agent regexes, this is generally safe to do as the library puts it:

```
    /// Enable or disable unicode support. This is enabled by default.
    /// Unicode regexes are much more complex and take up more memory.
    /// Most uaparser implementation do not support unicode, so disabling
    /// this is generally safe to do.
```

It saves a lot of memory:

```
used memory `uaparser_no_unicode()`: peak: 28.38 MiB | total: 169.18 MiB | current: 28.32 MiB
used memory `uaparser()`: peak: 165.05 MiB | total: 1.10 GiB | current: 164.80 MiB
```

And using the parser with 10 threads:

```
used memory `uaparser_used(false)`: peak: 109.06 MiB | total: 254.88 MiB | current: 109.06 MiB
used memory `uaparser_used(true)`: peak: 519.80 MiB | total: 1.46 GiB | current: 519.71 MiB
```