### PR TITLE
feat(spooler): Implement backpressure mechanism based on atomics

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -175,7 +175,7 @@ impl EnvelopeBufferService {
         // In case the project cache is not ready, we defer popping to first try and handle incoming
         // messages and only come back to this in case within the timeout no data was received.
         while !self.project_cache_ready.load(Ordering::Relaxed) {
-            tokio::time::sleep(Duration::from_nanos(1)).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         relay_statsd::metric!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -175,7 +175,7 @@ impl EnvelopeBufferService {
         // In case the project cache is not ready, we defer popping to first try and handle incoming
         // messages and only come back to this in case within the timeout no data was received.
         while !self.project_cache_ready.load(Ordering::Relaxed) {
-            tokio::time::sleep(Duration::ZERO).await;
+            tokio::task::yield_now().await;
         }
 
         relay_statsd::metric!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -175,7 +175,7 @@ impl EnvelopeBufferService {
         // In case the project cache is not ready, we defer popping to first try and handle incoming
         // messages and only come back to this in case within the timeout no data was received.
         while !self.project_cache_ready.load(Ordering::Relaxed) {
-            tokio::time::sleep(Duration::ZERO).await;
+            tokio::time::sleep(Duration::from_nanos(1)).await;
         }
 
         relay_statsd::metric!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -173,9 +173,10 @@ impl EnvelopeBufferService {
             tokio::time::sleep(self.sleep).await;
         }
 
-        // In case the project cache is not ready, we don't want to attempt popping.
+        // In case the project cache is not ready, we defer popping to first try and handle incoming
+        // messages and only come back to this in case within the timeout no data was received.
         if !self.project_cache_ready.load(Ordering::Relaxed) {
-            return future::pending().await;
+            tokio::time::sleep(DEFAULT_SLEEP).await;
         }
 
         relay_statsd::metric!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -1,7 +1,6 @@
 //! Types for buffering envelopes.
 
 use std::error::Error;
-use std::future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -175,8 +174,8 @@ impl EnvelopeBufferService {
 
         // In case the project cache is not ready, we defer popping to first try and handle incoming
         // messages and only come back to this in case within the timeout no data was received.
-        if !self.project_cache_ready.load(Ordering::Relaxed) {
-            tokio::time::sleep(DEFAULT_SLEEP).await;
+        while !self.project_cache_ready.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::ZERO).await;
         }
 
         relay_statsd::metric!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -175,7 +175,7 @@ impl EnvelopeBufferService {
         // In case the project cache is not ready, we defer popping to first try and handle incoming
         // messages and only come back to this in case within the timeout no data was received.
         while !self.project_cache_ready.load(Ordering::Relaxed) {
-            tokio::time::sleep(DEFAULT_SLEEP).await;
+            tokio::time::sleep(Duration::ZERO).await;
         }
 
         relay_statsd::metric!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -175,7 +175,7 @@ impl EnvelopeBufferService {
         // In case the project cache is not ready, we defer popping to first try and handle incoming
         // messages and only come back to this in case within the timeout no data was received.
         while !self.project_cache_ready.load(Ordering::Relaxed) {
-            tokio::task::yield_now().await;
+            tokio::time::sleep(DEFAULT_SLEEP).await;
         }
 
         relay_statsd::metric!(


### PR DESCRIPTION
This PR adds a new, simpler backpressure mechanism that relies on a shared `AtomicBool` flag. The rationale behind this implementation is that we observed `tokio` `oneshot` channels can experience spurious failures, causing the `Receiver` to return `Poll::Pending`, which skews the buffer towards more writes instead of reads, resulting in disk spooling and a consequent system slowdown. With `AtomicBool`, we aim to achieve better performance since the flag update should be relatively fast.

#skip-changelog