### PR TITLE
build: Update opentelemetry-proto to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,47 +244,19 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper 0.14.26",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core",
  "axum-macros",
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -286,23 +280,6 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
@@ -311,7 +288,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -328,12 +305,12 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
 dependencies = [
- "axum 0.7.5",
- "axum-core 0.4.3",
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -365,9 +342,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1552,25 +1529,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.9",
- "indexmap 2.2.5",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1788,17 +1746,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http 0.2.9",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1816,7 +1763,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1846,30 +1793,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.9",
- "http-body 0.4.5",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.9",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
@@ -1877,9 +1800,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1897,7 +1820,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1908,14 +1831,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 0.14.26",
+ "hyper",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -1926,7 +1850,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1944,10 +1868,10 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http-body",
+ "hyper",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tower",
  "tower-service",
@@ -2055,7 +1979,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -2769,23 +2693,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14#dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "once_cell",
- "ordered-float",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.4.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14#dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
  "hex",
  "opentelemetry",
@@ -2797,29 +2721,21 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.21.2"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14#dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float",
  "percent-encoding",
  "rand",
+ "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3124,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3134,15 +3050,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3303,7 +3219,7 @@ dependencies = [
  "rand",
  "ryu",
  "sha1_smol",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "url",
 ]
@@ -3868,7 +3784,7 @@ version = "24.8.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "axum 0.7.5",
+ "axum",
  "axum-extra",
  "axum-server",
  "backoff",
@@ -3928,7 +3844,7 @@ dependencies = [
  "serde_path_to_error",
  "similar-asserts",
  "smallvec",
- "socket2 0.5.7",
+ "socket2",
  "sqlx",
  "symbolic-common",
  "symbolic-unreal",
@@ -4010,12 +3926,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
+ "h2",
  "hickory-resolver",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -4690,16 +4606,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -5277,19 +5183,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -5367,24 +5263,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
+ "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "axum",
+ "base64 0.22.1",
  "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper 0.14.26",
+ "h2",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",
@@ -5425,7 +5323,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -5664,12 +5562,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16string"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -287,7 +287,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -309,7 +309,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -341,7 +341,7 @@ checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1521,7 +1521,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.2.5",
  "slab",
  "tokio",
@@ -1698,17 +1698,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1725,7 +1714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1736,7 +1725,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -1769,7 +1758,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1787,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1835,7 +1824,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -2341,7 +2330,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.1.0",
+ "http",
  "httparse",
  "memchr",
  "mime",
@@ -3869,7 +3858,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hickory-resolver",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5213,7 +5202,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5262,7 +5251,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ multer = "2.0.4"
 num-traits = "0.2.18"
 num_cpus = "1.13.0"
 once_cell = "1.13.1"
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "dd4c13bd69ca4b24d5a8f21024a466fbb35cdd14" }
+opentelemetry-proto = "0.7.0"
 parking_lot = "0.12.1"
 path-slash = "0.2.1"
 pest = "2.1.3"

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -872,7 +872,8 @@ mod tests {
 
         let event = Annotated::new(Event {
             release: Annotated::new(
-                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#").into(),
+                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#")
+                    .into(),
             ),
             ..Default::default()
         });

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -284,8 +284,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "middleware - fastify -> @fastify/multipart",
             "kind": 1,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key": "sentry.environment",
@@ -314,7 +314,7 @@ mod tests {
                 {
                     "key": "sentry.sample_rate",
                     "value": {
-                        "intValue": 1
+                        "intValue": "1"
                     }
                 },
                 {
@@ -326,7 +326,7 @@ mod tests {
                 {
                     "key": "sentry.exclusive_time_nano",
                     "value": {
-                        "intValue": 1000000000
+                        "intValue": "1000000000"
                     }
                 }
             ],
@@ -358,13 +358,13 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "middleware - fastify -> @fastify/multipart",
             "kind": 1,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key": "sentry.exclusive_time_nano",
                     "value": {
-                        "intValue": 3200000000
+                        "intValue": "3200000000"
                     }
                 }
             ]
@@ -382,8 +382,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "middleware - fastify -> @fastify/multipart",
             "kind": 1,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800"
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span);
@@ -398,8 +398,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "database query",
             "kind": 3,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key" : "db.name",
