### PR TITLE
feat(spans): Infer span.op if not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add a config option to add default tags to all Relay Sentry events. ([#3944](https://github.com/getsentry/relay/pull/3944))
 - Automatically derive `client.address` and `user.geo` for standalone spans. ([#4047](https://github.com/getsentry/relay/pull/4047))
+- Configurable span.op inference. ([#4056](https://github.com/getsentry/relay/pull/4056))
 
 ## 24.9.0
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `spanOpDefaults` to global config. ([#4056](https://github.com/getsentry/relay/pull/4056))
+
 ## 0.9.1
 
 - Add REPLAY_VIDEO entry to DataCategory. ([#3847](https://github.com/getsentry/relay/pull/3847))

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -275,6 +275,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         replay_id: config.replay_id,
         span_allowed_hosts: &[], // only supported in relay
         scrub_mongo_description: ScrubMongoDescription::Disabled, // only supported in relay
+        span_op_defaults: Default::default(), // only supported in relay
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -5,7 +5,7 @@ use std::io::BufReader;
 use std::path::Path;
 
 use relay_base_schema::metrics::MetricNamespace;
-use relay_event_normalization::{MeasurementsConfig, ModelCosts};
+use relay_event_normalization::{MeasurementsConfig, ModelCosts, SpanOpDefaults};
 use relay_filter::GenericFiltersConfig;
 use relay_quotas::Quota;
 use serde::{de, Deserialize, Serialize};
@@ -49,6 +49,13 @@ pub struct GlobalConfig {
     /// Configuration for AI span measurements.
     #[serde(skip_serializing_if = "is_missing")]
     pub ai_model_costs: ErrorBoundary<ModelCosts>,
+
+    /// Configuration to derive the `span.op` from other span fields.
+    #[serde(
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub span_op_defaults: SpanOpDefaults,
 }
 
 impl GlobalConfig {
@@ -337,7 +344,7 @@ pub enum BucketEncoding {
 
 /// Returns `true` if this value is equal to `Default::default()`.
 fn is_default<T: Default + PartialEq>(t: &T) -> bool {
-    *t == T::default()
+    t == &T::default()
 }
 
 fn default_on_error<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -249,8 +249,8 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     // TODO: Parts of this processor should probably be a filter so we
     // can revert some changes to ProcessingAction)
     let mut transactions_processor = transactions::TransactionsProcessor::new(
-        config.transaction_name_config.clone(),
-        config.span_op_defaults.clone(),
+        config.transaction_name_config,
+        config.span_op_defaults,
     );
     let _ = transactions_processor.process_event(event, meta, ProcessingState::root());
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -34,9 +34,9 @@ use crate::span::tag_extraction::extract_span_tags_from_event;
 use crate::utils::{self, get_event_user_tag, MAX_DURATION_MOBILE_MS};
 use crate::{
     breakdowns, event_error, legacy, mechanism, remove_other, schema, span, stacktrace,
-    transactions, trimming, user_agent, BreakdownsConfig, CombinedMeasurementsConfig, GeoIpLookup,
-    MaxChars, ModelCosts, PerformanceScoreConfig, RawUserAgentInfo, SpanDescriptionRule,
-    TransactionNameConfig,
+    transactions, trimming, user_agent, BorrowedSpanOpDefaults, BreakdownsConfig,
+    CombinedMeasurementsConfig, GeoIpLookup, MaxChars, ModelCosts, PerformanceScoreConfig,
+    RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig,
 };
 
 /// Configuration for [`normalize_event`].
@@ -161,6 +161,9 @@ pub struct NormalizationConfig<'a> {
 
     /// Controls whether or not MongoDB span descriptions will be scrubbed.
     pub scrub_mongo_description: ScrubMongoDescription,
+
+    /// Rules to infer `span.op` from other span fields.
+    pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
 }
 
 impl<'a> Default for NormalizationConfig<'a> {
@@ -194,6 +197,7 @@ impl<'a> Default for NormalizationConfig<'a> {
             replay_id: Default::default(),
             span_allowed_hosts: Default::default(),
             scrub_mongo_description: ScrubMongoDescription::Disabled,
+            span_op_defaults: Default::default(),
         }
     }
 }
@@ -244,8 +248,10 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     // (internally noops for non-transaction events).
     // TODO: Parts of this processor should probably be a filter so we
     // can revert some changes to ProcessingAction)
-    let mut transactions_processor =
-        transactions::TransactionsProcessor::new(config.transaction_name_config.clone());
+    let mut transactions_processor = transactions::TransactionsProcessor::new(
+        config.transaction_name_config.clone(),
+        config.span_op_defaults.clone(),
+    );
     let _ = transactions_processor.process_event(event, meta, ProcessingState::root());
 
     // Process security reports first to ensure all props.

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -14,7 +14,7 @@ use crate::regexes::TRANSACTION_NAME_NORMALIZER_REGEX;
 use crate::TransactionNameRule;
 
 /// Configuration for sanitizing unparameterized transaction names.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TransactionNameConfig<'r> {
     /// Rules for identifier replacement that were discovered by Sentry's transaction clusterer.
     pub rules: &'r [TransactionNameRule],
@@ -191,7 +191,8 @@ impl Processor for TransactionsProcessor<'_> {
 /// Rules used to infer `span.op` from other span fields.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct SpanOpDefaults {
-    rules: Vec<SpanOpDefaultRule>,
+    /// List of rules to apply. First match wins.
+    pub rules: Vec<SpanOpDefaultRule>,
 }
 
 impl SpanOpDefaults {
@@ -204,7 +205,7 @@ impl SpanOpDefaults {
 }
 
 /// Borrowed version of [`SpanOpDefaults`].
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct BorrowedSpanOpDefaults<'a> {
     rules: &'a [SpanOpDefaultRule],
 }
@@ -224,10 +225,13 @@ impl BorrowedSpanOpDefaults<'_> {
     }
 }
 
+/// A rule to infer [`Span::op`] from other span fields.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-struct SpanOpDefaultRule {
-    condition: RuleCondition,
-    value: String,
+pub struct SpanOpDefaultRule {
+    /// When to set the given value.
+    pub condition: RuleCondition,
+    /// Value for the [`Span::op`]. Only set if omitted by the SDK.
+    pub value: String,
 }
 
 /// Span status codes for the Ruby Rack integration that indicate raw URLs being sent as

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1610,6 +1610,7 @@ impl EnvelopeProcessorService {
                 } else {
                     ScrubMongoDescription::Disabled
                 },
+                span_op_defaults: global_config.span_op_defaults.borrow(),
             };
 
             metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -16,8 +16,9 @@ use relay_event_normalization::{
     TransactionsProcessor,
 };
 use relay_event_normalization::{
-    normalize_transaction_name, ClientHints, FromUserAgentInfo, GeoIpLookup, ModelCosts,
-    SchemaProcessor, TimestampProcessor, TransactionNameRule, TrimmingProcessor,
+    normalize_transaction_name, BorrowedSpanOpDefaults, ClientHints, FromUserAgentInfo,
+    GeoIpLookup, ModelCosts, SchemaProcessor, TimestampProcessor, TransactionNameRule,
+    TrimmingProcessor,
 };
 use relay_event_schema::processor::{process_value, ProcessingState};
 use relay_event_schema::protocol::{BrowserContext, IpAddr, Span, SpanData};
@@ -370,6 +371,7 @@ struct NormalizeSpanConfig<'a> {
     client_ip: Option<IpAddr>,
     /// An initialized GeoIP lookup.
     geo_lookup: Option<&'a GeoIpLookup>,
+    span_op_defaults: BorrowedSpanOpDefaults<'a>,
 }
 
 impl<'a> NormalizeSpanConfig<'a> {
@@ -419,6 +421,7 @@ impl<'a> NormalizeSpanConfig<'a> {
             },
             client_ip,
             geo_lookup,
+            span_op_defaults: global_config.span_op_defaults.borrow(),
         }
     }
 }
@@ -474,6 +477,7 @@ fn normalize(
         scrub_mongo_description,
         client_ip,
         geo_lookup,
+        span_op_defaults,
     } = config;
 
     set_segment_attributes(annotated_span);
@@ -497,7 +501,7 @@ fn normalize(
     }
     process_value(
         annotated_span,
-        &mut TransactionsProcessor::new(Default::default()),
+        &mut TransactionsProcessor::new(Default::default(), span_op_defaults),
         ProcessingState::root(),
     )?;
 
@@ -1098,6 +1102,7 @@ mod tests {
             scrub_mongo_description: ScrubMongoDescription::Disabled,
             client_ip: Some(IpAddr("2.125.160.216".to_owned())),
             geo_lookup: Some(&GEO_LOOKUP),
+            span_op_defaults: Default::default(),
         }
     }
 


### PR DESCRIPTION
Add global option that allows inferring the span op, with rules like this:

```json
{
    "span_op_defaults": {
       "rules": [{
            "condition": {
                "op": "not",
                "inner": {
                    "op": "eq",
                    "name": "span.data.messaging\\.system",
                    "value": null,
                },
            },
            "value": "message"
        }]
    }
}
```


ref: https://github.com/getsentry/relay/issues/3637