### PR TITLE
ref(redis): Update to redis client version 0.27.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,8 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.2"
-source = "git+https://github.com/getsentry/redis-rs.git?rev=fc7d98cc10c16fa7c0c31de64dc1b713354a4384#fc7d98cc10c16fa7c0c31de64dc1b713354a4384"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6baebe319ef5e4b470f248335620098d1c2e9261e995be05f56f719ca4bdb2"
 dependencies = [
  "arc-swap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,7 @@ rand_pcg = "0.3.1"
 rayon = "1.10"
 rdkafka = "0.36.2"
 rdkafka-sys = "4.3.0"
-# Git revision until https://github.com/redis-rs/redis-rs/pull/1097 (merged) and https://github.com/redis-rs/redis-rs/pull/1290 are released.
-redis = { git = "https://github.com/getsentry/redis-rs.git", rev = "fc7d98cc10c16fa7c0c31de64dc1b713354a4384", default-features = false }
+redis = { version = "0.27.4", default-features = false }
 regex = "1.10.2"
 regex-lite = "0.1.6"
 reqwest = "0.12.7"


### PR DESCRIPTION
Finally back to stable!

The data corruption issue on timeouts has been merged upstream and released 🎉 .

Fixes: https://github.com/getsentry/team-ingest/issues/368

#skip-changelog