### PR TITLE
Revert "ref(buffer): remove peek"

### DIFF
--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -21,6 +21,10 @@ impl EnvelopeStack for MemoryEnvelopeStack {
         Ok(())
     }
 
+    async fn peek(&mut self) -> Result<Option<&Envelope>, Self::Error> {
+        Ok(self.0.last().map(Box::as_ref))
+    }
+
     async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
         Ok(self.0.pop())
     }

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -14,6 +14,9 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     /// Pushes an [`Envelope`] on top of the stack.
     fn push(&mut self, envelope: Box<Envelope>) -> impl Future<Output = Result<(), Self::Error>>;
 
+    /// Peeks the [`Envelope`] on top of the stack.
+    fn peek(&mut self) -> impl Future<Output = Result<Option<&Envelope>, Self::Error>>;
+
     /// Pops the [`Envelope`] on top of the stack.
     fn pop(&mut self) -> impl Future<Output = Result<Option<Box<Envelope>>, Self::Error>>;
 


### PR DESCRIPTION
Reverts getsentry/relay#4136

The new version worked fine functionally speaking, but it created more traffic between the envelope buffer service and the project cache, which I want to investigate before proceeding.

#skip-changelog