### PR TITLE
feat(spooler): Implement backpressure in spooler via bounded queues

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -960,7 +960,7 @@ pub struct EnvelopeSpool {
     /// internal page stats.
     #[serde(default = "spool_disk_usage_refresh_frequency_ms")]
     disk_usage_refresh_frequency_ms: u64,
-    /// The amount of envelopes that can be put in the bounded buffer.
+    /// The amount of envelopes that the envelope buffer can push to its output queue.
     #[serde(default = "spool_max_backpressure_envelopes")]
     max_backpressure_envelopes: usize,
     /// Version of the spooler.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -912,6 +912,11 @@ fn spool_disk_usage_refresh_frequency_ms() -> u64 {
     100
 }
 
+/// Default bounded buffer size for handling backpressure.
+fn spool_max_backpressure_envelopes() -> usize {
+    500
+}
+
 /// Persistent buffering configuration for incoming envelopes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvelopeSpool {
@@ -955,6 +960,9 @@ pub struct EnvelopeSpool {
     /// internal page stats.
     #[serde(default = "spool_disk_usage_refresh_frequency_ms")]
     disk_usage_refresh_frequency_ms: u64,
+    /// The amount of envelopes that can be put in the bounded buffer.
+    #[serde(default = "spool_max_backpressure_envelopes")]
+    max_backpressure_envelopes: usize,
     /// Version of the spooler.
     #[serde(default)]
     version: EnvelopeSpoolVersion,
@@ -991,6 +999,7 @@ impl Default for EnvelopeSpool {
             max_batches: spool_envelopes_stack_max_batches(),
             max_envelope_delay_secs: spool_envelopes_max_envelope_delay_secs(),
             disk_usage_refresh_frequency_ms: spool_disk_usage_refresh_frequency_ms(),
+            max_backpressure_envelopes: spool_max_backpressure_envelopes(),
             version: EnvelopeSpoolVersion::default(),
         }
     }
@@ -2210,6 +2219,11 @@ impl Config {
     /// Returns the refresh frequency for disk usage monitoring as a [`Duration`] object.
     pub fn spool_disk_usage_refresh_frequency_ms(&self) -> Duration {
         Duration::from_millis(self.values.spool.envelopes.disk_usage_refresh_frequency_ms)
+    }
+
+    /// Returns the maximum number of envelopes that can be put in the bounded buffer.
+    pub fn spool_max_backpressure_envelopes(&self) -> usize {
+        self.values.spool.envelopes.max_backpressure_envelopes
     }
 
     /// Returns the maximum size of an event payload in bytes.

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -242,7 +242,7 @@ impl ServiceState {
         )
         .spawn_handler(processor_rx);
 
-        let (envelopes_tx, envelopes_rx) = mpsc::channel(500);
+        let (envelopes_tx, envelopes_rx) = mpsc::channel(config.spool_max_backpressure_envelopes());
         let envelope_buffer = EnvelopeBufferService::new(
             config.clone(),
             MemoryChecker::new(memory_stat.clone(), config.clone()),

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -3,6 +3,17 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::{Context, Result};
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use rayon::ThreadPool;
+use relay_cogs::Cogs;
+use relay_config::{Config, RedisConnection, RedisPoolConfigs};
+use relay_redis::{RedisConfigOptions, RedisError, RedisPool, RedisPools};
+use relay_system::{channel, Addr, Service};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+
 use crate::metrics::{MetricOutcomes, MetricStats};
 use crate::services::buffer::{self, EnvelopeBufferService, ObservableEnvelopeBuffer};
 use crate::services::cogs::{CogsService, CogsServiceRecorder};
@@ -20,16 +31,6 @@ use crate::services::store::StoreService;
 use crate::services::test_store::{TestStore, TestStoreService};
 use crate::services::upstream::{UpstreamRelay, UpstreamRelayService};
 use crate::utils::{MemoryChecker, MemoryStat};
-use anyhow::{Context, Result};
-use axum::extract::FromRequestParts;
-use axum::http::request::Parts;
-use rayon::ThreadPool;
-use relay_cogs::Cogs;
-use relay_config::{Config, RedisConnection, RedisPoolConfigs};
-use relay_redis::{RedisConfigOptions, RedisError, RedisPool, RedisPools};
-use relay_system::{channel, Addr, Service};
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
 
 /// Indicates the type of failure of the server.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, thiserror::Error)]

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -242,13 +242,14 @@ impl ServiceState {
         )
         .spawn_handler(processor_rx);
 
-        let (project_cache_bounded_tx, project_cache_bounded_rx) = mpsc::channel(500);
+        let (envelopes_tx, envelopes_rx) = mpsc::channel(500);
         let envelope_buffer = EnvelopeBufferService::new(
             config.clone(),
             MemoryChecker::new(memory_stat.clone(), config.clone()),
             global_config_rx.clone(),
             buffer::Services {
-                project_cache: project_cache_bounded_tx,
+                envelopes_tx,
+                project_cache: project_cache.clone(),
                 outcome_aggregator: outcome_aggregator.clone(),
                 test_store: test_store.clone(),
             },
@@ -271,7 +272,7 @@ impl ServiceState {
             MemoryChecker::new(memory_stat.clone(), config.clone()),
             project_cache_services,
             global_config_rx,
-            project_cache_bounded_rx,
+            envelopes_rx,
             redis_pools
                 .as_ref()
                 .map(|pools| pools.project_configs.clone()),

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -705,4 +705,36 @@ mod tests {
             Some(ProjectCache::UpdateProject(key)) if key == project_key
         ))
     }
+
+    #[tokio::test]
+    async fn output_is_throttled() {
+        tokio::time::pause();
+        let (service, global_tx, mut envelopes_rx, _project_cache_rx, _) = buffer_service();
+        global_tx.send_replace(global_config::Status::Ready(Arc::new(
+            GlobalConfig::default(),
+        )));
+
+        let addr = service.start();
+
+        // Send 10 messages, with a bounded queue size of 5.
+        let envelope = new_envelope(false, "foo");
+        let project_key = envelope.meta().public_key();
+        for _ in 0..10 {
+            addr.send(EnvelopeBuffer::Push(envelope.clone()));
+        }
+        addr.send(EnvelopeBuffer::Ready(project_key));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut messages = vec![];
+        envelopes_rx.recv_many(&mut messages, 100).await;
+
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| matches!(message, DequeuedEnvelope(..)))
+                .count(),
+            5
+        );
+    }
 }

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -164,13 +164,18 @@ impl EnvelopeBufferService {
             tokio::time::sleep(self.sleep).await;
         }
 
