### PR TITLE
chore(server): Remove native placeholders from transaction processing

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1701,10 +1701,6 @@ impl EnvelopeProcessorService {
         let profile_id = profile::filter(state);
         profile::transfer_id(state, profile_id);
 
-        if_processing!(self.inner.config, {
-            attachment::create_placeholders(state);
-        });
-
         event::finalize(state, &self.inner.config)?;
         self.normalize_event(state)?;
 

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -12,7 +12,7 @@ use crate::statsd::RelayTimers;
 
 #[cfg(feature = "processing")]
 use {
-    crate::services::processor::EventProcessing, crate::utils, relay_event_schema::protocol::Event,
+    crate::services::processor::ErrorGroup, crate::utils, relay_event_schema::protocol::Event,
     relay_protocol::Annotated,
 };
 
@@ -23,7 +23,7 @@ use {
 ///
 /// If the event payload was empty before, it is created.
 #[cfg(feature = "processing")]
-pub fn create_placeholders<G: EventProcessing>(state: &mut ProcessEnvelopeState<G>) {
+pub fn create_placeholders(state: &mut ProcessEnvelopeState<ErrorGroup>) {
     let envelope = state.managed_envelope.envelope();
     let minidump_attachment =
         envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::Minidump));


### PR DESCRIPTION
This was copied over from the unified envelope processing pipeline, but is not
needed for transaction events.

#skip-changelog

