### PR TITLE
instr(buffer): Measure compression gains

### DIFF
--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -186,6 +186,10 @@ pub enum RelayHistograms {
     /// This is not quite the same as the actual size of a serialized envelope, because it ignores
     /// the envelope header and item headers.
     BufferEnvelopeBodySize,
+    /// Size of a serialized envelope pushed to the envelope buffer (sampled).
+    BufferEnvelopeSize,
+    /// Size of a compressed envelope pushed to the envelope buffer (sampled).
+    BufferEnvelopeSizeCompressed,
     /// The number of batches emitted per partition.
     BatchesPerPartition,
     /// The number of buckets in a batch emitted.
@@ -315,6 +319,8 @@ impl HistogramMetric for RelayHistograms {
                 "buffer.backpressure_envelopes_count"
             }
             RelayHistograms::BufferEnvelopeBodySize => "buffer.envelope_body_size",
+            RelayHistograms::BufferEnvelopeSize => "buffer.envelope_size",
+            RelayHistograms::BufferEnvelopeSizeCompressed => "buffer.envelope_size.compressed",
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",
@@ -546,6 +552,8 @@ pub enum RelayTimers {
     BufferDrain,
     /// Timing in milliseconds for the time it takes for the envelopes to be serialized.
     BufferEnvelopesSerialization,
+    /// Timing in milliseconds for the time it takes for the envelopes to be compressed (sampled).
+    BufferEnvelopeCompression,
 }
 
 impl TimerMetric for RelayTimers {
@@ -595,6 +603,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::BufferPop => "buffer.pop.duration",
             RelayTimers::BufferDrain => "buffer.drain.duration",
             RelayTimers::BufferEnvelopesSerialization => "buffer.envelopes_serialization",
+            RelayTimers::BufferEnvelopeCompression => "buffer.envelopes_compression",
         }
     }
 }


### PR DESCRIPTION
Before we implement compression for spooling, measure the compression ratio and compression times to estimate the cost / benefit of this approach.

ref: https://github.com/getsentry/team-ingest/issues/345

#skip-changelog