### PR TITLE
chore(metrics): Remove support for extrapolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update definitions for user agent parsing. ([#3951](https://github.com/getsentry/relay/pull/3951))
 - Extend project config API to be revision aware. ([#3947](https://github.com/getsentry/relay/pull/3947))
 - Removes `processing.max_secs_in_past` from the main config in favor of event retention from the project config. ([#3958](https://github.com/getsentry/relay/pull/3958))
+- Remove support for extrapolation of metrics. ([#3969](https://github.com/getsentry/relay/pull/3969))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -184,19 +184,6 @@ pub struct Options {
     )]
     pub span_extraction_sample_rate: Option<f32>,
 
-    /// The maximum duplication factor used to extrapolate distribution metrics from sampled data.
-    ///
-    /// This applies as long as Relay duplicates distribution values to extrapolate. The default is
-    /// `0`, which disables extrapolation of distributions completely. This option does not apply to
-    /// any other metric types.
-    #[serde(
-        default,
-        rename = "sentry-metrics.extrapolation.duplication-limit",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub extrapolation_duplication_limit: usize,
-
     /// List of values on span description that are allowed to be sent to Sentry without being scrubbed.
     ///
     /// At this point, it doesn't accept IP addresses in CIDR format.. yet.

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -302,10 +302,6 @@ pub struct MetricExtractionConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<TagMapping>,
 
-    /// Extrapolation for metrics extracted from sampled data.
-    #[serde(default, skip_serializing_if = "ExtrapolationConfig::is_empty")]
-    pub extrapolate: ExtrapolationConfig,
-
     /// This config has been extended with fields from `conditional_tagging`.
     ///
     /// At the moment, Relay will parse `conditional_tagging` rules and insert them into the `tags`
@@ -343,7 +339,6 @@ impl MetricExtractionConfig {
             global_groups: BTreeMap::new(),
             metrics: Default::default(),
             tags: Default::default(),
-            extrapolate: Default::default(),
             _conditional_tags_extended: false,
             _span_metrics_extended: false,
         }
@@ -643,39 +638,6 @@ pub fn convert_conditional_tagging(project_config: &mut ProjectConfig) {
     }
 }
 
-/// Configuration for metric extrapolation from sampled data.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExtrapolationConfig {
-    /// A list of MRI glob patterns to include in extrapolation.
-    #[serde(default)]
-    pub include: Vec<LazyGlob>,
-
-    /// A list of MRI glob patterns to exclude from extrapolation, overriding inclusion.
-    #[serde(default)]
-    pub exclude: Vec<LazyGlob>,
-}
-
-impl ExtrapolationConfig {
-    /// Returns `true` if this config is empty.
-    pub fn is_empty(&self) -> bool {
-        self.include.is_empty()
-    }
-
-    /// Returns `true` if the given metric resource identifier matches the include and exclude
-    /// patterns.
-    pub fn matches(&self, mri: &str) -> bool {
-        !self
-            .exclude
-            .iter()
-            .any(|glob| glob.compiled().is_match(mri))
-            && self
-                .include
-                .iter()
-                .any(|glob| glob.compiled().is_match(mri))
-    }
-}
-
 struct TaggingRuleConverter<I: Iterator<Item = TaggingRule>> {
     rules: std::iter::Peekable<I>,
     tags: Vec<TagSpec>,
@@ -853,24 +815,5 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["tag1"]
         );
-    }
-
-    #[test]
-    fn test_extrapolation() {
-        let json = serde_json::json!({
-            "version": 1,
-            "extrapolate": {
-                "include": ["?:transactions/*", "?:spans/*", "?:custom/*"],
-                "exclude": ["c:spans/usage@none", "c:transactions/usage@none", "c:transactions/count_per_root_project@none"]
-            }
-        });
-
-        let config: MetricExtractionConfig = serde_json::from_value(json).unwrap();
-        let extrapolate = config.extrapolate;
-
-        assert!(!extrapolate.is_empty());
-        assert!(extrapolate.matches("d:custom/foo@none"));
-        assert!(extrapolate.matches("d:spans/foo@none"));
-        assert!(!extrapolate.matches("c:spans/usage@none"));
     }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -29,17 +29,13 @@ use relay_event_schema::protocol::{
     ClientReport, Event, EventId, EventType, IpAddr, Metrics, NetworkReportError,
 };
 use relay_filter::FilterStatKey;
-use relay_metrics::{
-    Bucket, BucketMetadata, BucketValue, BucketView, BucketsView, FiniteF64, MetricMeta,
-    MetricNamespace,
-};
+use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricMeta, MetricNamespace};
 use relay_pii::PiiConfigError;
 use relay_profiling::ProfileId;
 use relay_protocol::{Annotated, Value};
 use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::config::RuleId;
 use relay_sampling::evaluation::{ReservoirCounters, ReservoirEvaluator, SamplingDecision};
-use relay_sampling::DynamicSamplingContext;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
 use reqwest::header;
@@ -591,29 +587,12 @@ type ExtractedEvent = (Annotated<Event>, usize);
 #[derive(Debug)]
 pub struct ProcessingExtractedMetrics {
     metrics: ExtractedMetrics,
-    project: Arc<ProjectInfo>,
-    global: Arc<GlobalConfig>,
-    extrapolation_factor: Option<FiniteF64>,
 }
 
 impl ProcessingExtractedMetrics {
-    pub fn new(
-        project: Arc<ProjectInfo>,
-        global: Arc<GlobalConfig>,
-        dsc: Option<&DynamicSamplingContext>,
-    ) -> Self {
-        let factor = match dsc.and_then(|dsc| dsc.sample_rate) {
-            // no need for extrapolation if sample rate is 1.0, and a sample rate of `0` or lower is
-            // invalid, in which case we also skip.
-            Some(rate) if rate > 0.0 && rate < 1.0 => FiniteF64::new(1.0 / rate),
-            _ => None,
-        };
-
+    pub fn new() -> Self {
         Self {
             metrics: ExtractedMetrics::default(),
-            project,
-            global,
-            extrapolation_factor: factor,
         }
     }
 
@@ -637,7 +616,6 @@ impl ProcessingExtractedMetrics {
             bucket.metadata.extracted_from_indexed =
                 sampling_decision == Some(SamplingDecision::Keep);
         }
-        self.extrapolate(&mut buckets);
         self.metrics.project_metrics.extend(buckets);
     }
 
@@ -651,7 +629,6 @@ impl ProcessingExtractedMetrics {
             bucket.metadata.extracted_from_indexed =
                 sampling_decision == Some(SamplingDecision::Keep);
         }
-        self.extrapolate(&mut buckets);
         self.metrics.sampling_metrics.extend(buckets);
     }
 
@@ -678,55 +655,6 @@ impl ProcessingExtractedMetrics {
     fn retain(&mut self, mut f: impl FnMut(&Bucket) -> bool) {
         self.metrics.project_metrics.retain(&mut f);
         self.metrics.sampling_metrics.retain(&mut f);
-    }
-
-    fn extrapolate(&self, buckets: &mut [Bucket]) {
-        let Some(factor) = self.extrapolation_factor else {
-            return;
-        };
-
-        let extrapolate = match self.project.config().metric_extraction {
-            ErrorBoundary::Ok(ref config) if !config.extrapolate.is_empty() => &config.extrapolate,
-            _ => return,
-        };
-
-        let duplication = (factor.to_f64().round() as usize)
-            .min(self.global.options.extrapolation_duplication_limit)
-            .max(1);
-
-        for bucket in buckets {
-            if !extrapolate.matches(&bucket.name) {
-                continue;
-            }
-
-            match bucket.value {
-                BucketValue::Counter(ref mut counter) => {
-                    *counter = counter.saturating_mul(factor);
-                }
-                BucketValue::Distribution(ref mut dist) => {
-                    // Duplicate values in the distribution to ensure that higher sample rates are
-                    // represented correctly in the final distribution sketch. This is inefficient
-                    // and there are two ways to optimize this:
-                    //  1. Store the sample rate or weight directly in the distribution structure.
-                    //     Then duplicate on the fly in the kafka producer.
-                    //  2. Change the schema to include sample rates or weights and then extrapolate
-                    //     in storage.
-                    *dist = std::mem::take(dist)
-                        .into_iter()
-                        .flat_map(|f| std::iter::repeat(f).take(duplication))
-                        .collect();
-                }
-                BucketValue::Set(_) => {
-                    // do nothing for sets
-                }
-                BucketValue::Gauge(ref mut gauge) => {
-                    gauge.sum = gauge.sum.saturating_mul(factor);
-                    gauge.count = FiniteF64::new(gauge.count as f64)
-                        .map(|f| f.saturating_mul(factor).to_f64() as u64)
-                        .unwrap_or(u64::MAX);
-                }
-            }
-        }
     }
 }
 
@@ -1325,7 +1253,6 @@ impl EnvelopeProcessorService {
     fn prepare_state<G>(
         &self,
         config: Arc<Config>,
-        global_config: Arc<GlobalConfig>,
         mut managed_envelope: TypedEnvelope<G>,
         project_id: ProjectId,
         project_state: Arc<ProjectInfo>,
@@ -1360,15 +1287,7 @@ impl EnvelopeProcessorService {
             reservoir.set_redis(org_id, quotas_pool);
         }
 
-        let extracted_metrics = ProcessingExtractedMetrics::new(
-            project_state.clone(),
-            global_config,
-            // The processor sometimes computes a DSC just-in-time for dynamic sampling if it is not
-            // provided by the SDK so that trace rules can still match. Metric extraction won't see
-            // this generated DSC. However, metric extraction just needs the client sample rate,
-            // which is never affected by this. Hence, this operation is safe.
-            managed_envelope.envelope().dsc(),
-        );
+        let extracted_metrics = ProcessingExtractedMetrics::new();
 
         ProcessEnvelopeState {
             event: Annotated::empty(),
@@ -1971,7 +1890,6 @@ impl EnvelopeProcessorService {
                 let managed_envelope = managed_envelope.try_into()?;
                 let mut state = self.prepare_state(
                     self.inner.config.clone(),
-                    self.inner.global_config.current(),
                     managed_envelope,
                     project_id,
                     project_state,
@@ -3318,11 +3236,10 @@ mod tests {
     use insta::assert_debug_snapshot;
     use relay_base_schema::metrics::{DurationUnit, MetricUnit};
     use relay_common::glob2::LazyGlob;
-    use relay_dynamic_config::{ExtrapolationConfig, MetricExtractionConfig, ProjectConfig};
+    use relay_dynamic_config::ProjectConfig;
     use relay_event_normalization::{RedactionRule, TransactionNameRule};
     use relay_event_schema::protocol::TransactionSource;
     use relay_pii::DataScrubbingConfig;
-    use serde::Deserialize;
     use similar_asserts::assert_eq;
 
     use crate::metrics_extraction::transactions::types::{
@@ -3947,188 +3864,6 @@ mod tests {
                 ),
                 Internal,
             ),
-        ]
-        "###);
-    }
-
-    #[test]
-    fn test_extrapolate() {
-        let mut project_info = ProjectInfo::default();
-        project_info.config.metric_extraction = ErrorBoundary::Ok(MetricExtractionConfig {
-            extrapolate: ExtrapolationConfig {
-                include: vec![LazyGlob::new("*")],
-                exclude: vec![],
-            },
-            ..Default::default()
-        });
-
-        let dsc = DynamicSamplingContext::deserialize(serde_json::json!({
-            "trace_id": "00000000-0000-0000-0000-000000000000",
-            "public_key": "abd0f232775f45feab79864e580d160b",
-            "sample_rate": "0.2",
-        }))
-        .unwrap();
-
-        let mut global_config = GlobalConfig::default();
-        global_config.options.extrapolation_duplication_limit = 3;
-
-        let mut extracted_metrics = ProcessingExtractedMetrics::new(
-            Arc::new(project_info),
-            Arc::new(global_config),
-            Some(&dsc),
-        );
-
-        let buckets = serde_json::from_value(serde_json::json!([
-          {
-            "timestamp": 1615889440,
-            "width": 10,
-            "name": "endpoint.response_time",
-            "type": "d",
-            "value": [
-              36.0,
-              49.0,
-              57.0,
-              68.0
-            ],
-            "tags": {
-              "route": "user_index"
-            }
-          },
-          {
-            "timestamp": 1615889440,
-            "width": 10,
-            "name": "endpoint.hits",
-            "type": "c",
-            "value": 4.0,
-            "tags": {
-              "route": "user_index"
-            }
-          },
-          {
-            "timestamp": 1615889440,
-            "width": 10,
-            "name": "endpoint.parallel_requests",
-            "type": "g",
-            "value": {
-              "last": 25.0,
-              "min": 17.0,
-              "max": 42.0,
-              "sum": 2210.0,
-              "count": 85
-            }
-          },
-          {
-            "timestamp": 1615889440,
-            "width": 10,
-            "name": "endpoint.users",
-            "type": "s",
-            "value": [
-              3182887624u32,
-              4267882815u32
-            ],
-            "tags": {
-              "route": "user_index"
-            }
-          }
-        ]))
-        .unwrap();
-
-        extracted_metrics.extend_project_metrics(buckets, None);
-
-        insta::assert_debug_snapshot!(extracted_metrics.metrics.project_metrics, @r###"
-        [
-            Bucket {
-                timestamp: UnixTimestamp(1615889440),
-                width: 10,
-                name: MetricName(
-                    "endpoint.response_time",
-                ),
-                value: Distribution(
-                    [
-                        36.0,
-                        36.0,
-                        36.0,
-                        49.0,
-                        49.0,
-                        49.0,
-                        57.0,
-                        57.0,
-                        57.0,
-                        68.0,
-                        68.0,
-                        68.0,
-                    ],
-                ),
-                tags: {
-                    "route": "user_index",
-                },
-                metadata: BucketMetadata {
-                    merges: 1,
-                    received_at: None,
-                    extracted_from_indexed: false,
-                },
-            },
-            Bucket {
-                timestamp: UnixTimestamp(1615889440),
-                width: 10,
-                name: MetricName(
-                    "endpoint.hits",
-                ),
-                value: Counter(
-                    20.0,
-                ),
-                tags: {
-                    "route": "user_index",
-                },
-                metadata: BucketMetadata {
-                    merges: 1,
-                    received_at: None,
-                    extracted_from_indexed: false,
-                },
-            },
-            Bucket {
-                timestamp: UnixTimestamp(1615889440),
-                width: 10,
-                name: MetricName(
-                    "endpoint.parallel_requests",
-                ),
-                value: Gauge(
-                    GaugeValue {
-                        last: 25.0,
-                        min: 17.0,
-                        max: 42.0,
-                        sum: 11050.0,
-                        count: 425,
-                    },
-                ),
-                tags: {},
-                metadata: BucketMetadata {
-                    merges: 1,
-                    received_at: None,
-                    extracted_from_indexed: false,
-                },
-            },
-            Bucket {
-                timestamp: UnixTimestamp(1615889440),
-                width: 10,
-                name: MetricName(
-                    "endpoint.users",
-                ),
-                value: Set(
-                    {
-                        3182887624,
-                        4267882815,
-                    },
-                ),
-                tags: {
-                    "route": "user_index",
-                },
-                metadata: BucketMetadata {
-                    merges: 1,
-                    received_at: None,
-                    extracted_from_indexed: false,
-                },
-            },
         ]
         "###);
     }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -18,7 +18,7 @@ use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_cogs::{AppFeature, Cogs, FeatureWeights, ResourceId, Token};
 use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding, NormalizationLevel, RelayMode};
-use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary, Feature, GlobalConfig};
+use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary, Feature};
 use relay_event_normalization::{
     normalize_event, validate_event, ClockDriftProcessor, CombinedMeasurementsConfig,
     EventValidationConfig, GeoIpLookup, MeasurementsConfig, NormalizationConfig, RawUserAgentInfo,
@@ -50,7 +50,7 @@ use {
         CardinalityLimit, CardinalityLimiter, CardinalityLimitsSplit, RedisSetLimiter,
         RedisSetLimiterOptions,
     },
-    relay_dynamic_config::{CardinalityLimiterMode, MetricExtractionGroups},
+    relay_dynamic_config::{CardinalityLimiterMode, GlobalConfig, MetricExtractionGroups},
     relay_metrics::RedisMetricMetaStore,
     relay_quotas::{Quota, RateLimitingError, RedisRateLimiter},
     relay_redis::{RedisPool, RedisPools},

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -237,7 +237,6 @@ mod tests {
     use bytes::Bytes;
     use relay_base_schema::events::EventType;
     use relay_base_schema::project::{ProjectId, ProjectKey};
-    use relay_dynamic_config::GlobalConfig;
     use relay_dynamic_config::{MetricExtractionConfig, TransactionMetricsConfig};
     use relay_event_schema::protocol::{EventId, LenientString};
     use relay_protocol::RuleCondition;
@@ -437,11 +436,7 @@ mod tests {
                 event: Annotated::from(event),
                 metrics: Default::default(),
                 sample_rates: None,
-                extracted_metrics: ProcessingExtractedMetrics::new(
-                    project_state.clone(),
-                    Arc::new(GlobalConfig::default()),
-                    envelope.dsc(),
-                ),
+                extracted_metrics: ProcessingExtractedMetrics::new(),
                 config: config.clone(),
                 project_state,
                 sampling_project_state: None,
@@ -713,11 +708,7 @@ mod tests {
             spans_extracted: false,
             metrics: Default::default(),
             sample_rates: Default::default(),
-            extracted_metrics: ProcessingExtractedMetrics::new(
-                project_info.clone(),
-                Arc::new(GlobalConfig::default()),
-                envelope.dsc(),
-            ),
+            extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
             project_state: project_info,
             sampling_project_state: {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -704,11 +704,7 @@ mod tests {
             event: Annotated::from(event),
             metrics: Default::default(),
             sample_rates: None,
-            extracted_metrics: ProcessingExtractedMetrics::new(
-                project_state.clone(),
-                Arc::new(GlobalConfig::default()),
-                managed_envelope.envelope().dsc(),
-            ),
+            extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
             project_state,
             sampling_project_state: None,


### PR DESCRIPTION
Extrapolation is not going to be implemented on metrics. Instead, extrapolation
will happen exclusively on sampled data at querty time.

This PR removes the support for extrapolation. 

See also https://github.com/getsentry/sentry/pull/76780

