### PR TITLE
ref(server): Simplify global config subscription

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -177,7 +177,8 @@ impl ServiceState {
         .start();
         let outcome_aggregator = OutcomeAggregator::new(&config, outcome_producer.clone()).start();
 
-        let global_config = GlobalConfigService::new(config.clone(), upstream_relay.clone());
+        let (global_config, global_config_rx) =
+            GlobalConfigService::new(config.clone(), upstream_relay.clone());
         let global_config_handle = global_config.handle();
         // The global config service must start before dependant services are
         // started. Messages like subscription requests to the global config
@@ -256,13 +257,13 @@ impl ServiceState {
             project_cache: project_cache.clone(),
             test_store: test_store.clone(),
             upstream_relay: upstream_relay.clone(),
-            global_config: global_config.clone(),
         };
 
         ProjectCacheService::new(
             config.clone(),
             MemoryChecker::new(memory_stat.clone(), config.clone()),
             project_cache_services,
+            global_config_rx,
             redis_pools
                 .as_ref()
                 .map(|pools| pools.project_configs.clone()),

--- a/relay-server/src/services/global_config.rs
+++ b/relay-server/src/services/global_config.rs
@@ -108,10 +108,7 @@ pub struct Get;
 ///
 /// For a one-off update, [`GlobalConfigService`] responds to
 /// [`GlobalConfigManager::Get`] messages with the latest instance of the
-/// [`GlobalConfig`]. For continued updates, you can subscribe with
-/// [`GlobalConfigManager::Subscribe`] to get a receiver back where up-to-date
-/// instances will be sent to, while [`GlobalConfigService`] manages the update
-/// frequency from upstream.
+/// [`GlobalConfig`].
 pub enum GlobalConfigManager {
     /// Returns the most recent global config.
     Get(relay_system::Sender<Status>),
@@ -183,10 +180,6 @@ impl fmt::Debug for GlobalConfigHandle {
 }
 
 /// Service implementing the [`GlobalConfigManager`] interface.
-///
-/// The service offers two alternatives to fetch the [`GlobalConfig`]:
-/// responding to a [`Get`] message with the config for one-off requests, or
-/// subscribing to updates with [`Subscribe`] to keep up-to-date.
 #[derive(Debug)]
 pub struct GlobalConfigService {
     config: Arc<Config>,


### PR DESCRIPTION
Remove the extra async message by returning the service's watch handle directly from `GlobalConfigService`'s constructor.

This prepares for https://github.com/getsentry/relay/pull/3989, which subscribes the envelope buffer service to global config.

#skip-changelog.