### PR TITLE
feat(spool): Prioritize regular messages over dequeued envelopes

### DIFF
--- a/relay-server/src/services/project_cache.rs
+++ b/relay-server/src/services/project_cache.rs
@@ -1480,14 +1480,14 @@ impl Service for ProjectCacheService {
                             broker.handle_periodic_unspool()
                         })
                     }
-                    Some(message) = envelopes_rx.recv() => {
-                        metric!(timer(RelayTimers::ProjectCacheTaskDuration), task = "handle_envelope", {
-                            broker.handle_envelope(message)
-                        })
-                    }
                     Some(message) = rx.recv() => {
                         metric!(timer(RelayTimers::ProjectCacheTaskDuration), task = "handle_message", {
                             broker.handle_message(message)
+                        })
+                    }
+                    Some(message) = envelopes_rx.recv() => {
+                        metric!(timer(RelayTimers::ProjectCacheTaskDuration), task = "handle_envelope", {
+                            broker.handle_envelope(message)
                         })
                     }
                     else => break,


### PR DESCRIPTION
During INC-913 we saw that we accumulated a backlog on the project cache (`CheckEnvelope`) while unspooling, even though we restrict unspooled envelopes in a custom bounded channel. Since there's always unspooled envelopes available, and they get prioritized over regular service messages, they seem to starve the request handler.

#skip-changelog