### PR TITLE
fix(pattern): Incorrect matches with adjacent any and wildcard matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
 - Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
+- Incorrect pattern matches involving adjacent any and wildcard matchers. ([#4072](https://github.com/getsentry/relay/pull/4072))
 
 **Features:**
 


### PR DESCRIPTION
Joining `?` with `*` is an invalid optimization, the `?` implicitly forces a minimum length match, where as `*` matches 0..N characters.
