### PR TITLE
feat(metrics): Use new counting strategy when producing spans

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -200,6 +200,18 @@ pub struct Options {
     )]
     pub http_span_allowed_hosts: Vec<String>,
 
+    /// `true` if the new counting strategy for accepted payloads is enabled.
+    ///
+    /// The new strategy affects how consumers emit accepted outcomes but there is an edge case for
+    /// spans since they are not consumed by Sentry consumers and rather directly ingested by Snuba,
+    /// thus this requires Relay to emit accepted outcomes.
+    #[serde(
+        rename = "consumers.use_new_counting_strategy",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub use_new_counting_strategy: bool,
+
     /// Deprecated, still forwarded for older downstream Relays.
     #[doc(hidden)]
     #[serde(


### PR DESCRIPTION
This PR implements the new counting strategy when producing spans. The counting strategy follows the same logic as implemented in the consumers in this PR (https://github.com/getsentry/sentry/pull/79661).

The high-level idea is that now the billing consumer emits accepted outcomes for the categories `Transaction`, `Span`, `Profile` only if the received metrics have their indexed data not stored (the tag `indexed` is not present in the usage metric). The same outcome is now also emitted directly where data is produced and consumed, basically alongside the emission of `TransactionIndexed`, `SpanIndexed`, `ProfileIndexed`.

Part of: https://github.com/getsentry/relay/issues/3696