### PR TITLE
feat(spooler): Add additional metrics to the envelope buffer

### DIFF
--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -238,7 +238,7 @@ where
                 prio.received_at = received_at;
             });
 
-        self.total_count.fetch_add(1, AtomicOrdering::Relaxed);
+        self.total_count.fetch_add(1, AtomicOrdering::SeqCst);
         self.track_total_count();
 
         Ok(())
@@ -298,7 +298,7 @@ where
         // We are fine with the count going negative, since it represents that more data was popped,
         // than it was initially counted, meaning that we had a wrong total count from
         // initialization.
-        self.total_count.fetch_sub(1, AtomicOrdering::Relaxed);
+        self.total_count.fetch_sub(1, AtomicOrdering::SeqCst);
         self.track_total_count();
 
         Ok(Some(envelope))
@@ -430,7 +430,7 @@ where
         match total_count {
             Ok(total_count) => {
                 self.total_count
-                    .store(total_count as i64, AtomicOrdering::Relaxed);
+                    .store(total_count as i64, AtomicOrdering::SeqCst);
                 self.total_count_initialized = true;
             }
             Err(error) => {
@@ -446,7 +446,7 @@ where
 
     /// Emits a metric to track the total count of envelopes that are in the envelope buffer.
     fn track_total_count(&self) {
-        let total_count = self.total_count.load(AtomicOrdering::Relaxed) as f64;
+        let total_count = self.total_count.load(AtomicOrdering::SeqCst) as f64;
         let initialized = match self.total_count_initialized {
             true => "true",
             false => "false",

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -284,6 +284,7 @@ where
 
         match next_received_at {
             None => {
+                relay_statsd::metric!(counter(RelayCounters::BufferEnvelopeStacksPopped) += 1);
                 self.pop_stack(project_key_pair);
             }
             Some(next_received_at) => {

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::convert::Infallible;
 use std::error::Error;
-use std::sync::atomic::AtomicIsize;
+use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -163,7 +163,7 @@ struct EnvelopeBuffer<P: StackProvider> {
     /// count might not succeed if it takes more than a set timeout. For example, if we load the
     /// count of all envelopes from disk, and it takes more than the time we set, we will mark the
     /// initial count as 0 and just count incoming and outgoing envelopes from the buffer.
-    total_count: Arc<AtomicIsize>,
+    total_count: Arc<AtomicI64>,
     /// Whether the count initialization succeeded or not.
     ///
     /// This boolean is just used for tagging the metric that tracks the total count of envelopes
@@ -178,7 +178,7 @@ impl EnvelopeBuffer<MemoryStackProvider> {
             stacks_by_project: Default::default(),
             priority_queue: Default::default(),
             stack_provider: MemoryStackProvider::new(memory_checker),
-            total_count: Arc::new(AtomicIsize::new(0)),
+            total_count: Arc::new(AtomicI64::new(0)),
             total_count_initialized: false,
         }
     }
@@ -192,7 +192,7 @@ impl EnvelopeBuffer<SqliteStackProvider> {
             stacks_by_project: Default::default(),
             priority_queue: Default::default(),
             stack_provider: SqliteStackProvider::new(config).await?,
-            total_count: Arc::new(AtomicIsize::new(0)),
+            total_count: Arc::new(AtomicI64::new(0)),
             total_count_initialized: false,
         })
     }
@@ -429,7 +429,7 @@ where
         match total_count {
             Ok(total_count) => {
                 self.total_count
-                    .store(total_count as isize, AtomicOrdering::Relaxed);
+                    .store(total_count as i64, AtomicOrdering::Relaxed);
                 self.total_count_initialized = true;
             }
             Err(error) => {

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -1,11 +1,16 @@
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::convert::Infallible;
-use std::time::Instant;
+use std::error::Error;
+use std::sync::atomic::Ordering as AtomicOrdering;
+use std::sync::atomic::{AtomicIsize, AtomicU64};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use hashbrown::HashSet;
 use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
+use tokio::time::timeout;
 
 use crate::envelope::Envelope;
 use crate::services::buffer::common::ProjectKeyPair;
@@ -15,7 +20,7 @@ use crate::services::buffer::envelope_store::sqlite::SqliteEnvelopeStoreError;
 use crate::services::buffer::stack_provider::memory::MemoryStackProvider;
 use crate::services::buffer::stack_provider::sqlite::SqliteStackProvider;
 use crate::services::buffer::stack_provider::StackProvider;
-use crate::statsd::{RelayCounters, RelayGauges, RelayTimers};
+use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::MemoryChecker;
 
 /// Polymorphic envelope buffering interface.
@@ -152,6 +157,18 @@ struct EnvelopeBuffer<P: StackProvider> {
     /// This indirection is needed because different stack implementations might need different
     /// initialization (e.g. a database connection).
     stack_provider: P,
+    /// The total count of envelopes that the buffer is working with.
+    ///
+    /// Note that this count is not meant to be perfectly accurate since the initialization of the
+    /// count might not succeed if it takes more than a set timeout. For example, if we load the
+    /// count of all envelopes from disk, and it takes more than the time we set, we will mark the
+    /// initial count as 0 and just count incoming and outgoing envelopes from the buffer.
+    total_count: Arc<AtomicIsize>,
+    /// Whether the count initialization succeeded or not.
+    ///
+    /// This boolean is just used for tagging the metric that tracks the total count of envelopes
+    /// in the buffer.
+    total_count_initialized: bool,
 }
 
 impl EnvelopeBuffer<MemoryStackProvider> {
@@ -161,6 +178,8 @@ impl EnvelopeBuffer<MemoryStackProvider> {
             stacks_by_project: Default::default(),
             priority_queue: Default::default(),
             stack_provider: MemoryStackProvider::new(memory_checker),
+            total_count: Arc::new(AtomicIsize::new(0)),
+            total_count_initialized: false,
         }
     }
 }
@@ -173,6 +192,8 @@ impl EnvelopeBuffer<SqliteStackProvider> {
             stacks_by_project: Default::default(),
             priority_queue: Default::default(),
             stack_provider: SqliteStackProvider::new(config).await?,
+            total_count: Arc::new(AtomicIsize::new(0)),
+            total_count_initialized: false,
         })
     }
 }
@@ -184,7 +205,7 @@ where
     /// Initializes the [`EnvelopeBuffer`] given the initialization state from the
     /// [`StackProvider`].
     pub async fn initialize(&mut self) {
-        relay_statsd::metric!(timer(RelayTimers::SpoolInitialization), {
+        relay_statsd::metric!(timer(RelayTimers::BufferInitialization), {
             let initialization_state = self.stack_provider.initialize().await;
             self.load_stacks(initialization_state.project_key_pairs)
                 .await;
@@ -215,6 +236,8 @@ where
             .change_priority_by(&project_key_pair, |prio| {
                 prio.received_at = received_at;
             });
+
+        self.total_count.fetch_add(1, AtomicOrdering::Relaxed);
 
         Ok(())
     }
@@ -256,6 +279,7 @@ where
             .peek()
             .await?
             .map(|next_envelope| next_envelope.meta().start_time());
+
         match next_received_at {
             None => {
                 self.pop_stack(project_key_pair);
@@ -267,6 +291,12 @@ where
                     });
             }
         }
+
+        // We are fine with the count going negative, since it represents that more data was popped,
+        // than it was initially counted, meaning that we had a wrong total count from
+        // initialization.
+        self.total_count.fetch_sub(1, AtomicOrdering::Relaxed);
+
         Ok(Some(envelope))
     }
 
@@ -302,6 +332,7 @@ where
                     });
             }
         }
