### PR TITLE
feat(buffer): Disable dequeueing with user signal

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -10,6 +10,8 @@ use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
 use relay_system::{Addr, FromMessage, Interface, NoResponse, Receiver, Service};
 use relay_system::{Controller, Shutdown};
+use tokio::signal;
+use tokio::signal::unix::SignalKind;
 use tokio::sync::mpsc::Permit;
 use tokio::sync::{mpsc, watch};
 use tokio::time::{timeout, Instant};
@@ -155,13 +157,14 @@ impl EnvelopeBufferService {
     async fn ready_to_pop(
         &mut self,
         buffer: &PolymorphicEnvelopeBuffer,
+        dequeue: bool,
     ) -> Option<Permit<DequeuedEnvelope>> {
         relay_statsd::metric!(
             counter(RelayCounters::BufferReadyToPop) += 1,
             status = "checking"
         );
 
-        self.system_ready(buffer).await;
+        self.system_ready(buffer, dequeue).await;
 
         relay_statsd::metric!(
             counter(RelayCounters::BufferReadyToPop) += 1,
@@ -192,7 +195,7 @@ impl EnvelopeBufferService {
     /// - We should not pop from disk into memory when relay's overall memory capacity
     ///   has been reached.
     /// - We need a valid global config to unspool.
-    async fn system_ready(&self, buffer: &PolymorphicEnvelopeBuffer) {
+    async fn system_ready(&self, buffer: &PolymorphicEnvelopeBuffer, dequeue: bool) {
         loop {
             // We should not unspool from external storage if memory capacity has been reached.
             // But if buffer storage is in memory, unspooling can reduce memory usage.
@@ -200,7 +203,7 @@ impl EnvelopeBufferService {
                 !buffer.is_external() || self.memory_checker.check_memory().has_capacity();
             let global_config_ready = self.global_config_rx.borrow().is_ready();
 
-            if memory_ready && global_config_ready {
+            if memory_ready && global_config_ready && dequeue {
                 return;
             }
             tokio::time::sleep(DEFAULT_SLEEP).await;
@@ -376,6 +379,9 @@ impl Service for EnvelopeBufferService {
         let mut global_config_rx = self.global_config_rx.clone();
         let services = self.services.clone();
 
+        let dequeue = Arc::<AtomicBool>::new(true.into());
+        let dequeue1 = dequeue.clone();
+
         tokio::spawn(async move {
             let buffer = PolymorphicEnvelopeBuffer::from_config(&config, memory_checker).await;
 
@@ -412,7 +418,7 @@ impl Service for EnvelopeBufferService {
                     // On the one hand, we might want to prioritize dequeuing over enqueuing
                     // so we do not exceed the buffer capacity by starving the dequeue.
                     // on the other hand, prioritizing old messages violates the LIFO design.
-                    Some(permit) = self.ready_to_pop(&buffer) => {
+                    Some(permit) = self.ready_to_pop(&buffer, dequeue.load(Ordering::Relaxed)) => {
                         match Self::try_pop(&config, &mut buffer, &services, permit).await {
                             Ok(new_sleep) => {
                                 sleep = new_sleep;
@@ -448,6 +454,18 @@ impl Service for EnvelopeBufferService {
             }
 
             relay_log::info!("EnvelopeBufferService: stopping");
+        });
+
+        #[cfg(unix)]
+        tokio::spawn(async move {
+            let Ok(mut signal) = signal::unix::signal(SignalKind::user_defined1()) else {
+                return;
+            };
+            while let Some(()) = signal.recv().await {
+                let deq = !dequeue1.load(Ordering::Relaxed);
+                dequeue1.store(deq, Ordering::Relaxed);
+                relay_log::info!("SIGUSR1 receive, dequeue={}", deq);
+            }
         });
     }
 }

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -10,8 +10,6 @@ use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
 use relay_system::{Addr, FromMessage, Interface, NoResponse, Receiver, Service};
 use relay_system::{Controller, Shutdown};
-use tokio::signal;
-use tokio::signal::unix::SignalKind;
 use tokio::sync::mpsc::Permit;
 use tokio::sync::{mpsc, watch};
 use tokio::time::{timeout, Instant};
@@ -458,7 +456,8 @@ impl Service for EnvelopeBufferService {
 
         #[cfg(unix)]
         tokio::spawn(async move {
-            let Ok(mut signal) = signal::unix::signal(SignalKind::user_defined1()) else {
+            use tokio::signal::unix::{signal, SignalKind};
+            let Ok(mut signal) = signal(SignalKind::user_defined1()) else {
                 return;
             };
             while let Some(()) = signal.recv().await {


### PR DESCRIPTION
Add a temporary signal handler for testing purposes that allows pausing all dequeueing from the envelope buffer.

Tested manually with:

```shell
kill -USR1 $(pidof relay)
kill -USR1 $(pidof relay)
```

```log
 INFO relay_server::services::buffer: SIGUSR1 receive, dequeue=false
 INFO relay_server::services::buffer: SIGUSR1 receive, dequeue=true
 ```

ref: https://github.com/getsentry/team-ingest/issues/534

#skip-changelog
