### PR TITLE
ci: update actions/upload-artifact to v4 with merge

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,8 +2,6 @@ name: Binary Release Build
 
 on:
   push:
-    branches:
-      - release/**
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -34,10 +34,13 @@ jobs:
           zip relay-Linux-x86_64-debug.zip relay.debug
           mv relay relay-Linux-x86_64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-linux
           path: target/release/relay-Linux-x86_64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   macos:
     name: macOS
@@ -62,10 +65,13 @@ jobs:
           mv relay relay-Darwin-x86_64
           zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-macos
           path: target/release/relay-Darwin-x86_64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   windows:
     name: Windows
@@ -89,7 +95,22 @@ jobs:
           7z a relay-Windows-x86_64-pdb.zip relay.pdb
           mv relay.exe relay-Windows-x86_64.exe
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-windows
           path: target/release/relay-Windows-x86_64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [linux, macos, windows]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          # Craft expects release assets to be a single artifact named after the sha.
+          name: ${{ github.sha }}
+          pattern: artifact-*
+          delete-merged: true

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,8 +2,6 @@ name: Binary Release Build
 
 on:
   push:
-    branches:
-      - release/**
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,7 +38,6 @@ jobs:
           path: target/release/relay-Linux-x86_64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
 
   macos:
     name: macOS
@@ -71,7 +68,6 @@ jobs:
           path: target/release/relay-Darwin-x86_64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
 
   windows:
     name: Windows
@@ -101,7 +97,6 @@ jobs:
           path: target/release/relay-Windows-x86_64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
 
   merge:
     name: Create Release Artifact

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,6 +2,8 @@ name: Binary Release Build
 
 on:
   push:
+    branches:
+      - release/**
 
 env:
   CARGO_TERM_COLOR: always
@@ -102,11 +104,15 @@ jobs:
           compression-level: '0'
 
   merge:
+    name: Create Release Artifact
     runs-on: ubuntu-latest
     needs: [linux, macos, windows]
     steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+      # Note: due to the immutability of artifacts in upload-artifact v4,
+      # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.
+      # However in this case it is fine because this only runs on release/** branches,
+      # and the other runs on release-library/** branches.
+      - uses: actions/upload-artifact/merge@v4
         with:
           # Craft expects release assets to be a single artifact named after the sha.
           name: ${{ github.sha }}

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,6 +2,8 @@ name: Binary Release Build
 
 on:
   push:
+    branches:
+      - release/**
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,6 +40,7 @@ jobs:
           path: target/release/relay-Linux-x86_64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   macos:
     name: macOS
@@ -68,6 +71,7 @@ jobs:
           path: target/release/relay-Darwin-x86_64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   windows:
     name: Windows
@@ -97,6 +101,7 @@ jobs:
           path: target/release/relay-Windows-x86_64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   merge:
     name: Create Release Artifact

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -37,10 +37,13 @@ jobs:
         env:
           TARGET: ${{ matrix.build-arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-linux
           path: py/dist/*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   macos:
     strategy:
@@ -80,10 +83,13 @@ jobs:
           # consumed by cargo and setup.py to obtain the target dir
           CARGO_BUILD_TARGET: ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-macos
           path: py/dist/*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   sdist:
     name: Python sdist
@@ -102,7 +108,22 @@ jobs:
         run: python setup.py sdist --format=zip
         working-directory: py
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-sdist
           path: py/dist/*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [linux, macos, sdist]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          # Craft expects release assets to be a single artifact named after the sha.
+          name: ${{ github.sha }}
+          pattern: artifact-*
+          delete-merged: true

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -117,11 +117,15 @@ jobs:
           compression-level: '0'
 
   merge:
+    name: Create Release Artifact
     runs-on: ubuntu-latest
     needs: [linux, macos, sdist]
     steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+      # Note: due to the immutability of artifacts in upload-artifact v4,
+      # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.
+      # However in this case it is fine because this only runs on release-library/** branches,
+      # and the other runs on release/** branches.
+      - uses: actions/upload-artifact/merge@v4
         with:
           # Craft expects release assets to be a single artifact named after the sha.
           name: ${{ github.sha }}


### PR DESCRIPTION
Supersedes https://github.com/getsentry/relay/pull/3876 by using artifacts/merge to merge together multiple artifacts from different jobs into the single one named github.sha that craft expects.

Summarily, upload-artifact v3 is deprecated but v4 doesn't support mutating an artifact with the name name by uploading different filepaths to the same artifact. Because we need a single artifact "github.sha", we have to use actions/merge to create it. Alternatively craft could be modified but this is the easiest way forward and I like the idea of a unified artifact, it makes craft simpler.

ref: https://github.com/getsentry/craft/issues/552

#skip-changelog