### PR TITLE
perf(spans): Prevent span extraction when quota is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Use custom wildcard matching instead of regular expressions. ([#4073](https://github.com/getsentry/relay/pull/4073))
 - Allowlist the SentryUptimeBot user-agent. ([#4068](https://github.com/getsentry/relay/pull/4068))
 - Feature flags of graduated features are now hard-coded in Relay so they can be removed from Sentry. ([#4076](https://github.com/getsentry/relay/pull/4076), [#4080](https://github.com/getsentry/relay/pull/4080))
+- Prevent span extraction when quota is active to reduce load on redis. ([#4097](https://github.com/getsentry/relay/pull/4097))
 
 ## 24.9.0
 

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -118,6 +118,7 @@ impl DataCategory {
             "span" => Self::Span,
             "monitor_seat" => Self::MonitorSeat,
             "feedback" => Self::UserReportV2,
+            "user_report_v2" => Self::UserReportV2,
             "metric_bucket" => Self::MetricBucket,
             "span_indexed" => Self::SpanIndexed,
             "profile_duration" => Self::ProfileDuration,

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -874,6 +874,9 @@ impl Item {
 
     /// Counts how many spans are contained in a transaction payload.
     ///
+    /// The transaction itself represents a span as well, so this function returns
+    /// `len(event.spans) + 1`.
+    ///
     /// Returns zero if
     /// - the item is not a transaction,
     /// - the spans have already been extracted (in which case they are represented elsewhere).
@@ -887,7 +890,7 @@ impl Item {
             return 0;
         }
 
-        serde_json::from_slice::<PartialEvent>(&self.payload()).map_or(0, |event| event.spans.0)
+        serde_json::from_slice::<PartialEvent>(&self.payload()).map_or(0, |event| event.spans.0 + 1)
     }
 
     /// Determines whether the given item creates an event.

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -49,14 +49,12 @@ impl Extractable for Span {
 /// If this is a transaction event with spans, metrics will also be extracted from the spans.
 pub fn extract_metrics(
     event: &mut Event,
-    spans_extracted: bool,
     config: CombinedMetricExtractionConfig<'_>,
     max_tag_value_size: usize,
     span_extraction_sample_rate: Option<f32>,
 ) -> Vec<Bucket> {
     let mut metrics = generic::extract_metrics(event, config);
-    // If spans were already extracted for an event, we rely on span processing to extract metrics.
-    if !spans_extracted && sample(span_extraction_sample_rate.unwrap_or(1.0)) {
+    if sample(span_extraction_sample_rate.unwrap_or(1.0)) {
         extract_span_metrics_for_event(event, config, max_tag_value_size, &mut metrics);
     }
 
@@ -1202,7 +1200,6 @@ mod tests {
 
         extract_metrics(
             event.value_mut().as_mut().unwrap(),
-            false,
             combined_config(features, None).combined(),
             200,
             None,
@@ -1413,7 +1410,6 @@ mod tests {
 
         let metrics = extract_metrics(
             event.value_mut().as_mut().unwrap(),
-            false,
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
@@ -1470,7 +1466,6 @@ mod tests {
 
         let metrics = extract_metrics(
             event.value_mut().as_mut().unwrap(),
-            false,
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
@@ -1502,7 +1497,6 @@ mod tests {
 
         let metrics = extract_metrics(
             event.value_mut().as_mut().unwrap(),
-            false,
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
@@ -1765,7 +1759,6 @@ mod tests {
 
         let metrics = extract_metrics(
             event.value_mut().as_mut().unwrap(),
-            false,
             combined_config([Feature::ExtractCommonSpanMetricsFromEvent], None).combined(),
             200,
             None,
@@ -1906,13 +1899,7 @@ mod tests {
         );
         let config = binding.combined();
 
-        let _ = extract_metrics(
-            event.value_mut().as_mut().unwrap(),
-            false,
-            config,
-            200,
-            None,
-        );
+        let _ = extract_metrics(event.value_mut().as_mut().unwrap(), config, 200, None);
 
         insta::assert_debug_snapshot!(&event.value().unwrap()._metrics_summary);
         insta::assert_debug_snapshot!(

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -220,11 +220,8 @@ impl EnvelopeBufferService {
         services: &Services,
         envelopes_tx_permit: Permit<'a, DequeuedEnvelope>,
     ) -> Result<Duration, EnvelopeBufferError> {
-        relay_log::trace!("EnvelopeBufferService: peeking the buffer");
-
         let sleep = match buffer.peek().await? {
             Peek::Empty => {
-                relay_log::trace!("EnvelopeBufferService: peek returned empty");
                 relay_statsd::metric!(
                     counter(RelayCounters::BufferTryPop) += 1,
                     peek_result = "empty"
@@ -403,11 +400,7 @@ impl Service for EnvelopeBufferService {
             let mut shutdown = Controller::shutdown_handle();
 
             relay_log::info!("EnvelopeBufferService: starting");
-            let mut iteration = 0;
             loop {
-                iteration += 1;
-                relay_log::trace!("EnvelopeBufferService: loop iteration {iteration}");
-
                 let used_capacity = self.services.envelopes_tx.max_capacity()
                     - self.services.envelopes_tx.capacity();
                 relay_statsd::metric!(
@@ -446,7 +439,6 @@ impl Service for EnvelopeBufferService {
                         }
                     }
                     Ok(()) = global_config_rx.changed() => {
-                        relay_log::trace!("EnvelopeBufferService: received global config");
                         sleep = Duration::ZERO;
                     }
                     else => break,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1431,7 +1431,6 @@ impl EnvelopeProcessorService {
 
         let metrics = crate::metrics_extraction::event::extract_metrics(
             event,
-            state.spans_extracted,
             combined_config,
             self.inner
                 .config

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -12,7 +12,6 @@ use relay_system::{Addr, BroadcastChannel};
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 
-use crate::envelope::ItemType;
 use crate::services::metrics::{Aggregator, MergeBuckets};
 use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::processor::{EncodeMetricMeta, EnvelopeProcessor, ProcessProjectMetrics};
@@ -20,7 +19,6 @@ use crate::services::project::state::ExpiryState;
 use crate::services::project_cache::{
     CheckedEnvelope, ProcessMetrics, ProjectCache, RequestUpdate,
 };
-use crate::utils::{Enforcement, SeqCount};
 
 use crate::statsd::RelayCounters;
 use crate::utils::{EnvelopeLimiter, ManagedEnvelope, RetryBackoff};
@@ -557,18 +555,8 @@ impl Project {
             Ok(current_limits.check_with_quotas(quotas, item_scoping))
         });
 
-        let (mut enforcement, mut rate_limits) =
+        let (enforcement, mut rate_limits) =
             envelope_limiter.compute(envelope.envelope_mut(), &scoping)?;
-
-        let check_nested_spans = state
-            .as_ref()
-            .is_some_and(|s| s.has_feature(Feature::ExtractSpansFromEvent));
-
-        // If we can extract spans from the event, we want to try and count the number of nested
-        // spans to correctly emit negative outcomes in case the transaction itself is dropped.
-        if check_nested_spans {
-            sync_spans_to_enforcement(&envelope, &mut enforcement);
-        }
 
         enforcement.apply_with_outcomes(&mut envelope);
 
@@ -598,52 +586,9 @@ impl Project {
     }
 }
 
-/// Adds category limits for the nested spans inside a transaction.
-///
-/// On the fast path of rate limiting, we do not have nested spans of a transaction extracted
-/// as top-level spans, thus if we limited a transaction, we want to count and emit negative
-/// outcomes for each of the spans nested inside that transaction.
-fn sync_spans_to_enforcement(envelope: &ManagedEnvelope, enforcement: &mut Enforcement) {
-    if !enforcement.is_event_active() {
-        return;
-    }
-
-    let spans_count = count_nested_spans(envelope);
-    if spans_count == 0 {
-        return;
-    }
-
-    if enforcement.event.is_active() {
-        enforcement.spans = enforcement.event.clone_for(DataCategory::Span, spans_count);
-    }
-
-    if enforcement.event_indexed.is_active() {
-        enforcement.spans_indexed = enforcement
-            .event_indexed
-            .clone_for(DataCategory::SpanIndexed, spans_count);
-    }
-}
-
-/// Counts the nested spans inside the first transaction envelope item inside the [`Envelope`](crate::envelope::Envelope).
-fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
-    #[derive(Debug, Deserialize)]
-    struct PartialEvent {
-        spans: SeqCount,
-    }
-
-    envelope
-        .envelope()
-        .items()
-        .find(|item| *item.ty() == ItemType::Transaction && !item.spans_extracted())
-        .and_then(|item| serde_json::from_slice::<PartialEvent>(&item.payload()).ok())
-        // We do + 1, since we count the transaction itself because it will be extracted
-        // as a span and counted during the slow path of rate limiting.
-        .map_or(0, |event| event.spans.0 + 1)
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::envelope::{ContentType, Envelope, Item};
+    use crate::envelope::{ContentType, Envelope, Item, ItemType};
     use crate::extractors::RequestMeta;
     use crate::services::processor::ProcessingGroup;
     use relay_base_schema::project::ProjectId;

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -459,13 +459,13 @@ impl Enforcement {
     fn retain_item(&self, item: &mut Item) -> bool {
         // Remove event items and all items that depend on this event
         if self.event.is_active() && item.requires_event() {
-            if item.ty() == &ItemType::Transaction && self.spans_indexed.is_active() {
-                // We cannot remove nested spans from the transaction, but we can prevent them
-                // from being extracted into standalone spans.
-                item.set_spans_extracted(true);
-            }
-
             return false;
+        }
+
+        if item.ty() == &ItemType::Transaction && self.spans_indexed.is_active() {
+            // We cannot remove nested spans from the transaction, but we can prevent them
+            // from being extracted into standalone spans.
+            item.set_spans_extracted(true);
         }
 
         // When checking limits for categories that have an indexed variant,

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -197,6 +197,15 @@ class Sentry(SentryLike):
 
         return json.loads(item.payload.bytes)
 
+    def get_metrics(self, timeout=None):
+        envelope = self.captured_events.get(timeout=timeout)
+        items = envelope.items
+        assert len(items) == 1
+        item = items[0]
+        assert item.headers["type"] == "metric_buckets"
+
+        return item.payload.json
+
 
 def _get_project_id(public_key, project_configs):
     for project_id, project_config in project_configs.items():

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -7,6 +7,8 @@ import os
 import confluent_kafka as kafka
 from copy import deepcopy
 
+from sentry_relay.consts import DataCategory
+
 
 @pytest.fixture
 def get_topic_name():
@@ -220,27 +222,7 @@ class ConsumerBase:
 
 
 def category_value(category):
-    if category == "default":
-        return 0
-    if category == "error":
-        return 1
-    if category == "transaction":
-        return 2
-    if category == "security":
-        return 3
-    if category == "attachment":
-        return 4
-    if category == "session":
-        return 5
-    if category == "transaction_processed":
-        return 8
-    if category == "transaction_indexed":
-        return 9
-    if category == "user_report_v2":
-        return 14
-    if category == "metric_bucket":
-        return 15
-    assert False, "invalid category"
+    return DataCategory.parse(category)
 
 
 class OutcomesConsumer(ConsumerBase):

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -88,7 +88,7 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
     )
 
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
-    time.sleep(0.5)  # Wait for error
+    time.sleep(1.0)  # Wait for error
     error = str(mini_sentry.test_failures.pop(0))
     assert "Not enough memory" in error and ">= 42" in error
     error = str(mini_sentry.test_failures.pop(0))
@@ -105,7 +105,7 @@ def test_readiness_not_enough_memory_percent(mini_sentry, relay):
         wait_health_check=False,
     )
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
-    time.sleep(0.5)  # Wait for error
+    time.sleep(1.0)  # Wait for error
     error = str(mini_sentry.test_failures.pop(0))
     assert "Not enough memory" in error and ">= 1.00%" in error
     error = str(mini_sentry.test_failures.pop(0))

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -7,7 +7,6 @@ import json
 import signal
 import time
 import queue
-from itertools import chain
 from .consts import (
     TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
@@ -1207,19 +1206,21 @@ def test_no_transaction_metrics_when_filtered(mini_sentry, relay):
     relay = relay(mini_sentry, options=TEST_CONFIG)
     relay.send_transaction(project_id, tx)
 
-    # The only two envelopes received should be outcomes for Transaction and TransactionIndexed:
-    reports = [mini_sentry.get_client_report(), mini_sentry.get_client_report()]
-    filtered_events = list(
-        chain.from_iterable(report["filtered_events"] for report in reports)
-    )
+    # The only envelopes received should be outcomes for {Span,Transaction}[Indexed]?:
+    reports = [mini_sentry.get_client_report() for _ in range(4)]
+    filtered_events = [
+        outcome for report in reports for outcome in report["filtered_events"]
+    ]
     filtered_events.sort(key=lambda x: x["category"])
 
     assert filtered_events == [
+        {"reason": "release-version", "category": "span", "quantity": 2},
+        {"reason": "release-version", "category": "span_indexed", "quantity": 2},
         {"reason": "release-version", "category": "transaction", "quantity": 1},
         {"reason": "release-version", "category": "transaction_indexed", "quantity": 1},
     ]
 
-    assert mini_sentry.captured_events.qsize() == 0
+    assert mini_sentry.captured_events.empty
 
 
 def test_transaction_name_too_long(

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -754,7 +754,7 @@ def _get_span_payload():
     "category,outcome_categories",
     [
         ("session", []),
-        ("transaction", ["transaction", "transaction_indexed"]),
+        ("transaction", ["transaction", "transaction_indexed", "span", "span_indexed"]),
         ("user_report_v2", ["user_report_v2"]),
     ],
 )

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -771,10 +771,10 @@ def test_outcomes_rate_limit(
     relay = relay_with_processing(config)
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    reason_code = "transactions are banned"
+    reason_code = "banned"
     project_config["config"]["quotas"] = [
         {
-            "id": "transaction category",
+            "id": "some_id",
             "categories": [category],
             "limit": 0,
             "window": 1600,


### PR DESCRIPTION
Track spans inside a transaction item in `EnvelopeSummary::span_quantity`, and skip their extraction if the `span_indexed` category is rate limited.

This should reduce load on redis.

NOTE: With this PR, Relay will produce negative outcomes for spans in _any_ transaction, even for projects that do not have span extraction enabled (AM1). This should be fine, the product will simply ignore these outcomes.