### PR TITLE
feat(spooler): Implement eviction algorithm for `EnvelopeBuffer`

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -865,6 +865,11 @@ fn spool_envelopes_max_envelope_delay_secs() -> u64 {
     24 * 60 * 60
 }
 
+/// Default maximum number of stacks that can be evicted.
+fn spool_envelopes_max_evictable_stacks() -> usize {
+    100
+}
+
 /// Default maximum number of envelopes that can be evicted for each stack.
 fn spool_envelopes_max_evictable_envelopes() -> usize {
     100
@@ -909,6 +914,9 @@ pub struct EnvelopeSpool {
     /// they are dropped. Defaults to 24h.
     #[serde(default = "spool_envelopes_max_envelope_delay_secs")]
     max_envelope_delay_secs: u64,
+    /// Maximum number of stacks that can be evicted.
+    #[serde(default = "spool_envelopes_max_evictable_stacks")]
+    max_evictable_stacks: usize,
     /// Maximum number of envelopes that can be evicted for each stack.
     #[serde(default = "spool_envelopes_max_evictable_envelopes")]
     max_evictable_envelopes: usize,
@@ -947,6 +955,7 @@ impl Default for EnvelopeSpool {
             disk_batch_size: spool_envelopes_stack_disk_batch_size(),
             max_batches: spool_envelopes_stack_max_batches(),
             max_envelope_delay_secs: spool_envelopes_max_envelope_delay_secs(),
+            max_evictable_stacks: spool_envelopes_max_evictable_stacks(),
             max_evictable_envelopes: spool_envelopes_max_evictable_envelopes(),
             version: EnvelopeSpoolVersion::default(),
         }
@@ -2157,6 +2166,11 @@ impl Config {
     /// flushing one batch to disk.
     pub fn spool_envelopes_stack_max_batches(&self) -> usize {
         self.values.spool.envelopes.max_batches
+    }
+
+    /// Maximum number of stacks that can be evicted.
+    pub fn spool_envelopes_stack_max_evictable_stacks(&self) -> usize {
+        self.values.spool.envelopes.max_evictable_stacks
     }
 
     /// Maximum number of envelopes that can be evicted per stack.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -860,8 +860,14 @@ fn spool_envelopes_stack_max_batches() -> usize {
     2
 }
 
+/// Default maximum time between receiving the envelope and processing it.
 fn spool_envelopes_max_envelope_delay_secs() -> u64 {
     24 * 60 * 60
+}
+
+/// Default maximum number of envelopes that can be evicted for each stack.
+fn spool_envelopes_max_evictable_envelopes() -> usize {
+    100
 }
 
 /// Persistent buffering configuration for incoming envelopes.
@@ -903,6 +909,9 @@ pub struct EnvelopeSpool {
     /// they are dropped. Defaults to 24h.
     #[serde(default = "spool_envelopes_max_envelope_delay_secs")]
     max_envelope_delay_secs: u64,
+    /// Maximum number of envelopes that can be evicted for each stack.
+    #[serde(default = "spool_envelopes_max_evictable_envelopes")]
+    max_evictable_envelopes: usize,
     /// Version of the spooler.
     #[serde(default)]
     version: EnvelopeSpoolVersion,
@@ -938,6 +947,7 @@ impl Default for EnvelopeSpool {
             disk_batch_size: spool_envelopes_stack_disk_batch_size(),
             max_batches: spool_envelopes_stack_max_batches(),
             max_envelope_delay_secs: spool_envelopes_max_envelope_delay_secs(),
+            max_evictable_envelopes: spool_envelopes_max_evictable_envelopes(),
             version: EnvelopeSpoolVersion::default(),
         }
     }
@@ -2147,6 +2157,11 @@ impl Config {
     /// flushing one batch to disk.
     pub fn spool_envelopes_stack_max_batches(&self) -> usize {
         self.values.spool.envelopes.max_batches
+    }
+
+    /// Maximum number of envelopes that can be evicted per stack.
+    pub fn spool_envelopes_stack_max_evictable_envelopes(&self) -> usize {
+        self.values.spool.envelopes.max_evictable_envelopes
     }
 
     /// Returns `true` if version 2 of the spooling mechanism is used.

--- a/relay-server/benches/benches.rs
+++ b/relay-server/benches/benches.rs
@@ -99,6 +99,7 @@ fn benchmark_sqlite_envelope_stack(c: &mut Criterion) {
                                 envelope_store.clone(),
                                 disk_batch_size,
                                 2,
+                                10,
                                 ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
                                 ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
                             );
@@ -135,6 +136,7 @@ fn benchmark_sqlite_envelope_stack(c: &mut Criterion) {
                                     envelope_store.clone(),
                                     disk_batch_size,
                                     2,
+                                    10,
                                     ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
                                     ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
                                 );
@@ -175,6 +177,7 @@ fn benchmark_sqlite_envelope_stack(c: &mut Criterion) {
                                 envelope_store.clone(),
                                 disk_batch_size,
                                 2,
+                                10,
                                 ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
                                 ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
                             );

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -814,6 +814,7 @@ mod tests {
 
         for envelope in envelopes.clone() {
             buffer.push(envelope).await.unwrap();
+            // We sleep to make sure that the `last_update` of `QueueItem` is different.
             sleep(Duration::from_millis(1)).await;
         }
 

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -130,8 +130,7 @@ impl EnvelopeBuffer<SqliteStackProvider> {
             stacks_by_project: Default::default(),
             priority_queue: Default::default(),
             stack_provider: SqliteStackProvider::new(config).await?,
-            // TODO: add configuration.
-            max_evictable_stacks: 10,
+            max_evictable_stacks: config.spool_envelopes_stack_max_evictable_stacks(),
         })
     }
 }

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -563,9 +563,21 @@ mod tests {
         envelope
     }
 
+    fn mock_config() -> Config {
+        Config::from_json_value(serde_json::json!({
+            "spool": {
+                "envelopes": {
+                    "version": "experimental",
+                    "max_evictable_stacks": 3
+                }
+            }
+        }))
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn test_insert_pop() {
-        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(10);
+        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(&mock_config());
 
         let project_key1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
         let project_key2 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
@@ -649,7 +661,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_project_internal_order() {
-        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(10);
+        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(&mock_config());
 
         let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
 
@@ -676,7 +688,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sampling_projects() {
-        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(10);
+        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(&mock_config());
 
         let project_key1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
         let project_key2 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fef").unwrap();
@@ -754,7 +766,7 @@ mod tests {
 
         assert_ne!(stack_key1, stack_key2);
 
-        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(10);
+        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(&mock_config());
         buffer
             .push(new_envelope(project_key1, Some(project_key2), None))
             .await
@@ -768,7 +780,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_last_peek_internal_order() {
-        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(10);
+        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(&mock_config());
 
         let project_key_1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
         let event_id_1 = EventId::new();
@@ -798,7 +810,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_eviction() {
-        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(3);
+        let mut buffer = EnvelopeBuffer::<MemoryStackProvider>::new(&mock_config());
 
         let project_key_1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
         let project_key_2 = ProjectKey::parse("b56ae32be2584e0bbd7a4cbb95971fed").unwrap();

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -38,8 +38,8 @@ impl PolymorphicEnvelopeBuffer {
         if config.spool_envelopes_path().is_some() {
             panic!("Disk backend not yet supported for spool V2");
         }
-        // TODO: use configuration.
-        Self::InMemory(EnvelopeBuffer::<MemoryStackProvider>::new(100))
+
+        Self::InMemory(EnvelopeBuffer::<MemoryStackProvider>::new(config))
     }
 
     /// Adds an envelope to the buffer.
@@ -72,7 +72,7 @@ impl PolymorphicEnvelopeBuffer {
 
     /// Marks a project as ready or not ready.
     ///
-    /// The buffer reprioritizes its envelopes based on this information.
+    /// The buffer re-prioritizes its envelopes based on this information.
     pub fn mark_ready(&mut self, project: &ProjectKey, is_ready: bool) -> bool {
         match self {
             Self::Sqlite(buffer) => buffer.mark_ready(project, is_ready),
@@ -93,7 +93,7 @@ pub enum EnvelopeBufferError {
 
 /// An envelope buffer that holds an individual stack for each project/sampling project combination.
 ///
-/// Envelope stacks are organized in a priority queue, and are reprioritized every time an envelope
+/// Envelope stacks are organized in a priority queue, and are re-prioritized every time an envelope
 /// is pushed, popped, or when a project becomes ready.
 #[derive(Debug)]
 struct EnvelopeBuffer<P: StackProvider> {
@@ -112,12 +112,12 @@ struct EnvelopeBuffer<P: StackProvider> {
 
 impl EnvelopeBuffer<MemoryStackProvider> {
     /// Creates an empty buffer.
-    pub fn new(max_evictable_stacks: usize) -> Self {
+    pub fn new(config: &Config) -> Self {
         Self {
             stacks_by_project: Default::default(),
             priority_queue: Default::default(),
             stack_provider: MemoryStackProvider,
-            max_evictable_stacks,
+            max_evictable_stacks: config.spool_envelopes_stack_max_evictable_stacks(),
         }
     }
 }

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -1,8 +1,7 @@
+use crate::Envelope;
 use std::convert::Infallible;
 
-use crate::Envelope;
-
-use super::EnvelopeStack;
+use super::{EnvelopeStack, Evictable};
 
 #[derive(Debug)]
 pub struct MemoryEnvelopeStack(#[allow(clippy::vec_box)] Vec<Box<Envelope>>);
@@ -27,5 +26,11 @@ impl EnvelopeStack for MemoryEnvelopeStack {
 
     async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
         Ok(self.0.pop())
+    }
+}
+
+impl Evictable for MemoryEnvelopeStack {
+    async fn evict(&mut self) {
+        self.0.clear()
     }
 }

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -21,8 +21,14 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     fn pop(&mut self) -> impl Future<Output = Result<Option<Box<Envelope>>, Self::Error>>;
 }
 
+/// An object that can support eviction.
+pub trait Evictable: Send + std::fmt::Debug {
+    /// Evicts data from an [`Evictable`].
+    fn evict(&mut self) -> impl Future<Output = ()>;
+}
+
 pub trait StackProvider: std::fmt::Debug {
-    type Stack: EnvelopeStack;
+    type Stack: EnvelopeStack + Evictable;
 
     fn create_stack(&self, envelope: Box<Envelope>) -> Self::Stack;
 }

--- a/relay-server/src/services/buffer/sqlite_envelope_store.rs
+++ b/relay-server/src/services/buffer/sqlite_envelope_store.rs
@@ -547,9 +547,4 @@ mod tests {
             (own_key, sampling_key)
         );
     }
-
-    #[tokio::test]
-    async fn test_drop_envelope_stack() {
-        // TODO: test that dropping the envelope stack cleans up the db.
-    }
 }

--- a/relay-server/src/services/buffer/sqlite_envelope_store.rs
+++ b/relay-server/src/services/buffer/sqlite_envelope_store.rs
@@ -547,4 +547,9 @@ mod tests {
             (own_key, sampling_key)
         );
     }
+
+    #[tokio::test]
+    async fn test_drop_envelope_stack() {
+        // TODO: test that dropping the envelope stack cleans up the db.
+    }
 }

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -11,6 +11,7 @@ pub struct SqliteStackProvider {
     envelope_store: SqliteEnvelopeStore,
     disk_batch_size: usize,
     max_batches: usize,
+    max_evictable_envelopes: usize,
 }
 
 #[warn(dead_code)]
@@ -22,6 +23,7 @@ impl SqliteStackProvider {
             envelope_store,
             disk_batch_size: config.spool_envelopes_stack_disk_batch_size(),
             max_batches: config.spool_envelopes_stack_max_batches(),
+            max_evictable_envelopes: config.spool_envelopes_stack_max_evictable_envelopes(),
         })
     }
 }
@@ -37,6 +39,7 @@ impl StackProvider for SqliteStackProvider {
             self.envelope_store.clone(),
             self.disk_batch_size,
             self.max_batches,
+            self.max_evictable_envelopes,
             own_key,
             sampling_key,
         )

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -514,6 +514,10 @@ pub enum RelayTimers {
     ///  - `message`: The type of message that was processed.
     #[cfg(feature = "processing")]
     StoreServiceDuration,
+    /// Timing in milliseconds for constructing the LRU list of stacks.
+    BufferEvictLRUConstruction,
+    /// Timing in milliseconds to evict all the stacks determined by the LRU algorithm.
+    BufferEvictStacksEviction,
 }
 
 impl TimerMetric for RelayTimers {
@@ -555,6 +559,8 @@ impl TimerMetric for RelayTimers {
             RelayTimers::MetricRouterServiceDuration => "metrics.router.message.duration",
             #[cfg(feature = "processing")]
             RelayTimers::StoreServiceDuration => "store.message.duration",
+            RelayTimers::BufferEvictLRUConstruction => "buffer.evict.lru_construction",
+            RelayTimers::BufferEvictStacksEviction => "buffer.evict.stacks_eviction",
         }
     }
 }


### PR DESCRIPTION
This PR implements an eviction algorithm that can be triggered via the `evict` method call on the `EnvelopeBuffer`. The eviction policy aims to evict all the envelope stacks that are not ready or have been stale for the longest time.

The PR doesn't include the logic for triggering the eviction, since this is something that we can decide later on. Still, some possibilities include trying eviction via tickers that frequently monitor the capacity of Relay and evict data when in need.

Closes: https://github.com/getsentry/team-ingest/issues/518