### PR TITLE
fix(spooler): Fix total ordering of timestamps of envelopes

### DIFF
--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -13,7 +13,6 @@ use crate::Envelope;
 use futures::stream::StreamExt;
 use hashbrown::HashSet;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
-use relay_common::time::UnixTimestamp;
 use relay_config::Config;
 use sqlx::migrate::MigrateError;
 use sqlx::query::Query;

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -374,9 +374,7 @@ impl SqliteEnvelopeStore {
         //
         // Unfortunately we have to do this because SQLite `DELETE` with `RETURNING` doesn't
         // return deleted rows in a specific order.
-        let now = UnixTimestamp::now();
-        extracted_envelopes
-            .sort_by_key(|a| UnixTimestamp::from_datetime(a.received_at()).unwrap_or(now));
+        extracted_envelopes.sort_by_key(|a| a.meta().start_time());
 
         Ok(extracted_envelopes)
     }

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -374,9 +374,9 @@ impl SqliteEnvelopeStore {
         //
         // Unfortunately we have to do this because SQLite `DELETE` with `RETURNING` doesn't
         // return deleted rows in a specific order.
-        extracted_envelopes.sort_by_key(|a| {
-            UnixTimestamp::from_datetime(a.received_at()).unwrap_or(UnixTimestamp::now())
-        });
+        let now = UnixTimestamp::now();
+        extracted_envelopes
+            .sort_by_key(|a| UnixTimestamp::from_datetime(a.received_at()).unwrap_or(now));
 
         Ok(extracted_envelopes)
     }


### PR DESCRIPTION
This PR fixes the total ordering of envelopes since it was implemented wrong. This is because the field used for sorting was not deterministic so it could have been different between two closure calls.

The fix in this PR uses directly the stored field on the `Envelope` which is the same across closure calls.

#skip-changelog