### PR TITLE
fix(replays): Add validation for timestamps sent from the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes:**
 
 - Allow profile chunks without release. ([#4155](https://github.com/getsentry/relay/pull/4155))
+- Add validation for timestamps sent from the future. ([#4163](https://github.com/getsentry/relay/pull/4163))
 
 **Internal:**
 

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -86,7 +86,7 @@ pub fn validate(replay: &Replay) -> Result<(), ReplayError> {
         .value()
         .map_or(false, |v| v.into_inner() > Utc::now())
     {
-        return Err(ReplayError::InvalidPayload("xyz".to_string()));
+        return Err(ReplayError::DateInTheFuture);
     }
 
     Ok(())

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -184,7 +184,7 @@ fn normalize_type(replay: &mut Replay) {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use chrono::{TimeZone, Utc};
+    use chrono::{Duration, TimeZone, Utc};
     use insta::assert_json_snapshot;
     use relay_protocol::{assert_annotated_snapshot, get_value, SerializableAnnotated};
     use uuid::Uuid;
@@ -448,6 +448,40 @@ mod tests {
 }"#;
 
         let mut replay = Annotated::<Replay>::from_json(json).unwrap();
+        let validation_result = validate(replay.value_mut().as_mut().unwrap());
+        assert!(validation_result.is_err());
+    }
+
+    #[test]
+    fn test_future_timestamp_validation() {
+        let future_time = Utc::now() + Duration::hours(1);
+        let json = format!(
+            r#"{{
+  "event_id": "52df9022835246eeb317dbd739ccd059",
+  "replay_id": "52df9022835246eeb317dbd739ccd059",
+  "segment_id": 0,
+  "replay_type": "session",
+  "error_sample_rate": 0.5,
+  "session_sample_rate": 0.5,
+  "timestamp": {},
+  "replay_start_timestamp": 946684800.0,
+  "urls": ["localhost:9000"],
+  "error_ids": ["test"],
+  "trace_ids": [],
+  "platform": "myplatform",
+  "release": "myrelease",
+  "dist": "mydist",
+  "environment": "myenv",
+  "tags": [
+    [
+      "tag",
+      "value"
+    ]
+  ]
+}}"#,
+            future_time.timestamp()
+        );
+        let mut replay = Annotated::<Replay>::from_json(&json).unwrap();
         let validation_result = validate(replay.value_mut().as_mut().unwrap());
         assert!(validation_result.is_err());
     }

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -450,6 +450,9 @@ pub enum DiscardReason {
     InvalidReplayRecordingEvent,
     InvalidReplayVideoEvent,
 
+    /// (Relay) The event's timestamp was too far in the future.
+    DateInTheFuture,
+
     /// (Relay) Profiling related discard reasons
     Profiling(&'static str),
 
@@ -503,6 +506,7 @@ impl DiscardReason {
             DiscardReason::Profiling(reason) => reason,
             DiscardReason::InvalidSpan => "invalid_span",
             DiscardReason::FeatureDisabled(_) => "feature_disabled",
+            DiscardReason::DateInTheFuture => "date_in_the_future",
         }
     }
 }

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -190,6 +190,9 @@ fn handle_replay_event_item(
                 ReplayError::InvalidPayload(_) => {
                     ProcessingError::InvalidReplay(DiscardReason::InvalidReplayEvent)
                 }
+                ReplayError::DateInTheFuture => {
+                    ProcessingError::InvalidReplay(DiscardReason::DateInTheFuture)
+                }
             })
         }
     }


### PR DESCRIPTION
If a timestamp is from the future discard with a new reason.