### PR TITLE
ref: Add Rails 7 Health Endpoint

### DIFF
--- a/relay-filter/src/transaction_name.rs
+++ b/relay-filter/src/transaction_name.rs
@@ -49,6 +49,7 @@ mod tests {
             "*/health",
             "*/healthz",
             "*/ping",
+            "*/up",
         ]
         .map(|val| val.to_string())
         .to_vec();
@@ -88,6 +89,8 @@ mod tests {
             "123/health",
             "123/healthz",
             "123/ping",
+            "/up",
+            "123/up",
         ];
 
         for name in transaction_names {
@@ -119,6 +122,7 @@ mod tests {
             "delivery",
             "notready",
             "already",
+            "/upload",
         ];
         let config = _get_config();
 


### PR DESCRIPTION
Rails 7 uses `/up` as a default health check endpoint, let's ignore it.

ref: https://github.com/getsentry/sentry-docs/pull/11505

Please, whatever is missing to ship this - anyone who triages this help me carry this over the finish line.

#skip-changelog