### PR TITLE
ref(project-config): Graduate more feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,10 @@
 
 **Internal:**
 
+- Remove unused `cogs.enabled` configuration option. ([#4060](https://github.com/getsentry/relay/pull/4060))
 - Add the dynamic sampling rate to standalone spans as a measurement so that it can be stored, queried, and used for extrapolation. ([#4063](https://github.com/getsentry/relay/pull/4063))
 - Allowlist the SentryUptimeBot user-agent. ([#4068](https://github.com/getsentry/relay/pull/4068))
-
-**Internal:**
-
-- Remove unused `cogs.enabled` configuration option. ([#4060](https://github.com/getsentry/relay/pull/4060))
+- Feature flags of graduated features are now hard-coded in Relay so they can be removed from Sentry. ([#4076](https://github.com/getsentry/relay/pull/4076), [#4080](https://github.com/getsentry/relay/pull/4080))
 
 ## 24.9.0
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 
 /// Feature flags of graduated features are no longer sent by sentry, but Relay needs to insert them
 /// for outdated downstream Relays that may still rely on the feature flag.
-pub const GRADUATED_FEATURE_FLAGS: &[Feature] = &[Feature::UserReportV2Ingest];
+pub const GRADUATED_FEATURE_FLAGS: &[Feature] = &[
+    Feature::UserReportV2Ingest,
+    Feature::IngestUnsampledProfiles,
+];
 
 /// Features exposed by project config.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -30,13 +33,6 @@ pub enum Feature {
     /// Serialized as `organizations:session-replay-video-disabled`.
     #[serde(rename = "organizations:session-replay-video-disabled")]
     SessionReplayVideoDisabled,
-    /// Enables new User Feedback ingest.
-    ///
-    /// This feature has graduated and is hard-coded for external Relays.
-    ///
-    /// Serialized as `organizations:user-feedback-ingest`.
-    #[serde(rename = "organizations:user-feedback-ingest")]
-    UserReportV2Ingest,
     /// Enables device.class synthesis
     ///
     /// Enables device.class tag synthesis on mobile events.
@@ -102,31 +98,13 @@ pub enum Feature {
     /// Serialized as `organizations:performance-queries-mongodb-extraction`.
     #[serde(rename = "organizations:performance-queries-mongodb-extraction")]
     ScrubMongoDbDescriptions,
-
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(rename = "organizations:transaction-name-mark-scrubbed-as-sanitized")]
-    Deprecated1,
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(rename = "organizations:transaction-name-normalize")]
-    Deprecated2,
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(rename = "projects:extract-standalone-spans")]
-    Deprecated4,
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(rename = "projects:span-metrics-extraction-resource")]
-    Deprecated5,
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(rename = "projects:span-metrics-extraction-all-modules")]
-    Deprecated6,
-    /// Deprecated, still forwarded for older downstream Relays.
+    /// This feature has graduated and is hard-coded for external Relays.
     #[doc(hidden)]
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
-    Deprecated7,
+    IngestUnsampledProfiles,
+    /// This feature has graduated and is hard-coded for external Relays.
+    #[serde(rename = "organizations:user-feedback-ingest")]
+    UserReportV2Ingest,
     /// Forward compatibility.
     #[doc(hidden)]
     #[serde(other)]

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -45,7 +45,6 @@ pub enum Feature {
     /// Serialized as `organizations:custom-metrics`.
     #[serde(rename = "organizations:custom-metrics")]
     CustomMetrics,
-
     /// Enable processing profiles.
     ///
     /// Serialized as `organizations:profiling`.
@@ -61,19 +60,16 @@ pub enum Feature {
     /// Serialized as `projects:relay-otel-endpoint`.
     #[serde(rename = "projects:relay-otel-endpoint")]
     OtelEndpoint,
-
     /// Discard transactions in a spans-only world.
     ///
     /// Serialized as `projects:discard-transaction`.
     #[serde(rename = "projects:discard-transaction")]
     DiscardTransaction,
-
     /// Enable continuous profiling.
     ///
     /// Serialized as `organizations:continuous-profiling`.
     #[serde(rename = "organizations:continuous-profiling")]
     ContinuousProfiling,
-
     /// Enables metric extraction from spans for common modules.
     ///
     /// Serialized as `projects:span-metrics-extraction`.
@@ -85,24 +81,24 @@ pub enum Feature {
     /// Serialized as `projects:span-metrics-extraction-addons`.
     #[serde(rename = "projects:span-metrics-extraction-addons")]
     ExtractAddonsSpanMetricsFromEvent,
-
     /// When enabled, spans will be extracted from a transaction.
     ///
     /// Serialized as `organizations:indexed-spans-extraction`.
     #[serde(rename = "organizations:indexed-spans-extraction")]
     ExtractSpansFromEvent,
-
     /// Enables description scrubbing for MongoDB spans (and consequently, their presence in the
     /// Queries module inside Sentry).
     ///
     /// Serialized as `organizations:performance-queries-mongodb-extraction`.
     #[serde(rename = "organizations:performance-queries-mongodb-extraction")]
     ScrubMongoDbDescriptions,
+
     /// This feature has graduated and is hard-coded for external Relays.
     #[doc(hidden)]
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
     IngestUnsampledProfiles,
     /// This feature has graduated and is hard-coded for external Relays.
+    #[doc(hidden)]
     #[serde(rename = "organizations:user-feedback-ingest")]
     UserReportV2Ingest,
     /// Forward compatibility.


### PR DESCRIPTION
This PR

-  adds `IngestUnsampledProfiles` to graduated feature flags so it can be removed sentry-side.
- removes all remaining "Deprecated" feature flags because they are older than six months. After six months, it should be reasonable to ask customers with outdated relays to upgrade.

Closes https://github.com/getsentry/relay/issues/4033.