+
         changed
     }
 
@@ -380,6 +411,46 @@ where
                 .await
                 .expect("Pushing an empty stack raised an error");
         }
+    }
+
+    /// Loads the total count from the store if it takes less than a specified duration.
+    ///
+    /// The total count returned by the store is related to the count of elements that the buffer
+    /// will process, besides the count of elements that will be added and removed during its
+    /// lifecycle
+    async fn load_store_total_count(&mut self) {
+        let total_count = timeout(Duration::from_secs(1), async {
+            self.stack_provider.store_total_count().await
+        })
+        .await;
+        match total_count {
+            Ok(total_count) => {
+                self.total_count
+                    .store(total_count as isize, AtomicOrdering::Relaxed);
+                self.total_count_initialized = true;
+            }
+            Err(error) => {
+                self.total_count_initialized = false;
+                relay_log::error!(
+                    error = &error as &dyn Error,
+                    "failed to load the total envelope count of the store",
+                );
+            }
+        }
+    }
+
+    /// Emits a metric to track the total count of envelopes that are in the envelope buffer.
+    fn track_total_count(&self) {
+        let total_count = self.total_count.load(AtomicOrdering::Relaxed);
+        let initialized = match self.total_count_initialized {
+            true => "true",
+            false => "false",
+        };
+        relay_statsd::metric!(
+            histogram(RelayHistograms::BufferEnvelopesCount) = total_count,
+            initialized = initialized,
+            stack_type = self.stack_provider.stack_type()
+        );
     }
 }
 

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -9,7 +9,7 @@ use crate::services::buffer::envelope_stack::EnvelopeStack;
 use crate::services::buffer::envelope_store::sqlite::{
     SqliteEnvelopeStore, SqliteEnvelopeStoreError,
 };
