### PR TITLE
fix(processor): Use project retention to limit event timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add configuration option to specify the instance type of Relay. ([#3938](https://github.com/getsentry/relay/pull/3938))
 - Update definitions for user agent parsing. ([#3951](https://github.com/getsentry/relay/pull/3951))
 - Extend project config API to be revision aware. ([#3947](https://github.com/getsentry/relay/pull/3947))
+- Removes `processing.max_secs_in_past` from the main config in favor of event retention from the project config. ([#3958](https://github.com/getsentry/relay/pull/3958))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1068,10 +1068,6 @@ fn default_max_secs_in_future() -> u32 {
     60 // 1 minute
 }
 
-fn default_max_secs_in_past() -> u32 {
-    30 * 24 * 3600 // 30 days
-}
-
 fn default_max_session_secs_in_past() -> u32 {
     5 * 24 * 3600 // 5 days
 }
@@ -1100,9 +1096,6 @@ pub struct Processing {
     /// Maximum future timestamp of ingested events.
     #[serde(default = "default_max_secs_in_future")]
     pub max_secs_in_future: u32,
-    /// Maximum age of ingested events. Older events will be adjusted to `now()`.
-    #[serde(default = "default_max_secs_in_past")]
-    pub max_secs_in_past: u32,
     /// Maximum age of ingested sessions. Older sessions will be dropped.
     #[serde(default = "default_max_session_secs_in_past")]
     pub max_session_secs_in_past: u32,
@@ -1156,7 +1149,6 @@ impl Default for Processing {
             enabled: false,
             geoip_path: None,
             max_secs_in_future: default_max_secs_in_future(),
-            max_secs_in_past: default_max_secs_in_past(),
             max_session_secs_in_past: default_max_session_secs_in_past(),
             kafka_config: Vec::new(),
             secondary_kafka_configs: BTreeMap::new(),
@@ -2397,11 +2389,6 @@ impl Config {
     /// Events past this timestamp will be adjusted to `now()`. Sessions will be dropped.
     pub fn max_secs_in_future(&self) -> i64 {
         self.values.processing.max_secs_in_future.into()
-    }
-
-    /// Maximum age of ingested events. Older events will be adjusted to `now()`.
-    pub fn max_secs_in_past(&self) -> i64 {
-        self.values.processing.max_secs_in_past.into()
     }
 
     /// Maximum age of ingested sessions. Older sessions will be dropped.

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -12,6 +12,7 @@ use relay_quotas::ReasonCode;
 use relay_sampling::evaluation::MatchedRuleIds;
 use relay_system::Addr;
 
+use crate::constants::DEFAULT_EVENT_RETENTION;
 use crate::envelope::{ContentType, ItemType};
 use crate::services::outcome::{Outcome, RuleCategories, TrackOutcome};
 use crate::services::processor::{ClientReportGroup, ProcessEnvelopeState, MINIMUM_CLOCK_DRIFT};
@@ -130,7 +131,12 @@ pub fn process_client_reports(
         clock_drift_processor.process_timestamp(timestamp);
     }
 
-    let max_age = SignedDuration::seconds(config.max_secs_in_past());
+    let retention_days = state
+        .project_state
+        .config()
+        .event_retention
+        .unwrap_or(DEFAULT_EVENT_RETENTION);
+    let max_age = SignedDuration::days(retention_days.into());
     // also if we unable to parse the timestamp, we assume it's way too old here.
     let in_past = timestamp
         .as_datetime()

--- a/tests/integration/test_clock_drift.py
+++ b/tests/integration/test_clock_drift.py
@@ -74,7 +74,7 @@ def test_clock_drift_not_applied_when_sent_at_is_not_supplied(mini_sentry, relay
     relay = relay(mini_sentry)
     project_id = 42
     project_config = mini_sentry.add_basic_project_config(project_id)
-    project_config["config"]["eventRetention"] = 90
+    project_config["config"]["eventRetention"] = 30
 
     now = datetime.now(tz=timezone.utc)
     one_month_ago = now - timedelta(days=30)

--- a/tests/integration/test_clock_drift.py
+++ b/tests/integration/test_clock_drift.py
@@ -73,7 +73,8 @@ def test_clock_drift_not_applied_when_timestamp_is_recent(mini_sentry, relay):
 def test_clock_drift_not_applied_when_sent_at_is_not_supplied(mini_sentry, relay):
     relay = relay(mini_sentry)
     project_id = 42
-    mini_sentry.add_basic_project_config(project_id)
+    project_config = mini_sentry.add_basic_project_config(project_id)
+    project_config["config"]["eventRetention"] = 90
 
     now = datetime.now(tz=timezone.utc)
     one_month_ago = now - timedelta(days=30)

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -367,15 +367,11 @@ def test_minidump_with_processing(
     with open(dmp_path, "rb") as f:
         content = f.read()
 
-    relay = relay_with_processing(
-        {
-            # Prevent normalization from overwriting the minidump timestamp
-            "processing": {"max_secs_in_past": 2**32 - 1}
-        }
-    )
+    relay = relay_with_processing()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["eventRetention"] = 50000
 
     # Disable scurbbing, the basic and full project configs from the mini_sentry fixture
     # will modify the minidump since it contains user paths in the module list.  This breaks


### PR DESCRIPTION
Relay validates that event timestamps are within the most recent 30 days. This number was originally derived from event retention settings, which could be set to 30 days or 90 days on Sentry side. To ensure that events are never older than their maximum retention, which would cause them to get lost, Relay assumed the lower of these two numbers.

This PR uses the actual event retention setting for this normalization. Therefore, if an organization has the default of 90 days, all timestamps from the last 90 days will be accepted. 

Fixes https://github.com/getsentry/relay/issues/2703