### PR TITLE
fix(server): Disallow static mode for processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Breaking Changes:**
+
+- Only allow processing enabled in managed mode. ([#4087](https://github.com/getsentry/relay/pull/4087))
+
 **Bug Fixes**:
 
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -11,8 +11,8 @@ pub fn check_config(config: &Config) -> Result<()> {
         );
     }
 
-    if config.relay_mode() == RelayMode::Proxy && config.processing_enabled() {
-        anyhow::bail!("Processing cannot be enabled while in proxy mode.");
+    if config.relay_mode() != RelayMode::Managed && config.processing_enabled() {
+        anyhow::bail!("Processing can only be enabled in managed mode.");
     }
 
     #[cfg(feature = "processing")]

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -88,7 +88,7 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
     )
 
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
-    time.sleep(0.3)  # Wait for error
+    time.sleep(0.5)  # Wait for error
     error = str(mini_sentry.test_failures.pop(0))
     assert "Not enough memory" in error and ">= 42" in error
     error = str(mini_sentry.test_failures.pop(0))


### PR DESCRIPTION
We only support processing in managed mode, so we should make it a hard requirement for starting Relay.

Static and proxy mode only exists to put a proxy close to the SDKs in order to reduce latency and/or provide PII-scrubbing on premise before sending data to sentry. From [Sentry's product docs](https://docs.sentry.io/product/relay/):

> Sentry Relay offers enterprise-grade data security by providing a standalone service that acts as a middle layer between your application and sentry.io.

These modes were never intended to run in combination with `processing: true`, and doing so resulted in undefined behavior.

See also https://github.com/getsentry/relay/pull/3146.

ref: https://github.com/getsentry/sentry/issues/70473