### PR TITLE
instr(metrics): Set org_id as user for cardinality error

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2551,6 +2551,8 @@ impl EnvelopeProcessorService {
         limits: &[CardinalityLimit],
         buckets: Vec<Bucket>,
     ) -> Vec<Bucket> {
+        use relay_log::sentry::User;
+
         let global_config = self.inner.global_config.current();
         let cardinality_limiter_mode = global_config.options.cardinality_limiter_mode;
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2551,8 +2551,6 @@ impl EnvelopeProcessorService {
         limits: &[CardinalityLimit],
         buckets: Vec<Bucket>,
     ) -> Vec<Bucket> {
-        use relay_log::sentry::User;
-
         let global_config = self.inner.global_config.current();
         let cardinality_limiter_mode = global_config.options.cardinality_limiter_mode;
 
@@ -2586,7 +2584,7 @@ impl EnvelopeProcessorService {
                 relay_log::with_scope(
                     |scope| {
                         // Set the organization as user so we can alert on distinct org_ids.
-                        scope.set_user(Some(User {
+                        scope.set_user(Some(relay_log::sentry::User {
                             id: Some(scoping.organization_id.to_string()),
                             ..Default::default()
                         }));


### PR DESCRIPTION
Due to a limitation in the Alerts feature in Sentry, we cannot trigger an alert on `count_unique(tags.organization_id)`, but [we can alert on](https://docs.sentry.io/product/alerts/create-alerts/issue-alert-config/#when-conditions-triggers) `count_unique(user)`. To leverage this, set `user := organization_id`.

ref: https://github.com/getsentry/team-ingest/issues/306

#skip-changelog