-use crate::statsd::RelayCounters;
+use crate::statsd::RelayTimers;
 
 /// An error returned when doing an operation on [`SqliteEnvelopeStack`].
 #[derive(Debug, thiserror::Error)]
@@ -98,12 +98,12 @@ impl SqliteEnvelopeStack {
         // the buffer are lost in case of failure. We are doing this on purposes, since if we were
         // to have a database corruption during runtime, and we were to put the values back into
         // the buffer we will end up with an infinite cycle.
-        self.envelope_store
-            .insert_many(envelopes)
-            .await
-            .map_err(SqliteEnvelopeStackError::EnvelopeStoreError)?;
-
-        relay_statsd::metric!(counter(RelayCounters::BufferWritesDisk) += 1);
+        relay_statsd::metric!(timer(RelayTimers::BufferSpool), {
+            self.envelope_store
+                .insert_many(envelopes)
+                .await
+                .map_err(SqliteEnvelopeStackError::EnvelopeStoreError)?;
+        });
 
         // If we successfully spooled to disk, we know that data should be there.
         self.check_disk = true;
@@ -119,17 +119,16 @@ impl SqliteEnvelopeStack {
     /// In case an envelope fails deserialization due to malformed data in the database, the affected
     /// envelope will not be unspooled and unspooling will continue with the remaining envelopes.
     async fn unspool_from_disk(&mut self) -> Result<(), SqliteEnvelopeStackError> {
-        let envelopes = self
-            .envelope_store
-            .delete_many(
-                self.own_key,
-                self.sampling_key,
-                self.batch_size.get() as i64,
-            )
-            .await
-            .map_err(SqliteEnvelopeStackError::EnvelopeStoreError)?;
-
-        relay_statsd::metric!(counter(RelayCounters::BufferReadsDisk) += 1);
+        let envelopes = relay_statsd::metric!(timer(RelayTimers::BufferUnspool), {
+            self.envelope_store
+                .delete_many(
+                    self.own_key,
+                    self.sampling_key,
+                    self.batch_size.get() as i64,
+                )
+                .await
+                .map_err(SqliteEnvelopeStackError::EnvelopeStoreError)?
+        });
 
         if envelopes.is_empty() {
             // In case no envelopes were unspooled, we will mark the disk as empty until another

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -14,7 +14,6 @@ use futures::stream::StreamExt;
 use hashbrown::HashSet;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
 use relay_config::Config;
-use relay_statsd::metric;
 use sqlx::migrate::MigrateError;
 use sqlx::query::Query;
 use sqlx::sqlite::{
@@ -175,7 +174,7 @@ impl DiskUsage {
             .and_then(|r| r.try_get(0))
             .map_err(SqliteEnvelopeStoreError::FileSizeReadFailed)?;
 
-        metric!(gauge(RelayGauges::BufferDiskUsed) = usage as u64);
+        relay_statsd::metric!(gauge(RelayGauges::BufferDiskUsed) = usage as u64);
 
         Ok(usage as u64)
     }

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -401,6 +401,17 @@ impl SqliteEnvelopeStore {
     pub fn usage(&self) -> u64 {
         self.disk_usage.usage()
     }
+
+    /// Returns the total count of envelopes stored in the database.
+    pub async fn total_count(&self) -> Result<u64, SqliteEnvelopeStoreError> {
+        let row = build_count_all()
+            .fetch_one(&self.db)
+            .await
+            .map_err(SqliteEnvelopeStoreError::FetchError)?;
+
+        let total_count: i64 = row.get(0);
+        Ok(total_count as u64)
+    }
 }
 
 /// Deserializes an [`Envelope`] from a database row.
@@ -498,6 +509,14 @@ pub fn build_get_project_key_pairs<'a>() -> Query<'a, Sqlite, SqliteArguments<'a
     sqlx::query("SELECT DISTINCT own_key, sampling_key FROM envelopes;")
 }
 
+/// Returns the query to count the number of envelopes on disk.
+///
+/// Please note that this query is SLOW because SQLite doesn't use any metadata to satisfy it,
+/// meaning that it has to scan through all the rows and count them.
+pub fn build_count_all<'a>() -> Query<'a, Sqlite, SqliteArguments<'a>> {
+    sqlx::query("SELECT COUNT(1) FROM envelopes;")
+}
+
 #[cfg(test)]
 mod tests {
     use hashbrown::HashSet;
@@ -588,5 +607,19 @@ mod tests {
         // We now expect to read more disk usage because of the 10 elements.
         let usage_2 = disk_usage.usage();
         assert!(usage_2 >= usage_1);
+    }
+
+    #[tokio::test]
+    async fn test_total_count() {
+        let db = setup_db(true).await;
+        let mut store = SqliteEnvelopeStore::new(db.clone(), Duration::from_millis(1));
+
+        let envelopes = mock_envelopes(10);
+        store
+            .insert_many(envelopes.iter().map(|e| e.as_ref().try_into().unwrap()))
+            .await
+            .unwrap();
+
+        assert_eq!(store.total_count().await.unwrap(), envelopes.len() as u64);
     }
 }

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -158,6 +158,7 @@ impl EnvelopeBufferService {
                 self.sleep = DEFAULT_SLEEP;
             }
         }
+
         Ok(())
     }
 

--- a/relay-server/src/services/buffer/stack_provider/memory.rs
+++ b/relay-server/src/services/buffer/stack_provider/memory.rs
@@ -30,4 +30,13 @@ impl StackProvider for MemoryStackProvider {
     fn has_store_capacity(&self) -> bool {
         self.memory_checker.check_memory().has_capacity()
     }
+
+    async fn store_total_count(&self) -> u64 {
+        // The memory implementation doesn't have a store, so the count is 0.
+        0
+    }
+
+    fn stack_type<'a>(&self) -> &'a str {
+        "memory"
+    }
 }

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -42,4 +42,10 @@ pub trait StackProvider: std::fmt::Debug {
     /// Returns `true` if the store used by this [`StackProvider`] has space to add new
     /// stacks or items to the stacks.
     fn has_store_capacity(&self) -> bool;
+
+    /// Returns the total count of the store used by this [`StackProvider`].
+    fn store_total_count(&self) -> impl Future<Output = u64>;
+
+    /// Returns the string representation of the stack type offered by this [`StackProvider`].
+    fn stack_type<'a>(&self) -> &'a str;
 }

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -59,4 +59,22 @@ impl StackProvider for SqliteStackProvider {
     fn has_store_capacity(&self) -> bool {
         (self.envelope_store.usage() as usize) < self.max_disk_size
     }
+
+    async fn store_total_count(&self) -> u64 {
+        self.envelope_store
+            .total_count()
+            .await
+            .unwrap_or_else(|error| {
+                relay_log::error!(
+                    error = &error as &dyn Error,
+                    "failed to get the total count of envelopes for the sqlite envelope store",
+                );
+                // In case we have an error, we default to communicating a total count of 0.
+                0
+            })
+    }
+
+    fn stack_type<'a>(&self) -> &'a str {
+        "sqlite"
+    }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -173,6 +173,11 @@ pub enum RelayHistograms {
     BufferDiskSize,
     /// Number of attempts needed to dequeue spooled envelopes from disk.
     BufferDequeueAttempts,
+    /// Number of elements in the envelope buffer across all the stacks.
+    ///
+    /// This metric is tagged with:
+    /// - `storage_type`: The type of storage used in the envelope buffer.
+    BufferEnvelopesCount,
     /// The number of batches emitted per partition.
     BatchesPerPartition,
     /// The number of buckets in a batch emitted.
@@ -297,6 +302,7 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::BufferEnvelopesMemoryBytes => "buffer.envelopes_mem",
             RelayHistograms::BufferDiskSize => "buffer.disk_size",
             RelayHistograms::BufferDequeueAttempts => "buffer.dequeue_attempts",
+            RelayHistograms::BufferEnvelopesCount => "buffer.envelopes_count",
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",
@@ -512,8 +518,12 @@ pub enum RelayTimers {
     ///  - `message`: The type of message that was processed.
     #[cfg(feature = "processing")]
     StoreServiceDuration,
-    /// Timing in milliseconds for the time it takes for initialize the spooler.
-    SpoolInitialization,
+    /// Timing in milliseconds for the time it takes for initialize the buffer.
+    BufferInitialization,
+    /// Timing in milliseconds for the time it takes for the buffer to spool data to disk.
+    BufferSpool,
+    /// Timing in milliseconds for the time it takes for the buffer to unspool data from disk.
+    BufferUnspool,
 }
 
 impl TimerMetric for RelayTimers {
@@ -555,7 +565,9 @@ impl TimerMetric for RelayTimers {
             RelayTimers::MetricRouterServiceDuration => "metrics.router.message.duration",
             #[cfg(feature = "processing")]
             RelayTimers::StoreServiceDuration => "store.message.duration",
-            RelayTimers::SpoolInitialization => "spool.initialization",
+            RelayTimers::BufferInitialization => "buffer.initialization.duration",
+            RelayTimers::BufferSpool => "buffer.spool.duration",
+            RelayTimers::BufferUnspool => "buffer.unspool.duration",
         }
     }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -618,6 +618,9 @@ pub enum RelayCounters {
     /// This happens when the envelope buffer falsely assumes that the envelope's projects are loaded
     /// in the cache and sends the envelope onward, even though the project cache cannot handle it.
     BufferEnvelopesReturned,
+    /// Number of times an envelope stack is popped from the priority queue of stacks in the
+    /// envelope buffer.
+    BufferEnvelopeStacksPopped,
     ///
     /// Number of outcomes and reasons for rejected Envelopes.
     ///
@@ -833,6 +836,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::BufferEnvelopesRead => "buffer.envelopes_read",
             RelayCounters::BufferEnvelopesReturned => "buffer.envelopes_returned",
             RelayCounters::BufferStateTransition => "buffer.state.transition",
+            RelayCounters::BufferEnvelopeStacksPopped => "buffer.envelope_stacks_popped",
             RelayCounters::Outcomes => "events.outcomes",
             RelayCounters::ProjectStateGet => "project_state.get",
             RelayCounters::ProjectStateRequest => "project_state.request",


### PR DESCRIPTION
This PR adds new metrics to the spooler, for tracking:
- Number of envelopes in the spooler
- Number of times a stack is popped
- The performance of spooling and unspooling

Closes: https://github.com/getsentry/team-ingest/issues/524, https://github.com/getsentry/team-ingest/issues/520

#skip-changelog