### PR TITLE
feat(devservices): Add devservices cli tool

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@
 black==24.3.0
 blinker==1.8.2
 click==8.1.7
+devservices==0.0.3
 flake8==7.0.0
 confluent-kafka==2.1.1
 flask==3.0.3


### PR DESCRIPTION
This adds the devservices cli tool to be used once the venv is activated. The devservices [configurations](https://github.com/getsentry/relay/pull/4049) are already added to the snuba repo so you should be able to use it as soon as you install the new cli tool.

We are also offering a binary to be used for a system installation of devservices (installation instructions in the README [here](https://github.com/getsentry/devservices)). However, use this at your own risk given that we're changing things pretty constantly and bumping/downgrading versions isn't quite as easy as pinning to a version in the venv.

#skip-changelog