### PR TITLE
ref(quotas): Cache and enforce indexed quotas in processor

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2929,7 +2929,7 @@ impl<'a> RateLimiter<'a> {
         global_config: &GlobalConfig,
         state: &mut ProcessEnvelopeState<G>,
     ) -> Result<RateLimits, ProcessingError> {
-        if state.envelope().is_empty() {
+        if state.envelope().is_empty() && !state.has_event() {
             return Ok(RateLimits::default());
         }
 
@@ -2971,6 +2971,7 @@ impl<'a> RateLimiter<'a> {
         if event_active {
             state.remove_event();
             debug_assert!(state.envelope().is_empty());
+            debug_assert!(!state.has_event());
         }
 
         Ok(limits)

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -298,6 +298,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope: ManagedEnvelope::new(envelope, outcome_aggregator, test_store, group),
             project_info: Arc::new(ProjectInfo::default()),
+            rate_limits: Default::default(),
             sampling_project_info,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -438,6 +439,7 @@ mod tests {
                 extracted_metrics: ProcessingExtractedMetrics::new(),
                 config: config.clone(),
                 project_info,
+                rate_limits: Default::default(),
                 sampling_project_info: None,
                 project_id: ProjectId::new(42),
                 managed_envelope: ManagedEnvelope::new(
@@ -709,6 +711,7 @@ mod tests {
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
             project_info,
+            rate_limits: Default::default(),
             sampling_project_info: {
                 let mut state = ProjectInfo::default();
                 state.config.metric_extraction =

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -259,6 +259,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(project_state),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -389,6 +390,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(project_info),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -458,6 +460,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(project_state),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -529,6 +532,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(project_state),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -325,6 +325,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -379,6 +380,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -441,6 +443,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -481,6 +484,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };
@@ -529,6 +533,7 @@ mod tests {
         let message = ProcessEnvelope {
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
+            rate_limits: Default::default(),
             sampling_project_info: None,
             reservoir_counters: ReservoirCounters::default(),
         };

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -762,6 +762,7 @@ mod tests {
     };
     use relay_event_schema::protocol::{Contexts, Event, Span};
     use relay_protocol::get_value;
+    use relay_quotas::RateLimits;
     use relay_sampling::evaluation::{ReservoirCounters, ReservoirEvaluator};
     use relay_system::Addr;
 
@@ -821,6 +822,7 @@ mod tests {
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
             project_info,
+            rate_limits: RateLimits::default(),
             sampling_project_info: None,
             project_id: ProjectId::new(42),
             managed_envelope: managed_envelope.try_into().unwrap(),

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -23,7 +23,7 @@ use crate::services::project_cache::{
 use crate::utils::{Enforcement, SeqCount};
 
 use crate::statsd::RelayCounters;
-use crate::utils::{ApplyLimits, EnvelopeLimiter, ManagedEnvelope, RetryBackoff};
+use crate::utils::{CheckLimits, EnvelopeLimiter, ManagedEnvelope, RetryBackoff};
 
 pub mod state;
 
@@ -553,7 +553,7 @@ impl Project {
         let current_limits = self.rate_limits.current_limits();
 
         let quotas = state.as_deref().map(|s| s.get_quotas()).unwrap_or(&[]);
-        let envelope_limiter = EnvelopeLimiter::new(ApplyLimits::NonIndexed, |item_scoping, _| {
+        let envelope_limiter = EnvelopeLimiter::new(CheckLimits::NonIndexed, |item_scoping, _| {
             Ok(current_limits.check_with_quotas(quotas, item_scoping))
         });
 

--- a/relay-server/src/services/project.rs
+++ b/relay-server/src/services/project.rs
@@ -23,7 +23,7 @@ use crate::services::project_cache::{
 use crate::utils::{Enforcement, SeqCount};
 
 use crate::statsd::RelayCounters;
-use crate::utils::{EnvelopeLimiter, ManagedEnvelope, RetryBackoff};
+use crate::utils::{ApplyLimits, EnvelopeLimiter, ManagedEnvelope, RetryBackoff};
 
 pub mod state;
 
@@ -553,7 +553,7 @@ impl Project {
         let current_limits = self.rate_limits.current_limits();
 
         let quotas = state.as_deref().map(|s| s.get_quotas()).unwrap_or(&[]);
-        let envelope_limiter = EnvelopeLimiter::new(|item_scoping, _| {
+        let envelope_limiter = EnvelopeLimiter::new(ApplyLimits::NonIndexed, |item_scoping, _| {
             Ok(current_limits.check_with_quotas(quotas, item_scoping))
         });
 

--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -872,6 +872,8 @@ impl ProjectCacheBroker {
             ..
         }) = project.check_envelope(managed_envelope)
         {
+            let rate_limits = project.current_rate_limits().clone();
+
             let reservoir_counters = project.reservoir_counters();
 
             let sampling_project_info = managed_envelope
@@ -884,6 +886,7 @@ impl ProjectCacheBroker {
             let process = ProcessEnvelope {
                 envelope: managed_envelope,
                 project_info,
+                rate_limits,
                 sampling_project_info,
                 reservoir_counters,
             };
@@ -1156,6 +1159,7 @@ impl ProjectCacheBroker {
             services.envelope_processor.send(ProcessEnvelope {
                 envelope: managed_envelope,
                 project_info: project_info.clone(),
+                rate_limits: project.current_rate_limits().clone(),
                 sampling_project_info: sampling_project_info.clone(),
                 reservoir_counters,
             });

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -226,6 +226,8 @@ class ConsumerBase:
 
 
 def category_value(category):
+    if isinstance(category, DataCategory):
+        return category
     return DataCategory.parse(category)
 
 
@@ -243,7 +245,13 @@ class OutcomesConsumer(ConsumerBase):
         return outcomes[0]
 
     def assert_rate_limited(
-        self, reason, key_id=None, categories=None, quantity=None, timeout=1
+        self,
+        reason,
+        key_id=None,
+        categories=None,
+        quantity=None,
+        timeout=1,
+        ignore_other=False,
     ):
         if categories is None:
             outcome = self.get_outcome(timeout=timeout)
@@ -253,6 +261,8 @@ class OutcomesConsumer(ConsumerBase):
             outcomes = self.get_outcomes(timeout=timeout)
             expected = {category_value(category) for category in categories}
             actual = {outcome["category"] for outcome in outcomes}
+            if ignore_other:
+                actual = actual & set(categories)
             assert actual == expected, (actual, expected)
 
         for outcome in outcomes:


### PR DESCRIPTION
Instead of never caching indexed rate limits, cache them but only selectively enforce them. With the indexed rate limits being cached, this allows us to enforce cached rate limits in the processor without ever going to Redis.

#skip-changelog