### PR TITLE
ref(server): Organize project services in nested modules

### DIFF
--- a/relay-server/src/endpoints/batch_metrics.rs
+++ b/relay-server/src/endpoints/batch_metrics.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::extractors::{SignedBytes, StartTime};
 use crate::service::ServiceState;
 use crate::services::processor::ProcessBatchedMetrics;
-use crate::services::project_cache::BucketSource;
+use crate::services::projects::cache::BucketSource;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SendMetricsResponse {}

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -13,7 +13,7 @@ use crate::service::ServiceState;
 use crate::services::buffer::EnvelopeBuffer;
 use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::processor::{MetricData, ProcessMetricMeta, ProcessingGroup};
-use crate::services::project_cache::{CheckEnvelope, ProcessMetrics, ValidateEnvelope};
+use crate::services::projects::cache::{CheckEnvelope, ProcessMetrics, ValidateEnvelope};
 use crate::statsd::{RelayCounters, RelayHistograms};
 use crate::utils::{self, ApiErrorResponse, FormDataIter, ManagedEnvelope};
 

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -16,8 +16,10 @@ use crate::endpoints::forward;
 use crate::extractors::SignedJson;
 use crate::service::ServiceState;
 use crate::services::global_config::{self, StatusResponse};
-use crate::services::project::{LimitedParsedProjectState, ParsedProjectState, ProjectState};
-use crate::services::project_cache::{GetCachedProjectState, GetProjectState};
+use crate::services::projects::cache::{GetCachedProjectState, GetProjectState};
+use crate::services::projects::project::{
+    LimitedParsedProjectState, ParsedProjectState, ProjectState,
+};
 
 /// V2 version of this endpoint.
 ///
