### PR TITLE
ref(replay): Run geo info normalization on the replay user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add a config option to add default tags to all Relay Sentry events. ([#3944](https://github.com/getsentry/relay/pull/3944))
 - Automatically derive `client.address` and `user.geo` for standalone spans. ([#4047](https://github.com/getsentry/relay/pull/4047))
 - Add support for uploading compressed (gzip, xz, zstd, bzip2) minidumps. ([#4029](https://github.com/getsentry/relay/pull/4029))
+- Add user geo information to Replays. ([#4088](https://github.com/getsentry/relay/pull/4088))
 - Configurable span.op inference. ([#4056](https://github.com/getsentry/relay/pull/4056))
 
 **Internal:**

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1835,7 +1835,11 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<ReplayGroup>,
     ) -> Result<(), ProcessingError> {
-        replay::process(state, &self.inner.global_config.current())?;
+        replay::process(
+            state,
+            &self.inner.global_config.current(),
+            self.inner.geoip_lookup.as_ref(),
+        )?;
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
         });

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -794,7 +794,7 @@ impl<'a, Group> ProcessEnvelopeState<'a, Group> {
     /// Function for on-off switches that filter specific item types (profiles, spans)
     /// based on a feature flag.
     ///
-    /// If the project config did not come from the upstream, we keep the items
+    /// If the project config did not come from the upstream, we keep the items.
     fn should_filter(&self, feature: Feature) -> bool {
         match self.config.relay_mode() {
             RelayMode::Proxy | RelayMode::Static | RelayMode::Capture => false,

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -34,7 +34,9 @@ pub fn process(
 
     // If the replay video feature is not enabled check the envelope items for a
     // replay video event.
-    if state.should_filter(Feature::SessionReplayVideoDisabled)
+    if state
+        .project_state
+        .has_feature(Feature::SessionReplayVideoDisabled)
         && count_replay_video_events(state) > 0
     {
         state.managed_envelope.drop_items_silently();

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use relay_base_schema::project::ProjectId;
 use relay_dynamic_config::{Feature, GlobalConfig, ProjectConfig};
 use relay_event_normalization::replay::{self, ReplayError};
-use relay_event_normalization::RawUserAgentInfo;
+use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo};
 use relay_event_schema::processor::{self, ProcessingState};
 use relay_event_schema::protocol::{EventId, Replay};
 use relay_pii::PiiProcessor;
@@ -24,91 +24,82 @@ use crate::statsd::{RelayCounters, RelayTimers};
 pub fn process(
     state: &mut ProcessEnvelopeState<ReplayGroup>,
     global_config: &GlobalConfig,
+    geoip_lookup: Option<&GeoIpLookup>,
 ) -> Result<(), ProcessingError> {
-    let project_state = &state.project_state;
-    let replays_disabled = state.should_filter(Feature::SessionReplay);
-    let scrubbing_enabled = project_state.has_feature(Feature::SessionReplayRecordingScrubbing);
-    let replay_video_disabled = project_state.has_feature(Feature::SessionReplayVideoDisabled);
-    let project_id = project_state.project_id;
-    let organization_id = project_state.organization_id;
-
-    let meta = state.envelope().meta().clone();
-    let client_addr = meta.client_addr();
-    let event_id = state.envelope().event_id();
-
-    let limit = state.config.max_replay_uncompressed_size();
-    let project_config = project_state.config();
-    let datascrubbing_config = project_config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|e| ProcessingError::PiiConfigError(e.clone()))?
-        .as_ref();
-    let mut scrubber = RecordingScrubber::new(
-        limit,
-        project_config.pii_config.as_ref(),
-        datascrubbing_config,
-    );
-
-    let user_agent = &RawUserAgentInfo {
-        user_agent: meta.user_agent(),
-        client_hints: meta.client_hints().as_deref(),
-    };
-    let combined_envelope_items =
-        project_state.has_feature(Feature::SessionReplayCombinedEnvelopeItems);
-
     // If the replay feature is not enabled drop the items silenty.
-    if replays_disabled {
+    if state.should_filter(Feature::SessionReplay) {
         state.managed_envelope.drop_items_silently();
         return Ok(());
     }
 
     // If the replay video feature is not enabled check the envelope items for a
     // replay video event.
-    if replay_video_disabled && count_replay_video_events(state) > 0 {
+    if state.should_filter(Feature::SessionReplayVideoDisabled)
+        && count_replay_video_events(state) > 0
+    {
         state.managed_envelope.drop_items_silently();
         return Ok(());
     }
 
+    let rs = {
+        let meta = state.envelope().meta();
+
+        ReplayState {
+            config: &state.project_state.config,
+            global_config,
+            geoip_lookup,
+            event_id: state.envelope().event_id(),
+            project_id: state.project_state.project_id,
+            organization_id: state.project_state.organization_id,
+            client_addr: meta.client_addr(),
+            user_agent: RawUserAgentInfo {
+                user_agent: meta.user_agent().map(|s| s.to_owned()),
+                client_hints: meta.client_hints().clone(),
+            },
+        }
+    };
+
+    let mut scrubber = if state
+        .project_state
+        .has_feature(Feature::SessionReplayRecordingScrubbing)
+    {
+        let datascrubbing_config = rs
+            .config
+            .datascrubbing_settings
+            .pii_config()
+            .map_err(|e| ProcessingError::PiiConfigError(e.clone()))?
+            .as_ref();
+
+        Some(RecordingScrubber::new(
+            state.config.max_replay_uncompressed_size(),
+            rs.config.pii_config.as_ref(),
+            datascrubbing_config,
+        ))
+    } else {
+        None
+    };
+
     for item in state.managed_envelope.envelope_mut().items_mut() {
-        // Set the combined payload header to the value of the combined feature.
-        item.set_replay_combined_payload(combined_envelope_items);
+        if state
+            .project_state
+            .has_feature(Feature::SessionReplayCombinedEnvelopeItems)
+        {
+            item.set_replay_combined_payload(true);
+        }
 
         match item.ty() {
             ItemType::ReplayEvent => {
-                let replay_event = handle_replay_event_item(
-                    item.payload(),
-                    &event_id,
-                    project_config,
-                    global_config,
-                    client_addr,
-                    user_agent,
-                    project_id,
-                    organization_id,
-                )?;
+                let replay_event = handle_replay_event_item(item.payload(), &rs)?;
                 item.set_payload(ContentType::Json, replay_event);
             }
             ItemType::ReplayRecording => {
-                let replay_recording = handle_replay_recording_item(
-                    item.payload(),
-                    &event_id,
-                    scrubbing_enabled,
-                    &mut scrubber,
-                )?;
+                let replay_recording =
+                    handle_replay_recording_item(item.payload(), scrubber.as_mut())?;
                 item.set_payload(ContentType::OctetStream, replay_recording);
             }
             ItemType::ReplayVideo => {
-                let replay_video = handle_replay_video_item(
-                    item.payload(),
-                    &event_id,
-                    project_config,
-                    global_config,
-                    client_addr,
-                    user_agent,
-                    scrubbing_enabled,
-                    &mut scrubber,
-                    project_id,
-                    organization_id,
-                )?;
+                let replay_video =
+                    handle_replay_video_item(item.payload(), scrubber.as_mut(), &rs)?;
                 item.set_payload(ContentType::OctetStream, replay_video);
             }
             _ => {}
@@ -118,29 +109,32 @@ pub fn process(
     Ok(())
 }
 
+#[derive(Debug)]
+struct ReplayState<'a> {
+    pub config: &'a ProjectConfig,
+    pub global_config: &'a GlobalConfig,
+    pub geoip_lookup: Option<&'a GeoIpLookup>,
+    pub event_id: Option<EventId>,
+    pub project_id: Option<ProjectId>,
+    pub organization_id: Option<u64>,
+    pub client_addr: Option<IpAddr>,
+    pub user_agent: RawUserAgentInfo<String>,
+}
+
 // Replay Event Processing.
 
-#[allow(clippy::too_many_arguments)]
 fn handle_replay_event_item(
     payload: Bytes,
-    event_id: &Option<EventId>,
-    config: &ProjectConfig,
-    global_config: &GlobalConfig,
-    client_ip: Option<IpAddr>,
-    user_agent: &RawUserAgentInfo<&str>,
-    project_id: Option<ProjectId>,
-    organization_id: Option<u64>,
+    state: &ReplayState<'_>,
 ) -> Result<Bytes, ProcessingError> {
-    let filter_settings = &config.filter_settings;
-
-    match process_replay_event(&payload, config, client_ip, user_agent) {
+    match process_replay_event(&payload, state) {
         Ok(replay) => {
             if let Some(replay_type) = replay.value() {
                 relay_filter::should_filter(
                     replay_type,
-                    client_ip,
-                    filter_settings,
-                    global_config.filters(),
+                    state.client_addr,
+                    &state.config.filter_settings,
+                    state.global_config.filters(),
                 )
                 .map_err(ProcessingError::ReplayFiltered)?;
 
@@ -151,9 +145,9 @@ fn handle_replay_event_item(
                         metric!(counter(RelayCounters::ReplayExceededSegmentLimit) += 1);
 
                         relay_log::warn!(
-                            ?event_id,
-                            project_id = project_id.map(|v| v.value()),
-                            organization_id = organization_id,
+                            event_id = ?state.event_id,
+                            project_id = state.project_id.map(|v| v.value()),
+                            organization_id = state.organization_id,
                             segment_id = segment_id,
                             "replay segment-exceeded-limit"
                         );
@@ -166,7 +160,7 @@ fn handle_replay_event_item(
                 Err(error) => {
                     relay_log::error!(
                         error = &error as &dyn Error,
-                        ?event_id,
+                        event_id = ?state.event_id,
                         "failed to serialize replay"
                     );
                     Ok(payload)
@@ -176,9 +170,9 @@ fn handle_replay_event_item(
         Err(error) => {
             relay_log::warn!(
                 error = &error as &dyn Error,
-                ?event_id,
-                project_id = project_id.map(|v| v.value()),
-                organization_id = organization_id,
+                event_id = ?state.event_id,
+                project_id = state.project_id.map(|v| v.value()),
+                organization_id = state.organization_id,
                 "invalid replay event"
             );
             Err(match error {
@@ -202,9 +196,7 @@ fn handle_replay_event_item(
 /// Validates, normalizes, and scrubs PII from a replay event.
 fn process_replay_event(
     payload: &[u8],
-    config: &ProjectConfig,
-    client_ip: Option<IpAddr>,
-    user_agent: &RawUserAgentInfo<&str>,
+    state: &ReplayState<'_>,
 ) -> Result<Annotated<Replay>, ReplayError> {
     let mut replay =
         Annotated::<Replay>::from_json_bytes(payload).map_err(ReplayError::CouldNotParse)?;
@@ -214,18 +206,25 @@ fn process_replay_event(
     };
 
     replay::validate(replay_value)?;
-    replay::normalize(&mut replay, client_ip, user_agent);
+    replay::normalize(
+        &mut replay,
+        state.client_addr,
+        state.user_agent.as_deref(),
+        state.geoip_lookup,
+    );
 
-    if let Some(ref config) = config.pii_config {
+    if let Some(ref config) = state.config.pii_config {
         let mut processor = PiiProcessor::new(config.compiled());
         processor::process_value(&mut replay, &mut processor, ProcessingState::root())
             .map_err(|e| ReplayError::CouldNotScrub(e.to_string()))?;
     }
 
-    let pii_config = config
+    let pii_config = state
+        .config
         .datascrubbing_settings
         .pii_config()
         .map_err(|e| ReplayError::CouldNotScrub(e.to_string()))?;
+
     if let Some(config) = pii_config {
         let mut processor = PiiProcessor::new(config.compiled());
         processor::process_value(&mut replay, &mut processor, ProcessingState::root())
@@ -239,13 +238,14 @@ fn process_replay_event(
 
 fn handle_replay_recording_item(
     payload: Bytes,
-    event_id: &Option<EventId>,
-    scrubbing_enabled: bool,
-    scrubber: &mut RecordingScrubber,
+    scrubber: Option<&mut RecordingScrubber>,
 ) -> Result<Bytes, ProcessingError> {
     // XXX: Processing is there just for data scrubbing. Skip the entire expensive
     // processing step if we do not need to scrub.
-    if !scrubbing_enabled || scrubber.is_empty() {
+    let Some(scrubber) = scrubber else {
+        return Ok(payload);
+    };
+    if scrubber.is_empty() {
         return Ok(payload);
     }
 
@@ -253,19 +253,11 @@ fn handle_replay_recording_item(
     // decompressed temporarily and then immediately re-compressed. However, to
     // limit memory pressure, we use the replay limit as a good overall limit for
     // allocations.
-    let parsed_recording = metric!(timer(RelayTimers::ReplayRecordingProcessing), {
+    metric!(timer(RelayTimers::ReplayRecordingProcessing), {
         scrubber.process_recording(&payload)
-    });
-
-    match parsed_recording {
-        Ok(recording) => Ok(recording.into()),
-        Err(e) => {
-            relay_log::warn!("replay-recording-event: {e} {event_id:?}");
-            Err(ProcessingError::InvalidReplay(
-                DiscardReason::InvalidReplayRecordingEvent,
-            ))
-        }
-    }
+    })
+    .map(Into::into)
+    .map_err(|_| ProcessingError::InvalidReplay(DiscardReason::InvalidReplayRecordingEvent))
 }
 
 // Replay Video Processing
@@ -277,48 +269,23 @@ struct ReplayVideoEvent {
     replay_video: Bytes,
 }
 
-#[allow(clippy::too_many_arguments)]
 fn handle_replay_video_item(
     payload: Bytes,
-    event_id: &Option<EventId>,
-    config: &ProjectConfig,
-    global_config: &GlobalConfig,
-    client_ip: Option<IpAddr>,
-    user_agent: &RawUserAgentInfo<&str>,
-    scrubbing_enabled: bool,
-    scrubber: &mut RecordingScrubber,
-    project_id: Option<ProjectId>,
-    organization_id: Option<u64>,
+    scrubber: Option<&mut RecordingScrubber>,
+    state: &ReplayState<'_>,
 ) -> Result<Bytes, ProcessingError> {
     let ReplayVideoEvent {
         replay_event,
         replay_recording,
         replay_video,
-    } = match rmp_serde::from_slice(&payload) {
-        Ok(result) => result,
-        Err(e) => {
-            relay_log::warn!("replay-video-event: {e} {event_id:?}");
-            return Err(ProcessingError::InvalidReplay(
-                DiscardReason::InvalidReplayVideoEvent,
-            ));
-        }
-    };
+    } = rmp_serde::from_slice(&payload)
+        .map_err(|_| ProcessingError::InvalidReplay(DiscardReason::InvalidReplayVideoEvent))?;
 
     // Process as a replay-event envelope item.
-    let replay_event = handle_replay_event_item(
-        replay_event,
-        event_id,
-        config,
-        global_config,
-        client_ip,
-        user_agent,
-        project_id,
-        organization_id,
-    )?;
+    let replay_event = handle_replay_event_item(replay_event, state)?;
 
     // Process as a replay-recording envelope item.
-    let replay_recording =
-        handle_replay_recording_item(replay_recording, event_id, scrubbing_enabled, scrubber)?;
+    let replay_recording = handle_replay_recording_item(replay_recording, scrubber)?;
 
     // Verify the replay-video payload is not empty.
     if replay_video.is_empty() {


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry/issues/50639

Additionally refactors the normalization code a bit to bundle a lot of the arguments that are passed around in a single struct. Also updates the feature flag checks to use `should_filter` instead of `has_feature` to make it work on Proxy Relays.
