### PR TITLE
test(filter): more tests for `SchemeDomainPort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Remove the OTEL spans endpoint in favor of Envelopes. ([#3973](https://github.com/getsentry/relay/pull/3973))
 - Remove the `generate-schema` tool. Relay no longer exposes JSON schema for the event protocol. Consult the Rust type documentation of the `relay-event-schema` crate instead. ([#3974](https://github.com/getsentry/relay/pull/3974))
 - Allow creation of `SqliteEnvelopeBuffer` from config, and load existing stacks from db on startup. ([#3967](https://github.com/getsentry/relay/pull/3967))
+- Add tests for `SchemeDomainPort`. ([#4015](https://github.com/getsentry/relay/pull/4015))
 
 ## 24.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 - Remove the OTEL spans endpoint in favor of Envelopes. ([#3973](https://github.com/getsentry/relay/pull/3973))
 - Remove the `generate-schema` tool. Relay no longer exposes JSON schema for the event protocol. Consult the Rust type documentation of the `relay-event-schema` crate instead. ([#3974](https://github.com/getsentry/relay/pull/3974))
 - Allow creation of `SqliteEnvelopeBuffer` from config, and load existing stacks from db on startup. ([#3967](https://github.com/getsentry/relay/pull/3967))
-- Add tests for `SchemeDomainPort`. ([#4015](https://github.com/getsentry/relay/pull/4015))
 
 ## 24.8.0
 

--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -232,6 +232,12 @@ mod tests {
             ("abc.com/something]:", None, Some("abc.com"), None),
             ("abc.co]m/[something:", None, Some("abc.co]m"), None),
             ("]abc.com:9000", None, Some("]abc.com"), Some("9000")),
+            (
+                "https://api.example.com/foo/00000000-0000-0000-0000-000000000000?includes[]=user&includes[]=image&includes[]=author&includes[]=tag",
+                Some("https"),
+                Some("api.example.com"),
+                None,
+            )
         ];
 
         for (url, scheme, domain, port) in examples {
@@ -265,6 +271,40 @@ mod tests {
                 Some("[1fff:0:a88:85a3::ac1f]"),
                 Some("8001"),
             ),
+            // invalid IPv6 for localhost since it's not inside brackets
+            ("::1", None, Some(":"), Some("1")),
+            ("[::1]", None, Some("[::1]"), None),
+            (
+                "http://[fe80::862a:fdff:fe78:a2bf%13]",
+                Some("http"),
+                Some("[fe80::862a:fdff:fe78:a2bf%13]"),
+                None,
+            ),
+            // invalid addresses. although these results don't represent correct results,
+            // they are here to make sure the application won't crash.
+            ("192.168.1.1.1", None, Some("192.168.1.1.1"), None),
+            ("192.168.1.300", None, Some("192.168.1.300"), None),
+            (
+                "[2001:0db8:85a3:::8a2e:0370:7334]",
+                None,
+                Some("[2001:0db8:85a3:::8a2e:0370:7334]"),
+                None,
+            ),
+            ("[fe80::1::]", None, Some("[fe80::1::]"), None),
+            ("fe80::1::", None, Some("fe80::1:"), Some("")),
+            (
+                "[2001:0db8:85a3:xyz::8a2e:0370:7334]",
+                None,
+                Some("[2001:0db8:85a3:xyz::8a2e:0370:7334]"),
+                None,
+            ),
+            (
+                "2001:0db8:85a3:xyz::8a2e:0370:7334",
+                None,
+                Some("2001:0db8:85a3:xyz::8a2e:0370"),
+                Some("7334"),
+            ),
+            ("192.168.0.1/24", None, Some("192.168.0.1"), None),
         ];
 
         for (url, scheme, domain, port) in examples {


### PR DESCRIPTION
Adding more tests for the `SchemeDomainPort`

#skip-changelog

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
