### PR TITLE
instr(auth): Tag authentication failure by number of attempts

### DIFF
--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -1204,7 +1204,8 @@ impl AuthMonitor {
                 Err(err) => {
                     relay_log::error!(
                         error = &err as &dyn std::error::Error,
-                        "authentication encountered error"
+                        tags.attempt = backoff.attempt(),
+                        "authentication encountered error",
                     );
 
                     // ChannelClosed indicates that there are no more listeners, so we stop

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -1202,11 +1202,13 @@ impl AuthMonitor {
                     }
                 }
                 Err(err) => {
-                    relay_log::error!(
-                        error = &err as &dyn std::error::Error,
-                        tags.attempt = backoff.attempt(),
-                        "authentication encountered error",
-                    );
+                    if backoff.attempt() > 1 {
+                        relay_log::error!(
+                            error = &err as &dyn std::error::Error,
+                            tags.attempts = backoff.attempt(),
+                            "authentication encountered error",
+                        );
+                    }
 
                     // ChannelClosed indicates that there are no more listeners, so we stop
                     // authenticating.


### PR DESCRIPTION
We've been getting authentication errors. Tag with the number of attempts to see how often this happens more than once. Suppress errors for single failures.

ref: [SENTRY-FOR-SENTRY-9RB](https://sentry-st.sentry.io/issues/5800508355/)

#skip-changelog