### PR TITLE
fix(buffer): Cycle through unready projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@
 - Add `EnvelopeStore` trait and implement `DiskUsage` for tracking disk usage. ([#3925](https://github.com/getsentry/relay/pull/3925))
 - Increase replay recording limit to two hours. ([#3961](https://github.com/getsentry/relay/pull/3961))
 - Make EnvelopeBuffer a Service. ([#3965](https://github.com/getsentry/relay/pull/3965))
-
-**Internal**:
-
 - No longer send COGS data to dedicated Kafka topic. ([#3953](https://github.com/getsentry/relay/pull/3953))
 
 ## 24.8.0

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -141,7 +141,7 @@ impl EnvelopeBufferService {
                 self.project_cache.send(DequeuedEnvelope(envelope));
                 self.changes = true;
             }
-            Peek::NotReady(envelope) => {
+            Peek::NotReady(stack_key, envelope) => {
                 relay_log::trace!("EnvelopeBufferService request update");
                 let project_key = envelope.meta().public_key();
                 self.project_cache.send(UpdateProject(project_key));
@@ -152,6 +152,8 @@ impl EnvelopeBufferService {
                         self.project_cache.send(UpdateProject(sampling_key));
                     }
                 }
+                // deprioritize the stack to prevent head-of-line blocking
+                self.buffer.mark_seen(&stack_key);
                 self.changes = false;
             }
         }


### PR DESCRIPTION
Restore `last_peek` behavior with an explicit function call. This prevents reprioritization between `peek` and `pop`.

See https://github.com/getsentry/relay/pull/3922, https://github.com/getsentry/relay/pull/3960.

Closes: https://github.com/getsentry/team-ingest/issues/523

#skip-changelog