### PR TITLE
feat(buffer): Disable back pressure

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -515,36 +515,4 @@ mod tests {
         // Nothing was dequeued, memory not ready:
         assert_eq!(project_cache_rx.len(), 0);
     }
-
-    // #[tokio::test]
-    // async fn output_is_throttled() {
-    //     tokio::time::pause();
-    //     let (service, global_tx, mut project_cache_rx) = buffer_service();
-    //     global_tx.send_replace(global_config::Status::Ready(Arc::new(
-    //         GlobalConfig::default(),
-    //     )));
-
-    //     let addr = service.start();
-
-    //     // Send five messages:
-    //     let envelope = new_envelope(false, "foo");
-    //     let project_key = envelope.meta().public_key();
-    //     for _ in 0..5 {
-    //         addr.send(EnvelopeBuffer::Push(envelope.clone()));
-    //     }
-    //     addr.send(EnvelopeBuffer::Ready(project_key));
-
-    //     tokio::time::sleep(Duration::from_millis(100)).await;
-
-    //     let mut messages = vec![];
-    //     project_cache_rx.recv_many(&mut messages, 100).await;
-
-    //     assert_eq!(
-    //         messages
-    //             .iter()
-    //             .filter(|message| matches!(message, ProjectCache::HandleDequeuedEnvelope(..)))
-    //             .count(),
-    //         1
-    //     );
-    // }
 }


### PR DESCRIPTION
In the experimental new buffer implementation, do not wait for project cache to push an unspooled message to it.

This risks flooding the service queue, but we have a second back pressure in place that stops dequeueing envelopes when the memory threshold has been reached.

#skip-changelog