### PR TITLE
fix(test): Increase outcome timeouts to make test consistent

### DIFF
--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -924,6 +924,7 @@ def test_processing_quota_transaction_indexing(
         "get_lost",
         categories=[DataCategory.TRANSACTION, DataCategory.TRANSACTION_INDEXED],
         ignore_other=True,
+        timeout=3,
     )
 
     with pytest.raises(HTTPError) as exc_info:
@@ -933,6 +934,7 @@ def test_processing_quota_transaction_indexing(
         "get_lost",
         categories=[DataCategory.TRANSACTION, DataCategory.TRANSACTION_INDEXED],
         ignore_other=True,
+        timeout=3,
     )
 
 


### PR DESCRIPTION
The `Transaction` outcome requires a metric flush, which may not be fast enough with a 1s timeout. The outcomes before already await the metrics and produce the outcomes faster (without the metrics cycle).

#skip-changelog