### PR TITLE
feat(project-config): Query project configs with revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features:**
+
+- Extend project config API to be revision aware. ([#3947](https://github.com/getsentry/relay/pull/3947)).
+
 **Bug Fixes**:
 
 - Keep frames from both ends of the stacktrace when trimming frames. ([#3905](https://github.com/getsentry/relay/pull/3905))

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -152,7 +152,6 @@ async fn inner(
         })
         .collect();
 
-    // Skip unparsable public keys. The downstream Relay will consider them `ProjectState::missing`.
     let (global, global_status) = if inner.global {
         match state.global_config().send(global_config::Get).await? {
             global_config::Status::Ready(config) => (Some(config), Some(StatusResponse::Ready)),

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -6,7 +6,8 @@ use axum::handler::Handler;
 use axum::http::Request;
 use axum::response::{IntoResponse, Result};
 use axum::{Json, RequestExt};
-use futures::future;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use relay_base_schema::project::ProjectKey;
 use relay_dynamic_config::{ErrorBoundary, GlobalConfig};
 use serde::{Deserialize, Serialize};
@@ -79,6 +80,8 @@ struct GetProjectStatesResponseWrapper {
     configs: HashMap<ProjectKey, ProjectStateWrapper>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pending: Vec<ProjectKey>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unchanged: Vec<ProjectKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
     global: Option<Arc<GlobalConfig>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -92,13 +95,34 @@ struct GetProjectStatesResponseWrapper {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GetProjectStatesRequest {
+    /// The list of all requested project configs.
     public_keys: Vec<ErrorBoundary<ProjectKey>>,
+    /// List of revisions for all project configs.
+    ///
+    /// This length of this list if specified must be the same length
+    /// as [`Self::public_keys`], the items are asssociated by index.
+    revisions: Option<ErrorBoundary<Vec<Option<String>>>>,
     #[serde(default)]
     full_config: bool,
     #[serde(default)]
     no_cache: bool,
     #[serde(default)]
     global: bool,
+}
+
+fn into_valid_keys(
+    public_keys: Vec<ErrorBoundary<ProjectKey>>,
+    revisions: Option<ErrorBoundary<Vec<Option<String>>>>,
+) -> impl Iterator<Item = (ProjectKey, Option<String>)> {
+    let revisions = revisions.and_then(|e| e.ok()).unwrap_or_default();
+    let revisions = revisions.into_iter().chain(std::iter::repeat(None));
+
+    std::iter::zip(public_keys, revisions).filter_map(|(public_key, revision)| {
+        // Skip unparsable public keys.
+        // The downstream Relay will consider them `ProjectState::missing`.
+        let public_key = public_key.ok()?;
+        Some((public_key, revision))
+    })
 }
 
 async fn inner(
@@ -112,22 +136,23 @@ async fn inner(
     let no_cache = inner.no_cache;
     let keys_len = inner.public_keys.len();
 
+    let mut futures: FuturesUnordered<_> = into_valid_keys(inner.public_keys, inner.revisions)
+        .map(|(project_key, revision)| async move {
+            let state_result = if version.version >= ENDPOINT_V3 && !no_cache {
+                project_cache
+                    .send(GetCachedProjectState::new(project_key))
+                    .await
+            } else {
+                project_cache
+                    .send(GetProjectState::new(project_key).no_cache(no_cache))
+                    .await
+            };
+
+            (project_key, revision, state_result)
+        })
+        .collect();
+
     // Skip unparsable public keys. The downstream Relay will consider them `ProjectState::missing`.
-    let valid_keys = inner.public_keys.into_iter().filter_map(|e| e.ok());
-    let futures = valid_keys.map(|project_key| async move {
-        let state_result = if version.version >= ENDPOINT_V3 && !no_cache {
-            project_cache
-                .send(GetCachedProjectState::new(project_key))
-                .await
-        } else {
-            project_cache
-                .send(GetProjectState::new(project_key).no_cache(no_cache))
-                .await
-        };
-
-        (project_key, state_result)
-    });
-
     let (global, global_status) = if inner.global {
         match state.global_config().send(global_config::Get).await? {
             global_config::Status::Ready(config) => (Some(config), Some(StatusResponse::Ready)),
@@ -143,8 +168,10 @@ async fn inner(
     };
 
     let mut pending = Vec::with_capacity(keys_len);
+    let mut unchanged = Vec::with_capacity(keys_len);
     let mut configs = HashMap::with_capacity(keys_len);
-    for (project_key, state_result) in future::join_all(futures).await {
+
+    while let Some((project_key, revision, state_result)) = futures.next().await {
         let project_info = match state_result? {
             ProjectState::Enabled(info) => info,
             ProjectState::Disabled => {
@@ -156,6 +183,12 @@ async fn inner(
                 continue;
             }
         };
+
+        // Only ever omit responses when there was a valid revision in the first place.
+        if revision.is_some() && project_info.rev == revision {
+            unchanged.push(project_key);
+            continue;
+        }
 
         // If public key is known (even if rate-limited, which is Some(false)), it has
         // access to the project config
@@ -187,6 +220,7 @@ async fn inner(
     Ok(Json(GetProjectStatesResponseWrapper {
         configs,
         pending,
+        unchanged,
         global,
         global_status,
     }))

--- a/relay-server/src/services/project/state.rs
+++ b/relay-server/src/services/project/state.rs
@@ -114,3 +114,13 @@ pub struct LimitedParsedProjectState {
     #[serde(flatten)]
     pub info: ProjectInfo,
 }
+
+/// Response indicating whether a project state needs to be updated
+/// or the upstream does not have a newer version.
+#[derive(Debug, Clone)]
+pub enum UpstreamProjectState {
+    /// The upstream sent a [`ProjectState`].
+    New(ProjectState),
+    /// The upstream indicated that there is no newer version of the state available.
+    Unchanged,
+}

--- a/relay-server/src/services/project/state.rs
+++ b/relay-server/src/services/project/state.rs
@@ -122,5 +122,5 @@ pub enum UpstreamProjectState {
     /// The upstream sent a [`ProjectState`].
     New(ProjectState),
     /// The upstream indicated that there is no newer version of the state available.
-    Unchanged,
+    NotModified,
 }

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -502,7 +502,7 @@ impl ProjectSource {
                 }
                 // Redis reported that we're holding an up-to-date version of the state already,
                 // refresh the state and return the old cached state again.
-                Ok(UpstreamProjectState::Unchanged) => {
+                Ok(UpstreamProjectState::NotModified) => {
                     return Ok(ProjectFetchState::refresh(cached_state))
                 }
                 Err(error) => {
@@ -526,7 +526,7 @@ impl ProjectSource {
 
         match state {
             UpstreamProjectState::New(state) => Ok(ProjectFetchState::new(state.sanitized())),
-            UpstreamProjectState::Unchanged => Ok(ProjectFetchState::refresh(cached_state)),
+            UpstreamProjectState::NotModified => Ok(ProjectFetchState::refresh(cached_state)),
         }
     }
 }

--- a/relay-server/src/services/project_redis.rs
+++ b/relay-server/src/services/project_redis.rs
@@ -80,7 +80,7 @@ impl RedisProjectSource {
                     counter(RelayCounters::ProjectStateRedis) += 1,
                     hit = "revision",
                 );
-                return Ok(UpstreamProjectState::Unchanged);
+                return Ok(UpstreamProjectState::NotModified);
             }
         }
 
@@ -111,7 +111,7 @@ impl RedisProjectSource {
                 counter(RelayCounters::ProjectStateRedis) += 1,
                 hit = "project_config_revision"
             );
-            Ok(UpstreamProjectState::Unchanged)
+            Ok(UpstreamProjectState::NotModified)
         } else {
             metric!(
                 counter(RelayCounters::ProjectStateRedis) += 1,

--- a/relay-server/src/services/project_redis.rs
+++ b/relay-server/src/services/project_redis.rs
@@ -5,6 +5,7 @@ use relay_config::Config;
 use relay_redis::{RedisError, RedisPool};
 use relay_statsd::metric;
 
+use crate::services::project::state::UpstreamProjectState;
 use crate::services::project::{ParsedProjectState, ProjectState};
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 
@@ -54,16 +55,13 @@ impl RedisProjectSource {
 
     /// Fetches a project config from Redis.
     ///
-    /// Returns `None` if the the project config stored in Redis has the same `revision`.
-    /// Always returns a project state if the passed `revision` is `None`.
-    ///
     /// The returned project state is [`ProjectState::Pending`] if the requested project config is not
     /// stored in Redis.
     pub fn get_config_if_changed(
         &self,
         key: ProjectKey,
         revision: Option<&str>,
-    ) -> Result<Option<ProjectState>, RedisProjectError> {
+    ) -> Result<UpstreamProjectState, RedisProjectError> {
         let mut client = self.redis.client()?;
         let mut connection = client.connection()?;
 
@@ -82,7 +80,7 @@ impl RedisProjectSource {
                     counter(RelayCounters::ProjectStateRedis) += 1,
                     hit = "revision",
                 );
-                return Ok(None);
+                return Ok(UpstreamProjectState::Unchanged);
             }
         }
 
@@ -96,7 +94,7 @@ impl RedisProjectSource {
                 counter(RelayCounters::ProjectStateRedis) += 1,
                 hit = "false"
             );
-            return Ok(Some(ProjectState::Pending));
+            return Ok(UpstreamProjectState::New(ProjectState::Pending));
         };
 
         let response = ProjectState::from(parse_redis_response(response.as_slice())?);
@@ -113,13 +111,13 @@ impl RedisProjectSource {
                 counter(RelayCounters::ProjectStateRedis) += 1,
                 hit = "project_config_revision"
             );
-            Ok(None)
+            Ok(UpstreamProjectState::Unchanged)
         } else {
             metric!(
                 counter(RelayCounters::ProjectStateRedis) += 1,
                 hit = "project_config"
             );
-            Ok(Some(response))
+            Ok(UpstreamProjectState::New(response))
         }
     }
 

--- a/relay-server/src/services/project_upstream.rs
+++ b/relay-server/src/services/project_upstream.rs
@@ -35,9 +35,18 @@ use crate::utils::{RetryBackoff, SleepHandle};
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetProjectStates {
+    /// List of requested project keys.
     public_keys: Vec<ProjectKey>,
+    /// List of revisions for each project key.
+    ///
+    /// The revisions are mapped by index to the project key,
+    /// this is a separate field to keep the API compatible.
     revisions: Vec<Option<String>>,
+    /// If `true` the upstream should return a full configuration.
+    ///
+    /// Upstreams will ignore this for non-internal Relays.
     full_config: bool,
+    /// If `true` the upstream should not serve from cache.
     no_cache: bool,
 }
 
@@ -54,6 +63,10 @@ pub struct GetProjectStatesResponse {
     /// The [`ProjectKey`]'s that couldn't be immediately retrieved from the upstream.
     #[serde(default)]
     pending: HashSet<ProjectKey>,
+    /// The [`ProjectKey`]'s that the upstream has no updates for.
+    ///
+    /// List is only populated when the request contains revision information
+    /// for all requested configurations.
     #[serde(default)]
     unchanged: HashSet<ProjectKey>,
 }


### PR DESCRIPTION
Follow-up to to #3892, now also implements the revision fetching in the project config API.

Sentry does not need to be updated and this is not a breaking change and works with any combinations of Relays.

Extends the project config API with another field `revisions` which optionally contains the revisions for all requested public keys. If there are are revisions, the response is extended with a field `unchanged` which contains all project keys which were unchanged (have the same revision), similar to how `pending` is handled.
