### PR TITLE
fix(tests): Fix flaky `test_readiness_not_enough_memory_bytes`

### DIFF
--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -7,7 +7,6 @@ import time
 import tempfile
 import os
 
-import pytest
 from requests import HTTPError
 
 

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -102,7 +102,6 @@ def assert_not_enough_memory(relay, mini_sentry, expected_comparison):
     assert False, f"Not all errors represented: {errors}"
 
 
-@pytest.mark.parametrize("i", range(100))  # remove before merge
 def test_readiness_not_enough_memory_bytes(mini_sentry, relay, i):
     relay = relay(
         mini_sentry,
@@ -113,7 +112,6 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay, i):
     assert_not_enough_memory(relay, mini_sentry, ">= 42")
 
 
-@pytest.mark.parametrize("i", range(100))  # remove before merge
 def test_readiness_not_enough_memory_percent(mini_sentry, relay, i):
     relay = relay(
         mini_sentry,

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -88,11 +88,11 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
     )
 
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
-    error = str(mini_sentry.test_failures.get(timeout=2))
+    error = str(mini_sentry.test_failures.get(timeout=5))
     assert "Not enough memory" in error and ">= 42" in error
-    error = str(mini_sentry.test_failures.get(timeout=2))
+    error = str(mini_sentry.test_failures.get(timeout=5))
     assert "Health check probe 'system memory'" in error
-    error = str(mini_sentry.test_failures.get(timeout=2))
+    error = str(mini_sentry.test_failures.get(timeout=5))
     assert "Health check probe 'spool health'" in error
     assert response.status_code == 503
 
@@ -105,11 +105,11 @@ def test_readiness_not_enough_memory_percent(mini_sentry, relay):
     )
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
 
-    error = str(mini_sentry.test_failures.get(timeout=2))
+    error = str(mini_sentry.test_failures.get(timeout=5))
     assert "Not enough memory" in error and ">= 1.00%" in error
-    error = str(mini_sentry.test_failures.get(timeout=2))
+    error = str(mini_sentry.test_failures.get(timeout=5))
     assert "Health check probe 'system memory'" in error
-    error = str(mini_sentry.test_failures.get(timeout=2))
+    error = str(mini_sentry.test_failures.get(timeout=5))
     assert "Health check probe 'spool health'" in error
     assert response.status_code == 503
 

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -102,7 +102,7 @@ def assert_not_enough_memory(relay, mini_sentry, expected_comparison):
     assert False, f"Not all errors represented: {errors}"
 
 
-def test_readiness_not_enough_memory_bytes(mini_sentry, relay, i):
+def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
     relay = relay(
         mini_sentry,
         {"relay": {"mode": "proxy"}, "health": {"max_memory_bytes": 42}},
@@ -112,7 +112,7 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay, i):
     assert_not_enough_memory(relay, mini_sentry, ">= 42")
 
 
-def test_readiness_not_enough_memory_percent(mini_sentry, relay, i):
+def test_readiness_not_enough_memory_percent(mini_sentry, relay):
     relay = relay(
         mini_sentry,
         {"relay": {"mode": "proxy"}, "health": {"max_memory_percent": 0.01}},

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -86,7 +86,7 @@ def assert_not_enough_memory(relay, mini_sentry, expected_comparison):
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
     assert response.status_code == 503
     errors = ""
-    for _ in range(10):
+    for _ in range(100):
         try:
             errors += f"{mini_sentry.test_failures.get(timeout=1)}\n"
         except queue.Empty:
@@ -102,7 +102,7 @@ def assert_not_enough_memory(relay, mini_sentry, expected_comparison):
     assert False, f"Not all errors represented: {errors}"
 
 
-@pytest.mark.parametrize("i", range(10))  # remove before merge
+@pytest.mark.parametrize("i", range(100))  # remove before merge
 def test_readiness_not_enough_memory_bytes(mini_sentry, relay, i):
     relay = relay(
         mini_sentry,
@@ -113,7 +113,7 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay, i):
     assert_not_enough_memory(relay, mini_sentry, ">= 42")
 
 
-@pytest.mark.parametrize("i", range(10))  # remove before merge
+@pytest.mark.parametrize("i", range(100))  # remove before merge
 def test_readiness_not_enough_memory_percent(mini_sentry, relay, i):
     relay = relay(
         mini_sentry,

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -6,6 +6,7 @@ import time
 import tempfile
 import os
 
+import pytest
 from requests import HTTPError
 
 
@@ -80,7 +81,8 @@ def test_readiness_proxy(mini_sentry, relay):
     assert response.status_code == 200
 
 
-def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
+@pytest.mark.parametrize("iteration", range(10))  # remove before merge
+def test_readiness_not_enough_memory_bytes(mini_sentry, relay, iteration):
     relay = relay(
         mini_sentry,
         {"relay": {"mode": "proxy"}, "health": {"max_memory_bytes": 42}},

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -88,7 +88,7 @@ def assert_not_enough_memory(relay, mini_sentry, expected_comparison):
     errors = ""
     for _ in range(100):
         try:
-            errors += f"{mini_sentry.test_failures.get(timeout=1)}\n"
+            errors += f"{mini_sentry.test_failures.get(timeout=10)}\n"
         except queue.Empty:
             break
         if (

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -90,9 +90,9 @@ def test_readiness_not_enough_memory_bytes(mini_sentry, relay):
     response = wait_get(relay, "/api/relay/healthcheck/ready/")
     error = str(mini_sentry.test_failures.get(timeout=2))
     assert "Not enough memory" in error and ">= 42" in error
-    error = str(mini_sentry.test_failures.get(timeout=1))
+    error = str(mini_sentry.test_failures.get(timeout=2))
     assert "Health check probe 'system memory'" in error
-    error = str(mini_sentry.test_failures.get(timeout=1))
+    error = str(mini_sentry.test_failures.get(timeout=2))
     assert "Health check probe 'spool health'" in error
     assert response.status_code == 503
 
@@ -107,9 +107,9 @@ def test_readiness_not_enough_memory_percent(mini_sentry, relay):
 
     error = str(mini_sentry.test_failures.get(timeout=2))
     assert "Not enough memory" in error and ">= 1.00%" in error
-    error = str(mini_sentry.test_failures.get(timeout=1))
+    error = str(mini_sentry.test_failures.get(timeout=2))
     assert "Health check probe 'system memory'" in error
-    error = str(mini_sentry.test_failures.get(timeout=1))
+    error = str(mini_sentry.test_failures.get(timeout=2))
     assert "Health check probe 'spool health'" in error
     assert response.status_code == 503
 


### PR DESCRIPTION
Unflake `test_readiness_not_enough_memory` and `test_readiness_not_enough_bytes`. The relay errors expected by these tests did not always occur in order, and not always within 1 second.

I confirmed by brute force that these tests no longer fail, even with 100 repetitions: https://github.com/getsentry/relay/actions/runs/11235435151/job/31233375132?pr=4115#step:8:735

Fixes https://github.com/getsentry/relay/issues/4090.

#skip-changelog