### PR TITLE
ref(redis): Changes redis fork to improved PR for timeout issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,8 +3127,8 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.3"
-source = "git+https://github.com/getsentry/redis-rs.git?rev=939e5df6f9cc976b0a53987f6eb3f76b2c398bd6#939e5df6f9cc976b0a53987f6eb3f76b2c398bd6"
+version = "0.27.2"
+source = "git+https://github.com/getsentry/redis-rs.git?rev=fc7d98cc10c16fa7c0c31de64dc1b713354a4384#fc7d98cc10c16fa7c0c31de64dc1b713354a4384"
 dependencies = [
  "arc-swap",
  "combine",
@@ -3142,7 +3142,6 @@ dependencies = [
  "ryu",
  "sha1_smol",
  "socket2",
- "tokio",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,8 @@ rand_pcg = "0.3.1"
 rayon = "1.10"
 rdkafka = "0.36.2"
 rdkafka-sys = "4.3.0"
-# Git revision until https://github.com/redis-rs/redis-rs/pull/1097 (merged) and https://github.com/redis-rs/redis-rs/pull/1253 are released.
-redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "939e5df6f9cc976b0a53987f6eb3f76b2c398bd6", default-features = false }
+# Git revision until https://github.com/redis-rs/redis-rs/pull/1097 (merged) and https://github.com/redis-rs/redis-rs/pull/1290 are released.
+redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "fc7d98cc10c16fa7c0c31de64dc1b713354a4384", default-features = false }
 regex = "1.10.2"
 regex-lite = "0.1.6"
 reqwest = "0.12.7"

--- a/relay-cardinality/benches/redis_impl.rs
+++ b/relay-cardinality/benches/redis_impl.rs
@@ -27,7 +27,7 @@ fn build_limiter(redis: RedisPool, reset_redis: bool) -> RedisSetLimiter {
     let mut connection = client.connection().unwrap();
 
     if reset_redis {
-        redis::cmd("FLUSHALL").execute(&mut connection);
+        redis::cmd("FLUSHALL").exec(&mut connection).unwrap();
     }
 
     RedisSetLimiter::new(

--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -278,7 +278,10 @@ mod tests {
         let script = CardinalityScript::load();
         let keys = keys(Uuid::new_v4(), &["a", "b", "c"]);
 
-        redis::cmd("SCRIPT").arg("FLUSH").execute(&mut connection);
+        redis::cmd("SCRIPT")
+            .arg("FLUSH")
+            .exec(&mut connection)
+            .unwrap();
         script
             .invoke_one(&mut connection, 50, 3600, 0..30, keys)
             .unwrap();


### PR DESCRIPTION
Changes the Redis fork commit to an updated PR which tracks connection state instead of hard retting the timed out connection, see https://github.com/redis-rs/redis-rs/pull/1290.

This implicitly also bumps the Redis client version to 0.27.

The PR branch was pushed to the `getsentry/redis-rs` fork.

Related: https://github.com/getsentry/team-ingest/issues/368

#skip-changelog