### PR TITLE
fix(spooler): Fix datetime comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use `matches_any_origin` to scrub HTTP hosts in spans. ([#3939](https://github.com/getsentry/relay/pull/3939)).
 - Keep frames from both ends of the stacktrace when trimming frames. ([#3905](https://github.com/getsentry/relay/pull/3905))
+- Use `UnixTimestamp` instead of `DateTime` when sorting envelopes from disk. ([#4025](https://github.com/getsentry/relay/pull/4025))
 
 **Features**:
 

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -120,7 +120,7 @@ impl SqliteEnvelopeStack {
     /// In case an envelope fails deserialization due to malformed data in the database, the affected
     /// envelope will not be unspooled and unspooling will continue with the remaining envelopes.
     async fn unspool_from_disk(&mut self) -> Result<(), SqliteEnvelopeStackError> {
-        let mut envelopes = relay_statsd::metric!(timer(RelayTimers::BufferUnspool), {
+        let envelopes = relay_statsd::metric!(timer(RelayTimers::BufferUnspool), {
             self.envelope_store
                 .delete_many(
                     self.own_key,
@@ -138,11 +138,6 @@ impl SqliteEnvelopeStack {
 
             return Ok(());
         }
-
-        // Since the store returns the envelopes sorted in descending order, we want to put them
-        // in reverse into the vector in the buffer, because we want to pop the last element always,
-        // which has to be the newest (aka with the biggest timestamp).
-        envelopes.reverse();
 
         // We push in the back of the buffer, since we still want to give priority to
         // incoming envelopes that have a more recent timestamp.

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -552,9 +552,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(extracted_envelopes.len(), 5);
-        for i in 0..5 {
+        for (i, extracted_envelope) in extracted_envelopes.iter().enumerate().take(5) {
             assert_eq!(
-                extracted_envelopes[i].event_id(),
+                extracted_envelope.event_id(),
                 envelopes[5..][4 - i].event_id()
             );
         }
@@ -566,9 +566,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(extracted_envelopes.len(), 5);
-        for i in 0..5 {
+        for (i, extracted_envelope) in extracted_envelopes.iter().enumerate().take(5) {
             assert_eq!(
-                extracted_envelopes[i].event_id(),
+                extracted_envelope.event_id(),
                 envelopes[0..5][4 - i].event_id()
             );
         }

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::error::Error;
 use std::path::Path;
 use std::pin::pin;
@@ -371,12 +370,12 @@ impl SqliteEnvelopeStore {
             }
         }
 
-        // We sort envelopes by `received_at`.
+        // We sort envelopes by `received_at` in ascending order.
         //
         // Unfortunately we have to do this because SQLite `DELETE` with `RETURNING` doesn't
         // return deleted rows in a specific order.
         extracted_envelopes.sort_by_key(|a| {
-            Reverse(UnixTimestamp::from_datetime(a.received_at()).unwrap_or(UnixTimestamp::now()))
+            UnixTimestamp::from_datetime(a.received_at()).unwrap_or(UnixTimestamp::now())
         });
 
         Ok(extracted_envelopes)
@@ -553,10 +552,7 @@ mod tests {
             .unwrap();
         assert_eq!(extracted_envelopes.len(), 5);
         for (i, extracted_envelope) in extracted_envelopes.iter().enumerate().take(5) {
-            assert_eq!(
-                extracted_envelope.event_id(),
-                envelopes[5..][4 - i].event_id()
-            );
+            assert_eq!(extracted_envelope.event_id(), envelopes[5..][i].event_id());
         }
 
         // We check that if we load more than the envelopes stored on disk, we still get back at
@@ -567,10 +563,7 @@ mod tests {
             .unwrap();
         assert_eq!(extracted_envelopes.len(), 5);
         for (i, extracted_envelope) in extracted_envelopes.iter().enumerate().take(5) {
-            assert_eq!(
-                extracted_envelope.event_id(),
-                envelopes[0..5][4 - i].event_id()
-            );
+            assert_eq!(extracted_envelope.event_id(), envelopes[0..5][i].event_id());
         }
     }
 


### PR DESCRIPTION
This PR uses `UnixTimestamp` instead of `DateTime` to compare timestamps when sorting data from disk.

This fixes an issue that raised the following panic (https://doc.rust-lang.org/src/core/slice/sort/shared/smallsort.rs.html#862) which caused the envelope buffer service to crash and stop handling envelopes.

ref: https://github.com/rust-lang/rust/issues/129561