+        relay_statsd::metric!(
+            counter(RelayCounters::BufferReadyToPop) += 1,
+            status = "slept"
+        );
+
         while self.services.project_cache.capacity() == 0 {
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
 
         relay_statsd::metric!(
             counter(RelayCounters::BufferReadyToPop) += 1,
-            status = "acquired"
+            status = "checked"
         );
 
         Ok(())

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -180,7 +180,7 @@ impl EnvelopeBufferService {
         let used_capacity =
             self.services.envelopes_tx.max_capacity() - self.services.envelopes_tx.capacity();
         relay_statsd::metric!(
-            histogram(RelayHistograms::BufferBackpressureEnvelopesCount) = used_capacity
+            histogram(RelayHistograms::BufferBackpressureEnvelopesCount) = used_capacity as u64
         );
 
         let permit = self.services.envelopes_tx.reserve().await.ok();

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -487,7 +487,7 @@ mod tests {
                 memory_checker,
                 global_rx,
                 Services {
-                    project_cache: project_cache,
+                    project_cache,
                     outcome_aggregator,
                     test_store: Addr::dummy(),
                 },
@@ -525,7 +525,7 @@ mod tests {
     async fn pop_requires_global_config() {
         relay_log::init_test!();
         tokio::time::pause();
-        let (service, global_tx, mut project_cache_rx, _) = buffer_service();
+        let (service, global_tx, project_cache_rx, _) = buffer_service();
 
         let addr = service.start();
 
@@ -579,7 +579,7 @@ mod tests {
             memory_checker,
             global_rx,
             Services {
-                project_cache: project_cache,
+                project_cache,
                 outcome_aggregator: Addr::dummy(),
                 test_store: Addr::dummy(),
             },
@@ -623,7 +623,7 @@ mod tests {
             memory_checker,
             global_rx,
             Services {
-                project_cache: project_cache,
+                project_cache,
                 outcome_aggregator,
                 test_store: Addr::dummy(),
             },

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -236,6 +236,8 @@ impl EnvelopeBufferService {
                     .expect("Element disappeared despite exclusive excess");
 
                 Self::drop_expired(envelope, services);
+
+                sleep = Duration::ZERO; // try next pop immediately
             }
             Peek::Ready(_) => {
                 relay_log::trace!("EnvelopeBufferService: popping envelope");

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -1326,6 +1326,7 @@ pub struct ProjectCacheService {
     memory_checker: MemoryChecker,
     services: Services,
     global_config_rx: watch::Receiver<global_config::Status>,
+    /// Bounded channel used exclusively to receive envelopes from the envelope buffer.
     envelopes_rx: mpsc::Receiver<DequeuedEnvelope>,
     redis: Option<RedisPool>,
 }

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -255,6 +255,7 @@ pub struct SpoolHealth;
 pub struct RefreshIndexCache(pub HashSet<QueueKey>);
 
 /// Handle an envelope that was popped from the envelope buffer.
+#[derive(Debug)]
 pub struct DequeuedEnvelope(pub Box<Envelope>);
 
 /// A request to update a project, typically sent by the envelope buffer.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -178,6 +178,9 @@ pub enum RelayHistograms {
     /// This metric is tagged with:
     /// - `storage_type`: The type of storage used in the envelope buffer.
     BufferEnvelopesCount,
+    /// Number of envelopes in the backpressure buffer between the envelope buffer
+    /// and the project cache.
+    BufferBackpressureEnvelopesCount,
     /// The number of batches emitted per partition.
     BatchesPerPartition,
     /// The number of buckets in a batch emitted.
@@ -303,6 +306,9 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::BufferDiskSize => "buffer.disk_size",
             RelayHistograms::BufferDequeueAttempts => "buffer.dequeue_attempts",
             RelayHistograms::BufferEnvelopesCount => "buffer.envelopes_count",
+            RelayHistograms::BufferBackpressureEnvelopesCount => {
+                "buffer.backpressure_envelopes_count"
+            }
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",


### PR DESCRIPTION
This PR implements a backpressure mechanism in the spooler which uses a bounded buffer of size `x`. The bounded buffer is used exclusively for sending envelopes to the project cache.

Closes: https://github.com/getsentry/team-ingest/issues/541

#skip-changelog