### PR TITLE
fix: arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
 
       - name: Install Cross
         # We need a nightly version of cross for `cross-util`.
-        run: cargo install cross --git https://github.com/cross-rs/cross --rev 085092c
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 1901fd7
 
       - name: Compile
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Bumped `sentry-native` submodule to v0.7.8. ([#3940](https://github.com/getsentry/relay/pull/3940))
+- Bumped arm64 cross compile image to `edge` tag. ([#3943](https://github.com/getsentry/relay/pull/3943))
 
 ## 24.8.0
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -7,7 +7,7 @@ pre-build = [
     # Enable multiarch and install the necessary dependencies
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update",
-    "apt-get -y install libclang-8-dev clang-8 zlib1g-dev:$CROSS_DEB_ARCH",
+    "apt-get -y install libclang-8-dev zlib1g-dev:$CROSS_DEB_ARCH",
 
     "curl -sL https://sentry.io/get-cli/ | sh",
 ]
@@ -15,8 +15,4 @@ pre-build = [
 [target.aarch64-unknown-linux-gnu]
 # We're using a nightly `cross`, let's still use a stable image.
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
-env.passthrough = [
-    "CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_gnu=",
-    "CXX=/usr/aarch64-linux-gnu/bin/g++",
-    "CC=/usr/aarch64-linux-gnu/bin/gcc",
-]
+env.passthrough = ["CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_gnu="]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,12 +1,22 @@
 [build]
 pre-build = [
-    # Use azure mirrors for faster downloads.
+    # Use Azure mirrors for faster downloads
     "sed -i -e 's/archive.archive.ubuntu.com/azure.archive.ubuntu.com/' /etc/apt/sources.list",
     "sed -i -e 's/security.archive.ubuntu.com/azure.archive.ubuntu.com/' /etc/apt/sources.list",
-    "apt-get update && apt-get --assume-yes install libclang-8-dev clang-8",
+
+    # Enable multiarch and install the necessary dependencies
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update",
+    "apt-get -y install libclang-8-dev clang-8 zlib1g-dev:$CROSS_DEB_ARCH",
+
     "curl -sL https://sentry.io/get-cli/ | sh",
 ]
 
 [target.aarch64-unknown-linux-gnu]
 # We're using a nightly `cross`, let's still use a stable image.
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+env.passthrough = [
+    "CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_gnu=",
+    "CXX=/usr/aarch64-linux-gnu/bin/g++",
+    "CC=/usr/aarch64-linux-gnu/bin/gcc",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+[toolchain]
+channel = "1.80.1"
+profile = "default"
+components = [
+    "rustc",
+    "cargo",
+    "clippy",
+    "rustfmt",
+    "rust-analyzer",
+    "rust-src",
+]


### PR DESCRIPTION
Bump ARM cross compile image to `edge` tag, which upgrades GCC to 9.4.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
