### PR TITLE
fix(buffer): Ignore dropped global config watch

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -436,7 +436,7 @@ impl Service for EnvelopeBufferService {
                             break;
                         }
                     }
-                    _ = global_config_rx.changed() => {
+                    Ok(()) = global_config_rx.changed() => {
                         relay_log::trace!("EnvelopeBufferService: received global config");
                         sleep = Duration::ZERO;
                     }


### PR DESCRIPTION
`rx.changed().await` on a watch will return an error if the sender has been dropped. This can cause the envelope buffer service loop to busy-loop on shutdown.

#skip-changelog