### PR TITLE
feat(spooler): Add file backed envelope stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bench-buffer"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "clap",
+ "rand",
+ "relay-config",
+ "relay-server",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -923,7 +923,7 @@ fn spool_max_backpressure_memory_percent() -> f32 {
 }
 
 /// Default for max opened files, 100000.
-fn spool_envelopes_max_opened_files() -> usize {
+fn spool_envelopes_max_open_files() -> usize {
     100000
 }
 
@@ -985,8 +985,8 @@ pub struct EnvelopeSpool {
     #[serde(default = "spool_max_backpressure_memory_percent")]
     max_backpressure_memory_percent: f32,
     /// Maximum number of opened files for the envelope spool.
-    #[serde(default = "spool_envelopes_max_opened_files")]
-    max_opened_files: usize,
+    #[serde(default = "spool_envelopes_max_open_files")]
+    max_open_files: usize,
     /// Version of the spooler.
     #[serde(default)]
     version: EnvelopeSpoolVersion,
@@ -1042,7 +1042,7 @@ impl Default for EnvelopeSpool {
             disk_usage_refresh_frequency_ms: spool_disk_usage_refresh_frequency_ms(),
             max_backpressure_envelopes: spool_max_backpressure_envelopes(),
             max_backpressure_memory_percent: spool_max_backpressure_memory_percent(),
-            max_opened_files: spool_envelopes_max_opened_files(),
+            max_open_files: spool_envelopes_max_open_files(),
             version: EnvelopeSpoolVersion::default(),
             buffer_strategy: EnvelopeBufferStrategy::default(),
         }
@@ -2271,8 +2271,8 @@ impl Config {
     }
 
     /// Returns the maximum number of opened files for the envelope spool.
-    pub fn spool_envelopes_max_opened_files(&self) -> usize {
-        self.values.spool.envelopes.max_opened_files
+    pub fn spool_envelopes_max_open_files(&self) -> usize {
+        self.values.spool.envelopes.max_open_files
     }
 
     /// Returns the envelope buffer strategy.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -730,7 +730,8 @@ pub enum HttpEncoding {
     /// These structures are defined in [RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)
     /// and [RFC 1951](https://datatracker.ietf.org/doc/html/rfc1951).
     Deflate,
-    /// A format using the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77), with a 32-bit CRC.
+    /// A format using the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77)
+    /// (LZ77), with a 32-bit CRC.
     ///
     /// This is the original format of the UNIX gzip program. The HTTP/1.1 standard also recommends
     /// that the servers supporting this content-encoding should recognize `x-gzip` as an alias, for
@@ -2661,7 +2662,7 @@ impl Default for Config {
 mod tests {
     use super::*;
 
-    /// Regression test for renaming the envelope buffer size.
+    /// Regression test for renaming the envelope buffer flags.
     #[test]
     fn test_event_buffer_size() {
         let yaml = r###"

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1022,6 +1022,7 @@ pub enum EnvelopeBufferStrategy {
     Memory,
     /// Use a SQLite database for envelope buffering.
     Sqlite,
+    #[cfg(not(windows))]
     /// Use a file-backed system for envelope buffering.
     FileBacked,
 }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -922,9 +922,10 @@ fn spool_max_backpressure_memory_percent() -> f32 {
     0.9
 }
 
-/// Default for max opened files, 100000.
+/// Default for the maximum number of files containing envelopes that can be opened at the same
+/// time.
 fn spool_envelopes_max_open_files() -> usize {
-    100000
+    512
 }
 
 /// Persistent buffering configuration for incoming envelopes.
@@ -1025,6 +1026,18 @@ pub enum EnvelopeBufferStrategy {
     #[cfg(not(windows))]
     /// Use a file-backed system for envelope buffering.
     FileBacked,
+}
+
+impl EnvelopeBufferStrategy {
+    /// Return `true` whether the [`EnvelopeBufferStrategy`] requires a path to be specified,
+    /// `false` otherwise.
+    pub fn requires_path(&self) -> bool {
+        match self {
+            EnvelopeBufferStrategy::Memory => false,
+            EnvelopeBufferStrategy::Sqlite => true,
+            EnvelopeBufferStrategy::FileBacked => true,
+        }
+    }
 }
 
 impl Default for EnvelopeSpool {

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1015,7 +1015,7 @@ pub enum EnvelopeSpoolVersion {
 
 /// The strategy to use for envelope buffering.
 #[derive(Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum EnvelopeBufferStrategy {
     /// Use an in-memory buffer for envelopes.
     #[default]

--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -266,12 +266,20 @@ mod services;
 mod statsd;
 mod utils;
 
-pub use self::envelope::Envelope; // pub for benchmarks
+// pub for benchmarks
+pub use self::envelope::Envelope;
+// pub for benchmarks
 pub use self::services::buffer::{
-    EnvelopeStack, PolymorphicEnvelopeBuffer, SqliteEnvelopeStack, SqliteEnvelopeStore,
-}; // pub for benchmarks
+    EnvelopeStack, PolymorphicEnvelopeBuffer, ProjectKeyPair, SqliteEnvelopeStack,
+    SqliteEnvelopeStore,
+};
+// pub for benchmarks
+#[cfg(not(windows))]
+pub use self::services::buffer::{FileBackedEnvelopeStack, FileBackedEnvelopeStore};
+// pub for benchmarks
 pub use self::services::spooler::spool_utils;
-pub use self::utils::{MemoryChecker, MemoryStat}; // pub for benchmarks
+// pub for benchmarks
+pub use self::utils::{MemoryChecker, MemoryStat};
 
 #[cfg(test)]
 mod testutils;

--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -5,11 +5,14 @@ use crate::Envelope;
 /// Struct that represents two project keys.
 #[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct ProjectKeyPair {
+    /// [`ProjectKey`] of the project to which the event belongs.
     pub own_key: ProjectKey,
+    /// [`ProjectKey`] of the root project of the trace to which the event belongs.
     pub sampling_key: ProjectKey,
 }
 
 impl ProjectKeyPair {
+    /// Creates a new [`ProjectKeyPair`].
     pub fn new(own_key: ProjectKey, sampling_key: ProjectKey) -> Self {
         Self {
             own_key,
@@ -17,12 +20,17 @@ impl ProjectKeyPair {
         }
     }
 
+    /// Creates a new [`ProjectKeyPair`] from an [`Envelope`].
     pub fn from_envelope(envelope: &Envelope) -> Self {
         let own_key = envelope.meta().public_key();
         let sampling_key = envelope.sampling_key().unwrap_or(own_key);
         Self::new(own_key, sampling_key)
     }
 
+    /// Returns an iterator that yields the `own_key` and `sampling_key`.
+    ///
+    /// The `sampling_key` will be returned as a second element of the iterator only if
+    /// it's different from the `own_key`.
     pub fn iter(&self) -> impl Iterator<Item = ProjectKey> {
         let Self {
             own_key,

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -75,7 +75,7 @@ impl PolymorphicEnvelopeBuffer {
             }
             (EnvelopeBufferStrategy::FileBacked, Some(_)) => {
                 relay_log::trace!(
-                    "PolymorphicEnvelopeBuffer: initializing file backed envelope buffer"
+                    "PolymorphicEnvelopeBuffer: initializing file-backed envelope buffer"
                 );
                 let buffer = EnvelopeBuffer::<FileBackedStackProvider>::new(config).await?;
                 Self::FileBacked(buffer)

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::convert::Infallible;
-use std::error::Error;
 use std::mem;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering as AtomicOrdering;
@@ -11,7 +10,7 @@ use std::time::Duration;
 use hashbrown::HashSet;
 use relay_base_schema::project::ProjectKey;
 use relay_config::{Config, EnvelopeBufferStrategy};
-use tokio::time::{timeout, Instant};
+use tokio::time::Instant;
 
 use crate::envelope::Envelope;
 use crate::services::buffer::common::ProjectKeyPair;

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -1041,7 +1041,12 @@ mod tests {
     #[tokio::test]
     async fn test_initialize_buffer() {
         let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().to_str().unwrap().to_string();
+        let path = temp_dir
+            .path()
+            .join("buffer.db")
+            .to_str()
+            .unwrap()
+            .to_string();
         let config = mock_config(&path);
         let mut store = SqliteEnvelopeStore::prepare(&config).await.unwrap();
         let mut buffer = EnvelopeBuffer::<SqliteStackProvider>::new(&config)

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -658,6 +658,7 @@ mod tests {
     use relay_sampling::DynamicSamplingContext;
     use std::str::FromStr;
     use std::sync::Arc;
+    use tempfile::TempDir;
     use uuid::Uuid;
 
     use crate::envelope::{Item, ItemType};
@@ -1039,11 +1040,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_initialize_buffer() {
-        let path = std::env::temp_dir()
-            .join(Uuid::new_v4().to_string())
-            .into_os_string()
-            .into_string()
-            .unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().to_str().unwrap().to_string();
         let config = mock_config(&path);
         let mut store = SqliteEnvelopeStore::prepare(&config).await.unwrap();
         let mut buffer = EnvelopeBuffer::<SqliteStackProvider>::new(&config)

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -157,12 +157,13 @@ impl PolymorphicEnvelopeBuffer {
         }
     }
 
-    /// Returns `true` whether the buffer has capacity to accept new [`Envelope`]s.
-    pub fn has_capacity(&self) -> bool {
+    /// Returns `true` whether the buffer has capacity to accept new [`Envelope`]s, `false`
+    /// otherwise.
+    pub async fn has_capacity(&self) -> bool {
         match self {
-            Self::Sqlite(buffer) => buffer.has_capacity(),
-            Self::InMemory(buffer) => buffer.has_capacity(),
-            Self::FileBacked(buffer) => buffer.has_capacity(),
+            Self::Sqlite(buffer) => buffer.has_capacity().await,
+            Self::InMemory(buffer) => buffer.has_capacity().await,
+            Self::FileBacked(buffer) => buffer.has_capacity().await,
         }
     }
 
@@ -455,8 +456,8 @@ where
     }
 
     /// Returns `true` if the underlying storage has the capacity to store more envelopes.
-    pub fn has_capacity(&self) -> bool {
-        self.stack_provider.has_store_capacity()
+    pub async fn has_capacity(&self) -> bool {
+        self.stack_provider.has_store_capacity().await
     }
 
     /// Flushes the envelope buffer.

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -87,6 +87,12 @@ impl PolymorphicEnvelopeBuffer {
                 Self::FileBacked(buffer)
             }
             _ => {
+                if config.spool_envelope_buffer_strategy().requires_path()
+                    && config.spool_envelopes_path().is_none()
+                {
+                    relay_log::warn!("PolymorphicEnvelopeBuffer: a buffer strategy that requires a path was configured but the path was not supplied, defaulting to memory");
+                }
+
                 relay_log::trace!("PolymorphicEnvelopeBuffer: initializing memory envelope buffer");
                 let buffer = EnvelopeBuffer::<MemoryStackProvider>::new(memory_checker);
                 Self::InMemory(buffer)

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -488,6 +488,7 @@ mod tests {
                 .unwrap();
             file.set_len(0).await.unwrap(); // Clear the file
             file.write_all(b"malformed data").await.unwrap();
+            file.flush().await.unwrap();
         }
 
         // Attempt to pop from the stack with malformed data
@@ -542,7 +543,6 @@ mod tests {
         }
     }
 
-    // Add this new test
     #[tokio::test]
     async fn test_empty_file_removal() {
         let envelope_store = setup_envelope_store(10).await;

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -18,8 +18,6 @@ use tokio::sync::Mutex;
 static ALLOWED_ERROR_KINDS: LazyLock<HashSet<io::ErrorKind>> = LazyLock::new(|| {
     let mut error_kinds = HashSet::new();
     error_kinds.insert(io::ErrorKind::InvalidInput);
-    #[cfg(windows)]
-    error_kinds.insert(io::ErrorKind::Uncategorized);
 
     error_kinds
 });

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -151,7 +151,7 @@ async fn seek_truncate(
     match file.seek(SeekFrom::End(-(from_end as i64))).await {
         Ok(_) => Ok(true),
         Err(error) if ALLOWED_ERROR_KINDS.contains(&error.kind()) => {
-            relay_log::error!(error = &error as &dyn Error, "failed to seek the file",);
+            relay_log::error!(error = &error as &dyn Error, "failed to seek the file");
             truncate_file(file, 0).await?;
             Ok(false)
         }

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -296,12 +296,12 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
-    fn mock_config(path: &str, max_opened_files: usize) -> Arc<Config> {
+    fn mock_config(path: &str, max_open_files: usize) -> Arc<Config> {
         Config::from_json_value(serde_json::json!({
             "spool": {
                 "envelopes": {
                     "path": path,
-                    "max_opened_files": max_opened_files
+                    "max_open_files": max_open_files
                 }
             }
         }))
@@ -310,11 +310,11 @@ mod tests {
     }
 
     async fn setup_envelope_store(
-        max_opened_files: usize,
+        max_open_files: usize,
     ) -> (Arc<Mutex<FileBackedEnvelopeStore>>, TempDir) {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let path = temp_dir.path().to_str().unwrap().to_string();
-        let config = mock_config(&path, max_opened_files);
+        let config = mock_config(&path, max_open_files);
         let store = Arc::new(Mutex::new(
             FileBackedEnvelopeStore::new(&config).await.unwrap(),
         ));

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -1,0 +1,151 @@
+use crate::envelope::{Envelope, EnvelopeError};
+use crate::services::buffer::common::ProjectKeyPair;
+use crate::services::buffer::envelope_stack::EnvelopeStack;
+use crate::services::buffer::files_manager::{FilesManager, FilesManagerError};
+use crate::statsd::RelayTimers;
+use std::io;
+use std::io::SeekFrom;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+const ENVELOPE_SIZE_FIELD_BYTES: u64 = 8;
+
+/// An error returned when doing an operation on [`FileBackedEnvelopeStack`].
+#[derive(Debug, thiserror::Error)]
+pub enum FileBackedEnvelopeStackError {
+    #[error("failed to perform I/O operation: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("failed to work with envelope: {0}")]
+    Envelope(#[from] EnvelopeError),
+
+    #[error("failed to get file from FilesManager: {0}")]
+    FilesManager(#[from] FilesManagerError),
+}
+
+/// An envelope stack that writes and reads envelopes to and from disk files.
+///
+/// Each `FileBackedEnvelopeStack` corresponds to a file on disk, named with the pattern
+/// `own_key-sampling_key`. The envelopes are appended to the file in a custom binary format.
+///
+/// The format for each envelope in the file is:
+/// - `envelope_bytes` (variable length)
+/// - `size` of the envelope_bytes (8 bytes, u64 in little-endian)
+///
+/// This allows reading the file from the end by first reading the `size`, then the `envelope_bytes`.
+#[derive(Debug)]
+pub struct FileBackedEnvelopeStack {
+    project_key_pair: ProjectKeyPair,
+    files_manager: Arc<Mutex<FilesManager>>,
+}
+
+impl FileBackedEnvelopeStack {
+    pub fn new(project_key_pair: ProjectKeyPair, files_manager: Arc<Mutex<FilesManager>>) -> Self {
+        Self {
+            project_key_pair,
+            files_manager,
+        }
+    }
+
+    /// Reads and removes the last envelope from the file.
+    async fn read_and_remove_last_envelope(
+        &mut self,
+    ) -> Result<Option<Box<Envelope>>, FileBackedEnvelopeStackError> {
+        let mut files_manager = self.files_manager.lock().await;
+        let file = files_manager.get_file(self.project_key_pair).await?;
+
+        // Get the file size
+        let file_size = file.metadata().await?.len();
+        if file_size < ENVELOPE_SIZE_FIELD_BYTES {
+            return Ok(None);
+        }
+
+        // Read the size of the last envelope
+        let mut envelope_size_buf = [0u8; ENVELOPE_SIZE_FIELD_BYTES as usize];
+        file.seek(SeekFrom::End(-(ENVELOPE_SIZE_FIELD_BYTES as i64)))
+            .await?;
+        file.read_exact(&mut envelope_size_buf).await?;
+        let envelope_size = u64::from_le_bytes(envelope_size_buf);
+        if file_size < envelope_size + ENVELOPE_SIZE_FIELD_BYTES {
+            // File is corrupted or incomplete
+            return Ok(None);
+        }
+
+        // Read the envelope data
+        let mut envelope_buf = Vec::with_capacity(envelope_size as usize);
+        file.seek(SeekFrom::End(
+            -((envelope_size + ENVELOPE_SIZE_FIELD_BYTES) as i64),
+        ))
+        .await?;
+        file.read_exact(&mut envelope_buf).await?;
+
+        // Deserialize envelope
+        let envelope = Envelope::parse_bytes(envelope_buf.into())
+            .map_err(FileBackedEnvelopeStackError::Envelope)?;
+
+        // Truncate the file to remove the envelope
+        let new_size = file_size - envelope_size - ENVELOPE_SIZE_FIELD_BYTES;
+        file.set_len(new_size).await?;
+
+        Ok(Some(envelope))
+    }
+
+    /// Appends an envelope to the file.
+    async fn append_envelope(
+        &mut self,
+        envelope: &Envelope,
+    ) -> Result<(), FileBackedEnvelopeStackError> {
+        let mut files_manager = self.files_manager.lock().await;
+        let file = files_manager.get_file(self.project_key_pair).await?;
+
+        // Serialize envelope
+        let envelope_bytes = envelope.to_vec()?;
+
+        // Compute total size
+        let size = envelope_bytes.len();
+
+        // Construct buffer to write
+        let mut buffer = Vec::with_capacity(size + (ENVELOPE_SIZE_FIELD_BYTES as usize));
+        buffer.extend_from_slice(&envelope_bytes);
+        buffer.extend_from_slice(&size.to_le_bytes());
+
+        // Write data
+        file.seek(SeekFrom::End(0)).await?;
+        file.write_all(&buffer).await?;
+
+        Ok(())
+    }
+}
+
+impl EnvelopeStack for FileBackedEnvelopeStack {
+    type Error = FileBackedEnvelopeStackError;
+
+    async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), Self::Error> {
+        relay_statsd::metric!(timer(RelayTimers::BufferPush), {
+            self.append_envelope(&envelope).await?;
+        });
+        Ok(())
+    }
+
+    async fn peek(&mut self) -> Result<Option<&Envelope>, Self::Error> {
+        // Since we cannot return a reference to data on disk, this method isn't practical
+        // We'll need to adjust the trait to return an owned Envelope, or change the design
+        Ok(None)
+    }
+
+    async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
+        relay_statsd::metric!(timer(RelayTimers::BufferPop), {
+            if let Some(envelope) = self.read_and_remove_last_envelope().await? {
+                Ok(Some(envelope))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+
+    fn flush(self) -> Vec<Box<Envelope>> {
+        // Since data is already on disk, no action needed
+        vec![]
+    }
+}

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -108,12 +108,6 @@ impl EnvelopeStack for FileBackedEnvelopeStack {
         Ok(())
     }
 
-    async fn peek(&mut self) -> Result<Option<&Envelope>, Self::Error> {
-        // Since we cannot return a reference to data on disk, this method isn't practical
-        // We'll need to adjust the trait to return an owned Envelope, or change the design
-        Ok(None)
-    }
-
     async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
         let mut envelope_store = self.envelope_store.lock().await;
         let file = envelope_store.get_file(self.project_key_pair).await?;

--- a/relay-server/src/services/buffer/envelope_stack/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_stack/file_backed.rs
@@ -40,7 +40,7 @@ pub enum FileBackedEnvelopeStackError {
 
 /// An envelope stack that writes and reads envelopes to and from disk files.
 ///
-/// Each `FileBackedEnvelopeStack` corresponds to a file on disk, named with the pattern
+/// Each [`FileBackedEnvelopeStack`] corresponds to a file on disk, named with the pattern
 /// `own_key-sampling_key`. The envelopes are appended to the file in a custom binary format.
 ///
 /// The file format is as follows:

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 
 use crate::envelope::Envelope;
 
+pub mod file_backed;
 pub mod memory;
 pub mod sqlite;
 

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 
 use crate::envelope::Envelope;
 
+#[cfg(not(windows))]
 pub mod file_backed;
 pub mod memory;
 pub mod sqlite;

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -250,7 +250,7 @@ mod tests {
     #[tokio::test]
     #[should_panic]
     async fn test_push_with_mismatching_project_keys() {
-        let db = setup_db(false).await;
+        let (db, _temp_file) = setup_db(false).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store,
@@ -267,7 +267,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_when_db_is_not_valid() {
-        let db = setup_db(false).await;
+        let (db, _temp_file) = setup_db(false).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store,
@@ -320,7 +320,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pop_when_db_is_not_valid() {
-        let db = setup_db(false).await;
+        let (db, _temp_file) = setup_db(false).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store,
@@ -340,7 +340,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pop_when_stack_is_empty() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store,
@@ -358,7 +358,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_below_threshold_and_pop() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store,
@@ -396,7 +396,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_push_above_threshold_and_pop() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store,
@@ -466,7 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drain() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
         let mut stack = SqliteEnvelopeStack::new(
             envelope_store.clone(),

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -1,6 +1,6 @@
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::services::buffer::envelope_stack::file_backed::get_total_count;
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashMap;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
 use relay_config::Config;
 use std::path::{Path, PathBuf};
@@ -112,6 +112,7 @@ impl FileBackedEnvelopeStore {
     /// with the correct extension. It does not recursively scan subdirectories.
     ///
     /// Returns the estimated size in bytes.
+    #[allow(dead_code)]
     pub async fn estimate_folder_size(&self) -> Result<u64, FileBackedEnvelopeStoreError> {
         let mut total_size = 0;
         let mut dir = read_dir(&self.base_path).await?;
@@ -334,12 +335,12 @@ mod tests {
 
         // Append envelopes to files
         for envelope in envelopes1 {
-            let mut file = store.get_envelopes_file(project_key_pair1).await.unwrap();
-            append_envelope(&mut file, &envelope).await.unwrap();
+            let file = store.get_envelopes_file(project_key_pair1).await.unwrap();
+            append_envelope(file, &envelope).await.unwrap();
         }
         for envelope in envelopes2 {
-            let mut file = store.get_envelopes_file(project_key_pair2).await.unwrap();
-            append_envelope(&mut file, &envelope).await.unwrap();
+            let file = store.get_envelopes_file(project_key_pair2).await.unwrap();
+            append_envelope(file, &envelope).await.unwrap();
         }
 
         // List project key pairs with counts

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -1,6 +1,6 @@
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::services::buffer::envelope_stack::file_backed::read_header;
-use crate::statsd::RelayGauges;
+use crate::statsd::{RelayCounters, RelayGauges};
 use hashbrown::HashMap;
 use priority_queue::PriorityQueue;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
@@ -296,6 +296,8 @@ impl EnvelopesFilesCache {
                     error = &error as &dyn Error,
                     "failed to remove the envelopes file",
                 );
+            } else {
+                relay_statsd::metric!(counter(RelayCounters::BufferRemovedEnvelopesFile) += 1);
             }
         }
     }

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -539,7 +539,7 @@ mod tests {
         }
 
         // Wait for the background task to update the folder size
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        sleep(Duration::from_millis(200)).await;
 
         // Check the folder size
         let folder_size = store.usage();

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -1,5 +1,5 @@
 use crate::services::buffer::common::ProjectKeyPair;
-use crate::services::buffer::envelope_stack::file_backed::get_total_count;
+use crate::services::buffer::envelope_stack::file_backed::read_header;
 use crate::statsd::RelayGauges;
 use hashbrown::HashMap;
 use priority_queue::PriorityQueue;
@@ -121,7 +121,10 @@ impl FileBackedEnvelopeStore {
                 if let Some(file_name) = path.file_name().and_then(|s| s.to_str()) {
                     if let Some(project_key_pair) = parse_envelopes_file_file_name(file_name) {
                         let file = self.get_file(project_key_pair).await?;
-                        let total_count = get_total_count(file).await.unwrap_or(0);
+                        let total_count = read_header(file)
+                            .await
+                            .unwrap()
+                            .map_or(0, |h| h.total_count);
 
                         project_key_pairs.insert(project_key_pair, total_count);
                     }

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -548,7 +548,7 @@ mod tests {
         store.remove_file(&project_key_pair).await.unwrap();
 
         // Verify the file no longer exists in cache or on disk
-        assert!(!store.files_cache.cache.get_mut(&project_key_pair).is_some());
+        assert!(store.files_cache.cache.get_mut(&project_key_pair).is_none());
         assert!(!file_path.exists());
 
         // Removing a non-existent file should not error

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -210,7 +210,8 @@ impl FileBackedEnvelopeStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::prelude::MetadataExt;
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -238,6 +239,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn test_create_evict_load() {
         let mut store = setup_envelope_store(5).await;
         let project_key_pair = ProjectKeyPair {

--- a/relay-server/src/services/buffer/envelope_store/file_backed.rs
+++ b/relay-server/src/services/buffer/envelope_store/file_backed.rs
@@ -401,7 +401,7 @@ impl FolderSizeTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::buffer::envelope_stack::file_backed::append_envelope;
+    use crate::services::buffer::envelope_stack::file_backed::push_envelope;
     use crate::services::buffer::testutils::utils::mock_envelopes;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
@@ -484,11 +484,11 @@ mod tests {
         // Append envelopes to files
         for envelope in envelopes1 {
             let file = store.get_file(project_key_pair1).await.unwrap();
-            append_envelope(file, &envelope).await.unwrap();
+            push_envelope(file, &envelope).await.unwrap();
         }
         for envelope in envelopes2 {
             let file = store.get_file(project_key_pair2).await.unwrap();
-            append_envelope(file, &envelope).await.unwrap();
+            push_envelope(file, &envelope).await.unwrap();
         }
 
         // List project key pairs with counts

--- a/relay-server/src/services/buffer/envelope_store/mod.rs
+++ b/relay-server/src/services/buffer/envelope_store/mod.rs
@@ -1,1 +1,2 @@
+pub mod file_backed;
 pub mod sqlite;

--- a/relay-server/src/services/buffer/envelope_store/mod.rs
+++ b/relay-server/src/services/buffer/envelope_store/mod.rs
@@ -1,2 +1,3 @@
+#[cfg(not(windows))]
 pub mod file_backed;
 pub mod sqlite;

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -126,8 +126,7 @@ impl DiskUsage {
         Ok(disk_usage)
     }
 
-    /// Returns the disk usage and asynchronously updates it in case a `refresh_frequency_ms`
-    /// elapsed.
+    /// Returns the last known disk usage.
     fn usage(&self) -> u64 {
         self.last_known_usage.load(Ordering::Relaxed)
     }

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -14,7 +14,7 @@ use crate::Envelope;
 use futures::stream::StreamExt;
 use hashbrown::HashSet;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
-use relay_config::Config;
+use relay_config::{Config, EnvelopeSpoolPath};
 use sqlx::migrate::MigrateError;
 use sqlx::query::Query;
 use sqlx::sqlite::{
@@ -203,7 +203,7 @@ impl SqliteEnvelopeStore {
     /// the folders where data will be stored.
     pub async fn prepare(config: &Config) -> Result<SqliteEnvelopeStore, SqliteEnvelopeStoreError> {
         // If no path is provided, we can't do disk spooling.
-        let Some(path) = config.spool_envelopes_path() else {
+        let Some(path) = config.spool_envelopes_path().map(EnvelopeSpoolPath::path) else {
             return Err(SqliteEnvelopeStoreError::NoFilePath);
         };
 

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -401,14 +401,14 @@ impl SqliteEnvelopeStore {
     }
 
     /// Returns the total count of envelopes stored in the database.
-    pub async fn total_count(&self) -> Result<u64, SqliteEnvelopeStoreError> {
+    pub async fn total_count(&self) -> Result<u32, SqliteEnvelopeStoreError> {
         let row = build_count_all()
             .fetch_one(&self.db)
             .await
             .map_err(SqliteEnvelopeStoreError::Fetch)?;
 
         let total_count: i64 = row.get(0);
-        Ok(total_count as u64)
+        Ok(total_count as u32)
     }
 }
 

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -526,7 +526,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_delete_envelopes() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let mut envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
 
         let own_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
@@ -563,7 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_and_get_project_keys_pairs() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let mut envelope_store = SqliteEnvelopeStore::new(db, Duration::from_millis(100));
 
         let own_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
@@ -588,7 +588,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_estimate_disk_usage() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let mut store = SqliteEnvelopeStore::new(db.clone(), Duration::from_millis(1));
         let disk_usage = DiskUsage::prepare(db, Duration::from_millis(1))
             .await
@@ -615,7 +615,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_total_count() {
-        let db = setup_db(true).await;
+        let (db, _temp_file) = setup_db(true).await;
         let mut store = SqliteEnvelopeStore::new(db.clone(), Duration::from_millis(1));
 
         let envelopes = mock_envelopes(10);

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -625,6 +625,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(store.total_count().await.unwrap(), envelopes.len() as u64);
+        assert_eq!(store.total_count().await.unwrap(), envelopes.len() as u32);
     }
 }

--- a/relay-server/src/services/buffer/files_manager.rs
+++ b/relay-server/src/services/buffer/files_manager.rs
@@ -1,0 +1,276 @@
+use crate::services::buffer::common::ProjectKeyPair;
+use hashbrown::{HashMap, HashSet};
+use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
+use relay_config::Config;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use tokio::fs::{read_dir, DirBuilder, File, OpenOptions};
+use tokio::io;
+
+const FILE_EXTENSION: &str = "spool";
+
+/// An error returned when doing an operation on [`FilesManager`].
+#[derive(Debug, thiserror::Error)]
+pub enum FilesManagerError {
+    #[error("failed work with a file: {0}")]
+    FileError(#[from] io::Error),
+
+    #[error("failed to create the spool file: {0}")]
+    FileSetupError(io::Error),
+
+    #[error("no file path for the spool was provided")]
+    NoFilePath,
+
+    #[error("failed to parse project key: {0}")]
+    ProjectKeyParseError(#[from] ParseProjectKeyError),
+}
+
+#[derive(Debug)]
+pub struct FilesManager {
+    base_path: PathBuf,
+    max_opened_files: usize,
+    cache: HashMap<ProjectKeyPair, CacheEntry>,
+}
+
+#[derive(Debug)]
+struct CacheEntry {
+    file: File,
+    last_access: Instant,
+}
+
+impl FilesManager {
+    pub async fn new(config: &Config) -> Result<Self, FilesManagerError> {
+        // If no path is provided, we can't do disk spooling.
+        let Some(base_path) = config.spool_envelopes_path() else {
+            return Err(FilesManagerError::NoFilePath);
+        };
+
+        Ok(FilesManager {
+            base_path,
+            max_opened_files: config.spool_envelopes_max_opened_files(),
+            cache: HashMap::new(),
+        })
+    }
+
+    pub async fn get_file(
+        &mut self,
+        project_key_pair: ProjectKeyPair,
+    ) -> Result<&mut File, FilesManagerError> {
+        if !self.cache.contains_key(&project_key_pair) {
+            let file = Self::load_or_create_file(self.base_path.clone(), &project_key_pair).await?;
+            self.insert_into_cache(project_key_pair, file);
+        }
+
+        let cache_entry = self
+            .cache
+            .get_mut(&project_key_pair)
+            .expect("file to be in the cache");
+
+        Ok(&mut cache_entry.file)
+    }
+
+    pub async fn list_project_key_pairs(
+        &self,
+    ) -> Result<HashSet<ProjectKeyPair>, FilesManagerError> {
+        let mut project_key_pairs = HashSet::new();
+
+        let mut dir = read_dir(&self.base_path).await?;
+        while let Some(entry) = dir.next_entry().await? {
+            let path = entry.path();
+
+            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some(FILE_EXTENSION) {
+                if let Some(file_name) = path.file_stem().and_then(|s| s.to_str()) {
+                    if let Some((own_key, sampling_key)) = file_name.split_once('-') {
+                        project_key_pairs.insert(ProjectKeyPair {
+                            own_key: ProjectKey::parse(own_key)?,
+                            sampling_key: ProjectKey::parse(sampling_key)?,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(project_key_pairs)
+    }
+
+    async fn load_or_create_file(
+        base_path: PathBuf,
+        key_pair: &ProjectKeyPair,
+    ) -> Result<File, FilesManagerError> {
+        let filename = format!(
+            "{}-{}.{}",
+            key_pair.own_key, key_pair.sampling_key, FILE_EXTENSION
+        );
+
+        let filepath = base_path.join(filename);
+        Self::create_spool_directory(&filepath).await?;
+
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(filepath)
+            .await
+            .map_err(FilesManagerError::FileError)
+    }
+
+    /// Creates the directories for the spool file.
+    async fn create_spool_directory(path: &Path) -> Result<(), FilesManagerError> {
+        let Some(parent) = path.parent() else {
+            return Ok(());
+        };
+
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            relay_log::debug!("creating directory for spooling file: {}", parent.display());
+            DirBuilder::new()
+                .recursive(true)
+                .create(&parent)
+                .await
+                .map_err(FilesManagerError::FileSetupError)?;
+        }
+
+        Ok(())
+    }
+
+    fn insert_into_cache(&mut self, key_pair: ProjectKeyPair, file: File) {
+        if self.cache.len() >= self.max_opened_files {
+            self.evict_lru();
+        }
+
+        self.cache.insert(
+            key_pair,
+            CacheEntry {
+                file,
+                last_access: Instant::now(),
+            },
+        );
+    }
+
+    fn evict_lru(&mut self) {
+        if let Some(lru_project_key_pair) = self
+            .cache
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_access)
+            .map(|(&key, _)| key)
+        {
+            self.cache.remove(&lru_project_key_pair);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::prelude::MetadataExt;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    fn mock_config(path: &str, max_opened_files: usize) -> Arc<Config> {
+        Config::from_json_value(serde_json::json!({
+            "spool": {
+                "envelopes": {
+                    "path": path,
+                    "max_opened_files": max_opened_files
+                }
+            }
+        }))
+        .unwrap()
+        .into()
+    }
+
+    async fn setup_files_manager(max_opened_files: usize) -> FilesManager {
+        let path = std::env::temp_dir()
+            .join(Uuid::new_v4().to_string())
+            .into_os_string()
+            .into_string()
+            .unwrap();
+        let config = mock_config(&path, max_opened_files);
+        FilesManager::new(&config)
+            .await
+            .expect("Failed to create FilesManager")
+    }
+
+    #[tokio::test]
+    async fn test_create_evict_load() {
+        let mut files_manager = setup_files_manager(5).await;
+        let project_key_pair = ProjectKeyPair {
+            own_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            sampling_key: ProjectKey::parse("b94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+        };
+
+        // First call should create the file
+        let file_ino = files_manager
+            .get_file(project_key_pair)
+            .await
+            .unwrap()
+            .metadata()
+            .await
+            .unwrap()
+            .ino();
+
+        // We evict the file to see if re-opening gives the same ino.
+        files_manager.evict_lru();
+        assert!(files_manager.cache.is_empty());
+
+        // Second call should load the file from disk since it was evicted
+        let cached_file_ino = files_manager
+            .get_file(project_key_pair)
+            .await
+            .unwrap()
+            .metadata()
+            .await
+            .unwrap()
+            .ino();
+        assert_eq!(file_ino, cached_file_ino);
+    }
+
+    #[tokio::test]
+    async fn test_list_project_key_pairs() {
+        let mut files_manager = setup_files_manager(5).await;
+        let project_key_pair1 = ProjectKeyPair {
+            own_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            sampling_key: ProjectKey::parse("b94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+        };
+        let project_key_pair2 = ProjectKeyPair {
+            own_key: ProjectKey::parse("c94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            sampling_key: ProjectKey::parse("d94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+        };
+
+        // Create two files
+        files_manager.get_file(project_key_pair1).await.unwrap();
+        files_manager.get_file(project_key_pair2).await.unwrap();
+
+        // List project key pairs
+        let key_pairs = files_manager.list_project_key_pairs().await.unwrap();
+        assert_eq!(key_pairs.len(), 2);
+        assert!(key_pairs.contains(&project_key_pair1));
+        assert!(key_pairs.contains(&project_key_pair2));
+    }
+
+    #[tokio::test]
+    async fn test_cache_eviction() {
+        let mut files_manager = setup_files_manager(5).await;
+
+        // Create 6 files (max_size is 5)
+        for i in 0..6 {
+            let project_key_pair = ProjectKeyPair {
+                own_key: ProjectKey::parse(&format!("c{}4ae32be2584e0bbd7a4cbb95971fee", i))
+                    .unwrap(),
+                sampling_key: ProjectKey::parse(&format!("c{}4ae32be2584e0bbd7a4cbb95971fee", i))
+                    .unwrap(),
+            };
+            files_manager.get_file(project_key_pair).await.unwrap();
+        }
+
+        // Check that the cache size is still 5
+        assert_eq!(files_manager.cache.len(), 5);
+
+        // The first file should have been evicted
+        let first_key_pair = ProjectKeyPair {
+            own_key: ProjectKey::parse("c04ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+            sampling_key: ProjectKey::parse("c04ae32be2584e0bbd7a4cbb95971fee").unwrap(),
+        };
+        assert!(!files_manager.cache.contains_key(&first_key_pair));
+    }
+}

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -15,7 +15,6 @@ use tokio::sync::{mpsc, watch};
 use tokio::time::{timeout, Instant};
 
 use crate::envelope::Envelope;
-use crate::services::buffer::common::ProjectKeyPair;
 use crate::services::buffer::envelope_buffer::Peek;
 use crate::services::global_config;
 use crate::services::outcome::DiscardReason;
@@ -36,9 +35,17 @@ pub use envelope_buffer::PolymorphicEnvelopeBuffer;
 // pub for benchmarks
 pub use envelope_stack::sqlite::SqliteEnvelopeStack;
 // pub for benchmarks
+#[cfg(not(windows))]
+pub use envelope_stack::file_backed::FileBackedEnvelopeStack;
+// pub for benchmarks
 pub use envelope_stack::EnvelopeStack;
 // pub for benchmarks
 pub use envelope_store::sqlite::SqliteEnvelopeStore;
+// pub for benchmarks
+#[cfg(not(windows))]
+pub use envelope_store::file_backed::FileBackedEnvelopeStore;
+// pub for benchmarks
+pub use common::ProjectKeyPair;
 
 mod common;
 mod envelope_buffer;

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -43,6 +43,7 @@ mod common;
 mod envelope_buffer;
 mod envelope_stack;
 mod envelope_store;
+mod files_manager;
 mod stack_provider;
 mod testutils;
 

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -364,9 +364,9 @@ impl EnvelopeBufferService {
         }
     }
 
-    fn update_observable_state(&self, buffer: &mut PolymorphicEnvelopeBuffer) {
+    async fn update_observable_state(&self, buffer: &mut PolymorphicEnvelopeBuffer) {
         self.has_capacity
-            .store(buffer.has_capacity(), Ordering::Relaxed);
+            .store(buffer.has_capacity().await, Ordering::Relaxed);
     }
 }
 
@@ -446,7 +446,7 @@ impl Service for EnvelopeBufferService {
                 }
 
                 self.sleep = sleep;
-                self.update_observable_state(&mut buffer);
+                self.update_observable_state(&mut buffer).await;
             }
 
             relay_log::info!("EnvelopeBufferService: stopping");

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -469,12 +469,11 @@ impl Service for EnvelopeBufferService {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
-
     use relay_dynamic_config::GlobalConfig;
     use relay_quotas::DataCategory;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
     use tokio::sync::mpsc;
-    use uuid::Uuid;
 
     use crate::testutils::new_envelope;
     use crate::MemoryStat;
@@ -593,6 +592,8 @@ mod tests {
     async fn pop_requires_memory_capacity() {
         tokio::time::pause();
 
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().to_str().unwrap().to_string();
         let EnvelopeBufferServiceResult {
             service,
             envelopes_rx,
@@ -605,7 +606,7 @@ mod tests {
                     "envelopes": {
                         "version": "experimental",
                         "buffer_strategy": "file_backed",
-                        "path": std::env::temp_dir().join(Uuid::new_v4().to_string()),
+                        "path": path,
                     }
                 },
                 "health": {

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -43,7 +43,6 @@ mod common;
 mod envelope_buffer;
 mod envelope_stack;
 mod envelope_store;
-mod files_manager;
 mod stack_provider;
 mod testutils;
 

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -588,6 +588,7 @@ mod tests {
         assert_eq!(project_cache_rx.len(), 0);
     }
 
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn pop_requires_memory_capacity() {
         tokio::time::pause();

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -39,9 +39,6 @@ impl FileBackedStackProvider {
 impl StackProvider for FileBackedStackProvider {
     type Stack = FileBackedEnvelopeStack;
 
-    /// Initializes the stack provider by loading existing project key pairs from the file system.
-    ///
-    /// If the initialization fails, it logs an error and returns an empty initialization state.
     async fn initialize(&self) -> InitializationState {
         let project_key_pairs_with_counts = self
             .envelope_store
@@ -67,10 +64,6 @@ impl StackProvider for FileBackedStackProvider {
         }
     }
 
-    /// Creates a new `FileBackedEnvelopeStack` for the given project key pair.
-    ///
-    /// This method ignores the `stack_creation_type` parameter as the file-backed
-    /// implementation doesn't distinguish between creation types.
     fn create_stack(
         &self,
         _stack_creation_type: StackCreationType,
@@ -79,34 +72,22 @@ impl StackProvider for FileBackedStackProvider {
         FileBackedEnvelopeStack::new(project_key_pair, self.envelope_store.clone())
     }
 
-    /// Checks if there's available capacity in the store.
-    ///
-    /// This implementation always returns true, assuming unlimited disk capacity.
-    /// It can be extended to check actual disk capacity if needed.
     fn has_store_capacity(&self) -> bool {
         // Implement logic to check disk capacity if needed
         true
     }
 
-    /// Returns the total count of envelopes in the store.
-    ///
-    /// This implementation always returns 0. It can be extended to provide an
-    /// actual count if needed.
     async fn store_total_count(&self) -> u32 {
         // Optionally implement this to count total envelopes
         0
     }
 
-    /// Returns the type of the stack as a string.
     fn stack_type<'a>(&self) -> &'a str {
         "file_backed"
     }
 
-    /// Flushes the given envelope stacks.
-    ///
-    /// This method is a no-op for file-backed stacks, as the data is already
-    /// persisted on disk.
-    async fn flush(&mut self, _envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
+    async fn flush(&mut self, _envelope_stacks: impl IntoIterator<Item = Self::Stack>) -> bool {
         // Since data is already on disk, no action needed
+        true
     }
 }

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -93,8 +93,8 @@ impl StackProvider for FileBackedStackProvider {
         FileBackedEnvelopeStack::new(project_key_pair, self.envelope_store.clone())
     }
 
-    fn has_store_capacity(&self) -> bool {
-        (self.envelope_store.blocking_lock().usage() as usize) < self.max_disk_size
+    async fn has_store_capacity(&self) -> bool {
+        (self.envelope_store.lock().await.usage() as usize) < self.max_disk_size
     }
 
     fn stack_type<'a>(&self) -> &'a str {

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -1,0 +1,72 @@
+use hashbrown::HashSet;
+use relay_config::Config;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::services::buffer::common::ProjectKeyPair;
+use crate::services::buffer::envelope_stack::file_backed::FileBackedEnvelopeStack;
+use crate::services::buffer::files_manager::{FilesManager, FilesManagerError};
+use crate::services::buffer::stack_provider::{
+    InitializationState, StackCreationType, StackProvider,
+};
+
+/// A stack provider that manages `FileBackedEnvelopeStack` instances.
+///
+/// It uses an LRU cache to keep at most `n` open files.
+#[derive(Debug)]
+pub struct FileBackedStackProvider {
+    files_manager: Arc<Mutex<FilesManager>>,
+}
+
+impl FileBackedStackProvider {
+    pub async fn new(config: &Config) -> Result<Self, FilesManagerError> {
+        let files_manager = FilesManager::new(config).await?;
+
+        Ok(Self {
+            files_manager: Arc::new(Mutex::new(files_manager)),
+        })
+    }
+}
+
+impl StackProvider for FileBackedStackProvider {
+    type Stack = FileBackedEnvelopeStack;
+
+    async fn initialize(&self) -> InitializationState {
+        // TODO: handle error when loading pairs.
+        let project_key_pairs = self
+            .files_manager
+            .lock()
+            .await
+            .list_project_key_pairs()
+            .await
+            .unwrap_or(HashSet::new());
+
+        InitializationState { project_key_pairs }
+    }
+
+    fn create_stack(
+        &self,
+        _stack_creation_type: StackCreationType,
+        project_key_pair: ProjectKeyPair,
+    ) -> Self::Stack {
+        FileBackedEnvelopeStack::new(project_key_pair, self.files_manager.clone())
+    }
+
+    fn has_store_capacity(&self) -> bool {
+        // Implement logic to check disk capacity if needed
+        true
+    }
+
+    async fn store_total_count(&self) -> u64 {
+        // Optionally implement this to count total envelopes
+        0
+    }
+
+    fn stack_type<'a>(&self) -> &'a str {
+        "file_backed"
+    }
+
+    async fn flush(&mut self, _envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
+        // Since data is already on disk, no action needed
+    }
+}

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -14,13 +14,19 @@ use crate::services::buffer::stack_provider::{
 
 /// A stack provider that manages `FileBackedEnvelopeStack` instances.
 ///
-/// It uses an LRU cache to keep at most `n` open files.
+/// This provider uses a file-backed envelope store to persist envelopes on disk.
+/// It implements the `StackProvider` trait, providing methods to initialize,
+/// create stacks, and manage the overall state of the envelope storage.
 #[derive(Debug)]
 pub struct FileBackedStackProvider {
     envelope_store: Arc<Mutex<FileBackedEnvelopeStore>>,
 }
 
 impl FileBackedStackProvider {
+    /// Creates a new `FileBackedStackProvider` instance.
+    ///
+    /// This method initializes the underlying `FileBackedEnvelopeStore` using the provided
+    /// configuration.
     pub async fn new(config: &Config) -> Result<Self, FileBackedEnvelopeStoreError> {
         let envelope_store = FileBackedEnvelopeStore::new(config).await?;
 
@@ -33,6 +39,9 @@ impl FileBackedStackProvider {
 impl StackProvider for FileBackedStackProvider {
     type Stack = FileBackedEnvelopeStack;
 
+    /// Initializes the stack provider by loading existing project key pairs from the file system.
+    ///
+    /// If the initialization fails, it logs an error and returns an empty initialization state.
     async fn initialize(&self) -> InitializationState {
         let project_key_pairs_result = self
             .envelope_store
@@ -52,6 +61,10 @@ impl StackProvider for FileBackedStackProvider {
         }
     }
 
+    /// Creates a new `FileBackedEnvelopeStack` for the given project key pair.
+    ///
+    /// This method ignores the `stack_creation_type` parameter as the file-backed
+    /// implementation doesn't distinguish between creation types.
     fn create_stack(
         &self,
         _stack_creation_type: StackCreationType,
@@ -60,20 +73,33 @@ impl StackProvider for FileBackedStackProvider {
         FileBackedEnvelopeStack::new(project_key_pair, self.envelope_store.clone())
     }
 
+    /// Checks if there's available capacity in the store.
+    ///
+    /// This implementation always returns true, assuming unlimited disk capacity.
+    /// It can be extended to check actual disk capacity if needed.
     fn has_store_capacity(&self) -> bool {
         // Implement logic to check disk capacity if needed
         true
     }
 
+    /// Returns the total count of envelopes in the store.
+    ///
+    /// This implementation always returns 0. It can be extended to provide an
+    /// actual count if needed.
     async fn store_total_count(&self) -> u64 {
         // Optionally implement this to count total envelopes
         0
     }
 
+    /// Returns the type of the stack as a string.
     fn stack_type<'a>(&self) -> &'a str {
         "file_backed"
     }
 
+    /// Flushes the given envelope stacks.
+    ///
+    /// This method is a no-op for file-backed stacks, as the data is already
+    /// persisted on disk.
     async fn flush(&mut self, _envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
         // Since data is already on disk, no action needed
     }

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -1,11 +1,14 @@
 use hashbrown::HashSet;
 use relay_config::Config;
+use std::error::Error;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::services::buffer::envelope_stack::file_backed::FileBackedEnvelopeStack;
-use crate::services::buffer::files_manager::{FilesManager, FilesManagerError};
+use crate::services::buffer::envelope_store::file_backed::{
+    FileBackedEnvelopeStore, FileBackedEnvelopeStoreError,
+};
 use crate::services::buffer::stack_provider::{
     InitializationState, StackCreationType, StackProvider,
 };
@@ -15,15 +18,15 @@ use crate::services::buffer::stack_provider::{
 /// It uses an LRU cache to keep at most `n` open files.
 #[derive(Debug)]
 pub struct FileBackedStackProvider {
-    files_manager: Arc<Mutex<FilesManager>>,
+    envelope_store: Arc<Mutex<FileBackedEnvelopeStore>>,
 }
 
 impl FileBackedStackProvider {
-    pub async fn new(config: &Config) -> Result<Self, FilesManagerError> {
-        let files_manager = FilesManager::new(config).await?;
+    pub async fn new(config: &Config) -> Result<Self, FileBackedEnvelopeStoreError> {
+        let envelope_store = FileBackedEnvelopeStore::new(config).await?;
 
         Ok(Self {
-            files_manager: Arc::new(Mutex::new(files_manager)),
+            envelope_store: Arc::new(Mutex::new(envelope_store)),
         })
     }
 }
@@ -32,16 +35,22 @@ impl StackProvider for FileBackedStackProvider {
     type Stack = FileBackedEnvelopeStack;
 
     async fn initialize(&self) -> InitializationState {
-        // TODO: handle error when loading pairs.
-        let project_key_pairs = self
-            .files_manager
+        let project_key_pairs_result = self
+            .envelope_store
             .lock()
             .await
             .list_project_key_pairs()
-            .await
-            .unwrap_or(HashSet::new());
-
-        InitializationState { project_key_pairs }
+            .await;
+        match project_key_pairs_result {
+            Ok(project_key_pairs) => InitializationState { project_key_pairs },
+            Err(error) => {
+                relay_log::error!(
+                    error = &error as &dyn Error,
+                    "failed to load project key pairs from the file system",
+                );
+                InitializationState::empty()
+            }
+        }
     }
 
     fn create_stack(
@@ -49,7 +58,7 @@ impl StackProvider for FileBackedStackProvider {
         _stack_creation_type: StackCreationType,
         project_key_pair: ProjectKeyPair,
     ) -> Self::Stack {
-        FileBackedEnvelopeStack::new(project_key_pair, self.files_manager.clone())
+        FileBackedEnvelopeStack::new(project_key_pair, self.envelope_store.clone())
     }
 
     fn has_store_capacity(&self) -> bool {

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -1,4 +1,3 @@
-use hashbrown::HashSet;
 use relay_config::Config;
 use std::error::Error;
 use std::sync::Arc;

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -1,4 +1,3 @@
-use hashbrown::HashMap;
 use relay_config::Config;
 use std::error::Error;
 use std::sync::Arc;

--- a/relay-server/src/services/buffer/stack_provider/file_backed.rs
+++ b/relay-server/src/services/buffer/stack_provider/file_backed.rs
@@ -49,6 +49,7 @@ impl StackProvider for FileBackedStackProvider {
             .await
             .list_project_key_pairs()
             .await;
+
         match project_key_pairs_result {
             Ok(project_key_pairs) => InitializationState { project_key_pairs },
             Err(error) => {

--- a/relay-server/src/services/buffer/stack_provider/memory.rs
+++ b/relay-server/src/services/buffer/stack_provider/memory.rs
@@ -43,10 +43,12 @@ impl StackProvider for MemoryStackProvider {
         "memory"
     }
 
-    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
+    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) -> bool {
         for envelope_stack in envelope_stacks {
             // The flushed envelopes will be immediately dropped.
             let _ = envelope_stack.flush();
         }
+
+        false
     }
 }

--- a/relay-server/src/services/buffer/stack_provider/memory.rs
+++ b/relay-server/src/services/buffer/stack_provider/memory.rs
@@ -34,11 +34,6 @@ impl StackProvider for MemoryStackProvider {
         self.memory_checker.check_memory().has_capacity()
     }
 
-    async fn store_total_count(&self) -> u32 {
-        // The memory implementation doesn't have a store, so the count is 0.
-        0
-    }
-
     fn stack_type<'a>(&self) -> &'a str {
         "memory"
     }

--- a/relay-server/src/services/buffer/stack_provider/memory.rs
+++ b/relay-server/src/services/buffer/stack_provider/memory.rs
@@ -30,7 +30,7 @@ impl StackProvider for MemoryStackProvider {
         MemoryEnvelopeStack::new()
     }
 
-    fn has_store_capacity(&self) -> bool {
+    async fn has_store_capacity(&self) -> bool {
         self.memory_checker.check_memory().has_capacity()
     }
 

--- a/relay-server/src/services/buffer/stack_provider/memory.rs
+++ b/relay-server/src/services/buffer/stack_provider/memory.rs
@@ -34,7 +34,7 @@ impl StackProvider for MemoryStackProvider {
         self.memory_checker.check_memory().has_capacity()
     }
 
-    async fn store_total_count(&self) -> u64 {
+    async fn store_total_count(&self) -> u32 {
         // The memory implementation doesn't have a store, so the count is 0.
         0
     }

--- a/relay-server/src/services/buffer/stack_provider/memory.rs
+++ b/relay-server/src/services/buffer/stack_provider/memory.rs
@@ -38,12 +38,10 @@ impl StackProvider for MemoryStackProvider {
         "memory"
     }
 
-    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) -> bool {
+    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
         for envelope_stack in envelope_stacks {
             // The flushed envelopes will be immediately dropped.
             let _ = envelope_stack.flush();
         }
-
-        false
     }
 }

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -65,11 +65,8 @@ pub trait StackProvider: std::fmt::Debug {
     fn stack_type<'a>(&self) -> &'a str;
 
     /// Flushes the supplied [`EnvelopeStack`]s and consumes the [`StackProvider`].
-    ///
-    /// Returns `true` if the envelopes have been flushed to storage and the buffer is safe to be
-    /// dropped, `false` otherwise.
     fn flush(
         &mut self,
         envelope_stacks: impl IntoIterator<Item = Self::Stack>,
-    ) -> impl Future<Output = bool>;
+    ) -> impl Future<Output = ()>;
 }

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -1,10 +1,7 @@
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::EnvelopeStack;
 use hashbrown::HashSet;
-use std::error::Error;
 use std::future::Future;
-use std::time::Duration;
-use tokio::time::timeout;
 
 pub mod file_backed;
 pub mod memory;

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -88,8 +88,11 @@ pub trait StackProvider: std::fmt::Debug {
     fn stack_type<'a>(&self) -> &'a str;
 
     /// Flushes the supplied [`EnvelopeStack`]s and consumes the [`StackProvider`].
+    ///
+    /// Returns `true` if the envelopes have been flushed to storage and the buffer is safe to be
+    /// dropped, `false` otherwise.
     fn flush(
         &mut self,
         envelope_stacks: impl IntoIterator<Item = Self::Stack>,
-    ) -> impl Future<Output = ()>;
+    ) -> impl Future<Output = bool>;
 }

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -59,7 +59,7 @@ pub trait StackProvider: std::fmt::Debug {
 
     /// Returns `true` if the store used by this [`StackProvider`] has space to add new
     /// stacks or items to the stacks.
-    fn has_store_capacity(&self) -> bool;
+    fn has_store_capacity(&self) -> impl Future<Output = bool>;
 
     /// Returns the string representation of the stack type offered by this [`StackProvider`].
     fn stack_type<'a>(&self) -> &'a str;

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -16,12 +16,12 @@ pub mod sqlite;
 #[derive(Debug)]
 pub struct InitializationState {
     pub project_key_pairs: HashSet<ProjectKeyPair>,
-    pub store_total_count: u64,
+    pub store_total_count: u32,
 }
 
 impl InitializationState {
     /// Create a new [`InitializationState`].
-    pub fn new(project_key_pairs: HashSet<ProjectKeyPair>, store_total_count: u64) -> Self {
+    pub fn new(project_key_pairs: HashSet<ProjectKeyPair>, store_total_count: u32) -> Self {
         Self {
             project_key_pairs,
             store_total_count,
@@ -66,7 +66,7 @@ pub trait StackProvider: std::fmt::Debug {
 
     /// Returns the total count of the store used by this [`StackProvider`] and bounds the maximum
     /// time for execution.
-    async fn store_total_count_bounded(&self) -> u64 {
+    async fn store_total_count_bounded(&self) -> u32 {
         let store_total_count = timeout(Duration::from_secs(1), async {
             self.store_total_count().await
         })
@@ -82,7 +82,7 @@ pub trait StackProvider: std::fmt::Debug {
     }
 
     /// Returns the total count of the store used by this [`StackProvider`].
-    fn store_total_count(&self) -> impl Future<Output = u64>;
+    fn store_total_count(&self) -> impl Future<Output = u32>;
 
     /// Returns the string representation of the stack type offered by this [`StackProvider`].
     fn stack_type<'a>(&self) -> &'a str;

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -3,6 +3,7 @@ use crate::EnvelopeStack;
 use hashbrown::HashSet;
 use std::future::Future;
 
+pub mod file_backed;
 pub mod memory;
 pub mod sqlite;
 

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -3,6 +3,7 @@ use crate::EnvelopeStack;
 use hashbrown::HashSet;
 use std::future::Future;
 
+#[cfg(not(windows))]
 pub mod file_backed;
 pub mod memory;
 pub mod sqlite;

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -64,26 +64,6 @@ pub trait StackProvider: std::fmt::Debug {
     /// stacks or items to the stacks.
     fn has_store_capacity(&self) -> bool;
 
-    /// Returns the total count of the store used by this [`StackProvider`] and bounds the maximum
-    /// time for execution.
-    async fn store_total_count_bounded(&self) -> u32 {
-        let store_total_count = timeout(Duration::from_secs(1), async {
-            self.store_total_count().await
-        })
-        .await;
-
-        store_total_count.unwrap_or_else(|error| {
-            relay_log::error!(
-                error = &error as &dyn Error,
-                "failed to load the total envelope count of the store",
-            );
-            0
-        })
-    }
-
-    /// Returns the total count of the store used by this [`StackProvider`].
-    fn store_total_count(&self) -> impl Future<Output = u32>;
-
     /// Returns the string representation of the stack type offered by this [`StackProvider`].
     fn stack_type<'a>(&self) -> &'a str;
 

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -64,8 +64,11 @@ impl StackProvider for SqliteStackProvider {
     type Stack = SqliteEnvelopeStack;
 
     async fn initialize(&self) -> InitializationState {
-        match self.envelope_store.project_key_pairs().await {
-            Ok(project_key_pairs) => InitializationState::new(project_key_pairs),
+        let project_key_pairs = self.envelope_store.project_key_pairs().await;
+        let store_total_count = self.store_total_count_bounded().await;
+
+        match project_key_pairs {
+            Ok(project_key_pairs) => InitializationState::new(project_key_pairs, store_total_count),
             Err(error) => {
                 relay_log::error!(
                     error = &error as &dyn Error,

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -72,7 +72,7 @@ impl StackProvider for SqliteStackProvider {
             Err(error) => {
                 relay_log::error!(
                     error = &error as &dyn Error,
-                    "failed to initialize the sqlite stack provider"
+                    "failed to load project key pairs and envelope counts from sqlite"
                 );
                 InitializationState::empty()
             }
@@ -103,7 +103,7 @@ impl StackProvider for SqliteStackProvider {
         (self.envelope_store.usage() as usize) < self.max_disk_size
     }
 
-    async fn store_total_count(&self) -> u64 {
+    async fn store_total_count(&self) -> u32 {
         self.envelope_store
             .total_count()
             .await

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -122,7 +122,7 @@ impl StackProvider for SqliteStackProvider {
         )
     }
 
-    fn has_store_capacity(&self) -> bool {
+    async fn has_store_capacity(&self) -> bool {
         (self.envelope_store.usage() as usize) < self.max_disk_size
     }
 

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -121,7 +121,7 @@ impl StackProvider for SqliteStackProvider {
         "sqlite"
     }
 
-    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
+    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) -> bool {
         relay_log::trace!("Flushing sqlite envelope buffer");
 
         relay_statsd::metric!(timer(RelayTimers::BufferDrain), {
@@ -141,6 +141,8 @@ impl StackProvider for SqliteStackProvider {
                 self.drain_many(envelopes).await;
             }
         });
+
+        true
     }
 }
 

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -130,7 +130,7 @@ impl StackProvider for SqliteStackProvider {
         "sqlite"
     }
 
-    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) -> bool {
+    async fn flush(&mut self, envelope_stacks: impl IntoIterator<Item = Self::Stack>) {
         relay_log::trace!("Flushing sqlite envelope buffer");
 
         relay_statsd::metric!(timer(RelayTimers::BufferDrain), {
@@ -150,8 +150,6 @@ impl StackProvider for SqliteStackProvider {
                 self.drain_many(envelopes).await;
             }
         });
-
-        true
     }
 }
 

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -28,6 +28,12 @@ use crate::statsd::RelayCounters;
 
 /// Set the number of keep-alive retransmissions to be carried out before declaring that remote end
 /// is not available.
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "windows"
+)))]
 const KEEPALIVE_RETRIES: u32 = 5;
 
 /// Set a timeout for reading client request headers. If a client does not transmit the entire

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -540,6 +540,13 @@ pub enum RelayTimers {
     BufferDrain,
     /// Timing in milliseconds for the time it takes for the envelopes to be serialized.
     BufferEnvelopesSerialization,
+    /// Timing in milliseconds for the time it takes for the envelope to be serialized.
+    BufferEnvelopeSerialization,
+    /// Timing in milliseconds for the time it takes to write an envelope to a file.
+    BufferEnvelopeFileWriting,
+    /// Timing in milliseconds for the time it takes for the total count of envelopes to be read
+    /// from a file.
+    BufferTotalCountReading,
 }
 
 impl TimerMetric for RelayTimers {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -660,6 +660,9 @@ pub enum RelayCounters {
     BufferSpooledEnvelopes,
     /// Number of envelopes unspooled from disk.
     BufferUnspooledEnvelopes,
+    /// Number of times a file containing envelopes is removed.
+    #[cfg(not(windows))]
+    BufferRemovedEnvelopesFile,
     ///
     /// Number of outcomes and reasons for rejected Envelopes.
     ///
@@ -882,6 +885,8 @@ impl CounterMetric for RelayCounters {
             RelayCounters::BufferReadyToPop => "buffer.ready_to_pop",
             RelayCounters::BufferSpooledEnvelopes => "buffer.spooled_envelopes",
             RelayCounters::BufferUnspooledEnvelopes => "buffer.unspooled_envelopes",
+            #[cfg(not(windows))]
+            RelayCounters::BufferRemovedEnvelopesFile => "buffer.removed_envelopes_file",
             RelayCounters::Outcomes => "events.outcomes",
             RelayCounters::ProjectStateGet => "project_state.get",
             RelayCounters::ProjectStateRequest => "project_state.request",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -596,6 +596,9 @@ impl TimerMetric for RelayTimers {
             RelayTimers::BufferPop => "buffer.pop.duration",
             RelayTimers::BufferDrain => "buffer.drain.duration",
             RelayTimers::BufferEnvelopesSerialization => "buffer.envelopes_serialization",
+            RelayTimers::BufferEnvelopeSerialization => "buffer.envelope_serialization",
+            RelayTimers::BufferEnvelopeFileWriting => "buffer.envelope_file_writing",
+            RelayTimers::BufferTotalCountReading => "buffer.total_count_reading",
         }
     }
 }

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -61,7 +61,13 @@ def test_graceful_shutdown_with_sqlite_buffer(mini_sentry, relay):
         mini_sentry,
         {
             "limits": {"shutdown_timeout": 2},
-            "spool": {"envelopes": {"version": "experimental", "path": db_file_path}},
+            "spool": {
+                "envelopes": {
+                    "version": "experimental",
+                    "path": db_file_path,
+                    "buffer_strategy": "file_backed",
+                }
+            },
         },
     )
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -65,7 +65,7 @@ def test_graceful_shutdown_with_sqlite_buffer(mini_sentry, relay):
                 "envelopes": {
                     "version": "experimental",
                     "path": db_file_path,
-                    "buffer_strategy": "file_backed",
+                    "buffer_strategy": "sqlite",
                 }
             },
         },

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -98,6 +98,9 @@ def test_graceful_shutdown_with_file_backed_buffer(mini_sentry, relay):
     from time import sleep
     import os
 
+    # The errors thrown by Relay are expected in this code path
+    mini_sentry.fail_on_relay_error = False
+
     # Create a temporary directory for the envelope files
     envelope_files_folder = os.path.join(tempfile.mkdtemp())
 

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -176,6 +176,7 @@ def test_readiness_disk_spool(mini_sentry, relay):
             # if the config contains max_disk_size and max_memory_size set both to 0, Relay will never passes readiness check
             "envelopes": {
                 "version": "experimental",
+                "buffer_strategy": "sqlite",
                 "path": dbfile,
                 "max_disk_size": 24577,  # one more than the initial size
                 "disk_batch_size": 1,
@@ -188,7 +189,7 @@ def test_readiness_disk_spool(mini_sentry, relay):
 
     # Second sent event can trigger error on the relay size, since the spool is full now.
     for _ in range(20):
-        # It takes ~10 events to make SQLlite use more pages.
+        # It takes ~10 events to make SQLite use more pages.
         try:
             relay.send_event(project_key)
         except HTTPError as e:

--- a/tools/bench-buffer/Cargo.toml
+++ b/tools/bench-buffer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bench-buffer"
+version = "0.1.0"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Generates documentation for metrics"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+edition = "2021"
+publish = false
+
+[dependencies]
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+rand = { workspace = true }
+relay-config = { path = "../../relay-config" }
+relay-server = { path = "../../relay-server" }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/tools/bench-buffer/results/single_project/100kib/sqlite-batch-size-001.txt
+++ b/tools/bench-buffer/results/single_project/100kib/sqlite-batch-size-001.txt
@@ -1,0 +1,14 @@
+Args { envelope_size_kib: 100, batch_size: 1, implementation: Sqlite, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 310.80 MiB / s
+Write throughput: 373.06 MiB / s
+Write throughput: 366.92 MiB / s
+Write throughput: 370.62 MiB / s
+Write throughput: 364.88 MiB / s
+Write throughput: 369.19 MiB / s
+Write throughput: 326.61 MiB / s
+Write throughput: 374.09 MiB / s
+Write throughput: 365.88 MiB / s
+Read throughput: 699.96 MiB / s
+Read throughput: 712.12 MiB / s
+Read throughput: 705.66 MiB / s
+Read throughput: 712.95 MiB / s

--- a/tools/bench-buffer/results/single_project/10kib/files-34c824b.txt
+++ b/tools/bench-buffer/results/single_project/10kib/files-34c824b.txt
@@ -1,0 +1,19 @@
+Args { envelope_size_kib: 10, batch_size: 1, implementation: Files, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 290.84 MiB / s
+Write throughput: 319.12 MiB / s
+Write throughput: 329.35 MiB / s
+Write throughput: 322.49 MiB / s
+Write throughput: 324.31 MiB / s
+Write throughput: 336.89 MiB / s
+Write throughput: 338.60 MiB / s
+Write throughput: 330.94 MiB / s
+Write throughput: 332.15 MiB / s
+Read throughput: 129.70 MiB / s
+Read throughput: 129.95 MiB / s
+Read throughput: 130.80 MiB / s
+Read throughput: 130.07 MiB / s
+Read throughput: 128.42 MiB / s
+Read throughput: 129.46 MiB / s
+Read throughput: 124.96 MiB / s
+Read throughput: 129.98 MiB / s
+Read throughput: 131.46 MiB / s

--- a/tools/bench-buffer/results/single_project/10kib/files-453c2c1.txt
+++ b/tools/bench-buffer/results/single_project/10kib/files-453c2c1.txt
@@ -1,0 +1,19 @@
+Args { envelope_size_kib: 10, batch_size: 1, implementation: Files, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 194.51 MiB / s
+Write throughput: 202.08 MiB / s
+Write throughput: 202.23 MiB / s
+Write throughput: 210.04 MiB / s
+Write throughput: 210.67 MiB / s
+Write throughput: 211.86 MiB / s
+Write throughput: 212.08 MiB / s
+Write throughput: 209.63 MiB / s
+Write throughput: 197.00 MiB / s
+Read throughput: 128.75 MiB / s
+Read throughput: 128.45 MiB / s
+Read throughput: 128.95 MiB / s
+Read throughput: 126.90 MiB / s
+Read throughput: 130.09 MiB / s
+Read throughput: 128.91 MiB / s
+Read throughput: 129.45 MiB / s
+Read throughput: 126.73 MiB / s
+Read throughput: 130.14 MiB / s

--- a/tools/bench-buffer/results/single_project/10kib/files-a150550.txt
+++ b/tools/bench-buffer/results/single_project/10kib/files-a150550.txt
@@ -1,0 +1,19 @@
+Args { envelope_size_kib: 10, batch_size: 1, implementation: Files, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 338.79 MiB / s
+Write throughput: 385.85 MiB / s
+Write throughput: 389.17 MiB / s
+Write throughput: 406.35 MiB / s
+Write throughput: 406.01 MiB / s
+Write throughput: 403.89 MiB / s
+Write throughput: 405.80 MiB / s
+Write throughput: 402.34 MiB / s
+Write throughput: 401.03 MiB / s
+Read throughput: 141.90 MiB / s
+Read throughput: 147.72 MiB / s
+Read throughput: 147.93 MiB / s
+Read throughput: 146.74 MiB / s
+Read throughput: 146.93 MiB / s
+Read throughput: 145.51 MiB / s
+Read throughput: 143.21 MiB / s
+Read throughput: 147.90 MiB / s
+Read throughput: 146.40 MiB / s

--- a/tools/bench-buffer/results/single_project/10kib/sqlite-batch-size-001.txt
+++ b/tools/bench-buffer/results/single_project/10kib/sqlite-batch-size-001.txt
@@ -1,0 +1,20 @@
+Args { envelope_size_kib: 10, batch_size: 1, implementation: Sqlite, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 126.02 MiB / s
+Write throughput: 133.38 MiB / s
+Write throughput: 137.90 MiB / s
+Write throughput: 136.24 MiB / s
+Write throughput: 136.43 MiB / s
+Write throughput: 136.23 MiB / s
+Write throughput: 138.20 MiB / s
+Write throughput: 137.36 MiB / s
+Write throughput: 129.41 MiB / s
+Write throughput: 135.30 MiB / s
+Read throughput: 126.61 MiB / s
+Read throughput: 126.31 MiB / s
+Read throughput: 126.00 MiB / s
+Read throughput: 126.12 MiB / s
+Read throughput: 126.09 MiB / s
+Read throughput: 123.67 MiB / s
+Read throughput: 126.46 MiB / s
+Read throughput: 126.03 MiB / s
+Read throughput: 126.84 MiB / s

--- a/tools/bench-buffer/results/single_project/10kib/sqlite-batch-size-010.txt
+++ b/tools/bench-buffer/results/single_project/10kib/sqlite-batch-size-010.txt
@@ -1,0 +1,14 @@
+Args { envelope_size_kib: 10, batch_size: 10, implementation: Sqlite, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 235.82 MiB / s
+Write throughput: 293.12 MiB / s
+Write throughput: 291.29 MiB / s
+Write throughput: 292.72 MiB / s
+Write throughput: 292.97 MiB / s
+Write throughput: 278.57 MiB / s
+Write throughput: 286.45 MiB / s
+Write throughput: 257.00 MiB / s
+Write throughput: 278.85 MiB / s
+Read throughput: 483.75 MiB / s
+Read throughput: 477.82 MiB / s
+Read throughput: 482.04 MiB / s
+Read throughput: 488.47 MiB / s

--- a/tools/bench-buffer/results/single_project/10kib/sqlite-batch-size-100.txt
+++ b/tools/bench-buffer/results/single_project/10kib/sqlite-batch-size-100.txt
@@ -1,0 +1,13 @@
+Args { envelope_size_kib: 10, batch_size: 100, implementation: Sqlite, mode: Sequential, projects: 1, duration_secs: 20 }
+Write throughput: 270.02 MiB / s
+Write throughput: 338.78 MiB / s
+Write throughput: 341.56 MiB / s
+Write throughput: 346.76 MiB / s
+Write throughput: 341.32 MiB / s
+Write throughput: 343.75 MiB / s
+Write throughput: 304.05 MiB / s
+Write throughput: 341.52 MiB / s
+Write throughput: 328.29 MiB / s
+Read throughput: 709.01 MiB / s
+Read throughput: 705.72 MiB / s
+Read throughput: 710.09 MiB / s

--- a/tools/bench-buffer/src/main.rs
+++ b/tools/bench-buffer/src/main.rs
@@ -1,0 +1,218 @@
+use bytes::Bytes;
+use clap::{Parser, ValueEnum};
+use relay_config::Config;
+use relay_server::{Envelope, MemoryChecker, MemoryStat, PolymorphicEnvelopeBuffer};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Impl {
+    Memory,
+    Sqlite,
+    Files,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Mode {
+    Sequential,
+    Interleaved,
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    envelope_size_kib: usize,
+    #[arg(long)]
+    batch_size: usize,
+    #[arg(long)]
+    implementation: Impl,
+    #[arg(long)]
+    mode: Mode,
+    #[arg(long)]
+    projects: usize,
+    #[arg(long, default_value_t = 60)]
+    duration_secs: u64,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    println!("{:?}", &args);
+
+    let dir = tempfile::tempdir().unwrap();
+
+    let config = Arc::new(
+        Config::from_json_value(serde_json::json!({
+            "spool": {
+                "envelopes": {
+                    "buffer_strategy": match args.implementation {
+                        Impl::Memory => "memory",
+                        Impl::Files => "file_backed",
+                        Impl::Sqlite => "sqlite",
+                    },
+                    "path": match args.implementation {
+                        Impl::Memory => None,
+                        Impl::Files => Some(dir.path().to_owned()),
+                        Impl::Sqlite => Some(dir.path().join("envelopes.db")),
+                    },
+                    "disk_batch_size": args.batch_size,
+                }
+            }
+        }))
+        .unwrap(),
+    );
+
+    let memory_checker = MemoryChecker::new(MemoryStat::default(), config.clone());
+    let buffer = PolymorphicEnvelopeBuffer::from_config(&config, memory_checker)
+        .await
+        .unwrap();
+
+    match args.mode {
+        Mode::Sequential => {
+            run_sequential(
+                buffer,
+                args.envelope_size_kib * 1024,
+                args.projects,
+                Duration::from_secs(args.duration_secs),
+            )
+            .await
+        }
+        Mode::Interleaved => {
+            run_interleaved(
+                buffer,
+                args.envelope_size_kib * 1024,
+                args.projects,
+                Duration::from_secs(args.duration_secs),
+            )
+            .await
+        }
+    };
+
+    println!("Cleaning up temporary files...");
+    drop(dir);
+    println!("Done...");
+}
+
+async fn run_sequential(
+    mut buffer: PolymorphicEnvelopeBuffer,
+    envelope_size: usize,
+    project_count: usize,
+    duration: Duration,
+) {
+    // Determine envelope size once:
+    let proto_envelope = mock_envelope(envelope_size, project_count);
+    let bytes_per_envelope = proto_envelope.to_vec().unwrap().len();
+
+    let start_time = Instant::now();
+
+    let mut last_check = Instant::now();
+    let mut write_duration = Duration::ZERO;
+    let mut writes = 0;
+    while start_time.elapsed() < duration / 2 {
+        let envelope = mock_envelope(envelope_size, project_count);
+
+        let before = Instant::now();
+        buffer.push(envelope).await.unwrap();
+        let after = Instant::now();
+
+        write_duration += after - before;
+        writes += 1;
+
+        if (after - last_check) > Duration::from_secs(1) {
+            let throughput = (writes * bytes_per_envelope) as f64 / write_duration.as_secs_f64();
+            let throughput = throughput / 1024.0 / 1024.0;
+            println!("Write throughput: {throughput:.2} MiB / s");
+            write_duration = Duration::ZERO;
+            writes = 0;
+            last_check = after;
+        }
+    }
+
+    let mut last_check = Instant::now();
+    let mut read_duration = Duration::ZERO;
+    let mut reads = 0;
+    while start_time.elapsed() < duration {
+        let before = Instant::now();
+        if buffer.pop().await.unwrap().is_none() {
+            break;
+        };
+        let after = Instant::now();
+
+        read_duration += after - before;
+        reads += 1;
+
+        if (after - last_check) > Duration::from_secs(1) {
+            let throughput = (reads * bytes_per_envelope) as f64 / read_duration.as_secs_f64();
+            let throughput = throughput / 1024.0 / 1024.0;
+            println!("Read throughput: {throughput:.2} MiB / s");
+            read_duration = Duration::ZERO;
+            reads = 0;
+            last_check = after;
+        }
+    }
+}
+
+async fn run_interleaved(
+    mut buffer: PolymorphicEnvelopeBuffer,
+    envelope_size: usize,
+    project_count: usize,
+    duration: Duration,
+) {
+    // Determine envelope size once:
+    let proto_envelope = mock_envelope(envelope_size, project_count);
+    let bytes_per_envelope = proto_envelope.to_vec().unwrap().len();
+
+    let start_time = Instant::now();
+
+    let mut last_check = Instant::now();
+    let mut write_duration = Duration::ZERO;
+    let mut read_duration = Duration::ZERO;
+    let mut iterations = 0;
+    while start_time.elapsed() < duration {
+        let envelope = mock_envelope(envelope_size, project_count);
+
+        let before = Instant::now();
+        buffer.push(envelope).await.unwrap();
+        let after_write = Instant::now();
+        buffer.pop().await.unwrap();
+        let after_read = Instant::now();
+
+        write_duration += after_write - before;
+        read_duration += after_read - after_write;
+        iterations += 1;
+
+        if (after_read - last_check) > Duration::from_secs(1) {
+            let write_throughput =
+                (iterations * bytes_per_envelope) as f64 / write_duration.as_secs_f64();
+            let write_throughput = write_throughput / 1024.0 / 1024.0;
+            let read_throughput =
+                (iterations * bytes_per_envelope) as f64 / read_duration.as_secs_f64();
+            let read_throughput = read_throughput / 1024.0 / 1024.0;
+            println!("Write throughput: {write_throughput:.2} MiB / s");
+
+            println!("Read throughput: {read_throughput:.2} MiB / s");
+            write_duration = Duration::ZERO;
+            read_duration = Duration::ZERO;
+            iterations = 0;
+
+            last_check = after_read;
+        }
+    }
+}
+
+fn mock_envelope(payload_size: usize, project_count: usize) -> Box<Envelope> {
+    let project_key = (rand::random::<f64>() * project_count as f64) as u128;
+    let bytes = Bytes::from(format!(
+            "\
+             {{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://{:032x}:@sentry.io/42\"}}\n\
+             {{\"type\":\"attachment\"}}\n\
+             {}\n\
+             ",
+            project_key,
+            "X".repeat(payload_size)
+        ));
+
+    let mut envelope = Envelope::parse_bytes(bytes).unwrap();
+    envelope.set_start_time(Instant::now());
+    envelope
+}


### PR DESCRIPTION
This PR implements a new file backend envelope stack, creating a file per `own_key` `project_key` combination. The files have a custom format designed for fast access and the data layout is explained in code comments.

The whole idea of this mechanism is that we always append and remove data from the end of the file, meaning no in-memory buffering takes place. When a file is found to be empty, it will be removed from the file system.

In the future, given our file-per-pair model, we could parallelize spools and batch them.