### PR TITLE
instr(system): Measure service idle time

### DIFF
--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -1064,6 +1064,13 @@ mod tests {
         }
     }
 
+    fn skip_idle_time(captures: Vec<String>) -> Vec<String> {
+        captures
+            .into_iter()
+            .filter(|c| !c.starts_with("service.idle_time_nanos:"))
+            .collect()
+    }
+
     #[test]
     fn test_backpressure_metrics() {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -1097,7 +1104,7 @@ mod tests {
             })
         });
 
-        assert!(captures.is_empty());
+        assert!(skip_idle_time(captures).is_empty());
 
         // Advance to 6.5 * INTERVAL. The service should pull the first message immediately, another
         // message every 2 INTERVALS. The messages are fully handled after 6 INTERVALS, but we
@@ -1109,7 +1116,7 @@ mod tests {
         });
 
         assert_eq!(
-            captures,
+            skip_idle_time(captures),
             [
                 "service.back_pressure:2|g|#service:mock", // 2 * INTERVAL
                 "service.back_pressure:1|g|#service:mock", // 4 * INTERVAL

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -38,7 +38,7 @@ pub enum SystemCounters {
 impl CounterMetric for SystemCounters {
     fn name(&self) -> &'static str {
         match self {
-            Self::ServiceIdleTime => "service.idle_time",
+            Self::ServiceIdleTime => "service.idle_time_nanos",
         }
     }
 }

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::GaugeMetric;
+use relay_statsd::{GaugeMetric, TimerMetric};
 
 /// Gauge metrics for Relay system components.
 pub enum SystemGauges {
@@ -17,6 +17,25 @@ impl GaugeMetric for SystemGauges {
     fn name(&self) -> &'static str {
         match *self {
             SystemGauges::ServiceBackPressure => "service.back_pressure",
+        }
+    }
+}
+
+/// Timer metrics for Relay system components.
+pub enum SystemTimers {
+    /// The amount of time a service spends waiting for new messages.
+    ///
+    /// This is an indicator of how much more load a service can take on.
+    ///
+    /// This metric is tagged with:
+    ///  - `service`: The fully qualified type name of the service implementation.
+    ServiceIdleTime,
+}
+
+impl TimerMetric for SystemTimers {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::ServiceIdleTime => "service.idle_time",
         }
     }
 }

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -1,4 +1,4 @@
-use relay_statsd::{GaugeMetric, TimerMetric};
+use relay_statsd::{CounterMetric, GaugeMetric};
 
 /// Gauge metrics for Relay system components.
 pub enum SystemGauges {
@@ -21,18 +21,21 @@ impl GaugeMetric for SystemGauges {
     }
 }
 
-/// Timer metrics for Relay system components.
-pub enum SystemTimers {
+/// Counter metrics for Relay system components.
+pub enum SystemCounters {
     /// The amount of time a service spends waiting for new messages.
     ///
     /// This is an indicator of how much more load a service can take on.
+    ///
+    /// Caveat: Some services circumvent the service framework by using custom incoming queues.
+    /// For these, we cannot fully rely on this metric.
     ///
     /// This metric is tagged with:
     ///  - `service`: The fully qualified type name of the service implementation.
     ServiceIdleTime,
 }
 
-impl TimerMetric for SystemTimers {
+impl CounterMetric for SystemCounters {
     fn name(&self) -> &'static str {
         match self {
             Self::ServiceIdleTime => "service.idle_time",


### PR DESCRIPTION
Introduce a metric which measures how much time a service spends waiting for the next incoming message. If this metric approaches zero over time, it means the service is getting close to capacity.

This will help us estimate how much more load a service can take on.

Caveat: Some services circumvent the service framework by using custom incoming queues. For these, we cannot fully rely on this metric.

#skip-changelog