### PR TITLE
feat(server): Add server sample rate to standalone span payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Add a config option to add default tags to all Relay Sentry events. ([#3944](https://github.com/getsentry/relay/pull/3944))
 - Automatically derive `client.address` and `user.geo` for standalone spans. ([#4047](https://github.com/getsentry/relay/pull/4047))
 
+**Internal:**
+
+- Add the dynamic sampling rate to standalone spans as a measurement so that it can be stored, queried, and used for extrapolation. ([#4063](https://github.com/getsentry/relay/pull/4063))
+
 ## 24.9.0
 
 **Bug Fixes**:

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1711,6 +1711,7 @@ impl EnvelopeProcessorService {
             false => SamplingResult::Pending,
         };
 
+        #[cfg(feature = "processing")]
         let server_sample_rate = match sampling_result {
             SamplingResult::Match(ref sampling_match) => Some(sampling_match.sample_rate()),
             SamplingResult::NoMatch | SamplingResult::Pending => None,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1711,6 +1711,11 @@ impl EnvelopeProcessorService {
             false => SamplingResult::Pending,
         };
 
+        let server_sample_rate = match sampling_result {
+            SamplingResult::Match(ref sampling_match) => Some(sampling_match.sample_rate()),
+            SamplingResult::NoMatch | SamplingResult::Pending => None,
+        };
+
         if let Some(outcome) = sampling_result.into_dropped_outcome() {
             let keep_profiles = global_config.options.unsampled_profiles_enabled;
             // Process profiles before dropping the transaction, if necessary.
@@ -1753,7 +1758,7 @@ impl EnvelopeProcessorService {
                 .project_state
                 .has_feature(Feature::ExtractSpansFromEvent)
             {
-                span::extract_from_event(state, &global_config);
+                span::extract_from_event(state, &global_config, server_sample_rate);
             }
 
             self.enforce_quotas(state)?;


### PR DESCRIPTION
Adds a new measurement field named `server_sample_rate` that contains the sample
rate applied during dynamic sampling, if any. The rate is passed directly into
the span extraction function from the processor, where the sampling result is
computed.

Note that this will not directly work with standalone span ingestion:
 - The client sample rate is no longer materialized as part of normalization.
   This also has the benefit that transaction event payloads do not have this
   redundant data. Once standalone spans can be ingested, this measurement has
   to be added there, too.
 - Dynamic sampling is not implemented for standalone spans yet.

Ref https://github.com/getsentry/relay/issues/4038