### PR TITLE
feat(spans): only extract user.geo.subregion if mobile or frontend project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Remove the OTEL spans endpoint in favor of Envelopes. ([#3973](https://github.com/getsentry/relay/pull/3973))
 - Remove the `generate-schema` tool. Relay no longer exposes JSON schema for the event protocol. Consult the Rust type documentation of the `relay-event-schema` crate instead. ([#3974](https://github.com/getsentry/relay/pull/3974))
 - Allow creation of `SqliteEnvelopeBuffer` from config, and load existing stacks from db on startup. ([#3967](https://github.com/getsentry/relay/pull/3967))
+- Only tag `user.geo.subregion` on frontend and mobile projects. ([#4013](https://github.com/getsentry/relay/pull/4013))
 
 ## 24.8.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -180,7 +180,8 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
     let is_app_start = RuleCondition::glob("span.op", "app.start.*")
         & RuleCondition::eq("span.description", APP_START_ROOT_SPAN_DESCRIPTIONS);
 
-    let should_extract_geo = is_allowed_browser.clone() | is_mobile.clone() | is_resource.clone();
+    let should_extract_geo =
+        (is_allowed_browser.clone() & (is_resource.clone() | is_http.clone())) | is_mobile.clone();
 
     // Metrics for addon modules are only extracted if the feature flag is enabled:
     let is_addon = is_ai.clone() | is_queue_op.clone() | is_cache.clone();

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -171,6 +171,11 @@ mod tests {
                     "span_id": "bd429c44b67a3eb4",
                     "op": "mYOp",
                     "status": "ok"
+                },
+                "browser": {
+                    "name": "Chrome",
+                    "version": "120.1.1",
+                    "type": "browser"
                 }
             },
             "request": {

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__both_feature_flags_enabled.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__both_feature_flags_enabled.snap
@@ -178,6 +178,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -205,6 +206,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -235,6 +237,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -262,6 +265,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -310,6 +314,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -337,6 +342,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -367,6 +373,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -394,6 +401,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -442,6 +450,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -469,6 +478,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -499,6 +509,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -526,6 +537,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -573,6 +585,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -599,6 +612,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -628,6 +642,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -654,6 +669,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -702,6 +718,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -729,6 +746,7 @@ expression: metrics
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
             "span.status_code": "500",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -759,6 +777,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -786,6 +805,7 @@ expression: metrics
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
             "span.status_code": "500",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -835,6 +855,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -863,6 +884,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -894,6 +916,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -922,6 +945,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -971,6 +995,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -999,6 +1024,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1030,6 +1056,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1058,6 +1085,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1107,6 +1135,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1135,6 +1164,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1166,6 +1196,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1194,6 +1225,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1243,6 +1275,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1271,6 +1304,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1302,6 +1336,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1330,6 +1365,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1379,6 +1415,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1407,6 +1444,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1438,6 +1476,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1466,6 +1505,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1515,6 +1555,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1543,6 +1584,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1574,6 +1616,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1602,6 +1645,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4784,6 +4828,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4811,6 +4856,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4841,6 +4887,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4868,6 +4915,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4916,6 +4964,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4943,6 +4992,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4973,6 +5023,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5000,6 +5051,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5048,6 +5100,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5075,6 +5128,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5105,6 +5159,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5132,6 +5187,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5179,6 +5235,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5205,6 +5262,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5234,6 +5292,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5260,6 +5319,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5309,6 +5369,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5337,6 +5398,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5368,6 +5430,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5396,6 +5459,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5445,6 +5509,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5473,6 +5538,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5504,6 +5570,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5532,6 +5599,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5581,6 +5649,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5609,6 +5678,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5640,6 +5710,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5668,6 +5739,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5717,6 +5789,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5745,6 +5818,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5776,6 +5850,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5804,6 +5879,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5853,6 +5929,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5881,6 +5958,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5912,6 +5990,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5940,6 +6019,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5989,6 +6069,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6017,6 +6098,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6048,6 +6130,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -6076,6 +6159,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__only_common.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__only_common.snap
@@ -178,6 +178,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -205,6 +206,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -235,6 +237,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -262,6 +265,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -310,6 +314,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -337,6 +342,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -367,6 +373,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -394,6 +401,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -442,6 +450,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -469,6 +478,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -499,6 +509,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -526,6 +537,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -573,6 +585,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -599,6 +612,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -628,6 +642,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -654,6 +669,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -702,6 +718,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -729,6 +746,7 @@ expression: metrics
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
             "span.status_code": "500",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -759,6 +777,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -786,6 +805,7 @@ expression: metrics
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
             "span.status_code": "500",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -835,6 +855,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -863,6 +884,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -894,6 +916,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -922,6 +945,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -971,6 +995,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -999,6 +1024,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1030,6 +1056,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1058,6 +1085,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1107,6 +1135,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1135,6 +1164,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1166,6 +1196,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1194,6 +1225,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1243,6 +1275,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1271,6 +1304,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1302,6 +1336,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1330,6 +1365,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1379,6 +1415,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1407,6 +1444,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1438,6 +1476,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1466,6 +1505,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1515,6 +1555,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1543,6 +1584,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1574,6 +1616,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -1602,6 +1645,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4482,6 +4526,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4509,6 +4554,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4539,6 +4585,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4566,6 +4613,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "d9dc18637d441612",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4614,6 +4662,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4641,6 +4690,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4671,6 +4721,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4698,6 +4749,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "25faf23529f71d3e",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4746,6 +4798,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4773,6 +4826,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4803,6 +4857,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4830,6 +4885,7 @@ expression: metrics
             "span.domain": "domain.tld",
             "span.group": "488f09b46e5978be",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4877,6 +4933,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4903,6 +4960,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4932,6 +4990,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -4958,6 +5017,7 @@ expression: metrics
             "span.description": "GET *",
             "span.group": "37e3d9fab1ae9162",
             "span.op": "http.client",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5007,6 +5067,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5035,6 +5096,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5066,6 +5128,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5094,6 +5157,7 @@ expression: metrics
             "span.group": "464fe695f9cf639c",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5143,6 +5207,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5171,6 +5236,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5202,6 +5268,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5230,6 +5297,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5279,6 +5347,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5307,6 +5376,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5338,6 +5408,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5366,6 +5437,7 @@ expression: metrics
             "span.group": "72ab88b506cb04b2",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5415,6 +5487,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5443,6 +5516,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5474,6 +5548,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5502,6 +5577,7 @@ expression: metrics
             "span.group": "c8e531abe96ff360",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5551,6 +5627,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5579,6 +5656,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5610,6 +5688,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5638,6 +5717,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5687,6 +5767,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5715,6 +5796,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5746,6 +5828,7 @@ expression: metrics
             "transaction": "gEt /api/:version/users/",
             "transaction.method": "POST",
             "transaction.op": "myop",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,
@@ -5774,6 +5857,7 @@ expression: metrics
             "span.group": "86818d1c74ecfc66",
             "span.op": "http.client",
             "span.status_code": "200",
+            "user.geo.subregion": "155",
         },
         metadata: BucketMetadata {
             merges: 1,


### PR DESCRIPTION
work towards https://github.com/getsentry/sentry/issues/75230

We saw a noticeable increase in clickhouse rows after tagging spans with `user.geo.subregion`. However, this feature is only intended for frontend and mobile, so it makes sense we just don't allow other SDKs to extract these tags. 

This should help a lot, if you look at the sentry org, the sentry backend project emits a most 330k http spans per minute, while the frontend emits at most 30k.