### PR TITLE
log(replays): Add organization-id and project-id to log messages

### DIFF
--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -120,6 +120,7 @@ pub fn process(
 
 // Replay Event Processing.
 
+#[allow(clippy::too_many_arguments)]
 fn handle_replay_event_item(
     payload: Bytes,
     event_id: &Option<EventId>,

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -161,7 +161,7 @@ fn handle_replay_event_item(
             relay_log::warn!(
                 error = &error as &dyn Error,
                 ?event_id,
-                project_id = project_id.map(|v| v.to_string()),
+                project_id = project_id.map(|v| v.value()),
                 organization_id = organization_id,
                 "invalid replay event"
             );

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::net::IpAddr;
 
 use bytes::Bytes;
-use relay_base_schema::project::{self, ProjectId};
+use relay_base_schema::project::ProjectId;
 use relay_dynamic_config::{Feature, GlobalConfig, ProjectConfig};
 use relay_event_normalization::replay::{self, ReplayError};
 use relay_event_normalization::RawUserAgentInfo;

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::net::IpAddr;
 
 use bytes::Bytes;
+use relay_base_schema::project::{self, ProjectId};
 use relay_dynamic_config::{Feature, GlobalConfig, ProjectConfig};
 use relay_event_normalization::replay::{self, ReplayError};
 use relay_event_normalization::RawUserAgentInfo;
@@ -28,6 +29,8 @@ pub fn process(
     let replays_disabled = state.should_filter(Feature::SessionReplay);
     let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
     let replay_video_disabled = project_state.has_feature(Feature::SessionReplayVideoDisabled);
+    let project_id = project_state.project_id;
+    let organization_id = project_state.organization_id;
 
     let meta = state.envelope().meta().clone();
     let client_addr = meta.client_addr();
@@ -79,6 +82,8 @@ pub fn process(
                     global_config,
                     client_addr,
                     user_agent,
+                    project_id,
+                    organization_id,
                 )?;
                 item.set_payload(ContentType::Json, replay_event);
             }
@@ -101,6 +106,8 @@ pub fn process(
                     user_agent,
                     scrubbing_enabled,
                     &mut scrubber,
+                    project_id,
+                    organization_id,
                 )?;
                 item.set_payload(ContentType::OctetStream, replay_video);
             }
@@ -120,6 +127,8 @@ fn handle_replay_event_item(
     global_config: &GlobalConfig,
     client_ip: Option<IpAddr>,
     user_agent: &RawUserAgentInfo<&str>,
+    project_id: Option<ProjectId>,
+    organization_id: Option<u64>,
 ) -> Result<Bytes, ProcessingError> {
     let filter_settings = &config.filter_settings;
 
@@ -151,6 +160,8 @@ fn handle_replay_event_item(
             relay_log::warn!(
                 error = &error as &dyn Error,
                 ?event_id,
+                project_id = project_id.map(|v| v.to_string()),
+                organization_id = organization_id,
                 "invalid replay event"
             );
             Err(match error {
@@ -259,6 +270,8 @@ fn handle_replay_video_item(
     user_agent: &RawUserAgentInfo<&str>,
     scrubbing_enabled: bool,
     scrubber: &mut RecordingScrubber,
+    project_id: Option<ProjectId>,
+    organization_id: Option<u64>,
 ) -> Result<Bytes, ProcessingError> {
     let ReplayVideoEvent {
         replay_event,
@@ -282,6 +295,8 @@ fn handle_replay_video_item(
         global_config,
         client_ip,
         user_agent,
+        project_id,
+        organization_id,
     )?;
 
     // Process as a replay-recording envelope item.


### PR DESCRIPTION
So we can look up log messages by project and org.

#skip-changelog