@@ -440,8 +440,8 @@ mod tests {
             "parentSpanId": "0c7a7dea069bf5a6",
             "name": "http client request",
             "kind": 3,
-            "startTimeUnixNano": 1697620454980000000,
-            "endTimeUnixNano": 1697620454980078800,
+            "startTimeUnixNano": "1697620454980000000",
+            "endTimeUnixNano": "1697620454980078800",
             "attributes": [
                 {
                     "key" : "http.request.method",
@@ -473,8 +473,8 @@ mod tests {
             "traceId": "4c79f60c11214eb38604f4ae0781bfb2",
             "spanId": "fa90fdead5f74052",
             "parentSpanId": "fa90fdead5f74051",
-            "startTimeUnixNano": 123000000000,
-            "endTimeUnixNano": 123500000000,
+            "startTimeUnixNano": "123000000000",
+            "endTimeUnixNano": "123500000000",
             "status": {"code": 0, "message": "foo"},
             "attributes": [
                 {
@@ -561,7 +561,7 @@ mod tests {
                                                 {
                                                     "key": "count",
                                                     "value": {
-                                                        "intValue": 2
+                                                        "intValue": "2"
                                                     }
                                                 },
                                                 {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -300,8 +300,8 @@ def envelope_with_spans(
                         "traceId": "89143b0763095bd9c9955e8175d1fb23",
                         "spanId": "a342abb1214ca181",
                         "name": "my 1st OTel span",
-                        "startTimeUnixNano": int(start.timestamp() * 1e9),
-                        "endTimeUnixNano": int(end.timestamp() * 1e9),
+                        "startTimeUnixNano": str(int(start.timestamp() * 1e9)),
+                        "endTimeUnixNano": str(int(end.timestamp() * 1e9)),
                         "attributes": [
                             {
                                 "key": "sentry.op",
@@ -312,8 +312,8 @@ def envelope_with_spans(
                             {
                                 "key": "sentry.exclusive_time_nano",
                                 "value": {
-                                    "intValue": int(
-                                        (end - start).total_seconds() * 1e9
+                                    "intValue": str(
+                                        int((end - start).total_seconds() * 1e9)
                                     ),
                                 },
                             },
@@ -440,14 +440,14 @@ def make_otel_span(start, end):
                                 "traceId": "89143b0763095bd9c9955e8175d1fb24",
                                 "spanId": "d342abb1214ca182",
                                 "name": "my 2nd OTel span",
-                                "startTimeUnixNano": int(start.timestamp() * 1e9),
-                                "endTimeUnixNano": int(end.timestamp() * 1e9),
+                                "startTimeUnixNano": str(int(start.timestamp() * 1e9)),
+                                "endTimeUnixNano": str(int(end.timestamp() * 1e9)),
                                 "attributes": [
                                     {
                                         "key": "sentry.exclusive_time_nano",
                                         "value": {
-                                            "intValue": int(
-                                                (end - start).total_seconds() * 1e9
+                                            "intValue": str(
+                                                int((end - start).total_seconds() * 1e9)
                                             ),
                                         },
                                     },
@@ -717,8 +717,10 @@ def test_span_reject_invalid_timestamps(
                         "traceId": "89143b0763095bd9c9955e8175d1fb23",
                         "spanId": "a342abb1214ca181",
                         "name": "span with invalid timestamps",
-                        "startTimeUnixNano": int(start_yesterday.timestamp() * 1e9),
-                        "endTimeUnixNano": int(end_yesterday.timestamp() * 1e9),
+                        "startTimeUnixNano": str(
+                            int(start_yesterday.timestamp() * 1e9)
+                        ),
+                        "endTimeUnixNano": str(int(end_yesterday.timestamp() * 1e9)),
                     },
                 ).encode()
             ),
@@ -733,8 +735,8 @@ def test_span_reject_invalid_timestamps(
                         "traceId": "89143b0763095bd9c9955e8175d1fb23",
                         "spanId": "a342abb1214ca181",
                         "name": "span with valid timestamps",
-                        "startTimeUnixNano": int(start_today.timestamp() * 1e9),
-                        "endTimeUnixNano": int(end_today.timestamp() * 1e9),
+                        "startTimeUnixNano": str(int(start_today.timestamp() * 1e9)),
+                        "endTimeUnixNano": str(int(end_today.timestamp() * 1e9)),
                     },
                 ).encode()
             ),


### PR DESCRIPTION
Updates the `opentelemetry-proto` dependency to the latest version. This changes
the serde deserializer for integers from numbers to strings. This means for
`intValue` and all timestamp fields, the client has to send strings now. See
updated tests for examples.

#skip-changelog

