### PR TITLE
feat(spans): Extract standalone CLS span metrics and performance score

### DIFF
--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -965,39 +965,120 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
         ),
         (
             GroupKey::SpanMetricsTx,
-            vec![MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.score.total@ratio".into(),
-                field: Some("span.measurements.score.total.value".into()),
-                condition: Some(
-                    // If transactions are extracted from spans, the transaction processing pipeline
-                    // will take care of this metric.
-                    is_allowed_browser.clone() & RuleCondition::eq("span.was_transaction", false),
-                ),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction.op")
-                        .from_field("span.sentry_tags.transaction.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            }],
+            vec![
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.total@ratio".into(),
+                    field: Some("span.measurements.score.total.value".into()),
+                    condition: Some(
+                        // If transactions are extracted from spans, the transaction processing pipeline
+                        // will take care of this metric.
+                        is_allowed_browser.clone()
+                            & RuleCondition::eq("span.was_transaction", false),
+                    ),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction.op")
+                            .from_field("span.sentry_tags.transaction.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.cls@ratio".into(),
+                    field: Some("span.measurements.score.cls.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.weight.cls@ratio".into(),
+                    field: Some("span.measurements.score.weight.cls.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.cls@ratio".into(),
+                    field: Some("span.measurements.cls.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+            ],
             vec![],
         ),
     ]

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -3382,6 +3382,107 @@ mod tests {
     }
 
     #[test]
+    fn test_computes_standalone_cls_performance_score() {
+        let json = r#"
+        {
+            "type": "transaction",
+            "timestamp": "2021-04-26T08:00:05+0100",
+            "start_timestamp": "2021-04-26T08:00:00+0100",
+            "measurements": {
+                "cls": {"value": 0.5}
+            }
+        }
+        "#;
+
+        let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
+
+        let performance_score: PerformanceScoreConfig = serde_json::from_value(json!({
+            "profiles": [
+            {
+                "name": "Default",
+                "scoreComponents": [
+                    {
+                        "measurement": "fcp",
+                        "weight": 0.15,
+                        "p10": 900.0,
+                        "p50": 1600.0,
+                        "optional": true,
+                    },
+                    {
+                        "measurement": "lcp",
+                        "weight": 0.30,
+                        "p10": 1200.0,
+                        "p50": 2400.0,
+                        "optional": true,
+                    },
+                    {
+                        "measurement": "cls",
+                        "weight": 0.15,
+                        "p10": 0.1,
+                        "p50": 0.25,
+                        "optional": true,
+                    },
+                    {
+                        "measurement": "ttfb",
+                        "weight": 0.10,
+                        "p10": 200.0,
+                        "p50": 400.0,
+                        "optional": true,
+                    },
+                ],
+                "condition": {
+                    "op": "and",
+                    "inner": [],
+                },
+            }
+            ]
+        }))
+        .unwrap();
+
+        normalize(
+            &mut event,
+            &mut Meta::default(),
+            &NormalizationConfig {
+                performance_score: Some(&performance_score),
+                ..Default::default()
+            },
+        );
+
+        insta::assert_ron_snapshot!(SerializableAnnotated(&event.measurements), {}, @r###"
+        {
+          "cls": {
+            "value": 0.5,
+            "unit": "none",
+          },
+          "score.cls": {
+            "value": 0.16615877613713903,
+            "unit": "ratio",
+          },
+          "score.total": {
+            "value": 0.16615877613713903,
+            "unit": "ratio",
+          },
+          "score.weight.cls": {
+            "value": 1.0,
+            "unit": "ratio",
+          },
+          "score.weight.fcp": {
+            "value": 0.0,
+            "unit": "ratio",
+          },
+          "score.weight.lcp": {
+            "value": 0.0,
+            "unit": "ratio",
+          },
+          "score.weight.ttfb": {
+            "value": 0.0,
+            "unit": "ratio",
+          },
+        }
+        "###);
+    }
+
+    #[test]
     fn test_computed_performance_score_uses_first_matching_profile() {
         let json = r#"
         {

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -750,7 +750,9 @@ pub fn extract_tags(
             }
         }
         if let Some(measurements) = span.measurements.value() {
-            if span_op.starts_with("ui.interaction.") && measurements.contains_key("inp") {
+            if (span_op.starts_with("ui.interaction.") && measurements.contains_key("inp"))
+                || span_op.starts_with("ui.webvital.")
+            {
                 if let Some(transaction) = span
                     .data
                     .value()

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1653,7 +1653,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_span_metrics_performance_score() {
+    fn test_extract_span_metrics_inp_performance_score() {
         let json = r#"
             {
                 "op": "ui.interaction.click",
@@ -1686,6 +1686,46 @@ mod tests {
             "d:spans/webvital.score.inp@ratio",
             "d:spans/webvital.score.total@ratio",
             "d:spans/webvital.score.weight.inp@ratio",
+        ] {
+            assert!(metrics.iter().any(|b| &*b.name == mri));
+            assert!(metrics.iter().any(|b| b.tags.contains_key("browser.name")));
+            assert!(metrics.iter().any(|b| b.tags.contains_key("span.op")));
+        }
+    }
+
+    #[test]
+    fn test_extract_span_metrics_cls_performance_score() {
+        let json = r#"
+            {
+                "op": "ui.webvital.cls",
+                "span_id": "bd429c44b67a3eb4",
+                "start_timestamp": 1597976302.0000000,
+                "timestamp": 1597976302.0000000,
+                "exclusive_time": 0,
+                "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                "sentry_tags": {
+                    "browser.name": "Chrome",
+                    "op": "ui.webvital.cls"
+                },
+                "measurements": {
+                    "score.total": {"value": 1.0},
+                    "score.cls": {"value": 1.0},
+                    "score.weight.cls": {"value": 1.0},
+                    "cls": {"value": 1.0}
+                }
+            }
+        "#;
+        let span = Annotated::<Span>::from_json(json).unwrap();
+        let metrics = generic::extract_metrics(
+            span.value().unwrap(),
+            combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
+        );
+
+        for mri in [
+            "d:transactions/measurements.cls@ratio",
+            "d:transactions/measurements.score.cls@ratio",
+            "d:transactions/measurements.score.total@ratio",
+            "d:transactions/measurements.score.weight.cls@ratio",
         ] {
             assert!(metrics.iter().any(|b| &*b.name == mri));
             assert!(metrics.iter().any(|b| b.tags.contains_key("browser.name")));

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -384,9 +384,9 @@ impl<'a> NormalizeSpanConfig<'a> {
 fn set_segment_attributes(span: &mut Annotated<Span>) {
     let Some(span) = span.value_mut() else { return };
 
-    // Identify INP spans and make sure they are not wrapped in a segment.
+    // Identify INP spans or other WebVital spans and make sure they are not wrapped in a segment.
     if let Some(span_op) = span.op.value() {
-        if span_op.starts_with("ui.interaction.") {
+        if span_op.starts_with("ui.interaction.") || span_op.starts_with("ui.webvital.") {
             span.is_segment = None.into();
             span.parent_span_id = None.into();
             span.segment_id = None.into();


### PR DESCRIPTION
As of [this update](https://github.com/getsentry/sentry-javascript/pull/13056) to the JS SDK, we now can send CLS as a standalone span to Relay, similar to INP standalone spans. This update enables the extraction of standalone CLS spans to indexed and metrics datasets, with CLS Performance score calculation. These metrics are still written to the `transaction` namespace to not break any product areas using CLS

#skip-changelog