### PR TITLE
ref(metric-extraction): Match glob rule condition case sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Add the dynamic sampling rate to standalone spans as a measurement so that it can be stored, queried, and used for extrapolation. ([#4063](https://github.com/getsentry/relay/pull/4063))
 - Use custom wildcard matching instead of regular expressions. ([#4073](https://github.com/getsentry/relay/pull/4073))
 - Allowlist the SentryUptimeBot user-agent. ([#4068](https://github.com/getsentry/relay/pull/4068))
+- Match metric extra glob rules case sensitive. ([#4126](https://github.com/getsentry/relay/pull/4126))
 - Feature flags of graduated features are now hard-coded in Relay so they can be removed from Sentry. ([#4076](https://github.com/getsentry/relay/pull/4076), [#4080](https://github.com/getsentry/relay/pull/4080))
 
 ## 24.9.0

--- a/relay-protocol/src/condition.rs
+++ b/relay-protocol/src/condition.rs
@@ -2,7 +2,7 @@
 //!
 //! The root type is [`RuleCondition`].
 
-use relay_pattern::{CaseInsensitive, TypedPatterns};
+use relay_pattern::TypedPatterns;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -163,7 +163,7 @@ pub struct GlobCondition {
     /// A list of glob patterns to check.
     ///
     /// Note that this cannot be a single value, it must be a list of values.
-    pub value: TypedPatterns<CaseInsensitive>,
+    pub value: TypedPatterns,
 }
 
 impl GlobCondition {


### PR DESCRIPTION
Glob rule conditions match on a very limited set of fields those can all be case sensitive matches, this speeds up the matching process.

In the future we might want to introduce case insensitive conditions if necessary (or change back).