### PR TITLE
ref(glob): Switch glob3 implemention to pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,9 +3677,9 @@ version = "24.8.0"
 dependencies = [
  "chrono",
  "criterion",
- "globset",
  "once_cell",
  "regex-lite",
+ "relay-pattern",
  "sentry-types",
  "serde",
  "serde_test",
@@ -3948,7 +3948,6 @@ dependencies = [
  "criterion",
  "memchr",
  "regex-lite",
- "relay-common",
 ]
 
 [[package]]

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -14,9 +14,9 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-globset = { workspace = true }
 once_cell = { workspace = true }
 regex-lite = { workspace = true }
+relay-pattern = { workspace = true }
 sentry-types = { workspace = true }
 serde = { workspace = true }
 

--- a/relay-pattern/Cargo.toml
+++ b/relay-pattern/Cargo.toml
@@ -18,7 +18,6 @@ regex-lite = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-relay-common = { workspace = true }
 
 [[bench]]
 name = "benches"

--- a/relay-pattern/benches/benches.rs
+++ b/relay-pattern/benches/benches.rs
@@ -1,19 +1,12 @@
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 
-use relay_common::glob3::GlobPatterns;
 use relay_pattern::Pattern;
 
 fn bench(group: &mut BenchmarkGroup<'_, WallTime>, haystack: &str, needle: &str) {
     group.bench_function("pattern", |b| {
         let pattern = Pattern::new(needle).unwrap();
         b.iter(|| assert!(pattern.is_match(haystack)))
-    });
-
-    group.bench_function("glob3", |b| {
-        let glob = GlobPatterns::new(vec![needle.to_owned()]);
-        assert!(glob.is_match(haystack)); // Force initialization
-        b.iter(|| assert!(glob.is_match(haystack)))
     });
 }
 

--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -74,7 +74,7 @@ impl fmt::Display for Error {
 }
 
 /// `Pattern` represents a successfully parsed Relay pattern.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pattern {
     pattern: String,
     options: Options,
@@ -163,7 +163,7 @@ struct Options {
 ///
 /// Certain patterns can be matched more efficiently while the complex
 /// patterns fallback to a regex.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum MatchStrategy {
     /// The pattern is a single literal string.
     ///


### PR DESCRIPTION
Switches the `glob3` implementation to `Pattern`. All existing tests are still passing.

#skip-changelog