### PR TITLE
fix(profiling): Profile chunk release is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes:**
 
-- Profile chunk release is optional. ([#4155](https://github.com/getsentry/relay/pull/4155))
+- Allow profile chunks without release. ([#4155](https://github.com/getsentry/relay/pull/4155))
 
 ## 24.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes:**
+
+- Profile chunk release is optional. ([#4155](https://github.com/getsentry/relay/pull/4155))
+
 ## 24.10.0
 
 **Breaking Changes:**
@@ -11,7 +17,6 @@
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
 - Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
 - Incorrect pattern matches involving adjacent any and wildcard matchers. ([#4072](https://github.com/getsentry/relay/pull/4072))
-- Profile chunk release is optional. ([#4155](https://github.com/getsentry/relay/pull/4155))
 
 **Features:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
 - Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
 - Incorrect pattern matches involving adjacent any and wildcard matchers. ([#4072](https://github.com/getsentry/relay/pull/4072))
-- Make release is optional on profile chunks. (#[4155](https://github.com/getsentry/relay/pull/4155))
+- Profile chunk release is optional. ([#4155](https://github.com/getsentry/relay/pull/4155))
 
 **Features:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
 - Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
 - Incorrect pattern matches involving adjacent any and wildcard matchers. ([#4072](https://github.com/getsentry/relay/pull/4072))
+- Make release is optional on profile chunks. (#[4155](https://github.com/getsentry/relay/pull/4155))
 
 **Features:**
 

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -33,6 +33,8 @@ pub struct ProfileMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<String>,
     pub platform: String,
+
+    #[serde(default)]
     pub release: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -33,9 +33,7 @@ pub struct ProfileMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<String>,
     pub platform: String,
-
-    #[serde(default)]
-    pub release: String,
+    pub release: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_sdk: Option<ClientSdk>,


### PR DESCRIPTION
We were dropping all chunks where the release was not specified.