### PR TITLE
feat(server): abort on panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use `matches_any_origin` to scrub HTTP hosts in spans. ([#3939](https://github.com/getsentry/relay/pull/3939)).
 - Keep frames from both ends of the stacktrace when trimming frames. ([#3905](https://github.com/getsentry/relay/pull/3905))
+- Abort the process when a service panics. ([#4026](https://github.com/getsentry/relay/pull/4026))
 
 **Features**:
 

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -309,14 +309,10 @@ pub fn run(config: Config) -> anyhow::Result<()> {
         loop {
             select! {
                 Some(res) = join_handles.next() => {
-                    match res {
-                        Ok(()) => {
-                            relay_log::trace!("Service exited normally.");
-                        }
-                        Err(e) => {
-                            if e.is_panic() {
-                                std::panic::resume_unwind(e.into_panic());
-                            }
+                    if let Err(e) = res {
+                        if e.is_panic() {
+                            // Re-trigger panic to terminate the process:
+                            std::panic::resume_unwind(e.into_panic());
                         }
                     }
                 }

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -278,6 +278,7 @@ mod testutils;
 
 use std::sync::Arc;
 
+use futures::StreamExt;
 use relay_config::Config;
 use relay_system::{Controller, Service};
 
@@ -303,6 +304,13 @@ pub fn run(config: Config) -> anyhow::Result<()> {
         Controller::start(config.shutdown_timeout());
         let service = ServiceState::start(config.clone())?;
         HttpServer::new(config, service.clone())?.start();
+
+        for x in service.join_handles() {}
+        // while let Some(res) = service.join_handles().next() {
+
+        // }
+
+        // TODO: await simultaneously
         Controller::shutdown_handle().finished().await;
         anyhow::Ok(())
     })?;

--- a/relay-server/src/services/cogs.rs
+++ b/relay-server/src/services/cogs.rs
@@ -1,8 +1,8 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use relay_cogs::{CogsMeasurement, CogsRecorder, ResourceId};
 use relay_config::Config;
 use relay_system::{Addr, FromMessage, Interface, Service};
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::task::JoinHandle;
 
 use crate::statsd::RelayCounters;
 
@@ -54,12 +54,12 @@ impl CogsService {
 impl Service for CogsService {
     type Interface = CogsReport;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 self.handle_report(message);
             }
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/global_config.rs
+++ b/relay-server/src/services/global_config.rs
@@ -22,6 +22,7 @@ use relay_system::{Addr, AsyncResponse, Controller, FromMessage, Interface, Serv
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::services::upstream::{
@@ -338,7 +339,7 @@ impl GlobalConfigService {
 impl Service for GlobalConfigService {
     type Interface = GlobalConfigManager;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut shutdown_handle = Controller::shutdown_handle();
 
@@ -384,7 +385,7 @@ impl Service for GlobalConfigService {
                 }
             }
             relay_log::info!("global config service stopped");
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -246,7 +246,10 @@ impl AggregatorService {
 impl Service for AggregatorService {
     type Interface = Aggregator;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        mut self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_millis(self.flush_interval_ms));
             let mut shutdown = Controller::shutdown_handle();
@@ -264,7 +267,7 @@ impl Service for AggregatorService {
                     else => break,
                 }
             }
-        });
+        })
     }
 }
 
@@ -361,7 +364,10 @@ mod tests {
     impl Service for TestReceiver {
         type Interface = TestInterface;
 
-        fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+        fn spawn_handler(
+            self,
+            mut rx: relay_system::Receiver<Self::Interface>,
+        ) -> tokio::task::JoinHandle<()> {
             tokio::spawn(async move {
                 while let Some(message) = rx.recv().await {
                     let buckets = message.0.buckets;
@@ -370,7 +376,7 @@ mod tests {
                         self.add_buckets(buckets);
                     }
                 }
-            });
+            })
         }
     }
 

--- a/relay-server/src/services/metrics/router.rs
+++ b/relay-server/src/services/metrics/router.rs
@@ -5,6 +5,7 @@ use relay_config::aggregator::Condition;
 use relay_config::{AggregatorServiceConfig, ScopedAggregatorConfig};
 use relay_metrics::MetricNamespace;
 use relay_system::{Addr, NoResponse, Recipient, Service};
+use tokio::task::JoinHandle;
 
 use crate::services::metrics::{
     Aggregator, AggregatorHandle, AggregatorService, FlushBuckets, MergeBuckets,
@@ -53,7 +54,7 @@ impl RouterService {
 impl Service for RouterService {
     type Interface = Aggregator;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut router = StartedRouter::start(self);
             relay_log::info!("metrics router started");
@@ -72,7 +73,7 @@ impl Service for RouterService {
                 }
             }
             relay_log::info!("metrics router stopped");
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -29,6 +29,7 @@ use relay_sampling::evaluation::MatchedRuleIds;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
 use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
 
 #[cfg(feature = "processing")]
 use crate::service::ServiceError;
@@ -682,7 +683,7 @@ impl HttpOutcomeProducer {
 impl Service for HttpOutcomeProducer {
     type Interface = TrackRawOutcome;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -694,7 +695,7 @@ impl Service for HttpOutcomeProducer {
                     else => break,
                 }
             }
-        });
+        })
     }
 }
 
@@ -775,7 +776,7 @@ impl ClientReportOutcomeProducer {
 impl Service for ClientReportOutcomeProducer {
     type Interface = TrackOutcome;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -787,7 +788,7 @@ impl Service for ClientReportOutcomeProducer {
                     else => break,
                 }
             }
-        });
+        })
     }
 }
 
