### PR TITLE
instr(buffer): Measure envelope size

### DIFF
--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -14,6 +14,7 @@ use relay_config::Config;
 use tokio::time::{timeout, Instant};
 
 use crate::envelope::Envelope;
+use crate::envelope::Item;
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::services::buffer::envelope_stack::sqlite::SqliteEnvelopeStackError;
 use crate::services::buffer::envelope_stack::EnvelopeStack;
@@ -80,7 +81,7 @@ impl PolymorphicEnvelopeBuffer {
     pub async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), EnvelopeBufferError> {
         relay_statsd::metric!(
             histogram(RelayHistograms::BufferEnvelopeBodySize) =
-                envelope.items().map(Item::len).sum()
+                envelope.items().map(Item::len).sum::<usize>() as u64
         );
 
         relay_statsd::metric!(timer(RelayTimers::BufferPush), {

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -78,6 +78,11 @@ impl PolymorphicEnvelopeBuffer {
 
     /// Adds an envelope to the buffer.
     pub async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), EnvelopeBufferError> {
+        relay_statsd::metric!(
+            histogram(RelayHistograms::BufferEnvelopeBodySize) =
+                envelope.items().map(Item::len).sum()
+        );
+
         relay_statsd::metric!(timer(RelayTimers::BufferPush), {
             match self {
                 Self::Sqlite(buffer) => buffer.push(envelope).await,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -181,6 +181,11 @@ pub enum RelayHistograms {
     /// Number of envelopes in the backpressure buffer between the envelope buffer
     /// and the project cache.
     BufferBackpressureEnvelopesCount,
+    /// The amount of bytes in the item payloads of an envelope pushed to the envelope buffer.
+    ///
+    /// This is not quite the same as the actual size of a serialized envelope, because it ignores
+    /// the envelope header and item headers.
+    BufferEnvelopeBodySize,
     /// The number of batches emitted per partition.
     BatchesPerPartition,
     /// The number of buckets in a batch emitted.
@@ -309,6 +314,7 @@ impl HistogramMetric for RelayHistograms {
             RelayHistograms::BufferBackpressureEnvelopesCount => {
                 "buffer.backpressure_envelopes_count"
             }
+            RelayHistograms::BufferEnvelopeBodySize => "buffer.envelope_body_size",
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",


### PR DESCRIPTION
Collect a histogram metric for the size of the envelopes that get pushed into the envelope buffer. This will help us tune batch sizes for writing.

We already have a metric for item sizes in the request handler, but we want one for the entire envelope & restrict it to envelopes that actually make it to the buffer (exclude rate limited).

#skip-changelog