### PR TITLE
fix(projects): Treat fetch failures as pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Accept incoming requests even if there was an error fetching their project config. ([#4140](https://github.com/getsentry/relay/pull/4140))
+
 ## 24.11.1
 
 **Breaking Changes**:

--- a/relay-server/src/services/projects/cache/service.rs
+++ b/relay-server/src/services/projects/cache/service.rs
@@ -124,9 +124,7 @@ impl ProjectCacheService {
                         "failed to fetch project from source: {fetch:?}"
                     );
 
-                    // TODO: change this to ProjectState::Pending once we consider it safe to do so.
-                    // see https://github.com/getsentry/relay/pull/4140.
-                    ProjectState::Disabled.into()
+                    ProjectState::Pending.into()
                 }
             };
 


### PR DESCRIPTION
When we fail to fetch a project state for any reason (max retries exceeded, redis error), we should not mark the project as invalid.

Currently we treat the project as if the DSN was invalid, and respond to clients with a 403 response. This might have made sense as a defensive measure in a pre-spooling world where envelopes could not be buffered for a longer period of time, but with spooling and time-based envelope eviction, we can now safely buffer them.

ref: [INC-888](https://getsentry.atlassian.net/browse/INC-888)

[INC-888]: https://getsentry.atlassian.net/browse/INC-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

blocked by: https://github.com/getsentry/team-ingest/issues/345