### PR TITLE
fix(profiles): Use the duration reported by the profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
+- Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
 
 **Features:**
 

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -153,7 +153,7 @@ impl AndroidProfilingEvent {
     }
 
     fn has_transaction_metadata(&self) -> bool {
-        !self.metadata.transaction_name.is_empty() && self.metadata.duration_ns > 0
+        !self.metadata.transaction_name.is_empty()
     }
 }
 
@@ -170,7 +170,6 @@ fn parse_profile(payload: &[u8]) -> Result<AndroidProfilingEvent, ProfileError> 
 
         // this is for compatibility
         profile.metadata.active_thread_id = transaction.active_thread_id;
-        profile.metadata.duration_ns = transaction.duration_ns();
         profile.metadata.trace_id = transaction.trace_id;
         profile.metadata.transaction_id = transaction.id;
         profile
@@ -206,6 +205,9 @@ fn parse_profile(payload: &[u8]) -> Result<AndroidProfilingEvent, ProfileError> 
     if profile.profile.elapsed_time > MAX_PROFILE_DURATION {
         return Err(ProfileError::DurationIsTooLong);
     }
+
+    // Use duration given by the profiler and not reported by the SDK.
+    profile.metadata.duration_ns = profile.profile.elapsed_time.as_nanos() as u64;
 
     Ok(profile)
 }

--- a/relay-profiling/src/android.rs
+++ b/relay-profiling/src/android.rs
@@ -322,7 +322,6 @@ mod tests {
         );
         assert_eq!(profile.metadata.active_thread_id, 12345);
         assert_eq!(profile.metadata.transaction_name, "transaction1");
-        assert_eq!(profile.metadata.duration_ns, 1000000000);
     }
 
     #[test]

--- a/relay-profiling/src/transaction_metadata.rs
+++ b/relay-profiling/src/transaction_metadata.rs
@@ -46,10 +46,6 @@ impl TransactionMetadata {
     pub fn valid(&self) -> bool {
         !self.id.is_nil() && !self.name.is_empty() && !self.trace_id.is_nil()
     }
-
-    pub fn duration_ns(&self) -> u64 {
-        self.relative_end_ns.saturating_sub(self.relative_start_ns)
-    }
 }
 
 #[cfg(test)]

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -872,8 +872,7 @@ mod tests {
 
         let event = Annotated::new(Event {
             release: Annotated::new(
-                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#")
-                    .into(),
+                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#").into(),
             ),
             ..Default::default()
         });

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -872,7 +872,8 @@ mod tests {
 
         let event = Annotated::new(Event {
             release: Annotated::new(
-                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#").into(),
+                String::from("���7��#1G����7��#1G����7��#1G����7��#1G����7��#")
+                    .into(),
             ),
             ..Default::default()
         });


### PR DESCRIPTION
We received values for the `duration_ns` field like `18446744073709550616` nanoseconds which is 584 years. It's safe to say that's not correct.

`duration_ns` is a field used for compatibility with our other formats and was reported by the SDK at first then we chose to use the value reported by the transaction. Both of these were wrong.

Since we do reject profiles longer than 30s using the value reported by the profiler itself, we might as well overwrite the value of `duration_ns` with the one reported by the profiler.