@@ -89,7 +91,7 @@ struct GetProjectStatesResponseWrapper {
 
 /// Request payload of the project config endpoint.
 ///
-/// This is a replica of [`GetProjectStates`](crate::services::project_upstream::GetProjectStates)
+/// This is a replica of [`GetProjectStates`](crate::services::projects::source::upstream::GetProjectStates)
 /// which allows skipping invalid project keys.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -12,7 +12,7 @@ use crate::services::metrics::{Aggregator, RouterService};
 use crate::services::outcome::{OutcomeProducer, OutcomeProducerService, TrackOutcome};
 use crate::services::outcome_aggregator::OutcomeAggregator;
 use crate::services::processor::{self, EnvelopeProcessor, EnvelopeProcessorService};
-use crate::services::project_cache::{ProjectCache, ProjectCacheService, Services};
+use crate::services::projects::cache::{ProjectCache, ProjectCacheService, Services};
 use crate::services::relays::{RelayCache, RelayCacheService};
 use crate::services::stats::RelayStats;
 #[cfg(feature = "processing")]

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -21,7 +21,7 @@ use crate::services::outcome::DiscardReason;
 use crate::services::outcome::Outcome;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::ProcessingGroup;
-use crate::services::project_cache::{DequeuedEnvelope, ProjectCache, UpdateProject};
+use crate::services::projects::cache::{DequeuedEnvelope, ProjectCache, UpdateProject};
 
 use crate::services::test_store::TestStore;
 use crate::statsd::{RelayCounters, RelayHistograms};

--- a/relay-server/src/services/mod.rs
+++ b/relay-server/src/services/mod.rs
@@ -7,7 +7,7 @@
 //! and dispatches the graceful shutdown signal. Internally, it creates several other services
 //! comprising the service state:
 //!
-//!  - [`ProjectCache`](project_cache::ProjectCache): A cache that serves queries for project
+//!  - [`ProjectCache`](projects::cache::ProjectCache): A cache that serves queries for project
 //!    configurations. Its requests are debounced and batched based on a configured interval (100ms
 //!    by default). Also, missing projects are cached for some time.
 //!  - [`EnvelopeProcessor`](processor::EnvelopeProcessor): A worker pool for CPU-intensive tasks.
@@ -35,10 +35,7 @@ pub mod metrics;
 pub mod outcome;
 pub mod outcome_aggregator;
 pub mod processor;
-pub mod project;
-pub mod project_cache;
-pub mod project_local;
-pub mod project_upstream;
+pub mod projects;
 pub mod relays;
 pub mod server;
 pub mod spooler;
@@ -46,7 +43,5 @@ pub mod stats;
 pub mod test_store;
 pub mod upstream;
 
-#[cfg(feature = "processing")]
-pub mod project_redis;
 #[cfg(feature = "processing")]
 pub mod store;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -72,10 +72,10 @@ use crate::services::global_config::GlobalConfigHandle;
 use crate::services::metrics::{Aggregator, MergeBuckets};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::event::FiltersStatus;
-use crate::services::project::{ProjectInfo, ProjectState};
-use crate::services::project_cache::{
+use crate::services::projects::cache::{
     AddMetricMeta, BucketSource, ProcessMetrics, ProjectCache, UpdateRateLimits,
 };
+use crate::services::projects::project::{ProjectInfo, ProjectState};
 use crate::services::test_store::{Capture, TestStore};
 use crate::services::upstream::{
     SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -252,7 +252,7 @@ mod tests {
     use crate::services::processor::{
         ProcessEnvelope, ProcessingExtractedMetrics, ProcessingGroup, SpanGroup,
     };
-    use crate::services::project::ProjectInfo;
+    use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{
         self, create_test_processor, new_envelope, state_with_rule_and_condition,
     };

--- a/relay-server/src/services/processor/metrics.rs
+++ b/relay-server/src/services/processor/metrics.rs
@@ -5,8 +5,8 @@ use relay_quotas::Scoping;
 
 use crate::metrics::MetricOutcomes;
 use crate::services::outcome::Outcome;
-use crate::services::project::ProjectInfo;
-use crate::services::project_cache::BucketSource;
+use crate::services::projects::cache::BucketSource;
+use crate::services::projects::project::ProjectInfo;
 
 /// Checks if the namespace of the passed bucket is valid.
 ///

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -152,7 +152,7 @@ mod tests {
     use crate::envelope::Envelope;
     use crate::extractors::RequestMeta;
     use crate::services::processor::{ProcessEnvelope, ProcessingGroup};
-    use crate::services::project::ProjectInfo;
+    use crate::services::projects::project::ProjectInfo;
     use crate::testutils::create_test_processor;
     use crate::utils::ManagedEnvelope;
 

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -274,7 +274,7 @@ mod tests {
     use crate::extractors::RequestMeta;
     use crate::services::outcome::RuleCategory;
     use crate::services::processor::{ProcessEnvelope, ProcessingGroup};
-    use crate::services::project::ProjectInfo;
+    use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{self, create_test_processor};
     use crate::utils::ManagedEnvelope;
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -768,7 +768,7 @@ mod tests {
 
     use crate::envelope::Envelope;
     use crate::services::processor::{ProcessingExtractedMetrics, ProcessingGroup};
-    use crate::services::project::ProjectInfo;
+    use crate::services::projects::project::ProjectInfo;
     use crate::utils::ManagedEnvelope;
 
     use super::*;

--- a/relay-server/src/services/projects/cache.rs
+++ b/relay-server/src/services/projects/cache.rs
@@ -9,7 +9,7 @@ use crate::services::global_config;
 use crate::services::processor::{
     EncodeMetrics, EnvelopeProcessor, MetricData, ProcessEnvelope, ProcessingGroup, ProjectMetrics,
 };
-use crate::services::project::state::UpstreamProjectState;
+use crate::services::projects::project::state::UpstreamProjectState;
 use crate::Envelope;
 use chrono::{DateTime, Utc};
 use hashbrown::HashSet;
@@ -29,11 +29,13 @@ use tokio::time::Instant;
 
 use crate::services::metrics::{Aggregator, FlushBuckets};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
-use crate::services::project::{Project, ProjectFetchState, ProjectSender, ProjectState};
-use crate::services::project_local::{LocalProjectSource, LocalProjectSourceService};
+use crate::services::projects::project::{Project, ProjectFetchState, ProjectSender, ProjectState};
+use crate::services::projects::source::local::{LocalProjectSource, LocalProjectSourceService};
 #[cfg(feature = "processing")]
-use crate::services::project_redis::RedisProjectSource;
-use crate::services::project_upstream::{UpstreamProjectSource, UpstreamProjectSourceService};
+use crate::services::projects::source::redis::RedisProjectSource;
+use crate::services::projects::source::upstream::{
+    UpstreamProjectSource, UpstreamProjectSourceService,
+};
 use crate::services::spooler::{
     self, Buffer, BufferService, DequeueMany, Enqueue, QueueKey, RemoveMany, RestoreIndex,
     UnspooledEnvelope, BATCH_KEY_COUNT,
@@ -669,7 +671,7 @@ impl ProjectCacheBroker {
     /// Ideally, we would use `check_expiry` to determine expiry here.
     /// However, for eviction, we want to add an additional delay, such that we do not delete
     /// a project that has expired recently and for which a fetch is already underway in
-    /// [`super::project_upstream`].
+    /// [`super::source::upstream`].
     fn evict_stale_project_caches(&mut self) {
         let eviction_start = Instant::now();
         let delta = 2 * self.config.project_cache_expiry() + self.config.project_grace_period();

--- a/relay-server/src/services/projects/mod.rs
+++ b/relay-server/src/services/projects/mod.rs
@@ -1,0 +1,3 @@
+pub mod cache;
+pub mod project;
+pub mod source;

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -16,8 +16,7 @@ use crate::envelope::ItemType;
 use crate::services::metrics::{Aggregator, MergeBuckets};
 use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::processor::{EncodeMetricMeta, EnvelopeProcessor, ProcessProjectMetrics};
-use crate::services::project::state::ExpiryState;
-use crate::services::project_cache::{
+use crate::services::projects::cache::{
     CheckedEnvelope, ProcessMetrics, ProjectCache, RequestUpdate,
 };
 use crate::utils::{Enforcement, SeqCount};
@@ -28,7 +27,8 @@ use crate::utils::{CheckLimits, EnvelopeLimiter, ManagedEnvelope, RetryBackoff};
 pub mod state;
 
 pub use state::{
-    LimitedParsedProjectState, ParsedProjectState, ProjectFetchState, ProjectInfo, ProjectState,
+    ExpiryState, LimitedParsedProjectState, ParsedProjectState, ProjectFetchState, ProjectInfo,
+    ProjectState,
 };
 
 /// Sender type for messages that respond with project states.
@@ -433,7 +433,7 @@ impl Project {
     /// `no_cache` should be passed from the requesting call. Updates with `no_cache` will always
     /// take precedence.
     ///
-    /// [`ValidateEnvelope`]: crate::services::project_cache::ValidateEnvelope
+    /// [`ValidateEnvelope`]: crate::services::projects::cache::ValidateEnvelope
     pub fn update_state(
         &mut self,
         project_cache: &Addr<ProjectCache>,
@@ -515,7 +515,7 @@ impl Project {
 
     /// Runs the checks on incoming envelopes.
     ///
-    /// See, [`crate::services::project_cache::CheckEnvelope`] for more information
+    /// See, [`crate::services::projects::cache::CheckEnvelope`] for more information
     ///
     /// * checks the rate limits
     /// * validates the envelope meta in `check_request` - determines whether the given request

--- a/relay-server/src/services/projects/project/state/fetch_state.rs
+++ b/relay-server/src/services/projects/project/state/fetch_state.rs
@@ -5,8 +5,8 @@ use tokio::time::Instant;
 use relay_config::Config;
 use relay_dynamic_config::ProjectConfig;
 
-use crate::services::project::state::info::ProjectInfo;
-use crate::services::project::ProjectState;
+use crate::services::projects::project::state::info::ProjectInfo;
+use crate::services::projects::project::ProjectState;
 
 /// Hides a cached project state and only exposes it if it has not expired.
 #[derive(Clone, Debug)]
@@ -65,7 +65,7 @@ impl ProjectFetchState {
 
     /// Create a config that immediately counts as expired.
     ///
-    /// This is what [`Project`](crate::services::project::Project) initializes itself with.
+    /// This is what [`Project`](crate::services::projects::project::Project) initializes itself with.
     pub fn expired() -> Self {
         Self {
             // Make sure the state immediately qualifies as expired:

--- a/relay-server/src/services/projects/project/state/info.rs
+++ b/relay-server/src/services/projects/project/state/info.rs
@@ -16,7 +16,7 @@ use url::Url;
 use crate::envelope::Envelope;
 use crate::extractors::RequestMeta;
 use crate::services::outcome::DiscardReason;
-use crate::services::project::PublicKeyConfig;
+use crate::services::projects::project::PublicKeyConfig;
 
 /// Information about an enabled project.
 ///
@@ -189,7 +189,7 @@ impl ProjectInfo {
     /// scoping.
     ///
     /// To get the own scoping of this ProjectKey without amending request information, use
-    /// [`Project::scoping`](crate::services::project::Project::scoping) instead.
+    /// [`Project::scoping`](crate::services::projects::project::Project::scoping) instead.
     pub fn scope_request(&self, meta: &RequestMeta) -> Scoping {
         let mut scoping = meta.get_partial_scoping();
 

--- a/relay-server/src/services/projects/project/state/mod.rs
+++ b/relay-server/src/services/projects/project/state/mod.rs
@@ -22,7 +22,7 @@ pub enum ProjectState {
     Disabled,
     /// A project to which one of the following conditions apply:
     /// - The project has not yet been fetched.
-    /// - The upstream returned "pending" for this project (see [`crate::services::project_upstream`]).
+    /// - The upstream returned "pending" for this project (see [`crate::services::projects::source::upstream`]).
     /// - The upstream returned an unparsable project so we have to try again.
     /// - The project has expired and must be treated as "has not been fetched".
     Pending,
@@ -95,7 +95,7 @@ pub struct ParsedProjectState {
     /// Project info.
     ///
     /// This contains no information when `disabled` is `true`, except for
-    /// public keys in static project configs (see [`crate::services::project_local`]).
+    /// public keys in static project configs (see [`crate::services::projects::source::local`]).
     #[serde(flatten)]
     pub info: ProjectInfo,
 }
@@ -109,7 +109,7 @@ pub struct LimitedParsedProjectState {
     /// Limited project info for external Relays.
     ///
     /// This contains no information when `disabled` is `true`, except for
-    /// public keys in static project configs (see [`crate::services::project_local`]).
+    /// public keys in static project configs (see [`crate::services::projects::source::local`]).
     #[serde(with = "LimitedProjectInfo")]
     #[serde(flatten)]
     pub info: ProjectInfo,

--- a/relay-server/src/services/projects/source/local.rs
+++ b/relay-server/src/services/projects/source/local.rs
@@ -9,8 +9,8 @@ use relay_system::{AsyncResponse, FromMessage, Interface, Receiver, Sender, Serv
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 
-use crate::services::project::{ParsedProjectState, ProjectState};
-use crate::services::project_cache::FetchOptionalProjectState;
+use crate::services::projects::cache::FetchOptionalProjectState;
+use crate::services::projects::project::{ParsedProjectState, ProjectState};
 
 /// Service interface of the local project source.
 #[derive(Debug)]
@@ -196,7 +196,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::services::project::{ProjectInfo, PublicKeyConfig};
+    use crate::services::projects::project::{ProjectInfo, PublicKeyConfig};
 
     /// Tests that we can follow the symlinks and read the project file properly.
     #[tokio::test]

--- a/relay-server/src/services/projects/source/mod.rs
+++ b/relay-server/src/services/projects/source/mod.rs
@@ -1,0 +1,4 @@
+pub mod local;
+#[cfg(feature = "processing")]
+pub mod redis;
+pub mod upstream;

--- a/relay-server/src/services/projects/source/redis.rs
+++ b/relay-server/src/services/projects/source/redis.rs
@@ -5,8 +5,8 @@ use relay_config::Config;
 use relay_redis::{RedisError, RedisPool};
 use relay_statsd::metric;
 
-use crate::services::project::state::UpstreamProjectState;
-use crate::services::project::{ParsedProjectState, ProjectState};
+use crate::services::projects::project::state::UpstreamProjectState;
+use crate::services::projects::project::{ParsedProjectState, ProjectState};
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
 
 #[derive(Debug, Clone)]

--- a/relay-server/src/services/projects/source/upstream.rs
+++ b/relay-server/src/services/projects/source/upstream.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 
-use crate::services::project::state::UpstreamProjectState;
-use crate::services::project::ParsedProjectState;
-use crate::services::project::ProjectState;
-use crate::services::project_cache::FetchProjectState;
+use crate::services::projects::cache::FetchProjectState;
+use crate::services::projects::project::state::UpstreamProjectState;
+use crate::services::projects::project::ParsedProjectState;
+use crate::services::projects::project::ProjectState;
 use crate::services::upstream::{
     Method, RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay, UpstreamRequestError,
 };

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -13,7 +13,7 @@
 //! be happening.
 //!
 //! The initial state is always [`InMemory`], and if the Relay can properly fetch all the
-//! [`crate::services::project::ProjectState`] it continues to use the memory as temporary spool.
+//! [`crate::services::projects::project::ProjectState`] it continues to use the memory as temporary spool.
 //!
 //! Keeping the envelopes in memory as long as we can, we ensure the fast unspool operations and
 //! fast processing times.
@@ -55,7 +55,7 @@ use crate::envelope::{Envelope, EnvelopeError};
 use crate::extractors::StartTime;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::ProcessingGroup;
-use crate::services::project_cache::{ProjectCache, RefreshIndexCache, UpdateSpoolIndex};
+use crate::services::projects::cache::{ProjectCache, RefreshIndexCache, UpdateSpoolIndex};
 use crate::services::test_store::TestStore;
 use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::{ManagedEnvelope, MemoryChecker};

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -20,7 +20,7 @@ use crate::service::create_redis_pools;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::{self, EnvelopeProcessorService};
-use crate::services::project::ProjectInfo;
+use crate::services::projects::project::ProjectInfo;
 use crate::services::test_store::TestStore;
 use crate::utils::{ThreadPool, ThreadPoolBuilder};
 


### PR DESCRIPTION
Organizing all the `project_*.rs` files we have in the `services/` module in a module structure.

```
projects
├── cache.rs // <- services/project_cache.rs
├── mod.rs
├── project
│   ├── mod.rs // <- services/project.rs
│   └── state // <- services/project/state/*
│       ├── fetch_state.rs
│       ├── info.rs
│       └── mod.rs
└── source
    ├── local.rs // <- services/project_local.rs
    ├── mod.rs
    ├── redis.rs // <- services/project_redis.rs
    └── upstream.rs // <- services/project_upstream.rs
```

This only moves files around, no functional changes. It is a preparation to split out more of the convoluted services into smaller digestible parts. For example, the `project_cache.rs` module contains a lot of utility and helper types not relevant for the service itself, it should be possible to split this out eventually.

I chose `projects` as the base module to avoid having a `project/project/` module, also I think it makes sense, it manages all projects and the nested module just represents a single project.

#skip-changelog