### PR TITLE
ref(buffer): remove peek

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,5 @@
   "[markdown]": {
     "editor.rulers": [80],
     "editor.tabSize": 2
-  },
-  "makefile.configureOnOpen": false
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,6 @@
   "[markdown]": {
     "editor.rulers": [80],
     "editor.tabSize": 2
-  }
+  },
+  "makefile.configureOnOpen": false
 }

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -30,10 +30,11 @@ use crate::utils::MemoryChecker;
 
 /// Polymorphic envelope buffering interface.
 ///
-/// TPeek::NotReady { field1: stack_key, field2: _ }isk-based or memory-based,
+/// The underlying buffer can either be disk-based or memory-based,
 /// depending on the given configuration.
 ///
-/// NOTE: This is implemented as an enum because a trait object withPeek::NotReady { field1: _, field2: _ }/// object safe.
+/// NOTE: This is implemented as an enum because a trait object with async methods would not be
+/// object safe.
 #[derive(Debug)]
 #[allow(private_interfaces)]
 pub enum PolymorphicEnvelopeBuffer {

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -21,10 +21,6 @@ impl EnvelopeStack for MemoryEnvelopeStack {
         Ok(())
     }
 
-    async fn peek(&mut self) -> Result<Option<&Envelope>, Self::Error> {
-        Ok(self.0.last().map(Box::as_ref))
-    }
-
     async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
         Ok(self.0.pop())
     }

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -14,9 +14,6 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     /// Pushes an [`Envelope`] on top of the stack.
     fn push(&mut self, envelope: Box<Envelope>) -> impl Future<Output = Result<(), Self::Error>>;
 
-    /// Peeks the [`Envelope`] on top of the stack.
-    fn peek(&mut self) -> impl Future<Output = Result<Option<&Envelope>, Self::Error>>;
-
     /// Pops the [`Envelope`] on top of the stack.
     fn pop(&mut self) -> impl Future<Output = Result<Option<Box<Envelope>>, Self::Error>>;
 

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -375,7 +375,7 @@ mod tests {
         );
 
         // We pop 4 envelopes.
-        for envelope in envelopes.iter().rev() {
+        for envelope in envelopes.clone()[0..4].iter().rev() {
             let popped_envelope = stack.pop().await.unwrap().unwrap();
             assert_eq!(
                 popped_envelope.event_id().unwrap(),

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -221,7 +221,7 @@ impl EnvelopeBufferService {
         services: &Services,
         envelopes_tx_permit: Permit<'a, DequeuedEnvelope>,
     ) -> Result<Duration, EnvelopeBufferError> {
-        let sleep = match buffer.peek().await {
+        let sleep = match buffer.peek() {
             None => {
                 relay_statsd::metric!(
                     counter(RelayCounters::BufferTryPop) += 1,
@@ -242,6 +242,7 @@ impl EnvelopeBufferService {
                         peek_result = "expired"
                     );
                     if let Some(envelope) = buffer.pop().await? {
+                        debug_assert_eq!(envelope.meta().start_time(), received_at.into_std());
                         Self::drop_expired(envelope, services);
                     }
 


### PR DESCRIPTION
The envelope buffer does not need to peek to function correctly. Without peek, the stack interface becomes easier to implement.

When an element is removed from a stack, we now keep the `received_at` of the popped element. This means that we relax the LIFO constraint for the sake of simplicity: a stack might be top-priority even though an other stack might have newer envelopes, but only until the next pop.

Another side effect is that empty stacks remain in the priority queue until another pop attempt is made.

ref: https://github.com/getsentry/team-ingest/issues/345

#skip-changelog