### PR TITLE
feat: add client SDK name to envelope metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal:**
 
 - Add a metric that counts span volume in the root project for dynamic sampling (`c:spans/count_per_root_project@none`) ([#4134](https://github.com/getsentry/relay/pull/4134))
+- Add client SDK name to envelope metrics. ([#4183](https://github.com/getsentry/relay/pull/4183))
 
 ## 24.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 **Internal:**
 
 - Add a metric that counts span volume in the root project for dynamic sampling (`c:spans/count_per_root_project@none`) ([#4134](https://github.com/getsentry/relay/pull/4134))
-- Add client SDK name to envelope metrics. ([#4183](https://github.com/getsentry/relay/pull/4183))
 
 ## 24.10.0
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -345,10 +345,12 @@ pub async fn handle_envelope(
     state: &ServiceState,
     envelope: Box<Envelope>,
 ) -> Result<Option<EventId>, BadStoreRequest> {
+    let client_name = envelope.meta().client_name().unwrap_or("unknown");
     for item in envelope.items() {
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
-            item_type = item.ty().name()
+            item_type = item.ty().name(),
+            client_name = client_name
         )
     }
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -345,12 +345,12 @@ pub async fn handle_envelope(
     state: &ServiceState,
     envelope: Box<Envelope>,
 ) -> Result<Option<EventId>, BadStoreRequest> {
-    let client_name = envelope.meta().client_name().unwrap_or("unknown");
+    let client_name = envelope.meta().client_name().unwrap_or("proprietary");
     for item in envelope.items() {
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
             item_type = item.ty().name(),
-            client_name = client_name
+            sdk = client_name,
         )
     }
 


### PR DESCRIPTION
Add SDK client name without version number to envelope metrics

#skip-changelog