### PR TITLE
ref: Remove sample_rates from envelope item headers and processor

### DIFF
--- a/relay-event-schema/src/protocol/metrics.rs
+++ b/relay-event-schema/src/protocol/metrics.rs
@@ -1,26 +1,6 @@
-use relay_protocol::{Annotated, Array, Empty, FromValue, IntoValue};
+use relay_protocol::{Annotated, Empty, FromValue, IntoValue};
 
 use crate::processor::ProcessValue;
-
-#[derive(Clone, Debug, Default, Empty, PartialEq, FromValue, IntoValue)]
-pub struct SampleRate {
-    /// The unique identifier of the sampling rule or mechanism.
-    ///
-    /// For client-side sampling, this identifies the sampling mechanism:
-    ///  - `client_rate`: Default base sample rate configured in client options. Only reported in
-    ///    the absence of the traces sampler callback.
-    ///  - `client_sampler`: Return value from the traces sampler callback during runtime. Always
-    ///    overrides the `client_rate`.
-    ///
-    /// For server-side sampling, this identifies the dynamic sampling rule.
-    id: Annotated<String>,
-
-    /// The effective sample rate in the range `(0..1]`.
-    ///
-    /// While allowed in the protocol, a value of `0` can never occur in practice since such events
-    /// would never be reported to Sentry and thus never generate this metric.
-    rate: Annotated<f64>,
-}
 
 /// Metrics captured during event ingestion and processing.
 ///
@@ -156,12 +136,6 @@ pub struct Metrics {
     /// This metric is measured in Sentry and should be reported in all processing tasks.
     #[metastructure(field = "flag.processing.fatal")]
     pub flag_processing_fatal: Annotated<bool>,
-
-    /// A list of cumulative sample rates applied to this event.
-    ///
-    /// Multiple entries in `sample_rates` mean that the event was sampled multiple times. The
-    /// effective sample rate is multiplied.
-    pub sample_rates: Annotated<Array<SampleRate>>,
 }
 
 // Do not process Metrics

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -539,13 +539,6 @@ pub struct ItemHeaders {
     #[serde(default, skip)]
     source_quantities: Option<SourceQuantities>,
 
-    /// A list of cumulative sample rates applied to this event.
-    ///
-    /// Multiple entries in `sample_rates` mean that the event was sampled multiple times. The
-    /// effective sample rate is multiplied.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    sample_rates: Option<Value>,
-
     /// Flag indicating if metrics have already been extracted from the item.
     ///
     /// In order to only extract metrics once from an item while through a
@@ -645,7 +638,6 @@ impl Item {
                 rate_limited: false,
                 replay_combined_payload: false,
                 source_quantities: None,
-                sample_rates: None,
                 other: BTreeMap::new(),
                 metrics_extracted: false,
                 spans_extracted: false,
@@ -800,11 +792,6 @@ impl Item {
         self.headers.rate_limited = rate_limited;
     }
 
-    /// Removes sample rates from the headers, if any.
-    pub fn take_sample_rates(&mut self) -> Option<Value> {
-        self.headers.sample_rates.take()
-    }
-
     /// Returns the contained source quantities.
     pub fn source_quantities(&self) -> Option<SourceQuantities> {
         self.headers.source_quantities
@@ -824,13 +811,6 @@ impl Item {
     /// Sets the replay_combined_payload for this item.
     pub fn set_replay_combined_payload(&mut self, combined_payload: bool) {
         self.headers.replay_combined_payload = combined_payload;
-    }
-
-    /// Sets sample rates for this item.
-    pub fn set_sample_rates(&mut self, sample_rates: Value) {
-        if matches!(sample_rates, Value::Array(ref a) if !a.is_empty()) {
-            self.headers.sample_rates = Some(sample_rates);
-        }
     }
 
     /// Returns the metrics extracted flag.

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -33,7 +33,7 @@ use relay_filter::FilterStatKey;
 use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricMeta, MetricNamespace};
 use relay_pii::PiiConfigError;
 use relay_profiling::ProfileId;
-use relay_protocol::{Annotated, Value};
+use relay_protocol::Annotated;
 use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::config::RuleId;
 use relay_sampling::evaluation::{ReservoirCounters, ReservoirEvaluator, SamplingDecision};
@@ -713,12 +713,6 @@ struct ProcessEnvelopeState<'a, Group> {
     /// persisted into the Event. All modifications afterwards will have no effect.
     metrics: Metrics,
 
-    /// A list of cumulative sample rates applied to this event.
-    ///
-    /// This element is obtained from the event or transaction item and re-serialized into the
-    /// resulting item.
-    sample_rates: Option<Value>,
-
     /// Metrics extracted from items in the envelope.
     ///
     /// Relay can extract metrics for sessions and transactions, which is controlled by
@@ -1295,7 +1289,6 @@ impl EnvelopeProcessorService {
             event_metrics_extracted: false,
             spans_extracted: false,
             metrics: Metrics::default(),
-            sample_rates: None,
             extracted_metrics,
             project_state,
             config,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -435,7 +435,6 @@ mod tests {
             ProcessEnvelopeState::<TransactionGroup> {
                 event: Annotated::from(event),
                 metrics: Default::default(),
-                sample_rates: None,
                 extracted_metrics: ProcessingExtractedMetrics::new(),
                 config: config.clone(),
                 project_state,
@@ -707,7 +706,6 @@ mod tests {
             event_metrics_extracted: false,
             spans_extracted: false,
             metrics: Default::default(),
-            sample_rates: Default::default(),
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
             project_state: project_info,

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -773,7 +773,6 @@ mod tests {
         ProcessEnvelopeState {
             event: Annotated::from(event),
             metrics: Default::default(),
-            sample_rates: None,
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
             project_state,

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -430,44 +430,6 @@ def test_span_exclusive_time(mini_sentry, relay_with_processing, transactions_co
     ]
 
 
-def test_sample_rates(mini_sentry, relay_chain):
-    relay = relay_chain(min_relay_version="21.1.0")
-    mini_sentry.add_basic_project_config(42)
-
-    sample_rates = [
-        {"id": "client_sampler", "rate": 0.01},
-        {"id": "dynamic_user", "rate": 0.5},
-    ]
-
-    envelope = Envelope()
-    envelope.add_event({"message": "hello, world!"})
-    envelope.items[0].headers["sample_rates"] = sample_rates
-    relay.send_envelope(42, envelope)
-
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    assert envelope.items[0].headers["sample_rates"] == sample_rates
-
-
-def test_sample_rates_metrics(mini_sentry, relay_with_processing, events_consumer):
-    events_consumer = events_consumer()
-
-    relay = relay_with_processing()
-    mini_sentry.add_basic_project_config(42)
-
-    sample_rates = [
-        {"id": "client_sampler", "rate": 0.01},
-        {"id": "dynamic_user", "rate": 0.5},
-    ]
-
-    envelope = Envelope()
-    envelope.add_event({"message": "hello, world!"})
-    envelope.items[0].headers["sample_rates"] = sample_rates
-    relay.send_envelope(42, envelope)
-
-    event, _ = events_consumer.get_event()
-    assert event["_metrics"]["sample_rates"] == sample_rates
-
-
 def test_buffer_envelopes_without_global_config(
     mini_sentry, relay_with_processing, events_consumer
 ):


### PR DESCRIPTION
The `sample_rates` field was originally added to Envelope item headers to track
which sampling rules and rates were applied by SDKs and the server. This was
however never fully implemented, and today Relay relies on the DSC and trace
header to obtain the client sample rate.

This removes the `sample_rates` field without replacement.

#skip-changelog

