### PR TITLE
tmp(statsd): Disable high-volume timers to assess performance

### DIFF
--- a/relay-metrics/src/aggregator.rs
+++ b/relay-metrics/src/aggregator.rs
@@ -468,11 +468,11 @@ fn get_flush_time(
     let initial_flush = bucket_key.timestamp + config.bucket_interval() + config.initial_delay();
     let backdated = initial_flush <= now;
 
-    let delay = now.as_secs() as i64 - bucket_key.timestamp.as_secs() as i64;
-    relay_statsd::metric!(
-        histogram(MetricHistograms::BucketsDelay) = delay as f64,
-        backdated = if backdated { "true" } else { "false" },
-    );
+    // let delay = now.as_secs() as i64 - bucket_key.timestamp.as_secs() as i64;
+    // relay_statsd::metric!(
+    //     histogram(MetricHistograms::BucketsDelay) = delay as f64,
+    //     backdated = if backdated { "true" } else { "false" },
+    // );
 
     let flush_timestamp = if backdated {
         // If the initial flush time has passed or can't be represented, we want to treat the

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -98,6 +98,7 @@ pub enum MetricHistograms {
     /// This metric is tagged with:
     ///  - `backdated`: A flag indicating whether the metric was reported within the `initial_delay`
     ///    time period (`false`) or after the initial delay has expired (`true`).
+    #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
     BucketsDelay,
 
     /// Distribution of invalid bucket timestamps observed, relative to the time of observation.

--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -9,7 +9,7 @@ use relay_metrics::aggregator::AggregateMetricsError;
 use relay_metrics::{aggregator, Bucket, UnixTimestamp};
 use relay_system::{Controller, FromMessage, Interface, NoResponse, Recipient, Service, Shutdown};
 
-use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
+use crate::statsd::{RelayCounters, RelayHistograms};
 
 /// Aggregator for metric buckets.
 ///
@@ -29,17 +29,6 @@ pub enum Aggregator {
     /// Message is used only for tests to get the current number of buckets in `AggregatorService`.
     #[cfg(test)]
     BucketCountInquiry(BucketCountInquiry, relay_system::Sender<usize>),
-}
-
-impl Aggregator {
-    /// Returns the name of the message variant.
-    pub fn variant(&self) -> &'static str {
-        match self {
-            Aggregator::MergeBuckets(_) => "MergeBuckets",
-            #[cfg(test)]
-            Aggregator::BucketCountInquiry(_, _) => "BucketCountInquiry",
-        }
-    }
 }
 
 impl Interface for Aggregator {}

--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -220,10 +220,11 @@ impl AggregatorService {
     }
 
     fn handle_message(&mut self, message: Aggregator) {
-        let ty = message.variant();
-        relay_statsd::metric!(
-            timer(RelayTimers::AggregatorServiceDuration),
-            message = ty,
+        // let ty = message.variant();
+        // relay_statsd::metric!(
+        //     timer(RelayTimers::AggregatorServiceDuration),
+        //     message = ty,
+        {
             {
                 match message {
                     Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
@@ -233,7 +234,8 @@ impl AggregatorService {
                     }
                 }
             }
-        )
+        }
+        // )
     }
 
     fn handle_shutdown(&mut self, message: Shutdown) {

--- a/relay-server/src/services/metrics/router.rs
+++ b/relay-server/src/services/metrics/router.rs
@@ -9,7 +9,6 @@ use relay_system::{Addr, NoResponse, Recipient, Service};
 use crate::services::metrics::{
     Aggregator, AggregatorHandle, AggregatorService, FlushBuckets, MergeBuckets,
 };
-use crate::statsd::RelayTimers;
 use crate::utils;
 
 /// Service that routes metrics & metric buckets to the appropriate aggregator.

--- a/relay-server/src/services/metrics/router.rs
+++ b/relay-server/src/services/metrics/router.rs
@@ -105,10 +105,11 @@ impl StartedRouter {
     }
 
     fn handle_message(&mut self, message: Aggregator) {
-        let ty = message.variant();
-        relay_statsd::metric!(
-            timer(RelayTimers::MetricRouterServiceDuration),
-            message = ty,
+        // let ty = message.variant();
+        // relay_statsd::metric!(
+        //     timer(RelayTimers::MetricRouterServiceDuration),
+        //     message = ty,
+        {
             {
                 match message {
                     Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
@@ -116,7 +117,8 @@ impl StartedRouter {
                     Aggregator::BucketCountInquiry(_, _sender) => (), // not supported
                 }
             }
-        )
+        }
+        // )
     }
 
     fn handle_merge_buckets(&mut self, message: MergeBuckets) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2904,10 +2904,11 @@ impl EnvelopeProcessorService {
     }
 
     fn handle_message(&self, message: EnvelopeProcessor) {
-        let ty = message.variant();
+        // let ty = message.variant();
         let feature_weights = self.feature_weights(&message);
 
-        metric!(timer(RelayTimers::ProcessMessageDuration), message = ty, {
+        // metric!(timer(RelayTimers::ProcessMessageDuration), message = ty, {
+        {
             let mut cogs = self.inner.cogs.timed(ResourceId::Relay, feature_weights);
 
             match message {
@@ -2924,7 +2925,8 @@ impl EnvelopeProcessorService {
                 EnvelopeProcessor::SubmitEnvelope(m) => self.handle_submit_envelope(*m),
                 EnvelopeProcessor::SubmitClientReports(m) => self.handle_submit_client_reports(*m),
             }
-        });
+        }
+        // });
     }
 
     fn feature_weights(&self, message: &EnvelopeProcessor) -> FeatureWeights {

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -1263,10 +1263,11 @@ impl ProjectCacheBroker {
     }
 
     fn handle_message(&mut self, message: ProjectCache) {
-        let ty = message.variant();
-        metric!(
-            timer(RelayTimers::ProjectCacheMessageDuration),
-            message = ty,
+        // let ty = message.variant();
+        // metric!(
+        //     timer(RelayTimers::ProjectCacheMessageDuration),
+        //     message = ty,
+        {
             {
                 match message {
                     ProjectCache::RequestUpdate(message) => self.handle_request_update(message),
@@ -1291,7 +1292,8 @@ impl ProjectCacheBroker {
                     }
                 }
             }
-        )
+        }
+        // )
     }
 }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -464,6 +464,7 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     ///
     ///  - `message`: The type of message that was processed.
+    #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
     ProcessMessageDuration,
     /// Timing in milliseconds for handling a project cache message.
     ///
@@ -503,11 +504,13 @@ pub enum RelayTimers {
     ///
     /// This metric is tagged with:
     ///  - `message`: The type of message that was processed.
+    #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
     AggregatorServiceDuration,
     /// Timing in milliseconds for processing a message in the metric router service.
     ///
     /// This metric is tagged with:
     ///  - `message`: The type of message that was processed.
+    #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
     MetricRouterServiceDuration,
     /// Timing in milliseconds for processing a message in the metric store service.
     ///

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -469,6 +469,7 @@ pub enum RelayTimers {
     ///
     /// This metric is tagged with:
     ///  - `message`: The type of message that was processed.
+    #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
     ProjectCacheMessageDuration,
     /// Timing in milliseconds for processing a message in the buffer service.
     ///
@@ -551,7 +552,9 @@ impl TimerMetric for RelayTimers {
             RelayTimers::HealthCheckDuration => "health.message.duration",
             #[cfg(feature = "processing")]
             RelayTimers::RateLimitBucketsDuration => "processor.rate_limit_buckets",
+            #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
             RelayTimers::AggregatorServiceDuration => "metrics.aggregator.message.duration",
+            #[allow(dead_code)] // TODO: Temporarily disabled for a performance measurement.
             RelayTimers::MetricRouterServiceDuration => "metrics.router.message.duration",
             #[cfg(feature = "processing")]
             RelayTimers::StoreServiceDuration => "store.message.duration",


### PR DESCRIPTION
In recent refactors we noticed an increase in CPU utilization that could be
caused by more statsd timers. These are not aggegated in memory and sent
directly to the statsd agent.

This is an experiment to assess the CPU impact of the highest volume timers that
Relay tracks. If we notice a significant jump, we will investigate further.

#skip-changelog

