### PR TITLE
fix(buffer): Reject envelopes at high watermark, unspool at low watermark

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -352,8 +352,7 @@ pub async fn handle_envelope(
         )
     }
 
-    // TODO(jjbayer): Remove this check once spool v1 is removed.
-    if state.envelope_buffer().is_none() && state.memory_checker().check_memory().is_exceeded() {
+    if state.memory_checker().check_memory().is_exceeded() {
         return Err(BadStoreRequest::QueueFailed);
     };
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -245,7 +245,7 @@ impl ServiceState {
         let (envelopes_tx, envelopes_rx) = mpsc::channel(config.spool_max_backpressure_envelopes());
         let envelope_buffer = EnvelopeBufferService::new(
             config.clone(),
-            MemoryChecker::new(memory_stat.clone(), config.clone()),
+            memory_stat.clone(),
             global_config_rx.clone(),
             buffer::Services {
                 envelopes_tx,

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -41,11 +41,11 @@ pub enum PolymorphicEnvelopeBuffer {
 }
 
 impl PolymorphicEnvelopeBuffer {
-    /// Returns true if the implementation stores envelopes on external storage (e.g. disk).
-    pub fn is_external(&self) -> bool {
+    /// Returns true if the implementation stores all envelopes in RAM.
+    pub fn is_memory(&self) -> bool {
         match self {
-            PolymorphicEnvelopeBuffer::InMemory(_) => false,
-            PolymorphicEnvelopeBuffer::Sqlite(_) => true,
+            PolymorphicEnvelopeBuffer::InMemory(_) => true,
+            PolymorphicEnvelopeBuffer::Sqlite(_) => false,
         }
     }
 


### PR DESCRIPTION
The new envelope buffer model assumed that we did not need to check memory in the request handler, because envelopes "would go straight to disk anyway". In practice this does not work because even the disk buffer uses memory to cache batches.

This PR

* Reintroduces the memory check in the request handler, rejecting envelopes when the 95% watermark has surpassed.
* To prevent flip-flopping, introduces a lower 90% watermark for dequeuing (was previously 95%).

#skip-changelog