### PR TITLE
ref(server): Consistent naming for project state and project info

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -168,7 +168,7 @@ pub trait EventProcessing {}
 /// A trait for processing groups that can be dynamically sampled.
 pub trait Sampling {
     /// Whether dynamic sampling should run under the given project's conditions.
-    fn supports_sampling(project_state: &ProjectInfo) -> bool;
+    fn supports_sampling(project_info: &ProjectInfo) -> bool;
 
     /// Whether reservoir sampling applies to this processing group (a.k.a. data type).
     fn supports_reservoir_sampling() -> bool;
@@ -178,9 +178,9 @@ processing_group!(TransactionGroup, Transaction);
 impl EventProcessing for TransactionGroup {}
 
 impl Sampling for TransactionGroup {
-    fn supports_sampling(project_state: &ProjectInfo) -> bool {
+    fn supports_sampling(project_info: &ProjectInfo) -> bool {
         // For transactions, we require transaction metrics to be enabled before sampling.
-        matches!(&project_state.config.transaction_metrics, Some(ErrorBoundary::Ok(c)) if c.is_enabled())
+        matches!(&project_info.config.transaction_metrics, Some(ErrorBoundary::Ok(c)) if c.is_enabled())
     }
 
     fn supports_reservoir_sampling() -> bool {
@@ -199,9 +199,9 @@ processing_group!(CheckInGroup, CheckIn);
 processing_group!(SpanGroup, Span);
 
 impl Sampling for SpanGroup {
-    fn supports_sampling(project_state: &ProjectInfo) -> bool {
+    fn supports_sampling(project_info: &ProjectInfo) -> bool {
         // If no metrics could be extracted, do not sample anything.
-        matches!(&project_state.config().metric_extraction, ErrorBoundary::Ok(c) if c.is_supported())
+        matches!(&project_info.config().metric_extraction, ErrorBoundary::Ok(c) if c.is_supported())
     }
 
     fn supports_reservoir_sampling() -> bool {
@@ -720,14 +720,14 @@ struct ProcessEnvelopeState<'a, Group> {
     extracted_metrics: ProcessingExtractedMetrics,
 
     /// The state of the project that this envelope belongs to.
-    project_state: Arc<ProjectInfo>,
+    project_info: Arc<ProjectInfo>,
 
     /// The config of this Relay instance.
     config: Arc<Config>,
 
     /// The state of the project that initiated the current trace.
     /// This is the config used for trace-based dynamic sampling.
-    sampling_project_state: Option<Arc<ProjectInfo>>,
+    sampling_project_info: Option<Arc<ProjectInfo>>,
 
     /// The id of the project that this envelope is ingested into.
     ///
@@ -798,7 +798,7 @@ impl<'a, Group> ProcessEnvelopeState<'a, Group> {
     fn should_filter(&self, feature: Feature) -> bool {
         match self.config.relay_mode() {
             RelayMode::Proxy | RelayMode::Static | RelayMode::Capture => false,
-            RelayMode::Managed => !self.project_state.has_feature(feature),
+            RelayMode::Managed => !self.project_info.has_feature(feature),
         }
     }
 }
@@ -1250,15 +1250,15 @@ impl EnvelopeProcessorService {
         config: Arc<Config>,
         mut managed_envelope: TypedEnvelope<G>,
         project_id: ProjectId,
-        project_state: Arc<ProjectInfo>,
-        sampling_project_state: Option<Arc<ProjectInfo>>,
+        project_info: Arc<ProjectInfo>,
+        sampling_project_info: Option<Arc<ProjectInfo>>,
         reservoir_counters: Arc<Mutex<BTreeMap<RuleId, i64>>>,
     ) -> ProcessEnvelopeState<G> {
         let envelope = managed_envelope.envelope_mut();
 
         // Set the event retention. Effectively, this value will only be available in processing
         // mode when the full project config is queried from the upstream.
-        if let Some(retention) = project_state.config.event_retention {
+        if let Some(retention) = project_info.config.event_retention {
             envelope.set_retention(retention);
         }
 
@@ -1290,9 +1290,9 @@ impl EnvelopeProcessorService {
             spans_extracted: false,
             metrics: Metrics::default(),
             extracted_metrics,
-            project_state,
+            project_info,
             config,
-            sampling_project_state,
+            sampling_project_info,
             project_id,
             managed_envelope,
             reservoir,
@@ -1310,9 +1310,9 @@ impl EnvelopeProcessorService {
             None => return Ok(()),
         };
 
-        let project_state = &state.project_state;
+        let project_info = &state.project_info;
         let global_config = self.inner.global_config.current();
-        let quotas = CombinedQuotas::new(&global_config, project_state.get_quotas());
+        let quotas = CombinedQuotas::new(&global_config, project_info.get_quotas());
 
         if quotas.is_empty() {
             return Ok(());
@@ -1378,7 +1378,7 @@ impl EnvelopeProcessorService {
         // it is not present in the actual project config payload.
         let global = self.inner.global_config.current();
         let combined_config = {
-            let config = match &state.project_state.config.metric_extraction {
+            let config = match &state.project_info.config.metric_extraction {
                 ErrorBoundary::Ok(ref config) if config.is_supported() => config,
                 _ => return Ok(()),
             };
@@ -1403,7 +1403,7 @@ impl EnvelopeProcessorService {
         };
 
         // Require a valid transaction metrics config.
-        let tx_config = match &state.project_state.config.transaction_metrics {
+        let tx_config = match &state.project_info.config.transaction_metrics {
             Some(ErrorBoundary::Ok(tx_config)) => tx_config,
             Some(ErrorBoundary::Err(e)) => {
                 relay_log::debug!("Failed to parse legacy transaction metrics config: {e}");
@@ -1444,7 +1444,7 @@ impl EnvelopeProcessorService {
             .extracted_metrics
             .extend_project_metrics(metrics, Some(sampling_decision));
 
-        if !state.project_state.has_feature(Feature::DiscardTransaction) {
+        if !state.project_info.has_feature(Feature::DiscardTransaction) {
             let transaction_from_dsc = state
                 .managed_envelope
                 .envelope()
@@ -1505,7 +1505,7 @@ impl EnvelopeProcessorService {
         let http_span_allowed_hosts = global_config.options.http_span_allowed_hosts.as_slice();
 
         let retention_days: i64 = state
-            .project_state
+            .project_info
             .config
             .event_retention
             .unwrap_or(DEFAULT_EVENT_RETENTION)
@@ -1523,7 +1523,7 @@ impl EnvelopeProcessorService {
             };
 
             let key_id = state
-                .project_state
+                .project_info
                 .get_public_key_config()
                 .and_then(|key| Some(key.numeric_id?.to_string()));
             if full_normalization && key_id.is_none() {
@@ -1538,7 +1538,7 @@ impl EnvelopeProcessorService {
                 client: request_meta.client().map(str::to_owned),
                 key_id,
                 protocol_version: Some(request_meta.version().to_string()),
-                grouping_config: state.project_state.config.grouping_config.clone(),
+                grouping_config: state.project_info.config.grouping_config.clone(),
                 client_ip: client_ipaddr.as_ref(),
                 client_sample_rate: state
                     .managed_envelope
@@ -1555,20 +1555,20 @@ impl EnvelopeProcessorService {
                         .max_name_length
                         .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),
                 ),
-                breakdowns_config: state.project_state.config.breakdowns_v2.as_ref(),
-                performance_score: state.project_state.config.performance_score.as_ref(),
+                breakdowns_config: state.project_info.config.breakdowns_v2.as_ref(),
+                performance_score: state.project_info.config.performance_score.as_ref(),
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
-                    rules: &state.project_state.config.tx_name_rules,
+                    rules: &state.project_info.config.tx_name_rules,
                 },
                 device_class_synthesis_config: state
-                    .project_state
+                    .project_info
                     .has_feature(Feature::DeviceClassSynthesis),
                 enrich_spans: state
-                    .project_state
+                    .project_info
                     .has_feature(Feature::ExtractSpansFromEvent)
                     || state
-                        .project_state
+                        .project_info
                         .has_feature(Feature::ExtractCommonSpanMetricsFromEvent),
                 max_tag_value_length: self
                     .inner
@@ -1579,12 +1579,12 @@ impl EnvelopeProcessorService {
                 is_renormalize: false,
                 remove_other: full_normalization,
                 emit_event_errors: full_normalization,
-                span_description_rules: state.project_state.config.span_description_rules.as_ref(),
+                span_description_rules: state.project_info.config.span_description_rules.as_ref(),
                 geoip_lookup: self.inner.geoip_lookup.as_ref(),
                 ai_model_costs: ai_model_costs.as_ref(),
                 enable_trimming: true,
                 measurements: Some(CombinedMeasurementsConfig::new(
-                    state.project_state.config().measurements.as_ref(),
+                    state.project_info.config().measurements.as_ref(),
                     global_config.measurements.as_ref(),
                 )),
                 normalize_spans: true,
@@ -1595,7 +1595,7 @@ impl EnvelopeProcessorService {
                     .and_then(|ctx| ctx.replay_id),
                 span_allowed_hosts: http_span_allowed_hosts,
                 scrub_mongo_description: if state
-                    .project_state
+                    .project_info
                     .has_feature(Feature::ScrubMongoDbDescriptions)
                 {
                     ScrubMongoDescription::Enabled
@@ -1749,7 +1749,7 @@ impl EnvelopeProcessorService {
             self.extract_transaction_metrics(state, SamplingDecision::Keep, profile_id)?;
 
             if state
-                .project_state
+                .project_info
                 .has_feature(Feature::ExtractSpansFromEvent)
             {
                 span::extract_from_event(state, &global_config, server_sample_rate);
@@ -1880,8 +1880,8 @@ impl EnvelopeProcessorService {
         &self,
         mut managed_envelope: ManagedEnvelope,
         project_id: ProjectId,
-        project_state: Arc<ProjectInfo>,
-        sampling_project_state: Option<Arc<ProjectInfo>>,
+        project_info: Arc<ProjectInfo>,
+        sampling_project_info: Option<Arc<ProjectInfo>>,
         reservoir_counters: Arc<Mutex<BTreeMap<RuleId, i64>>>,
     ) -> Result<ProcessingStateResult, ProcessingError> {
         // Get the group from the managed envelope context, and if it's not set, try to guess it
@@ -1889,7 +1889,7 @@ impl EnvelopeProcessorService {
         let group = managed_envelope.group();
 
         // Pre-process the envelope headers.
-        if let Some(sampling_state) = sampling_project_state.as_ref() {
+        if let Some(sampling_state) = sampling_project_info.as_ref() {
             // Both transactions and standalone span envelopes need a normalized DSC header
             // to make sampling rules based on the segment/transaction name work correctly.
             managed_envelope
@@ -1904,8 +1904,8 @@ impl EnvelopeProcessorService {
                     self.inner.config.clone(),
                     managed_envelope,
                     project_id,
-                    project_state,
-                    sampling_project_state,
+                    project_info,
+                    sampling_project_info,
                     reservoir_counters,
                 );
                 match self.$fn(&mut state) {
@@ -2380,7 +2380,7 @@ impl EnvelopeProcessorService {
     fn rate_limit_buckets(
         &self,
         scoping: Scoping,
-        project_state: &ProjectInfo,
+        project_info: &ProjectInfo,
         mut buckets: Vec<Bucket>,
     ) -> Vec<Bucket> {
         let Some(rate_limiter) = self.inner.rate_limiter.as_ref() else {
@@ -2393,7 +2393,7 @@ impl EnvelopeProcessorService {
             .filter_map(|bucket| bucket.name.try_namespace())
             .counts();
 
-        let quotas = CombinedQuotas::new(&global_config, project_state.get_quotas());
+        let quotas = CombinedQuotas::new(&global_config, project_info.get_quotas());
 
         for (namespace, quantity) in namespaces {
             let item_scoping = scoping.metric_bucket(namespace);
@@ -2429,7 +2429,7 @@ impl EnvelopeProcessorService {
             }
         }
 
-        match MetricsLimiter::create(buckets, project_state.config.quotas.clone(), scoping) {
+        match MetricsLimiter::create(buckets, project_info.config.quotas.clone(), scoping) {
             Err(buckets) => buckets,
             Ok(bucket_limiter) => self.apply_other_rate_limits(bucket_limiter),
         }

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -50,7 +50,7 @@ pub fn create_placeholders<G: EventProcessing>(state: &mut ProcessEnvelopeState<
 /// logic; otherwise the entire attachment is treated as a single binary blob.
 pub fn scrub<G>(state: &mut ProcessEnvelopeState<G>) {
     let envelope = state.managed_envelope.envelope_mut();
-    if let Some(ref config) = state.project_state.config.pii_config {
+    if let Some(ref config) = state.project_info.config.pii_config {
         let minidump = envelope
             .get_item_by_mut(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -39,7 +39,7 @@ use crate::utils::{self, SamplingResult};
 ///
 /// If there is no transaction event in the envelope, this function will do nothing.
 pub fn ensure_dsc(state: &mut ProcessEnvelopeState<TransactionGroup>) {
-    if state.envelope().dsc().is_some() && state.sampling_project_state.is_some() {
+    if state.envelope().dsc().is_some() && state.sampling_project_info.is_some() {
         return;
     }
 
@@ -48,13 +48,13 @@ pub fn ensure_dsc(state: &mut ProcessEnvelopeState<TransactionGroup>) {
     let Some(event) = state.event.value() else {
         return;
     };
-    let Some(key_config) = state.project_state.get_public_key_config() else {
+    let Some(key_config) = state.project_info.get_public_key_config() else {
         return;
     };
 
     if let Some(dsc) = utils::dsc_from_event(key_config.public_key, event) {
         state.envelope_mut().set_dsc(dsc);
-        state.sampling_project_state = Some(state.project_state.clone());
+        state.sampling_project_info = Some(state.project_info.clone());
     }
 }
 
@@ -63,16 +63,16 @@ pub fn run<Group>(state: &mut ProcessEnvelopeState<Group>) -> SamplingResult
 where
     Group: Sampling,
 {
-    if !Group::supports_sampling(&state.project_state) {
+    if !Group::supports_sampling(&state.project_info) {
         return SamplingResult::Pending;
     }
 
-    let sampling_config = match state.project_state.config.sampling {
+    let sampling_config = match state.project_info.config.sampling {
         Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
         _ => None,
     };
 
-    let root_state = state.sampling_project_state.as_ref();
+    let root_state = state.sampling_project_info.as_ref();
     let root_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
         Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
         _ => None,
@@ -196,7 +196,7 @@ pub fn tag_error_with_sampling_decision<G: EventProcessing>(
         return;
     };
 
-    let root_state = state.sampling_project_state.as_ref();
+    let root_state = state.sampling_project_info.as_ref();
     let sampling_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
         Some(ErrorBoundary::Ok(ref config)) => config,
         _ => return,
@@ -414,14 +414,14 @@ mod tests {
                 ..Event::default()
             };
 
-            let mut project_state = state_with_rule_and_condition(
+            let mut project_info = state_with_rule_and_condition(
                 Some(0.0),
                 RuleType::Transaction,
                 RuleCondition::all(),
             );
 
             if let Some(version) = version {
-                project_state.config.transaction_metrics =
+                project_info.config.transaction_metrics =
                     ErrorBoundary::Ok(relay_dynamic_config::TransactionMetricsConfig {
                         version,
                         ..Default::default()
@@ -429,7 +429,7 @@ mod tests {
                     .into();
             }
 
-            let project_state = Arc::new(project_state);
+            let project_info = Arc::new(project_info);
             let envelope = new_envelope(false, "foo");
 
             ProcessEnvelopeState::<TransactionGroup> {
@@ -437,8 +437,8 @@ mod tests {
                 metrics: Default::default(),
                 extracted_metrics: ProcessingExtractedMetrics::new(),
                 config: config.clone(),
-                project_state,
-                sampling_project_state: None,
+                project_info,
+                sampling_project_info: None,
                 project_id: ProjectId::new(42),
                 managed_envelope: ManagedEnvelope::new(
                     envelope,
@@ -708,8 +708,8 @@ mod tests {
             metrics: Default::default(),
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
-            project_state: project_info,
-            sampling_project_state: {
+            project_info,
+            sampling_project_info: {
                 let mut state = ProjectInfo::default();
                 state.config.metric_extraction =
                     ErrorBoundary::Ok(MetricExtractionConfig::default());

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -284,7 +284,7 @@ pub fn filter<G: EventProcessing>(
     };
 
     let client_ip = state.managed_envelope.envelope().meta().client_addr();
-    let filter_settings = &state.project_state.config.filter_settings;
+    let filter_settings = &state.project_info.config.filter_settings;
 
     metric!(timer(RelayTimers::EventProcessingFiltering), {
         relay_filter::should_filter(event, client_ip, filter_settings, global_config.filters())
@@ -303,7 +303,7 @@ pub fn filter<G: EventProcessing>(
     let supported_generic_filters = global_config.filters.is_ok()
         && relay_filter::are_generic_filters_supported(
             global_config.filters().map(|f| f.version),
-            state.project_state.config.filter_settings.generic.version,
+            state.project_info.config.filter_settings.generic.version,
         );
     if supported_generic_filters {
         Ok(FiltersStatus::Ok)
@@ -319,7 +319,7 @@ pub fn scrub<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
 ) -> Result<(), ProcessingError> {
     let event = &mut state.event;
-    let config = &state.project_state.config;
+    let config = &state.project_info.config;
 
     if config.datascrubbing_settings.scrub_data {
         if let Some(event) = event.value_mut() {

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -89,7 +89,7 @@ pub fn transfer_id(
 
 /// Processes profiles and set the profile ID in the profile context on the transaction if successful.
 pub fn process(state: &mut ProcessEnvelopeState<TransactionGroup>) -> Option<ProfileId> {
-    let profiling_enabled = state.project_state.has_feature(Feature::Profiling);
+    let profiling_enabled = state.project_info.has_feature(Feature::Profiling);
     let mut profile_id = None;
 
     state.managed_envelope.retain_items(|item| match item.ty() {

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -15,9 +15,7 @@ use {
 
 /// Removes profile chunks from the envelope if the feature is not enabled.
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
-    let continuous_profiling_enabled = state
-        .project_state
-        .has_feature(Feature::ContinuousProfiling);
+    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling);
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk if !continuous_profiling_enabled => ItemAction::DropSilently,
         _ => ItemAction::Keep,
@@ -27,9 +25,7 @@ pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
 /// Processes profile chunks.
 #[cfg(feature = "processing")]
 pub fn process(state: &mut ProcessEnvelopeState<ProfileChunkGroup>, config: &Config) {
-    let continuous_profiling_enabled = state
-        .project_state
-        .has_feature(Feature::ContinuousProfiling);
+    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling);
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk => {
             if !continuous_profiling_enabled {

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -35,7 +35,7 @@ pub fn process(
     // If the replay video feature is not enabled check the envelope items for a
     // replay video event.
     if state
-        .project_state
+        .project_info
         .has_feature(Feature::SessionReplayVideoDisabled)
         && count_replay_video_events(state) > 0
     {
@@ -47,12 +47,12 @@ pub fn process(
         let meta = state.envelope().meta();
 
         ReplayProcessingConfig {
-            config: &state.project_state.config,
+            config: &state.project_info.config,
             global_config,
             geoip_lookup,
             event_id: state.envelope().event_id(),
-            project_id: state.project_state.project_id,
-            organization_id: state.project_state.organization_id,
+            project_id: state.project_info.project_id,
+            organization_id: state.project_info.organization_id,
             client_addr: meta.client_addr(),
             user_agent: RawUserAgentInfo {
                 user_agent: meta.user_agent().map(|s| s.to_owned()),
@@ -62,7 +62,7 @@ pub fn process(
     };
 
     let mut scrubber = if state
-        .project_state
+        .project_info
         .has_feature(Feature::SessionReplayRecordingScrubbing)
     {
         let datascrubbing_config = rpc
@@ -83,7 +83,7 @@ pub fn process(
 
     for item in state.managed_envelope.envelope_mut().items_mut() {
         if state
-            .project_state
+            .project_info
             .has_feature(Feature::SessionReplayCombinedEnvelopeItems)
         {
             item.set_replay_combined_payload(true);

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -132,7 +132,7 @@ pub fn process_client_reports(
     }
 
     let retention_days = state
-        .project_state
+        .project_info
         .config()
         .event_retention
         .unwrap_or(DEFAULT_EVENT_RETENTION);

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -24,7 +24,7 @@ use crate::utils::ItemAction;
 /// are out of range after clock drift correction.
 pub fn process(state: &mut ProcessEnvelopeState<SessionGroup>, config: &Config) {
     let received = state.managed_envelope.received_at();
-    let metrics_config = state.project_state.config().session_metrics;
+    let metrics_config = state.project_info.config().session_metrics;
     let envelope = state.managed_envelope.envelope_mut();
     let client = envelope.meta().client().map(|x| x.to_owned());
     let client_addr = envelope.meta().client_addr();

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -56,21 +56,21 @@ pub fn process(
     // once for all spans in the envelope.
     let sampling_result = dynamic_sampling::run(state);
 
-    let span_metrics_extraction_config = match state.project_state.config.metric_extraction {
+    let span_metrics_extraction_config = match state.project_info.config.metric_extraction {
         ErrorBoundary::Ok(ref config) if config.is_enabled() => Some(config),
         _ => None,
     };
     let normalize_span_config = NormalizeSpanConfig::new(
         &state.config,
         global_config,
-        state.project_state.config(),
+        state.project_info.config(),
         &state.managed_envelope,
         state.envelope().meta().client_addr().map(IpAddr::from),
         geo_lookup,
     );
 
     let client_ip = state.managed_envelope.envelope().meta().client_addr();
-    let filter_settings = &state.project_state.config.filter_settings;
+    let filter_settings = &state.project_info.config.filter_settings;
 
     let mut dynamic_sampling_dropped_spans = 0;
     state.managed_envelope.retain_items(|item| {
@@ -149,7 +149,7 @@ pub fn process(
             return ItemAction::DropSilently;
         }
 
-        if let Err(e) = scrub(&mut annotated_span, &state.project_state.config) {
+        if let Err(e) = scrub(&mut annotated_span, &state.project_info.config) {
             relay_log::error!("failed to scrub span: {e}");
         }
 
@@ -322,7 +322,7 @@ pub fn extract_from_event(
             .max_tag_value_length,
         &[],
         if state
-            .project_state
+            .project_info
             .config
             .features
             .has(Feature::ScrubMongoDbDescriptions)
@@ -364,7 +364,7 @@ pub fn extract_from_event(
 /// Removes the transaction in case the project has made the transition to spans-only.
 pub fn maybe_discard_transaction(state: &mut ProcessEnvelopeState<TransactionGroup>) {
     if state.event_type() == Some(EventType::Transaction)
-        && state.project_state.has_feature(Feature::DiscardTransaction)
+        && state.project_info.has_feature(Feature::DiscardTransaction)
     {
         state.remove_event();
         state.managed_envelope.update();
@@ -781,13 +781,13 @@ mod tests {
         );
 
         let dummy_envelope = Envelope::parse_bytes(bytes).unwrap();
-        let mut project_state = ProjectInfo::default();
-        project_state
+        let mut project_info = ProjectInfo::default();
+        project_info
             .config
             .features
             .0
             .insert(Feature::ExtractCommonSpanMetricsFromEvent);
-        let project_state = Arc::new(project_state);
+        let project_info = Arc::new(project_info);
 
         let event = Event {
             ty: EventType::Transaction.into(),
@@ -820,8 +820,8 @@ mod tests {
             metrics: Default::default(),
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
-            project_state,
-            sampling_project_state: None,
+            project_info,
+            sampling_project_info: None,
             project_id: ProjectId::new(42),
             managed_envelope: managed_envelope.try_into().unwrap(),
             event_metrics_extracted: false,


### PR DESCRIPTION
Rename a few instances of `project_state` to `project_info` where the value is actually a `ProjectInfo` not a `ProjectState`.

#skip-changelog