### PR TITLE
ref(relay): Use `DateTime` instead of `Instant` for `start_time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Add a metric that counts span volume in the root project for dynamic sampling (`c:spans/count_per_root_project@none`). ([#4134](https://github.com/getsentry/relay/pull/4134))
 - Add a tag `target_project_id` to both root project metrics for dynamic sampling (`c:transactions/count_per_root_project@none` and `c:spans/count_per_root_project@none`) which shows the flow trace traffic from root to target projects. ([#4170](https://github.com/getsentry/relay/pull/4170))
+- Use `DateTime<Utc>` instead of `Instant` for tracking the received time of the `Envelope`. ([#4184](https://github.com/getsentry/relay/pull/4184))
 
 ## 24.10.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ name = "bench-buffer"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "clap",
  "rand",
  "relay-config",

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -11,11 +11,6 @@ pub fn instant_to_system_time(instant: Instant) -> SystemTime {
     SystemTime::now() - instant.elapsed()
 }
 
-/// Converts an `Instant` into a `DateTime`.
-pub fn instant_to_date_time(instant: Instant) -> chrono::DateTime<chrono::Utc> {
-    instant_to_system_time(instant).into()
-}
-
 /// Returns the number of milliseconds contained by this `Duration` as `f64`.
 ///
 /// The returned value does include the fractional (nanosecond) part of the duration.

--- a/relay-server/benches/benches.rs
+++ b/relay-server/benches/benches.rs
@@ -6,7 +6,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::{Pool, Sqlite};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 

--- a/relay-server/benches/benches.rs
+++ b/relay-server/benches/benches.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use chrono::Utc;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use relay_config::Config;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
@@ -66,7 +67,7 @@ fn mock_envelope_with_project_key(project_key: &ProjectKey, size: &str) -> Box<E
     ));
 
     let mut envelope = Envelope::parse_bytes(bytes).unwrap();
-    envelope.set_received_at(Instant::now());
+    envelope.set_received_at(Utc::now());
     envelope
 }
 

--- a/relay-server/benches/benches.rs
+++ b/relay-server/benches/benches.rs
@@ -66,7 +66,7 @@ fn mock_envelope_with_project_key(project_key: &ProjectKey, size: &str) -> Box<E
     ));
 
     let mut envelope = Envelope::parse_bytes(bytes).unwrap();
-    envelope.set_start_time(Instant::now());
+    envelope.set_received_at(Instant::now());
     envelope
 }
 

--- a/relay-server/src/endpoints/batch_metrics.rs
+++ b/relay-server/src/endpoints/batch_metrics.rs
@@ -2,7 +2,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 
-use crate::extractors::{SignedBytes, StartTime};
+use crate::extractors::{ReceivedAt, SignedBytes};
 use crate::service::ServiceState;
 use crate::services::processor::ProcessBatchedMetrics;
 use crate::services::projects::cache::BucketSource;
@@ -12,7 +12,7 @@ struct SendMetricsResponse {}
 
 pub async fn handle(
     state: ServiceState,
-    start_time: StartTime,
+    received_at: ReceivedAt,
     body: SignedBytes,
 ) -> impl IntoResponse {
     if !body.relay.internal {
@@ -22,7 +22,7 @@ pub async fn handle(
     state.processor().send(ProcessBatchedMetrics {
         payload: body.body,
         source: BucketSource::Internal,
-        start_time: start_time.into_inner(),
+        received_at: received_at.into_inner(),
         sent_at: None,
     });
 

--- a/relay-server/src/endpoints/batch_metrics.rs
+++ b/relay-server/src/endpoints/batch_metrics.rs
@@ -12,7 +12,7 @@ struct SendMetricsResponse {}
 
 pub async fn handle(
     state: ServiceState,
-    received_at: ReceivedAt,
+    ReceivedAt(received_at): ReceivedAt,
     body: SignedBytes,
 ) -> impl IntoResponse {
     if !body.relay.internal {
@@ -22,7 +22,7 @@ pub async fn handle(
     state.processor().send(ProcessBatchedMetrics {
         payload: body.body,
         source: BucketSource::Internal,
-        received_at: received_at.into_inner(),
+        received_at,
         sent_at: None,
     });
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -276,7 +276,7 @@ fn queue_envelope(
             relay_log::trace!("sending metrics into processing queue");
             state.project_cache().send(ProcessMetrics {
                 data: MetricData::Raw(metric_items.into_vec()),
-                start_time: envelope.meta().start_time().into(),
+                received_at: envelope.received_at(),
                 sent_at: envelope.sent_at(),
                 project_key: envelope.meta().public_key(),
                 source: envelope.meta().into(),

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1226,7 +1226,7 @@ impl Envelope {
     /// Returns the time elapsed in seconds since the envelope was received by this Relay.
     ///
     /// In case the elapsed time is negative, it is assumed that no time elapsed.
-    pub fn elapsed(&self) -> Duration {
+    pub fn age(&self) -> Duration {
         (Utc::now() - self.received_at())
             .to_std()
             .unwrap_or(Duration::ZERO)

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -36,7 +36,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Write};
 use std::ops::AddAssign;
-use std::time::Instant;
+use std::time::Duration;
 use uuid::Uuid;
 
 use bytes::Bytes;
@@ -1219,10 +1219,17 @@ impl Envelope {
     }
 
     /// Returns the time at which the envelope was received at this Relay.
-    ///
-    /// This is the date time equivalent to [`start_time`](Self::start_time).
     pub fn received_at(&self) -> DateTime<Utc> {
-        relay_common::time::instant_to_date_time(self.meta().start_time())
+        self.meta().received_at()
+    }
+
+    /// Returns the time elapsed in seconds since the envelope was received by this Relay.
+    ///
+    /// In case the elapsed time is negative, it is assumed that no time elapsed.
+    pub fn elapsed(&self) -> Duration {
+        (Utc::now() - self.received_at())
+            .to_std()
+            .unwrap_or(Duration::ZERO)
     }
 
     /// Sets the event id on the envelope.
@@ -1235,9 +1242,9 @@ impl Envelope {
         self.headers.sent_at = Some(sent_at);
     }
 
-    /// Sets the start time to the provided `Instant`.
-    pub fn set_start_time(&mut self, start_time: Instant) {
-        self.headers.meta.set_start_time(start_time)
+    /// Sets the received at to the provided `DateTime`.
+    pub fn set_received_at(&mut self, start_time: DateTime<Utc>) {
+        self.headers.meta.set_received_at(start_time)
     }
 
     /// Sets the data retention in days for items in this envelope.

--- a/relay-server/src/extractors/mod.rs
+++ b/relay-server/src/extractors/mod.rs
@@ -1,15 +1,15 @@
 mod content_type;
 mod forwarded_for;
 mod mime;
+mod received_at;
 mod remote;
 mod request_meta;
 mod signed_json;
-mod start_time;
 
 pub use self::content_type::*;
 pub use self::forwarded_for::*;
 pub use self::mime::*;
+pub use self::received_at::*;
 pub use self::remote::*;
 pub use self::request_meta::*;
 pub use self::signed_json::*;
-pub use self::start_time::*;

--- a/relay-server/src/extractors/received_at.rs
+++ b/relay-server/src/extractors/received_at.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 
 /// The time at which the request started.
 #[derive(Clone, Copy, Debug)]
-pub struct ReceivedAt(DateTime<Utc>);
+pub struct ReceivedAt(pub DateTime<Utc>);
 
 impl ReceivedAt {
     pub fn now() -> Self {
@@ -18,13 +18,6 @@ impl ReceivedAt {
     #[inline]
     pub fn into_inner(self) -> DateTime<Utc> {
         self.0
-    }
-
-    /// Returns the [`ReceivedAt`] corresponding to provided timestamp.
-    pub fn from_timestamp_millis(timestamp: i64) -> Self {
-        let datetime = DateTime::<Utc>::from_timestamp_millis(timestamp).unwrap_or_else(Utc::now);
-
-        Self(datetime)
     }
 }
 
@@ -41,25 +34,5 @@ where
             .expect("ReceivedAt middleware is not configured");
 
         Ok(start_time)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::Duration;
-
-    #[test]
-    fn start_time_from_timestamp() {
-        let elapsed = Duration::from_secs(10);
-        let now = Utc::now();
-        let past = now - chrono::Duration::from_std(elapsed).unwrap();
-        let start_time = ReceivedAt::from_timestamp_millis(past.timestamp_millis()).into_inner();
-
-        // Check that the difference between the now and generated start_time is about 10s
-        let diff = now - start_time;
-        let diff_duration = diff.to_std().unwrap();
-        assert!(diff_duration < elapsed + Duration::from_millis(50));
-        assert!(diff_duration > elapsed - Duration::from_millis(50));
     }
 }

--- a/relay-server/src/extractors/received_at.rs
+++ b/relay-server/src/extractors/received_at.rs
@@ -13,12 +13,6 @@ impl ReceivedAt {
     pub fn now() -> Self {
         Self(Utc::now())
     }
-
-    /// Returns the `Instant` of this start time.
-    #[inline]
-    pub fn into_inner(self) -> DateTime<Utc> {
-        self.0
-    }
 }
 
 #[axum::async_trait]

--- a/relay-server/src/extractors/received_at.rs
+++ b/relay-server/src/extractors/received_at.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::time::Duration;
 
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
@@ -40,7 +39,7 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let Extension(start_time) = Extension::from_request_parts(parts, state)
             .await
-            .expect("StartTime middleware is not configured");
+            .expect("ReceivedAt middleware is not configured");
 
         Ok(start_time)
     }
@@ -49,6 +48,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn start_time_from_timestamp() {

--- a/relay-server/src/extractors/received_at.rs
+++ b/relay-server/src/extractors/received_at.rs
@@ -22,8 +22,7 @@ impl ReceivedAt {
 
     /// Returns the [`ReceivedAt`] corresponding to provided timestamp.
     pub fn from_timestamp_millis(timestamp: i64) -> Self {
-        let datetime =
-            DateTime::<Utc>::from_timestamp_millis(timestamp).unwrap_or_else(|| Utc::now());
+        let datetime = DateTime::<Utc>::from_timestamp_millis(timestamp).unwrap_or_else(Utc::now);
 
         Self(datetime)
     }

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -487,6 +487,8 @@ impl FromRequestParts<ServiceState> for PartialMeta {
                 .map_or(false, |ri| ri.internal);
         }
 
+        let ReceivedAt(received_at) = ReceivedAt::from_request_parts(parts, state).await?;
+
         Ok(RequestMeta {
             dsn: None,
             version: default_version(),
@@ -502,9 +504,7 @@ impl FromRequestParts<ServiceState> for PartialMeta {
                 .into_inner(),
             user_agent: ua.user_agent,
             no_cache: false,
-            received_at: ReceivedAt::from_request_parts(parts, state)
-                .await?
-                .into_inner(),
+            received_at,
             client_hints: ua.client_hints,
             from_internal_relay,
         })

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -1,3 +1,19 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::convert::Infallible;
+use std::error::Error;
+use std::mem;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering as AtomicOrdering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use hashbrown::HashSet;
+use relay_base_schema::project::ProjectKey;
+use relay_config::Config;
+use tokio::time::{timeout, Instant};
+
 use crate::envelope::Envelope;
 use crate::envelope::Item;
 use crate::services::buffer::common::ProjectKeyPair;
@@ -9,20 +25,6 @@ use crate::services::buffer::stack_provider::sqlite::SqliteStackProvider;
 use crate::services::buffer::stack_provider::{StackCreationType, StackProvider};
 use crate::statsd::{RelayCounters, RelayGauges, RelayHistograms, RelayTimers};
 use crate::utils::MemoryChecker;
-use chrono::{DateTime, Utc};
-use hashbrown::HashSet;
-use relay_base_schema::project::ProjectKey;
-use relay_config::Config;
-use std::cmp::Ordering;
-use std::collections::BTreeSet;
-use std::convert::Infallible;
-use std::error::Error;
-use std::mem;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::Ordering as AtomicOrdering;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::time::{timeout, Instant};
 
 /// Polymorphic envelope buffering interface.
 ///

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -244,9 +244,9 @@ impl EnvelopeStack for SqliteEnvelopeStack {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
-
+    use chrono::Utc;
     use relay_base_schema::project::ProjectKey;
+    use std::time::Duration;
 
     use super::*;
     use crate::services::buffer::testutils::utils::{mock_envelope, mock_envelopes, setup_db};
@@ -265,7 +265,7 @@ mod tests {
             true,
         );
 
-        let envelope = mock_envelope(Instant::now());
+        let envelope = mock_envelope(Utc::now());
         let _ = stack.push(envelope).await;
     }
 
@@ -291,7 +291,7 @@ mod tests {
 
         // We push 1 more envelope which results in spooling, which fails because of a database
         // problem.
-        let envelope = mock_envelope(Instant::now());
+        let envelope = mock_envelope(Utc::now());
         assert!(matches!(
             stack.push(envelope).await,
             Err(SqliteEnvelopeStackError::EnvelopeStoreError(_))
@@ -299,7 +299,7 @@ mod tests {
 
         // The stack now contains the last of the 3 elements that were added. If we add a new one
         // we will end up with 2.
-        let envelope = mock_envelope(Instant::now());
+        let envelope = mock_envelope(Utc::now());
         assert!(stack.push(envelope.clone()).await.is_ok());
         assert_eq!(stack.batches_buffer_size, 3);
 
@@ -446,7 +446,7 @@ mod tests {
 
         // We insert a new envelope, to test the load from disk happening during `peek()` gives
         // priority to this envelope in the stack.
-        let envelope = mock_envelope(Instant::now());
+        let envelope = mock_envelope(Utc::now());
         assert!(stack.push(envelope.clone()).await.is_ok());
 
         // We pop and expect the newly inserted element.

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -374,7 +374,7 @@ impl SqliteEnvelopeStore {
         //
         // Unfortunately we have to do this because SQLite `DELETE` with `RETURNING` doesn't
         // return deleted rows in a specific order.
-        extracted_envelopes.sort_by_key(|a| a.meta().received_at());
+        extracted_envelopes.sort_by_key(|a| a.received_at());
 
         Ok(extracted_envelopes)
     }

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -20,7 +20,6 @@ use tokio::fs::DirBuilder;
 use tokio::time::sleep;
 
 use crate::envelope::EnvelopeError;
-use crate::extractors::ReceivedAt;
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::statsd::RelayGauges;
 use crate::Envelope;

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -1,8 +1,10 @@
-use crate::envelope::EnvelopeError;
-use crate::extractors::ReceivedAt;
-use crate::services::buffer::common::ProjectKeyPair;
-use crate::statsd::RelayGauges;
-use crate::Envelope;
+use std::error::Error;
+use std::path::Path;
+use std::pin::pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
 use futures::stream::StreamExt;
 use hashbrown::HashSet;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
@@ -14,14 +16,14 @@ use sqlx::sqlite::{
     SqliteRow, SqliteSynchronous,
 };
 use sqlx::{Pool, QueryBuilder, Row, Sqlite};
-use std::error::Error;
-use std::path::Path;
-use std::pin::pin;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::fs::DirBuilder;
 use tokio::time::sleep;
+
+use crate::envelope::EnvelopeError;
+use crate::extractors::ReceivedAt;
+use crate::services::buffer::common::ProjectKeyPair;
+use crate::statsd::RelayGauges;
+use crate::Envelope;
 
 /// Struct that contains all the fields of an [`Envelope`] that are mapped to the database columns.
 pub struct InsertEnvelope {

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -1,10 +1,4 @@
-use std::error::Error;
-use std::path::Path;
-use std::pin::pin;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
-
+use chrono::{DateTime, Utc};
 use futures::stream::StreamExt;
 use hashbrown::HashSet;
 use relay_base_schema::project::{ParseProjectKeyError, ProjectKey};
@@ -16,6 +10,12 @@ use sqlx::sqlite::{
     SqliteRow, SqliteSynchronous,
 };
 use sqlx::{Pool, QueryBuilder, Row, Sqlite};
+use std::error::Error;
+use std::path::Path;
+use std::pin::pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::fs::DirBuilder;
 use tokio::time::sleep;
 
@@ -428,8 +428,8 @@ fn extract_envelope(row: SqliteRow) -> Result<Box<Envelope>, SqliteEnvelopeStore
         .try_get("received_at")
         .map_err(SqliteEnvelopeStoreError::FetchError)?;
 
-    let received_at = ReceivedAt::from_timestamp_millis(received_at);
-    envelope.set_received_at(received_at.into_inner());
+    let received_at = DateTime::from_timestamp_millis(received_at).unwrap_or(Utc::now());
+    envelope.set_received_at(received_at);
 
     Ok(envelope)
 }

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -291,7 +291,7 @@ impl EnvelopeBufferService {
     }
 
     fn expired(config: &Config, envelope: &Envelope) -> bool {
-        envelope.elapsed() > config.spool_envelopes_max_age()
+        envelope.age() > config.spool_envelopes_max_age()
     }
 
     fn drop_expired(envelope: Box<Envelope>, services: &Services) {

--- a/relay-server/src/services/buffer/testutils.rs
+++ b/relay-server/src/services/buffer/testutils.rs
@@ -1,13 +1,12 @@
 #[cfg(test)]
 pub mod utils {
-    use std::collections::BTreeMap;
-    use std::time::{Duration, Instant};
-
+    use chrono::{DateTime, Utc};
     use relay_base_schema::project::ProjectKey;
     use relay_event_schema::protocol::EventId;
     use relay_sampling::DynamicSamplingContext;
     use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
     use sqlx::{Pool, Sqlite};
+    use std::collections::BTreeMap;
     use tokio::fs::DirBuilder;
     use uuid::Uuid;
 
@@ -55,7 +54,7 @@ pub mod utils {
         RequestMeta::new(dsn)
     }
 
-    pub fn mock_envelope(instant: Instant) -> Box<Envelope> {
+    pub fn mock_envelope(received_at: DateTime<Utc>) -> Box<Envelope> {
         let event_id = EventId::new();
         let mut envelope = Envelope::from_request(Some(event_id), request_meta());
 
@@ -73,7 +72,7 @@ pub mod utils {
         };
 
         envelope.set_dsc(dsc);
-        envelope.set_start_time(instant);
+        envelope.set_received_at(received_at);
 
         envelope.add_item(Item::new(ItemType::Transaction));
 
@@ -82,9 +81,9 @@ pub mod utils {
 
     #[allow(clippy::vec_box)]
     pub fn mock_envelopes(count: usize) -> Vec<Box<Envelope>> {
-        let instant = Instant::now();
+        let now = Utc::now();
         (0..count)
-            .map(|i| mock_envelope(instant - Duration::from_secs((count - i) as u64)))
+            .map(|i| mock_envelope(now - chrono::Duration::seconds((count - i) as i64)))
             .collect()
     }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2191,7 +2191,7 @@ impl EnvelopeProcessorService {
         let ProcessBatchedMetrics {
             payload,
             source,
-            received_at: start_time,
+            received_at,
             sent_at,
         } = message;
 
@@ -2220,7 +2220,7 @@ impl EnvelopeProcessorService {
                 data: MetricData::Parsed(buckets),
                 project_key,
                 source,
-                received_at: start_time.into(),
+                received_at,
                 sent_at,
             });
         }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2102,7 +2102,7 @@ impl EnvelopeProcessorService {
 
     fn handle_process_envelope(&self, message: ProcessEnvelope) {
         let project_key = message.envelope.envelope().meta().public_key();
-        let wait_time = message.envelope.elapsed();
+        let wait_time = message.envelope.age();
         metric!(timer(RelayTimers::EnvelopeWaitTime) = wait_time);
 
         let group = message.envelope.group().variant();

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -57,6 +57,7 @@ use {
     relay_redis::{RedisPool, RedisPools},
     std::iter::Chain,
     std::slice::Iter,
+    std::time::Instant,
     symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
 };
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -920,7 +920,7 @@ pub struct ProcessProjectMetrics {
     pub project_key: ProjectKey,
     /// Whether to keep or reset the metric metadata.
     pub source: BucketSource,
-    /// The instant at which the request was received.
+    /// The wall clock time at which the request was received.
     pub received_at: DateTime<Utc>,
     /// The value of the Envelope's [`sent_at`](Envelope::sent_at) header for clock drift
     /// correction.
@@ -995,9 +995,9 @@ pub struct ProcessBatchedMetrics {
     pub payload: Bytes,
     /// Whether to keep or reset the metric metadata.
     pub source: BucketSource,
-    /// The instant at which the request was received.
+    /// The wall clock time at which the request was received.
     pub received_at: DateTime<Utc>,
-    /// The instant at which the request was received.
+    /// The wall clock time at which the request was received.
     pub sent_at: Option<DateTime<Utc>>,
 }
 

--- a/relay-server/src/services/projects/cache.rs
+++ b/relay-server/src/services/projects/cache.rs
@@ -207,7 +207,7 @@ pub struct ProcessMetrics {
     pub project_key: ProjectKey,
     /// Whether to keep or reset the metric metadata.
     pub source: BucketSource,
-    /// The instant at which the request was received.
+    /// The wall clock time at which the request was received.
     pub received_at: DateTime<Utc>,
     /// The value of the Envelope's [`sent_at`](crate::envelope::Envelope::sent_at)
     /// header for clock drift correction.

--- a/relay-server/src/services/projects/cache.rs
+++ b/relay-server/src/services/projects/cache.rs
@@ -208,7 +208,7 @@ pub struct ProcessMetrics {
     /// Whether to keep or reset the metric metadata.
     pub source: BucketSource,
     /// The instant at which the request was received.
-    pub start_time: Instant,
+    pub received_at: DateTime<Utc>,
     /// The value of the Envelope's [`sent_at`](crate::envelope::Envelope::sent_at)
     /// header for clock drift correction.
     pub sent_at: Option<DateTime<Utc>>,

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -176,7 +176,7 @@ impl Project {
             data: message.data,
             project_key: message.project_key,
             source: message.source,
-            start_time: message.start_time.into(),
+            received_at: message.received_at,
             sent_at: message.sent_at,
         }
     }

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -52,7 +52,6 @@ use tokio::fs::DirBuilder;
 use tokio::sync::mpsc;
 
 use crate::envelope::{Envelope, EnvelopeError};
-use crate::extractors::ReceivedAt;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::ProcessingGroup;
 use crate::services::projects::cache::{ProjectCache, RefreshIndexCache, UpdateSpoolIndex};

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -744,6 +744,7 @@ impl OnDisk {
         managed_envelope: ManagedEnvelope,
     ) -> Result<(), BufferError> {
         let received_at = managed_envelope.received_at().timestamp_millis();
+        println!("RECEIVED AT INSERT {:?}", received_at);
         sql::insert(
             key,
             managed_envelope.into_envelope().to_vec().unwrap(),
@@ -1418,7 +1419,7 @@ mod tests {
             };
 
             let envelope = empty_managed_envelope();
-            let start_time_sent = envelope.received_at();
+            let received_at_sent = envelope.received_at();
             addr.send(Enqueue {
                 key,
                 value: envelope,
@@ -1441,13 +1442,13 @@ mod tests {
                 key: _,
                 managed_envelope,
             } = rx.recv().await.unwrap();
-            let start_time_received = managed_envelope.received_at();
+            let received_at_received = managed_envelope.received_at();
 
             // Check if the original start time elapsed to the same second as the restored one.
-            //
-            // Using `.as_secs_f64()` to get the nanos fraction as well and then round it up to get
-            // similar number of seconds if one of the instants runs forward a bit.
-            assert_eq!(start_time_received, start_time_sent);
+            assert_eq!(
+                received_at_received.timestamp_millis(),
+                received_at_sent.timestamp_millis()
+            );
         }
     }
 

--- a/relay-server/src/services/spooler/mod.rs
+++ b/relay-server/src/services/spooler/mod.rs
@@ -744,7 +744,6 @@ impl OnDisk {
         managed_envelope: ManagedEnvelope,
     ) -> Result<(), BufferError> {
         let received_at = managed_envelope.received_at().timestamp_millis();
-        println!("RECEIVED AT INSERT {:?}", received_at);
         sql::insert(
             key,
             managed_envelope.into_envelope().to_vec().unwrap(),

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use relay_base_schema::data_category::DataCategory;
 use relay_base_schema::project::ProjectId;
 use relay_common::time::{instant_to_date_time, UnixTimestamp};
@@ -172,7 +173,7 @@ impl StoreService {
         let scoping = managed.scoping();
         let envelope = managed.take_envelope();
 
-        match self.store_envelope(envelope, managed.start_time(), scoping) {
+        match self.store_envelope(envelope, managed.received_at(), scoping) {
             Ok(()) => managed.accept(),
             Err(error) => {
                 managed.reject(Outcome::Invalid(DiscardReason::Internal));
@@ -188,7 +189,7 @@ impl StoreService {
     fn store_envelope(
         &self,
         mut envelope: Box<Envelope>,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         scoping: Scoping,
     ) -> Result<(), StoreError> {
         let retention = envelope.retention();
@@ -234,7 +235,7 @@ impl StoreService {
                     self.produce_user_report(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
-                        start_time,
+                        received_at,
                         item,
                     )?;
                 }
@@ -243,7 +244,7 @@ impl StoreService {
                     self.produce_user_report_v2(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
-                        start_time,
+                        received_at,
                         item,
                         remote_addr,
                     )?;
@@ -252,7 +253,7 @@ impl StoreService {
                     scoping.organization_id,
                     scoping.project_id,
                     scoping.key_id,
-                    start_time,
+                    received_at,
                     retention,
                     item,
                 )?,
@@ -261,7 +262,7 @@ impl StoreService {
                         event_id,
                         scoping,
                         item.payload(),
-                        start_time,
+                        received_at,
                         retention,
                     )?;
                 }
@@ -276,22 +277,22 @@ impl StoreService {
                     self.produce_replay_event(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
-                        start_time,
+                        received_at,
                         retention,
                         &item.payload(),
                     )?;
                 }
                 ItemType::CheckIn => {
                     let client = envelope.meta().client();
-                    self.produce_check_in(scoping.project_id, start_time, client, retention, item)?
+                    self.produce_check_in(scoping.project_id, received_at, client, retention, item)?
                 }
                 ItemType::Span => {
-                    self.produce_span(scoping, start_time, event_id, retention, item)?
+                    self.produce_span(scoping, received_at, event_id, retention, item)?
                 }
                 ItemType::ProfileChunk => self.produce_profile_chunk(
                     scoping.organization_id,
                     scoping.project_id,
-                    start_time,
+                    received_at,
                     retention,
                     item,
                 )?,
@@ -347,7 +348,7 @@ impl StoreService {
                 &recording.payload(),
                 replay_event.as_deref(),
                 None,
-                start_time,
+                received_at,
                 retention,
             )?;
         }
@@ -361,7 +362,7 @@ impl StoreService {
                 topic,
                 KafkaMessage::Event(EventKafkaMessage {
                     payload: event_item.payload(),
-                    start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+                    start_time: received_at.timestamp() as u64,
                     event_id,
                     project_id,
                     remote_addr,
@@ -615,14 +616,14 @@ impl StoreService {
         &self,
         event_id: EventId,
         project_id: ProjectId,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         item: &Item,
     ) -> Result<(), StoreError> {
         let message = KafkaMessage::UserReport(UserReportKafkaMessage {
             project_id,
             event_id,
             payload: item.payload(),
-            start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+            start_time: received_at.timestamp() as u64,
         });
 
         self.produce(KafkaTopic::Attachments, message)
@@ -632,7 +633,7 @@ impl StoreService {
         &self,
         event_id: EventId,
         project_id: ProjectId,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         item: &Item,
         remote_addr: Option<String>,
     ) -> Result<(), StoreError> {
@@ -640,7 +641,7 @@ impl StoreService {
             project_id,
             event_id,
             payload: item.payload(),
-            start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+            start_time: received_at.timestamp() as u64,
             remote_addr,
             attachments: vec![],
         });
@@ -685,7 +686,7 @@ impl StoreService {
         organization_id: u64,
         project_id: ProjectId,
         key_id: Option<u64>,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         retention_days: u16,
         item: &Item,
     ) -> Result<(), StoreError> {
@@ -693,7 +694,7 @@ impl StoreService {
             organization_id,
             project_id,
             key_id,
-            received: UnixTimestamp::from_instant(start_time).as_secs(),
+            received: received_at.timestamp() as u64,
             retention_days,
             headers: BTreeMap::from([(
                 "sampled".to_string(),
@@ -709,7 +710,7 @@ impl StoreService {
         &self,
         replay_id: EventId,
         project_id: ProjectId,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         retention_days: u16,
         payload: &[u8],
     ) -> Result<(), StoreError> {
@@ -717,7 +718,7 @@ impl StoreService {
             replay_id,
             project_id,
             retention_days,
-            start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+            start_time: received_at.timestamp() as u64,
             payload,
         };
         self.produce(KafkaTopic::ReplayEvents, KafkaMessage::ReplayEvent(message))?;
@@ -732,7 +733,7 @@ impl StoreService {
         payload: &[u8],
         replay_event: Option<&[u8]>,
         replay_video: Option<&[u8]>,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         retention: u16,
     ) -> Result<(), StoreError> {
         // Maximum number of bytes accepted by the consumer.
@@ -755,7 +756,7 @@ impl StoreService {
                 quantity: 1,
                 remote_addr: None,
                 scoping,
-                timestamp: instant_to_date_time(start_time),
+                timestamp: received_at,
             });
             return Ok(());
         }
@@ -766,7 +767,7 @@ impl StoreService {
                 project_id: scoping.project_id,
                 key_id: scoping.key_id,
                 org_id: scoping.organization_id,
-                received: UnixTimestamp::from_instant(start_time).as_secs(),
+                received: received_at.timestamp() as u64,
                 retention_days: retention,
                 payload,
                 replay_event,
@@ -783,7 +784,7 @@ impl StoreService {
         event_id: Option<EventId>,
         scoping: Scoping,
         payload: Bytes,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         retention: u16,
     ) -> Result<(), StoreError> {
         #[derive(Deserialize)]
@@ -806,7 +807,7 @@ impl StoreService {
                 quantity: 1,
                 remote_addr: None,
                 scoping,
-                timestamp: instant_to_date_time(start_time),
+                timestamp: received_at,
             });
             return Ok(());
         };
@@ -814,7 +815,7 @@ impl StoreService {
         self.produce_replay_event(
             event_id.ok_or(StoreError::NoEventId)?,
             scoping.project_id,
-            start_time,
+            received_at,
             retention,
             replay_event,
         )?;
@@ -825,7 +826,7 @@ impl StoreService {
             replay_recording,
             Some(replay_event),
             Some(replay_video),
-            start_time,
+            received_at,
             retention,
         )
     }
@@ -833,7 +834,7 @@ impl StoreService {
     fn produce_check_in(
         &self,
         project_id: ProjectId,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         client: Option<&str>,
         retention_days: u16,
         item: &Item,
@@ -842,7 +843,7 @@ impl StoreService {
             message_type: CheckInMessageType::CheckIn,
             project_id,
             retention_days,
-            start_time: UnixTimestamp::from_instant(start_time).as_secs(),
+            start_time: received_at.timestamp() as u64,
             sdk: client.map(str::to_owned),
             payload: item.payload(),
             routing_key_hint: item.routing_hint(),
@@ -856,7 +857,7 @@ impl StoreService {
     fn produce_span(
         &self,
         scoping: Scoping,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         event_id: Option<EventId>,
         retention_days: u16,
         item: &Item,
@@ -878,7 +879,7 @@ impl StoreService {
                     quantity: 1,
                     remote_addr: None,
                     scoping,
-                    timestamp: instant_to_date_time(start_time),
+                    timestamp: received_at,
                 });
                 return Ok(());
             }
@@ -920,7 +921,7 @@ impl StoreService {
             quantity: 1,
             remote_addr: None,
             scoping,
-            timestamp: instant_to_date_time(start_time),
+            timestamp: received_at,
         });
 
         Ok(())
@@ -1025,14 +1026,14 @@ impl StoreService {
         &self,
         organization_id: u64,
         project_id: ProjectId,
-        start_time: Instant,
+        received_at: DateTime<Utc>,
         retention_days: u16,
         item: &Item,
     ) -> Result<(), StoreError> {
         let message = ProfileChunkKafkaMessage {
             organization_id,
             project_id,
-            received: UnixTimestamp::from_instant(start_time).as_secs(),
+            received: received_at.timestamp() as u64,
             retention_days,
             payload: item.payload(),
         };

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -6,13 +6,12 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::Arc;
-use std::time::Instant;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use relay_base_schema::data_category::DataCategory;
 use relay_base_schema::project::ProjectId;
-use relay_common::time::{instant_to_date_time, UnixTimestamp};
+use relay_common::time::UnixTimestamp;
 use relay_config::Config;
 use relay_event_schema::protocol::{EventId, VALID_PLATFORMS};
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -1,13 +1,14 @@
 //! Envelope context type and helpers to ensure outcomes.
 
-use chrono::{DateTime, Utc};
-use relay_quotas::{DataCategory, Scoping};
-use relay_system::Addr;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use relay_quotas::{DataCategory, Scoping};
+use relay_system::Addr;
 
 use crate::envelope::{Envelope, Item};
 use crate::extractors::RequestMeta;

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -502,14 +502,14 @@ impl ManagedEnvelope {
     /// Returns the time elapsed in seconds since the envelope was received by this Relay.
     ///
     /// In case the elapsed time is negative, it is assumed that no time elapsed.
-    pub fn elapsed(&self) -> Duration {
-        self.envelope.elapsed()
+    pub fn age(&self) -> Duration {
+        self.envelope.age()
     }
 
     /// Resets inner state to ensure there's no more logging.
     fn finish(&mut self, counter: RelayCounters, handling: Handling) {
         relay_statsd::metric!(counter(counter) += 1, handling = handling.as_str());
-        relay_statsd::metric!(timer(RelayTimers::EnvelopeTotalTime) = self.elapsed());
+        relay_statsd::metric!(timer(RelayTimers::EnvelopeTotalTime) = self.age());
 
         self.context.done = true;
     }

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -1,14 +1,13 @@
 //! Envelope context type and helpers to ensure outcomes.
 
+use chrono::{DateTime, Utc};
+use relay_quotas::{DataCategory, Scoping};
+use relay_system::Addr;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::{Deref, DerefMut};
-use std::time::Instant;
-
-use chrono::{DateTime, Utc};
-use relay_quotas::{DataCategory, Scoping};
-use relay_system::Addr;
+use std::time::Duration;
 
 use crate::envelope::{Envelope, Item};
 use crate::extractors::RequestMeta;
@@ -492,24 +491,24 @@ impl ManagedEnvelope {
         ) * 1000.) as usize
     }
 
-    /// Returns the instant at which the envelope was received at this Relay.
-    ///
-    /// This is the monotonic time equivalent to [`received_at`](Self::received_at).
-    pub fn start_time(&self) -> Instant {
-        self.meta().start_time()
-    }
-
     /// Returns the time at which the envelope was received at this Relay.
     ///
-    /// This is the date time equivalent to [`start_time`](Self::start_time).
+    /// This is the date time equivalent to [`start_time`](Self::received_at).
     pub fn received_at(&self) -> DateTime<Utc> {
         self.envelope.received_at()
+    }
+
+    /// Returns the time elapsed in seconds since the envelope was received by this Relay.
+    ///
+    /// In case the elapsed time is negative, it is assumed that no time elapsed.
+    pub fn elapsed(&self) -> Duration {
+        self.envelope.elapsed()
     }
 
     /// Resets inner state to ensure there's no more logging.
     fn finish(&mut self, counter: RelayCounters, handling: Handling) {
         relay_statsd::metric!(counter(counter) += 1, handling = handling.as_str());
-        relay_statsd::metric!(timer(RelayTimers::EnvelopeTotalTime) = self.start_time().elapsed());
+        relay_statsd::metric!(timer(RelayTimers::EnvelopeTotalTime) = self.elapsed());
 
         self.context.done = true;
     }

--- a/tools/bench-buffer/Cargo.toml
+++ b/tools/bench-buffer/Cargo.toml
@@ -17,3 +17,4 @@ relay-server = { path = "../../relay-server" }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+chrono = { workspace = true }

--- a/tools/bench-buffer/src/main.rs
+++ b/tools/bench-buffer/src/main.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use chrono::Utc;
 use clap::{Parser, ValueEnum};
 use relay_config::Config;
 use relay_server::{Envelope, MemoryChecker, MemoryStat, PolymorphicEnvelopeBuffer};
@@ -210,6 +211,6 @@ fn mock_envelope(payload_size: usize, project_count: usize) -> Box<Envelope> {
         ));
 
     let mut envelope = Envelope::parse_bytes(bytes).unwrap();
-    envelope.set_received_at(Instant::now());
+    envelope.set_received_at(Utc::now());
     envelope
 }

--- a/tools/bench-buffer/src/main.rs
+++ b/tools/bench-buffer/src/main.rs
@@ -210,6 +210,6 @@ fn mock_envelope(payload_size: usize, project_count: usize) -> Box<Envelope> {
         ));
 
     let mut envelope = Envelope::parse_bytes(bytes).unwrap();
-    envelope.set_start_time(Instant::now());
+    envelope.set_received_at(Instant::now());
     envelope
 }


### PR DESCRIPTION
This PR changes the `start_time` field of several components within Relay from type `Instant` to `DateTime<Utc>` and renames it to `received_at`.

Closes: https://github.com/getsentry/team-ingest/issues/564