### PR TITLE
feat(replays): Record too long discard reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Record too long discard reason. ([#3950](https://github.com/getsentry/relay/pull/3950))
+- Record too long discard reason for session replays. ([#3950](https://github.com/getsentry/relay/pull/3950))
 
 ## 24.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Keep frames from both ends of the stacktrace when trimming frames. ([#3905](https://github.com/getsentry/relay/pull/3905))
 
+**Internal**:
+
+- Record too long discard reason. ([#3950](https://github.com/getsentry/relay/pull/3950))
+
 ## 24.8.0
 
 **Bug Fixes**:

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -29,6 +29,12 @@ pub enum ReplayError {
     #[error("invalid payload {0}")]
     InvalidPayload(String),
 
+    /// The Replay has consumed its segment limit.
+    ///
+    /// This is returned from [`validate`].
+    #[error("invalid replay length")]
+    TooLong,
+
     /// An error occurred during PII scrubbing of the Replay.
     ///
     /// This erorr is usually returned when the PII configuration fails to parse.
@@ -56,9 +62,7 @@ pub fn validate(replay: &Replay) -> Result<(), ReplayError> {
     const MAX_SEGMENT_ID: u64 = 60 * 60 / 5;
 
     if segment_id > MAX_SEGMENT_ID {
-        return Err(ReplayError::InvalidPayload(
-            "segment_id limit exceeded".to_string(),
-        ));
+        return Err(ReplayError::TooLong);
     }
 
     if replay

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -449,6 +449,7 @@ pub enum DiscardReason {
     InvalidReplayEventPii,
     InvalidReplayRecordingEvent,
     InvalidReplayVideoEvent,
+    ReplayExceededSegmentLimit,
 
     /// (Relay) Profiling related discard reasons
     Profiling(&'static str),
@@ -500,6 +501,7 @@ impl DiscardReason {
             DiscardReason::InvalidReplayEventPii => "invalid_replay_pii_scrubber_failed",
             DiscardReason::InvalidReplayRecordingEvent => "invalid_replay_recording",
             DiscardReason::InvalidReplayVideoEvent => "invalid_replay_video",
+            DiscardReason::ReplayExceededSegmentLimit => "replay_too_long",
             DiscardReason::Profiling(reason) => reason,
             DiscardReason::InvalidSpan => "invalid_span",
             DiscardReason::FeatureDisabled(_) => "feature_disabled",

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -501,7 +501,7 @@ impl DiscardReason {
             DiscardReason::InvalidReplayEventPii => "invalid_replay_pii_scrubber_failed",
             DiscardReason::InvalidReplayRecordingEvent => "invalid_replay_recording",
             DiscardReason::InvalidReplayVideoEvent => "invalid_replay_video",
-            DiscardReason::ReplayExceededSegmentLimit => "replay_too_long",
+            DiscardReason::ReplayExceededSegmentLimit => "replay_segment_limit_exceeded",
             DiscardReason::Profiling(reason) => reason,
             DiscardReason::InvalidSpan => "invalid_span",
             DiscardReason::FeatureDisabled(_) => "feature_disabled",

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -166,6 +166,9 @@ fn handle_replay_event_item(
                 ReplayError::InvalidPayload(_) => {
                     ProcessingError::InvalidReplay(DiscardReason::InvalidReplayEvent)
                 }
+                ReplayError::TooLong => {
+                    ProcessingError::InvalidReplay(DiscardReason::ReplayExceededSegmentLimit)
+                }
             })
         }
     }


### PR DESCRIPTION
When a replay exceeds the segment limit we should report that and make it viewable in the stats interface.