### PR TITLE
ref(ua): Bump uap-core to v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Features**:
 
 - Add configuration option to specify the instance type of Relay. ([#3938](https://github.com/getsentry/relay/pull/3938))
+- Update definitions for user agent parsing. ([#3951](https://github.com/getsentry/relay/pull/3951))
 
 ## 24.8.0
 


### PR DESCRIPTION
Updates the uap-core module to the latest release `v0.18.0`.

I've successfully run the uap-rs test suite with this tag. Note that user agent
strings are less reliable and Relay mostly uses client hints to detect browsers,
and we do not use user agents to detect exotic devices. As such, we do not rely
on the latest definitions in case this update should cause issues.

Closes https://github.com/getsentry/relay/issues/3902
