### PR TITLE
fix(spans): check sdk platform for user.geo.subregion tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Remove the `generate-schema` tool. Relay no longer exposes JSON schema for the event protocol. Consult the Rust type documentation of the `relay-event-schema` crate instead. ([#3974](https://github.com/getsentry/relay/pull/3974))
 - Allow creation of `SqliteEnvelopeBuffer` from config, and load existing stacks from db on startup. ([#3967](https://github.com/getsentry/relay/pull/3967))
 - Only tag `user.geo.subregion` on frontend and mobile projects. ([#4013](https://github.com/getsentry/relay/pull/4013))
+- Check if sdk platform is `javascript` for `user.geo.subregion` tag. ([#4023](https://github.com/getsentry/relay/pull/4023))
 
 ## 24.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,7 @@
 - Remove the OTEL spans endpoint in favor of Envelopes. ([#3973](https://github.com/getsentry/relay/pull/3973))
 - Remove the `generate-schema` tool. Relay no longer exposes JSON schema for the event protocol. Consult the Rust type documentation of the `relay-event-schema` crate instead. ([#3974](https://github.com/getsentry/relay/pull/3974))
 - Allow creation of `SqliteEnvelopeBuffer` from config, and load existing stacks from db on startup. ([#3967](https://github.com/getsentry/relay/pull/3967))
-- Only tag `user.geo.subregion` on frontend and mobile projects. ([#4013](https://github.com/getsentry/relay/pull/4013))
-- Check if sdk platform is `javascript` for `user.geo.subregion` tag. ([#4023](https://github.com/getsentry/relay/pull/4023))
+- Only tag `user.geo.subregion` on frontend and mobile projects. ([#4013](https://github.com/getsentry/relay/pull/4013), [#4023](https://github.com/getsentry/relay/pull/4023))
 
 ## 24.8.0
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -320,8 +320,9 @@ fn extract_shared_tags(event: &Event) -> BTreeMap<SpanTagKey, String> {
         }
 
         // We only want this on frontend or mobile modules.
-        let should_extract_geo =
-            event.context::<BrowserContext>().is_some() || MOBILE_SDKS.contains(&event.sdk_name());
+        let should_extract_geo = (event.context::<BrowserContext>().is_some()
+            && event.platform.as_str() == Some("javascript"))
+            || MOBILE_SDKS.contains(&event.sdk_name());
 
         if should_extract_geo {
             if let Some(country_code) = user.geo.value().and_then(|geo| geo.country_code.value()) {
@@ -2745,6 +2746,9 @@ LIMIT 1
                     "trace": {
                         "trace_id": "ff62a8b040f340bda5d830223def1d81",
                         "span_id": "bd429c44b67a3eb4"
+                    },
+                    "browser": {
+                        "name": "Chrome"
                     }
                 },
                 "user": {


### PR DESCRIPTION
Work towards https://github.com/getsentry/sentry/issues/75230
This is an extension of this PR https://github.com/getsentry/relay/pull/4013

I assumed that Backend SDK transactions would not have a browser context, so i used that as a means to check if the project is a frontend project. Turns out, python SDKs still set browser context on the transaction (I guess this is the browser the user made the request from?). So to fix this, we can just check the platform directly as frontend is typically/always javascript.