### PR TITLE
ref(profiling): forward profiles of non-sampled transactions (with no options filtering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Record too long discard reason for session replays. ([#3950](https://github.com/getsentry/relay/pull/3950))
 - Add `EnvelopeStore` trait and implement `DiskUsage` for tracking disk usage. ([#3925](https://github.com/getsentry/relay/pull/3925))
+- Forward profiles of non-sampled transactions (with no options filtering). ([#3963](https://github.com/getsentry/relay/pull/3963))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -112,6 +112,10 @@ pub enum Feature {
     #[doc(hidden)]
     #[serde(rename = "projects:span-metrics-extraction-all-modules")]
     Deprecated6,
+    /// Deprecated, still forwarded for older downstream Relays.
+    #[doc(hidden)]
+    #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
+    Deprecated7,
     /// Forward compatibility.
     #[doc(hidden)]
     #[serde(other)]

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -61,13 +61,6 @@ pub enum Feature {
     /// Serialized as `projects:relay-otel-endpoint`.
     #[serde(rename = "projects:relay-otel-endpoint")]
     OtelEndpoint,
-    /// Enable processing and extracting data from profiles that would normally be dropped by dynamic sampling.
-    ///
-    /// This is required for [slowest function aggregation](https://github.com/getsentry/snuba/blob/b5311b404a6bd73a9e1997a46d38e7df88e5f391/snuba/snuba_migrations/functions/0001_functions.py#L209-L256). The profile payload will be dropped on the sentry side.
-    ///
-    /// Serialized as `projects:profiling-ingest-unsampled-profiles`.
-    #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
-    IngestUnsampledProfiles,
 
     /// Discard transactions in a spans-only world.
     ///

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -207,6 +207,24 @@ pub struct Options {
     )]
     pub http_span_allowed_hosts: Vec<Host>,
 
+    /// Deprecated, still forwarded for older downstream Relays.
+    #[doc(hidden)]
+    #[serde(
+        rename = "profiling.profile_metrics.unsampled_profiles.platforms",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub deprecated1: Vec<String>,
+
+    /// Deprecated, still forwarded for older downstream Relays.
+    #[doc(hidden)]
+    #[serde(
+        rename = "profiling.profile_metrics.unsampled_profiles.sample_rate",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub deprecated2: f32,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -107,6 +107,13 @@ fn is_err_or_empty(filters_config: &ErrorBoundary<GenericFiltersConfig>) -> bool
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Options {
+    /// Kill switch for shutting down unsampled_profile metrics
+    #[serde(
+        rename = "profiling.profile_metrics.unsampled_profiles.enabled",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub unsampled_profiles_enabled: bool,
     /// Kill switch for shutting down profile function metrics
     /// ingestion in the generic-metrics platform
     #[serde(

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -107,31 +107,6 @@ fn is_err_or_empty(filters_config: &ErrorBoundary<GenericFiltersConfig>) -> bool
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Options {
-    /// List of platform names for which we allow using unsampled profiles for the purpose
-    /// of improving profile (function) metrics
-    #[serde(
-        rename = "profiling.profile_metrics.unsampled_profiles.platforms",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "Vec::is_empty"
-    )]
-    pub profile_metrics_allowed_platforms: Vec<String>,
-
-    /// Sample rate for tuning the amount of unsampled profiles that we "let through"
-    #[serde(
-        rename = "profiling.profile_metrics.unsampled_profiles.sample_rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub profile_metrics_sample_rate: f32,
-
-    /// Kill switch for shutting down unsampled_profile metrics
-    #[serde(
-        rename = "profiling.profile_metrics.unsampled_profiles.enabled",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub unsampled_profiles_enabled: bool,
-
     /// Kill switch for shutting down profile function metrics
     /// ingestion in the generic-metrics platform
     #[serde(
@@ -443,9 +418,6 @@ mod tests {
         }
       }
     ]
-  },
-  "options": {
-    "profiling.profile_metrics.unsampled_profiles.enabled": true
   }
 }"#;
 
@@ -458,8 +430,7 @@ mod tests {
     fn test_global_config_invalid_value_is_default() {
         let options: Options = serde_json::from_str(
             r#"{
-                "relay.cardinality-limiter.mode": "passive",
-                "profiling.profile_metrics.unsampled_profiles.sample_rate": "foo"
+                "relay.cardinality-limiter.mode": "passive"
             }"#,
         )
         .unwrap();

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1801,6 +1801,7 @@ impl EnvelopeProcessorService {
         attachment::scrub(state);
 
         if_processing!(self.inner.config, {
+            let global_config = self.inner.global_config.current();
             // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
             let profile_id = profile::process(state);
             profile::transfer_id(state, profile_id);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1747,8 +1747,6 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<TransactionGroup>,
     ) -> Result<(), ProcessingError> {
-        let global_config = self.inner.global_config.current();
-
         event::extract(state, &self.inner.config)?;
 
         let profile_id = profile::filter(state);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1776,18 +1776,14 @@ impl EnvelopeProcessorService {
         };
 
         if let Some(outcome) = sampling_result.into_dropped_outcome() {
-            let keep_profiles = dynamic_sampling::forward_unsampled_profiles(state, &global_config);
             // Process profiles before dropping the transaction, if necessary.
             // Before metric extraction to make sure the profile count is reflected correctly.
-            let profile_id = match keep_profiles {
-                true => profile::process(state),
-                false => profile_id,
-            };
+            let profile_id = profile::process(state);
 
             // Extract metrics here, we're about to drop the event/transaction.
             self.extract_transaction_metrics(state, SamplingDecision::Drop, profile_id)?;
 
-            dynamic_sampling::drop_unsampled_items(state, outcome, keep_profiles);
+            dynamic_sampling::drop_unsampled_items(state, outcome, true);
 
             // At this point we have:
             //  - An empty envelope.

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -237,6 +237,7 @@ mod tests {
     use bytes::Bytes;
     use relay_base_schema::events::EventType;
     use relay_base_schema::project::{ProjectId, ProjectKey};
+    use relay_dynamic_config::GlobalConfig;
     use relay_dynamic_config::{MetricExtractionConfig, TransactionMetricsConfig};
     use relay_event_schema::protocol::{EventId, LenientString};
     use relay_protocol::RuleCondition;

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 
 use chrono::Utc;
 use relay_config::Config;
-use relay_dynamic_config::{ErrorBoundary, Feature, GlobalConfig};
+use relay_dynamic_config::ErrorBoundary;
 use relay_event_schema::protocol::{Contexts, Event, TraceContext};
 use relay_protocol::{Annotated, Empty};
 use relay_sampling::config::RuleType;
@@ -16,7 +16,7 @@ use crate::services::outcome::Outcome;
 use crate::services::processor::{
     EventProcessing, ProcessEnvelopeState, Sampling, TransactionGroup,
 };
-use crate::utils::{self, sample, SamplingResult};
+use crate::utils::{self, SamplingResult};
 
 /// Ensures there is a valid dynamic sampling context and corresponding project state.
 ///
@@ -227,33 +227,6 @@ pub fn tag_error_with_sampling_decision<G: EventProcessing>(
         relay_log::trace!("tagged error with `sampled = {}` flag", sampled);
         context.sampled = Annotated::new(sampled);
     }
-}
-
-/// Determines whether profiles that would otherwise be dropped by dynamic sampling should be kept.
-pub fn forward_unsampled_profiles(
-    state: &ProcessEnvelopeState<TransactionGroup>,
-    global_config: &GlobalConfig,
-) -> bool {
-    let global_options = &global_config.options;
-
-    if !global_options.unsampled_profiles_enabled {
-        return false;
-    }
-
-    let event_platform = state
-        .event
-        .value()
-        .and_then(|e| e.platform.as_str())
-        .unwrap_or("");
-
-    state
-        .project_state
-        .has_feature(Feature::IngestUnsampledProfiles)
-        && global_options
-            .profile_metrics_allowed_platforms
-            .iter()
-            .any(|s| s == event_platform)
-        && sample(global_options.profile_metrics_sample_rate)
 }
 
 #[cfg(test)]

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -19,7 +19,7 @@ use crate::utils::ItemAction;
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) -> Option<ProfileId> {
     let profiling_disabled = state.should_filter(Feature::Profiling);
     let has_transaction = state.event_type() == Some(EventType::Transaction);
-    let keep_unsampled_profiles = !state.should_filter(Feature::IngestUnsampledProfiles);
+    let keep_unsampled_profiles = true;
 
     let mut profile_id = None;
     state.managed_envelope.retain_items(|item| match item.ty() {

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -665,6 +665,10 @@ def test_relay_chain(
 def test_relay_chain_keep_unsampled_profile(
     mini_sentry, relay, relay_with_processing, profiles_consumer, mode
 ):
+    mini_sentry.global_config["options"] = {
+        "profiling.profile_metrics.unsampled_profiles.enabled": True,
+    }
+
     profiles_consumer = profiles_consumer()
 
     # Create an envelope with a profile:

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -665,12 +665,6 @@ def test_relay_chain(
 def test_relay_chain_keep_unsampled_profile(
     mini_sentry, relay, relay_with_processing, profiles_consumer, mode
 ):
-    mini_sentry.global_config["options"] = {
-        "profiling.profile_metrics.unsampled_profiles.platforms": ["python"],
-        "profiling.profile_metrics.unsampled_profiles.sample_rate": 1.0,
-        "profiling.profile_metrics.unsampled_profiles.enabled": True,
-    }
-
     profiles_consumer = profiles_consumer()
 
     # Create an envelope with a profile:
@@ -706,7 +700,6 @@ def test_relay_chain_keep_unsampled_profile(
     }
     config["config"]["features"] = [
         "organizations:profiling",
-        "projects:profiling-ingest-unsampled-profiles",
     ]
 
     public_key = config["publicKeys"][0]["publicKey"]

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1277,6 +1277,16 @@ def test_profile_outcomes(
             "reason": "Sampled:3000",
             "source": expected_source,
         },
+        {
+            "category": 11,  # ProfileIndexed
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 1,  # Filtered
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "Sampled:3000",
+            "source": expected_source,
+        },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1277,16 +1277,6 @@ def test_profile_outcomes(
             "reason": "Sampled:3000",
             "source": expected_source,
         },
-        {
-            "category": 11,  # ProfileIndexed
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 1,  # Filtered
-            "project_id": 42,
-            "quantity": 1,
-            "reason": "Sampled:3000",
-            "source": expected_source,
-        },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")


### PR DESCRIPTION
Remove the options to shutdown, filter by platform or downsample the number of processed profiles we pass along to extract the metrics.

With this, all the `Processed Profiles` (that are not indexed), will be passed along, as we currently do, but without the further checks that are currently in place (*rollout rate*, *platforms*, etc.).

The global kill-switch is left, should we ever need it in case of incidents.