### PR TITLE
style(lints): Deny print macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ strip = true
 
 [workspace.lints.clippy]
 dbg_macro = "warn"
+print_stdout = "warn"
+print_stderr = "warn"
 
 [workspace.dependencies]
 relay-auth = { path = "relay-auth" }

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -817,6 +817,7 @@ mod tests {
     /// exchanged authentication structures.
     /// It follows test_registration but instead of asserting it prints the strings
     #[test]
+    #[allow(clippy::print_stdout, reason = "helper test to generate output")]
     fn test_generate_strings_for_test_auth_py() {
         let max_age = Duration::minutes(15);
         println!("Generating test data for test_auth.py...");

--- a/relay-filter/src/error_messages.rs
+++ b/relay-filter/src/error_messages.rs
@@ -142,13 +142,6 @@ mod tests {
 
         for config in &configs[..] {
             for &case in &cases[..] {
-                // Useful output to debug which testcase fails. Hidden if the test passes.
-                println!(
-                    "------------------------------------------------------------------------"
-                );
-                println!("Config: {config:?}");
-                println!("Case: {case:?}");
-
                 let (exc_type, exc_value, logentry_formatted, should_ingest) = case;
                 let event = Event {
                     exceptions: Annotated::new(Values::new(vec![Annotated::new(Exception {

--- a/relay-log/src/utils.rs
+++ b/relay-log/src/utils.rs
@@ -23,7 +23,7 @@ pub fn backtrace_enabled() -> bool {
 /// Prefer to use [`relay_log::error`](crate::error) over this function whenever possible. This
 /// function is intended to be used during startup, where initializing the logger may fail or when
 /// errors need to be logged before the logger has been initialized.
-#[allow(clippy::print_stderr)]
+#[allow(clippy::print_stderr, reason = "necessary for early logging")]
 pub fn ensure_error<E: AsRef<dyn Error>>(error: E) {
     if tracing::event_enabled!(Level::ERROR) {
         crate::error!(error = error.as_ref());

--- a/relay-log/src/utils.rs
+++ b/relay-log/src/utils.rs
@@ -23,6 +23,7 @@ pub fn backtrace_enabled() -> bool {
 /// Prefer to use [`relay_log::error`](crate::error) over this function whenever possible. This
 /// function is intended to be used during startup, where initializing the logger may fail or when
 /// errors need to be logged before the logger has been initialized.
+#[allow(clippy::print_stderr)]
 pub fn ensure_error<E: AsRef<dyn Error>>(error: E) {
     if tracing::event_enabled!(Level::ERROR) {
         crate::error!(error = error.as_ref());

--- a/relay-pii/src/builtin.rs
+++ b/relay-pii/src/builtin.rs
@@ -1321,7 +1321,6 @@ HdmUCGvfKiF2CodxyLon1XkK8pX+Ap86MbJhluqK
         ] {
             for redaction_method in &["mask", "remove", "hash", "replace"] {
                 let key = format!("@{rule_type}:{redaction_method}");
-                println!("looking up {key}");
                 assert!(BUILTIN_RULES_MAP.contains_key(key.as_str()));
             }
         }

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -1698,6 +1698,7 @@ mod tests {
 
     #[ignore] // Slow. Should probably be a criterion benchmark.
     #[tokio::test]
+    #[allow(clippy::print_stdout, reason = "benchmark test")]
     async fn compare_counts() {
         let path = std::env::temp_dir().join(Uuid::new_v4().to_string());
         let options = SqliteConnectOptions::new()

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -116,7 +116,11 @@
     html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
-#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(
+    clippy::derive_partial_eq_without_eq,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
 
 mod cli;
 mod cliapp;


### PR DESCRIPTION
Make sure leftovers from debugging are caught early.

#skip-changelog