### PR TITLE
ref(processor): Process metrics in batches

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -7,6 +7,7 @@ use relay_event_schema::protocol::{EventId, EventType};
 use relay_quotas::RateLimits;
 use relay_statsd::metric;
 use serde::Deserialize;
+use smallvec::smallvec;
 
 use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
 use crate::service::ServiceState;
@@ -275,10 +276,12 @@ fn queue_envelope(
         if !metric_items.is_empty() {
             relay_log::trace!("sending metrics into processing queue");
             state.project_cache().send(ProcessMetrics {
-                data: MetricData::Raw(metric_items.into_vec()),
+                data: smallvec![(
+                    envelope.meta().public_key(),
+                    MetricData::Raw(metric_items.into_vec())
+                )],
                 start_time: envelope.meta().start_time().into(),
                 sent_at: envelope.sent_at(),
-                project_key: envelope.meta().public_key(),
                 source: envelope.meta().into(),
             });
         }

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -15,11 +15,9 @@ use tokio::time::Instant;
 use crate::envelope::ItemType;
 use crate::services::metrics::{Aggregator, MergeBuckets};
 use crate::services::outcome::{DiscardReason, Outcome};
-use crate::services::processor::{EncodeMetricMeta, EnvelopeProcessor, ProcessProjectMetrics};
+use crate::services::processor::{EncodeMetricMeta, EnvelopeProcessor};
 use crate::services::project::state::ExpiryState;
-use crate::services::project_cache::{
-    CheckedEnvelope, ProcessMetrics, ProjectCache, RequestUpdate,
-};
+use crate::services::project_cache::{CheckedEnvelope, ProjectCache, RequestUpdate};
 use crate::utils::{Enforcement, SeqCount};
 
 use crate::statsd::RelayCounters;
@@ -164,23 +162,6 @@ impl Project {
         self.last_updated_at = Instant::now();
     }
 
-    /// Collects internal project state and assembles a [`ProcessProjectMetrics`] message.
-    pub fn process_metrics(&mut self, message: ProcessMetrics) -> ProcessProjectMetrics {
-        let project_state = self.current_state();
-        let rate_limits = self.rate_limits.current_limits().clone();
-
-        ProcessProjectMetrics {
-            project_state,
-            rate_limits,
-
-            data: message.data,
-            project_key: message.project_key,
-            source: message.source,
-            start_time: message.start_time.into(),
-            sent_at: message.sent_at,
-        }
-    }
-
     /// Returns a list of buckets back to the aggregator.
     ///
     /// This is used to return flushed buckets back to the aggregator if the project has not been
@@ -292,7 +273,7 @@ impl Project {
     /// needs to be upgraded with the `no_cache` flag to ensure a more recent update.
     fn fetch_state(
         &mut self,
-        project_cache: Addr<ProjectCache>,
+        project_cache: &Addr<ProjectCache>,
         no_cache: bool,
     ) -> &mut StateChannel {
         // If there is a running request and we do not need to upgrade it to no_cache, or if the
@@ -322,7 +303,7 @@ impl Project {
 
     fn get_or_fetch_state(
         &mut self,
-        project_cache: Addr<ProjectCache>,
+        project_cache: &Addr<ProjectCache>,
         mut no_cache: bool,
     ) -> GetOrFetch<'_> {
         // count number of times we are looking for the project state
@@ -374,7 +355,7 @@ impl Project {
     /// To wait for a valid state instead, use [`get_state`](Self::get_state).
     pub fn get_cached_state(
         &mut self,
-        project_cache: Addr<ProjectCache>,
+        project_cache: &Addr<ProjectCache>,
         no_cache: bool,
     ) -> ProjectState {
         match self.get_or_fetch_state(project_cache, no_cache) {
@@ -393,7 +374,7 @@ impl Project {
     /// are in the [grace period](Config::project_grace_period).
     pub fn get_state(
         &mut self,
-        project_cache: Addr<ProjectCache>,
+        project_cache: &Addr<ProjectCache>,
         sender: ProjectSender,
         no_cache: bool,
     ) {
@@ -418,7 +399,7 @@ impl Project {
     /// point. Therefore, this method is useful to trigger an update early if it is already clear
     /// that the project state will be needed soon. To retrieve an updated state, use
     /// [`Project::get_state`] instead.
-    pub fn prefetch(&mut self, project_cache: Addr<ProjectCache>, no_cache: bool) -> &mut Self {
+    pub fn prefetch(&mut self, project_cache: &Addr<ProjectCache>, no_cache: bool) -> &mut Self {
         self.get_cached_state(project_cache, no_cache);
         self
     }
@@ -744,7 +725,7 @@ mod tests {
             &envelope_processor,
             false,
         );
-        project.fetch_state(addr, false);
+        project.fetch_state(&addr, false);
     }
 
     fn create_project(config: Option<serde_json::Value>) -> Project {

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -7,7 +7,8 @@ use crate::extractors::RequestMeta;
 use crate::services::buffer::{EnvelopeBuffer, EnvelopeBufferError};
 use crate::services::global_config;
 use crate::services::processor::{
-    EncodeMetrics, EnvelopeProcessor, MetricData, ProcessEnvelope, ProcessingGroup, ProjectMetrics,
+    EncodeMetrics, EnvelopeProcessor, MetricData, ProcessEnvelope, ProcessProjectData,
+    ProcessProjectMetrics, ProcessingGroup, ProjectMetrics,
 };
 use crate::services::project::state::UpstreamProjectState;
 use crate::Envelope;
@@ -20,6 +21,7 @@ use relay_quotas::RateLimits;
 use relay_redis::RedisPool;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, Interface, Sender, Service};
+use smallvec::SmallVec;
 #[cfg(feature = "processing")]
 use tokio::sync::Semaphore;
 use tokio::sync::{mpsc, watch};
@@ -204,13 +206,11 @@ impl From<&RequestMeta> for BucketSource {
 /// Starts the processing flow for received metrics.
 ///
 /// Enriches the raw data with projcet information and forwards
-/// the metrics using [`ProcessProjectMetrics`](crate::services::processor::ProcessProjectMetrics).
+/// the metrics using [`ProcessProjectMetrics`].
 #[derive(Debug)]
 pub struct ProcessMetrics {
-    /// A list of metric items.
-    pub data: MetricData,
-    /// The target project.
-    pub project_key: ProjectKey,
+    /// Project associated metrics.
+    pub data: SmallVec<[(ProjectKey, MetricData); 1]>,
     /// Whether to keep or reset the metric metadata.
     pub source: BucketSource,
     /// The instant at which the request was received.
@@ -776,13 +776,13 @@ impl ProjectCacheBroker {
         let project_cache = self.services.project_cache.clone();
         let project = self.get_or_create_project(project_key);
 
-        project.get_state(project_cache, sender, no_cache);
+        project.get_state(&project_cache, sender, no_cache);
     }
 
     fn handle_get_cached(&mut self, message: GetCachedProjectState) -> ProjectState {
         let project_cache = self.services.project_cache.clone();
         self.get_or_create_project(message.project_key)
-            .get_cached_state(project_cache, false)
+            .get_cached_state(&project_cache, false)
     }
 
     fn handle_check_envelope(
@@ -795,7 +795,7 @@ impl ProjectCacheBroker {
         if let Some(sampling_key) = context.envelope().sampling_key() {
             if sampling_key != project_key {
                 let sampling_project = self.get_or_create_project(sampling_key);
-                sampling_project.prefetch(project_cache.clone(), false);
+                sampling_project.prefetch(&project_cache, false);
             }
         }
         let project = self.get_or_create_project(project_key);
@@ -803,7 +803,7 @@ impl ProjectCacheBroker {
         // Preload the project cache so that it arrives a little earlier in processing. However,
         // do not pass `no_cache`. In case the project is rate limited, we do not want to force
         // a full reload. Fetching must not block the store request.
-        project.prefetch(project_cache, false);
+        project.prefetch(&project_cache, false);
 
         project.check_envelope(context)
     }
@@ -819,14 +819,14 @@ impl ProjectCacheBroker {
             );
 
             let mut project = Project::new(project_key, self.config.clone());
-            project.prefetch(self.services.project_cache.clone(), false);
+            project.prefetch(&self.services.project_cache, false);
             self.projects.insert(project_key, project);
             self.enqueue(key, managed_envelope);
             return;
         };
 
         let project_cache = self.services.project_cache.clone();
-        let project_info = match project.get_cached_state(project_cache.clone(), false) {
+        let project_info = match project.get_cached_state(&project_cache, false) {
             ProjectState::Enabled(info) => info,
             ProjectState::Disabled => {
                 managed_envelope.reject(Outcome::Invalid(DiscardReason::ProjectId));
@@ -859,7 +859,7 @@ impl ProjectCacheBroker {
                 .envelope()
                 .sampling_key()
                 .and_then(|key| self.projects.get_mut(&key))
-                .and_then(|p| p.get_cached_state(project_cache, false).enabled())
+                .and_then(|p| p.get_cached_state(&project_cache, false).enabled())
                 .filter(|state| state.organization_id == project_info.organization_id);
 
             let process = ProcessEnvelope {
@@ -898,8 +898,7 @@ impl ProjectCacheBroker {
         let own_key = envelope.meta().public_key();
         let project = self.get_or_create_project(own_key);
 
-        let project_state =
-            project.get_cached_state(project_cache.clone(), envelope.meta().no_cache());
+        let project_state = project.get_cached_state(&project_cache, envelope.meta().no_cache());
 
         let project_state = match project_state {
             ProjectState::Enabled(state) => Some(state),
@@ -916,7 +915,7 @@ impl ProjectCacheBroker {
         let sampling_state = if let Some(sampling_key) = sampling_key {
             let state = self
                 .get_or_create_project(sampling_key)
-                .get_cached_state(project_cache, envelope.meta().no_cache());
+                .get_cached_state(&project_cache, envelope.meta().no_cache());
             match state {
                 ProjectState::Enabled(state) => Some(state),
                 ProjectState::Disabled => {
@@ -960,12 +959,34 @@ impl ProjectCacheBroker {
     fn handle_process_metrics(&mut self, message: ProcessMetrics) {
         let project_cache = self.services.project_cache.clone();
 
-        let message = self
-            .get_or_create_project(message.project_key)
-            .prefetch(project_cache, false)
-            .process_metrics(message);
+        let data = message
+            .data
+            .into_iter()
+            .map(|(project_key, data)| {
+                let project = self
+                    .get_or_create_project(project_key)
+                    .prefetch(&project_cache, false);
 
-        self.services.envelope_processor.send(message);
+                let project_state = project.current_state();
+                let rate_limits = project.current_rate_limits().clone();
+
+                ProcessProjectData {
+                    project_key,
+                    project_state,
+                    rate_limits,
+                    data,
+                }
+            })
+            .collect();
+
+        self.services
+            .envelope_processor
+            .send(ProcessProjectMetrics {
+                data,
+                source: message.source,
+                start_time: message.start_time.into(),
+                sent_at: message.sent_at,
+            });
     }
 
     fn handle_add_metric_meta(&mut self, message: AddMetricMeta) {
@@ -988,7 +1009,7 @@ impl ProjectCacheBroker {
                 ProjectState::Pending => {
                     no_project += 1;
                     // Schedule an update for the project just in case.
-                    project.prefetch(project_cache.clone(), false);
+                    project.prefetch(&project_cache, false);
                     project.return_buckets(&aggregator, buckets);
                     continue;
                 }
@@ -1051,10 +1072,10 @@ impl ProjectCacheBroker {
             let spool_v1 = self.spool_v1.as_mut().expect("no V1 spool configured");
             spool_v1.index.insert(key);
             self.get_or_create_project(key.own_key)
-                .prefetch(project_cache.clone(), false);
+                .prefetch(&project_cache, false);
             if key.own_key != key.sampling_key {
                 self.get_or_create_project(key.sampling_key)
-                    .prefetch(project_cache.clone(), false);
+                    .prefetch(&project_cache, false);
             }
         }
     }
@@ -1069,7 +1090,7 @@ impl ProjectCacheBroker {
 
         let own_key = envelope.meta().public_key();
         let project = self.get_or_create_project(own_key);
-        let project_state = project.get_cached_state(services.project_cache.clone(), false);
+        let project_state = project.get_cached_state(&services.project_cache, false);
 
         // Check if project config is enabled.
         let project_info = match project_state {
@@ -1095,7 +1116,7 @@ impl ProjectCacheBroker {
             (
                 sampling_key,
                 self.get_or_create_project(sampling_key)
-                    .get_cached_state(services.project_cache, false),
+                    .get_cached_state(&services.project_cache, false),
             )
         }) {
             Some((_, ProjectState::Enabled(info))) => {
@@ -1158,7 +1179,7 @@ impl ProjectCacheBroker {
         }
 
         let no_cache = false;
-        project.prefetch(project_cache, no_cache);
+        project.prefetch(&project_cache, no_cache);
     }
 
     /// Returns backoff timeout for an unspool attempt.
@@ -1190,7 +1211,7 @@ impl ProjectCacheBroker {
                 // Returns `Some` if the project is cached otherwise None and also triggers refresh
                 // in background.
                 !project
-                    .get_cached_state(self.services.project_cache.clone(), false)
+                    .get_cached_state(&self.services.project_cache.clone(), false)
                     .is_pending()
             })
         })


### PR DESCRIPTION
Instead of sending many messages for metrics, sends one big message.

The idea is to make backlogs when they occur more actionable.

#skip-changelog