### PR TITLE
fix(beta): Remove the warning of the beta linter

### DIFF
--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -697,7 +697,7 @@ mod tests {
 
         let contexts = contexts.value().unwrap();
         for i in 1..2 {
-            let other = match contexts.get_key(&format!("despacito{i}")).unwrap() {
+            let other = match contexts.get_key(format!("despacito{i}")).unwrap() {
                 Context::Other(ref x) => x,
                 _ => panic!("Context has changed type!"),
             };


### PR DESCRIPTION
Following warning was reporter on beta:
```
error: the borrowed expression implements the required traits
   --> relay-event-normalization/src/trimming.rs:700:48
    |
700 |             let other = match contexts.get_key(&format!("despacito{i}")).unwrap() {
    |                                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `format!("despacito{i}")`
```

which does not require taking a reference anymore.


#skip-changelog