@@ -1034,7 +1035,7 @@ impl OutcomeProducerService {
 impl Service for OutcomeProducerService {
     type Interface = OutcomeProducer;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         let Self { config, inner } = self;
 
         tokio::spawn(async move {
@@ -1045,7 +1046,7 @@ impl Service for OutcomeProducerService {
                 broker.handle_message(message, &config);
             }
             relay_log::info!("OutcomeProducer stopped.");
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/outcome_aggregator.rs
+++ b/relay-server/src/services/outcome_aggregator.rs
@@ -10,6 +10,7 @@ use relay_config::{Config, EmitOutcomes};
 use relay_quotas::{DataCategory, Scoping};
 use relay_statsd::metric;
 use relay_system::{Addr, Controller, Service, Shutdown};
+use tokio::task::JoinHandle;
 
 use crate::services::outcome::{Outcome, OutcomeProducer, TrackOutcome};
 use crate::statsd::RelayTimers;
@@ -138,7 +139,7 @@ impl OutcomeAggregator {
 impl Service for OutcomeAggregator {
     type Interface = TrackOutcome;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut shutdown = Controller::shutdown_handle();
             relay_log::info!("outcome aggregator started");
@@ -157,6 +158,6 @@ impl Service for OutcomeAggregator {
             }
 
             relay_log::info!("outcome aggregator stopped");
-        });
+        })
     }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2890,7 +2890,11 @@ impl EnvelopeProcessorService {
 impl Service for EnvelopeProcessorService {
     type Interface = EnvelopeProcessor;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    #[must_use]
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 let service = self.clone();
@@ -2899,7 +2903,7 @@ impl Service for EnvelopeProcessorService {
                     .spawn(move || service.handle_message(message))
                     .await;
             }
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -41,6 +41,7 @@ use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
 use reqwest::header;
 use smallvec::{smallvec, SmallVec};
+use tokio::task::JoinHandle;
 
 #[cfg(feature = "processing")]
 use {
@@ -2891,10 +2892,7 @@ impl Service for EnvelopeProcessorService {
     type Interface = EnvelopeProcessor;
 
     #[must_use]
-    fn spawn_handler(
-        self,
-        mut rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 let service = self.clone();

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -23,6 +23,7 @@ use relay_system::{Addr, FromMessage, Interface, Sender, Service};
 #[cfg(feature = "processing")]
 use tokio::sync::Semaphore;
 use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::services::metrics::{Aggregator, FlushBuckets};
@@ -1370,10 +1371,7 @@ impl ProjectCacheService {
 impl Service for ProjectCacheService {
     type Interface = ProjectCache;
 
-    fn spawn_handler(
-        self,
-        mut rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         let Self {
             config,
             memory_checker,

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -1370,7 +1370,10 @@ impl ProjectCacheService {
 impl Service for ProjectCacheService {
     type Interface = ProjectCache;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         let Self {
             config,
             memory_checker,
@@ -1506,7 +1509,7 @@ impl Service for ProjectCacheService {
             }
 
             relay_log::info!("project cache stopped");
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/project_local.rs
+++ b/relay-server/src/services/project_local.rs
@@ -7,6 +7,7 @@ use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_config::Config;
 use relay_system::{AsyncResponse, FromMessage, Interface, Receiver, Sender, Service};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::services::project::{ParsedProjectState, ProjectState};
@@ -164,7 +165,7 @@ async fn spawn_poll_local_states(
 impl Service for LocalProjectSourceService {
     type Interface = LocalProjectSource;
 
-    fn spawn_handler(mut self, mut rx: Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: Receiver<Self::Interface>) -> JoinHandle<()> {
         // Use a channel with size 1. If the channel is full because the consumer does not
         // collect the result, the producer will block, which is acceptable.
         let (state_tx, mut state_rx) = mpsc::channel(1);
@@ -185,7 +186,7 @@ impl Service for LocalProjectSourceService {
                 }
             }
             relay_log::info!("project local cache stopped");
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/project_upstream.rs
+++ b/relay-server/src/services/project_upstream.rs
@@ -16,6 +16,7 @@ use relay_system::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::services::project::state::UpstreamProjectState;
@@ -592,7 +593,7 @@ impl UpstreamProjectSourceService {
 impl Service for UpstreamProjectSourceService {
     type Interface = UpstreamProjectSource;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             relay_log::info!("project upstream cache started");
             loop {
@@ -607,6 +608,6 @@ impl Service for UpstreamProjectSourceService {
                 }
             }
             relay_log::info!("project upstream cache stopped");
-        });
+        })
     }
 }

--- a/relay-server/src/services/relays.rs
+++ b/relay-server/src/services/relays.rs
@@ -10,6 +10,7 @@ use relay_system::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::services::upstream::{Method, RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay};
 use crate::utils::{RetryBackoff, SleepHandle};
@@ -334,7 +335,7 @@ impl RelayCacheService {
 impl Service for RelayCacheService {
     type Interface = RelayCache;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             relay_log::info!("key cache started");
 
@@ -351,6 +352,6 @@ impl Service for RelayCacheService {
             }
 
             relay_log::info!("key cache stopped");
-        });
+        })
     }
 }

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -189,9 +189,9 @@ fn serve(listener: TcpListener, app: App, config: Arc<Config>) -> tokio::task::J
         .keep_alive_timeout(config.keepalive_timeout());
 
     let service = ServiceExt::<Request>::into_make_service_with_connect_info::<SocketAddr>(app);
-    let server_handle = tokio::spawn(server.serve(service));
+    let _server_handle = tokio::spawn(server.serve(service));
 
-    let shutdown_handle = tokio::spawn(async move {
+    tokio::spawn(async move {
         let Shutdown { timeout } = Controller::shutdown_handle().notified().await;
         relay_log::info!("Shutting down HTTP server");
 
@@ -199,9 +199,7 @@ fn serve(listener: TcpListener, app: App, config: Arc<Config>) -> tokio::task::J
             Some(timeout) => handle.graceful_shutdown(Some(timeout)),
             None => handle.shutdown(),
         }
-    });
-
-    server_handle // TODO: return both
+    }) // TODO: return both
 }
 
 /// HTTP server service.

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -13,6 +13,7 @@ use relay_config::Config;
 use relay_system::{Controller, Service, Shutdown};
 use socket2::TcpKeepalive;
 use tokio::net::{TcpSocket, TcpStream};
+use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
 use tower_http::compression::predicate::SizeAbove;
 use tower_http::compression::{CompressionLayer, DefaultPredicate, Predicate};
@@ -167,7 +168,7 @@ impl<S> Accept<TcpStream, S> for KeepAliveAcceptor {
     }
 }
 
-fn serve(listener: TcpListener, app: App, config: Arc<Config>) -> tokio::task::JoinHandle<()> {
+fn serve(listener: TcpListener, app: App, config: Arc<Config>) -> JoinHandle<()> {
     let handle = Handle::new();
 
     let mut server = axum_server::from_tcp(listener)
@@ -227,10 +228,7 @@ impl HttpServer {
 impl Service for HttpServer {
     type Interface = ();
 
-    fn spawn_handler(
-        self,
-        _rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         let Self {
             config,
             service,

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -1272,7 +1272,10 @@ impl BufferService {
 impl Service for BufferService {
     type Interface = Buffer;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        mut self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let mut shutdown = Controller::shutdown_handle();
 
@@ -1299,7 +1302,7 @@ impl Service for BufferService {
                     else => break,
                 }
             }
-        });
+        })
     }
 }
 
@@ -1591,7 +1594,10 @@ mod tests {
     impl Service for TestHealthService {
         type Interface = TestHealth;
 
-        fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+        fn spawn_handler(
+            self,
+            mut rx: relay_system::Receiver<Self::Interface>,
+        ) -> tokio::task::JoinHandle<()> {
             tokio::spawn(async move {
                 loop {
                     tokio::select! {
@@ -1599,7 +1605,7 @@ mod tests {
                         else => break,
                     }
                 }
-            });
+            })
         }
     }
 

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -50,6 +50,7 @@ use sqlx::sqlite::{
 use sqlx::{Pool, Row, Sqlite};
 use tokio::fs::DirBuilder;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::envelope::{Envelope, EnvelopeError};
 use crate::extractors::StartTime;
@@ -1272,10 +1273,7 @@ impl BufferService {
 impl Service for BufferService {
     type Interface = Buffer;
 
-    fn spawn_handler(
-        mut self,
-        mut rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut shutdown = Controller::shutdown_handle();
 
@@ -1331,6 +1329,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Mutex;
     use std::time::{Duration, Instant};
+    use tokio::task::JoinHandle;
     use uuid::Uuid;
 
     use crate::services::project_cache::SpoolHealth;
@@ -1594,10 +1593,7 @@ mod tests {
     impl Service for TestHealthService {
         type Interface = TestHealth;
 
-        fn spawn_handler(
-            self,
-            mut rx: relay_system::Receiver<Self::Interface>,
-        ) -> tokio::task::JoinHandle<()> {
+        fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
             tokio::spawn(async move {
                 loop {
                     tokio::select! {

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -5,6 +5,7 @@ use relay_config::{Config, RelayMode};
 use relay_redis::{RedisPool, RedisPools};
 use relay_statsd::metric;
 use relay_system::{Addr, Service};
+use tokio::task::JoinHandle;
 use tokio::time::interval;
 
 use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
@@ -136,10 +137,7 @@ impl RelayStats {
 impl Service for RelayStats {
     type Interface = ();
 
-    fn spawn_handler(
-        self,
-        _rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         let Some(mut ticker) = self.config.metrics_periodic_interval().map(interval) else {
             return tokio::spawn(async {});
         };

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -136,9 +136,12 @@ impl RelayStats {
 impl Service for RelayStats {
     type Interface = ();
 
-    fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        self,
+        _rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         let Some(mut ticker) = self.config.metrics_periodic_interval().map(interval) else {
-            return;
+            return tokio::spawn(async {});
         };
 
         tokio::spawn(async move {
@@ -150,6 +153,6 @@ impl Service for RelayStats {
                 );
                 ticker.tick().await;
             }
-        });
+        })
     }
 }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1044,7 +1044,10 @@ impl StoreService {
 impl Service for StoreService {
     type Interface = Store;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         let this = Arc::new(self);
 
         tokio::spawn(async move {
@@ -1058,7 +1061,7 @@ impl Service for StoreService {
             }
 
             relay_log::info!("store forwarder stopped");
-        });
+        })
     }
 }
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Instant;
+use tokio::task::JoinHandle;
 
 use bytes::Bytes;
 use relay_base_schema::data_category::DataCategory;
@@ -1044,10 +1045,7 @@ impl StoreService {
 impl Service for StoreService {
     type Interface = Store;
 
-    fn spawn_handler(
-        self,
-        mut rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         let this = Arc::new(self);
 
         tokio::spawn(async move {

--- a/relay-server/src/services/test_store.rs
+++ b/relay-server/src/services/test_store.rs
@@ -134,11 +134,14 @@ impl TestStoreService {
 impl relay_system::Service for TestStoreService {
     type Interface = TestStore;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        mut self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 self.handle_message(message);
             }
-        });
+        })
     }
 }

--- a/relay-server/src/services/test_store.rs
+++ b/relay-server/src/services/test_store.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use relay_config::{Config, RelayMode};
 use relay_event_schema::protocol::EventId;
 use relay_system::{AsyncResponse, FromMessage, NoResponse, Sender};
+use tokio::task::JoinHandle;
 
 use crate::envelope::Envelope;
 use crate::services::outcome::Outcome;
@@ -134,10 +135,7 @@ impl TestStoreService {
 impl relay_system::Service for TestStoreService {
     type Interface = TestStore;
 
-    fn spawn_handler(
-        mut self,
-        mut rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 self.handle_message(message);

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -28,6 +28,7 @@ pub use reqwest::Method;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::http::{HttpError, Request, RequestBuilder, Response, StatusCode};
@@ -1255,7 +1256,7 @@ enum ConnectionState {
     /// The connection is interrupted and reconnection is in progress.
     ///
     /// If the task has finished, connection should be considered `Connected`.
-    Reconnecting(tokio::task::JoinHandle<()>),
+    Reconnecting(JoinHandle<()>),
 }
 
 /// Maintains outage state of the connection to the upstream.
@@ -1498,10 +1499,7 @@ impl UpstreamRelayService {
 impl Service for UpstreamRelayService {
     type Interface = UpstreamRelay;
 
-    fn spawn_handler(
-        self,
-        mut rx: relay_system::Receiver<Self::Interface>,
-    ) -> tokio::task::JoinHandle<()> {
+    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> JoinHandle<()> {
         let Self { config } = self;
 
         let client = SharedClient::build(config.clone());

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -1498,7 +1498,10 @@ impl UpstreamRelayService {
 impl Service for UpstreamRelayService {
     type Interface = UpstreamRelay;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+    ) -> tokio::task::JoinHandle<()> {
         let Self { config } = self;
 
         let client = SharedClient::build(config.clone());
@@ -1540,6 +1543,6 @@ impl Service for UpstreamRelayService {
                     else => break,
                 }
             }
-        });
+        }) // TODO: return both
     }
 }

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -129,7 +129,7 @@ impl ShutdownHandle {
 /// impl Service for MyService {
 ///     type Interface = ();
 ///
-///     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+///     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) -> tokio::task::JoinHandle<()> {
 ///         tokio::spawn(async move {
 ///             let mut shutdown = Controller::shutdown_handle();
 ///


### PR DESCRIPTION
Make the tasks spawned by services joinable, and abort the entire process if one of the join handles returns a panic.

This is a partial implementation that requires follow-up. Only `EnvelopeBuffer` and `EnvelopeProcessor` are actively monitored for panics for now.

ref: https://getsentry.atlassian.net/browse/INC-875