### PR TITLE
Revert "build(deps): bump sentry-native to 0.7.8."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-**Internal**:
-
-- Bumped `sentry-native` submodule to v0.7.8. ([#3940](https://github.com/getsentry/relay/pull/3940))
-
 ## 24.8.0
 
 **Bug Fixes**:


### PR DESCRIPTION
Reverts getsentry/relay#3940

Unfortunately this breaks the arm build, the gcc version is too old (ancient you could say).

#skip-changelog