### PR TITLE
feat(spans): Retain empty attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Allow profile chunks without release. ([#4155](https://github.com/getsentry/relay/pull/4155))
 - Add validation for timestamps sent from the future. ([#4163](https://github.com/getsentry/relay/pull/4163))
 
+
+**Features:**
+
+- Retain empty strings in `span.data` and `event.contexts.trace.data`. ([#4174](https://github.com/getsentry/relay/pull/4174))
+
 **Internal:**
 
 - Add a metric that counts span volume in the root project for dynamic sampling (`c:spans/count_per_root_project@none`). ([#4134](https://github.com/getsentry/relay/pull/4134))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 **Features:**
 
-- Retain empty strings in `span.data` and `event.contexts.trace.data`. ([#4174](https://github.com/getsentry/relay/pull/4174))
+- Retain empty string values in `span.data` and `event.contexts.trace.data`. ([#4174](https://github.com/getsentry/relay/pull/4174))
 
 **Internal:**
 

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -197,7 +197,8 @@ mod tests {
         "tok": "test"
       },
       "custom_field": "something"
-    }
+    },
+    "custom_field_empty": ""
   },
   "other": "value",
   "type": "trace"
@@ -222,15 +223,15 @@ mod tests {
                         );
                         map
                     }),
-                    other: {
-                        let mut map = Object::new();
-                        map.insert(
-                            "custom_field".into(),
-                            Annotated::new(Value::String("something".into())),
-                        );
-                        map
-                    },
+                    other: Object::from([(
+                        "custom_field".into(),
+                        Annotated::new(Value::String("something".into())),
+                    )]),
                 }),
+                other: Object::from([(
+                    "custom_field_empty".into(),
+                    Annotated::new(Value::String("".into())),
+                )]),
                 ..Default::default()
             }),
             other: {

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -135,7 +135,7 @@ pub struct TraceContext {
     pub sampled: Annotated<bool>,
 
     /// Data of the trace's root span.
-    #[metastructure(pii = "maybe", skip_serialization = "empty")]
+    #[metastructure(pii = "maybe", skip_serialization = "null")]
     pub data: Annotated<SpanData>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -506,7 +506,7 @@ pub struct SpanData {
         additional_properties,
         pii = "true",
         retain = "true",
-        skip_serialization = "null"
+        skip_serialization = "null" // applies to child elements
     )]
     pub other: Object<Value>,
 }
@@ -933,7 +933,18 @@ mod tests {
     }
 
     #[test]
-    fn test_span_data_empty_field() {
+    fn test_span_data_empty_well_known_field() {
+        let span = r#"{
+            "data": {
+                "lcp.url": ""
+            }
+        }"#;
+        let span: Annotated<Span> = Annotated::from_json(span).unwrap();
+        assert_eq!(span.to_json().unwrap(), r#"{"data":{"lcp.url":""}}"#);
+    }
+
+    #[test]
+    fn test_span_data_empty_custom_field() {
         let span = r#"{
             "data": {
                 "custom_field_empty": ""
@@ -944,5 +955,14 @@ mod tests {
             span.to_json().unwrap(),
             r#"{"data":{"custom_field_empty":""}}"#
         );
+    }
+
+    #[test]
+    fn test_span_data_completely_empty() {
+        let span = r#"{
+            "data": {}
+        }"#;
+        let span: Annotated<Span> = Annotated::from_json(span).unwrap();
+        assert_eq!(span.to_json().unwrap(), r#"{"data":{}}"#);
     }
 }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -931,4 +931,18 @@ mod tests {
         assert_eq!(data.get_value("code\\.namespace"), Some(Val::String("ns")));
         assert_eq!(data.get_value("unknown"), None);
     }
+
+    #[test]
+    fn test_span_data_empty_field() {
+        let span = r#"{
+            "data": {
+                "custom_field_empty": ""
+            }
+        }"#;
+        let span: Annotated<Span> = Annotated::from_json(span).unwrap();
+        assert_eq!(
+            span.to_json().unwrap(),
+            r#"{"data":{"custom_field_empty":""}}"#
+        );
+    }
 }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -506,7 +506,7 @@ pub struct SpanData {
         additional_properties,
         pii = "true",
         retain = "true",
-        skip_serialization = "empty"
+        skip_serialization = "null"
     )]
     pub other: Object<Value>,
 }


### PR DESCRIPTION
Currently well-known span attributes may be set to `""`, but custom attributes (which end up in the `other` field) are removed if their value is empty.

To be consistent in itself and with [open telemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute), we should allow empty non-null values.

Apply this change also to `event.contexts.trace.data` because it is supposed to be consistent with `span.data`.