### PR TITLE
fix(spooler): Make the backpressure management cancellation safe

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -129,9 +129,11 @@ impl EnvelopeBufferService {
     /// Wait for the configured amount of time and make sure the project cache is ready to receive.
     async fn ready_to_pop(&mut self) -> Result<(), SendError> {
         tokio::time::sleep(self.sleep).await;
-        if let Some(project_cache_ready) = self.project_cache_ready.take() {
+        if let Some(project_cache_ready) = self.project_cache_ready.as_mut() {
             project_cache_ready.await?;
+            self.project_cache_ready = None;
         }
+
         Ok(())
     }
 

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -872,8 +872,7 @@ mod tests {
 
         let event = Annotated::new(Event {
             release: Annotated::new(
-                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#")
-                    .into(),
+                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#").into(),
             ),
             ..Default::default()
         });

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -872,7 +872,8 @@ mod tests {
 
         let event = Annotated::new(Event {
             release: Annotated::new(
-                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#").into(),
+                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#")
+                    .into(),
             ),
             ..Default::default()
         });


### PR DESCRIPTION
This PR makes the backpressure management of the spooler cancellation safe. The problem of the previous implementation was that we would take the future, await on it, and in case of a cancellation before the next poll, we would lose the future because it was taken, meaning that new envelopes would be pushed without backpressure to the project cache.

This PR introduces a fix which keeps the future's reference around until it has successfully completed.

#skip-changelog